### PR TITLE
[copp]: Update add_ip/remove_ip script to fit more ports

### DIFF
--- a/ansible/roles/test/files/helpers/add_ip.sh
+++ b/ansible/roles/test/files/helpers/add_ip.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-for i in $(seq 0 31); do
+for i in `cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}'`; do
   last_el=$((1+i*2))
   ip address add 10.0.0.$last_el/31 dev eth$i
 done

--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-for i in $(seq 0 31); do
+for i in `cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}'`; do
   ip address flush dev eth$i
 done


### PR DESCRIPTION
This is to use the /proc/net/dev to get all the devices starting with eth
and then assign or flush the corresponding IPs