### PR TITLE
[link state] match exact dut name in the link list

### DIFF
--- a/ansible/linkstate/testbed_inv.py
+++ b/ansible/linkstate/testbed_inv.py
@@ -43,7 +43,7 @@ def parse_topology(topology_name, vm_start):
 
 def parse_links(links, dut, ports):
     with open(links) as fp:
-        result = set(line.split(',')[2] for line in fp if line.startswith(dut))
+        result = set(line.split(',')[2] for line in fp if line.startswith(dut + ','))
     return list(result)
 
 def extract_hostvars(filename, host):


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
When 1 dut name is prefix of another dut, this change will prevent
the shorter name to match longer name by mistake.

How did you verify/test it?
Run linkstate test on a dut whose name is prefix of another
