### PR TITLE
[pfcwd]: cache the ansible facts

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -42,6 +42,7 @@
 - set_fact:
     ansible_eth0_ipv4_addr: "{{ansible_eth0['ipv4']['address']}}"
     ansible_ethernet0_mac_addr: "{{ansible_Ethernet0['macaddress']}}"
+    ansible_date_time: "{{ansible_date_time}}"
 
 - set_fact:
     used: false


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
Ansible facts expires during the test run. Cache the result at the beginning.
How did you verify/test it?
Tested on DUT
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
