### PR TITLE
Fix snmp queue test

### DIFF
--- a/ansible/roles/test/tasks/snmp/queues.yml
+++ b/ansible/roles/test/tasks/snmp/queues.yml
@@ -5,5 +5,5 @@
 
 - fail:
     msg: "Port {{ item.key }} does not has queue counters"
-  when: not item.value.queues
+  when: "{{ item.value.description | match('^Ethernet') }} and {{ item.value['queues'] is not defined }}"
   with_dict: "{{ snmp_interfaces }}"


### PR DESCRIPTION
Only test queue on Ethernet interfaces, ie. not on LAG, vlan interfaces.