### PR TITLE
Fix include_vars call in eos role

### DIFF
--- a/ansible/roles/eos/tasks/main.yml
+++ b/ansible/roles/eos/tasks/main.yml
@@ -1,6 +1,6 @@
 # Gather minigraph facts
 - name: Gathering facts about the device
-  include_vars: name=vars/configurations/{{ filename }}
+  include_vars: vars/configurations/{{ filename }}
 
 - name: copy boot-config
   copy: src=boot-config


### PR DESCRIPTION
Ansible module include_vars name parameter was introduced in v2.2
Use free-form to be compatible with required version