### PR TITLE
use command to gather host distribution, kernel version facts

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -15,17 +15,29 @@
 
 # Need latest ubuntu 4.10 kernel to fix a openvswitch bug
 # https://bugs.launchpad.net/ubuntu/+source/kernel-package/+bug/1685742
+- name: get host distribution
+  shell: grep ^NAME /etc/os-release | awk -F '=' '{print $2}' | tr -d '"'
+  register: host_distribution
+
+- name: get host distribution version
+  shell: grep ^VERSION_ID /etc/os-release | awk -F '=' '{print $2}' | tr -d '"'
+  register: host_distribution_version
+
+- name: get host kernel version
+  shell: uname -r
+  register: host_kernel
+
 - name: Check if kernel upgrade needed
   set_fact:
     kernel_upgrade_needed: true
   when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version == "17.04"
-    - ansible_kernel.find('4.10.0') != -1
-    - "{{ ansible_kernel | regex_replace('4.10.0-([0-9]+)-.*', '\\1') | int < 25 }}"
+    - host_distribution.stdout == "Ubuntu"
+    - host_distribution_version.stdout == "17.04"
+    - host_kernel.find('4.10.0') != -1
+    - "{{ host_kernel | regex_replace('4.10.0-([0-9]+)-.*', '\\1') | int < 25 }}"
 
 - block:
-    - debug: msg="{{ ansible_kernel }}"
+    - debug: msg="{{ host_kernel }}"
 
     - name: Upgrade kernel package
       apt: pkg={{ item }} state=latest
@@ -44,14 +56,14 @@
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu zesty stable
     state: present
   become: yes
-  when: ansible_distribution_version == "17.04"
+  when: host_distribution_version == "17.04"
 
 - name: Add docker repository for 16.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     state: present
   become: yes
-  when: ansible_distribution_version == "16.04"
+  when: host_distribution_version == "16.04"
 
 - name: Install necessary packages
   apt: pkg={{ item }} update_cache=yes cache_valid_time=86400

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -28,6 +28,7 @@
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 
 - hosts: servers:&vm_host
+  gather_facts: no
   vars_files:
     - vars/docker_registry.yml
   pre_tasks:

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -15,6 +15,7 @@
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 
 - hosts: servers:&vm_host
+  gather_facts: no
   vars_files:
     - vars/docker_registry.yml
   pre_tasks:

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -14,6 +14,7 @@
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 
 - hosts: servers:&vm_host
+  gatheer_facts: no
   vars_files:
     - vars/docker_registry.yml
   pre_tasks:

--- a/ansible/testbed_start_VMs.yml
+++ b/ansible/testbed_start_VMs.yml
@@ -16,6 +16,7 @@
 #
 
 - hosts: servers:&vm_host
+  gather_facts: no
   vars_files:
     - vars/azure_storage.yml
   tasks:

--- a/ansible/testbed_stop_VMs.yml
+++ b/ansible/testbed_stop_VMs.yml
@@ -11,5 +11,6 @@
 #
 
 - hosts: servers:&vm_host
+  gather_facts: no
   roles:
   - { role: vm_set, action: 'stop' }


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)
disable ansible gather_facts as it takes too long (7 minutes) to
get those facts

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
A: use shell script to gather those facts directly

How did you verify/test it?
A: run ansible on real host

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
