### PR TITLE
[deploy minigraph]add default enable BGP to deploy minigraph step

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -100,12 +100,14 @@
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true
-        ignore_errors: true
         shell: config load_minigraph -y
+
+      - name: execute cli "config bgp startup all" to bring up all bgp sessions for test
+        become: true
+        shell: config bgp startup all
 
       - name: execute cli "config save -y" to save current minigraph as startup-config
         become: true
-        ignore_errors: true
         shell: config save -y
         when: save is defined and save|bool == true
     when: deploy is defined and deploy|bool == true

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -127,7 +127,7 @@ function deploy_minigraph
 
   read_file $1
 
-  ansible-playbook -i lab config_sonic_basedon_testbed.yml --vault-password-file="$2" -l "$dut" -e vm_base="$vm_base" -e topo="$topo" -e deploy=true
+  ansible-playbook -i lab config_sonic_basedon_testbed.yml --vault-password-file="$2" -l "$dut" -e vm_base="$vm_base" -e topo="$topo" -e deploy=true -e save=true
 
   echo Done
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Deploy minigraph, if image default BGP admin off, need one more step to enable them for test
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
- How did you do it?
    * add one more step of enabling bgp in generate minigraph playbook when deploy==true, 
    * also, fix the testbed-cli.sh deploy option to save configuration, early version does not have "save" option, didn't update with new options
    * should not ignore errors when load minigraph fail


- How did you verify/test it?
tested in my local testbed

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
