### PR TITLE
[t1-64-lag]: Add new t1-64-lag topology

### DIFF
--- a/ansible/minigraph/switch-t1-64-lag.xml
+++ b/ansible/minigraph/switch-t1-64-lag.xml
@@ -1,0 +1,2396 @@
+<DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+      <BGPSession>
+        <StartRouter>ARISTA01T0</StartRouter>
+        <StartPeer>10.0.0.33</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.32</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA01T0</StartRouter>
+        <StartPeer>FC00::42</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::41</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA02T0</StartRouter>
+        <StartPeer>10.0.0.35</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.34</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA02T0</StartRouter>
+        <StartPeer>FC00::46</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::45</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA03T0</StartRouter>
+        <StartPeer>10.0.0.37</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.36</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA03T0</StartRouter>
+        <StartPeer>FC00::4A</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::49</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA04T0</StartRouter>
+        <StartPeer>10.0.0.39</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.38</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA04T0</StartRouter>
+        <StartPeer>FC00::4E</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::4D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA05T0</StartRouter>
+        <StartPeer>10.0.0.41</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.40</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA05T0</StartRouter>
+        <StartPeer>FC00::52</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::51</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA06T0</StartRouter>
+        <StartPeer>10.0.0.43</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.42</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA06T0</StartRouter>
+        <StartPeer>FC00::56</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::55</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA07T0</StartRouter>
+        <StartPeer>10.0.0.45</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.44</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA07T0</StartRouter>
+        <StartPeer>FC00::5A</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA08T0</StartRouter>
+        <StartPeer>10.0.0.47</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.46</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA08T0</StartRouter>
+        <StartPeer>FC00::5E</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::5D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA09T0</StartRouter>
+        <StartPeer>10.0.0.49</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.48</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA09T0</StartRouter>
+        <StartPeer>FC00::62</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA10T0</StartRouter>
+        <StartPeer>10.0.0.51</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.50</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA10T0</StartRouter>
+        <StartPeer>FC00::66</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::65</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA11T0</StartRouter>
+        <StartPeer>10.0.0.53</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.52</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA11T0</StartRouter>
+        <StartPeer>FC00::6A</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::69</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA12T0</StartRouter>
+        <StartPeer>10.0.0.55</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.54</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA12T0</StartRouter>
+        <StartPeer>FC00::6E</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::6D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA13T0</StartRouter>
+        <StartPeer>10.0.0.57</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.56</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA13T0</StartRouter>
+        <StartPeer>FC00::72</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::71</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA14T0</StartRouter>
+        <StartPeer>10.0.0.59</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.58</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA14T0</StartRouter>
+        <StartPeer>FC00::76</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::75</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA15T0</StartRouter>
+        <StartPeer>10.0.0.61</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.60</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA15T0</StartRouter>
+        <StartPeer>FC00::7A</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::79</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA16T0</StartRouter>
+        <StartPeer>10.0.0.63</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.62</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA16T0</StartRouter>
+        <StartPeer>FC00::7E</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::7D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA17T0</StartRouter>
+        <StartPeer>10.0.0.65</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.64</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA17T0</StartRouter>
+        <StartPeer>FC00::82</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::81</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA18T0</StartRouter>
+        <StartPeer>10.0.0.67</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.66</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA18T0</StartRouter>
+        <StartPeer>FC00::86</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::85</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA19T0</StartRouter>
+        <StartPeer>10.0.0.69</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.68</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA19T0</StartRouter>
+        <StartPeer>FC00::8A</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::89</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA20T0</StartRouter>
+        <StartPeer>10.0.0.71</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>10.0.0.70</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA20T0</StartRouter>
+        <StartPeer>FC00::8E</StartPeer>
+        <EndRouter>switch-t1-64-lag</EndRouter>
+        <EndPeer>FC00::8D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>10.0.0.0</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>FC00::1</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>10.0.0.4</StartPeer>
+        <EndRouter>ARISTA03T2</EndRouter>
+        <EndPeer>10.0.0.5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>FC00::5</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::6</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>10.0.0.8</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>10.0.0.9</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>FC00::9</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>FC00::A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>10.0.0.12</StartPeer>
+        <EndRouter>ARISTA07T2</EndRouter>
+        <EndPeer>10.0.0.13</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag</StartRouter>
+        <StartPeer>FC00::D</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>FC00::E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>switch-t1-64-lag</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.33</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.35</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.37</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.39</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.41</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.43</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.45</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.47</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.49</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.51</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.53</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.55</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.65</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.67</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.69</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.71</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.5</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.9</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.13</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64001</a:ASN>
+        <a:Hostname>ARISTA01T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64002</a:ASN>
+        <a:Hostname>ARISTA02T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64003</a:ASN>
+        <a:Hostname>ARISTA03T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64004</a:ASN>
+        <a:Hostname>ARISTA04T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64005</a:ASN>
+        <a:Hostname>ARISTA05T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64006</a:ASN>
+        <a:Hostname>ARISTA06T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64007</a:ASN>
+        <a:Hostname>ARISTA07T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64008</a:ASN>
+        <a:Hostname>ARISTA08T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64009</a:ASN>
+        <a:Hostname>ARISTA09T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64010</a:ASN>
+        <a:Hostname>ARISTA10T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64011</a:ASN>
+        <a:Hostname>ARISTA11T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64012</a:ASN>
+        <a:Hostname>ARISTA12T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64013</a:ASN>
+        <a:Hostname>ARISTA13T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64014</a:ASN>
+        <a:Hostname>ARISTA14T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64015</a:ASN>
+        <a:Hostname>ARISTA15T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64016</a:ASN>
+        <a:Hostname>ARISTA16T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64017</a:ASN>
+        <a:Hostname>ARISTA17T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64018</a:ASN>
+        <a:Hostname>ARISTA18T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64019</a:ASN>
+        <a:Hostname>ARISTA19T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64020</a:ASN>
+        <a:Hostname>ARISTA20T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA01T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA03T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA05T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA07T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.64.247.225/23</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.64.247.225/23</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:2::32/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:2::32/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>switch-t1-64-lag</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel0</Name>
+          <AttachTo>fortyGigE1/1/1;fortyGigE1/1/2</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel4</Name>
+          <AttachTo>fortyGigE1/1/5;fortyGigE1/1/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel8</Name>
+          <AttachTo>fortyGigE1/2/1;fortyGigE1/2/2</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel12</Name>
+          <AttachTo>fortyGigE1/2/5;fortyGigE1/2/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel34</Name>
+          <AttachTo>fortyGigE1/3/3</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel36</Name>
+          <AttachTo>fortyGigE1/3/5</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel37</Name>
+          <AttachTo>fortyGigE1/3/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel38</Name>
+          <AttachTo>fortyGigE1/3/7</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel39</Name>
+          <AttachTo>fortyGigE1/3/8</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel42</Name>
+          <AttachTo>fortyGigE1/3/11</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel44</Name>
+          <AttachTo>fortyGigE1/3/13</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel45</Name>
+          <AttachTo>fortyGigE1/3/14</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel46</Name>
+          <AttachTo>fortyGigE1/3/15</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel47</Name>
+          <AttachTo>fortyGigE1/3/16</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel50</Name>
+          <AttachTo>fortyGigE1/4/3</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel52</Name>
+          <AttachTo>fortyGigE1/4/5</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel53</Name>
+          <AttachTo>fortyGigE1/4/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel54</Name>
+          <AttachTo>fortyGigE1/4/7</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel55</Name>
+          <AttachTo>fortyGigE1/4/8</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel58</Name>
+          <AttachTo>fortyGigE1/4/11</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel60</Name>
+          <AttachTo>fortyGigE1/4/13</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel61</Name>
+          <AttachTo>fortyGigE1/4/14</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel62</Name>
+          <AttachTo>fortyGigE1/4/15</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel63</Name>
+          <AttachTo>fortyGigE1/4/16</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces/>
+      <IPInterfaces>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0</AttachTo>
+          <Prefix>10.0.0.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0</AttachTo>
+          <Prefix>FC00::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel4</AttachTo>
+          <Prefix>10.0.0.4/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel4</AttachTo>
+          <Prefix>FC00::5/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel8</AttachTo>
+          <Prefix>10.0.0.8/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel8</AttachTo>
+          <Prefix>FC00::9/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel12</AttachTo>
+          <Prefix>10.0.0.12/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel12</AttachTo>
+          <Prefix>FC00::D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel34</AttachTo>
+          <Prefix>10.0.0.32/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel34</AttachTo>
+          <Prefix>FC00::41/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel36</AttachTo>
+          <Prefix>10.0.0.34/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel36</AttachTo>
+          <Prefix>FC00::45/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel37</AttachTo>
+          <Prefix>10.0.0.36/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel37</AttachTo>
+          <Prefix>FC00::49/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel38</AttachTo>
+          <Prefix>10.0.0.38/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel38</AttachTo>
+          <Prefix>FC00::4D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel39</AttachTo>
+          <Prefix>10.0.0.40/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel39</AttachTo>
+          <Prefix>FC00::51/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel42</AttachTo>
+          <Prefix>10.0.0.42/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel42</AttachTo>
+          <Prefix>FC00::55/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel44</AttachTo>
+          <Prefix>10.0.0.44/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel44</AttachTo>
+          <Prefix>FC00::59/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel45</AttachTo>
+          <Prefix>10.0.0.46/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel45</AttachTo>
+          <Prefix>FC00::5D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel46</AttachTo>
+          <Prefix>10.0.0.48/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel46</AttachTo>
+          <Prefix>FC00::61/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel47</AttachTo>
+          <Prefix>10.0.0.50/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel47</AttachTo>
+          <Prefix>FC00::65/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel50</AttachTo>
+          <Prefix>10.0.0.52/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel50</AttachTo>
+          <Prefix>FC00::69/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel52</AttachTo>
+          <Prefix>10.0.0.54/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel52</AttachTo>
+          <Prefix>FC00::6D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel53</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel53</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel54</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel54</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel55</AttachTo>
+          <Prefix>10.0.0.60/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel55</AttachTo>
+          <Prefix>FC00::79/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel58</AttachTo>
+          <Prefix>10.0.0.62/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel58</AttachTo>
+          <Prefix>FC00::7D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel60</AttachTo>
+          <Prefix>10.0.0.64/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel60</AttachTo>
+          <Prefix>FC00::81/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel61</AttachTo>
+          <Prefix>10.0.0.66/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel61</AttachTo>
+          <Prefix>FC00::85/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel62</AttachTo>
+          <Prefix>10.0.0.68/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel62</AttachTo>
+          <Prefix>FC00::89/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel63</AttachTo>
+          <Prefix>10.0.0.70/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel63</AttachTo>
+          <Prefix>FC00::8D/126</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces/>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/1/1</EndPort>
+        <StartDevice>ARISTA01T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/1/2</EndPort>
+        <StartDevice>ARISTA01T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/1/5</EndPort>
+        <StartDevice>ARISTA03T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/1/6</EndPort>
+        <StartDevice>ARISTA03T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/2/1</EndPort>
+        <StartDevice>ARISTA05T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/2/2</EndPort>
+        <StartDevice>ARISTA05T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/2/5</EndPort>
+        <StartDevice>ARISTA07T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/2/6</EndPort>
+        <StartDevice>ARISTA07T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/3</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/3</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/6</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/7</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/8</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/11</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/11</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/14</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/15</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/3/16</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/3</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/3</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/6</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/7</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/8</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/11</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/11</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/14</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/15</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag</EndDevice>
+        <EndPort>fortyGigE1/4/16</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="LeafRouter">
+        <Hostname>switch-t1-64-lag</Hostname>
+        <HwSku>Force10-S6100</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>10.64.247.225</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA01T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.204</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA01T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.200</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA02T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.205</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA03T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.206</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA03T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.201</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA04T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.207</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA05T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.208</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA05T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.202</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA06T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.209</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA07T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.210</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA07T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.203</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA08T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.211</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA09T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.212</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA10T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.213</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA11T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.214</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA12T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.215</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA13T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.216</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA14T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.217</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA15T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.218</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA16T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.219</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA17T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.220</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA18T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.221</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA19T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.222</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA20T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.223</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+    </Devices>
+  </PngDec>
+  <DeviceInfos>
+    <DeviceInfo>
+      <AutoNegotiation>true</AutoNegotiation>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>Force10-S6100</HwSku> 
+      <ManagementInterfaces/>
+    </DeviceInfo> 
+  </DeviceInfos>
+  <Hostname>switch-t1-64-lag</Hostname>
+  <HwSku>Force10-S6100</HwSku>
+</DeviceMiniGraph>

