### PR TITLE
[extract_log] Improve extract_log script

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -90,7 +90,7 @@ def extract_line(directory, filename, target_string):
         file = gzip.GzipFile(path)
     else:
         file = open(path)
-    result = []
+    result = None
     with file:
         # This might be a gunzip file or logrotate issue, there has
         # been '\x00's in front of the log entry timestamp which

--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -90,9 +90,16 @@ def extract_line(directory, filename, target_string):
         file = gzip.GzipFile(path)
     else:
         file = open(path)
-    result = None
+    result = []
     with file:
-        result = [(filename, line) for line in file if target_string in line and 'nsible' not in line]
+        for line in file:
+            # This might be a gunzip file issue, there has been '\x00's in front of the
+            # log entry timestamp which messes up with the comparator.
+            # Prehandle lines to remove these sub-strings
+            line = line.replace('\x00', '')
+            if target_string in line and 'nsible' not in line:
+                result.append((filename, line))
+
     return result
 
 
@@ -159,9 +166,12 @@ def extract_latest_line_with_string(directory, filenames, start_string):
     for filename in filenames:
         target_lines.extend(extract_line(directory, filename, start_string))
 
-    sorted_target_lines = sorted(target_lines, cmp=comparator)
+    target = target_lines[0] if len(target_lines) > 0 else None
+    for line in target_lines:
+        if comparator(line, target) > 0:
+            target = line
 
-    return sorted_target_lines[-1]
+    return target
 
 
 def calculate_files_to_copy(filenames, file_with_latest_line):

--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -92,13 +92,11 @@ def extract_line(directory, filename, target_string):
         file = open(path)
     result = []
     with file:
-        for line in file:
-            # This might be a gunzip file issue, there has been '\x00's in front of the
-            # log entry timestamp which messes up with the comparator.
-            # Prehandle lines to remove these sub-strings
-            line = line.replace('\x00', '')
-            if target_string in line and 'nsible' not in line:
-                result.append((filename, line))
+        # This might be a gunzip file or logrotate issue, there has
+        # been '\x00's in front of the log entry timestamp which
+        # messes up with the comparator.
+        # Prehandle lines to remove these sub-strings
+        result = [(filename, line.replace('\x00', '')) for line in file if target_string in line and 'nsible' not in line]
 
     return result
 


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
- Some log entries has '\x00' sub-strings in front of
  time stamp, these sub strings are messing up with the
  comparator, adding a pre-handling to remove them.
- Replace sort O(n x log(n)) with a look up (O(N)).

How did you verify/test it?
Run fast-reboot test on my dut.