### PR TITLE
[snmp_facts] increase get command timeout to fix cpu test failure

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -291,7 +291,7 @@ def main():
     results = Tree()
 
     # Getting system description could take more than 1 second on some Dell platform
-    # (e.g. S6000), increse timeout to tolerate the delay.
+    # (e.g. S6000) when cpu utilization is high, increse timeout to tolerate the delay.
     errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
         snmp_auth,
         cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=5.0),

--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -302,7 +302,7 @@ def main():
     )
 
     if errorIndication:
-        module.fail_json(msg=str(errorIndication))
+        module.fail_json(msg=str(errorIndication) + ' querying system infomation.')
 
     for oid, val in varBinds:
         current_oid = oid.prettyPrint()
@@ -337,7 +337,7 @@ def main():
     )
 
     if errorIndication:
-        module.fail_json(msg=str(errorIndication))
+        module.fail_json(msg=str(errorIndication) + ' querying interface details')
 
     interface_indexes = []
 
@@ -401,7 +401,7 @@ def main():
     )
 
     if errorIndication:
-        module.fail_json(msg=str(errorIndication))
+        module.fail_json(msg=str(errorIndication) + ' querying interface counters')
 
     for varBinds in varTable:
         for oid, val in varBinds:
@@ -458,7 +458,7 @@ def main():
         )
 
         if errorIndication:
-            module.fail_json(msg=str(errorIndication))
+            module.fail_json(msg=str(errorIndication) + ' querying CPU busy indeces')
 
         for oid, val in varBinds:
             current_oid = oid.prettyPrint()
@@ -476,7 +476,7 @@ def main():
     )
 
     if errorIndication:
-        module.fail_json(msg=str(errorIndication))
+        module.fail_json(msg=str(errorIndication) + ' querying PFC counters')
 
     for varBinds in varTable:
         for oid, val in varBinds:
@@ -504,7 +504,7 @@ def main():
     )
 
     if errorIndication:
-        module.fail_json(msg=str(errorIndication))
+        module.fail_json(msg=str(errorIndication) + ' querying QoS stats')
 
     for varBinds in varTable:
         for oid, val in varBinds:
@@ -524,7 +524,7 @@ def main():
     )
 
     if errorIndication:
-        module.fail_json(msg=str(errorIndication))
+        module.fail_json(msg=str(errorIndication) + ' querying FRU')
 
     for varBinds in varTable:
         for oid, val in varBinds:


### PR DESCRIPTION
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
- Separate system description query and increase query timeout to 5 seconds.
- The rest of the query still use default timeout: 1 second.

How did you verify/test it?
- Before the change, snmp cpu test consistently fails on Dell S6000 platform.
- With the change, snmp cpu test passes on Dell S6000 platform.
