### PR TITLE
[fast-reboot test]: Cosmetic fixes

### DIFF
--- a/ansible/roles/test/files/ptftests/fast-reboot.py
+++ b/ansible/roles/test/files/ptftests/fast-reboot.py
@@ -489,6 +489,7 @@ class FastReloadTest(BaseTest):
         self.log("From server dst addr: %s" % self.from_server_dst_addr)
         self.log("From server dst ports: %s" % self.from_server_dst_ports)
         self.log("From upper layer number of packets: %d" % self.nr_vl_pkts)
+        self.log("VMs: %s" % str(self.test_params['arista_vms']))
 
         self.dataplane = ptf.dataplane_instance
         for p in self.dataplane.ports.values():
@@ -612,7 +613,14 @@ class FastReloadTest(BaseTest):
         no_routing_stop = None
 
         arista_vms = self.test_params['arista_vms'][1:-1].split(",")
-        ssh_targets = [vm[1:-1] for vm in arista_vms]
+        ssh_targets = []
+        for vm in arista_vms:
+            if (vm.startswith("'") or vm.startswith('"')) and (vm.endswith("'") or vm.endswith('"')):
+                ssh_targets.append(vm[1:-1])
+            else:
+                ssh_targets.append(vm)
+
+        self.log("Converted addresses VMs: %s" % str(ssh_targets))
 
         self.ssh_jobs = []
         for addr in ssh_targets:

--- a/ansible/roles/test/files/ptftests/fast-reboot.py
+++ b/ansible/roles/test/files/ptftests/fast-reboot.py
@@ -699,7 +699,7 @@ class FastReloadTest(BaseTest):
 
         self.log("How many packets were received back when control plane was down: %d Expected: %d" % (no_cp_replies, self.nr_vl_pkts))
 
-        has_info = all(len(info) > 0 for info in self.info.values())
+        has_info = any(len(info) > 0 for info in self.info.values())
         if has_info:
             self.log("-"*50)
             self.log("Additional info:")

--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -113,6 +113,7 @@
         - dut_mac='{{ ansible_Ethernet0['macaddress'] }}'
         - default_ip_range='192.168.0.0/16'
         - vlan_ip_range=\"{{ minigraph_vlan_interfaces[0]['subnet'] }}\"
+        - lo_v6_prefix=\"{{ minigraph_lo_interfaces | map(attribute='addr') | ipv6 | first | ipsubnet(64) }}\"
         - arista_vms=\"{{ vm_hosts }}\"
 
   always:

--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -117,6 +117,10 @@
         - arista_vms=\"{{ vm_hosts }}\"
 
   always:
+    - name: Copy test results from ptf to the local box /tmp/fast-reboot.log
+      fetch: src='/tmp/fast-reboot.log' dest='/tmp' flat=true
+      delegate_to: "{{ ptf_host }}"
+
     - name: Remove existing ip from ptf host
       script: roles/test/files/helpers/remove_ip.sh
       delegate_to: "{{ ptf_host }}"


### PR DESCRIPTION
1. Output list of VMs received from Ansible and converted to a list of values. Ansible is not stable adding or not adding quotes to variable
2. Output information messages if there're any
3. Provide Loopback ipv6 address deduced from minigraph. Recently SONiC changed its behavior by announcing ipv6 /64 prefix for lo.
4. Copy fast-reboot test results to a local /tmp