### PR TITLE
[lag_2]:modified files to get lag members from mini graph

### DIFF
--- a/ansible/roles/test/tasks/lag_lacp_timing_test.yml
+++ b/ansible/roles/test/tasks/lag_lacp_timing_test.yml
@@ -16,17 +16,17 @@
     packet_timing: "{{ lacp_timer }}"
     packet_timeout: 35
 
-- name: Check LACP timing on eth{{ iface_behind_lag_member_0 }} (interface behind {{ vm_name }}).
+- name: Check LACP timing on eth{{ iface_behind_lag_member[0] }} (interface behind {{ vm_name }}).
   include: lag_run_ptf.yml
   vars:
     lag_ptf_test_name: LacpTimingTest
-    params: "exp_iface={{ iface_behind_lag_member_0 }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}"
+    params: "exp_iface={{ iface_behind_lag_member[0] }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}"
     change_dir: /tmp
 
-- name: Check LACP timing on eth{{ iface_behind_lag_member_1 }} (interface behind {{ vm_name }}).
+- name: Check LACP timing on eth{{ iface_behind_lag_member[1] }} (interface behind {{ vm_name }}).
   include: lag_run_ptf.yml
   vars:
     lag_ptf_test_name: LacpTimingTest
-    params: "exp_iface={{ iface_behind_lag_member_1 }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}"
+    params: "exp_iface={{ iface_behind_lag_member[1] }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}"
     change_dir: /tmp
-  when: iface_behind_lab_member_1 is defined
+  when: iface_behind_lag_member[1] is defined

--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -52,13 +52,12 @@
     wait_down_time: 120
 
 ### Now prepare for the remote VM interfaces that using PTF docker to check teh LACP DU packet rate is correct 
+- set_fact: 
+     iface_behind_lag_member: []
 - set_fact:
-    iface_behind_lag_member_0: "{{ topology['VMs'][peer_device]['vlans'][0] }}"
-
-- set_fact:
-    iface_behind_lag_member_1: "{{ topology['VMs'][peer_device]['vlans'][1] }}"
-  when: testbed_type == 't1-lag'
-
+     iface_behind_lag_member: "{{iface_behind_lag_member}}+ ['{{minigraph_port_indices[item.key]}}']"
+  with_dict: "{{ minigraph_neighbors }}"
+  when: peer_device == "{{item.value.name}}"
 - set_fact:
     neighbor_lag_intfs: []
 


### PR DESCRIPTION
**Issue:** 

The script for Lag_2 [single_lag_test.yml] takes the interface number from topo_t1-lag.yml vlan info.
The topo_t1-lag.yml file has the vlan listed in contiguous order from 0 to31.  For non-contiguous ports, getting port from vlan info yields wrong port details.
Link to issue : #313

_**Snip from single_lag_test.yml**_

set_fact:
iface_behind_lag_member_0: "{{ topology['VMs'][peer_device]['vlans'][0] }}"

set_fact:
iface_behind_lag_member_1: "{{ topology['VMs'][peer_device]['vlans'][1] }}"

**What I did :** 
script: ansible/roles/test/tasks/single_lag_test.yml

- Modified  the script to get the lag port details from minigraph_port_indices of the port.
- when the peer_device name matches with the minigraph neighbour name, the port indices of the port is extracted and stored in a list. 
- The list members ( lag ports) are used in the script lag_lacp_timing_test.yml