### PR TITLE
add disconnect/connect vm to testbed-cli.sh

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -37,10 +37,14 @@ description:
       - binds internal interfaces of the docker container to correspoinding VM ports
     - With cmd: 'unbind' the module:
       - destroys everything what was created with command 'bind'
+    - With cmd: 'connect-vms' the module:
+      - disconnect all VM ports from the DUT
+    - With cmd: 'disconnect-vms' the module:
+      - reconnect all VM ports to the DUT
 
 
 Parameters:
-    - cmd: One of the commands: 'create', 'bind', 'renumber', 'unbind', 'destroy'
+    - cmd: One of the commands: 'create', 'bind', 'renumber', 'unbind', 'destroy', 'connect-vms', 'disconnect-vms'
     - vm_set_name: name of the current vm set. It will be used for generation of interface names
     - topo: dictionary with VMs topology. Check vars/topo_*.yml for details
     - vm_names: list of VMs represented on a current host
@@ -306,7 +310,7 @@ class VMTopology(object):
 
         return
 
-    def bind_fp_ports(self):
+    def bind_fp_ports(self, disconnect_vm=False):
         for attr in self.VMs.itervalues():
             for vlan_num, vlan in enumerate(attr['vlans']):
                vlan_id = self.vlan_base + vlan
@@ -315,7 +319,7 @@ class VMTopology(object):
                port0_bridge = OVS_FP_BRIDGE_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                vm_tap = OVS_FP_TAP_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                self.create_phys_vlan(vlan_iface, vlan_id)
-               self.bind_phys_vlan(port0_bridge, vlan_iface, injected_iface, vm_tap)
+               self.bind_phys_vlan(port0_bridge, vlan_iface, injected_iface, vm_tap, disconnect_vm)
 
         return
 
@@ -392,7 +396,7 @@ class VMTopology(object):
 
         return
 
-    def bind_phys_vlan(self, br_name, vlan_iface, injected_iface, vm_iface):
+    def bind_phys_vlan(self, br_name, vlan_iface, injected_iface, vm_iface, disconnect_vm=False):
         ports = VMTopology.get_ovs_br_ports(br_name)
 
         if injected_iface not in ports:
@@ -409,11 +413,18 @@ class VMTopology(object):
         # clear old bindings
         VMTopology.cmd('ovs-ofctl del-flows %s' % br_name)
 
-        # Add flow from a VM to an external iface
-        VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vm_iface_id, vlan_iface_id))
+        if disconnect_vm:
+            # Drop packets from VM
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=drop" % (br_name, vm_iface_id))
+        else:
+            # Add flow from a VM to an external iface
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vm_iface_id, vlan_iface_id))
 
-        # Add flow from external iface to a VM and a ptf container
-        VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s,%s" % (br_name, vlan_iface_id, vm_iface_id, injected_iface_id))
+        if disconnect_vm:
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vlan_iface_id, injected_iface_id))
+        else:
+            # Add flow from external iface to a VM and a ptf container
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s,%s" % (br_name, vlan_iface_id, vm_iface_id, injected_iface_id))
 
         # Add flow from a ptf container to an external iface
         VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, injected_iface_id, vlan_iface_id))
@@ -611,7 +622,7 @@ def check_params(module, params, mode):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            cmd=dict(required=True, choices=['create', 'bind', 'renumber', 'unbind', 'destroy']),
+            cmd=dict(required=True, choices=['create', 'bind', 'renumber', 'unbind', 'destroy', "connect-vms", "disconnect-vms"]),
             vm_set_name=dict(required=False, type='str'),
             topo=dict(required=False, type='dict'),
             vm_names=dict(required=True, type='list'),
@@ -749,6 +760,34 @@ def main():
                 net.bind_fp_ports()
             if hostif_exists:
                 net.inject_host_ports()
+        elif cmd == 'connect-vms' or cmd == 'disconnect-vms':
+            check_params(module, ['vm_set_name',
+                                  'topo',
+                                  'ext_iface'], cmd)
+
+            vm_set_name = module.params['vm_set_name']
+            topo = module.params['topo']
+            ext_iface = module.params['ext_iface']
+            vlan_base = module.params['vlan_base']
+
+            if len(vm_set_name) > VM_SET_NAME_MAX_LEN:
+                raise Exception("vm_set_name can't be longer than %d characters: %s (%d)" % (VM_SET_NAME_MAX_LEN, vm_set_name, len(vm_set_name)))
+
+            hostif_exists, vms_exists = check_topo(topo)
+
+            if vms_exists:
+                check_params(module, ['vm_base', 'vlan_base'], cmd)
+                vm_base = module.params['vm_base']
+            else:
+                vm_base = None
+
+            net.init(vm_set_name, topo, vm_base, vlan_base, ext_iface)
+
+            if vms_exists:
+                if cmd == 'connect-vms':
+                    net.bind_fp_ports()
+                else:
+                    net.bind_fp_ports(True)
         else:
             raise Exception("Got wrong cmd: %s. Ansible bug?" % cmd)
 

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -421,6 +421,7 @@ class VMTopology(object):
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vm_iface_id, vlan_iface_id))
 
         if disconnect_vm:
