### PR TITLE
[test case] Add test: restart swss service

### DIFF
--- a/ansible/roles/test/tasks/restart_swss.yml
+++ b/ansible/roles/test/tasks/restart_swss.yml
@@ -1,0 +1,25 @@
+- name: Restart swss service
+  become: true
+  service:
+    name: swss
+    state: restarted
+
+- name: wait for 2 minutes for swss service to recover
+  pause:
+    seconds: 120
+
+- name: do basic sanity check before each test
+  include: base_sanity.yml
+  vars:
+     recover: false
+
+- name: validate all interfaces are up
+  include: interface.yml
+  vars:
+     recover: false
+
+- name: Restart dhcp_relay service
+  become: true
+  service:
+    name: dhcp_relay
+    state: restarted

--- a/ansible/roles/test/tasks/restart_swss.yml
+++ b/ansible/roles/test/tasks/restart_swss.yml
@@ -8,7 +8,7 @@
   pause:
     seconds: 120
 
-- name: do basic sanity check before each test
+- name: check basic sanity of the device
   include: base_sanity.yml
   vars:
      recover: false

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -154,6 +154,10 @@ testcases:
       filename: run_config_cleanup.yml
       topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    restart_swss_service:
+      filename: restart_swss.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+
     sensors:
       filename: sensors_check.yml
       topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
How did you do it?
There was a script to restart swss, it was used as utility by a
few other tests. And it didn't wait long enough for swss service
to recover, it didn't check if the system recovered eventually.

This test also restarts dhcp_relay service to make sure that it
will listen on right interfaces. So the system would be left at
a healthy state.


How did you verify/test it?
Tested on one platform.
