### PR TITLE
[hwsku]: Add Accton-AS7712-32X

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -1024,3 +1024,76 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+
+  Accton-AS7712-32X:
+    alarms:
+      fan:
+      - as7712_32x_fan-i2c-2-66/fan1/fan1_fault
+      - as7712_32x_fan-i2c-2-66/fan2/fan2_fault
+      - as7712_32x_fan-i2c-2-66/fan3/fan3_fault
+      - as7712_32x_fan-i2c-2-66/fan4/fan4_fault
+      - as7712_32x_fan-i2c-2-66/fan5/fan5_fault
+      - as7712_32x_fan-i2c-2-66/fan6/fan6_fault
+      - as7712_32x_fan-i2c-2-66/fan11/fan11_fault
+      - as7712_32x_fan-i2c-2-66/fan12/fan12_fault
+      - as7712_32x_fan-i2c-2-66/fan13/fan13_fault
+      - as7712_32x_fan-i2c-2-66/fan14/fan14_fault
+      - as7712_32x_fan-i2c-2-66/fan15/fan15_fault
+      - as7712_32x_fan-i2c-2-66/fan16/fan16_fault
+      power: []
+      temp:
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+      - ym2651-i2c-10-58/temp1/temp1_fault
+      - ym2651-i2c-11-5b/temp1/temp1_fault
+    compares:
+      fan: []
+      power: []
+      temp:
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+      - - lm75-i2c-3-48/temp1/temp1_input
+        - lm75-i2c-3-48/temp1/temp1_max
+      - - lm75-i2c-3-49/temp1/temp1_input
+        - lm75-i2c-3-49/temp1/temp1_max
+      - - lm75-i2c-3-4a/temp1/temp1_input
+        - lm75-i2c-3-4a/temp1/temp1_max
+    non_zero:
+      fan:
+      - as7712_32x_fan-i2c-2-66/fan1/fan1_input
+      - as7712_32x_fan-i2c-2-66/fan2/fan2_input
+      - as7712_32x_fan-i2c-2-66/fan3/fan3_input
+      - as7712_32x_fan-i2c-2-66/fan4/fan4_input
+      - as7712_32x_fan-i2c-2-66/fan5/fan5_input
+      - as7712_32x_fan-i2c-2-66/fan6/fan6_input
+      - as7712_32x_fan-i2c-2-66/fan11/fan11_input
+      - as7712_32x_fan-i2c-2-66/fan12/fan12_input
+      - as7712_32x_fan-i2c-2-66/fan13/fan13_input
+      - as7712_32x_fan-i2c-2-66/fan14/fan14_input
+      - as7712_32x_fan-i2c-2-66/fan15/fan15_input
+      - as7712_32x_fan-i2c-2-66/fan16/fan16_input
+      - ym2651-i2c-10-58/fan1/fan1_input
+      - ym2651-i2c-11-5b/fan1/fan1_input
+      power:
+      - ym2651-i2c-11-5b/power1/power1_input
+      - ym2651-i2c-10-58/power1/power1_input
+      temp: []
+    psu_skips:
+      ym2651-i2c-10-58:
+        number: 2
+        side: right
+        skip_list:
+        - ym2651-i2c-10-58
+      ym2651-i2c-11-5b:
+        number: 1
+        side: left
+        skip_list:
+        - ym2651-i2c-11-5b

--- a/ansible/group_vars/sonic/vars
+++ b/ansible/group_vars/sonic/vars
@@ -2,13 +2,13 @@ ansible_ssh_user: admin
 
 sonic_version: "v2"
 
-broadcom_hwskus: [ 'Force10-S6000' ]
+broadcom_hwskus: [ "Force10-S6000", "Accton-AS7712-32X" ]
 
 mellanox_hwskus: [ 'ACS-MSN2700' ]
 
 cavium_hwskus: [ "AS7512", "XP-SIM" ]
 
-sensor_hwskus: [ "ACS-MSN2700", "Force10-S6000" ]
+sensor_hwskus: [ "ACS-MSN2700", "Force10-S6000", "Accton-AS7712-32X" ]
 
 ## Note:
 ## Docker volumes should be list instead of dict. However, if we want to keep code DRY, we

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -487,6 +487,9 @@ def parse_xml(filename, hostname):
             port_alias_map["Ethernet%d" % i] = "Ethernet%d" % (i - 1)
         for i in range(49, 65):
             port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 49) * 4 + 48)
+    elif hwsku == "Accton-AS7712-32X":
+        for i in range(1, 33):
+            port_alias_map["hundredGigE%d" % i] = "Ethernet%d" % ((i - 1) * 4)
     else:
         for i in range(0, 128, 4):
             port_alias_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
* Add the hwsku device, Accton-AS7712-32X
Signed-off-by: polly_hsu@edge-core.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add the hwsku device, Accton-AS7712-32X
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
- How did you do it?
- How did you verify/test it?
Setup the testbed and framwork based on `https://github.com/Azure/sonic-mgmt/tree/master/ansible/doc`
- Any platform specific information? 
Accton-AS7712-32X
- Supported testbed topology if it's a new test case?
t0 / t1 / t1-lag / ptf32

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

  