+            # Add flow from external iface to ptf container
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vlan_iface_id, injected_iface_id))
         else:
             # Add flow from external iface to a VM and a ptf container

--- a/ansible/roles/vm_set/tasks/connect_vms.yml
+++ b/ansible/roles/vm_set/tasks/connect_vms.yml
@@ -1,0 +1,12 @@
+- name: Connect VMs to {{ topo }}. base vm = {{ VM_base }} base vlan = {{ vlan_base }}
+  vm_topology:
+    cmd: "connect-vms"
+    vm_set_name: "{{ vm_set_name }}"
+    topo: "{{ topology }}"
+    vm_names: "{{ VM_hosts }}"
+    vm_base: "{{ VM_base }}"
+    vlan_base: "{{ vlan_base }}"
+    ext_iface: "{{ external_iface }}"
+    fp_mtu: "{{ fp_mtu_size }}"
+    max_fp_num: "{{ max_fp_num }}"
+  become: yes

--- a/ansible/roles/vm_set/tasks/disconnect_vms.yml
+++ b/ansible/roles/vm_set/tasks/disconnect_vms.yml
@@ -1,0 +1,11 @@
+- name: Disconnect VMs to {{ topo }}. base vm = {{ VM_base }} base vlan = {{ vlan_base }}
+  vm_topology:
+    cmd: "disconnect-vms"
+    vm_set_name: "{{ vm_set_name }}"
+    topo: "{{ topology }}"
+    vm_names: "{{ VM_hosts }}"
+    vm_base: "{{ VM_base }}"
+    vlan_base: "{{ vlan_base }}"
+    ext_iface: "{{ external_iface }}"
+    max_fp_num: "{{ max_fp_num }}"
+  become: yes

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -156,3 +156,10 @@
   include: renumber_topo.yml
   when: action == 'renumber_topo'
 
+- name: Connect VMs
+  include: connect_vms.yml
+  when: action == 'connect_vms'
+
+- name: Disconnect VMs
+  include: disconnect_vms.yml
+  when: action == 'disconnect_vms'

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -7,6 +7,7 @@ function usage
   echo "testbed-cli. Interface to testbeds"
   echo "Usage : $0 { start-vms | stop-vms    } server-name vault-password-file"
   echo "Usage : $0 { add-topo  | remove-topo | renumber-topo | connect-topo } topo-name vault-password-file"
+  echo "Usage : $0 { connect-vms  | disconnect-vms } topo-name vault-password-file"
   echo "Usage : $0 { config-vm } topo-name vm-name vault-password-file"
   echo "Usage : $0 { gen-mg | deploy-mg | test-mg } topo-name inventory vault-password-file"
   echo
@@ -110,6 +111,29 @@ function renumber_topo
   echo Done
 }
 
+function connect_vms
+{
+  echo "Connect VMs '$1'"
+
+  read_file $1
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_connect_vms.yml --vault-password-file="$2" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e topo="$topo" -e vm_set_name="$testbed_name"
+
+  echo Done
+}
+
+function disconnect_vms
+{
+  echo "Disconnect VMs '$1'"
+
+  read_file $1
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_disconnect_vms.yml --vault-password-file="$2" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e topo="$topo" -e vm_set_name="$testbed_name"
+
+  echo Done
+}
+
+
 function generate_minigraph
 {
   echo "Generating minigraph '$1'"
@@ -180,6 +204,10 @@ case "$1" in
   renumber-topo) renumber_topo $2 $3
                ;;
   connect-topo) connect_topo $2 $3
+               ;;
+  connect-vms) connect_vms $2 $3
+               ;;
+  disconnect-vms) disconnect_vms $2 $3
                ;;
   config-vm)   config_vm $2 $3 $4
                ;;

