### PR TITLE
[run_test]print system version info before running test

### DIFF
--- a/ansible/roles/test/tasks/test_sonic_by_testname.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_testname.yml
@@ -23,6 +23,13 @@
 - debug: var=testcases[testcase_name]['required_vars']
   when: testcases[testcase_name]['required_vars'] is defined
 
+- name: gather system version information
+  shell: "show ver"
+  register: versions
+
+- name: print system versions
+  debug: var=versions.stdout_lines
+
 - name: run test case {{ testcases[testcase_name]['filename'] }} file
   include: "{{ testcases[testcase_name]['filename'] }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
print system version info before running any test case 

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### - How did you do it?
add a show system version command before calling test
#### - How did you verify/test it?
verified in local tests
```
TASK [test : gather system version information] ********************************
Tuesday 10 April 2018  14:44:48 +0000 (0:00:00.072)       0:00:26.648 ********* 
changed: [sonic-01]

TASK [test : print system versions] ********************************************
Tuesday 10 April 2018  14:44:50 +0000 (0:00:02.122)       0:00:28.770 ********* 
ok: [sonic-01] => {
    "versions.stdout_lines": [
        "SONiC Software Version: SONiC.HEAD.366-88157ee", 
        "Distribution: Debian 8.10", 
        "Kernel: 3.16.0-5-amd64", 
        "Build commit: 88157ee", 
        "Build date: Mon Apr  9 13:56:33 UTC 2018"
        "Built by: sonicbld@jenkins-slave-phx-2", 
        "", 
        "Docker images:", 
        "REPOSITORY                 TAG                 IMAGE ID            SIZE", 
        "docker-syncd-brcm          HEAD.366-88157ee    839e8c2105da        358.2 MB"
        "docker-syncd-brcm          latest              839e8c2105da        358.2 MB"
        "docker-orchagent-brcm      HEAD.366-88157ee    7e444175183d        287 MB"
        "docker-orchagent-brcm      latest              7e444175183d        287 MB"
        "docker-dhcp-relay          HEAD.366-88157ee    7d7b30d54d2e        280.1 MB"
        "docker-dhcp-relay          latest              7d7b30d54d2e        280.1 MB"
        "docker-database            HEAD.366-88157ee    8ddc14279569        278.8 MB"
        "docker-database            latest              8ddc14279569        278.8 MB"
        "docker-snmp-sv2            HEAD.366-88157ee    29cc88d58fbc        319.3 MB"
        "docker-snmp-sv2            latest              29cc88d58fbc        319.3 MB"
        "docker-teamd               HEAD.366-88157ee    f133e597d3d2        284.1 MB"
        "docker-teamd               latest              f133e597d3d2        284.1 MB"
        "docker-router-advertiser   HEAD.366-88157ee    0d817f4dbaa9        276.4 MB"
        "docker-router-advertiser   latest              0d817f4dbaa9        276.4 MB"
        "docker-platform-monitor    HEAD.366-88157ee    f2dbb81efdbe        298.4 MB"
        "docker-platform-monitor    latest              f2dbb81efdbe        298.4 MB"
        "docker-lldp-sv2            HEAD.366-88157ee    143d7a71ed6d        297.2 MB"
        "docker-lldp-sv2            latest              143d7a71ed6d        297.2 MB"
        "docker-fpm-quagga          HEAD.366-88157ee    edac1d341731        290.6 MB"
        "docker-fpm-quagga          latest              edac1d341731        290.6 MB"
    ]
}
'''
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation
 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->