### PR TITLE
[DHCP Relay Test]: Obtain DHCP servers and their count from minigraph

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -260,6 +260,26 @@ def parse_cpg(cpg, hname):
 
     return bgp_sessions, myasn
 
+def parse_meta(meta, hname):
+    syslog_servers = []
+    dhcp_servers = []
+    ntp_servers = []
+    device_metas = meta.find(str(QName(ns, "Devices")))
+    for device in device_metas.findall(str(QName(ns1, "DeviceMetadata"))):
+        if device.find(str(QName(ns1, "Name"))).text == hname:
+            properties = device.find(str(QName(ns1, "Properties")))
+            for device_property in properties.findall(str(QName(ns1, "DeviceProperty"))):
+                name = device_property.find(str(QName(ns1, "Name"))).text
+                value = device_property.find(str(QName(ns1, "Value"))).text
+                value_group = value.split(';') if value and value != "" else []
+                if name == "DhcpResources":
+                    dhcp_servers = value_group
+                elif name == "NtpResources":
+                    ntp_servers = value_group
+                elif name == "SyslogResources":
+                    syslog_servers = value_group
+    return syslog_servers, dhcp_servers, ntp_servers
+
 
 def get_console_info(devices, dev, port):
     for k, v in devices.items():
@@ -343,6 +363,9 @@ def parse_xml(filename, hostname):
     lo_intf = None
     neighbors = None
     devices = None
+    syslog_servers = []
+    dhcp_servers = []
+    ntp_servers = []
 
     hwsku_qn = QName(ns, "HwSku")
     for child in root:
@@ -375,6 +398,8 @@ def parse_xml(filename, hostname):
             (neighbors, devices, console_dev, console_port, mgmt_dev, mgmt_port) = parse_png(child, hostname)
         elif child.tag == str(QName(ns, "UngDec")):
             (u_neighbors, u_devices, _, _, _, _) = parse_png(child, hostname)
+        elif child.tag == str(QName(ns, "MetadataDeclaration")):
+            (syslog_servers, dhcp_servers, ntp_servers) = parse_meta(child, hostname)
 
     # Replace port with alias in Vlan interfaces members
     if vlan_intfs is not None:
@@ -443,6 +468,9 @@ def parse_xml(filename, hostname):
     results['minigraph_console'] = get_console_info(devices, console_dev, console_port)
     results['minigraph_mgmt'] = get_mgmt_info(devices, mgmt_dev, mgmt_port)
     results['minigraph_port_indices'] = port_index_map
+    results['syslog_servers'] = syslog_servers
+    results['dhcp_servers'] = dhcp_servers
+    results['ntp_servers'] = ntp_servers
 
     return results
 

--- a/ansible/roles/sonic-common/tasks/dhcp_relay.yml
+++ b/ansible/roles/sonic-common/tasks/dhcp_relay.yml
@@ -1,9 +1,3 @@
-- name: Copy DHCP relay docker config file to device
-  become: true
-  template: src=dhcp_relay.yml.j2
-            dest=/etc/sonic/dhcp_relay.yml
-            mode=0644
-
 - name: Ensure DHCP Relay container started
   include: sonicdocker.yml
   vars:

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -91,11 +91,6 @@ class DHCPTest(DataplaneBaseTest):
     DHCP_LEASE_TIME_LEN = 6
     LEASE_TIME = 86400
 
-    # Number of DHCP servers relay is forwarding to
-    # Currently this is the number of DHCP servers specified in str.yml
-    # TODO: Calculate this number dynamically
-    NUM_DHCP_SERVERS = 48
-
     def __init__(self):
         DataplaneBaseTest.__init__(self)
 
@@ -107,6 +102,7 @@ class DHCPTest(DataplaneBaseTest):
 
         # These are the interfaces we are injected into that link to out leaf switches
         self.server_port_indices = ast.literal_eval(self.test_params['leaf_port_indices'])
+        self.num_dhcp_servers = int(self.test_params['num_dhcp_servers'])
         self.server_ip = self.test_params['server_ip']
 
         self.relay_iface_name = self.test_params['relay_iface_name']
@@ -290,8 +286,8 @@ class DHCPTest(DataplaneBaseTest):
 
         # Count the number of these packets received on the ports connected to our leaves
         discover_count = testutils.count_matched_packets_all_ports(self, masked_discover, self.server_port_indices)
-        self.assertTrue(discover_count == self.NUM_DHCP_SERVERS,
-                "Failed: Discover count of %d != %d (NUM_DHCP_SERVERS)" % (discover_count, self.NUM_DHCP_SERVERS))
+        self.assertTrue(discover_count == self.num_dhcp_servers,
+                "Failed: Discover count of %d != %d (num_dhcp_servers)" % (discover_count, self.num_dhcp_servers))
 
     # Simulate a DHCP server sending a DHCPOFFER message to client.
     # We do this by injecting a DHCPOFFER message on the link connected to one
@@ -357,8 +353,8 @@ class DHCPTest(DataplaneBaseTest):
 
         # Count the number of these packets received on the ports connected to our leaves
         request_count = testutils.count_matched_packets_all_ports(self, masked_request, self.server_port_indices)
-        self.assertTrue(request_count == self.NUM_DHCP_SERVERS,
-                "Failed: Request count of %d != %d (NUM_DHCP_SERVERS)" % (request_count, self.NUM_DHCP_SERVERS))
+        self.assertTrue(request_count == self.num_dhcp_servers,
+                "Failed: Request count of %d != %d (num_dhcp_servers)" % (request_count, self.num_dhcp_servers))
 
     # Simulate a DHCP server sending a DHCPOFFER message to client from one of our leaves
     def server_send_ack(self):

--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -42,6 +42,7 @@
     ptf_test_params:
       - client_port_index=\"{{ client_port_index }}\"
       - leaf_port_indices=\"{{ leaf_port_indices }}\"
+      - num_dhcp_servers=\"{{ dhcp_servers | length }}\"
       - server_ip=\"{{ dhcp_servers[0] }}\"
       - relay_iface_name=\"{{ minigraph_vlan_interfaces[0]['name'] }}\"
       - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"


### PR DESCRIPTION
- Add functionality to parse DHCP, NTP and Syslog servers from minigraph to minigraph_facts.py, based on Taoyu’s work in sonic-config-engine.