### PR TITLE
[test infrastructure] allow overriding recover system actioin

### DIFF
--- a/ansible/roles/test/tasks/base_sanity.yml
+++ b/ansible/roles/test/tasks/base_sanity.yml
@@ -36,7 +36,7 @@
 
      when:
        - ({{ ps_out.stdout_lines | length }} <= 0) or ({{ orch_out.stdout_lines | length }} <= 0)
-       - recover is defined
+       - recover == "true"
 
    - name: Get syslog error information
      shell: cat /var/log/syslog |tail -n 5000 |grep -i error

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -24,7 +24,7 @@
 
   when:
     - ansible_interface_link_down_ports | length > 0
-    - recover is defined
+    - recover == "true"
 
 - debug: msg="Found link down ports {{ansible_interface_link_down_ports}}"
   when: ansible_interface_link_down_ports | length > 0

--- a/ansible/roles/test/tasks/test_sonic_by_testname.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_testname.yml
@@ -4,15 +4,19 @@
 - debug: msg="!!!!!!!!!!!!!!!!!!!! start to run test {{ testcase_name }} !!!!!!!!!!!!!!!!!!!!"
 - debug: msg="!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 
+- set_fact:
+    allow_recover: true
+  when: allow_recover is not defined
+
 - name: do basic sanity check before each test
   include: base_sanity.yml
   vars: 
-     recover: true
+     recover: "{{ allow_recover }}"
 
 - name: validate all interfaces is up
   include: interface.yml
   vars:
-     recover: true
+     recover: "{{ allow_recover }}"
 
 ### by default, when calling a test case name, we pass 'testbed_type', 'ptf_host, 'dut_name(ansible_hoatname)' down to test playbook.
 ### if your test playbook requires more extra vars then default, please make sure you handled them correctly within test playbook.


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Allow test script to disable test system recover

How did you verify/test it?
On my dut, kill orchagent. Run any test case by referencing test case name. The dut will be rebooted to recover from the failure status.
Repeat the same test, passing in extra var allow_recover=false, the test will fail at early sanity check stage.
Repeat the test, passing in extra var allow_recover=true, the test will run after recovering the system with reboot.
