### PR TITLE
[set mac] change mac address formatting

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -3,7 +3,7 @@
 for i in $(ifconfig | grep eth | cut -f 1 -d ' ')
 do
   prefix=$(ifconfig $i | grep HWaddr | cut -c39-53)
-  suffix=$( printf "%02d" ${i##eth})
+  suffix=$( printf "%02x" ${i##eth})
   mac=$prefix$suffix  
   echo $i $mac
   ifconfig $i hw ether $mac


### PR DESCRIPTION
The old formatting using the mac address last byte to present decimal value.
e.g. eth21 will have last byte as :21 (hexidecimal).

While this scheme gives great benefit to manual debugging and log reading. It
limits the number of interface supported to 100 [00..99].

t0-116 topology has 120 enabled interfaces which exceeds the above limite.

This change has been tested on a DUT with T0-116 topology.