### PR TITLE
add port speed and fec configuration in sonic fanout

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -156,9 +156,9 @@ class Parse_Lab_Graph():
                 start_dev = link.attrib['StartDevice']
                 end_dev = link.attrib['EndDevice']
                 if start_dev:
-                    self.links[start_dev][link.attrib['StartPort']] = {'peerdevice':link.attrib['EndDevice'], 'peerport': link.attrib['EndPort']}
+                    self.links[start_dev][link.attrib['StartPort']] = {'peerdevice':link.attrib['EndDevice'], 'peerport': link.attrib['EndPort'], 'speed': link.attrib['BandWidth']}
                 if end_dev:
-                    self.links[end_dev][link.attrib['EndPort']] = {'peerdevice': link.attrib['StartDevice'], 'peerport': link.attrib['StartPort']}
+                    self.links[end_dev][link.attrib['EndPort']] = {'peerdevice': link.attrib['StartDevice'], 'peerport': link.attrib['StartPort'], 'speed': link.attrib['BandWidth']}
         self.devices = deviceinfo
         self.vlanport = devicel2info
 

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,5 +1,9 @@
 - debug: msg="{{ device_info }}"
 
+- name: find interface name mapping
+  port_alias: hwsku="{{ device_info["HwSku"] }}"
+  connection: local
+
 - name: prepare fanout switch admin login info
   set_fact: ansible_user={{ fanout_sonic_user }} ansible_password={{ fanout_sonic_password }}
 
@@ -17,7 +21,7 @@
     ansible_python_interpreter: docker exec -i swss python
 
 - name: generate config_db.json
-  shell: sonic-cfggen -j /etc/sonic/vlan.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+  shell: sonic-cfggen -H -j /etc/sonic/vlan.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
   become: yes
 
 - name: reload config_db.json

--- a/ansible/roles/fanout/templates/sonic_deploy.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy.j2
@@ -7,6 +7,17 @@
     }
 },
 
+"PORT": {
+{% for alias in device_conn %}
+    "{{ port_alias_map[alias] }}": {
+{% if device_conn[alias]['speed'] == "100000" %}
+        "fec" : "rs",
+{% endif %}
+        "speed" : "{{ device_conn[alias]['speed'] }}"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
 "VLAN": {
 {% for vlanid in device_vlan_list | unique %}
     "Vlan{{ vlanid }}": {
@@ -17,17 +28,17 @@
 
 {% set ns = {'firstPrinted': False} %}
 "VLAN_MEMBER": {
-{% for port in device_port_vlans %}
-{% if device_port_vlans[port]['mode'] == 'Access' %}
+{% for alias in device_port_vlans %}
+{% if device_port_vlans[alias]['mode'] == 'Access' %}
 {% if ns.firstPrinted %},{% endif %}
-    "Vlan{{ device_port_vlans[port]['vlanids'] }}|{{ port }}": {
+    "Vlan{{ device_port_vlans[alias]['vlanids'] }}|{{ port_alias_map[alias] }}": {
         "tagging_mode" : "untagged"
     }
 {% if ns.update({'firstPrinted': True}) %} {% endif %}
-{% elif device_port_vlans[port]['mode'] == 'Trunk' %}
-  {% for vlanid in device_port_vlans[port]['vlanlist'] %}
+{% elif device_port_vlans[alias]['mode'] == 'Trunk' %}
+  {% for vlanid in device_port_vlans[alias]['vlanlist'] %}
 {% if ns.firstPrinted %},{% endif %}
-    "Vlan{{ vlanid }}|{{ port }}": {
+    "Vlan{{ vlanid }}|{{ port_alias_map[alias] }}": {
         "tagging_mode" : "tagged"
     }
 {% if ns.update({'firstPrinted': True}) %} {% endif %}


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
1. add port speed and fec configuration in sonic fanout
2. export port_alias_map/port_name_map in port_alias library. port_alias_map is the alias to port name map, port_name_map is the port name to alias name.

How did you verify/test it?
Tested on real sonic fanout switch

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
