### PR TITLE
[fib]: Add FIB test support for t1-64-lag topology

### DIFF
--- a/ansible/roles/test/tasks/fib.yml
+++ b/ansible/roles/test/tasks/fib.yml
@@ -7,13 +7,13 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1', 't0', 't0-64']
+  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't0', 't0-64']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['spine']}}"
-  when: testbed_type in ['t1', 't1-lag']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag']
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
@@ -21,7 +21,7 @@
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"
-  when: testbed_type in ['t1', 't1-lag']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
@@ -56,6 +56,7 @@
     ptf_test_dir: ptftests
     ptf_test_path: fib_test.FibTest
     ptf_platform: remote
+    ptf_extra_options: --platform-dir ptftests
     ptf_test_params:
       - testbed_type='{{testbed_type}}'
       - router_mac='{{ansible_Ethernet0['macaddress']}}'

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -4,6 +4,8 @@
 {% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' %}
 0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+{% elif testbed_type == 't1-64-lag' %}
+0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
 {% endif %}
 
 {#routes to uplink#}
@@ -21,6 +23,11 @@
 
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+
+{% elif testbed_type == 't1-64-lag' %}
+192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 [0 1] [4 5] [16 17] [20 21]
+
+20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
 
 {% elif testbed_type == 't0' or testbed_type == 't0-64' %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +


### PR DESCRIPTION
- the north bound LAG ports are fixed for this topology and are hardcoded