### PR TITLE
Fix typo in acl test case name

### DIFF
--- a/ansible/roles/test/tasks/acl/acl_orchagent_logic_test/acl_orchagent_logic_test.yml
+++ b/ansible/roles/test/tasks/acl/acl_orchagent_logic_test/acl_orchagent_logic_test.yml
@@ -185,7 +185,7 @@
         run_cleanup: false
       include: "{{ run_config_test }}"
 
-    - name: Rule test - invalid ip type.
+    - name: Rule test - valid ip type.
       vars:
         config_file: "{{ config_ip_type_valid_1 }}"
         test_expect_file: "{{ config_empty_expect }}"


### PR DESCRIPTION
Simple typo fix
In the acl_orchagent_logic_test.yml:

    - name: Rule test - invalid ip type.
      vars:
        config_file: "{{ config_ip_type_valid_1 }}"
        test_expect_file: "{{ config_empty_expect }}"
        errors_expected: false
        run_cleanup: false
      include: "{{ run_config_test }}"

The test case includes a "valid" test file, but it is named as "invalid" test