### PR TITLE
Adding Save & Reload testcase for ACL

### DIFF
--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -81,6 +81,25 @@
         command_to_run: "acl-loader update incremental /tmp/acltb_test_rules_part_2.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
+         
+    - name: Run the test
+      include: ptf_runner.yml
+      vars:
+          ptf_test_name: ACL Test
+          ptf_test_dir: acstests
+          ptf_test_path: acltb_test.AclTest
+          ptf_platform: remote
+          ptf_test_params:
+            - verbose=True
+            - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
+            - switch_info=\"/tmp/acltb_switch_info.txt\"
+            - testbed_type=\"{{ testbed_type }}\"
+            
+    - name: Save the applied ACL in ConfigDB
+      command: config save -y 			
+    
+    - name: Reboot the switch 
+      include: common_tasks/reboot_sonic.yml
 
     - name: Run the test
       include: ptf_runner.yml
@@ -94,10 +113,19 @@
             - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
-
+            
   always:
+    # Copy ACL config to the switch
+    - name: Copy ACL config file to the DUT
+      copy: src="roles/test/tasks/acl/{{ item }}" dest="/tmp/"
+      with_items:
+        - "acltb_test_rules-del.json"
+      
     - name: Clean up ACL rules.
       vars:
         command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
+
+    - name: Ensure ConfigDB is cleaned up 
+      command: config save -y 	      

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -81,7 +81,7 @@
         command_to_run: "acl-loader update incremental /tmp/acltb_test_rules_part_2.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
-         
+
     - name: Run the test
       include: ptf_runner.yml
       vars:
@@ -94,11 +94,11 @@
             - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
-            
+
     - name: Save the applied ACL in ConfigDB
-      command: config save -y 			
-    
-    - name: Reboot the switch 
+      command: config save -y
+
+    - name: Reboot the switch
       include: common_tasks/reboot_sonic.yml
 
     - name: Run the test
@@ -113,10 +113,13 @@
             - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
-            
+
   always:
     - name: Clean up ACL rules.
-      command: acl-loader delete
+      vars:
+        command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
+        errors_expected: false
+      include: roles/test/tasks/run_command_with_log_analyzer.yml
 
-    - name: Ensure ConfigDB is cleaned up 
-      command: config save -y 	      
+    - name: Ensure ConfigDB is cleaned up
+      command: config save -y

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -115,17 +115,8 @@
             - testbed_type=\"{{ testbed_type }}\"
             
   always:
-    # Copy ACL config to the switch
-    - name: Copy ACL config file to the DUT
-      copy: src="roles/test/tasks/acl/{{ item }}" dest="/tmp/"
-      with_items:
-        - "acltb_test_rules-del.json"
-      
     - name: Clean up ACL rules.
-      vars:
-        command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
-        errors_expected: false
-      include: roles/test/tasks/run_command_with_log_analyzer.yml
+      command: acl-loader delete
 
     - name: Ensure ConfigDB is cleaned up 
       command: config save -y 	      


### PR DESCRIPTION
This checkin adds changes to perform save and reload test case for ACL rules

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
How did you do it?
Installed the ACL rules in the switch, 
pushed the changes to configDB, 
performed a reload, 
re-run the traffic test
How did you verify/test it?
Using PTF traffic test, verified the desired packets are blocked after save and reload. 
Any platform specific information?
Supported testbed topology if it's a new test case?
[t1, t1-lag, t1-64-lag]
[aclreload.log](https://github.com/Azure/sonic-mgmt/files/1769509/aclreload.log)

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
successful test run log in T1 topology is attached along with pull request. 