### PR TITLE
Added two test cases of LAG testing (on t1-lag topology)

### DIFF
--- a/ansible/group_vars/str/strinfo.json
+++ b/ansible/group_vars/str/strinfo.json
@@ -16,7 +16,7 @@
         "Arista": {
             "user": "admin",
             "passwd": ["password", "123456"],
-            "enable": null
+            "enable": ["password"]
         },
         "Force10": {
             "user": "admin",

--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -481,3 +481,43 @@ class LagAllRoutes(BaseTest,RouterUtility):
                     
         assert(test_result)
     #---------------------------------------------------------------------
+
+
+class LagMembersTrafficTest(BaseTest,RouterUtility):
+    '''
+    @ summary: run traffic from <src_iface> to <dst_addr>. All packets should arrive to <check_pkts_iface>.
+
+    @ param: dst_addr   -   destination address of the traffic (usually LAG interface IP)
+    @ param: src_iface  -   interface, where traffic is sent from
+    @ param: check_pkts_iface   -   where packets should arrive (because usually one of LAG members is being DOWN in test purposes).
+    @ param: num_of_pkts        -   amount of traffic to send
+    '''
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = testutils.test_params_get()
+        print("test params = %s" % self.test_params)
+
+    def setUp(self):
+        '''
+        @summary: Setup for the test
+        '''
+        self.dataplane = ptf.dataplane_instance
+
+    def runTest(self):
+        self.dst_addr = self.test_params['dst_addr']
+        self.src_iface = int(self.test_params['src_iface'])
+        self.check_pkts_iface = int(self.test_params['check_pkts_iface'])
+        self.num_of_pkts = int(self.test_params['num_of_pkts'])
+
+        # Generate packet.
+        pkt = scapy.Ether()
+        pkt /= scapy.IP(src='10.0.0.99', dst=self.dst_addr)
+        pkt /= scapy.ICMP()
+        pkt /= ("Yellow Sun")
+
+        # Send packet and verify it on dst port.
+        i = 0
+        while i < int(self.num_of_pkts):
+            send_packet(self, self.src_iface, pkt)
+            verify_packet(self, pkt, self.check_pkts_iface)
+            i += 1

--- a/ansible/roles/test/tasks/lag_dut_lacp_test.yml
+++ b/ansible/roles/test/tasks/lag_dut_lacp_test.yml
@@ -1,0 +1,19 @@
+#---------------------------------------------------------
+# The following actions are to be done on DUT:
+#   1) Check LACP rate on DUT.
+#   2) Verify if it's slow and raise an error in another case.
+#---------------------------------------------------------
+
+- name: Read teamd state for {{ lag_iface }} on DUT.
+  shell: docker exec -i teamd teamdctl {{ lag_iface }} state
+  register: teamd_state
+
+- name: Verify LACP rate.
+  shell: echo {{ teamd_state.stdout_lines }} | grep "fast rate" | sed -n "s/.*fast rate. //p" | sed -n "s/]//p"
+  register: lacp_rate
+
+- debug:
+    msg: "Fast-rate value set to {{ lacp_rate.stdout }}"
+
+- fail: msg="Wrong LACP rate set for {{ lag_iface }} LAG interface; 'fast rate' is set to '{{ lacp_rate.stdout }}'"
+  when: lacp_rate.stdout != 'no'

--- a/ansible/roles/test/tasks/lag_vm_lacp_test.yml
+++ b/ansible/roles/test/tasks/lag_vm_lacp_test.yml
@@ -1,0 +1,51 @@
+#---------------------------------------------------------
+# --- Part of lagall.yml test ---
+#---------------------------------------------------------
+# This test verifies that the LACP rate is the same on DUT and VMs.
+#
+# The following actions are to be done for each VM:
+#   1) Perform show running-config on VM.
+#   2) Parse the result by bash commands and read LACP rate.
+#   3) Verify if it's slow and raise an error in another case.
+#
+# @ params: login_creds     -   credentials for Arista VM
+# @ params: lag_member_0      -    First LAG member on VM
+# @ params: lag_member_1      -    Second LAG member on VM
+# @ params: vm_ip             -    Taken from lag_link_flap_vars.yml
+# @ params: vm_name
+#---------------------------------------------------------
+
+- debug:
+    msg: "VM under test is {{ vm_name }}"
+
+        # --- TEST FIRST LAG MEMBER ---
+- name: Read first LAG member configuration to learn LACP rate.
+  include: run_cisco_script.yml
+  vars:
+    template: roles/vm_set/templates/lag_lacp.j2
+    host: "{{ vm_ip }}"
+    log_in: "{{ login_creds }}"
+    show_iface: "{{ lag_member_0 }}"
+
+- name: Get LACP rate.
+  shell: echo {{ cisco_script_res }} | grep lacp | sed -n "s/.*rate //p"
+  register: lacp_rate
+
+- fail: msg="Wrong LACP rate for {{ lag_member_0 }} on {{ vm_name }} VM"
+  when: lacp_rate.stdout != 'slow'
+
+        # --- TEST SECOND LAG MEMBER ---
+- name: Read second LAG member configuration to learn LACP rate.
+  include: run_cisco_script.yml
+  vars:
+    template: roles/vm_set/templates/lag_lacp.j2
+    host: "{{ vm_ip }}"
+    log_in: "{{ login_creds }}"
+    show_iface: "{{ lag_member_1 }}"
+
+- name: Get LACP rate.
+  shell: echo {{ cisco_script_res }} | grep lacp | sed -n "s/.*rate //p"
+  register: lacp_rate
+
+- fail: msg="Wrong LACP rate for {{ lag_member_1 }} on {{ vm_name }} VM"
+  when: lacp_rate.stdout != 'slow'

--- a/ansible/roles/test/tasks/lag_vm_ports_send_traffic.yml
+++ b/ansible/roles/test/tasks/lag_vm_ports_send_traffic.yml
@@ -1,0 +1,15 @@
+#-----------------------
+# Send traffic from PTF docker and verify all the packets arrived.
+#
+# Parameters:
+#   @ param: vm_under_test  -   VM name that contains LAG being tested
+#   @ param: dst_addr   -   destination address of the traffic (usually it's VM LAG interface IP)
+#   @ param: src_iface  -   interface, where traffic is sent from
+#   @ param: check_pkts_iface   -   where packets should arrive (because usually one of LAG members is being DOWN in test purposes).
+#   @ param: number_of_pkts        -   amount of traffic to send
+#-----------------------
+- name: Run traffic from eth{{ src_iface }} (PTF docker) to {{ dst_addr }} (VM LAG iface) on {{ vm_under_test }}; sniff packets on eth{{ check_pkts_iface }} (PTF docker).
+  shell: ptf --test-dir . --platform remote lag_test.LagMembersTrafficTest -t "dst_addr='{{ dst_addr }}'; src_iface={{ src_iface }}; check_pkts_iface={{ check_pkts_iface }}; num_of_pkts={{ number_of_pkts }}"
+  args:
+    chdir: "{{ change_dir }}"
+  delegate_to: "{{ ptf_docker }}"

--- a/ansible/roles/test/tasks/lag_vm_ports_test.yml
+++ b/ansible/roles/test/tasks/lag_vm_ports_test.yml
@@ -65,7 +65,7 @@
         dst_addr: "{{ lag_ip }}"
         src_iface: "{{ not_behind_lag_iface }}"
         check_pkts_iface: "{{ iface_behind_lag_member_0 }}"
-        number_of_packets: "{{ num_of_pkts }}"
+        number_of_pkts: "{{ num_of_pkts }}"
         change_dir: /tmp
   always:
     - name: Put up LAG member interface {{ lag_member_1 }} on {{ vm_name }}.

--- a/ansible/roles/test/tasks/lag_vm_ports_test.yml
+++ b/ansible/roles/test/tasks/lag_vm_ports_test.yml
@@ -1,0 +1,78 @@
+#---------------------------------------------------------
+# --- Part of lagall.yml test ---
+#---------------------------------------------------------
+# Shutdown each LAG member on VMs.
+#
+# The following actions are to be done for each LAG (and each VM):
+#   1.1) Put DOWN EOS interface on VM (simulation of the halt of sending LACP packets).
+#   1.2) Verify all the traffic goes through another LAG member and no packets lost.
+#
+# @ params: login_creds     -   credentials for Arista VM
+# @ params: vm_name
+# @ params: lag_ip          -   LAG interface IP address
+# @ params: lag_member_0    -   First LAG member on VM
+# @ params: lag_member_1    -   Second LAG member on VM
+# @ params: iface_behind_lag_member_0   -   PTF docker iface, connected to LAG VM
+# @ params: iface_behind_lag_member_1   -   PTF docker iface, connected to LAG VM
+# @ params: not_behind_lag_iface        -   PTF docker interface that is connected to non-LAG VM (meaning eth31)
+# @ params: vm_ip       -    VM mgmt IP; taken from lag_link_flap_vars.yml
+# @ params: num_of_pkts -    number of packets to send while PTF test.
+#---------------------------------------------------------
+
+        # --- TEST FIRST LAG MEMBER ---
+- block:
+    - name: Put down LAG member interface {{ lag_member_0 }} on {{ vm_name }}.
+      include: run_cisco_script.yml
+      vars:
+        template: roles/vm_set/templates/lag_vm_ports.j2
+        host: "{{ vm_ip }}"
+        log_in: "{{ login_creds }}"
+        config_iface: "{{ lag_member_0 }}"
+        state: 'shutdown'
+
+    - include: lag_vm_ports_send_traffic.yml
+      vars:
+        vm_under_test: "{{ vm_name }}"
+        dst_addr: "{{ lag_ip }}"
+        src_iface: "{{ not_behind_lag_iface }}"
+        check_pkts_iface: "{{ iface_behind_lag_member_1 }}"
+        number_of_pkts: "{{ num_of_pkts }}"
+        change_dir: /tmp
+  always:
+    - name: Put up LAG member interface {{ lag_member_0 }} on {{ vm_name }}.
+      include: run_cisco_script.yml
+      vars:
+        template: roles/vm_set/templates/lag_vm_ports.j2
+        host: "{{ vm_ip }}"
+        log_in: "{{ login_creds }}"
+        config_iface: "{{ lag_member_0 }}"
+        state: 'no shutdown'
+
+        # --- TEST SECOND LAG MEMBER ---
+- block:
+    - name: Put down LAG member interface {{ lag_member_1 }} on {{ vm_name }}.
+      include: run_cisco_script.yml
+      vars:
+        template: roles/vm_set/templates/lag_vm_ports.j2
+        host: "{{ vm_ip }}"
+        log_in: "{{ login_creds }}"
+        config_iface: "{{ lag_member_1 }}"
+        state: 'shutdown'
+
+    - include: lag_vm_ports_send_traffic.yml
+      vars:
+        vm_under_test: "{{ vm_name }}"
+        dst_addr: "{{ lag_ip }}"
+        src_iface: "{{ not_behind_lag_iface }}"
+        check_pkts_iface: "{{ iface_behind_lag_member_0 }}"
+        number_of_packets: "{{ num_of_pkts }}"
+        change_dir: /tmp
+  always:
+    - name: Put up LAG member interface {{ lag_member_1 }} on {{ vm_name }}.
+      include: run_cisco_script.yml
+      vars:
+        template: roles/vm_set/templates/lag_vm_ports.j2
+        host: "{{ vm_ip }}"
+        log_in: "{{ switch_login['arista'] }}"
+        config_iface: "{{ lag_member_1 }}"
+        state: 'no shutdown'

--- a/ansible/roles/test/tasks/lagall.yml
+++ b/ansible/roles/test/tasks/lagall.yml
@@ -1,0 +1,127 @@
+#-----------------------------------
+# File: lagall.yml
+# Author: Anton Patenko <c_antonp@mellanox.com>
+#-----------------------------------
+# This file runs all the LAG tests.
+#
+# In order to run tests it performs the list of actions:
+#   1) Reads DUT minigraph facts.
+#   2) Creates a list "dut_lag_members" of DUT LAG members, using minigraph facts.
+#   3) Reads LLDP information.
+#   4) Creates a dictionary "lag_vms" of VMs that have LAG configured, using LLDP data and DUT LAG members:
+#       "VM name": [ "VM mgmt IP"]
+#   5) Gathers VM LAG interface IP and some other data about interfaces (see vars-sections in "Start tests" block).
+#   6) Runs the tests.
+#
+# Warning! This test is supposed to be ran on T1-LAG topology.
+#
+# Run command (from ansible/): ansible-playbook test_sonic.yml -i inventory --limit <DUT_inventory_hostname> --tags lag -vvvvv
+#-----------------------------------
+
+- set_fact:
+    ptf_docker: ptf-fib
+
+- name: Read DUT minigraph facts.
+  minigraph_facts: host={{ inventory_hostname }}
+  connection: local
+  become: no
+
+- set_fact:
+    dut_lag_members: []
+
+# item.1 - reference to list's element value
+# minigraph_portchannel_interfaces  -   taken from minigraph_facts
+- name: Create a list of LAG members.
+  set_fact:
+    dut_lag_members: "{{ dut_lag_members }} + [ '{{ item.1['members'][0] }}' ] + [ '{{ item.1['members'][1] }}' ]"
+  with_indexed_items: "{{ minigraph_portchannel_interfaces }}"
+
+- name: Gather information from LLDP.
+  lldp:
+  vars:
+      ansible_shell_type: docker
+      ansible_python_interpreter: docker exec -i lldp python
+
+- debug:
+    msg: "{{ dut_lag_members }}"
+
+- debug:
+    msg: "{{ lldp }}"
+
+# Create dictionary { "VM hostname" : "VM mgmt-ip" } to store info about LAG VMs;
+# "combine" filter is used for appending to the dictionary.
+- name: Get VMs that have LAG configured.
+  set_fact:
+    lag_vms: "{{ lag_vms|default({}) | combine( {lldp[item.1]['chassis']['name']: [ lldp[item.1]['chassis']['mgmt-ip'] ]} ) }}"
+  with_indexed_items: "{{ dut_lag_members }}"
+
+# Append VM LAG members to the previous dictionary.
+- name: Get LAG members for each VM.
+  set_fact:
+    lag_vms: "{{ lag_vms | combine( { lldp[item.1]['chassis']['name']: lag_vms[lldp[item.1]['chassis']['name']] | union([ lldp[item.1]['port']['ifname'] ]) }) }}"
+  with_indexed_items: "{{ dut_lag_members }}"
+
+- debug:
+    msg: "VMs that have LAG configured - {{ lag_vms.keys() }}"
+
+- name: Get credentials for Arista VMs.
+  include_vars: group_vars/str/strinfo.json
+
+- name: Add VMs information to in-memory inventory.
+  add_host: name={{ lag_vms[item][0] }} ansible_ssh_user={{ switch_login['Arista']['user'] }} ansible_ssh_pass={{ switch_login['Arista']['passwd'][0] }}
+  with_items: lag_vms.keys()
+
+#-----------------------------------
+# Start tests
+#-----------------------------------
+
+- name: Copy PTF test into PTF-docker.
+  copy: src=roles/test/files/acstests/{{ item }} dest=/tmp/{{ item }}
+  with_items:
+    - lag_test.py
+    - acs_base_test.py
+    - router_utils.py
+  delegate_to: "{{ ptf_docker }}"
+
+- name: Include testbed topology configuration (to get LAG_IP and PTF docker ifaces, that are behind LAG VMs).
+  include_vars: vars/topo_t1-lag.yml
+
+- name: --TEST-- LAG members UP and DOWN on all VMs.
+  include: lag_vm_ports_test.yml
+  vars:
+    login_creds: "{{ switch_login['Arista'] }}"
+    lag_ip: "{{ configuration[item]['interfaces']['Port-Channel1']['ipv4'] }}"
+    lag_member_0: "{{ lag_vms[item][1] }}"
+    lag_member_1: "{{ lag_vms[item][2] }}"
+    iface_behind_lag_member_0: "{{ topology['VMs'][item]['vlans'][0] }}"
+    iface_behind_lag_member_1: "{{ topology['VMs'][item]['vlans'][1] }}"
+    not_behind_lag_iface: 31
+    vm_ip: "{{ lag_vms[item][0] }}"
+    vm_name: "{{ item }}"
+    num_of_pkts: 100
+  with_items: lag_vms.keys()
+
+- name: --TEST-- LACP verification on all VMs.
+  include: lag_vm_lacp_test.yml
+  vars:
+    login_creds: "{{ switch_login['Arista'] }}"
+    lag_member_0: "{{ lag_vms[item][1] }}"
+    lag_member_1: "{{ lag_vms[item][2] }}"
+    vm_ip: "{{ lag_vms[item][0] }}"
+    vm_name: "{{ item }}"
+  with_items: lag_vms.keys()
+
+# Get a list of LAGs on DUT.
+- set_fact:
+    dut_lags: []
+
+- name: Create a list of LAG members.
+  set_fact:
+    dut_lags: "{{ dut_lags }} + [ '{{ item.1['name'] }}' ]"
+  with_indexed_items: "{{ minigraph_portchannel_interfaces }}"
+
+- name: --TEST-- LACP verification on DUT LAGs.
+  include: lag_dut_lacp_test.yml
+  vars:
+    lag_iface: "{{ item.1 }}"
+  with_indexed_items: "{{ dut_lags }}"

--- a/ansible/roles/test/tasks/lagall.yml
+++ b/ansible/roles/test/tasks/lagall.yml
@@ -17,7 +17,6 @@
 #
 # Run command (from ansible/): ansible-playbook test_sonic.yml -i inventory --limit <DUT_inventory_hostname> --tags lag -vvvvv
 #-----------------------------------
-
 - set_fact:
     ptf_docker: ptf-fib
 
@@ -83,7 +82,7 @@
     - router_utils.py
   delegate_to: "{{ ptf_docker }}"
 
-- name: Include testbed topology configuration (to get LAG_IP and PTF docker ifaces, that are behind LAG VMs).
+- name: Include testbed topology configuration (to get LAG IP and PTF docker ifaces, that are behind LAG VMs).
   include_vars: vars/topo_t1-lag.yml
 
 - name: --TEST-- LAG members UP and DOWN on all VMs.
@@ -115,7 +114,7 @@
 - set_fact:
     dut_lags: []
 
-- name: Create a list of LAG members.
+- name: Get a list of LAGs on DUT.
   set_fact:
     dut_lags: "{{ dut_lags }} + [ '{{ item.1['name'] }}' ]"
   with_indexed_items: "{{ minigraph_portchannel_interfaces }}"

--- a/ansible/roles/test/tasks/run_cisco_script.yml
+++ b/ansible/roles/test/tasks/run_cisco_script.yml
@@ -1,0 +1,57 @@
+#---------------------------------
+# This script runs script for Cisco cli on remote host:
+#   1) Reads terminal length value.
+#   2) Sets terminal length to 0.
+#   2) Runs script.
+#   3) Sets terminal value to default.
+#
+# @ params: template    -   j2-file that contains cli commands
+# @ params: host        -   remote host, where to run the script
+# @ params: log_in      -   credentials to host
+#---------------------------------
+
+- name: Get terminal characteristics.
+  action: apswitch template=roles/vm_set/templates/get_terminal_length.j2
+  connection: switch
+  args:
+    host: "{{ host }}"
+    enable: yes
+    login: "{{ log_in }}"
+    timeout: 300
+  register: cisco_script_res
+
+- name: Get terminal length default.
+  shell: echo {{ cisco_script_res }} | sed -n "s/.*Length. //p" | sed -n "s/ rows.*//p"
+  register: terminal_length
+
+- name: Disable terminal paging.
+  action: apswitch template=roles/vm_set/templates/set_terminal_length.j2
+  connection: switch
+  args:
+    host: "{{ host }}"
+    enable: yes
+    login: "{{ log_in }}"
+    timeout: 300
+  vars:
+    terminal_length_value: '0'
+
+- name: Run cisco script on {{ host }} host.
+  action: apswitch template={{ template }}
+  connection: switch
+  args:
+    host: "{{ host }}"
+    enable: yes
+    login: "{{ log_in }}"
+    timeout: 300
+  register: cisco_script_res
+
+- name: Set terminal length back to default.
+  action: apswitch template=roles/vm_set/templates/set_terminal_length.j2
+  connection: switch
+  args:
+    host: "{{ host }}"
+    enable: yes
+    login: "{{ log_in }}"
+    timeout: 300
+  vars:
+    terminal_length_value: "{{ terminal_length.stdout }}"

--- a/ansible/roles/test/tasks/sonic.yml
+++ b/ansible/roles/test/tasks/sonic.yml
@@ -71,3 +71,7 @@
 - name: Test ACL
   include: acl.yml
   tags: acl
+
+- name: Test LAG link flap.
+  include: lagall.yml
+  tags: lag

--- a/ansible/roles/vm_set/templates/get_terminal_length.j2
+++ b/ansible/roles/vm_set/templates/get_terminal_length.j2
@@ -1,0 +1,3 @@
+enable
+!
+show terminal

--- a/ansible/roles/vm_set/templates/lag_lacp.j2
+++ b/ansible/roles/vm_set/templates/lag_lacp.j2
@@ -1,0 +1,7 @@
+enable
+!
+configure
+!
+show running-config interfaces {{ show_iface }}
+!
+end

--- a/ansible/roles/vm_set/templates/lag_vm_ports.j2
+++ b/ansible/roles/vm_set/templates/lag_vm_ports.j2
@@ -1,0 +1,9 @@
+enable
+!
+configure
+!
+interface {{ config_iface }}
+!
+{{ state }}
+!
+end

--- a/ansible/roles/vm_set/templates/set_terminal_length.j2
+++ b/ansible/roles/vm_set/templates/set_terminal_length.j2
@@ -1,0 +1,3 @@
+enable
+!
+terminal length {{ terminal_length_value| int }}


### PR DESCRIPTION
1) VM LAG members traffic testing
2) LACP rate verifying on VMs and DUT

Note: there is also an issue with SSH connection to VMs, so sometimes, when running cisco scripts, the test can hang.

Full LAG test plan is available here:
https://github.com/Azure/SONiC/wiki/LAG-test-plan