### PR TITLE
call test by test case name

### DIFF
--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+import os
+import traceback
+import ipaddr as ipaddress
+import csv
+from operator import itemgetter
+from itertools import groupby
+import yaml
+
+DOCUMENTATION = '''
+module: test_facts.py
+version_added:  2.0.0.2
+short_description: get lab testbed and testcases information related to run tests
+options:
+    - testbed_file:
+      Description: the CSV file name which describe all testbeds
+      Default: TESTBED_FILE
+      required: False
+    - testbed_name:
+      Description: the unique name of one testbed topology specified in the first column of each row of CSV file
+      Default: None
+      Required: False
+    - testcases_file:
+      Description: the yml file name which include all testcases properties
+      Dedfault: TESTCASES_FILE
+      required: False
+'''
+
+EXAMPLES = '''
+    Testbed CSV file example:
+        # conf-name,group-name,topo,ptf_image_name,ptf_mgmt_ip,server,vm_base,dut,comment
+        ptf1-m,ptf1,ptf32,docker-ptf-sai-mlnx,10.255.0.188/24,server_1,,str-msn2700-01,Tests ptf
+        vms-t1,vms1-1,t1,docker-ptf-sai-mlnx,10.255.0.178/24,server_1,VM0100,str-msn2700-01,Tests vms
+        vms-t1-lag,vms1-1,t1-lag,docker-ptf-sai-mlnx,10.255.0.178/24,server_1,VM0100,str-msn2700-01,Tests vms
+        ...
+
+    Testcases YAML File example:
+        testcases:
+            acl:
+                filename: acl.yml
+                topologies: [t1, t1-lag, t1-64-lag]
+                execvar:
+                  ptf_host:
+                  testbed_type:
+            arp:
+                filename: arpall.yml
+                topologies: [ptf32, ptf64]
+                execvars:
+                  ptf_host:
+            bgp_fact:
+                filename: bgp_fact.yml
+                topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-lag-64]
+            ...
+
+    To use it:
+    - name: gather all predefined testbed topology information
+      test_facts:
+
+    - name: get vms-t1 topology information
+      test_facts: testbed_name="vms-t1"
+'''
+
+RETURN = '''
+    Ansible_facts:
+        "testbed_facts": {
+            "vms1-1": {
+                "dut": "str-s6000-1",
+                "owner": "Tests vms",
+                "ptf_image_name": "docker-ptf-sai-mlnx",
+                "ptf_ip": "10.255.0.178",
+                "ptf_netmask": "255.255.255.0",
+                "server": "server_1",
+                "testbed-name": "vmst-1",
+                "topo": "t1",
+                "vm_base": "VM0100"
+            }
+            ....
+        }
+        "topo_testcases": {
+                ptf32:     [arpall, copp, everflow, neighbour, neighbour_mac_noptf, qos, snmp, syslog]
+                ptf64:     [arpall, copp, everflow, neighbour, neighbour_mac_noptf, qos, snmp, syslop]
+                t0:        [bgp_fact, bgp_speaker, decap, dhcp_relay, fast-reboot, fib, fdb, lldp, lag_2, pfc_wd]
+                t0-64:     [bgp_fact, bgp_speaker, decap, dhcp_relay, fast-reboot, fib, fdb, lldp, lag_2, pfc_wd]
+                t0-64-32:  [bgp_fact, bgp_speaker, decap, dhcp_relay, fast-reboot, fib, fdb, lldp, lag_2, pfc_wd]
+                t1:        [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, pfc_wd]
+                t1-lag:    [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
+                t1-64-lag: [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
+            }
+'''
+
+### Default testbed file name
+TESTBED_FILE = 'testbed.csv'
+TESTCASE_FILE = 'roles/test/vars/testcases.yml'
+
+
+class ParseTestbedTopoinfo():
+    '''
+    Parse the CSV file used to describe whole testbed info
+    Please refer to the example of the CSV file format
+    CSV file first line is title
+    The topology name in title is using uniq-name | conf-name
+    '''
+    def __init__(self, testbed_file):
+        self.testbed_filename = testbed_file
+        self.testbed_topo = {}
+
+    def read_testbed_topo(self):
+        with open(self.testbed_filename) as f:
+            topo = csv.DictReader(f)
+            for line in topo:
+                tb_prop = {}
+                name = ''
+                for key in line:
+                    if ('uniq-name' in key or 'conf-name' in key) and '#' in line[key]:
+                        ### skip comment line
+                        continue
+                    elif 'uniq-name' in key or 'conf-name' in key:
+                        name = line[key]
+                    elif 'ptf_ip' in key and line[key]:
+                        ptfaddress = ipaddress.IPNetwork(line[key])
+                        tb_prop['ptf_ip'] = str(ptfaddress.ip)
+                        tb_prop['ptf_netmask'] = str(ptfaddress.netmask)
+                    else:
+                        tb_prop[key] = line[key]
+                if name:
+                    self.testbed_topo[name] = tb_prop
+        return
+
+    def get_testbed_info(self, testbed_name):
+        if testbed_name:
+            return self.testbed_topo[testbed_name]
+        else:
+            return self.testbed_topo
+
+class TestcasesTopology():
+    '''
+    Read testcases definition yaml file under ansible/roles/test/vars/testcases.yml
+    and return a list of available testcases for each pre-defined testbed topology
+    '''
+    def __init__(self, testcase_file):
+        self.testcase_filename = testcase_file
+        self.topo_testcase = {}
+
+    def read_testcases(self):
+        with open(self.testcase_filename) as f:
+            testcases = yaml.load(f)
+            if 'testcases' not in testcases:
+                raise Exception("not correct testcases file format??")
+            for tc,prop in testcases['testcases'].items():
+                for topo in prop['topologies']:
+                    if topo not in self.topo_testcase:
+                        self.topo_testcase[topo] = []
+                    self.topo_testcase[topo].append(tc)
+            return testcases['testcases']
+
+    def get_topo_testcase(self):
+        return self.topo_testcase
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            testbed_name=dict(required=False, default=None),
+            testbed_file=dict(required=False, default=TESTBED_FILE),
+            testcase_file=dict(requried=False, default=TESTCASE_FILE),
+        ),
+        supports_check_mode=True
+    )
+    m_args = module.params
+    testbed_file = m_args['testbed_file']
+    testbed_name = m_args['testbed_name']
+    testcase_file = m_args['testcase_file']
+    try:
+        topoinfo = ParseTestbedTopoinfo(testbed_file)
+        topoinfo.read_testbed_topo()
+        testbed_topo = topoinfo.get_testbed_info(testbed_name)
+        testcaseinfo = TestcasesTopology(testcase_file)
+        testcaseinfo.read_testcases()
+        testcase_topo = testcaseinfo.get_topo_testcase()
+        module.exit_json(ansible_facts={'testbed_facts': testbed_topo, 'topo_testcases': testcase_topo})
+    except (IOError, OSError):
+        module.fail_json(msg="Can not find lab testbed file  "+testbed_file+" or testcase file "+testcase_file+"??")
+    except Exception as e:
+        module.fail_json(msg=traceback.format_exc())
+
+from ansible.module_utils.basic import *
+if __name__== "__main__":
+    main()

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -128,7 +128,7 @@ class ParseTestbedTopoinfo():
 
     def get_testbed_info(self, testbed_name):
         if testbed_name:
-            return self.testbed_topo[testbed_name]
+            return [self.testbed_topo[testbed_name]]
         else:
             return self.testbed_topo
 
@@ -172,7 +172,7 @@ def main():
     try:
         topoinfo = ParseTestbedTopoinfo(testbed_file)
         topoinfo.read_testbed_topo()
-        testbed_topo = topoinfo.get_testbed_info(testbed_name)
+        testbed_topo = topoinfo.get_testbed_info(testbed_name)[0]
         testcaseinfo = TestcasesTopology(testcase_file)
         testcaseinfo.read_testcases()
         testcase_topo = testcaseinfo.get_topo_testcase()

--- a/ansible/roles/test/tasks/sonic.yml
+++ b/ansible/roles/test/tasks/sonic.yml
@@ -1,171 +1,71 @@
+- include_vars: "roles/test/vars/testcases.yml"
+
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
   connection: local
   become: no
-  tags: always
-
-### When calling the following tests, you need to provide a command line parameter
-### specifying which PTF docker image host to test against. For example,
-### -e "ptf_host=10.0.0.200"
-- fail: msg="Please set ptf_host variable"
-  when: ptf_host is not defined
-  tags: arp,dhcp_relay
 
 # Set sonic_hwsku
 - name: Set sonic_hwsku fact
   set_fact:
     sonic_hwsku: "{{minigraph_hwsku}}"
