### PR TITLE
[dir_bcast] enable dir_bcast test on t0-116 topology

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -57,6 +57,8 @@ class BcastTest(BaseTest):
             self.src_ports = range(1, 25) + range(28, 32)
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
+        if self.test_params['testbed_type'] == 't0-116':
+            self.src_ports = range(24, 32)
 
     #---------------------------------------------------------------------
 
@@ -120,8 +122,8 @@ class BcastTest(BaseTest):
         ''' 
         Check if broadcast packet is received on all member ports of vlan
         '''
+        logging.info("Received " + str(pkt_count) + " broadcast packets, expecting " + str(len(dst_port_list)))
         assert (pkt_count == len(dst_port_list))
-        logging.info("Received " + str(pkt_count) + " broadcast packets ")
     
         return
 

--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t0', 't0-64']
+  when: testbed_type not in ['t0', 't0-64', 't0-116']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 
@@ -34,6 +34,7 @@
     ptf_test_dir: ptftests
     ptf_test_path: dir_bcast_test.BcastTest
     ptf_platform: remote
+    ptf_platform_dir: ptftests
     ptf_test_params:
       - testbed_type='{{testbed_type}}'
       - router_mac='{{ansible_Ethernet0['macaddress']}}'


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
- Define source ports
- Improving logging (always logging received and expected packets)
- Figure out port_map automatically

How did you verify/test it?
Test passed on t0-116 topology