### PR TITLE
[Pfcwd]: Run function test on part of the ports each day

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -45,6 +45,9 @@
     ansible_date_time: "{{ansible_date_time}}"
 
 - set_fact:
+    seed: "{{ansible_date_time['weekday_number']}}"
+
+- set_fact:
     used: false
     first_pair: false
     pfc_wd_rx_port: "rx"
@@ -104,6 +107,13 @@
 
 - debug: msg="{{test_ports}}"
 
+- set_fact:
+    select_test_ports: "{{select_test_ports | default({}) | combine({item.key: item.value})}}"
+  with_dict: "{{test_ports}}"
+  when: item.value.test_port_id | int % 7 == seed | int
+
+- debug: msg="{{select_test_ports}}"
+
  #****************************************#
  #           Start tests                  #
  #****************************************#
@@ -116,7 +126,7 @@
 
     - name: Test PFC WD Functional tests.
       include: roles/test/tasks/pfc_wd/functional_test/functional_test.yml
-      with_dict: "{{test_ports}}"
+      with_dict: "{{select_test_ports}}"
 
     - name: Test PFC WD Timer accuracy.
       include: roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
Run function test on part of the ports each day depending on during which weekday the test runs.
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
