### PR TITLE
[minigraph-gen] fix AclInterface entries in minigraph

### DIFF
--- a/ansible/minigraph/lab-a7260-01.t0-116.xml
+++ b/ansible/minigraph/lab-a7260-01.t0-116.xml
@@ -280,19 +280,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/minigraph/lab-s6000-01.t0.xml
+++ b/ansible/minigraph/lab-s6000-01.t0.xml
@@ -280,19 +280,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/minigraph/lab-s6100-01.t0-64.xml
+++ b/ansible/minigraph/lab-s6100-01.t0-64.xml
@@ -280,19 +280,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/minigraph/lab-s6100-01.t1-64-lag.xml
+++ b/ansible/minigraph/lab-s6100-01.t1-64-lag.xml
@@ -1146,19 +1146,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/minigraph/str-msn2700-01.t0.xml
+++ b/ansible/minigraph/str-msn2700-01.t0.xml
@@ -280,19 +280,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/minigraph/str-msn2700-01.t1-lag.xml
+++ b/ansible/minigraph/str-msn2700-01.t1-lag.xml
@@ -1066,19 +1066,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/minigraph/str-msn2700-01.t1.xml
+++ b/ansible/minigraph/str-msn2700-01.t1.xml
@@ -1346,19 +1346,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -103,19 +103,25 @@
       <DataAcls/>
       <AclInterfaces>
         <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
           <Type>SNMP</Type>
+          <File>Router_Protect_AP.xml</File>
        </AclInterface>
        <AclInterface>
           <AttachTo>ERSPAN</AttachTo>
           <InAcl>Everflow</InAcl>
           <Type>Everflow</Type>
         </AclInterface>
-          <AclInterface>
+        <AclInterface>
+          <ElementType>DataAcl</ElementType>
+          <Name i:nil="true"/>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
+          <File>Router_Protect_AP.xml</File>
         </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Add AclInterface values needed by service_acl test.

How did you verify/test it?

```
for tbname in `grep ^vms testbed.csv  | awk -F ',' '{print $1}'`; do ./testbed-cli.sh test-mg $tbname lab password.txt; done | grep unreachable
str-msn2700-01             : ok=11   changed=0    unreachable=0    failed=0   
str-msn2700-01             : ok=11   changed=0    unreachable=0    failed=0   
str-msn2700-01             : ok=12   changed=0    unreachable=0    failed=0   
lab-s6000-01               : ok=12   changed=0    unreachable=0    failed=0   
lab-a7260-01               : ok=12   changed=0    unreachable=0    failed=0   
lab-s6100-01               : ok=12   changed=0    unreachable=0    failed=0   
lab-s6100-01               : ok=11   changed=0    unreachable=0    failed=0   
```