### PR TITLE
[reboot test] call sudo reboot to reboot dut

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -1,4 +1,4 @@
-- name: rebooting {{ ansible_host }} ...
+- name: "rebooting {{ inventory_hostname }} : {{ ansible_host }} ..."
   shell: sudo reboot
   async: 1
   poll: 0

--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -1,4 +1,4 @@
-- name: reboot
+- name: rebooting {{ ansible_host }} ...
   shell: sudo reboot
   async: 1
   poll: 0

--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -1,6 +1,5 @@
 - name: reboot
-  become: true
-  shell: shutdown -r now "Warning! System is being rebooted remotely by reboot_sonic.yml"
+  shell: sudo reboot
   async: 1
   poll: 0
   ignore_errors: true


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
- Using reboot allow the dut to reboot with platform specific reboot tools.
- Ansible behaves differently with "become: yes + reboot" and "sudo reboot"
  It appears that only the later could reboot the DUT.
  This behavior might have caused by sonic intercepts reboot with a script.

How did you verify/test it?
Verified on one DUT with platform specific reboot tool
Verified on one DUT without platform specific reboot tool