### PR TITLE
[upgrade] don't fail playbook if the image is the same as installed

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -72,7 +72,10 @@
           become: true
           shell: sonic_installer install -y {{ image_url }}
           register: output
-          failed_when: output.rc != 0
+          ignore_errors: yes
+
+        - fail: msg="SONiC upgrade failed"
+          when: (output.rc != 0) and (not "'Running SONiC has the same version' in {{ output.stdout }}")
 
         - name: Reboot the switch {{ inventory_hostname }}
           become: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
don't fail playbook if the image is the same as installed

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
- How did you do it?
upgrade.yml playbook: doing sonic upgrade to the same image will fail the playbook
may it fail only when install fail but not due to try to install the same image 

- How did you verify/test it?
verified in my local testbed

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
