### PR TITLE
[fib, fdb] allow fib and fdb test info files to contain empty lines and comments

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb.py
+++ b/ansible/roles/test/files/ptftests/fdb.py
@@ -1,3 +1,4 @@
+import re
 from ipaddress import ip_address, ip_network
 
 class Fdb():
@@ -6,8 +7,12 @@ class Fdb():
         self._arp_dict = {}
         self._vlan_dict = {}
 
+        # filter out empty lines and lines starting with '#'
+        pattern = re.compile("^#.*$|^[ \t]*$")
+
         with open(file_path, 'r') as f:
             for line in f.readlines():
+                if pattern.match(line): continue
                 entry = line.split(' ', 1)
                 prefix = ip_network(unicode(entry[0]))
                 self._vlan_dict[prefix] = [int(i) for i in entry[1].split()]

--- a/ansible/roles/test/files/ptftests/fib.py
+++ b/ansible/roles/test/files/ptftests/fib.py
@@ -51,9 +51,12 @@ class Fib():
         for ip in EXCLUDE_IPV6_PREFIXES:
             self._ipv6_lpm_dict[ip] = self.NextHop()
 
+        # filter out empty lines and lines starting with '#'
+        pattern = re.compile("^#.*$|^[ \t]*$")
+
         with open(file_path, 'r') as f:
             for line in f.readlines():
-                if line[0] == '#': continue
+                if pattern.match(line): continue
                 entry = line.split(' ', 1)
                 prefix = ip_network(unicode(entry[0]))
                 next_hop = self.NextHop(entry[1])


### PR DESCRIPTION
While generating test info files for fib/fdb tests, some topology output file
contains empty lines.

This change allows these empty lines to be ignored during tests.