### PR TITLE
[lag_2] remove hard coded interval_count so it can be set by test

### DIFF
--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -81,7 +81,6 @@
   vars: 
     vm_name: "{{ peer_device }}"
     lacp_timer: 1
-    interval_count: 3
 
 # make sure portchannel peer rate is set to slow
 - name: make sure all lag members on VM are set to slow
@@ -99,4 +98,3 @@
   vars: 
     vm_name: "{{ peer_device }}"
     lacp_timer: 30
-    interval_count: 3


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
Remove hard coded interval_count in lag_2 test.

The default count is still 3. However, by removing these 2 lines, test owner could pass in extra variables to override interval_count without having to edit code.

How did you verify/test it?
- Passed lag_2 test with test by name without specifying interval_count.
- Passed lag_2 test with test by name with specifying interval_count=5.
- Passed lag_2 test with test by tag without specifying interval_count.
- Passed lag_2 test with test by tag with specifying interval_count=5.
- Executed another test with tag (fdb), no error.