### PR TITLE
[minigraph gen]fix find file when it's symbolic link

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -47,7 +47,7 @@ class SonicPortAliasMap():
         return
 
     def findfile(self):
-        for (rootdir, dirnames, filenames) in os.walk(FILE_PATH):
+        for (rootdir, dirnames, filenames) in os.walk(FILE_PATH, followlinks=True):
             if self.hwsku == rootdir.split('/')[-1] and len(dirnames) == 0 and PORTMAP_FILE in filenames:
                 self.filename = rootdir+'/'+PORTMAP_FILE
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fix generate graph when hardware platform sku is symbolic link  

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
- How did you do it?
add option  'followlinks'

- How did you verify/test it?
verified in my local environment

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
