### PR TITLE
add optional vm gateway

### DIFF
--- a/ansible/host_vars/STR-ACS-SERV-01.yml
+++ b/ansible/host_vars/STR-ACS-SERV-01.yml
@@ -1,5 +1,6 @@
 mgmt_bridge: br1
 mgmt_prefixlen: 23
 mgmt_gw: 10.255.0.1
+vm_mgmt_gw: 10.254.0.1
 external_iface: p4p1
 

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -24,7 +24,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 route-map DEFAULT_ROUTES permit
 !

--- a/ansible/roles/vm_set/tasks/start_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vm.yml
@@ -28,7 +28,7 @@
              password={{ password }}
              hostname={{ hostname }}
              mgmt_ip="{{ mgmt_ip_address }}/{{ mgmt_prefixlen }}"
-             mgmt_gw={{ mgmt_gw }}
+             mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
              new_login={{ new_login }}
              new_password={{ new_password }}
              new_root_password={{ new_root_password }}
@@ -53,7 +53,7 @@
              password={{ password }}
              hostname={{ hostname }}
              mgmt_ip="{{ mgmt_ip_address }}/{{ mgmt_prefixlen }}"
-             mgmt_gw={{ mgmt_gw }}
+             mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
              new_login={{ new_login }}
              new_password={{ new_password }}
              new_root_password={{ new_root_password }}


### PR DESCRIPTION
Allow user to specify separate gateway for eos VM. If the vm_mgmt_gw is not specified, then use default mgmt_gw instead.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
