### PR TITLE
[fast-reboot test] fix syslog reading issue

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -141,6 +141,7 @@
         file_prefix: 'syslog'
         start_string: 'Initializing cgroup subsys cpuset'
         target_filename: '/tmp/syslog'
+      become: yes
 
     - name: Copy the exctracted syslog entries to the local machine
       fetch:


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Explicitly specify that syslog task needs super user privillege.

How did you verify/test it?
Without the change, fast-reboot test failed when reading syslog.
With the change, fast-reboot test passed on my DUT.