### PR TITLE
Adapt LLDP test for different enviroments

### DIFF
--- a/ansible/library/lldp_facts.py
+++ b/ansible/library/lldp_facts.py
@@ -85,19 +85,19 @@ class DefineOid(object):
 
     def __init__(self,dotprefix=False):
         if dotprefix:
-            dp = "."
+            dp = ".1"
         else:
             dp = ""
 
         # From IF-MIB
-        self.if_descr       = dp + "1.0.8802.1.1.2.1.3.7.1.3"
+        self.if_descr       = dp + ".0.8802.1.1.2.1.3.7.1.3"
 
         # From LLDP-MIB
-        self.lldp_rem_port_id      = dp + "1.0.8802.1.1.2.1.4.1.1.7"
-        self.lldp_rem_port_desc    = dp + "1.0.8802.1.1.2.1.4.1.1.8"
-        self.lldp_rem_sys_desc     = dp + "1.0.8802.1.1.2.1.4.1.1.10"
-        self.lldp_rem_sys_name     = dp + "1.0.8802.1.1.2.1.4.1.1.9"
-        self.lldp_rem_chassis_id   = dp + "1.0.8802.1.1.2.1.4.1.1.5"
+        self.lldp_rem_port_id      = dp + ".0.8802.1.1.2.1.4.1.1.7"
+        self.lldp_rem_port_desc    = dp + ".0.8802.1.1.2.1.4.1.1.8"
+        self.lldp_rem_sys_desc     = dp + ".0.8802.1.1.2.1.4.1.1.10"
+        self.lldp_rem_sys_name     = dp + ".0.8802.1.1.2.1.4.1.1.9"
+        self.lldp_rem_chassis_id   = dp + ".0.8802.1.1.2.1.4.1.1.5"
 
 def get_iftable(snmp_data):
     """ Gets the interface table (if_index and interface) for a given device

--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -36,4 +36,4 @@
 - name: Iterate throguh each lldp neighbor and verify the information received by neighbor are also correct
   add_host: name={{ lldp[item]['chassis']['mgmt-ip'] }} groups=lldp_neighbors neighbor_interface={{lldp[item]['port']['ifname']}} dut_interface={{item}} hname={{lldp[item]['chassis']['mgmt-ip'] }} snmp_rocommunity={{ snmp_rocommunity }}
   with_items: lldp.keys()
-  when: lldp[item]['chassis']['mgmt-ip'] is defined 
+  when: item != "eth0"


### PR DESCRIPTION
Make lldp_facts work with different SNMP datapath formats
Exclude mgmt interface from lldp test