### PR TITLE
[minigraph templte] use consistent VLAN subnet

### DIFF
--- a/ansible/minigraph/lab-a7260-01.t0-116.xml
+++ b/ansible/minigraph/lab-a7260-01.t0-116.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/25</a:PeersRange>
+            <a:PeersRange>192.168.0.0/24</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/21</Subnets>
+          <Subnets>192.168.0.0/24</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/27</Prefix>
+          <Prefix>192.168.0.1/24</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/minigraph/lab-s6000-01.t0.xml
+++ b/ansible/minigraph/lab-s6000-01.t0.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/25</a:PeersRange>
+            <a:PeersRange>192.168.0.0/24</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/21</Subnets>
+          <Subnets>192.168.0.0/24</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/27</Prefix>
+          <Prefix>192.168.0.1/24</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/minigraph/lab-s6100-01.t0-64.xml
+++ b/ansible/minigraph/lab-s6100-01.t0-64.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/25</a:PeersRange>
+            <a:PeersRange>192.168.0.0/24</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/21</Subnets>
+          <Subnets>192.168.0.0/24</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/27</Prefix>
+          <Prefix>192.168.0.1/24</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/minigraph/str-msn2700-01.t0.xml
+++ b/ansible/minigraph/str-msn2700-01.t0.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/25</a:PeersRange>
+            <a:PeersRange>192.168.0.0/24</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/21</Subnets>
+          <Subnets>192.168.0.0/24</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/27</Prefix>
+          <Prefix>192.168.0.1/24</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -58,7 +58,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/25</a:PeersRange>
+            <a:PeersRange>192.168.0.0/24</a:PeersRange>
           </BGPPeer>
 {% endif %}
         </a:Peers>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -67,7 +67,7 @@
           <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/21</Subnets>
+          <Subnets>192.168.0.0/24</Subnets>
         </VlanInterface>
 {% endif %}
       </VlanInterfaces>
@@ -96,7 +96,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/27</Prefix>
+          <Prefix>192.168.0.1/24</Prefix>
         </IPInterface>
 {% endif %}
       </IPInterfaces>


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Fixed VLAN subnet inconsistency in minigraph template.

How did you verify/test it?
```
for tbname in `grep ^vms testbed.csv  | awk -F ',' '{print $1}'`; do ./testbed-cli.sh test-mg $tbname lab password.txt; done | grep unreachable
str-msn2700-01             : ok=12   changed=0    unreachable=0    failed=0   
str-msn2700-01             : ok=12   changed=0    unreachable=0    failed=0   
str-msn2700-01             : ok=13   changed=0    unreachable=0    failed=0   
lab-s6000-01               : ok=13   changed=0    unreachable=0    failed=0   
lab-a7260-01               : ok=13   changed=0    unreachable=0    failed=0   
lab-s6100-01               : ok=13   changed=0    unreachable=0    failed=0   
lab-s6100-01               : ok=12   changed=0    unreachable=0    failed=0   
```