### PR TITLE
Start mst before running syncd

### DIFF
--- a/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
+++ b/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
@@ -7,11 +7,13 @@ After=database.service
 User=root
 {% if sonic_hwsku == 'ACS-MSN2700' %}
 ExecStartPre=/etc/init.d/sxdkernel start
+ExecStartPre=/usr/bin/mst start
 {% endif %}
 ExecStart=/usr/bin/docker start -a syncd
 ExecStop=/usr/bin/docker stop syncd
 {% if sonic_hwsku == 'ACS-MSN2700' %}
 ExecStopPost=/etc/init.d/sxdkernel stop
+ExecStopPost=/usr/bin/mst stop
 {% endif %}
 Restart=always
 


### PR DESCRIPTION
mst modules must be loaded on Mellanox platform
prior to starting syncd in order to perform
firmware update