### PR TITLE
[sanity_test] add port layout definition for Arista 7260CX3 platform

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -449,6 +449,22 @@ def parse_xml(filename, hostname):
             port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
         for i in range(1,5) + range(29, 37):
             port_alias_map["Ethernet%d" % i] = "Ethernet%d" % ((i - 1) * 4)
+    elif hwsku == "Arista-7260CX3-C64":
+        for i in range(0, 256, 4):
+            port_alias_map["Ethernet%d" % i] = "Ethernet%d" % i
+    elif hwsku == "Arista-7260CX3-D108C8":
+        # All possible breakout 50G port numbers:
+        port_candidates = [ x for x in range(0, 256, 2)]
+
+        # Unsed ports are not configured:
+        unused_ports = [18, 20]
+
+        # Exclude 100G port number + 2 and unused 100G ports:
+        exclude_ports = [ ((x-1)*4+2) for x in unused_ports + range(45, 53) ] + [ ((x-1)*4) for x in unused_ports ]
+        valid_ports = list(set(port_candidates) - set(exclude_ports))
+
+        for i in valid_ports:
+            port_alias_map["Ethernet%d" % i] = "Ethernet%d" % i
     else:
         for i in range(0, 128, 4):
             port_alias_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
Define port layouts for Arista 7260CX3 platform:

- Arista-7260CX3-C64: 64 x 100G ports. The port names are at multiple of 4s.
- Arista-7260CX3-D108C8: 108 x 50G ports and 8 x 100G ports. 50G ports are at multiple of 2s, 100G at multiple of 4s. There are 2 unused 100G ports.