### PR TITLE
[dhcp_relay]: Add --relax flag to ptf command

### DIFF
--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -46,6 +46,7 @@
       - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
       - relay_iface_mac=\"{{ relay_iface_mac }}\"
       - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+    ptf_extra_options: "--relax"
 
 # Service restart and service stop -> start exhibited different behaviors.
 # Therefore testing them separately.
@@ -73,6 +74,7 @@
       - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
       - relay_iface_mac=\"{{ relay_iface_mac }}\"
       - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+    ptf_extra_options: "--relax"
 
 - name: Stop teamd on DUT
   shell: systemctl stop teamd
@@ -102,4 +104,5 @@
       - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
       - relay_iface_mac=\"{{ relay_iface_mac }}\"
       - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+    ptf_extra_options: "--relax"
 


### PR DESCRIPTION
To avoid other random packets to be collected during the test runtime.

```
ok: [str-s6100-acs-2] => {
    "out.stdout_lines": [
        "WARNING: Failed to execute tcpdump. Check it is installed and in the PATH",
        "WARNING: No route found for IPv6 destination :: (no default route?)",
        "dhcp_relay_test.DHCPTest ... FAIL",
        "",
        "======================================================================",
        "FAIL: dhcp_relay_test.DHCPTest",
        "----------------------------------------------------------------------",
        "Traceback (most recent call last):",
        "  File \"ptftests/dhcp_relay_test.py\", line 429, in runTest",
        "    self.verify_offer_received()",
        "  File \"ptftests/dhcp_relay_test.py\", line 354, in verify_offer_received",
        "    testutils.verify_packet(self, masked_offer, self.client_port_index)",
        "  File \"/usr/lib/python2.7/dist-packages/ptf/testutils.py\", line 2242, in verify_packet",
        "    % (device, port, result.format()))",
        "AssertionError: Expected packet was not received on device 0, port 6.",
        "========== EXPECTED ==========",
        "Mask: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000ÿÿÿÿÿÿÿÿÿÿÿÿ\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u00$
0ÿÿ\u0000\u0000ÿÿ\u0000\u0000ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ$
ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ\u0000\u0000\u0000\u0000\u0000\u0000$
ÿÿÿÿÿ",
        "========== RECEIVED ==========",
        "0 total packets.",
        "==============================",
        "",
        "",
        "----------------------------------------------------------------------",
        "Ran 1 test in 3.878s",
        "",
        "FAILED (failures=1)"
    ]
}
```