### PR TITLE
Update queue buffer-up via ptf test to skip result

### DIFF
--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -108,5 +108,5 @@ class PfcWdTest(BaseTest):
 
         if self.wd_action == 'drop':
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
-        else:
+        elif self.wd_action == 'forward':
             return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
@@ -131,7 +131,7 @@
           - port_dst='[{{pfc_wd_test_port_id}}]'
           - ip_dst='{{pfc_wd_test_neighbor_addr}}'
           - port_type='{{port_type}}'
-          - wd_action='drop'
+          - wd_action='dontcare'
         ptf_extra_options: "--relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
     - set_fact:


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

### Description of PR
Added to the ptf test the third state - when we do not care about the traffic - whether it passed or not
Used this state in one of the test cases (when we just need to fill in the buffer).
It helps to avoid random failures when PFC storm generator is not fast enough.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)
