### PR TITLE
[topology]: Fix t1-64-lag topology device link base indices

### DIFF
--- a/ansible/templates/topo/t1-64-lag.j2
+++ b/ansible/templates/topo/t1-64-lag.j2
@@ -324,35 +324,35 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>{{ inventory_hostname }}</EndDevice>
         <EndPort>{{ port_alias[32+index*8+2] }}</EndPort>
-        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartDevice>ARISTA{{ '%02d' % (index*5+1) }}T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>{{ inventory_hostname }}</EndDevice>
-        <EndPort>{{ port_alias[32+index*8+2] }}</EndPort>
-        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <EndPort>{{ port_alias[32+index*8+4] }}</EndPort>
+        <StartDevice>ARISTA{{ '%02d' % (index*5+2) }}T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>{{ inventory_hostname }}</EndDevice>
         <EndPort>{{ port_alias[32+index*8+5] }}</EndPort>
-        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartDevice>ARISTA{{ '%02d' % (index*5+3) }}T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>{{ inventory_hostname }}</EndDevice>
         <EndPort>{{ port_alias[32+index*8+6] }}</EndPort>
-        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartDevice>ARISTA{{ '%02d' % (index*5+4) }}T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>{{ inventory_hostname }}</EndDevice>
         <EndPort>{{ port_alias[32+index*8+7] }}</EndPort>
-        <StartDevice>ARISTA{{ '%02d' % (index+1) }}T0</StartDevice>
+        <StartDevice>ARISTA{{ '%02d' % (index*5+5) }}T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
 {% endfor %}


### PR DESCRIPTION
This piece of information is used in the LLDP test.
Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

```
TASK [test : Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)] ***
Friday 05 January 2018  00:22:33 +0000 (0:00:00.166)       0:00:26.667 ********
ok: [str-s6100-acs-5] => (item=Ethernet0)
ok: [str-s6100-acs-5] => (item=Ethernet1)
ok: [str-s6100-acs-5] => (item=Ethernet4)
ok: [str-s6100-acs-5] => (item=Ethernet5)
skipping: [str-s6100-acs-5] => (item=eth0)
ok: [str-s6100-acs-5] => (item=Ethernet58)
ok: [str-s6100-acs-5] => (item=Ethernet50)
ok: [str-s6100-acs-5] => (item=Ethernet52)
ok: [str-s6100-acs-5] => (item=Ethernet53)
ok: [str-s6100-acs-5] => (item=Ethernet54)
ok: [str-s6100-acs-5] => (item=Ethernet55)
ok: [str-s6100-acs-5] => (item=Ethernet38)
ok: [str-s6100-acs-5] => (item=Ethernet39)
ok: [str-s6100-acs-5] => (item=Ethernet16)
ok: [str-s6100-acs-5] => (item=Ethernet17)
ok: [str-s6100-acs-5] => (item=Ethernet36)
ok: [str-s6100-acs-5] => (item=Ethernet37)
ok: [str-s6100-acs-5] => (item=Ethernet34)
ok: [str-s6100-acs-5] => (item=Ethernet47)
ok: [str-s6100-acs-5] => (item=Ethernet46)
ok: [str-s6100-acs-5] => (item=Ethernet45)
ok: [str-s6100-acs-5] => (item=Ethernet44)
ok: [str-s6100-acs-5] => (item=Ethernet42)
ok: [str-s6100-acs-5] => (item=Ethernet61)
ok: [str-s6100-acs-5] => (item=Ethernet60)
ok: [str-s6100-acs-5] => (item=Ethernet63)
ok: [str-s6100-acs-5] => (item=Ethernet62)
ok: [str-s6100-acs-5] => (item=Ethernet21)
ok: [str-s6100-acs-5] => (item=Ethernet20)
```