### PR TITLE
[sonicdocker] Change container task order due to service dependencies

### DIFF
--- a/ansible/roles/sonicv2/tasks/sonic-brcm.yml
+++ b/ansible/roles/sonicv2/tasks/sonic-brcm.yml
@@ -31,19 +31,6 @@
        default_release={{ apt_default_release }}
        force=yes
 
-# Install docker containers
-- name: Start syncd docker container
-  include: sonicdocker.yml
-  vars:
-    docker_container: syncd
-    docker_image: "{{ image_id_syncd_rpc if host_saithrift is defined else image_id_syncd }}"
-    docker_privileged: yes
-    docker_state: reloaded
-    docker_volumes: "{{ syncd_docker_volumes }}"
-    docker_volumes_from:
-    - database
-  tags: syncd
-
 - name: Remove old copies of bcmcmd
   become: true
   file: path=/usr/sbin/bcmcmd
@@ -78,3 +65,17 @@
     docker_volumes_from:
     - database
   tags: orchagent
+
+# Install docker containers
+- name: Start syncd docker container
+  include: sonicdocker.yml
+  vars:
+    docker_container: syncd
+    docker_image: "{{ image_id_syncd_rpc if host_saithrift is defined else image_id_syncd }}"
+    docker_privileged: yes
+    docker_state: reloaded
+    docker_volumes: "{{ syncd_docker_volumes }}"
+    docker_volumes_from:
+    - database
+  tags: syncd
+

--- a/ansible/roles/sonicv2/tasks/sonic-cavm.yml
+++ b/ansible/roles/sonicv2/tasks/sonic-cavm.yml
@@ -16,20 +16,6 @@
     src: ssw_extra/{{ sonic_hwsku }}/port_config_{{ sonic_portsku }}.ini
     dest: /etc/ssw/{{ sonic_hwsku }}/port_config.ini
 
-# Install docker containers
-- name: Start syncd docker container
-  include: sonicdocker.yml
-  vars:
-    docker_container: syncd
-    docker_image: "{{ image_id_syncd_cavm }}"
-    docker_privileged: yes
-    docker_state: reloaded
-    docker_volumes: "{{ syncd_docker_volumes }}"
-    docker_volumes_from:
-    - database
-  when: host_saithrift is not defined
-  tags: syncd
-
 # Remove deprecated orchagent container
 - name: Remove orchagent docker container
   include: sonicdocker.yml
@@ -51,3 +37,18 @@
     docker_volumes_from:
     - database
   tags: orchagent
+
+# Install docker containers
+- name: Start syncd docker container
+  include: sonicdocker.yml
+  vars:
+    docker_container: syncd
+    docker_image: "{{ image_id_syncd_cavm }}"
+    docker_privileged: yes
+    docker_state: reloaded
+    docker_volumes: "{{ syncd_docker_volumes }}"
+    docker_volumes_from:
+    - database
+  when: host_saithrift is not defined
+  tags: syncd
+

--- a/ansible/roles/sonicv2/tasks/sonic-mlnx.yml
+++ b/ansible/roles/sonicv2/tasks/sonic-mlnx.yml
@@ -24,19 +24,6 @@
        default_release={{ apt_default_release }}
        force=yes
 
-# Install docker containers
-- name: Start syncd docker container
-  include: sonicdocker.yml
-  vars:
-    docker_container: syncd
-    docker_image: "{{ image_id_syncd_mlnx_rpc if host_saithrift is defined else image_id_syncd_mlnx }}"
-    docker_privileged: yes
-    docker_state: reloaded
-    docker_volumes: "{{ syncd_docker_volumes }}"
-    docker_volumes_from:
-    - database
-  tags: syncd
-
 # Remove deprecated orchagent container
 - name: Remove orchagent docker container
   include: sonicdocker.yml
@@ -58,3 +45,17 @@
     docker_volumes_from:
     - database
   tags: orchagent
+
+# Install docker containers
+- name: Start syncd docker container
+  include: sonicdocker.yml
+  vars:
+    docker_container: syncd
+    docker_image: "{{ image_id_syncd_mlnx_rpc if host_saithrift is defined else image_id_syncd_mlnx }}"
+    docker_privileged: yes
+    docker_state: reloaded
+    docker_volumes: "{{ syncd_docker_volumes }}"
+    docker_volumes_from:
+    - database
+  tags: syncd
+


### PR DESCRIPTION
With #110 changes syncd service require swss.service.
So change task order that at the moment syncd starts swss.service has been generated.

Otherwise deployment fails on TASK [sonicv2 : syncd - Post docker - restart container service] 
with message: "Failed to start syncd.service: Unit swss.service failed to load: No such file or directory" 

Note: reproduce on "bare" onie as swss.service might  have been generated before container dependencies introduced.

Signed-off-by: Nadiya.Stetskovych <Nadiya.Stetskovych@cavium.com>