### PR TITLE
[minigraph_facts] use mingraph on DUT to test

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -42,7 +42,7 @@ ns2 = "Microsoft.Search.Autopilot.NetMux"
 ns3 = "http://www.w3.org/2001/XMLSchema-instance"
 
 ANSIBLE_USER_MINIGRAPH_PATH = os.path.expanduser('~/.ansible/minigraph')
-ANSIBLE_LOCAL_MINIGRAPH_PATH = 'minigraph/{}.xml'
+ANSIBLE_LOCAL_MINIGRAPH_PATH = '{}.xml'
 ANSIBLE_USER_MINIGRAPH_MAX_AGE = 86400  # 24-hours (in seconds)
 
 class minigraph_encoder(json.JSONEncoder):
@@ -383,15 +383,12 @@ def reconcile_mini_graph_locations(filename, hostname):
     """
     if filename is not None:
         # literal filename specified. read directly from the file.
-        root = ET.parse(filename).getroot()
         mini_graph_path = filename
     else:
         # only the hostname was specified, determine the output path
-        mini_graph_path = os.path.join(ANSIBLE_USER_MINIGRAPH_PATH, hostname + '_minigraph.xml')
-        if os.path.exists(mini_graph_path) and file_age(mini_graph_path) < ANSIBLE_USER_MINIGRAPH_MAX_AGE:
-            # found a cached mini-graph, load it.
-            root = ET.parse(mini_graph_path).getroot()
+        mini_graph_path = '/etc/sonic/minigraph.xml'
 
+    root = ET.parse(mini_graph_path).getroot()
     return mini_graph_path, root
 
 
@@ -620,7 +617,7 @@ def main():
     local_file_path = ANSIBLE_LOCAL_MINIGRAPH_PATH.format(m_args['host'])
     if 'filename' in m_args and m_args['filename'] is not None:
         # literal filename specified
-        filename = "minigraph/%s" % m_args['filename']
+        filename = "%s" % m_args['filename']
     elif os.path.exists(local_file_path):
         # local project minigraph found for the hostname, use that file
         filename = local_file_path
@@ -638,7 +635,7 @@ def main():
 
 
 def print_parse_xml(hostname):
-    filename = '../minigraph/' + hostname + '.xml'
+    filename = hostname + '.xml'
     results = parse_xml(filename, hostname)
     print(json.dumps(results, indent=3, cls=minigraph_encoder))
 

--- a/ansible/roles/sonic-common/tasks/main.yml
+++ b/ansible/roles/sonic-common/tasks/main.yml
@@ -1,8 +1,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Set sonic_asic_type fact
   set_fact:

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -7,8 +7,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Read port reverse alias mapping
   set_fact:

--- a/ansible/roles/test/tasks/acltb_ranges_test.yml
+++ b/ansible/roles/test/tasks/acltb_ranges_test.yml
@@ -40,8 +40,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Read port reverse alias mapping
   set_fact:

--- a/ansible/roles/test/tasks/bgp_fact.yml
+++ b/ansible/roles/test/tasks/bgp_fact.yml
@@ -1,8 +1,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Print bgp neighbors in minigraph
   debug: msg="{{ minigraph_bgp }}"

--- a/ansible/roles/test/tasks/bgp_flap.yml
+++ b/ansible/roles/test/tasks/bgp_flap.yml
@@ -20,5 +20,3 @@
 
 - name: recover minigraph facts about the device(above steps loaded neighbors configuration)
   minigraph_facts: host="{{ inventory_hostname }}"
-  connection: local
-  become: no

--- a/ansible/roles/test/tasks/bgp_multipath_relax.yml
+++ b/ansible/roles/test/tasks/bgp_multipath_relax.yml
@@ -14,7 +14,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
 
 - name:  Find all V4 bgp neighbors from minigraph
   set_fact:

--- a/ansible/roles/test/tasks/bgp_nei_up.yml
+++ b/ansible/roles/test/tasks/bgp_nei_up.yml
@@ -9,8 +9,6 @@
 
 - name: Gathering minigraph facts about neighbor
   minigraph_facts: host={{ name }} filename="{{ vmhost_num }}-{{ name }}.xml"
-  connection: local
-  become: no
 
 - name: Configure BGP session of neighbor router to up
   action: cisco template=bgp_neighbor_noshut.j2

--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -11,8 +11,6 @@
 
     - name: Gather minigraph facts about the device
       minigraph_facts: host={{inventory_hostname}}
-      become: no
-      connection: local
 
     - name: print deployment id
       debug: msg="{{deployment_id}}"

--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -41,8 +41,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 # Obtain loopback ip of the device
 - name: Obtain loopback ip of the device

--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -16,7 +16,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}
-  connection: local
 
 - debug : msg="Start dir_bcast Test"
 

--- a/ansible/roles/test/tasks/everflow_testbed/run_test.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/run_test.yml
@@ -10,8 +10,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Print neighbors in minigraph
   debug: msg="{{ minigraph_neighbors }}"

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -11,7 +11,6 @@
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}
-  connection: local
 
 - name: Remove existing IPs from PTF host
   script: roles/test/files/helpers/remove_ip.sh

--- a/ansible/roles/test/tasks/fib.yml
+++ b/ansible/roles/test/tasks/fib.yml
@@ -25,7 +25,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
 
 # Generate route file
 - name: Generate route-port map information

--- a/ansible/roles/test/tasks/interface_up_down.yml
+++ b/ansible/roles/test/tasks/interface_up_down.yml
@@ -2,8 +2,6 @@
 #
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
-  become: no
 
 - name: Ensure LLDP Daemon started and Enabled
   become: true

--- a/ansible/roles/test/tasks/lag.yml
+++ b/ansible/roles/test/tasks/lag.yml
@@ -5,8 +5,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Print neighbors in minigraph
   debug: msg="{{ minigraph_neighbors }}"

--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -25,7 +25,6 @@
 
 - name: gathering minigraph of the device configuration
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
 
 - name: Gathering lab graph facts about the device
   conn_graph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/lagall.yml
+++ b/ansible/roles/test/tasks/lagall.yml
@@ -31,8 +31,6 @@
 
 - name: Read DUT minigraph facts.
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
-  become: no
 
 - set_fact:
     dut_lag_members: []

--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -2,8 +2,6 @@
 - name: Gathering minigraph facts about the device
   minigraph_facts:
     host: "{{ inventory_hostname }}"
-  become: no
-  connection: local
 
 - name: Print neighbors in minigraph
   debug: msg="{{ minigraph_neighbors }}"

--- a/ansible/roles/test/tasks/mac_update.yml
+++ b/ansible/roles/test/tasks/mac_update.yml
@@ -1,6 +1,5 @@
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
 
 - include: mac_entry_update.yml
   with_items: "{{ minigraph_interfaces }}"

--- a/ansible/roles/test/tasks/mtu.yml
+++ b/ansible/roles/test/tasks/mtu.yml
@@ -19,7 +19,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
 
 - debug : msg="Start MTU Test"
 

--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -31,8 +31,6 @@
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}
-  become: no
-  connection: local
 
 - set_fact:
     port_list: "{{minigraph_ports.keys()}}"

--- a/ansible/roles/test/tasks/reboot.yml
+++ b/ansible/roles/test/tasks/reboot.yml
@@ -6,8 +6,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
-  become: no
   when: minigraph_interfaces is not defined 
         
 - include: interface.yml

--- a/ansible/roles/test/tasks/sonic.yml
+++ b/ansible/roles/test/tasks/sonic.yml
@@ -2,8 +2,6 @@
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
-  become: no
 
 # Set sonic_hwsku
 - name: Set sonic_hwsku fact

--- a/ansible/roles/test/tasks/test_sonic_by_tag.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_tag.yml
@@ -1,7 +1,5 @@
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  connection: local
-  become: no
   tags: always
 
 ### When calling the following tests, you need to provide a command line parameter


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
With minigraph auto generation, each DUT is tested by a minigraph
generated during tests. As result, tests should collect minigraph
facts from the DUT instead of using local checked in version.

How did you verify/test it?
I cannot run all tests on my DUT. I was able to verify that following tests passed:

bgp_fact, bgp_speaker, decap, fdb, fib, reboot, lag_2. Also tested bgp_fact with tag.