### PR TITLE
[bug]: change maximum packet to 9114 to send in the mtu test

### DIFF
--- a/ansible/roles/test/files/ptftests/mtu_test.py
+++ b/ansible/roles/test/files/ptftests/mtu_test.py
@@ -27,15 +27,14 @@ class MtuTest(BaseTest):
     back. It also sends a jumbo frame to a route destination for verifying the 
     forwarding functionality
     
-    For the device configured with IP-MTU=9100, PHY-MTU=9122, 
-     - ICMP frame, the packet-len is 9114 (Subtracting 8 bytes of ICMP header from 9122)
-     - IP frame, the packet-len is 9122 (This includes the Layer 2 Ethernet header + FCS)
+    For the device configured with IP-MTU=9100, PHY-MTU=9114,
+     - ICMP/IP frame, the packet-len is 9114 (This includes the 14 bytes Layer 2 Ethernet header)
     '''
 
     #---------------------------------------------------------------------
     # Class variables
     #---------------------------------------------------------------------
-    DEFAULT_PACKET_LEN = 9122
+    DEFAULT_PACKET_LEN = 9114
     ICMP_HDR_LEN = 8
 
     def __init__(self):
@@ -61,7 +60,7 @@ class MtuTest(BaseTest):
         ip_dst = "10.0.0.0"
         src_mac = self.dataplane.get_mac(0, 0)
 
-        pktlen = (self.DEFAULT_PACKET_LEN - self.ICMP_HDR_LEN)
+        pktlen = self.DEFAULT_PACKET_LEN
 
         pkt = simple_icmp_packet(pktlen=pktlen,
                             eth_dst=self.router_mac,


### PR DESCRIPTION

### Description of PR
Since the test packet does not have vlan tag or CRC, only 14 bytes
should added to the L3 MTU (9100+14)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
- change the test packet to 9114 bytes.

How did you verify/test it?
- run mtu test on both broadcom and mellanox platform

Any platform specific information?

Supported testbed topology if it's a new test case?
t1

### Documentation 
N/A