### PR TITLE
add sonic fanout support

### DIFF
--- a/ansible/group_vars/fanout/secrets.yml
+++ b/ansible/group_vars/fanout/secrets.yml
@@ -1,2 +1,4 @@
 ansible_ssh_user: user
 ansible_ssh_pass: password
+fanout_sonic_user: admin
+fanout_sonic_password: password

--- a/ansible/lab
+++ b/ansible/lab
@@ -20,3 +20,4 @@ fanout
 [fanout]
 str-7260-10       ansible_host=10.251.0.13
 str-7260-11       ansible_host=10.251.0.234
+str-msn2700-02    ansible_host=10.251.0.235 os=sonic

--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -1,0 +1,30 @@
+- name: prepare fanout switch admin login info
+  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_pass={{ fanout_admin_password }}
+
+- name: create persistent shell login
+  file: path=/mnt/flash/rc.eos state=touch
+  become: yes
+
+- name: save persistent shell login
+  template: src=rc.eos.j2
+            dest=/mnt/flash/rc.eos
+  become: yes
+
+- name: build fanout startup config for Arista fanout leaf
+  template: src=arista_7260_deploy.j2
+            dest=/mnt/flash/startup-config
+  when: device_info.HwSku == "Arista-7260QX-64"
+  become: yes
+
+- name: build fanout startup config for 7060
+  template: src=arista_7060_deploy.j2
+            dest=/mnt/flash/startup-config
+  when: device_info.HwSku == "Arista-7060CX-32S"
+  become: yes
+
+- name: reboot
+  shell: sleep 2 && shutdown -r now "Reboot"
+  async: 1
+  poll: 0
+  ignore_errors: true
+  become: yes

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,0 +1,41 @@
+- debug: msg="{{ device_info }}"
+
+- name: prepare fanout switch admin login info
+  set_fact: ansible_user={{ fanout_sonic_user }} ansible_password={{ fanout_sonic_password }}
+
+- name: build fanout vlan config
+  template: src=sonic_deploy.j2
+            dest=/etc/sonic/vlan.json
+  become: yes
+
+- name: disable all copp rules
+  copy: content='[]'
+        dest=/etc/swss/config.d/00-copp.config.json
+  become: yes
+  vars:
+    ansible_shell_type: docker
+    ansible_python_interpreter: docker exec -i swss python
+
+- name: generate config_db.json
+  shell: sonic-cfggen -j /etc/sonic/vlan.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+  become: yes
+
+- name: reload config_db.json
+  shell: config reload -y
+  become: yes
+
+- name: stop and disable lldp service
+  service: name=lldp state=stopped enabled=no
+  become: yes
+
+- name: stop and disable dhcp_relay service
+  service: name=dhcp_relay state=stopped enabled=no
+  become: yes
+
+- name: stop and disable bgp service
+  service: name=bgp state=stopped enabled=no
+  become: yes
+
+- name: stop and disable teamd service
+  service: name=teamd state=stopped enabled=no
+  become: yes

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -13,36 +13,14 @@
 
 - set_fact: sw_type="{{ device_info['Type'] }}"
 
-- name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_pass={{ fanout_admin_password }}
+- set_fact: os='eos'
+  when: os is not defined
 
-- name: create persistent shell login
-  file: path=/mnt/flash/rc.eos state=touch
-  become: yes
+- include: fanout_eos.yml
+  when: os == 'eos'
 
-- name: save persistent shell login
-  template: src=rc.eos.j2
-            dest=/mnt/flash/rc.eos
-  become: yes
-
-- name: build fanout startup config for Arista fanout leaf
-  template: src=arista_7260_deploy.j2
-            dest=/mnt/flash/startup-config
-  when: device_info.HwSku == "Arista-7260QX-64" 
-  become: yes
-
-- name: build fanout startup config for 7060
-  template: src=arista_7060_deploy.j2
-            dest=/mnt/flash/startup-config
-  when: device_info.HwSku == "Arista-7060CX-32S"
-  become: yes
-
-- name: reboot
-  shell: sleep 2 && shutdown -r now "Reboot"
-  async: 1
-  poll: 0
-  ignore_errors: true
-  become: yes
+- include: fanout_sonic.yml
+  when: os == 'sonic'
 
 - block:
   - set_fact:

--- a/ansible/roles/fanout/templates/sonic_deploy.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy.j2
@@ -1,0 +1,45 @@
+{
+
+"DEVICE_METADATA": {
+    "localhost": {
+        "hwsku": "{{ device_info["HwSku"] }}",
+        "hostname": "{{ inventory_hostname }}"
+    }
+},
+
+"VLAN": {
+{% for vlanid in device_vlan_list | unique %}
+    "Vlan{{ vlanid }}": {
+        "vlanid": "{{ vlanid }}"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
+{% set ns = {'firstPrinted': False} %}
+"VLAN_MEMBER": {
+{% for port in device_port_vlans %}
+{% if device_port_vlans[port]['mode'] == 'Access' %}
+{% if ns.firstPrinted %},{% endif %}
+    "Vlan{{ device_port_vlans[port]['vlanids'] }}|{{ port }}": {
+        "tagging_mode" : "untagged"
+    }
+{% if ns.update({'firstPrinted': True}) %} {% endif %}
+{% elif device_port_vlans[port]['mode'] == 'Trunk' %}
+  {% for vlanid in device_port_vlans[port]['vlanlist'] %}
+{% if ns.firstPrinted %},{% endif %}
+    "Vlan{{ vlanid }}|{{ port }}": {
+        "tagging_mode" : "tagged"
+    }
+{% if ns.update({'firstPrinted': True}) %} {% endif %}
+  {% endfor %}
+{% endif %}
+{% endfor %}
+},
+
+"MGMT_INTERFACE": {
+    "eth0|{{ device_info["ManagementIp"] }}": {
+        "gwaddr": "{{ device_info["ManagementGw"] }}"
+    }
+}
+
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Allow to use sonic device as fanout switch

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
- Generate fanout switch configuration for sonic device
- disable bgp/lldp/dhcp_relay/teamd service on the sonic fanout switch
- remove all copp traps on sonic fanout switch

How did you verify/test it?
- Use sonic device as fanout and test

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
