### PR TITLE
[lldp]: verify DUT chassis id on neighbors

### DIFF
--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -44,6 +44,7 @@
     neighbor_interface: "{{ lldp[item]['port']['ifname'] }}"
     dut_interface: "{{ item }}"
     hname: "{{ lldp[item]['chassis']['mgmt-ip'] }}"
+    dut_chassis_id: "0x{{ ansible_eth0['macaddress'] | replace(':', '') }}"
     dut_hostname: "{{ inventory_hostname }}"
     dut_port_alias: "{{ minigraph_ports[item]['alias'] }}"
     dut_port_description: "{{ minigraph_neighbors[item]['name'] }}:{{ minigraph_neighbors[item]['port'] }}"

--- a/ansible/roles/test/tasks/lldp_neighbor.yml
+++ b/ansible/roles/test/tasks/lldp_neighbor.yml
@@ -13,7 +13,7 @@
 
 # FIXME: use more strict assertion
 - name: Verify the published DUT chassis id field is not empty
-  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_chassis_id'] }}' != ''"}
+  assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_chassis_id'] }}' == '{{ dut_chassis_id }}'"}
 
 - name: Verify the published DUT system description field is correct
   assert: {that: "'{{ ansible_lldp_facts[neighbor_interface]['neighbor_sys_desc'] }}' == '{{ dut_system_description }}'"}


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
- verify the dut chassis id on the neighbor devices

How did you verify/test it?
- test it on real device
```
ansible-playbook test_sonic.yml -i str --limit str-s6000-acs-7,lldp_neighbors --vault-password-file password.txt -e testcase_name=lldp -e testbed_name=vms12-t0-1
```
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
