### PR TITLE
[Arista7260cx3] hard code port layout to enable fdb test

### DIFF
--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64']
+  when: testbed_type not in ['t0', 't0-64', 't0-116']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 

--- a/ansible/roles/test/templates/fdb.j2
+++ b/ansible/roles/test/templates/fdb.j2
@@ -1,3 +1,7 @@
 {% for vlan in minigraph_vlan_interfaces %}
+{% if testbed_type == 't0-116' %}
+{{ vlan['subnet'] }} {% for n in range(0, 17) %} {{ n }} {% endfor %} 18 {% for n in range(20, 44) %} {{ n }} {% endfor %}{% for n in range(52, 64) %} {{ n }} {% endfor %}
+{% else %}
 {{ vlan['subnet'] }} {% for ifname in minigraph_vlans[vlan['attachto']]['members'] %} {{ minigraph_port_indices[ifname] }} {% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
- Port 18 and 20 are excluded in this test until the new bcm config file is in place.
- Port 42 is excluded from the test due to some abnormalness in tests, likely due to cable.