--- a/ansible/testbed_connect_vms.yml
+++ b/ansible/testbed_connect_vms.yml
@@ -1,0 +1,52 @@
+# This Playbook connect VMs to a topology
+#
+#
+# To renumber a topology please use following command
+# ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_connect_vms.yml --vault-password-file=~/.password -l server_3 -e vm_set_name=first -e VM_base=VM0300 -e ptf_ip=10.255.0.255/23 -e topo=t0 -e dut_name=str-msn-2700-05 -e ptf_imagename="docker_ptf"
+#
+# Parameters
+# -l server_3                - this playbook have to be limited to run only on one server
+# -e vm_set_name=first       - the name of vm_set
+# -e dut_name=str-msn2700-02 - the new value of a dut name, the dut will be connected to the current testbed
+# -e VM_base=VM0300          - the VM name which is used to as base to calculate VM name for this set
+# -e ptf_ip=10.255.0.255/23 - the ip address and prefix of ptf container mgmt interface
+# -e topo=t0                 - the name of removed topo
+# -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
+
+- hosts: servers:&vm_host
+  gather_facts: no
+  vars_files:
+    - vars/docker_registry.yml
+  pre_tasks:
+  - name: Check for a single host
+    fail: msg="Please use -l server_X to limit this playbook to one host"
+    when: "{{ play_hosts|length }} != 1"
+
+  - name: Check that variable vm_set_name is defined
+    fail: msg="Define vm_set_name variable with -e vm_set_name=something"
+    when: vm_set_name is not defined
+
+  - name: Check that variable dut_name is defined
+    fail: msg="Define dut_name variable with -e dut_name=something"
+    when: dut_name is not defined
+
+  - name: Check that variable VM_base is defined
+    fail: msg="Define VM_base variable with -e VM_base=something"
+    when: VM_base is not defined
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: topo is not defined or topo not in topologies
+
+  - name: Load topo variables
+    include_vars: "vars/topo_{{ topo }}.yml"
+
+  - name: Read dut minigraph
+    conn_graph_facts: host={{ dut_name }}
+    connection: local
+
+  - name: Extracting vlan_range
+    set_fact: vlan_base={{ device_vlan_list | min }}
+
+  roles:
+    - { role: vm_set, action: 'connect_vms' }

--- a/ansible/testbed_disconnect_vms.yml
+++ b/ansible/testbed_disconnect_vms.yml
@@ -1,0 +1,52 @@
+# This Playbook disconnect VMs from a topology
+#
+#
+# To renumber a topology please use following command
+# ANSIBLE_SCP_IF_SSH=y ansible-playbook -i veos testbed_disconnect_vms.yml --vault-password-file=~/.password -l server_3 -e vm_set_name=first -e VM_base=VM0300 -e ptf_ip=10.255.0.255/23 -e topo=t0 -e dut_name=str-msn-2700-05 -e ptf_imagename="docker_ptf"
+#
+# Parameters
+# -l server_3                - this playbook have to be limited to run only on one server
+# -e vm_set_name=first       - the name of vm_set
+# -e dut_name=str-msn2700-02 - the new value of a dut name, the dut will be connected to the current testbed
+# -e VM_base=VM0300          - the VM name which is used to as base to calculate VM name for this set
+# -e ptf_ip=10.255.0.255/23 - the ip address and prefix of ptf container mgmt interface
+# -e topo=t0                 - the name of removed topo
+# -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
+
+- hosts: servers:&vm_host
+  gather_facts: no
+  vars_files:
+    - vars/docker_registry.yml
+  pre_tasks:
+  - name: Check for a single host
+    fail: msg="Please use -l server_X to limit this playbook to one host"
+    when: "{{ play_hosts|length }} != 1"
+
+  - name: Check that variable vm_set_name is defined
+    fail: msg="Define vm_set_name variable with -e vm_set_name=something"
+    when: vm_set_name is not defined
+
+  - name: Check that variable dut_name is defined
+    fail: msg="Define dut_name variable with -e dut_name=something"
+    when: dut_name is not defined
+
+  - name: Check that variable VM_base is defined
+    fail: msg="Define VM_base variable with -e VM_base=something"
+    when: VM_base is not defined
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: topo is not defined or topo not in topologies
+
+  - name: Load topo variables
+    include_vars: "vars/topo_{{ topo }}.yml"
+
+  - name: Read dut minigraph
+    conn_graph_facts: host={{ dut_name }}
+    connection: local
+
+  - name: Extracting vlan_range
+    set_fact: vlan_base={{ device_vlan_list | min }}
+
+  roles:
+    - { role: vm_set, action: 'disconnect_vms' }


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

add disconnect/connect vm to testbed-cli.sh, which allows to connect/disconnect vm to the topology. This allows the DUT to only talk to the PTF container.

### Approach
How did you do it?

How did you verify/test it?
verify on DUT. disconnect/connect is around 90 seconds.
command line:

./testbed-cli.sh disconnect-vms topo 
./testbed-cli.sh connect-vms topo

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
