### PR TITLE
[interface_facts] improve interface facts comparing performance

### DIFF
--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -1,9 +1,11 @@
 - name: Get interface facts
-  interface_facts:
+  interface_facts: up_ports={{minigraph_ports}}
+
+- debug: msg="Found link down ports {{ansible_interface_link_down_ports}} "
+  when: ansible_interface_link_down_ports | length > 0
 
 - name: Verify interfaces are up correctly
-  assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
-  with_items: "{{ minigraph_ports }}"
+  assert: { that: "{{ ansible_interface_link_down_ports }}|length == 0" }
 
 - name: Verify port channel interfaces are up correctly
   assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }

--- a/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
+++ b/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
@@ -5,44 +5,43 @@
 - block:
     - set_fact:
         interface: "{{item}}"
-    
+
     - debug: msg={{interface}}
-    
+
     - set_fact:
         peer_device: "{{neighbors[interface]['peerdevice']}}"
         neighbor_interface: "{{neighbors[interface]['peerport']}}"
-    
+
     - conn_graph_facts: host={{ peer_device }}
       connection: local
-    
+
     - set_fact:
         peer_host: "{{device_info['mgmtip']}}"
         peer_hwsku: "{{device_info['HwSku']}}"
-    
+
     - set_fact:
         intfs_to_exclude: "{{interface}}"
-    
+
     - name: Shut down neighbor interface {{neighbor_interface}} on {{peer_host}}
       action: apswitch template=neighbor_interface_shut_single.j2
       args:
         host: "{{peer_host}}"
         login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
       connection: switch
-    
+
     - pause:
         seconds: 20
-    
-    - interface_facts:
-    
+
+    - interface_facts: up_ports={{minigraph_ports | difference(intfs_to_exclude)}}
+
+    - debug: msg="Found link down ports {{ansible_interface_link_down_ports}} "
+      when: ansible_interface_link_down_ports | length > 0
+
     - name: Verify interfaces are up correctly
-      assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
-      with_items: "{{ minigraph_ports }}"
-      when: item != "{{ intfs_to_exclude }}"
-      connection: local
-    
+      assert: { that: "{{ ansible_interface_link_down_ports }}|length == 0" }
+
     - name: Verify {{intfs_to_exclude}} is down correctly
       assert: { that: "'{{ ansible_interface_facts[intfs_to_exclude]['active'] }}' == 'False'" }
-      connection: local
 
   always:
     - name: Bring up neighbor interface {{neighbor_interface}} on {{peer_host}}
@@ -51,13 +50,14 @@
         host: "{{peer_host}}"
         login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
       connection: switch
-    
+
     - pause:
         seconds: 20
-    
-    - interface_facts:
-    
+
+    - interface_facts: up_ports={{minigraph_ports}}
+
+    - debug: msg="Found link down ports {{ansible_interface_link_down_ports}} "
+      when: ansible_interface_link_down_ports | length > 0
+
     - name: Verify all interfaces are up
-      assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
-      with_items: "{{ minigraph_ports }}"
-      connection: local
+      assert: { that: "{{ ansible_interface_link_down_ports }}|length == 0" }


### PR DESCRIPTION
Allow callers of interface_facts to pass in a list of ports of that
are expected to be up. The script will check their link status, return
list of ports that has link went down unexpectedly.

The caller, instead of looping in ansible to check all interface status,
can simply check if the link down list is empty.