### PR TITLE
Arista 7060 50G support 

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -391,6 +391,18 @@ def reconcile_mini_graph_locations(filename, hostname):
     root = ET.parse(mini_graph_path).getroot()
     return mini_graph_path, root
 
+def port_alias_map_50G(all_ports, s100G_ports):
+    # 50G ports
+    s50G_ports = list(set(all_ports) - set(s100G_ports))
+
+    for i in s50G_ports:
+        port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+        port_alias_map["Ethernet%d/3" % i] = "Ethernet%d" % ((i - 1) * 4 + 2)
+
+    for i in s100G_ports:
+        port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+
+    return port_alias_map
 
 def parse_xml(filename, hostname):
     mini_graph_path, root = reconcile_mini_graph_locations(filename, hostname)
@@ -452,6 +464,15 @@ def parse_xml(filename, hostname):
     elif hwsku == "Arista-7060CX-32S-C32":
         for i in range(1, 33):
             port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+    elif hwsku == "Arista-7060CX-32S-D48C8":
+        # All possible breakout 50G port numbers:
+        all_ports = [ x for x in range(1, 33)]
+
+        # 100G ports
+        s100G_ports = [ x for x in range(7, 11) ]
+        s100G_ports += [ x for x in range(23, 27) ]
+
+        port_alias_map = port_alias_map_50G(all_ports, s100G_ports)
     elif hwsku == "Arista-7260CX3-D108C8":
         # All possible breakout 50G port numbers:
         all_ports = [ x for x in range(1, 65)]
@@ -459,15 +480,7 @@ def parse_xml(filename, hostname):
         # 100G ports
         s100G_ports = [ x for x in range(13, 21) ]
 
-        # 50G ports
-        s50g_ports = list(set(all_ports) - set(s100G_ports))
-
-        for i in s50g_ports:
-            port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
-            port_alias_map["Ethernet%d/3" % i] = "Ethernet%d" % ((i - 1) * 4 + 2)
-
-        for i in s100G_ports:
-            port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+        port_alias_map = port_alias_map_50G(all_ports, s100G_ports)
     elif hwsku == "INGRASYS-S9100-C32":
         for i in range(1, 33):
             port_alias_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -17,6 +17,8 @@ ntp server vrf management {{ ntp_server }}
 spanning-tree mode none
 no spanning-tree vlan {{ device_vlan_range | list | join(',') }}
 !
+service unsupported-transceiver microsoft 361ac33e
+!
 aaa authorization exec default local
 aaa root secret 0 {{ lab_admin_pass }}
 !
@@ -32,7 +34,7 @@ vrf definition management
 {% set intf =  'Ethernet' + i|string + '/1'  %}
 interface {{ intf }}
 {% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
-{%     if device_port_vlans[intf]['speed'] == "100000" %}
+{%     if device_conn[intf]['speed'] == "100000" %}
    description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
@@ -40,14 +42,14 @@ interface {{ intf }}
    speed forced 100gfull
    error-correction encoding reed-solomon
    no shutdown
-{%     elif device_port_vlans[intf]['speed'] == "40000" %}
+{%     elif device_conn[intf]['speed'] == "40000" %}
    description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
    no shutdown
-{%     elif device_port_vlans[intf]['speed'] == "50000" %}
+{%     elif device_conn[intf]['speed'] == "50000" %}
    description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -17,8 +17,6 @@ ntp server vrf management {{ ntp_server }}
 spanning-tree mode none
 no spanning-tree vlan {{ device_vlan_range | list | join(',') }}
 !
-service unsupported-transceiver microsoft 361ac33e
-!
 aaa authorization exec default local
 aaa root secret 0 {{ lab_admin_pass }}
 !


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Added port-mapping for Arista-7060CX-32S-D48C8 SKU to support 50G speed

How did you verify/test it?
Load the minigraph on DUT and check if ports comes with expected speed

Any platform specific information?
Arista-7060

Supported testbed topology if it's a new test case?
t0

For the fanout deploy, observed that `speed `is present in `device_conn` instead of `device_port_vlans`. 
The sample output is shown below:

```
{"ansible_facts": {"device_conn": {"Ethernet1/1": {"peerdevice": "str-acs-2", "peerport": "Ethernet148", "speed": "50000"}, 
"Ethernet1/3": {"peerdevice": "str-acs-2", "peerport": "Ethernet150", "speed": "50000"},

"device_port_vlans": {"Ethernet1/1": {"mode": "Access", "vlanids": "1803", "vlanlist": [1803]}, 
"Ethernet1/3": {"mode": "Access", "vlanids": "1804", "vlanlist": [1804]}, 
"Ethernet10/1": {"mode": "Access", "vlanids": "1821", "vlanlist": [1821]}, 
```

