### PR TITLE
fix typo when assign dscp_mode for decap test

### DIFF
--- a/ansible/roles/test/tasks/test_sonic_by_testname.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_testname.yml
@@ -22,7 +22,7 @@
 
     - name: Set dscp_mode var for decap test for mellanox
       set_fact:
-          dhcp_mode: uniform
+          dscp_mode: uniform
       when:
         - sonic_hwsku in mellanox_hwskus
         - dscp_mode is not defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
fixed typo

How did you verify/test it?
verified in local build test

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
