### PR TITLE
Add ECN WRED configuration test

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -63,6 +63,12 @@ ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} --become --tags 
 ```
 - Requires switch connected to a PTF testbed
 
+##### ECN WRED test
+```
+ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} --become --tags ecn_wred
+```
+- Requires switch connected to a VM testbed
+
 ##### Everflow_testbed test
 ```
 ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} --tags everflow_testbed --extra-vars "testbed_type={TESTBED_TYPE} ptf_host={PTF_HOST}"

--- a/ansible/roles/test/tasks/ecn_wred.yml
+++ b/ansible/roles/test/tasks/ecn_wred.yml
@@ -1,0 +1,47 @@
+### This test implements several test cases from the test plan:
+### https://github.com/Azure/SONiC/wiki/QoS-configuration-in-Config-DB.-ECN-WRED-configuration-utility-test-plan
+### It requires no external connections
+###
+### Usage example:
+###    ansible-playbook test_sonic.yml -i inventory --limit arc-switch1028 --tags qosconfig -e skip_interface_check=true
+
+- set_fact:
+    test_files_dir="roles/test/tasks/qos"
+    tmp_dir="/tmp"
+    test_wred_values="[ '491520', '516096', '430080' ]"
+
+  # Read and store original rmin value for AZURE_LOSSY
+- name: Get red_min_threshold
+  shell: ecnconfig -l | grep -A20 AZURE_LOSSY | grep red_min_threshold | awk '{print $2}'
+  register: wred_value
+  failed_when: wred_value.rc != 0
+
+- set_fact:
+    red_min_threshold={{ wred_value.stdout }}
+
+- block:
+    - name: Copy test files to DUT
+      copy: src={{ item }} dest={{ tmp_dir }}
+      with_fileglob:
+         - "{{ test_files_dir }}/*"
+  vars:
+    ansible_shell_type: docker
+    ansible_python_interpreter: docker exec -i database python
+
+- block:
+    # Test case #3(MA): Check configuration applied
+    - name: Check if ASIC DB configured qos parameters
+      shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_QUEUE* | grep QUEUE
+      register: grep_queue
+      failed_when: grep_queue.rc != 0
+
+    # Run test with different values
+    - include: ecn_wred_worker.yml
+      with_items: "{{ test_wred_values }}"
+
+  always:
+    - name: Restore original value
+      shell: ecnconfig -p AZURE_LOSSY -rmin {{ red_min_threshold }}
+      register: ecn_restore
+      failed_when: ecn_restore.rc != 0
+

--- a/ansible/roles/test/tasks/ecn_wred_worker.yml
+++ b/ansible/roles/test/tasks/ecn_wred_worker.yml
@@ -1,0 +1,15 @@
+### Worker for qos_config.yml
+### Performs test with one given value
+
+# Set value...
+- name: Set WRED value {{ item }}
+  shell: ecnconfig -p AZURE_LOSSY -rmin {{ item }}
+  register: rc
+  failed_when: rc.rc != 0
+
+# ... and check ASIC DB if it is set
+- name: Get WRED objects
+  shell: docker exec database redis-cli -n 1 --eval {{ tmp_dir }}/get_red_min.lua , {{ item }} | grep {{ item }}
+  register: wred_objects
+  failed_when: wred_objects.rc != 0
+

--- a/ansible/roles/test/tasks/qos/get_red_min.lua
+++ b/ansible/roles/test/tasks/qos/get_red_min.lua
@@ -1,0 +1,15 @@
+-- this lua script is used in qosconfig test
+-- it automates walking thru WRED objects in the ASIC DB
+-- to check whether any of objects holds a record with
+-- red min threshold equal to given value
+
+local keys = redis.call("KEYS", "ASIC_STATE:SAI_OBJECT_TYPE_WRED*")
+local res=""
+for i, key in ipairs(keys) do
+  local val = redis.call("HGET", key, "SAI_WRED_ATTR_RED_MIN_THRESHOLD")
+  if val == ARGV[1] then
+    res = val
+  end
+end
+return res
+

--- a/ansible/roles/test/tasks/test_sonic_by_tag.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_tag.yml
@@ -162,6 +162,10 @@
   include: pfc_wd.yml
   tags: pfc_wd
 
+- name: ECN WRED configure test
+  include: ecn_wred.yml
+  tags: ecn_wred
+
 ### when calling this test, please add command line of testbed_type 
 ### -e testbed_type=t1
 - name: BGP multipath relax

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -54,7 +54,11 @@ testcases:
       topologies: [t0, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
- 
+
+    ecn_wred:
+      filename: ecn_wred.yml
+      topologies: [t0, t1, t1-lag]
+
     everflow_testbed:
       filename: everflow_testbed.yml
       topologies: [t1, t1-lag, t1-64-lag]


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

### Description of PR
Tests for the QoS/ECN configuration and ecnconfig utility

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
How did you verify/test it?
`ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} --become --tags ecn_wred`

Any platform specific information?
Platform independent. Requires SAI support set for ECN/WRED parameters

Supported testbed topology if it's a new test case?
Topology independent

### Documentation 
Test plan:
[QoS configuration in Config DB. ECN WRED configuration utility test plan](https://github.com/Azure/SONiC/wiki/QoS-configuration-in-Config-DB.-ECN-WRED-configuration-utility-test-plan)
