### PR TITLE
Fixes problems with database - swss - syncd synchronization.

### DIFF
--- a/ansible/roles/sonicv2/templates/etc/systemd/system/swss.j2
+++ b/ansible/roles/sonicv2/templates/etc/systemd/system/swss.j2
@@ -5,8 +5,8 @@ After=database.service
 
 [Service]
 User={{ sonicadmin_user }}
-# Wait for redis server start before database clean by checking the server listening port 6379
-ExecStartPre=/bin/bash -c "while true; do if [ -n \"$(netstat -l | grep 6379)\" ]; then break; fi; sleep 1; done"
+# Wait for redis server start before database clean
+ExecStartPre=/bin/bash -c "while true; do if [ \"$(/usr/bin/docker exec database redis-cli ping)\" == \"PONG\" ]; then break; fi; sleep 1; done"
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB

--- a/ansible/roles/sonicv2/templates/etc/systemd/system/swss.j2
+++ b/ansible/roles/sonicv2/templates/etc/systemd/system/swss.j2
@@ -5,6 +5,8 @@ After=database.service
 
 [Service]
 User={{ sonicadmin_user }}
+# Wait for redis server start before database clean by checking the server listening port 6379
+ExecStartPre=/bin/bash -c "while true; do if [ -n \"$(netstat -l | grep 6379)\" ]; then break; fi; sleep 1; done"
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB

--- a/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
+++ b/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=syncd container
-Requires=database.service
-After=database.service
+Requires=database.service swss.service
+After=database.service swss.service
 
 [Service]
 User=root


### PR DESCRIPTION
This PR fixes problem with database - swss - syncd synchronization.

There are two problems:

1.  The database is flushed in swss.service ExecStartPre without check that redis server is started already. Sometimes the flush is executed too early which makes swss failing. Here is the error log of this case:

Feb  2 12:56:23 switch2 INFO docker[798]: Could not connect to Redis at 127.0.0.1:6379: Connection refused
Feb  2 12:56:23 switch2 INFO docker[798]: Could not connect to Redis at 127.0.0.1:6379: Connection refused
Feb  2 12:56:23 switch2 NOTICE systemd[1]: swss.service: control process exited, code=exited status=1
Feb  2 12:56:23 switch2 ERR systemd[1]: Failed to start switch state service container.
Feb  2 12:56:23 switch2 NOTICE systemd[1]: Unit swss.service entered failed state.

In order to solve this to swss.service is added a bash loop which checks that redis server is up using redis-cli ping command. If it's not the loop sleeps for a second before the next try.

2. The second problem is related to a race condition between database flush performed in swss.service and HIDDEN variable set by syncd. Both the services are started simultaneously and sometimes the flush in swss is performed later than the set in syncd. When after this orchagent starting script checks the HLEN of HIDDEN variable it's always zero so the orchagent just doesn't start. 

As a solution syncd.service is made dependant on swss.service and should be executed after the last one is started.