### PR TITLE
[Arista7260cx3] hard code port layout to enable fib test

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -98,6 +98,8 @@ class FibTest(BaseTest):
             self.src_ports = range(1, 25) + range(28, 32)
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
+        if self.test_params['testbed_type'] == 't0-116':
+            self.src_ports = range(0, 17) + [18] + range(20,44) + range(52, 64)
     #---------------------------------------------------------------------
 
     def check_ip_range(self, ipv4=True):

--- a/ansible/roles/test/tasks/fib.yml
+++ b/ansible/roles/test/tasks/fib.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't0', 't0-64']
+  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't0', 't0-64', 't0-116']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 
@@ -17,7 +17,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0', 't0-64']
+  when: testbed_type in ['t0', 't0-64', 't0-116']
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -6,6 +6,8 @@
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 {% elif testbed_type == 't1-64-lag' %}
 0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
+{% elif testbed_type == 't0-116' %}
+0.0.0.0/0 [44 45] [46 47] [48 49] [50 51]
 {% endif %}
 
 {#routes to uplink#}
@@ -43,6 +45,19 @@
 
 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
+{% endif %}
+{% elif testbed_type == 't0-116' %}
+{% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (subnet * props.tor_subnet_size) ) %}
+{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet3 = ((suffix // 256) % 256) %}
+{% set octet4 = (suffix % 256) %}
+{% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
+{# Skip 192.168.0.0 as it is in Vlan1000 subnet  #}
+{% if octet2 != 168 and octet3 != 0 and octet4 != 0 %}
+192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} [44 45] [46 47] [48 49] [50 51]
+20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 [44 45] [46 47] [48 49] [50 51]
 {% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
- Excluding port 18, 20 until new bcm config is in place.
