### PR TITLE
[dhcp relay test] adding more test scenarios

### DIFF
--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -47,3 +47,59 @@
       - relay_iface_mac=\"{{ relay_iface_mac }}\"
       - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
 
+# Service restart and service stop -> start exhibited different behaviors.
+# Therefore testing them separately.
+- name: Restart teamd on DUT
+  shell: systemctl restart teamd
+  become: yes
+
+- name: sleep 60 seconds for lag and bgp to come up
+  pause: seconds=60
+
+- include: ptf_runner.yml
+  vars:
+    ptf_test_name: DHCP Relay Test
+    ptf_test_dir: ptftests
+    ptf_test_path: dhcp_relay_test.DHCPTest
+    ptf_platform: remote
+    ptf_platform_dir: ptftests
+    ptf_test_params:
+      - hostname=\"{{ inventory_hostname }}\"
+      - client_port_index=\"{{ client_port_index }}\"
+      - client_iface_alias=\"{{ client_iface_alias }}\"
+      - leaf_port_indices=\"{{ leaf_port_indices }}\"
+      - num_dhcp_servers=\"{{ dhcp_servers | length }}\"
+      - server_ip=\"{{ dhcp_servers[0] }}\"
+      - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
+      - relay_iface_mac=\"{{ relay_iface_mac }}\"
+      - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+
+- name: Stop teamd on DUT
+  shell: systemctl stop teamd
+  become: yes
+
+- name: Start teamd on DUT
+  shell: systemctl start teamd
+  become: yes
+
+- name: sleep 60 seconds for lag and bgp to come up
+  pause: seconds=60
+
+- include: ptf_runner.yml
+  vars:
+    ptf_test_name: DHCP Relay Test
+    ptf_test_dir: ptftests
+    ptf_test_path: dhcp_relay_test.DHCPTest
+    ptf_platform: remote
+    ptf_platform_dir: ptftests
+    ptf_test_params:
+      - hostname=\"{{ inventory_hostname }}\"
+      - client_port_index=\"{{ client_port_index }}\"
+      - client_iface_alias=\"{{ client_iface_alias }}\"
+      - leaf_port_indices=\"{{ leaf_port_indices }}\"
+      - num_dhcp_servers=\"{{ dhcp_servers | length }}\"
+      - server_ip=\"{{ dhcp_servers[0] }}\"
+      - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
+      - relay_iface_mac=\"{{ relay_iface_mac }}\"
+      - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
- Test that dhcp relay service continue to work after teamd service
  restarted
- Test that dhcp relay service continue to work after teamd service
  stopped and then started

How did you verify/test it?
Execute this test case against a dut running image contains following PR:
https://github.com/Azure/sonic-buildimage/pull/1356