--- a/ansible/roles/eos/templates/t1-64-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-spine.j2
@@ -1,0 +1,129 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management1
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+!
+route-map DEFAULT_ROUTES permit
+!
+{% for podset in range(0, props.podset_number) %}
+{% for tor in range(0, props.tor_number) %}
+{% for subnet in range(0, props.tor_subnet_number) %}
+ip route 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {{ props.nhipv4 }}
+ipv6 route 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {{ props.nhipv6 }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+!
+{% for podset in range(0, props.podset_number) %}
+{% for tor in range(0, props.tor_number) %}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit 192.168.{{ podset }}.{{ tor * 16 }}/28 ge 28
+ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
+ seq 10 permit 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16) }}::/60 ge 60
+exit
+{% endfor %}
+{% endfor %}
+!
+interface Management 1
+ description TO LAB MGMT SWITCH
+ vrf forwarding MGMT
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ no switchport
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 2
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+{% for podset in range(0, props.podset_number) %}
+{% if range(0, 1000)|random() >= props.failure_rate %}
+{% for tor in range(0, props.tor_number) %}
+{% set leafasn = props.leaf_asn_start + podset %}
+{% set torasn = props.tor_asn_start + tor %}
+route-map PREPENDAS permit {{ 2 * (podset * props.tor_number + tor + 1) }}
+  match ip address prefix-list test_ipv4_{{ podset }}_{{ tor }}
+  set as-path prepend {{ leafasn }} {{ torasn }}
+!
+route-map PREPENDAS permit {{ 2 * (podset * props.tor_number + tor + 1) + 1 }}
+  match ipv6 address prefix-list test_ipv6_{{ podset }}_{{ tor }}
+  set as-path prepend {{ leafasn }} {{ torasn }}
+!
+{% endfor %}
+{% endif %}
+{% endfor %}
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} default-originate route-map DEFAULT_ROUTES
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+ redistribute static route-map PREPENDAS
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end
+

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -1,0 +1,100 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% set tornum = host['tornum'] %}
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management1
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+!
+{% for subnet in range(0, props.tor_subnet_number) %}
+ip route 172.16.{{ tornum }}.{{ subnet }}/32 {{ props.nhipv4 }}
+ipv6 route 20AC:10{{ '%02X' % tornum }}:0:{{ '%02X' % subnet }}::/64 {{ props.nhipv6 }}
+{% endfor %}
+!
+interface Management 1
+ description TO LAB MGMT SWITCH
+ vrf forwarding MGMT
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ no switchport
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+{% for subnet in range(0, props.tor_subnet_number) %}
+ network 172.16.{{ tornum }}.{{ subnet }}/32
+ network 20AC:10{{ '%02X' % tornum }}:0:{{ '%02X' % subnet }}::/64
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end
+

