### PR TITLE
[fanout-switch-deploy] Support multiple speeds and port breakout

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -32,12 +32,47 @@ vrf definition management
 {% set intf =  'Ethernet' + i|string + '/1'  %}
 interface {{ intf }}
 {% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
+{%     if device_port_vlans[intf]['speed'] == "100000" %}
    description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 100gfull
+   error-correction encoding reed-solomon
    no shutdown
+{%     elif device_port_vlans[intf]['speed'] == "40000" %}
+   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport mode dot1q-tunnel
+   spanning-tree portfast
+   speed forced 40gfull
+   no error-correction encoding
+   no shutdown
+{%     elif device_port_vlans[intf]['speed'] == "50000" %}
+   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport mode dot1q-tunnel
+   spanning-tree portfast
+   speed forced 50gfull
+   no error-correction encoding
+   no shutdown
+{% set intf =  'Ethernet' + i|string + '/3'  %}
+interface {{ intf }}
+{%         if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
+   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport mode dot1q-tunnel
+   spanning-tree portfast
+   speed forced 50gfull
+   no error-correction encoding
+   no shutdown
+{%         else %}
+   shutdown
+{%         endif %}
+{%     else %}
+{#        Not valid speed value #}
+   shutdown
+{%     endif %}
 {% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %}
    description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
    switchport mode trunk

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -46,7 +46,6 @@ interface {{ intf }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
-   no error-correction encoding
    no shutdown
 {%     elif device_port_vlans[intf]['speed'] == "50000" %}
    description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Support multiple speeds and port breakout
- 100G port default has FEC turned on. Other ports FEC off.
- Support port break out to 2x50G ports.
- Support 40G port.

How did you verify/test it?
Re-deployed 2 duts with 50G breakout ports. Both works fine.