### PR TITLE
[everflow_test]: Use separated everflow session for tests.

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_tb_test.py
+++ b/ansible/roles/test/files/acstests/everflow_tb_test.py
@@ -147,7 +147,11 @@ class EverflowTest(BaseTest):
         inner_pkt = scapy.Ether(payload)
 
         masked_inner_pkt = Mask(inner_pkt)
-        masked_inner_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+        if scapy.IP in inner_pkt:
+            masked_inner_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+
+        if scapy.TCP in inner_pkt:
+            masked_inner_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
 
         return dataplane.match_exp_pkt(masked_inner_pkt, pkt2send)
 

--- a/ansible/roles/test/files/acstests/everflow_tb_test.py
+++ b/ansible/roles/test/files/acstests/everflow_tb_test.py
@@ -13,7 +13,7 @@ import ptf.packet as scapy
 import ptf.dataplane as dataplane
 import ptf.testutils as testutils
 from ptf.base_tests import BaseTest
-
+from ptf.mask import Mask
 
 def reportResults(test_name):
     '''
@@ -66,6 +66,7 @@ class EverflowTest(BaseTest):
         '''
 
         self.dataplane = ptf.dataplane_instance
+        self.hwsku = self.test_params['hwsku']
         self.router_mac = self.test_params['router_mac']
         self.session_src_ip = self.test_params['session_src_ip']
         self.session_dst_ip = self.test_params['session_dst_ip']
@@ -138,10 +139,17 @@ class EverflowTest(BaseTest):
         #if (scapy_pkt[scapy.IP].tos >> 2) != self.session_dscp:
         #    return False
 
-        payload = str(scapy_pkt[scapy.GRE].payload)[22:]
+        payload = str(scapy_pkt[scapy.GRE].payload)
+
+        if self.hwsku in ["ACS-MSN2700", "ACS-MSN2100", "ACS-MSN2410"]:
+            payload = str(scapy_pkt[scapy.GRE].payload)[22:]
+
         inner_pkt = scapy.Ether(payload)
 
-        return dataplane.match_exp_pkt(pkt2send, inner_pkt)
+        masked_inner_pkt = Mask(inner_pkt)
+        masked_inner_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+
+        return dataplane.match_exp_pkt(masked_inner_pkt, pkt2send)
 
 
     @reportResults("Verify SRC IP match")
@@ -172,13 +180,6 @@ class EverflowTest(BaseTest):
         return self.runSendReceiveTest(pkt, self.src_port, self.dst_ports)
 
 
-    @reportResults("Verify ether type match")
-    def verifyEthertype(self):
-        pkt = self.base_pkt.copy()
-        pkt['Ethernet'].type = 0x1234
-        return self.runSendReceiveTest(pkt, self.src_port, self.dst_ports)
-
-
     @reportResults("Verify IP protocol match")
     def verifyIpProtocol(self):
         pkt = self.base_pkt.copy()
@@ -194,16 +195,16 @@ class EverflowTest(BaseTest):
 
 
     @reportResults("Verify L4 SRC port range match")
-    def verifyL4SrcPort(self):
+    def verifyL4SrcPortRange(self):
         pkt = self.base_pkt.copy()
-        pkt['TCP'].sport = 0x123A
+        pkt['TCP'].sport = 4675
         return self.runSendReceiveTest(pkt, self.src_port, self.dst_ports)
 
 
     @reportResults("Verify L4 DST port range match")
-    def verifyL4DstPort(self):
+    def verifyL4DstPortRange(self):
         pkt = self.base_pkt.copy()
-        pkt['TCP'].dport = 0x123A
+        pkt['TCP'].dport = 4675
         return self.runSendReceiveTest(pkt, self.src_port, self.dst_ports)
 
 
@@ -235,19 +236,16 @@ class EverflowTest(BaseTest):
         if self.verifyL4DstPort():
             tests_passed += 1
 
-        if self.verifyEthertype():
-            tests_passed += 1
-
         if self.verifyIpProtocol():
             tests_passed += 1
 
         if self.verifyTcpFlags():
             tests_passed += 1
 
-        if self.verifyL4SrcPort():
+        if self.verifyL4SrcPortRange():
             tests_passed += 1
 
-        if self.verifyL4DstPort():
+        if self.verifyL4DstPortRange():
             tests_passed += 1
 
         if self.verifyIpDscp():

