### PR TITLE
[arista7260cx3] include port 18 and 20 as 50G breakout ports

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -462,11 +462,8 @@ def parse_xml(filename, hostname):
         # 100G ports
         s100G_ports = [ x for x in range(45, 53) ]
 
-        # Unsed ports are not configured:
-        unused_ports = [18, 20]
-
         # 50G ports
-        s50g_ports = list(set(all_ports) - set(s100G_ports) - set(unused_ports))
+        s50g_ports = list(set(all_ports) - set(s100G_ports)
 
         for i in s50g_ports:
             port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)


### PR DESCRIPTION
- Include port 18 and 20 in the test.
- port 18 and 20 are configured to be two 50G breakout ports each