### PR TITLE
Fix improper 'local_action' syntax

### DIFF
--- a/ansible/boot_onie.yml
+++ b/ansible/boot_onie.yml
@@ -27,37 +27,37 @@
         real_ansible_host: "{{ ansible_ssh_host }}"
 
     - name: Wait for switch to come back (to ONIE)
-      local_action:
-        wait_for:
-          host: "{{ real_ansible_host }}"
-          port: 22
-          state: started
-          delay: 60
-          timeout: 300
       become: false
+      local_action: wait_for
+      args:
+        host: "{{ real_ansible_host }}"
+        port: 22
+        state: started
+        delay: 60
+        timeout: 300
       changed_when: false
 
     - name: Wait for switch to reboot again
-      local_action:
-        wait_for:
-          host: "{{ real_ansible_host }}"
-          port: 22
-          state: stopped
-          delay: 5
-          timeout: 600
       become: false
+      local_action: wait_for
+      args:
+        host: "{{ real_ansible_host }}"
+        port: 22
+        state: stopped
+        delay: 5
+        timeout: 600
       changed_when: false
 
     - name: Wait for switch to come back (to SONiC)
-      local_action:
-        wait_for:
-          host: "{{ real_ansible_host }}"
-          port: 22
-          state: started
-          search_regex: "OpenSSH"
-          delay: 30
-          timeout: 600
       become: false
+      local_action: wait_for
+      args:
+        host: "{{ real_ansible_host }}"
+        port: 22
+        state: started
+        search_regex: "OpenSSH"
+        delay: 30
+        timeout: 600
       changed_when: false
 
     - name: Wait for the SONiC initialization process

--- a/ansible/roles/sonic-common/tasks/main.yml
+++ b/ansible/roles/sonic-common/tasks/main.yml
@@ -243,13 +243,13 @@
   tags: unsafe
 
 - name: After rebooting, wait for switch to come back
-  local_action:
-    wait_for:
-      host: "{{ inventory_hostname }}"
-      port: 22
-      state: started
-      delay: 30
-      timeout: 300
   become: false
+  local_action: wait_for
+  args:
+    host: "{{ inventory_hostname }}"
+    port: 22
+    state: started
+    delay: 30
+    timeout: 300
   when: reboot_required is defined
   tags: unsafe

--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -8,15 +8,15 @@
   pause: minutes=1
 
 - name: Wait for switch to come back
-  local_action:
-    wait_for:
-      host: "{{ ansible_host }}"
-      port: 22
-      state: started
-      search_regex: "OpenSSH_[\w\.]+ Debian"
-      delay: 10
-      timeout: 180
   become: false
+  local_action: wait_for
+  args:
+    host: "{{ ansible_host }}"
+    port: 22
+    state: started
+    search_regex: "OpenSSH_[\w\.]+ Debian"
+    delay: 10
+    timeout: 180
   changed_when: false
 
 - name: wait for 2 minute for prcesses and interfaces to be stable

--- a/ansible/roles/test/tasks/service_acl.yml
+++ b/ansible/roles/test/tasks/service_acl.yml
@@ -31,12 +31,12 @@
 # Note that the timeout here should be sufficiently long enough to allow
 # config_service_acls.sh to apply the new service ACLs
 - name: Ensure the SSH port on the DuT becomes closed to us
-  local_action:
-    wait_for:
-      host: "{{ ansible_host }}"
-      port: 22
-      state: stopped
-      timeout: 15
+  local_action: wait_for
+  args:
+    host: "{{ ansible_host }}"
+    port: 22
+    state: stopped
+    timeout: 15
 
 # Gather facts with SNMP version 2
 - name: Ensure attempt to gather basic SNMP facts about the device now times out
@@ -51,13 +51,13 @@
 # Note that the timeout here should be sufficiently long enough to allow
 # config_service_acls.sh to reset the ACLs to their original configuration
 - name: Wait until the original service ACLs are reinstated and the SSH port on the DUT is open to us once again
-  local_action:
-    wait_for:
-      host: "{{ ansible_host }}"
-      port: 22
-      state: started
-      search_regex: "OpenSSH"
-      timeout: 60
+  local_action: wait_for
+  args:
+    host: "{{ ansible_host }}"
+    port: 22
+    state: started
+    search_regex: "OpenSSH"
+    timeout: 60
 
 - name: Delete config_service_acls.sh from the DuT
   become: true

--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -31,13 +31,13 @@
           ignore_errors: true
 
         - name: Wait for switch to come back (to ONIE)
-          local_action:
-            wait_for:
-              host: "{{ real_ansible_host }}"
-              port: 22
-              state: started
-              delay: 60
-              timeout: 300
+          local_action: wait_for
+          args:
+            host: "{{ real_ansible_host }}"
+            port: 22
+            state: started
+            delay: 60
+            timeout: 300
           changed_when: false
 
         - name: Stop onie discovery
@@ -55,13 +55,13 @@
           ignore_errors: true
 
         - name: Wait for switch to reboot again (ONIE installation finishes)
-          local_action:
-            wait_for:
-              host: "{{ real_ansible_host }}"
-              port: 22
-              state: stopped
-              delay: 5
-              timeout: 600
+          local_action: wait_for
+          args:
+            host: "{{ real_ansible_host }}"
+            port: 22
+            state: stopped
+            delay: 5
+            timeout: 600
           changed_when: false
 
       when: upgrade_type == "onie"
@@ -86,14 +86,14 @@
       when: upgrade_type == "sonic"
 
     - name: Wait for switch {{ inventory_hostname }} to come back (to SONiC)
-      local_action:
-        wait_for:
-          host: "{{ real_ansible_host }}"
-          port: 22
-          state: started
-          search_regex: "OpenSSH"
-          delay: 30
-          timeout: 600
+      local_action: wait_for
+      args:
+        host: "{{ real_ansible_host }}"
+        port: 22
+        state: started
+        search_regex: "OpenSSH"
+        delay: 30
+        timeout: 600
       changed_when: false
 
     - name: Wait for SONiC initialization


### PR DESCRIPTION
Fix improper `local_action` nesting syntax introduced by https://github.com/Azure/sonic-mgmt/pull/527