### PR TITLE
[vlan]: add vlan test to test by testname

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -132,7 +132,7 @@ You might need to redeploy your VMs before you run this test due to the change f
 
 ### VLAN test
 ```
-ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} --become --tags vlan --extra-vars "testbed_type={TESTBED_TYPE} ptf_host={PTF_HOST}"
+ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} -e "testbed_name={TESTBED_NAME} testcase_name=vlan"
 ```
 - Requires switch connected to a t0 testbed
 - Requires switch connected to fanout switch and fanout switch need support [QinQ](https://en.wikipedia.org/wiki/IEEE_802.1ad).

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -134,3 +134,9 @@ testcases:
       filename: syslog.yml
       topologies: [t0, t0-64, t0-64-32,t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    vlan:
+      filename: vlantb.yml
+      topologies: [t0]
+      execvars: 
+          ptf_host:
+          testbed_type:


### PR DESCRIPTION
### Description of PR
add vlan test to test by testname

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
add vlan test to test by testname. define vlan test in roles/test/vars/testcases.yml

How did you verify/test it?
run vlan test
```
ansible-playbook -vvv -i str --limit str-s6000-acs-7 test_sonic.yml -e "testbed_name=vms3-3 testcase_name=vlan" --vault-password-file password.txt
```

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
