### PR TITLE
[ptf]: Update remote platform port map

### DIFF
--- a/ansible/roles/test/files/ptftests/remote.py
+++ b/ansible/roles/test/files/ptftests/remote.py
@@ -23,7 +23,7 @@ def get_ifaces():
         ifaces.append(iface)
 
     # Sort before return
-    return sorted(ifaces, key=lambda x: int(x.replace('eth', '')))
+    return ifaces
 
 
 def platform_config_update(config):
@@ -33,6 +33,6 @@ def platform_config_update(config):
     @param config The configuration dictionary to use/update
     """
 
-    remote_port_map = {(0, i) : v for i, v in enumerate(get_ifaces())}
+    remote_port_map = {(0, int(i.replace('eth', ''))) : i for i in get_ifaces()}
     config["port_map"] = remote_port_map.copy()
     config["caps_table_idx"] = 0


### PR DESCRIPTION
This change is made due to the situation I meet that in the `/proc/net/dev` file, not all interfaces are populated. See below:

```
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
 eth61: 4443030   22375    0 9685    0     0          0         0        0       0    0    0    0     0       0          0
 eth44: 4407872   22369    0 9693    0     0          0         0        0       0    0    0    0     0       0          0
 eth39: 4429251   22358    0 9695    0     0          0         0        0       0    0    0    0     0       0          0
 eth52: 4370210   22349    0 9683    0     0          0         0        0       0    0    0    0     0       0          0
 eth20: 3596469   20342    0 9700    0     0          0         0        0       0    0    0    0     0       0          0
  eth5: 3278642   20228    0 9693    0     0          0         0        0       0    0    0    0     0       0          0
 eth47: 4405016   22337    0 9693    0     0          0         0        0       0    0    0    0     0       0          0
 eth16: 3985129   20270    0 9694    0     0          0         0        0       0    0    0    0     0       0          0
 eth55: 4423247   22373    0 9685    0     0          0         0        0       0    0    0    0     0       0          0
 eth60: 4362326   22303    0 9695    0     0          0         0        0       0    0    0    0     0       0          0
 eth38: 4376767   22364    0 9687    0     0          0         0        0       0    0    0    0     0       0          0
  eth1: 2945543   19977    0 9691    0     0          0         0        0       0    0    0    0     0       0          0
 eth34: 5094781   22999    0 9698    0     0          0         0        0       0    0    0    0     0       0          0
 eth42: 4488027   22417    0 9693    0     0          0         0        0       0    0    0    0     0       0          0
 eth46: 4417958   22368    0 9695    0     0          0         0        0       0    0    0    0     0       0          0
  mgmt: 58671550  575320    0    0    0     0          0         0   566702    2613    0    0    0     0       0          0
 eth54: 4432899   22370    0 9685    0     0          0         0        0       0    0    0    0     0       0          0
 eth37: 4381439   22351    0 9687    0     0          0         0        0       0    0    0    0     0       0          0
 eth58: 4397105   22359    0 9696    0     0          0         0        0       0    0    0    0     0       0          0
    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
 eth63: 4372846   22356    0 9688    0     0          0         0        0       0    0    0    0     0       0          0
 eth50: 4377040   22321    0 9697    0     0          0         0        0       0    0    0    0     0       0          0
  eth0: 1943996   12078    0 9690    0     0          0         0        0       0    0    0    0     0       0          0
 eth45: 4431256   22386    0 9689    0     0          0         0        0       0    0    0    0     0       0          0
 eth53: 4377204   22386    0 9683    0     0          0         0        0       0    0    0    0     0       0          0
 eth21: 2188151   12383    0 9699    0     0          0         0        0       0    0    0    0     0       0          0
 eth36: 4382149   22326    0 9689    0     0          0         0        0       0    0    0    0     0       0          0
 eth62: 4388033   22380    0 9685    0     0          0         0        0       0    0    0    0     0       0          0
  eth4: 2294856   12560    0 9695    0     0          0         0        0       0    0    0    0     0       0          0
 eth17: 2217988   12626    0 9694    0     0          0         0        0       0    0    0    0     0       0          0
```

Since the interface index itself is indicating the port map, there is no need to sort and remap the port map.