### PR TITLE
[everflow]: Add support for t1-64-lag topology

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/run_test.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/run_test.yml
@@ -6,7 +6,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1']
+  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_1.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_1.yml
@@ -7,7 +7,7 @@
 
 - block:
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_2.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_2.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} via {{ neighbor_info_1['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,7 +16,7 @@
       shell: ip route add {{ session_prefix_2 }} via {{ unresolved_nexthop }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -26,7 +26,7 @@
       shell: ip route change {{ session_prefix_2 }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_3.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_3.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} via {{ neighbor_info_1['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,7 +16,7 @@
       shell: ip route add {{ session_prefix_2 }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_2}}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -27,7 +27,7 @@
       ignore_errors: yes
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}. 
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_4.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_4.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} via {{ neighbor_info_1['addr'] }} 
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="{{ neighbor_mac_1 }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="{{ neighbor_mac_1 }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,7 +16,7 @@
       shell: ip neigh replace {{ neighbor_info_1['addr'] }} lladdr "00:11:22:33:44:55" nud permanent dev {{ dst_port_1 }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on destination port {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="00:11:22:33:44:55";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";expected_dst_mac="00:11:22:33:44:55";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
@@ -6,7 +6,7 @@
 
 - block:
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_6.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_6.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,14 +16,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_7.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_7.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,14 +16,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on  {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest--platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_2 }} and {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest--platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -34,7 +34,7 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets are not received {{ dst_port_1 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest--platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -42,7 +42,7 @@
       failed_when: out.rc == 0
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_2 }} or {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest--platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_2_ptf_id }},{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_8.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_8.yml
@@ -6,7 +6,7 @@
       shell: ip route add {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -16,14 +16,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }} via {{ neighbor_info_3['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
@@ -34,14 +34,14 @@
       shell: ip route change {{ session_prefix_1 }} nexthop via {{ neighbor_info_1['addr'] }} via {{ neighbor_info_2['addr'] }}
 
     - name: Send traffic and verify that packets with correct Everflow header are received on {{ dst_port_1 }} or {{ dst_port_2 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_1_ptf_id }}, {{ dst_port_2_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
 
     - name: Send traffic and verify that packets are not received on {{ dst_port_3 }}.
-      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest  --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
+      shell: ptf --test-dir acstests everflow_tb_test.EverflowTest --platform-dir ptftests --platform remote -t 'hwsku="{{ sonic_hwsku }}";router_mac="{{ ansible_Ethernet0['macaddress'] }}";src_port="{{ src_port_ptf_id }}";dst_ports="{{ dst_port_3_ptf_id }}";session_src_ip="{{ session_src_ip }}";session_dst_ip="{{ session_dst_ip }}";session_ttl="{{ session_ttl }}";session_dscp="{{ session_dscp }}";verbose=True'
       args:
         chdir: /root
       delegate_to: "{{ ptf_host }}"


### PR DESCRIPTION
Add --platform-dir ptftests to all PTF shell command

The default remote.py in ptf package only support 32-port platform. For 64 port platform, we need to use the remote.py deployed in ptftests dir. therefore, we added --platform-dir in the ptf command line, and the new remote.py is backward compatible with the default ptf 32-port remote.py

TODO: Use PTF runner to invoke all the PTF tests
