### PR TITLE
[Lag 2] Allow lacp timing tests to retry limited times until succeeded

### DIFF
--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -83,6 +83,7 @@ class LacpTimingTest(BaseTest,RouterUtility):
     @ param: timeout        -   time to expect the LACP packet.
     @ param: packet_timing         -   time between two packets.
     @ param: ether_type     -   Ethernet type of expected packet.
+    @ param: interval_count -   Number of intervals to collect.
     '''
 
     def __init__(self):
@@ -96,17 +97,28 @@ class LacpTimingTest(BaseTest,RouterUtility):
         self.dataplane = ptf.dataplane_instance
 
     def getTimeInterval(self, masked_exp_pkt):
+        intervals = []
         # Verify two LACP packets.
-        (rcv_device, rcv_port, rcv_pkt, first_pkt_time) = self.dataplane.poll(port_number=self.exp_iface, timeout=self.timeout, exp_pkt=masked_exp_pkt)
         (rcv_device, rcv_port, rcv_pkt, last_pkt_time) = self.dataplane.poll(port_number=self.exp_iface, timeout=self.timeout, exp_pkt=masked_exp_pkt)
-
-        # Check the packet received.
-        self.assertTrue(rcv_pkt != None, "Failed to receive LACP packet\n")
-
-        # Get current packet timing
-        first_pkt_time = round(float(first_pkt_time), 2)
         last_pkt_time = round(float(last_pkt_time), 2)
-        current_pkt_timing = last_pkt_time - first_pkt_time
+
+        for i in range(0, self.interval_count):
+            (rcv_device, rcv_port, rcv_pkt, curr_pkt_time) = self.dataplane.poll(port_number=self.exp_iface, timeout=self.timeout, exp_pkt=masked_exp_pkt)
+
+            # Check the packet received.
+            self.assertTrue(rcv_pkt != None, "Failed to receive LACP packet\n")
+
+            # Get current packet timing
+            curr_pkt_time = round(float(curr_pkt_time), 2)
+
+            interval   = curr_pkt_time - last_pkt_time
+            intervals += [ interval ]
+
+            last_pkt_time = curr_pkt_time
+
+        # Get the median
+        intervals.sort()
+        current_pkt_timing = intervals[self.interval_count / 2]
         return current_pkt_timing
 
 
@@ -117,6 +129,13 @@ class LacpTimingTest(BaseTest,RouterUtility):
         self.timeout = self.test_params['timeout']
         self.packet_timing = self.test_params['packet_timing']
         self.ether_type = self.test_params['ether_type']
+        self.interval_count = int(self.test_params['interval_count'])
+        if self.interval_count < 1:
+            self.interval_count = 3
+
+        # Make sure the interval count is odd, so that we only look at one median interval
+        if self.interval_count % 2 == 0:
+            self.interval_count += 1
 
         # Generate a packet.
         exp_pkt = simple_eth_packet(eth_type=self.ether_type)
@@ -132,16 +151,5 @@ class LacpTimingTest(BaseTest,RouterUtility):
         self.dataplane.flush()
 
         # Check that packet timing matches the expected value.
-        current_pkt_timing = 0
-        retry_count = 0
-        while retry_count < 10:
-            try:
-                current_pkt_timing = self.getTimeInterval(masked_exp_pkt)
-                if abs(current_pkt_timing - float(self.packet_timing)) < 0.1:
-                    break
-                retry_count += 1
-            except:
-                retry_count += 1
-                pass
-
-        self.assertTrue(abs(current_pkt_timing - float(self.packet_timing)) < 0.1, "Bad packet timing: %.2f seconds while expected timing is %d seconds from %s" % (current_pkt_timing, self.packet_timing, self.exp_iface))
+        current_pkt_timing = self.getTimeInterval(masked_exp_pkt)
+        self.assertTrue(abs(current_pkt_timing - float(self.packet_timing)) < 0.1, "Bad packet timing: %.2f seconds while expected timing is %d seconds from port %s out of %d intervals" % (current_pkt_timing, self.packet_timing, self.exp_iface, self.interval_count))

--- a/ansible/roles/test/files/acstests/lag_test.py
+++ b/ansible/roles/test/files/acstests/lag_test.py
@@ -96,7 +96,7 @@ class LacpTimingTest(BaseTest,RouterUtility):
         '''
         self.dataplane = ptf.dataplane_instance
 
