### PR TITLE
[vlan]improve test to wait a bit longer for config reload

### DIFF
--- a/ansible/roles/test/tasks/vlan_cleanup.yml
+++ b/ansible/roles/test/tasks/vlan_cleanup.yml
@@ -19,3 +19,6 @@
 - name: Reload configuration
   shell: config reload -y
   become: true
+
+- name: wait for config reload
+  pause: seconds=60


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Improve vlan_clean test to wait longer for config reload

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
- How did you do it?
test call testname will validate SONiC process and interface status after each test case.
vlan_clean up sometimes failed after test was successful but post-check interfaces are not up yet

- How did you verify/test it?
tested on local testbed

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