-  tags: always
 
 - name: Set sonic_asic_type fact
   set_fact:
     sonic_asic_type: broadcom
   when: sonic_hwsku in broadcom_hwskus
-  tags: always
 
 - name: Set sonic_asic_type fact
   set_fact:
     sonic_asic_type: mellanox
   when: sonic_hwsku in mellanox_hwskus
-  tags: always
 
-- name: Verify interfaces are up
-  include: interface.yml
-  tags: always
+###########################################################################
+##### run test using ansible tag when no testbedname specified       ######
+###########################################################################
+- block:
+    - fail: msg="You didn't provide testbed_name=yourtestbedname, so will run by test by tag. Please specify tests you want to run using --tags"
+      when: tags is not defined
 
-- name: BGP facts test
-  include: bgp_fact.yml
-  tags: bgp_fact
+    - include: test_sonic_by_tag.yml
+  when:
+    - testbed_name is not defined
 
-- name: Neighbor mac change test
-  include: neighbour-mac.yml
-  tags: neighbour
+##########################################################################
+####### when give a testbed name, testcase name is required ##############
+####### TODO: to run all applicable tests for each topology ##############
+##########################################################################
+- fail: msg="Please specify a testcase_name to run a specific test associated with the testbed topology"
+  when:
+    - testbed_name is defined
+    - testcase_name is not defined
 
-- name: Test LLDP
-  include: lldp.yml
-  tags: lldp
+###############################################
+############# test by test case name  #########
+###############################################
+- block:
+    - name: Gathering testbed information
+      test_facts: testbed_name="{{ testbed_name }}"
+      connection: local
 
-- name: Test NTP
-  include: ntp.yml
-  tags: ntp
+    - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
+      when: testbed_facts['dut'] != inventory_hostname
 
-- name: Test SNMP Basic
-  include: snmp.yml
-  tags: snmp
+    - name: set testbed_type
+      set_fact:
+        testbed_type: "{{ testbed_facts['topo'] }}"
+        ptf_host: "{{ testbed_facts['ptf_ip'] }}"
+        topo: "topo_{{ testbed_facts['topo'] }}.yml"
 
-- name: Test DHCP Relay
-  include: dhcp_relay.yml
-  tags: dhcp_relay
-  when: minigraph_devices[inventory_hostname]['type'] == "ToRRouter"
+    - name: set vm
+      set_fact:
+        vm: "{{ testbed_facts['vm_base'] }}"
+      when: "testbed_facts['vm_base'] != ''"
 
-- name: Test Control-Plain policing COPP
-  include: copp.yml
-  tags: copp
+    - fail: msg="cannot find {{ testcase_name }} in available testcases or is not supported topology of this testbed {{ testbed_name }}"
+      when: (testcase_name is not defined) or (testbed_type not in testcases[testcase_name]['topologies'])
 
