### PR TITLE
allow upgrade sonic via onie or sonic-to-sonic upgrade method

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -1,6 +1,9 @@
 # Example usage:
 #
-# ansible-playbook upgrade_sonic.yml -i lab -l device -e "image_url='http://8.8.8.8/sonic-broadcom.bin'"
+# upgrade via sonic2sonic upgrade:
+#   ansible-playbook upgrade_sonic.yml -i lab -l devicename -e "upgrade_type=sonic" -e "image_url='http://8.8.8.8/sonic-broadcom.bin'"
+# upgrade via onie:
+#   ansible-playbook upgrade_sonic.yml -i lab -l devicename -e "upgrade_type=onie" -e "image_url='http://8.8.8.8/sonic-broadcom.bin'"
 
 - hosts: all
   gather_facts: no
@@ -9,24 +12,83 @@
     - name: Gather minigraph facts for the switch {{ inventory_hostname }}
       minigraph_facts: host={{ inventory_hostname }}
       connection: local
+      become: no
+      tags: always
 
-    - fail: msg="image_url is not defined"
-      when: image_url is not defined
+    - set_fact:
+        real_ansible_host: "{{ ansible_ssh_host }}"
 
-    - name: Install the target image from {{ image_url }}
-      become: true
-      shell: sonic_installer install -y {{ image_url }}
-      register: output
-      failed_when: output.rc != 0
+    - block:
 
-    - name: Reboot the switch {{ inventory_hostname }}
-      become: true
-      shell: shutdown -r now "Reboot"
-      async: 1
-      poll: 0
-      ignore_errors: true
+        - name: Set next boot device to ONIE
+          become: true
+          shell: grub-editenv /host/grub/grubenv set next_entry=ONIE
 
-    - name: Wait for switch {{ inventory_hostname }} to come back
+        - name: Reboot into ONIE
+          become: true
+          shell: sleep 2 && shutdown -r now "Boot into onie."
+          async: 1
+          poll: 0
+          ignore_errors: true
+
+        - name: Wait for switch to come back (to ONIE)
+          local_action:
+            wait_for host={{ real_ansible_host }}
+            port=22
+            state=started
+            delay=60
+            timeout=300
+          become: false
+          changed_when: false
+
+        - name: Stop onie discovery
+          shell: ssh root@{{ real_ansible_host }} '/bin/ash -ilc "onie-discovery-stop"'
+          delegate_to: 127.0.0.1
+          become: no
+
+          # since onie install will reboot the box, the shell command cannot exit in synchronized mode.
+          # Now, use async mode and set a maximum wait period, the next task will wait for installation
+          # to finish and switch to reboot
+        - name: Install the target image from {{ image_url }}
+          shell: ssh root@{{ real_ansible_host }} '/bin/ash -ilc "onie-nos-install {{ image_url }}"'
+          delegate_to: 127.0.0.1
+          become: no
+          async: 60
+          poll: 5
+          ignore_errors: true
+
+        - name: Wait for switch to reboot again (ONIE installation finishes)
+          local_action:
+            wait_for host={{ real_ansible_host }}
+            port=22
+            state=stopped
+            delay=5
+            timeout=600
+          become: false
+          changed_when: false
+
+      when: upgrade_type == "onie"
+
+    - block:
+        - fail: msg="image_url is not defined"
+          when: image_url is not defined
+
+        - name: Install the target image from {{ image_url }}
+          become: true
+          shell: sonic_installer install -y {{ image_url }}
+          register: output
+          failed_when: output.rc != 0
+
+        - name: Reboot the switch {{ inventory_hostname }}
+          become: true
+          shell: shutdown -r now "Reboot"
+          async: 1
+          poll: 0
+          ignore_errors: true
+
+      when: upgrade_type == "sonic"
+
+    - name: Wait for switch {{ inventory_hostname }} to come back (to SONiC)
       local_action:
         wait_for host={{ ansible_host }}
         port=22
@@ -34,7 +96,12 @@
         delay=30
         timeout=600
         search_regex=OpenSSH
+      become: false
       changed_when: false
 
     - name: Wait for SONiC initialization
       pause: seconds=60
+
+    - name: Set all bgp interfaces admin-up
+      become: true
+      shell: config bgp startup all

--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -12,7 +12,6 @@
     - name: Gather minigraph facts for the switch {{ inventory_hostname }}
       minigraph_facts: host={{ inventory_hostname }}
       connection: local
-      become: no
       tags: always
 
     - set_fact:
@@ -38,13 +37,11 @@
             state=started
             delay=60
             timeout=300
-          become: false
           changed_when: false
 
         - name: Stop onie discovery
           shell: ssh root@{{ real_ansible_host }} '/bin/ash -ilc "onie-discovery-stop"'
           delegate_to: 127.0.0.1
-          become: no
 
           # since onie install will reboot the box, the shell command cannot exit in synchronized mode.
           # Now, use async mode and set a maximum wait period, the next task will wait for installation
@@ -52,7 +49,6 @@
         - name: Install the target image from {{ image_url }}
           shell: ssh root@{{ real_ansible_host }} '/bin/ash -ilc "onie-nos-install {{ image_url }}"'
           delegate_to: 127.0.0.1
-          become: no
           async: 60
           poll: 5
           ignore_errors: true
@@ -64,7 +60,6 @@
             state=stopped
             delay=5
             timeout=600
-          become: false
           changed_when: false
 
       when: upgrade_type == "onie"
@@ -96,7 +91,6 @@
         delay=30
         timeout=600
         search_regex=OpenSSH
-      become: false
       changed_when: false
 
     - name: Wait for SONiC initialization


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
integrate boot_onie into upgrade sonic yml.

How did you verify/test it?
run local via both onie and sonic methods.
once boot into onie, we can use root to login and run onie-discover-stop and onie-nos-install to install new image. The assumption here is the dhcp server will assign correct IP to the DUT so that we can ssh to the onie.

Any platform specific information?
no.

Supported testbed topology if it's a new test case?



### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
