### PR TITLE
[syncd.service]: Flush only DBs related to switch state

### DIFF
--- a/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
+++ b/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
@@ -13,7 +13,9 @@ ExecStartPre=/etc/mlnx/msn2700 start
 ExecStartPre=-/etc/init.d/xpnet.sh stop
 ExecStartPre=/etc/init.d/xpnet.sh start
 {% endif %}
-ExecStartPre=/usr/bin/docker exec database redis-cli FLUSHALL
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB
 ExecStart=/usr/bin/docker start -a syncd
 ExecStop=/usr/bin/docker stop syncd
 {% if sonic_hwsku == 'ACS-MSN2700' %}


### PR DESCRIPTION
Instead of using FLUSHALL flush only those DBs
that need to be empty before system initialization.
This will allow us keep persistent data in other DBs,
like daemons logging severity level.