--- a/ansible/templates/topo/t1-64-lag.j2
+++ b/ansible/templates/topo/t1-64-lag.j2
@@ -1,0 +1,393 @@
+<DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+{% for index in range(20) %}
+      <BGPSession>
+        <StartRouter>ARISTA{{ '%02d' % (index + 1) }}T0</StartRouter>
+        <StartPeer>10.0.0.{{ (32 + index * 2 + 1) }}</StartPeer>
+        <EndRouter>{{ inventory_hostname }}</EndRouter>
+        <EndPeer>10.0.0.{{ (32 + index * 2) }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA{{ '%02d' % (index + 1) }}T0</StartRouter>
+        <StartPeer>FC00::{{ ('%0x' % (65+index*4+1)) | upper }}</StartPeer>
+        <EndRouter>{{ inventory_hostname }}</EndRouter>
+        <EndPeer>FC00::{{ ('%0x' % (65+index*4)) | upper}}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+{% endfor %}
+{% for index in range(2) %}
+      <BGPSession>
+        <StartRouter>{{ inventory_hostname }}</StartRouter>
+        <StartPeer>10.0.0.{{ index * 8 }}</StartPeer>
+        <EndRouter>ARISTA{{ '%02d' % (index * 4 + 1) }}T2</EndRouter>
+        <EndPeer>10.0.0.{{ (index * 8 + 1) }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>{{ inventory_hostname }}</StartRouter>
+        <StartPeer>FC00::{{ ('%0x' % (index * 8 + 1)) | upper }}</StartPeer>
+        <EndRouter>ARISTA{{ '%02d' % (index * 4 + 1) }}T2</EndRouter>
+        <EndPeer>FC00::{{ ('%0x' % (index * 8 + 2)) | upper }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>{{ inventory_hostname }}</StartRouter>
+        <StartPeer>10.0.0.{{ index * 8 + 4 }}</StartPeer>
+        <EndRouter>ARISTA{{ '%02d' % (index * 4 + 3) }}T2</EndRouter>
+        <EndPeer>10.0.0.{{ (index * 8 + 5) }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>{{ inventory_hostname }}</StartRouter>
+        <StartPeer>FC00::{{ ('%0x' % (index * 8 + 5)) | upper }}</StartPeer>
+        <EndRouter>ARISTA{{ '%02d' % (index * 4 + 1) }}T2</EndRouter>
+        <EndPeer>FC00::{{ ('%0x' % (index * 8 + 6)) | upper }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+{% endfor %}
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>{{ inventory_hostname }}</a:Hostname>
+        <a:Peers>
+{% for ip in range(20) %}
+          <BGPPeer>
+            <Address>10.0.0.{{ ip*2+33 }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+{% endfor %}
+{% for ip in range(0,8,2) %}
+          <BGPPeer>
+            <Address>10.0.0.{{ ip*2+1 }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+{% endfor %}
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% for i in range(1,21,1) %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>640{{ '%02d' % i }}</a:ASN>
+        <a:Hostname>ARISTA{{ '%02d' % i }}T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% endfor %}
+{% for i in range(1,9,2) %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA{{ '%02d' % i }}T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% endfor %}
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ ansible_host }}/{{ mgmt_subnet_mask_length }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ ansible_host }}/{{ mgmt_subnet_mask_length }}</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:2::32/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:2::32/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>{{ inventory_hostname }}</Hostname>
+      <PortChannelInterfaces>
+{% for index in range(2) %}
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{ index*8 }}</Name>
+          <AttachTo>{{ port_alias[index*16] }};{{ port_alias[index*16+1] }}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{ index*8+4 }}</Name>
+          <AttachTo>{{ port_alias[index*16+4] }};{{ port_alias[index*16+5] }}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+{% endfor %}
+{% for index in range(4) %}
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{32 + index * 8 + 2}}</Name>
+          <AttachTo>{{ port_alias[32 + index * 8 + 2] }}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{32 + index * 8 + 4}}</Name>
+          <AttachTo>{{ port_alias[32 + index * 8 + 4]}}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{32 + index * 8 + 5}}</Name>
+          <AttachTo>{{ port_alias[32 + index * 8 + 5] }}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{32 + index * 8 + 6}}</Name>
+          <AttachTo>{{ port_alias[32 + index * 8 + 6] }}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel{{32 + index * 8 + 7}}</Name>
+          <AttachTo>{{ port_alias[32 + index * 8 + 7] }}</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+{% endfor %}
+      </PortChannelInterfaces>
+      <VlanInterfaces/>
+      <IPInterfaces>
+{% for index in range(2) %}
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ index*8 }}</AttachTo>
+          <Prefix>10.0.0.{{ index*8 }}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ index*8 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (index*8+1)) | upper }}/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ index*8+4 }}</AttachTo>
+          <Prefix>10.0.0.{{ index*8+4 }}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ index*8+4 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (index*8+5)) | upper }}/126</Prefix>
+        </IPInterface>
+{% endfor %}
+{% for index in range(4) %}
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 2 }}</AttachTo>
+          <Prefix>10.0.0.{{ 32 + index * 10 }}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 2 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (64 + index * 20 + 1)) | upper }}/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 4 }}</AttachTo>
+          <Prefix>10.0.0.{{ 32 + index * 10 + 2}}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 4 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (64 + index * 20 + 5)) | upper }}/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 5 }}</AttachTo>
+          <Prefix>10.0.0.{{ 32 + index * 10 + 4}}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 5 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (64 + index * 20 + 9)) | upper }}/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 6 }}</AttachTo>
+          <Prefix>10.0.0.{{ 32 + index * 10 + 6}}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 6 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (64 + index * 20 + 13)) | upper }}/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 7 }}</AttachTo>
+          <Prefix>10.0.0.{{ 32 + index * 10 + 8}}/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel{{ 32 + index * 8 + 7 }}</AttachTo>
+          <Prefix>FC00::{{ ('%0x' % (64 + index * 20 + 17)) | upper }}/126</Prefix>
+        </IPInterface>
+{% endfor %}
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces/>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+{% for index in range(2) %}
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[index*16] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index*4+1) }}T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[index*16+1] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index*4+1) }}T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[index*16+4] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index*4+3) }}T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[index*16+5] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index*4+3) }}T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+{% endfor %}
+{% for index in range(4) %}
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[32+index*8+2] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[32+index*8+2] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[32+index*8+5] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[32+index*8+6] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ port_alias[32+index*8+7] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+{% endfor %}
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="LeafRouter">
+        <Hostname>{{ inventory_hostname }}</Hostname>
+        <HwSku>{{ hwsku }}</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>{{ ansible_host }}</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+{% if  VM_topo  %}
+{% for dev in neighbor_eosvm_mgmt.keys()|sort %}
+{% if 'T1' in dev %}
+{% set dev_type = 'LeafRouter' %}
+{% elif 'T2' in dev %}
+{% set dev_type = 'SpineRouter' %}
+{% elif 'T0' in dev %}
+{% set dev_type = 'ToRRouter' %}
+{% else %}
+{% set dev_type = 'Unknown' %}
+{% endif %}
+      <Device i:type="{{ dev_type }}">
+         <Hostname>"{{ dev }}"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>{{ neighbor_eosvm_mgmt[dev] }}</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+{% endfor %}
+{% endif %}
+    </Devices>
+  </PngDec>
+{% include 'dev_metadata.j2' %}
+  <Hostname>{{ inventory_hostname }}</Hostname>
+  <HwSku>{{ hwsku }}</HwSku>
+</DeviceMiniGraph>

