### PR TITLE
Increase time intervals for peer rate setting in LAG test

### DIFF
--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -74,7 +74,7 @@
   connection: switch
 
 - pause: 
-    seconds: 5
+    seconds: 20
  
 - name: test lacp packet sending rate is 1 seconds
   include: lag_lacp_timing_test.yml
@@ -91,7 +91,7 @@
   connection: switch
 
 - pause: 
-    seconds: 5
+    seconds: 20
  
 - name: test lacp packet sending rate is 30 seconds
   include: lag_lacp_timing_test.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)
Increase time intervals for peer rate setting in LAG test because 5sec is not enough to change a peer rate. The usual pause interval in LAG-2 test is 20sec, but for peer rate change is only 5sec. 
Changed peer rate pause to 20sec as others pause intervals. 


### Type of change
- [ ] Bug fix


### Approach
How did you do it?
Changed peer rate pause to 20sec instead of 5sec.

How did you verify/test it?
Run LAG-2 test. 

Any platform specific information?
No

Supported testbed topology if it's a new test case?


### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
