### PR TITLE
[lag_test]: Remove the unnecessary testbed_type check

### DIFF
--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -11,10 +11,6 @@
 - fail: msg="Please define testbed_type"
   when: testbed_type is not defined
 
-
-- fail: msg="this test only support t1-lag and t0 testbed_type"
-  when: testbed_type not in ['t1-lag', 't0', 't0-116']
-
 - name: gathering lag facts from device
   lag_facts: host={{ inventory_hostname }}
 


### PR DESCRIPTION
the testbed_type restriction is already in the vars/testcases.yml file

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
