### PR TITLE
[service_acl] Make test more robust and efficient

### DIFF
--- a/ansible/roles/test/tasks/service_acl.yml
+++ b/ansible/roles/test/tasks/service_acl.yml
@@ -6,7 +6,7 @@
   failed_when: not file_stat.stat.exists
 
 # Gather facts with SNMP version 2
-- name: Ensure we can gather basic SNMP facts about the device
+- name: Ensure we can gather basic SNMP facts from the device
   snmp_facts:
     host: "{{ ansible_host }}"
     version: "v2c"
@@ -28,20 +28,15 @@
   become: true
   shell: "nohup /tmp/config_service_acls.sh < /dev/null > /dev/null 2>&1 &"
 
-- name: Sleep for a few seconds to let new ACLs take effect
-  pause:
-    seconds: 5
-
-- name: Ensure SSH connection to DuT now times out
+# Note that the timeout here should be sufficiently long enough to allow
+# config_service_acls.sh to apply the new service ACLs
+- name: Ensure the SSH port on the DuT becomes closed to us
   wait_for:
-    port: "22"
-    state: "started"
-    host: "{{ inventory_hostname }}"
-    connect_timeout: "5"
-    timeout: "10"
-  delegate_to: "localhost"
-  register: result
-  failed_when: result.msg != "Timeout when waiting for {{ inventory_hostname }}:22"
+    port: 22
+    state: stopped
+    host: "{{ ansible_host }}"
+    timeout: 15
+  connection: local
 
 # Gather facts with SNMP version 2
 - name: Ensure attempt to gather basic SNMP facts about the device now times out
@@ -51,23 +46,27 @@
     community: "{{ snmp_rocommunity }}"
   connection: local
   register: result
-#  failed_when: "'No SNMP response received before timeout' not in result.msg"
   failed_when: result.msg != "No SNMP response received before timeout"
 
-# Adjust the number of seconds we sleep here relative to the number of seconds
-# config_service_acls.sh is set to sleep before applying the original service ACLs
-- name: Sleep to ensure config_service_acls.sh has reinstated the original service ACLs
-  pause:
-    seconds: 30
+# Note that the timeout here should be sufficiently long enough to allow
+# config_service_acls.sh to reset the ACLs to their original configuration
+- name: Wait until the original service ACLs are reinstated and the SSH port on the DUT is open to us once again
+  wait_for:
+    port: 22
+    state: started
+    host: "{{ ansible_host }}"
+    search_regex: "OpenSSH"
+    timeout: 60
+  connection: local
 
-- name: Delete config_service_acls.sh from the DuT (this also tests that we can once again SSH to the DuT)
+- name: Delete config_service_acls.sh from the DuT
   become: true
   file:
     state: absent
     path: /tmp/config_service_acls.sh
 
 # Gather facts with SNMP version 2
-- name: Ensure we can gather basic SNMP facts about the device once again
+- name: Ensure we can gather basic SNMP facts from the device once again
   snmp_facts:
     host: "{{ ansible_host }}"
     version: "v2c"


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Tweak the way we check for SSH port to be open/closed, removing long sleeps and instead using checks with timeouts. Therefore, successful runs of the test should take less time.