--- a/ansible/roles/test/tasks/everflow_testbed/apply_config/acl_rule_persistent.json
+++ b/ansible/roles/test/tasks/everflow_testbed/apply_config/acl_rule_persistent.json
@@ -3,7 +3,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_1": {
             "priority" : "50",
             "src_ip" : "20.0.0.10",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -11,7 +11,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_2": {
             "priority" : "50",
             "dst_ip" : "30.0.0.10",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -19,7 +19,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_3": {
             "priority" : "50",
             "l4_src_port" : "0x1235",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -27,7 +27,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_4": {
             "priority" : "50",
             "l4_dst_port" : "0x1235",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -35,7 +35,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_5": {
             "priority" : "50",
             "ether_type" : "0x1234",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -43,7 +43,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_6": {
             "priority" : "50",
             "ip_protocol" : "0x7E",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -51,7 +51,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_7": {
             "priority" : "50",
             "tcp_flags" : "0x12/0x12",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -59,7 +59,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_8": {
             "priority" : "50",
             "l4_src_port_range" : "4672-4681",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -67,7 +67,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_9": {
             "priority" : "50",
             "l4_dst_port_range" : "4672-4681",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     },
@@ -75,7 +75,7 @@
         "ACL_RULE_TABLE:acl_table_mirror:rule_10": {
             "priority" : "50",
             "dscp" : "51",
-            "mirror_action" : "session_1"
+            "mirror_action" : "test_session_1"
         },
         "OP": "SET"
     }

--- a/ansible/roles/test/tasks/everflow_testbed/apply_config/session.json
+++ b/ansible/roles/test/tasks/everflow_testbed/apply_config/session.json
@@ -1,6 +1,6 @@
 [
     {
-        "MIRROR_SESSION_TABLE:session_1": {
+        "MIRROR_SESSION_TABLE:test_session_1": {
             "src_ip": "1.1.1.1",
             "dst_ip": "2.2.2.2",
             "gre_type": "0x6558",

--- a/ansible/roles/test/tasks/everflow_testbed/del_config/session.json
+++ b/ansible/roles/test/tasks/everflow_testbed/del_config/session.json
@@ -1,6 +1,6 @@
 [
     {
-        "MIRROR_SESSION_TABLE:session_1": {
+        "MIRROR_SESSION_TABLE:test_session_1": {
         },
         "OP": "DEL"
     }

--- a/ansible/roles/test/tasks/everflow_testbed/get_session_info.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/get_session_info.yml
@@ -1,10 +1,6 @@
-- name: Get session name.
-  shell: docker exec -i swss redis-cli KEYS MIRROR_SESSION_TABLE:* | sed "s/MIRROR_SESSION_TABLE://"
-  register: session_name_info
-
 - name: Initialize session_name variable.
   set_fact:
-    session_name: "{{ session_name_info.stdout }}"
+    session_name: "test_session_1"
 
 - debug: msg="session name {{ session_name }}"
 

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_1.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_1.yml
@@ -6,7 +6,7 @@
 
 - block:
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_2.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_2.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} via {{ neighbor_info_1['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,7 +16,7 @@
       shell: ip route add {{ session_prefix_2 }} via {{ unresolved_nexthop }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -26,7 +26,7 @@
       shell: ip route change {{ session_prefix_2 }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_3.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_3.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} via {{ neighbor_info_1['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,7 +16,7 @@
       shell: ip route add {{ session_prefix_2 }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_2}}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -27,7 +27,7 @@
       ignore_errors: yes
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}. 
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_4.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_4.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} via {{ neighbor_info_1['addr'] }} 
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="{{ neighbor_mac_1 }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="{{ neighbor_mac_1 }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,7 +16,7 @@
       shell: ip neigh replace {{ neighbor_info_1['addr'] }} lladdr "00:11:22:33:44:55" nud permanent dev {{ dst_port_1 }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="00:11:22:33:44:55";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="00:11:22:33:44:55";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
@@ -5,7 +5,7 @@
 
 - block:
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_6.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_6.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,14 +16,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_7.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_7.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,14 +16,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on  {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_2 }} and {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -34,7 +34,7 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets are not received {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -42,7 +42,7 @@
       failed_when: out.rc == 0
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_2 }} or {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_8.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_8.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,14 +16,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -34,14 +34,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"


### PR DESCRIPTION
- Create and use separated everflow session for tests.
- Fix issue with L4 port range in PTF test.
- Handle difference in mirrored packets format on different platforms.
- Do not compare mirrored packet CHKSUM.
- Remove checking Ethertype in separated testcase as it redundant.
  Ethertype is checked in each testcase as well as other L2 fields.