### PR TITLE
Add one more Mellanox SKU string in everflow_tb_test script

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_tb_test.py
+++ b/ansible/roles/test/files/acstests/everflow_tb_test.py
@@ -141,7 +141,7 @@ class EverflowTest(BaseTest):
 
         payload = str(scapy_pkt[scapy.GRE].payload)
 
-        if self.hwsku in ["ACS-MSN2700", "ACS-MSN2100", "ACS-MSN2410", "ACS-MSN2740"]:
+        if self.hwsku in ["ACS-MSN2700", "ACS-MSN2100", "ACS-MSN2410", "ACS-MSN2740", "Mellanox-SN2700"]:
             payload = str(scapy_pkt[scapy.GRE].payload)[22:]
 
         inner_pkt = scapy.Ether(payload)


### PR DESCRIPTION
Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes Everflow Testbed Test with a new Mellanox SKU

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it? Add one more Mellanox SKU string in everflow_tb_test script
How did you verify/test it? Test with tag 'everflow_testbed'
Any platform specific information? Mellanox
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
