### PR TITLE
[Fast-Reboot test]: Don't crash the test, when we received no log output in a VM

### DIFF
--- a/ansible/roles/test/files/ptftests/fast-reboot.py
+++ b/ansible/roles/test/files/ptftests/fast-reboot.py
@@ -376,7 +376,7 @@ class FastReloadTest(BaseTest):
         self.check_param('default_ip_range', '', required = True)
         self.check_param('vlan_ip_range', '', required = True)
         self.check_param('lo_prefix', '10.1.0.32/32', required = False)
-        self.check_param('lo_v6_prefix', 'fc00:1::32/128', required = False)
+        self.check_param('lo_v6_prefix', 'fc00:1::/64', required = False)
         self.check_param('arista_vms', [], required = True)
         self.check_param('min_bgp_gr_timeout', 15, required = False)
 
@@ -696,7 +696,10 @@ class FastReloadTest(BaseTest):
         for ip in sorted(self.logs_info.keys()):
             self.log("Extracted log info from %s" % ip)
             for msg in sorted(self.logs_info[ip].keys()):
-                self.log("    %s : %d" % (msg, self.logs_info[ip][msg]))
+                if msg != 'error':
+                    self.log("    %s : %d" % (msg, self.logs_info[ip][msg]))
+                else:
+                    self.log("    %s" % self.logs_info[ip][msg])
             self.log("-"*50)
 
         self.log("Summary:")
@@ -847,7 +850,7 @@ class FastReloadTest(BaseTest):
 
         is_alive      = nr_from_s > self.nr_pc_pkts * 0.7 and nr_from_l > self.nr_vl_pkts * 0.7
         is_asic_weird = nr_from_s > self.nr_pc_pkts        or nr_from_l > self.nr_vl_pkts
-        # we receive more, then received. not populated FDB table
+        # we receive more, then sent. not populated FDB table
 
         return is_alive, is_asic_weird
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes following error
```
======================================================================
ERROR: fast-reboot.FastReloadTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ptftests/fast-reboot.py", line 699, in runTest
    self.log("    %s : %d" % (msg, self.logs_info[ip][msg]))
TypeError: %d format: a number is required, not str
```

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
