### PR TITLE
[upgrade]save bgp UP state after they are brough up

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -99,3 +99,7 @@
     - name: Set all bgp interfaces admin-up
       become: true
       shell: config bgp startup all
+
+    - name: save bgp admin-up states
+      become: true
+      shell: config save -y


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
- How did you do it?
last step of sonic upgrade/onie-boot is to bring all bgp neighbor up, but didn't save it
add one more step to save the bgp up state

- How did you verify/test it?
verified from local testbed steps

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
