### PR TITLE
[service_acl] Make test reliable when testing Arista service ACL solution

### DIFF
--- a/ansible/roles/test/files/helpers/config_service_acls.sh
+++ b/ansible/roles/test/files/helpers/config_service_acls.sh
@@ -75,8 +75,8 @@ EOF
 # Install the new service ACLs
 acl-loader update full /tmp/testacl.json
 
-# Sleep to allow Ansible playbook to attmept to connect and timeout
-sleep 30
+# Sleep to allow Ansible playbook ample time to attempt to connect and timeout
+sleep 60
 
 # Delete the test ACL config file
 rm -rf /tmp/testacl.json

--- a/ansible/roles/test/tasks/service_acl.yml
+++ b/ansible/roles/test/tasks/service_acl.yml
@@ -28,15 +28,20 @@
   become: true
   shell: "nohup /tmp/config_service_acls.sh < /dev/null > /dev/null 2>&1 &"
 
-# Note that the timeout here should be sufficiently long enough to allow
-# config_service_acls.sh to apply the new service ACLs
+- name: Sleep a bit to allow config_service_acls.sh to apply the new service ACLs
+  pause:
+    seconds: 5
+
 - name: Ensure the SSH port on the DuT becomes closed to us
   local_action: wait_for
   args:
     host: "{{ ansible_host }}"
     port: 22
-    state: stopped
-    timeout: 15
+    state: started
+    search_regex: "OpenSSH"
+    timeout: 10
+  register: result
+  failed_when: "'Timeout when waiting for search string OpenSSH' not in result.msg"
 
 # Gather facts with SNMP version 2
 - name: Ensure attempt to gather basic SNMP facts about the device now times out
@@ -57,7 +62,7 @@
     port: 22
     state: started
     search_regex: "OpenSSH"
-    timeout: 60
+    timeout: 90
 
 - name: Delete config_service_acls.sh from the DuT
   become: true


### PR DESCRIPTION
Arista service ACL solution behaves differently than the iptables solution used on all other platforms. Thus we cannot simply use `wait_for` with `state: stopped`.

This solution allows the test to behave reliably when testing either service ACL implementation.