### PR TITLE
[bug]neighbour-mac-noptf may fail due to interface not ready

### DIFF
--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -156,7 +156,8 @@
 
   always:
     - name: reset all changes
-      service:
-        name:  swss
-        state: restarted
+      shell: "config load_minigraph -y"
       become: yes
+
+    - name: wait for port channel interface to be up
+      pause: seconds=30


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes neighbour-mac-noptf

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
call a more general clean up of load minigraph then restart swss after test finish

#### How did you verify/test it?
tested locally and it pass the test

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
