### PR TITLE
Remove requirement for swss.service

### DIFF
--- a/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
+++ b/ansible/roles/sonicv2/templates/etc/systemd/system/syncd.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=syncd container
-Requires=database.service swss.service
+Requires=database.service
 After=database.service swss.service
 
 [Service]


### PR DESCRIPTION
syncd service can be installed without swss service.
It only has to be started after swss.