-- name: Fast-reboot test
-  include: fast-reboot.yml
-  when: minigraph_portchannel_interfaces | length > 0 and minigraph_vlan_interfaces | length > 0
-  tags: fast_reboot
-
-### when callng BGP flaps test, please add command line of which VMs host to test against
-### -e "vmhost_num='01'"
-- fail: msg="Please set vmhost_num variable"
-  when: vmhost_num is not defined
-  tags: sync
-
-- name: Test SyncD BGP Flaps
-  include: bgp_flap.yml
-  tags: sync
-
-- name: Test Syslog Basic
-  include: syslog.yml
-  tags: syslog
-
-- name: Test SNMP CPU
-  include: snmp/cpu.yml
-  tags: snmp_cpu
-  when: minigraph_hwsku == "Force10-S6000" or minigraph_hwsku == "ACS-S6000"
-
-- name: Test SNMP Interfaces
-  include: snmp/interfaces.yml
-  tags: snmp_interfaces
-
-- name: Test Interface Flap from Neighbor
-  include: link_flap.yml
-  tags: link_flap
-
-- name: Test kernel ARP behavior
-  include: arpall.yml
-  tags: arp
-
-- name: Test sensors
-  include: sensors_check.yml
-  tags: sensors
-
-- name: Test reboot
-  include: reboot.yml
-  tags: reboot
-
-### When calling this FIB test, please add command line of what testbed_type and which PTF docker to test against
-### -e "testbed_type=t1-lag ptf_host=10.0.0.200"
-- name: Fib test
-  include: fib.yml
-  tags: fib
-
-- name: MTU test
-  include: mtu.yml
-  tags: mtu
-
-### When calling this FDB test, please add command line of what testbed_type and which PTF docker to test agains
-### -e "testbed_type=t0 ptf_host=10.64.246.22"
-- name: FDB test
-  include: fdb.yml
-  tags: fdb
-
-### When calling this decap test, please add command line of what testbed_type, dscp_mode, and which PTF docker to test against
-#### -e "testbed_type=t1-lag dscp_mode=pipe ptf_host=10.0.0.200"
-- name: Decap test
-  include: decap.yml
-  tags: decap
-
-- name: BGP Speaker test
-  include: bgp_speaker.yml
-  tags: bgp_speaker
-
-- name: Test Everflow
-  include: everflow.yml
-  tags: everflow
-
-- name: Test Everflow on testbed
-  include: everflow_testbed.yml
-  tags: everflow_testbed
-
-- name: Test LAG
-  include: lagall.yml
-  tags: lag
-
-- name: Test LAG using lag graph file
-  include: lag_2.yml
-  tags: lag_2
-
-- name: Memory check
-  include: mem_check.yml
-  tags: mem_check
-
-- name: ACL test 
-  include: acltb.yml
-  tags: acl
-
-- name: PFC Watchdog test
-  include: pfc_wd.yml
-  tags: pfc_wd
-
-### when calling this test, please add command line of testbed_type 
-### -e testbed_type=t1
-- name: BGP multipath relax
-  include: bgp_multipath_relax.yml
-  tags: bgp_multipath_relax
-
-- name: neighbor mac change test without using ptf
-  include: neighbour-mac-noptf.yml
-  tags: neighbour_mac_noptf
+    - include: test_sonic_by_testname.yml
+  when:
+    - testbed_name is defined
+    - testcase_name is defined

