### PR TITLE
Pull syncd-rpc with sonic version tag

### DIFF
--- a/ansible/roles/sonic-common/tasks/snmp.yml
+++ b/ansible/roles/sonic-common/tasks/snmp.yml
@@ -28,7 +28,7 @@
   setup:
 
 - name: Gather SONiC base image version
-  shell: grep -E "menuentry ['](ACS)|(SONiC)-OS" /host/grub/grub.cfg | awk '{print $2}' | sed 's/'\''//g'
+  shell: grep -E "^menuentry [']((ACS)|(SONiC))-OS-" /host/grub/grub.cfg | awk '{print $2}' | sed 's/'\''//g'
   become: true
   register: result
   changed_when: false

--- a/ansible/swap_syncd.yml
+++ b/ansible/swap_syncd.yml
@@ -51,11 +51,21 @@
         value: 509430500
         sysctl_set: yes
 
+    - name: Gather SONiC base image version
+      shell: grep -E "^menuentry [']((ACS)|(SONiC))-OS-" /host/grub/grub.cfg | awk '{print $2}' | sed 's/'\''//g'
+      become: true
+      register: result
+      changed_when: false
+
+    - name: Set base image verison variable
+      set_fact:
+        sonic_image_version: "{{ result.stdout | regex_replace('.+-([^-]+)$', '\\1') }}"
+
     - name: Pull syncd-rpc docker from registry
-      shell: docker login -u {{docker_registry_username}} -p {{docker_registry_password}} -e "@" {{docker_registry_host}}; docker pull {{docker_registry_host}}/{{docker_rpc_image_name}} 
+      shell: docker login -u {{docker_registry_username}} -p {{docker_registry_password}} {{docker_registry_host}}; docker pull {{docker_registry_host}}/{{docker_rpc_image_name}}:{{sonic_image_version}}
 
     - name: Tag pulled images as syncd
-      shell: docker tag {{docker_registry_host}}/{{docker_rpc_image_name}} {{docker_syncd_name}}
+      shell: docker tag {{docker_registry_host}}/{{docker_rpc_image_name}}:{{sonic_image_version}} {{docker_syncd_name}}
 
     - name: Start swss service
       become: true


### PR DESCRIPTION
Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes RPC related test playbook: originally we pull _latest_ mlnx/brcm-syncd-rpc. We should restrict the image tag, which is the sonic_version string. So we have the flexibility to test different sonic branches, such as different SAI version for the same platform.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Add docker tag when docker pull.
How did you verify/test it?
Test swap_syncd.yml locally
Any platform specific information?
All
Supported testbed topology if it's a new test case?
All

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
