### PR TITLE
[fib_test]: Prevent overlap of source and destination ports.

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -87,10 +87,10 @@ class FibTest(BaseTest):
             self.source_port_list = range(1,25) + range(28,32)
             self.dest_port_list = [[i] for i in range(28,32)]
         elif self.testbed == 't1':
-            self.source_port_list = range(0,32)
+            self.source_port_list = range(16,32)
             self.dest_port_list = [[i] for i in range(0,16)]
         elif self.testbed == 't1-lag':
-            self.source_port_list = range(0,32)
+            self.source_port_list = range(16,32)
             self.dest_port_list = [[i, i+1] for i in range(0,16,2)]
     #---------------------------------------------------------------------
 


### PR DESCRIPTION
Due to overlap of source and destination port according to ECMP rules
some packets were send to the same port on which they were received.
Routing rules doesn't allow packets to be received from the port they
were sent to so such packets were dropped which caused test failure.