### PR TITLE
[deployment] add missing quotation marks that breaks

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -104,7 +104,7 @@
   become: true
   copy:
     src: roles/vm_set/files/vm_resumer.py
-    dest: {{ root_path }}
+    dest: "{{ root_path }}"
     mode: 0755
 
 - name: Retrieve a list of the defined VMs


### PR DESCRIPTION
This change is a bug fix.

  Without these quotation marks, the deployment script is failing

How did you do it?
  Added the missing quotation marks.

How did you verify/test it?
  Deployed a DUT. Without the change the deployment failed, with the change deployment succeeded.
