### PR TITLE
[sonic test] introduce a repeat harness

### DIFF
--- a/ansible/roles/test/tasks/repeat_harness.yml
+++ b/ansible/roles/test/tasks/repeat_harness.yml
@@ -1,0 +1,18 @@
+#-------------------------------------------------------------------
+# Repeat harness: Repeat a list of taks defined in repeat_tasks.yml,
+#                 by default, 10 times.
+#                 repeat count can be set by
+#                     --extra-vars 'test_iterations=<num>'
+#-------------------------------------------------------------------
+
+- name: Default test count
+  set_fact:
+    test_count=10
+
+- name: Update test count
+  set_fact:
+      test_count={{test_iterations}}
+  when: test_iterations is defined
+
+- include: repeat_tasks.yml iteration={{item}}
+  with_sequence: start=1 end={{test_count}}

--- a/ansible/roles/test/tasks/repeat_tasks.yml
+++ b/ansible/roles/test/tasks/repeat_tasks.yml
@@ -1,0 +1,9 @@
+- debug:
+    msg: "Repeat harness: iteration {{ iteration }} starts"
+
+# Add tasks here to be repeated:
+# e.g. - include: reboot.yml
+
+- debug:
+    msg: "Repeat harness: iteration {{ iteration }} ends"
+

--- a/ansible/roles/test/tasks/test_sonic_by_tag.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_tag.yml
@@ -106,6 +106,10 @@
   include: reboot.yml
   tags: reboot
 
+- name: Test case repeat harness
+  include: repeat_harness.yml
+  tags: repeat_harness
+
 ### When calling the following tests, please add command line of what testbed_type and which PTF docker to test against
 ### -e "testbed_type=t1-lag ptf_host=10.0.0.200"
 - name: Fib test

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -1,4 +1,8 @@
 testcases:
+    repeat_harness:
+      filename: repeat_harness.yml
+      topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+
     acl: 
       filename: acl.yml
       topologies: [t1, t1-lag, t1-64-lag]


### PR DESCRIPTION
- [x] Test case(improvement)

### Approach
How did you do it?
Introduce a test harness that repeats a user defined task list n times.

By default, n is 10, user can override n with
  -extra-vars 'test_iterations=<num>'

How did you verify/test it?
I needed this infrastructure to repeat some test cases continuously.

Known limitation:
The way ansible-playbook works is that the repeat_tasks.yml will be included <n> times. So when n gets bigger, the time to include becomes very long. There might be other side effects with huge n.