### PR TITLE
Finalize T0-116 topology

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -460,7 +460,7 @@ def parse_xml(filename, hostname):
         all_ports = [ x for x in range(1, 65)]
 
         # 100G ports
-        s100G_ports = [ x for x in range(45, 53) ]
+        s100G_ports = [ x for x in range(13, 21) ]
 
         # 50G ports
         s50g_ports = list(set(all_ports) - set(s100G_ports))

--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -4,7 +4,7 @@ Description:    This file contains the Decapasulation test for SONIC, to test De
                 Design is available in https://github.com/Azure/SONiC/wiki/IPv4-Decapsulation-test
                 
 Precondition:   Before the test start, all routes need to be defined as in the fib_info.txt file, in addition to the decap rule that need to be set as the dspc_mode
-topology:       SUpports t1, t1-lag and t0 topology
+topology:       SUpports t1, t1-lag, t0-116 and t0 topology
                       
 Usage:          Examples of how to start the test 
                 ptf  --test-dir /root/dor/ ip_decap_test_red --platform remote -t "verbose=True;fib_info='/root/fib_info.txt';lo_ip='10.1.0.32';router_mac='00:02:03:04:05:00';dscp_mode='pipe'; testbed_type='t1'"  --log-dir /tmp/logs --verbose 
@@ -62,6 +62,8 @@ class DecapPacketTest(BaseTest):
             self.src_ports = range(0, 32)
         if self.test_params['testbed_type'] == 't0':
             self.src_ports = range(1, 25) + range(28, 32)
+        if self.test_params['testbed_type'] == 't0-116':
+            self.src_ports = range(0, 24) + range(32, 120)
     #-----------------------------------------------------------------
     
     def send_and_verify(self, dst_ip, expected_ports, src_port, triple_encap = False):

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -99,7 +99,7 @@ class FibTest(BaseTest):
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
         if self.test_params['testbed_type'] == 't0-116':
-            self.src_ports = range(0, 17) + [18] + range(20,44) + range(52, 64)
+            self.src_ports = range(0, 24) + range(32, 120)
     #---------------------------------------------------------------------
 
     def check_ip_range(self, ipv4=True):

--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -6,7 +6,7 @@
   when: (testbed_type is not defined or ptf_host is not defined)
 
 - fail: msg="Invalid testbed_type value '{{testbed_type}}'"
-  when: testbed_type not in ['t0', 't0-64']
+  when: testbed_type not in ['t0', 't0-64', 't0-116']
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}

--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -7,10 +7,10 @@
         (dscp_mode is not defined) 
 
 - fail: msg="Invalid testbed_type value '{{testbed_type}}'"
-  when: testbed_type not in [ 't1', 't0', 't1-lag', 't1-64-lag']
+  when: testbed_type not in ['t1', 't0', 't1-lag', 't1-64-lag', 't0-116']
 
 - fail: msg="Invalid testbed_type value '{{dscp_mode}}'"
-  when: dscp_mode not in [ 'pipe','uniform']
+  when: dscp_mode not in ['pipe','uniform']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 
@@ -20,7 +20,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0']
+  when: testbed_type in ['t0', 't0-116']
 
 - name: Expand properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"

--- a/ansible/roles/test/templates/fdb.j2
+++ b/ansible/roles/test/templates/fdb.j2
@@ -1,7 +1,3 @@
 {% for vlan in minigraph_vlan_interfaces %}
-{% if testbed_type == 't0-116' %}
-{{ vlan['subnet'] }} {% for n in range(0, 17) %} {{ n }} {% endfor %} 18 {% for n in range(20, 44) %} {{ n }} {% endfor %}{% for n in range(52, 64) %} {{ n }} {% endfor %}
-{% else %}
 {{ vlan['subnet'] }} {% for ifname in minigraph_vlans[vlan['attachto']]['members'] %} {{ minigraph_port_indices[ifname] }} {% endfor %}