--- a/ansible/vars/topo_t1-64-lag.yml
+++ b/ansible/vars/topo_t1-64-lag.yml
@@ -1,0 +1,699 @@
+topology:
+  VMs:
+    ARISTA01T2:
+      vlans:
+        - 0
+        - 1
+      vm_offset: 0
+    ARISTA03T2:
+      vlans:
+        - 4 
+        - 5
+      vm_offset: 1
+    ARISTA05T2:
+      vlans:
+        - 16
+        - 17
+      vm_offset: 2
+    ARISTA07T2:
+      vlans:
+        - 20
+        - 21
+      vm_offset: 3
+    ARISTA01T0:
+      vlans:
+        - 34
+      vm_offset: 4
+    ARISTA02T0:
+      vlans:
+        - 36
+      vm_offset: 5
+    ARISTA03T0:
+      vlans:
+        - 37
+      vm_offset: 6
+    ARISTA04T0:
+      vlans:
+        - 38
+      vm_offset: 7
+    ARISTA05T0:
+      vlans:
+        - 39
+      vm_offset: 8
+    ARISTA06T0:
+      vlans:
+        - 42
+      vm_offset: 9
+    ARISTA07T0:
+      vlans:
+        - 44
+      vm_offset: 10
+    ARISTA08T0:
+      vlans:
+        - 45
+      vm_offset: 11
+    ARISTA09T0:
+      vlans:
+        - 46
+      vm_offset: 12
+    ARISTA10T0:
+      vlans:
+        - 47
+      vm_offset: 13
+    ARISTA11T0:
+      vlans:
+        - 50
+      vm_offset: 14
+    ARISTA12T0:
+      vlans:
+        - 52
+      vm_offset: 15
+    ARISTA13T0:
+      vlans:
+        - 53
+      vm_offset: 16
+    ARISTA14T0:
+      vlans:
+        - 54
+      vm_offset: 17
+    ARISTA15T0:
+      vlans:
+        - 55
+      vm_offset: 18
+    ARISTA16T0:
+      vlans:
+        - 58
+      vm_offset: 19
+    ARISTA17T0:
+      vlans:
+        - 60
+      vm_offset: 20
+    ARISTA18T0:
+      vlans:
+        - 61
+      vm_offset: 21
+    ARISTA19T0:
+      vlans:
+        - 62
+      vm_offset: 22
+    ARISTA20T0:
+      vlans:
+        - 63
+      vm_offset: 23
+
+configuration_properties:
+  common:
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+  spine:
+    swrole: spine
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    leaf_asn_start: 62001
+    tor_asn_start: 65501
+    failure_rate: 0
+  tor:
+    swrole: tor
+    tor_subnet_number: 5
+
+configuration:
+  ARISTA01T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.0
+        - FC00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.1/24
+        ipv6: fc0a::2/64
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+
+  ARISTA03T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.4
+        - FC00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.3/24
+        ipv6: fc0a::6/64
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::6/126
+
+  ARISTA05T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.8
+        - FC00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.5/24
+        ipv6: fc0a::a/64
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::a/126
+
+  ARISTA07T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.12
+        - FC00::D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.7/24
+        ipv6: fc0a::e/64
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::e/126
+
+  ARISTA01T0:
+    properties:
+    - common
+    - tor
+    tornum: 1
+    bgp:
+      asn: 64001
+      peers:
+        65100:
+        - 10.0.0.32
+        - FC00::41
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.17/24
+        ipv6: fc0a::22/64
+      Port-Channel1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+
+  ARISTA02T0:
+    properties:
+    - common
+    - tor
+    tornum: 2
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+        - 10.0.0.34
+        - FC00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.18/24
+        ipv6: fc0a::25/64
+      Port-Channel1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+
+  ARISTA03T0:
+    properties:
+    - common
+    - tor
+    tornum: 3
+    bgp:
+      asn: 64003
+      peers:
+        65100:
+        - 10.0.0.36
+        - FC00::49
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.19/24
+        ipv6: fc0a::26/64
+      Port-Channel1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+
+  ARISTA04T0:
+    properties:
+    - common
+    - tor
+    tornum: 4
+    bgp:
+      asn: 64004
+      peers:
+        65100:
+        - 10.0.0.38
+        - FC00::4D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.20/24
+        ipv6: fc0a::29/64
+      Port-Channel1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+
+  ARISTA05T0:
+    properties:
+    - common
+    - tor
+    tornum: 5
+    bgp:
+      asn: 64005
+      peers:
+        65100:
+        - 10.0.0.40
+        - FC00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.21/24
+        ipv6: fc0a::2a/64
+      Port-Channel1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+
+  ARISTA06T0:
+    properties:
+    - common
+    - tor
+    tornum: 6
+    bgp:
+      asn: 64006
+      peers:
+        65100:
+        - 10.0.0.42
+        - FC00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.22/24
+        ipv6: fc0a::2d/64
+      Port-Channel1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+
+  ARISTA07T0:
+    properties:
+    - common
+    - tor
+    tornum: 7
+    bgp:
+      asn: 64007
+      peers:
+        65100:
+        - 10.0.0.44
+        - FC00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.23/24
+        ipv6: fc0a::2e/64
+      Port-Channel1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+
+  ARISTA08T0:
+    properties:
+    - common
+    - tor
+    tornum: 8
+    bgp:
+      asn: 64008
+      peers:
+        65100:
+        - 10.0.0.46
+        - FC00::5D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.24/24
+        ipv6: fc0a::31/64
+      Port-Channel1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+
+  ARISTA09T0:
+    properties:
+    - common
+    - tor
+    tornum: 9
+    bgp:
+      asn: 64009
+      peers:
+        65100:
+        - 10.0.0.48
+        - FC00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.25/24
+        ipv6: fc0a::32/64
+      Port-Channel1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+
+  ARISTA10T0:
+    properties:
+    - common
+    - tor
+    tornum: 10
+    bgp:
+      asn: 64010
+      peers:
+        65100:
+        - 10.0.0.50
+        - FC00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.26/24
+        ipv6: fc0a::35/64
+      Port-Channel1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+
+  ARISTA11T0:
+    properties:
+    - common
+    - tor
+    tornum: 11
+    bgp:
+      asn: 64011
+      peers:
+        65100:
+        - 10.0.0.52
+        - FC00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.27/24
+        ipv6: fc0a::36/64
+      Port-Channel1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+
+  ARISTA12T0:
+    properties:
+    - common
+    - tor
+    tornum: 12
+    bgp:
+      asn: 64012
+      peers:
+        65100:
+        - 10.0.0.54
+        - FC00::6D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.28/24
+        ipv6: fc0a::39/64
+      Port-Channel1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+
+  ARISTA13T0:
+    properties:
+    - common
+    - tor
+    tornum: 13
+    bgp:
+      asn: 64013
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.29/24
+        ipv6: fc0a::3a/64
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+
+  ARISTA14T0:
+    properties:
+    - common
+    - tor
+    tornum: 14
+    bgp:
+      asn: 64014
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.30/24
+        ipv6: fc0a::3d/64
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+
+  ARISTA15T0:
+    properties:
+    - common
+    - tor
+    tornum: 15
+    bgp:
+      asn: 64015
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.31/24
+        ipv6: fc0a::3e/64
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+
+  ARISTA16T0:
+    properties:
+    - common
+    - tor
+    tornum: 16
+    bgp:
+      asn: 64016
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.32/24
+        ipv6: fc0a::41/64
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+
+  ARISTA17T0:
+    properties:
+    - common
+    - tor
+    tornum: 17
+    bgp:
+      asn: 64017
+      peers:
+        65100:
+        - 10.0.0.64
+        - FC00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.33/24
+        ipv6: fc0a::43/64
+      Port-Channel1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+
+  ARISTA18T0:
+    properties:
+    - common
+    - tor
+    tornum: 18
+    bgp:
+      asn: 64018
+      peers:
+        65100:
+        - 10.0.0.66
+        - FC00::85
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.34/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.34/24
+        ipv6: fc0a::45/64
+      Port-Channel1:
+        ipv4: 10.0.0.67/31
+        ipv6: fc00::86/126
+
+  ARISTA19T0:
+    properties:
+    - common
+    - tor
+    tornum: 19
+    bgp:
+      asn: 64019
+      peers:
+        65100:
+        - 10.0.0.68
+        - FC00::89
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.35/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.35/24
+        ipv6: fc0a::47/64
+      Port-Channel1:
+        ipv4: 10.0.0.69/31
+        ipv6: fc00::8a/126
+
+  ARISTA20T0:
+    properties:
+    - common
+    - tor
+    tornum: 20
+    bgp:
+      asn: 64020
+      peers:
+        65100:
+        - 10.0.0.70
+        - FC00::8D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100::24/128
+      Ethernet1:
+        lacp: 1
+      Ethernet9:
+        ipv4: 10.10.246.36/24
+        ipv6: fc0a::49/64
+      Port-Channel1:
+        ipv4: 10.0.0.71/31
+        ipv6: fc00::8e/126

--- a/ansible/veos
+++ b/ansible/veos
@@ -72,4 +72,4 @@ server_1
 server_2
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't0', 'ptf32', 'ptf64', 't0-64', 't0-64-32']
+topologies=['t1', 't1-lag', 't1-64-lag', 't0', 'ptf32', 'ptf64', 't0-64', 't0-64-32']


### PR DESCRIPTION
This topology is used upon a 64-port switch.
There are four dual-port LAGs connecting to spines and 24 sing-port LAGs
connecting to tors.