### PR TITLE
[testcases] enable arp on 1; copp on t1, t1-lag; add bgp_gr_helper

### DIFF
--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -8,7 +8,7 @@ testcases:
     
     arp:
       filename: arpall.yml
-      topologies: [ptf32, ptf64]
+      topologies: [ptf32, ptf64, t1]
       required_vars:
           ptf_host: 
     
@@ -37,7 +37,7 @@ testcases:
 
     copp:
       filename: copp.yml
-      topologies: [ptf32, ptf64]
+      topologies: [ptf32, ptf64, t1, t1-lag]
       required_vars:
           ptf_host:
  

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -12,6 +12,10 @@ testcases:
       required_vars:
           ptf_host: 
     
+    bgp_gr_helper:
+      filename: bgp_gr_helper.yml
+      topologies: [t1, t1-lag]
+
     bgp_fact:
       filename: bgp_fact.yml
       topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)
Enable to run
ARP test on t1 topology;
COPP test on t1, t1-lag.
Enable bgp_gr_helper test to be called by name.
 
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
By editing testcases.yml file
How did you verify/test it?
Run pipeline
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