--- a/ansible/roles/test/tasks/test_sonic_by_tag.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_tag.yml
@@ -1,0 +1,193 @@
+- name: Gathering minigraph facts about the device
+  minigraph_facts: host={{ inventory_hostname }}
+  connection: local
+  become: no
+  tags: always
+
+### When calling the following tests, you need to provide a command line parameter
+### specifying which PTF docker image host to test against. For example,
+### -e "ptf_host=10.0.0.200"
+- fail: msg="Please set ptf_host variable"
+  when: ptf_host is not defined
+  tags: arp,dhcp_relay,qos,saiserver
+
+# Set sonic_hwsku
+- name: Set sonic_hwsku fact
+  set_fact:
+    sonic_hwsku: "{{minigraph_hwsku}}"
+  tags: always
+
+- name: Set sonic_asic_type fact
+  set_fact:
+    sonic_asic_type: broadcom
+  when: sonic_hwsku in broadcom_hwskus
+  tags: always
+
+- name: Set sonic_asic_type fact
+  set_fact:
+    sonic_asic_type: mellanox
+  when: sonic_hwsku in mellanox_hwskus
+  tags: always
+
+- name: Verify interfaces are up
+  include: interface.yml
+  tags: always
+
+- name: BGP facts test
+  include: bgp_fact.yml
+  tags: bgp_fact
+
+- name: Neighbor mac change test
+  include: neighbour-mac.yml
+  tags: neighbour
+
+- name: Test LLDP
+  include: lldp.yml
+  tags: lldp
+
+- name: Test NTP
+  include: ntp.yml
+  tags: ntp
+
+- name: Test SNMP Basic
+  include: snmp.yml
+  tags: snmp
+
+- name: Test DHCP Relay
+  include: dhcp_relay.yml
+  tags: dhcp_relay
+  when: minigraph_devices[inventory_hostname]['type'] == "ToRRouter"
+
+- name: Test QOS
+  include: qos.yml
+  when: sonic_hwsku in broadcom_hwskus
+  tags: qos
+
+- name: Test QoS using SAI
+  include: qos_sai.yml
+  when: sonic_hwsku in mellanox_hwskus and sonic_version=='v2' and host_saithrift
+  tags: qos
+
+- name: Test Control-Plain policing COPP
+  include: copp.yml
+  tags: copp
+
+- name: Fast-reboot test
+  include: fast-reboot.yml
+  when: minigraph_portchannel_interfaces | length > 0 and minigraph_vlan_interfaces | length > 0
+  tags: fast_reboot
+
+### when callng BGP flaps test, please add command line of which VMs host to test against
+### -e "vmhost_num='01'"
+- fail: msg="Please set vmhost_num variable"
+  when: vmhost_num is not defined
+  tags: sync
+
+- name: Test SyncD BGP Flaps
+  include: bgp_flap.yml
+  tags: sync
+
+- name: Test Syslog Basic
+  include: syslog.yml
+  tags: syslog
+
+- name: Test SNMP CPU
+  include: snmp/cpu.yml
+  tags: snmp_cpu
+  when: minigraph_hwsku == "Force10-S6000" or minigraph_hwsku == "ACS-S6000"
+
+- name: Test SNMP Interfaces
+  include: snmp/interfaces.yml
+  tags: snmp_interfaces
+
+- name: Test Interface Flap from Neighbor
+  include: link_flap.yml
+  tags: link_flap
+
+- name: Test kernel ARP behavior
+  include: arpall.yml
+  tags: arp
+
+### When calling this basic_route, Chip is setup with proper parameters and
+### SAI API used by sswsyncd daemon are called. This test is mainly for validation purpose used by external vendors.
+- name: Test basic_router
+  include: basic_router.yml
+  tags: basic_router
+
+- name: Test sensors
+  include: sensors_check.yml
+  tags: sensors
+
+- name: Test reboot
+  include: reboot.yml
+  tags: reboot
+
+- name: SAIThrift tests
+  include: saiserver.yml
+  tags: saiserver
+
+### When calling this FIB test, please add command line of what testbed_type and which PTF docker to test against
+### -e "testbed_type=t1-lag ptf_host=10.0.0.200"
+- name: Fib test
+  include: fib.yml
+  tags: fib
+
+- name: MTU test
+  include: mtu.yml
+  tags: mtu
+
+### When calling this FDB test, please add command line of what testbed_type and which PTF docker to test agains
+### -e "testbed_type=t0 ptf_host=10.64.246.22"
+- name: FDB test
+  include: fdb.yml
+  tags: fdb
+
+### When calling this decap test, please add command line of what testbed_type, dscp_mode, and which PTF docker to test against
+#### -e "testbed_type=t1-lag dscp_mode=pipe ptf_host=10.0.0.200"
+- name: Decap test
+  include: decap.yml
+  tags: decap
+
+- name: BGP Speaker test
+  include: bgp_speaker.yml
+  tags: bgp_speaker
+
+- name: Test Everflow
+  include: everflow.yml
+  tags: everflow
+
+### When calling this everflow testbed test, please add command line of what testbed_type and which PTF docker to test against
+### -e "testbed_type=t1 ptf_host=10.0.0.200"
+- name: Test Everflow on testbed
+  include: everflow_testbed.yml
+  tags: everflow_testbed
+
+- name: Test LAG
+  include: lagall.yml
+  tags: lag
+
+- name: Test LAG using lag graph file
+  include: lag_2.yml
+  tags: lag_2
+
+- name: Memory check
+  include: mem_check.yml
+  tags: mem_check
+
+- name: ACL test 
+  include: acltb.yml
+  tags: acl
+
+- name: PFC Watchdog test
+  include: pfc_wd.yml
+  tags: pfc_wd
+
+### when calling this test, please add command line of testbed_type 
+### -e testbed_type=t1
+- name: BGP multipath relax
+  include: bgp_multipath_relax.yml
+  tags: bgp_multipath_relax
+
+- name: neighbor mac change test without using ptf
+  include: neighbour-mac-noptf.yml
+  tags: neighbour_mac_noptf

