### PR TITLE
Add ACL ranges test

### DIFF
--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -18,3 +18,10 @@
 - name: Clean up ACL test configuration on the testbed
   include: acltb_cleanup.yml
   tags: acltb_cleanup
+
+#-----------------------------------------
+# Run ACL ranges count test
+#-----------------------------------------
+- name: Acl ranges count test
+  include: acltb_ranges_test.yml
+  tags: acltb_ranges_test

--- a/ansible/roles/test/tasks/acltb_ranges_test.yml
+++ b/ansible/roles/test/tasks/acltb_ranges_test.yml
@@ -62,15 +62,11 @@
 
     - name: Load JSON configs
       shell: swssconfig /tmp/{{ item }}.json
-      register: res
-      failed_when: res.rc != 0
       with_items:
         - "{{ acltb_configs }}"
 
     - name: Change JSON configs to delete (table)
       shell: sed 's/SET/DEL/g' /tmp/{{ item }}.json >/tmp/del_{{ item }}.json
-      register: res
-      failed_when: res.rc != 0
       with_items:
         - "{{ acltb_configs }}"
 
@@ -80,8 +76,6 @@
 
     - name: Load JSON configs in reversed order
       shell: swssconfig /tmp/del_{{ item }}.json
-      register: res
-      failed_when: res.rc != 0
       with_items:
         - "{{ acltb_configs[::-1] }}"
 

--- a/ansible/roles/test/tasks/acltb_ranges_test.yml
+++ b/ansible/roles/test/tasks/acltb_ranges_test.yml
@@ -1,0 +1,112 @@
+# Usage example:
+#   ansible-playbook test_sonic.yml -i inventory --limit arc-switch1028 --tags acltb_ranges_test -b -e ranges_number=3 -e ptf_host=ptf-fib
+#
+# Variable "ranges_number" defines how many ACL range objects the test will attempt to create
+#
+
+# Input arguments check
+- fail: msg="ranges_number is not defined."
+  when: ranges_number is not defined
+
+# Set facts for ACL configuration
+- set_fact:
+    acltb_configs:
+      - "{{ 'acl_ranges_table' }}"
+      - "{{ 'acl_ranges_rules' }}"
+
+# Set facts for the loganalizer
+- set_fact:
+    testname: acl
+    run_dir: /tmp
+    out_dir: /tmp/ansible-loganalyzer-results
+    test_match_file: acltb_match_messages.txt
+    test_ignore_file: acltb_ignore_messages.txt
+    test_expect_file: acltb_expect_messages.txt
+    match_file: loganalyzer_common_match.txt
+    ignore_file: loganalyzer_common_ignore.txt
+
+# Separate set_fact is required to be able to use 'testname' fact.
+- set_fact:
+    testname_unique: "{{ testname }}.{{ ansible_date_time.date}}.{{ ansible_date_time.hour}}-{{ ansible_date_time.minute}}-{{ ansible_date_time.second}}"
+
+# Separate set_fact is required to be able to use 'testname_unique' fact.
+- set_fact:
+    test_out_dir: "{{ out_dir }}/{{testname_unique}}"
+    match_file_list: "{{ run_dir }}/{{test_match_file}},{{ run_dir }}/{{match_file}}"
+    ignore_file_list: "{{ run_dir }}/{{test_ignore_file}},{{ run_dir }}/{{ignore_file}}"
+    result_file: result.loganalysis.{{testname_unique}}.log
+    summary_file: summary.loganalysis.{{testname_unique}}.log
+
+# Gather minigraph facts
+- name: Gathering minigraph facts about the device
+  minigraph_facts: host={{ inventory_hostname }}
+  become: no
+  connection: local
+
+- name: Read port reverse alias mapping
+  set_fact:
+    alias_reverse_map: "{{ lookup('file', 'roles/sonicv2/files/ssw/{{ sonic_hwsku }}/alias_reverse_map.json') | from_json }}"
+
+- include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+  vars:
+    tests_location: "{{ 'roles/test/tasks' }}"
+
+# Outer block to execute laganalizer in always block
+- block:
+  # Perform the test: generate and apply acl jsons
+  - block:
+    - name: Copy JSON configs into docker filesystem
+      template: src={{ item }}.j2 dest=/tmp/{{ item }}.json
+      with_items:
+        - "{{ acltb_configs }}"
+
+    - name: Load JSON configs
+      shell: swssconfig /tmp/{{ item }}.json
+      register: res
+      failed_when: res.rc != 0
+      with_items:
+        - "{{ acltb_configs }}"
+
+    - name: Change JSON configs to delete (table)
+      shell: sed 's/SET/DEL/g' /tmp/{{ item }}.json >/tmp/del_{{ item }}.json
+      register: res
+      failed_when: res.rc != 0
+      with_items:
+        - "{{ acltb_configs }}"
+
+    - name: Pause 5 sec to let rules to settle down
+      pause:
+        seconds: 5
+
+    - name: Load JSON configs in reversed order
+      shell: swssconfig /tmp/del_{{ item }}.json
+      register: res
+      failed_when: res.rc != 0
+      with_items:
+        - "{{ acltb_configs[::-1] }}"
+
+    vars:
+      ansible_shell_type: docker
+      ansible_python_interpreter: docker exec -i swss python
+
+  always:
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+      vars:
+        tests_location: "{{ 'roles/test/tasks' }}"
+
+    # Output content of result files to ansible console
+    - shell: cat {{ test_out_dir }}/*
+      register: out
+    - debug: var=out.stdout_lines
+
+    - name: Get the total number of error messages.
+      shell: grep "TOTAL MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL MATCHES:[[:space:]]*//p"
+      register: errors_found
+
+    - name: Check the number of error messages (positive tests only).
+      fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }} test. Please see {{ test_out_dir }}/{{ result_file }}"
+      when: errors_found.stdout != "0"
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+      vars:
+        tests_location: "{{ 'roles/test/tasks' }}"

--- a/ansible/roles/test/templates/acl_ranges_rules.j2
+++ b/ansible/roles/test/templates/acl_ranges_rules.j2
@@ -1,0 +1,14 @@
+[
+{% for tor in range(ranges_number | int) %}
+    {
+        "ACL_RULE_TABLE:ACL_Testbed_Range_Test_Table:Rule{{ loop.index }}_port_range_test": {
+            "priority" : "50",
+            "l4_dst_port_range" : "{{ 1024 + loop.index * 16 }}-{{ 1024 + loop.index * 16 + 10 }}",
+            "packet_action" : "forward"
+        },
+        "OP": "SET"
+    }{% if not loop.last %},
+{% endif %}
+{% endfor %}
+
+]

--- a/ansible/roles/test/templates/acl_ranges_table.j2
+++ b/ansible/roles/test/templates/acl_ranges_table.j2
@@ -1,0 +1,10 @@
+[
+    {
+        "ACL_TABLE:ACL_Testbed_Range_Test_Table": {
+            "policy_desc" : "This_table_contains_rules_needed_for_the_testbed_ranges_test",
+            "type" : "L3",
+            "ports" : "{% for ifname, v in minigraph_neighbors.iteritems() %}{{"%s" % alias_reverse_map[ifname]}},{% endfor %}"
+        },
+        "OP": "SET"
+    }
+]


### PR DESCRIPTION
Usage example:
  ansible-playbook test_sonic.yml -i inventory --limit arc-switch1028 --tags acltb_ranges_test -b -e ranges_number=3 -e ptf_host=ptf-fib

 Variable "ranges_number" defines how many ACL range objects the test will attempt to create
