### PR TITLE
[fast-reboot] pass VM IP in as ASCII strings

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -10,7 +10,6 @@
         vm_hosts: "{{ neighbor_eosvm_mgmt.values() }}"
   when: testbed_type is defined and vm is defined
 
-
 - block:
     - fail: msg="Please set ptf_host variable"
       when: ptf_host is not defined
@@ -124,7 +123,7 @@
         - default_ip_range='192.168.0.0/16'
         - vlan_ip_range=\"{{ minigraph_vlan_interfaces[0]['subnet'] }}\"
         - lo_v6_prefix=\"{{ minigraph_lo_interfaces | map(attribute='addr') | ipv6 | first | ipsubnet(64) }}\"
-        - arista_vms=\"{{ vm_hosts }}\"
+        - arista_vms=\"['{{ vm_hosts | list | join("','") }}']\"
 
   always:
     - name: Copy test results from ptf to the local box /tmp/fast-reboot.log


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
When the VM IPs were passed in as unicode strings, there was an
exception which didn't cause the test to fail.

However, lacking of coordination with the VMs caused the test to pass
with false negative.

How did you verify/test it?
Tested on my DUT.