### PR TITLE
[fast-reboot] Remove supervisorctl path to fit latest version of PTF

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -31,11 +31,11 @@
       delegate_to: "{{ ptf_host }}"
 
     - name: Reread supervisor configuration
-      shell: /usr/bin/supervisorctl reread
+      shell: supervisorctl reread
       delegate_to: "{{ ptf_host }}"
 
     - name: Update supervisor configuration
-      shell: /usr/bin/supervisorctl update
+      shell: supervisorctl update
       delegate_to: "{{ ptf_host }}"
 
     - name: Remove old keys


### PR DESCRIPTION
Hi,

Would like to modify the path of supervisorctl in fast-reboot.yml because the path of /usr/bin/supervisorctl is no longer exist.
Please let me know if any, thanks.

---
Regards,
Kenie Liu
