### PR TITLE
add retries in onie installation

### DIFF
--- a/ansible/plugins/action/onie.py
+++ b/ansible/plugins/action/onie.py
@@ -22,6 +22,7 @@ class ActionModule(ActionBase):
         _install  = boolean(self._task.args.get('install', 'no'))
         _url      = self._task.args.get('url', None)
         _timeout  = self._task.args.get('timeout', None)
+        _nretry   = int(self._task.args.get('retry', 3))
 
         if _timeout is None:
             _timeout = 300
@@ -43,7 +44,8 @@ class ActionModule(ActionBase):
                                       host=_host,
                                       url=_url,
                                       install=_install,
-                                      timeout=_timeout)
+                                      timeout=_timeout,
+                                      retry=_nretry)
 
         return result
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
it looks like there are some random failures in the sonic onie
installation. Adding retries in the plugin. default to three retries.

How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
