### PR TITLE
[lldp_neighbor]: Add proper tests for system name, system description, port ID and port description

### DIFF
--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -7,30 +7,37 @@
 - name: Print neighbors in minigraph
   debug: msg="{{ minigraph_neighbors }}"
 
-- name: Gather information from lldp
+- name: Gather information from LLDP
   lldp:
   vars:
     ansible_shell_type: docker
     ansible_python_interpreter: docker exec -i lldp python
 
-- name: Print lldp information
+- name: Print LLDP information
   debug: msg="{{ lldp }}"
 
 - name: Verify LLDP information is available on most interfaces
   assert: { that: "{{ lldp|length }} > {{ minigraph_neighbors|length * 0.8 }}"}
 
-- name: Compare the lldp neighbors name with minigraph neigbhors name (exclude the management port)
+- name: Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
   assert: { that: "'{{ lldp[item]['chassis']['name'] }}' == '{{ minigraph_neighbors[item]['name'] }}'" }
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"
 
-- name: Compare the lldp neighbors interface with minigraph neigbhor interface (exclude the management port)
+- name: Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
   assert: { that: "'{{ lldp[item]['port']['ifname'] }}' == '{{ minigraph_neighbors[item]['port'] }}'" }
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"
 
-- name: Iterate throguh each lldp neighbor and verify the information received by neighbor are also correct
-  add_host: name={{ lldp[item]['chassis']['mgmt-ip'] }} groups=lldp_neighbors,eos neighbor_interface={{lldp[item]['port']['ifname']}} dut_interface={{item}} hname={{lldp[item]['chassis']['mgmt-ip'] }}
+- name: Iterate through each LLDP neighbor and verify the information received by neighbor are also correct
+  add_host:
+    name: "{{ lldp[item]['chassis']['mgmt-ip'] }}"
+    groups: "lldp_neighbors,eos"
+    neighbor_interface: "{{ lldp[item]['port']['ifname'] }}"
+    dut_interface: "{{ item }}"
+    hname: "{{ lldp[item]['chassis']['mgmt-ip'] }}"
+    dut_hostname: "{{ inventory_hostname }}"
+    dut_port_alias: "{{ minigraph_ports[item]['alias'] }}"
+    dut_port_description: "{{ minigraph_neighbors[item]['name'] }}:{{ minigraph_neighbors[item]['port'] }}"
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"
-

--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -32,7 +32,6 @@
 
 - block:
   - name: Obtain the system description of the DUT chassis
-    become: true
     shell: "docker exec -i lldp lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'"
     register: result
 

--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -1,6 +1,7 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
-  minigraph_facts: host={{ inventory_hostname }}
+  minigraph_facts:
+    host: "{{ inventory_hostname }}"
   become: no
   connection: local
 
@@ -29,7 +30,17 @@
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"
 
-- name: Iterate through each LLDP neighbor and verify the information received by neighbor are also correct
+- block:
+  - name: Obtain the system description of the DUT chassis
+    become: true
+    shell: "docker exec -i lldp lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'"
+    register: result
+
+  - name: Store system description of the DUT chassis as a fact
+    set_fact:
+      dut_system_description: "{{ result.stdout }}"
+
+- name: Iterate through each LLDP neighbor and verify the information received by neighbor is correct
   add_host:
     name: "{{ lldp[item]['chassis']['mgmt-ip'] }}"
     groups: "lldp_neighbors,eos"
@@ -39,5 +50,6 @@
     dut_hostname: "{{ inventory_hostname }}"
     dut_port_alias: "{{ minigraph_ports[item]['alias'] }}"
     dut_port_description: "{{ minigraph_neighbors[item]['name'] }}:{{ minigraph_neighbors[item]['port'] }}"
+    dut_system_description: "{{ dut_system_description }}"
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"

--- a/ansible/roles/test/tasks/lldp_neighbor.yml
+++ b/ansible/roles/test/tasks/lldp_neighbor.yml
@@ -1,23 +1,26 @@
 - name: Gather LLDP information from all neighbors by performing a SNMP walk
-  lldp_facts: host={{ hname }} version=v2c community={{ snmp_rocommunity }}
+  lldp_facts:
+    host: "{{ hname }}"
+    version: "v2c"
+    community: "{{ snmp_rocommunity }}"
   connection: local
 
 - name: Print LLDP facts from neighbors
   debug: msg="{{ ansible_lldp_facts }}"
 
-# FIXME: use more strict assertions
-- name: verify the dut system name field is not empty
-  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_name'] }}' != ''"}
+- name: Verify the published DuT system name field is correct
+  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_name'] }}' == '{{ dut_hostname }}'"}
 
-- name: verify the dut chassis id field is not empty
+# FIXME: use more strict assertion
+- name: Verify the published DuT chassis id field is not empty
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_chassis_id'] }}' != ''"}
 
-- name: verify the dut system description field is not empty
+# FIXME: use more strict assertion
+- name: Verify the published DuT system description field is not empty
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_desc'] }}' != ''"}
 
-- name: verify the dut port id field is not empty
-  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_id'] }}' != ''"}
+- name: Verify the published DuT port id field is correct
+  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_id'] }}' == '{{ dut_port_alias }}'"}
 
-- name: verify the dut port description field is published correctly
-  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_desc'] }}' != ''"}
-
+- name: Verify the published DuT port description field is correct
+  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_desc'] }}' == '{{ dut_port_description }}'"}

--- a/ansible/roles/test/tasks/lldp_neighbor.yml
+++ b/ansible/roles/test/tasks/lldp_neighbor.yml
@@ -15,9 +15,8 @@
 - name: Verify the published DUT chassis id field is not empty
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_chassis_id'] }}' != ''"}
 
-# FIXME: use more strict assertion
-- name: Verify the published DUT system description field is not empty
-  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_desc'] }}' != ''"}
+- name: Verify the published DUT system description field is correct
+  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_desc'] }}' == '{{ dut_system_description }}'"}
 
 - name: Verify the published DUT port id field is correct
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_id'] }}' == '{{ dut_port_alias }}'"}

--- a/ansible/roles/test/tasks/lldp_neighbor.yml
+++ b/ansible/roles/test/tasks/lldp_neighbor.yml
@@ -8,19 +8,19 @@
 - name: Print LLDP facts from neighbors
   debug: msg="{{ ansible_lldp_facts }}"
 
-- name: Verify the published DuT system name field is correct
+- name: Verify the published DUT system name field is correct
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_name'] }}' == '{{ dut_hostname }}'"}
 
 # FIXME: use more strict assertion
-- name: Verify the published DuT chassis id field is not empty
+- name: Verify the published DUT chassis id field is not empty
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_chassis_id'] }}' != ''"}
 
 # FIXME: use more strict assertion
-- name: Verify the published DuT system description field is not empty
+- name: Verify the published DUT system description field is not empty
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_desc'] }}' != ''"}
 
-- name: Verify the published DuT port id field is correct
+- name: Verify the published DUT port id field is correct
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_id'] }}' == '{{ dut_port_alias }}'"}
 
-- name: Verify the published DuT port description field is correct
+- name: Verify the published DUT port description field is correct
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_port_desc'] }}' == '{{ dut_port_description }}'"}


### PR DESCRIPTION
- Chassis ID test still only check for empty field; will require more work to implement proper test.