### PR TITLE
New Testcase - No stale entry when replacing ACL

### DIFF
--- a/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json
@@ -16,7 +16,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "source-ip-address": "10.0.0.2/32"
+                                        "source-ip-address": "21.0.0.0/8"
                                     }
                                 }
                             },
@@ -31,7 +31,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "192.168.0.16/32"
+                                        "destination-ip-address": "104.146.32.0/19"
                                     }
                                 }
                             },
@@ -47,6 +47,66 @@
                                 "transport": {
                                     "config": {
                                         "source-port": "4661"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "23.103.0.0/18"
+                                    }
+                                }
+                            },
+                            "5": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 5
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "104.44.94.0/23"
+                                    }
+                                }
+                            },
+                            "6": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 6
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "100.64.0.0/10"
+                                    }
+                                }
+                            },
+							"7": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 7
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "172.16.0.0/12"
                                     }
                                 }
                             },

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -55,7 +55,7 @@
       copy: src=roles/test/files/ptftests
             dest=/root
       delegate_to: "{{ ptf_host }}"
-
+      
     - name: Run the test
       include: ptf_runner.yml
       vars:
@@ -82,11 +82,99 @@
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
 
-    - name: Apply part 2 of ACL rules.
+    - name: Apply part 2 of ACL rules
       vars:
         command_to_run: "acl-loader update incremental /tmp/acltb_test_rules_part_2.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
+
+    - name: Get ACL entry keys in ConfDB
+      command: bash -c "docker exec -i database redis-cli --raw -n 4 KEYS '*ACL_RULE*'"
+      register: keys
+    - set_fact: acl_tbl_confdb_keys={{keys.stdout.split()}}
+
+    - name: Collect ConfDB ACL entries based on the ACL entry keys
+      command: bash -c "docker exec -i database redis-cli -n 4 HGETALL '{{item}}'"
+      register: confDBentries
+      with_items: "{{acl_tbl_confdb_keys}}"
+
+    - name: Extract the stdout values and store in a register
+      set_fact:
+        rule: "{{item.stdout}}"
+      with_items: "{{confDBentries.results}}"
+      register: rules
+
+    - name: Make a list of rules with qualifiers & actions
+      set_fact:
+        acl:  "{{ rules.results | map(attribute='ansible_facts.rule') | list }}"
+
+    - name: Join the acl entries for comparison
+      set_fact:
+        entries: "{{acl | join(' ')}}"
+
+    - name: Verify the acltb_test_rules_part_1 are not present in ConfDB
+      assert:
+        that:
+          - "'FORWARD\nSRC_IP\n21.0.0.0/8' not in entries"
+          - "'FORWARD\nDST_IP\n104.146.32.0/19' not in entries"
+          - "'FORWARD\nSRC_IP\n23.103.0.0/18' not in entries"
+          - "'FORWARD\nSRC_IP\n104.44.94.0/23' not in entries"
+          - "'FORWARD\nDST_IP\n100.64.0.0/10' not in entries"
+          - "'FORWARD\nDST_IP\n172.16.0.0/12' not in entries"
+        msg: Mismatch in ACL loaded via acl-loader JSON file Vs ConfDB
+
+    - name: Get ACL entry keys in ASICDB
+      command: bash -c "docker exec -i database redis-cli --raw -n 1 KEYS '*SAI_OBJECT_TYPE_ACL_ENTRY*'"
+      register: mask
+    - set_fact: acl_tbl_asicdb_keys={{mask.stdout.split()}}
+
+    - name: Collect ASICDB ACL entries based on the ACL entry keys
+      command: bash -c "docker exec -i database redis-cli -n 1 HGETALL {{item}}"
+      register: asicDBentries
+      with_items: "{{acl_tbl_asicdb_keys}}"
+
+    - name: Extract the stdout values and store in a register
+      set_fact:
+        rule: "{{item.stdout}}"
+      with_items: "{{asicDBentries.results}}"
+      register: rules
+
+    - name: Make a list of rules with qualifiers & actions
+      set_fact:
+        acl:  "{{ rules.results | map(attribute='ansible_facts.rule') | list }}"
+
+    - name: Join the acl entries for comparison
+      set_fact:
+        entries: "{{acl | join(' ')}}"
+
+    - name: Verify the acltb_test_rules_part_1 are not present in ASICDB
+      assert:
+        that:
+          - >
+            "'SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP\n21.0.0.0&mask:255.0.0.0\n
+            SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION\nSAI_PACKET_ACTION_FORWARD'
+            not in entries"
+          - >
+            "'SAI_ACL_ENTRY_ATTR_FIELD_DST_IP\n104.146.32.0&mask:255.255.224.0\n
+            SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION\nSAI_PACKET_ACTION_FORWARD'
+            not in entries"
+          - >
+            "'SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP\n23.103.0.0&mask:255.255.192.0\n
+            SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION\nSAI_PACKET_ACTION_FORWARD'
+            not in entries"
+          - >
+            "'SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP\n104.44.94.0&mask:255.255.254.0\n
+            SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION\nSAI_PACKET_ACTION_FORWARD'
+            not in entries"
+          - >
+            "'SAI_ACL_ENTRY_ATTR_FIELD_DST_IP\n100.64.0.0&mask:255.192.0.0\n
+            SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION\nSAI_PACKET_ACTION_FORWARD'
+            not in entries"
+          - >
+            "'SAI_ACL_ENTRY_ATTR_FIELD_DST_IP\n172.16.0.0&mask:255.240.0.0\n
+            SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION\nSAI_PACKET_ACTION_FORWARD'
+            not in entries"
+        msg: Mismatch in ACL loaded via acl-loader JSON file Vs ASICDB
 
     - name: Run the test
       include: ptf_runner.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Apply a set of rules say ACL1 on all the interfaces, replace ACL1 with different set of rules say ACL2. Ensure there are no stale entries related to ACL1 in ConfDB/ASICDB
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
How did you do it?
Create 2 set of ACL rules say acltb_test_rules_part1 & acltb_test_rules_part2. 
Apply part1 and replace it with part2. 
How did you verify/test it?
Verify no part1 related rules are present in ConfDB and ASIC DB. 
Any platform specific information?
Supported testbed topology if it's a new test case?
[t1, t1-lag, t1-64-lag]

[rulereplace.log](https://github.com/Azure/sonic-mgmt/files/1821272/rulereplace.log)

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
