### PR TITLE
Configure speed mode in syncd during deployment

### DIFF
--- a/ansible/group_vars/sonic/vars
+++ b/ansible/group_vars/sonic/vars
@@ -24,6 +24,7 @@ sensor_hwskus: [ "ACS-MSN2700", "Force10-S6000" ]
 
 syncd_docker_volumes_dict:
   "/host/machine.conf:/etc/machine.conf":
+   "/etc/ssw/:/etc/ssw/:ro":
 
 syncd_docker_volumes: "{{ syncd_docker_volumes_dict.keys() }}"
 

--- a/ansible/roles/sonicv2/tasks/sonic-cavm.yml
+++ b/ansible/roles/sonicv2/tasks/sonic-cavm.yml
@@ -16,9 +16,18 @@
     src: ssw_extra/{{ sonic_hwsku }}/port_config_{{ sonic_portsku }}.ini
     dest: /etc/ssw/{{ sonic_hwsku }}/port_config.ini
 
+# Setup profile for syncd
+- name: Setup profile configuration file
+  become: yes
+  template: src=etc/ssw/{{ sonic_hwsku }}/profile.ini.j2
+            dest=/etc/ssw/{{ sonic_hwsku }}/profile.ini
+            owner=root
+            group=root
+            mode=0644
+
 # Install docker containers
 - name: Start syncd docker container
-  include: ../../sonic-common/tasks/sonicdocker.yml
+  include: sonicdocker.yml
   vars:
     docker_container: syncd
     docker_image: "{{ image_id_syncd_cavm }}"


### PR DESCRIPTION
- As syncd starts with profile config file as parameter - setup config file before cavm-syncd container start. (It`s allow configure speed during deployment and not keep it hard coded ).
- Adding new mount point for syncd to read configured profile (as changing profile.ini inside container requires syncd deamon restart).
- Fix path for docker.yml

Signed-off-by: Nadiya.Stetskovych <Nadiya.Stetskovych@cavium.com>