### PR TITLE
[upgrade_sonic]: Fix the hostname in the wait_for condition

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -6,29 +6,29 @@
   gather_facts: no
   tasks:
 
-    - name: Gather minigraph facts about the device
+    - name: Gather minigraph facts for the switch {{ inventory_hostname }}
       minigraph_facts: host={{ inventory_hostname }}
       connection: local
 
     - fail: msg="image_url is not defined"
       when: image_url is not defined
 
-    - name: Install the target image
+    - name: Install the target image from {{ image_url }}
       become: true
       shell: sonic_installer install -y {{ image_url }}
       register: output
       failed_when: output.rc != 0
 
-    - name: Reboot
+    - name: Reboot the switch {{ inventory_hostname }}
       become: true
       shell: shutdown -r now "Reboot"
       async: 1
       poll: 0
       ignore_errors: true
 
-    - name: Wait for switch to come back
+    - name: Wait for switch {{ inventory_hostname }} to come back
       local_action:
-        wait_for host={{ inventory_hostname }}
+        wait_for host={{ ansible_host }}
         port=22
         state=started
         delay=30


### PR DESCRIPTION
* The host cannot be the inventory name. Otherwise it will not trigger
the action.
* Add more output messages

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
