### PR TITLE
[fast reboot]when call testcase by name, fetch all vms management info from testbe…

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -2,6 +2,16 @@
 # ansible-playbook sonic-test.yml -i str --limit device_1 --become --vault-password-file ~/password  --tags fast_reboot -e "ptf_host=10.0.0.21" -e "vm_hosts=['10.0.0.200','10.0.0.201','10.0.0.202','10.0.0.203']"
 
 - block:
+    - name: figure out fast reboot vm hosts
+      testbed_vm_info: base_vm={{ vm }} topo={{ testbed_type }}
+      connection: local
+
+    - set_fact:
+        vm_hosts: "{{ neighbor_eosvm_mgmt.values() }}"
+  when: testbed_type is defined and vm is defined
+
+
+- block:
     - fail: msg="Please set ptf_host variable"
       when: ptf_host is not defined
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
let fast-reboot work for call by testcase_name
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
- How did you do it?
  when call testcase by testcase_name and testbed_name, it already knows all VMs info, fetch it before run fast-reboot test. 

How did you verify/test it?
  tested locally in my testbed:

TASK [test : set_fact] *********************************************************
task path: /myfolder/sonic-mgmt-0205/ansible/roles/test/tasks/fast-reboot.yml:9
Thursday 08 February 2018  22:07:11 +0000 (0:00:00.161)       0:00:14.358 ***** 
ok: [str-s6000-acs-1] => {"ansible_facts": {"vm_hosts": ["10.255.46.19", "10.255.46.18", "10.255.46.17", "10.255.46.16"]}, "changed": false, "invocation": {"module_args": {"vm_hosts": ["10.255.46.19", "10.255.46.18", "10.255.46.17", "10.255.46.16"]}, "module_name": "set_fact"}}

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
