### PR TITLE
Fixing logic to identify proper 'port_config.ini' file.

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -48,7 +48,7 @@ class SonicPortAliasMap():
 
     def findfile(self):
         for (rootdir, dirnames, filenames) in os.walk(FILE_PATH):
-            if self.hwsku in rootdir and len(dirnames) == 0 and PORTMAP_FILE in filenames:
+            if self.hwsku == rootdir.split('/')[-1] and len(dirnames) == 0 and PORTMAP_FILE in filenames:
                 self.filename = rootdir+'/'+PORTMAP_FILE
 
     def get_portmap(self):


### PR DESCRIPTION
Upon collection of minigraph_facts by ansible scripts, these ones are being unable to identify the proper port-speeds within port_alias.py. In consequence, a bunch of testcases fail and an incorrect minigraph.xml configuration file is generated.

Current code assumes that each platform holds its port_config.ini file
within a flat folder struct -- something like this:

```
/usr/share/sonic/device/x86_64-dell_z9100_c2538-r0/
|-- Force10-Z9100
|   |-- port_config.ini
|   `-- sai.profile
|-- installer.conf
|-- minigraph.xml
```

However, there are platforms (e.g. Celestica) that support different
port-layouts, and as such, make use of a more structural folder
scheme:

```
/usr/share/sonic/device/x86_64-cel_seastone-r0/
|-- Seastone-DX010
|   |-- minigraph.xml
|   |-- port_config.ini
|   `-- sai.profile
|-- Seastone-DX010-10-50
|   |-- minigraph.xml
|   |-- port_config.ini
|   `-- sai.profile
|-- Seastone-DX010-50
|   |-- minigraph.xml
|   |-- port_config.ini
|   `-- sai.profile
```

The current code will erroneously pick a random port_config.ini file
within this folder hierarchy, so i'm fixing the file-identification logic to
fully match the SKU being utilized.
