### PR TITLE
[bgp_facts]: Add bgp_statistics in bgp_facts library return

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -66,6 +66,7 @@ class BgpModule(object):
         self.parse_summary()
         self.collect_data('neighbor')
         self.parse_neighbors()
+        self.get_statistics()
         self.module.exit_json(ansible_facts=self.facts)
 
     def collect_data(self, command_str):
@@ -162,6 +163,32 @@ class BgpModule(object):
         self.facts['bgp_neighbors'] = neighbors
         return
 
+    def get_statistics(self):
+        statistics = {}
+        statistics['ipv4'] = 0
+        statistics['ipv4_admin_down'] = 0
+        statistics['ipv4_idle'] = 0
+        statistics['ipv6'] = 0
+        statistics['ipv6_admin_down'] = 0
+        statistics['ipv6_idle'] = 0
+
+        for neighbor in self.facts['bgp_neighbors'].itervalues():
+            if neighbor['ip_version'] == 4:
+                statistics['ipv4'] += 1
+                if neighbor['admin'] == 'down':
+                    statistics['ipv4_admin_down'] += 1
+                elif neighbor['state'] != 'established':
+                    statistics['ipv4_idle'] += 1
+            elif neighbor['ip_version'] == 6:
+                statistics['ipv6'] += 1
+                if neighbor['admin'] == 'down':
+                    statistics['ipv6_admin_down'] += 1
+                elif neighbor['state'] != 'established':
+                    statistics['ipv6_idle'] += 1
+
+        self.facts['bgp_statistics'] = statistics
+
+        return
 
 def main():
     bgp = BgpModule()


### PR DESCRIPTION
Add the get_statistics function and return bgp_statistics in JSON
so that no further calculations are needed in Ansible playbook.

The current statistics includes # of IPv4/IPv6 sessions, admin down
sessions, and idle sessions.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