-{% endif %}
 {% endfor %}

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -7,7 +7,7 @@
 {% elif testbed_type == 't1-64-lag' %}
 0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
 {% elif testbed_type == 't0-116' %}
-0.0.0.0/0 [44 45] [46 47] [48 49] [50 51]
+0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
 {% endif %}
 
 {#routes to uplink#}
@@ -56,8 +56,8 @@
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
 {# Skip 192.168.0.0 as it is in Vlan1000 subnet  #}
 {% if octet2 != 168 and octet3 != 0 and octet4 != 0 %}
-192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} [44 45] [46 47] [48 49] [50 51]
-20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 [44 45] [46 47] [48 49] [50 51]
+192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} [24 25] [26 27] [28 29] [30 31]
+20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 [24 25] [26 27] [28 29] [30 31]
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -24,14 +24,6 @@ topology:
    - 21
    - 22
    - 23
-   - 24
-   - 25
-   - 26
-   - 27
-   - 28
-   - 29
-   - 30
-   - 31
    - 32
    - 33
    - 34
@@ -44,6 +36,14 @@ topology:
    - 41
    - 42
    - 43
+   - 44
+   - 45
+   - 46
+   - 47
+   - 48
+   - 49
+   - 50
+   - 51
    - 52
    - 53
    - 54
@@ -56,26 +56,82 @@ topology:
    - 61
    - 62
    - 63
+   - 64
+   - 65
+   - 66
+   - 67
+   - 68
+   - 69
+   - 70
+   - 71
+   - 72
+   - 73
+   - 74
+   - 75
+   - 76
+   - 77
+   - 78
+   - 79
+   - 80
+   - 81
+   - 82
+   - 83
+   - 84
+   - 85
+   - 86
+   - 87
+   - 88
+   - 89
+   - 90
+   - 91
+   - 92
+   - 93
+   - 94
+   - 95
+   - 96
+   - 97
+   - 98
+   - 99
+   - 100
+   - 101
+   - 102
+   - 103
+   - 104
+   - 105
+   - 106
+   - 107
+   - 108
+   - 109
+   - 110
+   - 111
+   - 112
+   - 113
+   - 114
+   - 115
+   - 116
+   - 117
+   - 118
+   - 119
   VMs:
     ARISTA01T1:
       vlans:
-        - 44
-        - 45
+        - 24
+        - 25
       vm_offset: 0
     ARISTA02T1:
       vlans:
-        - 46
-        - 47
+        - 26
+        - 27
       vm_offset: 1
     ARISTA03T1:
       vlans:
-        - 48
-        - 49
+        - 28
+        - 29
       vm_offset: 2
     ARISTA04T1:
       vlans:
-        - 50
-        - 51
+        - 30
+        - 31
       vm_offset: 3
 
 configuration_properties:
@@ -87,8 +143,8 @@ configuration_properties:
     max_tor_subnet_number: 16
     tor_subnet_size: 64
     spine_asn: 65534
-    leaf_asn_start: 64600
-    tor_asn_start: 65100
+    leaf_asn_start: 4200064600
+    tor_asn_start: 4200065100
     failure_rate: 0
     nhipv4: 10.10.246.100
     nhipv6: FC0A::C9
@@ -98,9 +154,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200064600
       peers:
-        65100:
+        4200065100:
         - 10.0.0.32
         - FC00::21
     interfaces:
@@ -122,9 +178,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200064600
       peers:
-        65100:
+        4200065100:
         - 10.0.0.34
         - FC00::25
     interfaces:
@@ -146,9 +202,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200064600
       peers:
-        65100:
+        4200065100:
         - 10.0.0.36
         - FC00::29
     interfaces:
@@ -170,9 +226,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200064600
       peers:
-        65100:
+        4200065100:
         - 10.0.0.38
         - FC00::2D
     interfaces:


### PR DESCRIPTION
1. Finalize T0-116 topology deployment template with production port map.
2. Update FIB, FDB, IP decap, and BGP speaker to work on T0-116 topology.

Change has been tested on a T0 DUT with T0-116 topology
