### PR TITLE
[vm]: change the default Front plane port to 4 instead of 8

### DIFF
--- a/ansible/group_vars/vm_host/main.yml
+++ b/ansible/group_vars/vm_host/main.yml
@@ -6,6 +6,7 @@ skip_image_downloading: false
 
 vm_console_base: 7000
 memory: 2097152
+max_fp_num: 4
 
 # proxy
 proxy_env:

--- a/ansible/roles/eos/tasks/main.yml
+++ b/ansible/roles/eos/tasks/main.yml
@@ -8,15 +8,27 @@
   set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
 
 - name: Extract VM names from the inventory
-  set_fact: VM_hosts={{ groups[current_server] | filter_by_prefix('VM') }}
+  set_fact: VM_list={{ groups[current_server] | filter_by_prefix('VM') }}
+
+- name: Get VM host name
+  set_fact: VM_host={{ groups[current_server] | difference(VM_list) }}
 
 - name: Generate hostname for target VM
-  set_fact: hostname={{ VM_hosts | extract_hostname(topology['VMs'], VM_base, inventory_hostname) }}
+  set_fact: hostname={{ VM_list | extract_hostname(topology['VMs'], VM_base, inventory_hostname) }}
   when: topology['VMs'] is defined
 
 - fail:
     msg: "cannot find {{ inventory_hostname }} in the topology"
   when: hostname == "hostname not found"
+
+- name: Get VM front panel interface number
+  shell: virsh domiflist {{ inventory_hostname }} | grep -E "^{{ inventory_hostname }}-t" | wc -l
+  register: fp_num
+  delegate_to: "{{ VM_host[0] }}"
+  become: yes
+
+- name: Set EOS backplane port name
+  set_fact: bp_ifname="Ethernet{{ fp_num.stdout|int + 1 }}"
 
 - name: Set properties list to default value, when properties are not defined
   set_fact: properties_list=[]

--- a/ansible/roles/eos/templates/t0-64-32-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-32-leaf.j2
@@ -98,6 +98,19 @@ interface {{ name }}
 !
 {% endfor %}
 !
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 {% for podset in range(0, props.podset_number) %}
 {% if range(0, 1000)|random() >= props.failure_rate %}
 {% for tor in range(0, props.tor_number) %}

--- a/ansible/roles/eos/templates/t0-64-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-leaf.j2
@@ -98,6 +98,19 @@ interface {{ name }}
 !
 {% endfor %}
 !
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 {% for podset in range(0, props.podset_number) %}
 {% if range(0, 1000)|random() >= props.failure_rate %}
 {% for tor in range(0, props.tor_number) %}

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -98,6 +98,19 @@ interface {{ name }}
 !
 {% endfor %}
 !
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 {% for podset in range(0, props.podset_number) %}
 {% if range(0, 1000)|random() >= props.failure_rate %}
 {% for tor in range(0, props.tor_number) %}

