### PR TITLE
[sonic tests] use host time instead of ansible time

### DIFF
--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -39,4 +39,4 @@
       - testbed_type='{{testbed_type}}'
       - router_mac='{{ansible_Ethernet0['macaddress']}}'
       - vlan_info='/root/vlan_info.txt'
-    ptf_extra_options: "--relax --debug info --log-file /tmp/dir_bcast.BcastTest.{{ansible_date_time.iso8601}}.log"
+    ptf_extra_options: "--relax --debug info --log-file /tmp/dir_bcast.BcastTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -60,5 +60,5 @@
       - router_mac='{{ansible_Ethernet0['macaddress']}}'
       - fdb_info='/root/fdb_info.txt'
       - vlan_ip='{{minigraph_vlan_interfaces[0]['addr']}}'
-    ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_test.FdbTest.{{ansible_date_time.iso8601}}.log "
+    ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_test.FdbTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
   

--- a/ansible/roles/test/tasks/fib.yml
+++ b/ansible/roles/test/tasks/fib.yml
@@ -63,4 +63,4 @@
       - fib_info='/root/fib_info.txt'
       - ipv4={{ipv4}}
       - ipv6={{ipv6}}
-    ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{ansible_date_time.iso8601}}.log "
+    ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "

--- a/ansible/roles/test/tasks/mtu.yml
+++ b/ansible/roles/test/tasks/mtu.yml
@@ -39,4 +39,4 @@
     ptf_test_params:
       - testbed_type='{{testbed_type}}'
       - router_mac='{{ansible_Ethernet0['macaddress']}}'
-    ptf_extra_options: "--relax --debug info --log-file /tmp/mtu_test.MtuTest.{{ansible_date_time.iso8601}}.log --socket-recv-size 16384"
+    ptf_extra_options: "--relax --debug info --log-file /tmp/mtu_test.MtuTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log --socket-recv-size 16384"

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
@@ -92,7 +92,7 @@
           - ip_src='{{pfc_wd_rx_neighbor_addr}}'
           - ip_dst='{{pfc_wd_test_neighbor_addr}}'
           - wd_action='drop'
-        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{ansible_date_time.iso8601}}.log "
+        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - name: "Send 10K packets to {{pfc_wd_test_port}}"
       include: roles/test/tasks/ptf_runner.yml
@@ -110,7 +110,7 @@
           - ip_src='{{pfc_wd_test_neighbor_addr}}'
           - ip_dst='{{pfc_wd_rx_neighbor_addr}}'
           - wd_action='drop'
-        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{ansible_date_time.iso8601}}.log "
+        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - name: "Send 10K packets via {{pfc_wd_test_port}} to verify that other queue is not affected"
       include: roles/test/tasks/ptf_runner.yml
@@ -128,7 +128,7 @@
           - ip_src='{{pfc_wd_rx_neighbor_addr}}'
           - ip_dst='{{pfc_wd_test_neighbor_addr}}'
           - wd_action='forward'
-        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{ansible_date_time.iso8601}}.log "
+        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - name: "Send 10K packets to {{pfc_wd_test_port}} to verify that other pg is not affected"
       include: roles/test/tasks/ptf_runner.yml
@@ -146,7 +146,7 @@
           - ip_src='{{pfc_wd_test_neighbor_addr}}'
           - ip_dst='{{pfc_wd_rx_neighbor_addr}}'
           - wd_action='forward'
-        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{ansible_date_time.iso8601}}.log "
+        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - set_fact:
         test_expect_file: "expect_pfc_wd_restore"
@@ -259,7 +259,7 @@
           - ip_src='{{pfc_wd_rx_neighbor_addr}}'
           - ip_dst='{{pfc_wd_test_neighbor_addr}}'
           - wd_action='forward'
-        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{ansible_date_time.iso8601}}.log "
+        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - name: "Send 10K packets to {{pfc_wd_test_port}}"
       include: roles/test/tasks/ptf_runner.yml
@@ -277,7 +277,7 @@
           - ip_src='{{pfc_wd_test_neighbor_addr}}'
           - ip_dst='{{pfc_wd_rx_neighbor_addr}}'
           - wd_action='forward'
-        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{ansible_date_time.iso8601}}.log "
+        ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - set_fact:
         test_expect_file: "expect_pfc_wd_restore"


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Ansible time could be cached, causing multiple consecutive tests using a same time stamp to create
log files and losing older log files.

Changing to local host time would make time stamp always unique.

How did you verify/test it?
I first noticed this issue when I use a script to execute a test case (e.g. fib) continuously, the log file name would be identical due to timestamp being identical for each test. After the fix, the log file names are always different.