### PR TITLE
[Linkstate propogator]: Remove leading and trailing whitespaces when reading veos file

### DIFF
--- a/ansible/linkstate/scripts/ptf_proxy.py
+++ b/ansible/linkstate/scripts/ptf_proxy.py
@@ -126,6 +126,7 @@ def parse_veos(vms):
         all = fp.read()
     rows = all.split('\n')
     for r in rows:
+        r = r.strip()
         if r == '':
             continue
         if not r.startswith('VM'):


### PR DESCRIPTION
Fix ptf_proxy. When parsing veos file the ptf_proxy could crash when it reads a line with trailing whitespaces. So remove trailing whitespaces before parsing.