--- a/ansible/roles/eos/templates/t1-64-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-spine.j2
@@ -77,6 +77,20 @@ interface {{ name }}
  no shutdown
 !
 {% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 {% for podset in range(0, props.podset_number) %}
 {% if range(0, 1000)|random() >= props.failure_rate %}
 {% for tor in range(0, props.tor_number) %}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -81,6 +81,20 @@ interface {{ name }}
  no shutdown
 !
 {% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  !

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -77,6 +77,20 @@ interface {{ name }}
  no shutdown
 !
 {% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 {% for podset in range(0, props.podset_number) %}
 {% if range(0, 1000)|random() >= props.failure_rate %}
 {% for tor in range(0, props.tor_number) %}

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -73,6 +73,20 @@ interface {{ name }}
  no shutdown
 !
 {% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  !

--- a/ansible/roles/eos/templates/t1-spine.j2
+++ b/ansible/roles/eos/templates/t1-spine.j2
@@ -70,6 +70,20 @@ interface {{ name }}
  no shutdown
 !
 {% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 {% for podset in range(0, props.podset_number) %}
 {% if range(0, 1000)|random() >= props.failure_rate %}
 {% for tor in range(0, props.tor_number) %}

--- a/ansible/roles/eos/templates/t1-tor.j2
+++ b/ansible/roles/eos/templates/t1-tor.j2
@@ -73,6 +73,20 @@ interface {{ name }}
  no shutdown
 !
 {% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  !

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -30,4 +30,5 @@
     mgmt_bridge: "{{ mgmt_bridge }}"
     ext_iface: "{{ external_iface }}"
     fp_mtu: "{{ fp_mtu_size }}"
+    max_fp_num: "{{ max_fp_num }}"
   become: yes

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -14,4 +14,5 @@
     vm_base: "{{ VM_base }}"
     vlan_base: "{{ vlan_base }}"
     ext_iface: "{{ external_iface }}"
+    max_fp_num: "{{ max_fp_num }}"
   become: yes

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -32,4 +32,5 @@
     mgmt_bridge: "{{ mgmt_bridge }}"
     ext_iface: "{{ external_iface }}"
     fp_mtu: "{{ fp_mtu_size }}"
+    max_fp_num: "{{ max_fp_num }}"
   become: yes

--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -52,6 +52,7 @@
     cmd:          'create'
     vm_names:     "{{ VM_hosts }}"
     fp_mtu:       "{{ fp_mtu_size }}"
+    max_fp_num:   "{{ max_fp_num }}"
 
 - name: Start VMs
   include: start_vm.yml
@@ -62,22 +63,6 @@
     serial_port: "{{ vm_console_base|int + vm_name[4:]|int }}"
     disk_image: "{{ root_path }}/disks/{{ vm_name }}_hdd.vmdk"
     mgmt_tap:  "{{ vm_name }}-m"
-    fp0_bridge: "br-{{ vm_name }}-0"
-    fp0_tap: "{{ vm_name }}-t0"
-    fp1_bridge: "br-{{ vm_name }}-1"
-    fp1_tap: "{{ vm_name }}-t1"
-    fp2_bridge: "br-{{ vm_name }}-2"
-    fp2_tap: "{{ vm_name }}-t2"
-    fp3_bridge: "br-{{ vm_name }}-3"
-    fp3_tap: "{{ vm_name }}-t3"
-    fp4_bridge: "br-{{ vm_name }}-4"
-    fp4_tap: "{{ vm_name }}-t4"
-    fp5_bridge: "br-{{ vm_name }}-5"
-    fp5_tap: "{{ vm_name }}-t5"
-    fp6_bridge: "br-{{ vm_name }}-6"
-    fp6_tap: "{{ vm_name }}-t6"
-    fp7_bridge: "br-{{ vm_name }}-7"
-    fp7_tap: "{{ vm_name }}-t7"
     port1_bridge: "br-{{ vm_name }}-back"
     port1_tap: "{{ vm_name }}-back"
   with_items: "{{ VM_hosts }}"

--- a/ansible/roles/vm_set/tasks/stop.yml
+++ b/ansible/roles/vm_set/tasks/stop.yml
@@ -8,5 +8,5 @@
 - name: Destroy VMs network
   vm_topology:
     cmd: 'destroy'
-    vm_names: "{{ VM_hosts }}"
+    vm_names:     "{{ VM_hosts }}"
   become: yes

--- a/ansible/roles/vm_set/templates/arista.xml.j2
+++ b/ansible/roles/vm_set/templates/arista.xml.j2
@@ -37,54 +37,14 @@
       <source bridge='{{ mgmt_bridge }}'/>
       <target dev='{{ mgmt_tap }}'/>
     </interface>
+{% for fp_num in range(0, max_fp_num) %}
     <interface type='bridge'>
       <model type='virtio'/>
-      <source bridge='{{ fp0_bridge }}'/>
-      <target dev='{{ fp0_tap }}'/>
+      <source bridge='br-{{ vm_name }}-{{ fp_num }}'/>
+      <target dev='{{ vm_name }}-t{{ fp_num }}'/>
       <virtualport type='openvswitch'/>
     </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp1_bridge }}'/>
-      <target dev='{{ fp1_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp2_bridge }}'/>
-      <target dev='{{ fp2_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp3_bridge }}'/>
-      <target dev='{{ fp3_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp4_bridge }}'/>
-      <target dev='{{ fp4_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp5_bridge }}'/>
-      <target dev='{{ fp5_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp6_bridge }}'/>
-      <target dev='{{ fp6_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
-    <interface type='bridge'>
-      <model type='virtio'/>
-      <source bridge='{{ fp7_bridge }}'/>
-      <target dev='{{ fp7_tap }}'/>
-      <virtualport type='openvswitch'/>
-    </interface>
+{% endfor %}
     <interface type='bridge'>
       <model type='virtio'/>
       <source bridge='{{ port1_bridge }}'/>

--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -167,12 +167,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.33/24
-        ipv6: fc0a::23/64
       Port-Channel1:
         ipv4: 10.0.0.33/31
         ipv6: fc00::22/126
+    bp_interface:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::23/64
 
   ARISTA02T1:
     properties:
@@ -191,12 +191,12 @@ configuration:
         lacp: 2
       Ethernet2:
         lacp: 2
-      Ethernet9:
-        ipv4: 10.10.246.35/24
-        ipv6: fc0a::26/64
       Port-Channel2:
         ipv4: 10.0.0.35/31
         ipv6: fc00::26/126
+    bp_interface:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::26/64
 
   ARISTA03T1:
     properties:
@@ -215,12 +215,12 @@ configuration:
         lacp: 3
       Ethernet2:
         lacp: 3
-      Ethernet9:
-        ipv4: 10.10.246.37/24
-        ipv6: fc0a::2A/64
       Port-Channel3:
         ipv4: 10.0.0.37/31
         ipv6: fc00::2A/126
+    bp_interface:
+      ipv4: 10.10.246.37/24
+      ipv6: fc0a::2A/64
 
   ARISTA04T1:
     properties:
@@ -239,9 +239,9 @@ configuration:
         lacp: 4
       Ethernet2:
         lacp: 4
-      Ethernet9:
-        ipv4: 10.10.246.39/24
-        ipv6: fc0a::2E/64
       Port-Channel4:
         ipv4: 10.0.0.39/31
         ipv6: fc00::2E/126
+    bp_interface:
+      ipv4: 10.10.246.39/24
+      ipv6: fc0a::2E/64

--- a/ansible/vars/topo_t0-64-32.yml
+++ b/ansible/vars/topo_t0-64-32.yml
@@ -79,12 +79,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.1/24
-        ipv6: fc0a::1/64
       Port-Channel1:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::1/64
 
   ARISTA02T1:
     properties:
@@ -103,12 +103,12 @@ configuration:
         lacp: 4
       Ethernet2:
         lacp: 4
-      Ethernet9:
-        ipv4: 10.10.246.2/24
-        ipv6: fc0a::2/64
       Port-Channel4:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::2/64
 
   ARISTA03T1:
     properties:
@@ -127,12 +127,12 @@ configuration:
         lacp: 16
       Ethernet2:
         lacp: 16
-      Ethernet9:
-        ipv4: 10.10.246.3/24
-        ipv6: fc0a::3/64
       Port-Channel16:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::3/64
 
   ARISTA04T1:
     properties:
@@ -151,10 +151,10 @@ configuration:
         lacp: 20
       Ethernet2:
         lacp: 20
-      Ethernet9:
-        ipv4: 10.10.246.4/24
-        ipv6: fc0a::4/64
       Port-Channel20:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::4/64
 

--- a/ansible/vars/topo_t0-64.yml
+++ b/ansible/vars/topo_t0-64.yml
@@ -111,12 +111,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.1/24
-        ipv6: fc0a::1/64
       Port-Channel1:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::1/64
 
   ARISTA02T1:
     properties:
@@ -135,12 +135,12 @@ configuration:
         lacp: 4
       Ethernet2:
         lacp: 4
-      Ethernet9:
-        ipv4: 10.10.246.2/24
-        ipv6: fc0a::2/64
       Port-Channel4:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::2/64
 
   ARISTA03T1:
     properties:
@@ -159,12 +159,12 @@ configuration:
         lacp: 16
       Ethernet2:
         lacp: 16
-      Ethernet9:
-        ipv4: 10.10.246.3/24
-        ipv6: fc0a::3/64
       Port-Channel16:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::3/64
 
   ARISTA04T1:
     properties:
@@ -183,9 +183,9 @@ configuration:
         lacp: 20
       Ethernet2:
         lacp: 20
-      Ethernet9:
-        ipv4: 10.10.246.4/24
-        ipv6: fc0a::4/64
       Port-Channel20:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::4/64

--- a/ansible/vars/topo_t0.yml
+++ b/ansible/vars/topo_t0.yml
@@ -77,12 +77,12 @@ configuration:
         ipv6: 2064:100::1d/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.29/24
-        ipv6: fc0a::3a/64
       Port-Channel1:
         ipv4: 10.0.0.57/31
         ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
 
   ARISTA02T1:
     properties:
@@ -99,12 +99,12 @@ configuration:
         ipv6: 2064:100::1e/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.30/24
-        ipv6: fc0a::3d/64
       Port-Channel1:
         ipv4: 10.0.0.59/31
         ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
 
   ARISTA03T1:
     properties:
@@ -121,12 +121,12 @@ configuration:
         ipv6: 2064:100::1f/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.31/24
-        ipv6: fc0a::3e/64
       Port-Channel1:
         ipv4: 10.0.0.61/31
         ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
 
   ARISTA04T1:
     properties:
@@ -143,10 +143,9 @@ configuration:
         ipv6: 2064:100::20/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.32/24
-        ipv6: fc0a::41/64
       Port-Channel1:
         ipv4: 10.0.0.63/31
         ipv6: fc00::7e/126
-
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64

--- a/ansible/vars/topo_t1-64-lag.yml
+++ b/ansible/vars/topo_t1-64-lag.yml
@@ -136,12 +136,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.1/24
-        ipv6: fc0a::2/64
       Port-Channel1:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
 
   ARISTA03T2:
     properties:
@@ -161,12 +161,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.3/24
-        ipv6: fc0a::6/64
       Port-Channel1:
         ipv4: 10.0.0.5/31
         ipv6: fc00::6/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::6/64
 
   ARISTA05T2:
     properties:
@@ -186,12 +186,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.5/24
-        ipv6: fc0a::a/64
       Port-Channel1:
         ipv4: 10.0.0.9/31
         ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::a/64
 
   ARISTA07T2:
     properties:
@@ -211,12 +211,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.7/24
-        ipv6: fc0a::e/64
       Port-Channel1:
         ipv4: 10.0.0.13/31
         ipv6: fc00::e/126
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::e/64
 
   ARISTA01T0:
     properties:
@@ -235,12 +235,12 @@ configuration:
         ipv6: 2064:100::11/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.17/24
-        ipv6: fc0a::22/64
       Port-Channel1:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::22/64
 
   ARISTA02T0:
     properties:
@@ -259,12 +259,12 @@ configuration:
         ipv6: 2064:100::12/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.18/24
-        ipv6: fc0a::25/64
       Port-Channel1:
         ipv4: 10.0.0.35/31
         ipv6: fc00::46/126
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::25/64
 
   ARISTA03T0:
     properties:
@@ -283,17 +283,17 @@ configuration:
         ipv6: 2064:100::13/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.19/24
-        ipv6: fc0a::26/64
       Port-Channel1:
         ipv4: 10.0.0.37/31
         ipv6: fc00::4a/126
-      vips:
-        ipv4: 
-          prefixes:
-            - 200.0.1.0/26
-          asn: 64700
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::26/64
+    vips:
+      ipv4: 
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
 
   ARISTA04T0:
     properties:
@@ -312,12 +312,12 @@ configuration:
         ipv6: 2064:100::14/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.20/24
-        ipv6: fc0a::29/64
       Port-Channel1:
         ipv4: 10.0.0.39/31
         ipv6: fc00::4e/126
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::29/64
 
   ARISTA05T0:
     properties:
@@ -336,17 +336,17 @@ configuration:
         ipv6: 2064:100::15/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.21/24
-        ipv6: fc0a::2a/64
       Port-Channel1:
         ipv4: 10.0.0.41/31
         ipv6: fc00::52/126
-      vips:
-        ipv4: 
-          prefixes:
-            - 200.0.1.0/26
-          asn: 64700
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::2a/64
+    vips:
+      ipv4: 
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
 
   ARISTA06T0:
     properties:
@@ -365,12 +365,12 @@ configuration:
         ipv6: 2064:100::16/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.22/24
-        ipv6: fc0a::2d/64
       Port-Channel1:
         ipv4: 10.0.0.43/31
         ipv6: fc00::56/126
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::2d/64
 
   ARISTA07T0:
     properties:
@@ -389,12 +389,12 @@ configuration:
         ipv6: 2064:100::17/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.23/24
-        ipv6: fc0a::2e/64
       Port-Channel1:
         ipv4: 10.0.0.45/31
         ipv6: fc00::5a/126
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::2e/64
 
   ARISTA08T0:
     properties:
@@ -413,12 +413,12 @@ configuration:
         ipv6: 2064:100::18/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.24/24
-        ipv6: fc0a::31/64
       Port-Channel1:
         ipv4: 10.0.0.47/31
         ipv6: fc00::5e/126
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::31/64
 
   ARISTA09T0:
     properties:
@@ -437,12 +437,12 @@ configuration:
         ipv6: 2064:100::19/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.25/24
-        ipv6: fc0a::32/64
       Port-Channel1:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::32/64
 
   ARISTA10T0:
     properties:
@@ -461,12 +461,12 @@ configuration:
         ipv6: 2064:100::1a/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.26/24
-        ipv6: fc0a::35/64
       Port-Channel1:
         ipv4: 10.0.0.51/31
         ipv6: fc00::66/126
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::35/64
 
   ARISTA11T0:
     properties:
@@ -485,12 +485,12 @@ configuration:
         ipv6: 2064:100::1b/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.27/24
-        ipv6: fc0a::36/64
       Port-Channel1:
         ipv4: 10.0.0.53/31
         ipv6: fc00::6a/126
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::36/64
 
   ARISTA12T0:
     properties:
@@ -509,12 +509,12 @@ configuration:
         ipv6: 2064:100::1c/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.28/24
-        ipv6: fc0a::39/64
       Port-Channel1:
         ipv4: 10.0.0.55/31
         ipv6: fc00::6e/126
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::39/64
 
   ARISTA13T0:
     properties:
@@ -533,12 +533,12 @@ configuration:
         ipv6: 2064:100::1d/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.29/24
-        ipv6: fc0a::3a/64
       Port-Channel1:
         ipv4: 10.0.0.57/31
         ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
 
   ARISTA14T0:
     properties:
@@ -557,12 +557,12 @@ configuration:
         ipv6: 2064:100::1e/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.30/24
-        ipv6: fc0a::3d/64
       Port-Channel1:
         ipv4: 10.0.0.59/31
         ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
 
   ARISTA15T0:
     properties:
@@ -581,12 +581,12 @@ configuration:
         ipv6: 2064:100::1f/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.31/24
-        ipv6: fc0a::3e/64
       Port-Channel1:
         ipv4: 10.0.0.61/31
         ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
 
   ARISTA16T0:
     properties:
@@ -605,12 +605,12 @@ configuration:
         ipv6: 2064:100::20/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.32/24
-        ipv6: fc0a::41/64
       Port-Channel1:
         ipv4: 10.0.0.63/31
         ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
 
   ARISTA17T0:
     properties:
@@ -629,12 +629,12 @@ configuration:
         ipv6: 2064:100::21/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.33/24
-        ipv6: fc0a::43/64
       Port-Channel1:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
+    bp_interface:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::43/64
 
   ARISTA18T0:
     properties:
@@ -653,12 +653,12 @@ configuration:
         ipv6: 2064:100::22/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.34/24
-        ipv6: fc0a::45/64
       Port-Channel1:
         ipv4: 10.0.0.67/31
         ipv6: fc00::86/126
+    bp_interface:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::45/64
 
   ARISTA19T0:
     properties:
@@ -677,12 +677,12 @@ configuration:
         ipv6: 2064:100::23/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.35/24
-        ipv6: fc0a::47/64
       Port-Channel1:
         ipv4: 10.0.0.69/31
         ipv6: fc00::8a/126
+    bp_interface:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::47/64
 
   ARISTA20T0:
     properties:
@@ -701,9 +701,9 @@ configuration:
         ipv6: 2064:100::24/128
       Ethernet1:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.36/24
-        ipv6: fc0a::49/64
       Port-Channel1:
         ipv4: 10.0.0.71/31
         ipv6: fc00::8e/126
+    bp_interface:
+      ipv4: 10.10.246.36/24
+      ipv6: fc0a::49/64

--- a/ansible/vars/topo_t1-lag.yml
+++ b/ansible/vars/topo_t1-lag.yml
@@ -140,12 +140,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.1/24
-        ipv6: fc0a::2/64
       Port-Channel1:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
 
   ARISTA03T2:
     properties:
@@ -165,12 +165,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.3/24
-        ipv6: fc0a::6/64
       Port-Channel1:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::6/64
 
   ARISTA05T2:
     properties:
@@ -190,12 +190,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.5/24
-        ipv6: fc0a::a/64
       Port-Channel1:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::a/64
 
   ARISTA07T2:
     properties:
@@ -215,12 +215,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.7/24
-        ipv6: fc0a::e/64
       Port-Channel1:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::e/64
 
   ARISTA09T2:
     properties:
@@ -240,12 +240,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.9/24
-        ipv6: fc0a::12/64
       Port-Channel1:
         ipv4: 10.0.0.17/31
         ipv6: fc00::22/126
+    bp_interface:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::12/64
 
   ARISTA11T2:
     properties:
@@ -265,12 +265,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.11/24
-        ipv6: fc0a::16/64
       Port-Channel1:
         ipv4: 10.0.0.21/31
         ipv6: fc00::2a/126
+    bp_interface:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::16/64
 
   ARISTA13T2:
     properties:
@@ -290,12 +290,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.13/24
-        ipv6: fc0a::1a/64
       Port-Channel1:
         ipv4: 10.0.0.25/31
         ipv6: fc00::32/126
+    bp_interface:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::1a/64
 
   ARISTA15T2:
     properties:
@@ -315,12 +315,12 @@ configuration:
         lacp: 1
       Ethernet2:
         lacp: 1
-      Ethernet9:
-        ipv4: 10.10.246.15/24
-        ipv6: fc0a::1e/64
       Port-Channel1:
         ipv4: 10.0.0.29/31
         ipv6: fc00::3a/126
+    bp_interface:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::1e/64
 
   ARISTA01T0:
     properties:
@@ -340,9 +340,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
-      Ethernet9:
-        ipv4: 10.10.246.17/24
-        ipv6: fc0a::22/64
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::22/64
     vips:
       ipv4:
         prefixes:
@@ -367,9 +367,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.35/31
         ipv6: fc00::46/126
-      Ethernet9:
-        ipv4: 10.10.246.18/24
-        ipv6: fc0a::25/64
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::25/64
 
   ARISTA03T0:
     properties:
@@ -389,9 +389,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.37/31
         ipv6: fc00::4a/126
-      Ethernet9:
-        ipv4: 10.10.246.19/24
-        ipv6: fc0a::26/64
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::26/64
     vips:
       ipv4:
         prefixes:
@@ -416,9 +416,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.39/31
         ipv6: fc00::4e/126
-      Ethernet9:
-        ipv4: 10.10.246.20/24
-        ipv6: fc0a::29/64
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::29/64
 
   ARISTA05T0:
     properties:
@@ -438,9 +438,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.41/31
         ipv6: fc00::52/126
-      Ethernet9:
-        ipv4: 10.10.246.21/24
-        ipv6: fc0a::2a/64
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::2a/64
 
   ARISTA06T0:
     properties:
@@ -460,9 +460,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.43/31
         ipv6: fc00::56/126
-      Ethernet9:
-        ipv4: 10.10.246.22/24
-        ipv6: fc0a::2d/64
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::2d/64
 
   ARISTA07T0:
     properties:
@@ -482,9 +482,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.45/31
         ipv6: fc00::5a/126
-      Ethernet9:
-        ipv4: 10.10.246.23/24
-        ipv6: fc0a::2e/64
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::2e/64
 
   ARISTA08T0:
     properties:
@@ -504,9 +504,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.47/31
         ipv6: fc00::5e/126
-      Ethernet9:
-        ipv4: 10.10.246.24/24
-        ipv6: fc0a::31/64
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::31/64
 
   ARISTA09T0:
     properties:
@@ -526,9 +526,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
-      Ethernet9:
-        ipv4: 10.10.246.25/24
-        ipv6: fc0a::32/64
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::32/64
 
   ARISTA10T0:
     properties:
@@ -548,9 +548,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.51/31
         ipv6: fc00::66/126
-      Ethernet9:
-        ipv4: 10.10.246.26/24
-        ipv6: fc0a::35/64
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::35/64
 
   ARISTA11T0:
     properties:
@@ -570,9 +570,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.53/31
         ipv6: fc00::6a/126
-      Ethernet9:
-        ipv4: 10.10.246.27/24
-        ipv6: fc0a::36/64
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::36/64
 
   ARISTA12T0:
     properties:
@@ -592,9 +592,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.55/31
         ipv6: fc00::6e/126
-      Ethernet9:
-        ipv4: 10.10.246.28/24
-        ipv6: fc0a::39/64
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::39/64
 
   ARISTA13T0:
     properties:
@@ -614,9 +614,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.57/31
         ipv6: fc00::72/126
-      Ethernet9:
-        ipv4: 10.10.246.29/24
-        ipv6: fc0a::3a/64
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
 
   ARISTA14T0:
     properties:
@@ -636,9 +636,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.59/31
         ipv6: fc00::76/126
-      Ethernet9:
-        ipv4: 10.10.246.30/24
-        ipv6: fc0a::3d/64
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
 
   ARISTA15T0:
     properties:
@@ -658,9 +658,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.61/31
         ipv6: fc00::7a/126
-      Ethernet9:
-        ipv4: 10.10.246.31/24
-        ipv6: fc0a::3e/64
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
 
   ARISTA16T0:
     properties:
@@ -680,7 +680,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.63/31
         ipv6: fc00::7e/126
-      Ethernet9:
-        ipv4: 10.10.246.32/24
-        ipv6: fc0a::41/64
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
 

--- a/ansible/vars/topo_t1.yml
+++ b/ansible/vars/topo_t1.yml
@@ -163,9 +163,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
-      Ethernet9:
-        ipv4: 10.10.246.1/24
-        ipv6: fc0a::2/64
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
 
   ARISTA02T2:
     properties:
@@ -184,9 +184,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.3/31
         ipv6: fc00::6/126
-      Ethernet9:
-        ipv4: 10.10.246.2/24
-        ipv6: fc0a::5/64
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::5/64
 
   ARISTA03T2:
     properties:
@@ -205,9 +205,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
-      Ethernet9:
-        ipv4: 10.10.246.3/24
-        ipv6: fc0a::6/64
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::6/64
 
   ARISTA04T2:
     properties:
@@ -226,9 +226,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.7/31
         ipv6: fc00::e/126
-      Ethernet9:
-        ipv4: 10.10.246.4/24
-        ipv6: fc0a::9/64
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::9/64
 
   ARISTA05T2:
     properties:
@@ -247,9 +247,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
-      Ethernet9:
-        ipv4: 10.10.246.5/24
-        ipv6: fc0a::a/64
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::a/64
 
   ARISTA06T2:
     properties:
@@ -268,9 +268,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.11/31
         ipv6: fc00::16/126
-      Ethernet9:
-        ipv4: 10.10.246.6/24
-        ipv6: fc0a::d/64
+    bp_interface:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::d/64
 
   ARISTA07T2:
     properties:
@@ -289,9 +289,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
-      Ethernet9:
-        ipv4: 10.10.246.7/24
-        ipv6: fc0a::e/64
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::e/64
 
   ARISTA08T2:
     properties:
@@ -310,9 +310,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.15/31
         ipv6: fc00::1e/126
-      Ethernet9:
-        ipv4: 10.10.246.8/24
-        ipv6: fc0a::11/64
+    bp_interface:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::11/64
 
   ARISTA09T2:
     properties:
@@ -331,9 +331,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.17/31
         ipv6: fc00::22/126
-      Ethernet9:
-        ipv4: 10.10.246.9/24
-        ipv6: fc0a::12/64
+    bp_interface:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::12/64
 
   ARISTA10T2:
     properties:
@@ -352,9 +352,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.19/31
         ipv6: fc00::26/126
-      Ethernet9:
-        ipv4: 10.10.246.10/24
-        ipv6: fc0a::15/64
+    bp_interface:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::15/64
 
   ARISTA11T2:
     properties:
@@ -373,9 +373,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.21/31
         ipv6: fc00::2a/126
-      Ethernet9:
-        ipv4: 10.10.246.11/24
-        ipv6: fc0a::16/64
+    bp_interface:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::16/64
 
   ARISTA12T2:
     properties:
@@ -394,9 +394,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.23/31
         ipv6: fc00::2e/126
-      Ethernet9:
-        ipv4: 10.10.246.12/24
-        ipv6: fc0a::19/64
+    bp_interface:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::19/64
 
   ARISTA13T2:
     properties:
@@ -415,9 +415,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.25/31
         ipv6: fc00::32/126
-      Ethernet9:
-        ipv4: 10.10.246.13/24
-        ipv6: fc0a::1a/64
+    bp_interface:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::1a/64
 
   ARISTA14T2:
     properties:
@@ -436,9 +436,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.27/31
         ipv6: fc00::36/126
-      Ethernet9:
-        ipv4: 10.10.246.14/24
-        ipv6: fc0a::1d/64
+    bp_interface:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::1d/64
 
   ARISTA15T2:
     properties:
@@ -457,9 +457,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.29/31
         ipv6: fc00::3a/126
-      Ethernet9:
-        ipv4: 10.10.246.15/24
-        ipv6: fc0a::1e/64
+    bp_interface:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::1e/64
 
   ARISTA16T2:
     properties:
@@ -478,9 +478,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.31/31
         ipv6: fc00::3e/126
-      Ethernet9:
-        ipv4: 10.10.246.16/24
-        ipv6: fc0a::21/64
+    bp_interface:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::21/64
 
   ARISTA01T0:
     properties:
@@ -493,6 +493,11 @@ configuration:
         65100:
         - 10.0.0.32
         - FC00::41
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
     interfaces:
       Loopback0:
         ipv4: 100.1.0.17/32
@@ -500,14 +505,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
-      Ethernet9:
-        ipv4: 10.10.246.17/24
-        ipv6: fc0a::22/64
-      vips:
-        ipv4:
-          prefixes:
-            - 200.0.1.0/26
-          asn: 64700
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::22/64
 
   ARISTA02T0:
     properties:
@@ -527,9 +527,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.35/31
         ipv6: fc00::46/126
-      Ethernet9:
-        ipv4: 10.10.246.18/24
-        ipv6: fc0a::25/64
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::25/64
 
   ARISTA03T0:
     properties:
@@ -542,6 +542,11 @@ configuration:
         65100:
         - 10.0.0.36
         - FC00::49
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
     interfaces:
       Loopback0:
         ipv4: 100.1.0.19/32
@@ -549,15 +554,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.37/31
         ipv6: fc00::4a/126
-      Ethernet9:
-        ipv4: 10.10.246.19/24
-        ipv6: fc0a::26/64
-      vips:
-        ipv4:
-          prefixes:
-            - 200.0.1.0/26
-          asn: 64700
-
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::26/64
 
   ARISTA04T0:
     properties:
@@ -577,9 +576,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.39/31
         ipv6: fc00::4e/126
-      Ethernet9:
-        ipv4: 10.10.246.20/24
-        ipv6: fc0a::29/64
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::29/64
 
   ARISTA05T0:
     properties:
@@ -599,9 +598,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.41/31
         ipv6: fc00::52/126
-      Ethernet9:
-        ipv4: 10.10.246.21/24
-        ipv6: fc0a::2a/64
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::2a/64
 
   ARISTA06T0:
     properties:
@@ -621,9 +620,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.43/31
         ipv6: fc00::56/126
-      Ethernet9:
-        ipv4: 10.10.246.22/24
-        ipv6: fc0a::2d/64
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::2d/64
 
   ARISTA07T0:
     properties:
@@ -643,9 +642,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.45/31
         ipv6: fc00::5a/126
-      Ethernet9:
-        ipv4: 10.10.246.23/24
-        ipv6: fc0a::2e/64
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::2e/64
 
   ARISTA08T0:
     properties:
@@ -665,9 +664,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.47/31
         ipv6: fc00::5e/126
-      Ethernet9:
-        ipv4: 10.10.246.24/24
-        ipv6: fc0a::31/64
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::31/64
 
   ARISTA09T0:
     properties:
@@ -687,9 +686,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
-      Ethernet9:
-        ipv4: 10.10.246.25/24
-        ipv6: fc0a::32/64
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::32/64
 
   ARISTA10T0:
     properties:
@@ -709,9 +708,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.51/31
         ipv6: fc00::66/126
-      Ethernet9:
-        ipv4: 10.10.246.26/24
-        ipv6: fc0a::35/64
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::35/64
 
   ARISTA11T0:
     properties:
@@ -731,9 +730,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.53/31
         ipv6: fc00::6a/126
-      Ethernet9:
-        ipv4: 10.10.246.27/24
-        ipv6: fc0a::36/64
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::36/64
 
   ARISTA12T0:
     properties:
@@ -753,9 +752,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.55/31
         ipv6: fc00::6e/126
-      Ethernet9:
-        ipv4: 10.10.246.28/24
-        ipv6: fc0a::39/64
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::39/64
 
   ARISTA13T0:
     properties:
@@ -775,9 +774,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.57/31
         ipv6: fc00::72/126
-      Ethernet9:
-        ipv4: 10.10.246.29/24
-        ipv6: fc0a::3a/64
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
 
   ARISTA14T0:
     properties:
@@ -797,9 +796,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.59/31
         ipv6: fc00::76/126
-      Ethernet9:
-        ipv4: 10.10.246.30/24
-        ipv6: fc0a::3d/64
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
 
   ARISTA15T0:
     properties:
@@ -819,9 +818,9 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.61/31
         ipv6: fc00::7a/126
-      Ethernet9:
-        ipv4: 10.10.246.31/24
-        ipv6: fc0a::3e/64
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
 
   ARISTA16T0:
     properties:
@@ -841,7 +840,6 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.63/31
         ipv6: fc00::7e/126
-      Ethernet9:
-        ipv4: 10.10.246.32/24
-        ipv6: fc0a::41/64
-
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64


### PR DESCRIPTION
### Description of PR

ovs has scalability issue which prevent us having more than 1000 interfaces
per host. This change also makes the VM configuration to generate back plane
port configuration based on the number of front plane port number.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?

How did you verify/test it?
tested 'start-vms', 'config-vm' and verify the created vm has 4 front panel ports, and config-vm generated correct eos configuration.

Any platform specific information?

Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