--- a/ansible/roles/test/tasks/test_sonic_by_testname.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_testname.yml
@@ -1,0 +1,38 @@
+- debug: msg="!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+- debug: msg="!!!!!!!!!!!!!!!!!!!! start to run test {{ testcase_name }} !!!!!!!!!!!!!!!!!!!!"
+- debug: msg="!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
+- name: do basic sanity check before each test
+  include: base_sanity.yml
+
+- name: validate all interfaces is up
+  include: interface.yml
+
+########### if your test playbook requires more extra_vars than ptf_host and testbed_type, you may specify them here
+########### ptf_host and testbed_type are handled by default
+########### configure extra vars if your testcases need more vars
+########### or when you call the playbook, you have to specify your extra_vars
+- block:
+    - name: Set dscp_mode for decap test for broadcom
+      set_fact:
+          dscp_mode: pipe
+      when:
+        - sonic_hwsku in broadcom_hwskus
+        - dscp_mode is not defined
+
+    - name: Set dscp_mode var for decap test for mellanox
+      set_fact:
+          dhcp_mode: uniform
+      when:
+        - sonic_hwsku in mellanox_hwskus
+        - dscp_mode is not defined
+
+- debug: var=testcases[testcase_name]['execvars']
+  when: testcases[testcase_name]['execvars'] is defined
+
+- name: run test case {{ testcases[testcase_name]['filename'] }} file
+  include: "{{ testcases[testcase_name]['filename'] }}"
+
+- debug: msg="!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+- debug: msg="!!!!!!!!!!!!!!!!!!!! end running test {{ testcase_name }} !!!!!!!!!!!!!!!!!!!!"
+- debug: msg="!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -1,0 +1,136 @@
+testcases:
+    acl: 
+      filename: acl.yml
+      topologies: [t1, t1-lag, t1-64-lag]
+      execvar:
+          ptf_host: 
+          testbed_type: 
+    
+    arp:
+      filename: arpall.yml
+      topologies: [ptf32, ptf64]
+      execvars: 
+          ptf_host: 
+    
+    bgp_fact:
+      filename: bgp_fact.yml
+      topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-64-lag]
+ 
+    
+    bgp_multipath_relax:
+      filename: bgp_multipath_relax.yml
+      topologies: [t1, t1-lag, t1-64-lag]
+      execvars:
+          ptf_host:
+          testbed_type:
+    
+    bgp_speaker:
+      filename: bgp_speaker.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116]
+      execvars:
+          ptf_host:
+          testbed_type:
+    
+    copp:
+      filename: copp.yml
+      topologies: [ptf32, ptf64]
+      execvars:
+          ptf_host:
+ 
+    decap:
+      filename: decap.yml
+      topologies: [t1, t1-lag, t1-64-lag]
+      execvars:
+          ptf_host: 
+          testbed_type: 
+          dscp_mode: 
+ 
+    dhcp_relay:
+      filename: dhcp_relay.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116]
+      execvars:
+          ptf_host:
+ 
+    everflow_testbed:
+      filename: everflow_testbed.yml
+      topologies: [t1, t1-lag, t1-64-lag]
+      execvars:
+          ptf_host:
+          testbed_type:
+    
+    fast-reboot:
+      filename: bgp_fact.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116]
+      execvars:
+          ptf_host:
+          vm_hosts:
+ 
+    fib:
+      filename: fib.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      execvars: 
+          ptf_host: 
+          testbed_type:
+ 
+    fdb:
+      filename: bgp_fact.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116]
+      execvars: 
+          ptf_host: 
+          testbed_type:
+ 
+    lag_2:
+      filename: lag_2.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1-lag, t1-64-lag]
+      execvars: 
+          ptf_host:
+          testbed_type:
+    
+    lldp:
+      filename: lldp.yml
+      topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-64-lag]
+    
+    link_flap:
+      filename: link_flap.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+    
+    mem_check:
+      filename: mem_check.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+    
+    neighbour:
+      filename: neighbour.yml
+      topologies: [ptf32, ptf64]
+      execvars: 
+          ptf_host:
+    
+    neighbour_mac_noptf:
+      filename: neighbour-mac-noptf.yml
+      topologies: [ptf32, ptf64]
+      execvars: 
+          ptf_host:
+     
+    pfc_wd:
+      filename: pfc_wd.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+
+    qos:
+      filename: qos.yml
+      topologies: [ptf32, ptf64]
+    
+    reboot:
+      filename: reboot.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+    
+    sensors_check:
+      filename: sensors_check.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+    
+    snmp:
+      filename: snmp.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+     
+    syslog:
+      filename: syslog.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -59,7 +59,7 @@ testcases:
           testbed_type:
     
     fast-reboot:
-      filename: bgp_fact.yml
+      filename: fast-reboot.yml
       topologies: [t0, t0-64, t0-64-32, t0-116]
       execvars:
           ptf_host:


### PR DESCRIPTION
Issue #361 
This PR trying to:
1. summarize all test cases in a yaml file roles/test/vars/testcases.yml, 
     for each test case, it specify test case name, test playbook file name and extra vars needed to execute playbook 
     so user will have an overview all available test cases, how to run it, ...
 
2. improve test calling by skip calling by tag, and use test case directly

Future todo:
  Was trying to run all applicable tests for one topology, but had some issues to run through Ansible playbook loops. Will out this to future improvement. Any suggestion? 
    