### PR TITLE
[Fast-reboot]: Ignore ansible output in extract_log

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -6,7 +6,8 @@ version_added:  "1.0"
 short_description: Unrotate logs and extract information starting from a row with predefined string
 description: The module scans the 'directory' in search of files which filenames start with 'file_prefix'.
 The found files are ungzipped and combined together in the rotation order. After that all lines after
-'start_string' are copied into a file with name 'target_filename'.
+'start_string' are copied into a file with name 'target_filename'. All input strings with 'nsible' in it
+aren't considered as 'start_string' to avoid clashing with ansible output.
 
 Options:
     - option-name: directory
@@ -91,7 +92,7 @@ def extract_line(directory, filename, target_string):
         file = open(path)
     result = None
     with file:
-        result = [(filename, line) for line in file if target_string in line]
+        result = [(filename, line) for line in file if target_string in line and 'nsible' not in line]
     return result
 
 


### PR DESCRIPTION
ansible put information about its' tasks into syslog. This breaks extract_log behavior for /var/log/syslog file. Fix it by ignoring starting rows with 'nsible' in them.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
When searching for start_strings skip any input rows with 'nsible' in it.

How did you verify/test it?
Run the changed source on the testbed switch
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