-    def getTimeInterval(self, masked_exp_pkt):
+    def getMedianInterval(self, masked_exp_pkt):
         intervals = []
         # Verify two LACP packets.
         (rcv_device, rcv_port, rcv_pkt, last_pkt_time) = self.dataplane.poll(port_number=self.exp_iface, timeout=self.timeout, exp_pkt=masked_exp_pkt)
@@ -151,5 +151,5 @@ class LacpTimingTest(BaseTest,RouterUtility):
         self.dataplane.flush()
 
         # Check that packet timing matches the expected value.
-        current_pkt_timing = self.getTimeInterval(masked_exp_pkt)
+        current_pkt_timing = self.getMedianInterval(masked_exp_pkt)
         self.assertTrue(abs(current_pkt_timing - float(self.packet_timing)) < 0.1, "Bad packet timing: %.2f seconds while expected timing is %d seconds from port %s out of %d intervals" % (current_pkt_timing, self.packet_timing, self.exp_iface, self.interval_count))

--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -57,6 +57,10 @@
   include_vars: vars/topo_t0.yml
   when: testbed_type == 't0'
 
+- name: Include testbed topology configuration (to get LAG IP and PTF docker interfaces, that are behind LAG VMs).
+  include_vars: vars/topo_t0-116.yml
+  when: testbed_type == 't0-116'
+
 - set_fact:
     dut_mac: "{{ ansible_Ethernet0['macaddress'] }}"
 

--- a/ansible/roles/test/tasks/lag_lacp_timing_test.yml
+++ b/ansible/roles/test/tasks/lag_lacp_timing_test.yml
@@ -7,6 +7,10 @@
 # @ params: iface_behind_lag_member_0   -   PTF docker iface, that receives all the packets that VM LAG member does.
 # @ params: iface_behind_lag_member_1   -   PTF docker iface, that receives all the packets that VM LAG member does.
 # @ params: vm_name     -       VM hostname that will be printed before running test.
+# @ params: interval_count              -   specifying how many packet internvals to test.
+#                                           When internval count is n, n+1 packets will be
+#                                           received to get n internvals, the test will
+#                                           then check the median internval.
 # 
 # Originally in lagall.yml, and lag_2.yml should cover it 
 #--------------------------------------------------------
@@ -16,17 +20,23 @@
     packet_timing: "{{ lacp_timer }}"
     packet_timeout: 35
 
+- set_fact:
+    interval_count: 3
+  when: interval_count is not defined
+
+- debug: msg="Finding median of {{ interval_count }} packet intervals"
+
 - name: Check LACP timing on eth{{ iface_behind_lag_member[0] }} (interface behind {{ vm_name }}).
   include: lag_run_ptf.yml
   vars:
     lag_ptf_test_name: LacpTimingTest
-    params: "exp_iface={{ iface_behind_lag_member[0] }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}"
+    params: "exp_iface={{ iface_behind_lag_member[0] }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}; interval_count={{ interval_count }}"
     change_dir: /tmp
 
 - name: Check LACP timing on eth{{ iface_behind_lag_member[1] }} (interface behind {{ vm_name }}).
   include: lag_run_ptf.yml
   vars:
     lag_ptf_test_name: LacpTimingTest
-    params: "exp_iface={{ iface_behind_lag_member[1] }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}"
+    params: "exp_iface={{ iface_behind_lag_member[1] }}; timeout={{ packet_timeout }}; packet_timing={{ packet_timing }}; ether_type={{ lacp_ether_type }}; interval_count={{ interval_count }}"
     change_dir: /tmp
   when: iface_behind_lag_member[1] is defined

--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -81,6 +81,7 @@
   vars: 
     vm_name: "{{ peer_device }}"
     lacp_timer: 1
+    interval_count: 3
 
 # make sure portchannel peer rate is set to slow
 - name: make sure all lag members on VM are set to slow
@@ -98,3 +99,4 @@
   vars: 
     vm_name: "{{ peer_device }}"
     lacp_timer: 30
+    interval_count: 3


### PR DESCRIPTION
- [X ] Test case(new/improvement)

### Approach
How did you do it?
lag_2 test has a pretty high failure rate. Most failures are at the lacp frame timing test. This test is testing if DUT would receive LACP frames at the internal consistent with the rate setting, fast: 1 sec, normal: 30 seconds. Test failures are almost always failed to receive 2 packets at the specified interval.

There are too many reasons that could happen. I propose that as long as we receive a pair of frames fits the expected interval within reasonable number of retries (10), the test should pass.

How did you verify/test it?
Repeated execute the lag_2 test, normally the test would fail with 10 retries. With the change, test executed for 70+ times.
