### PR TITLE
Extend vlan network size in the DUT minigraphs

### DIFF
--- a/ansible/minigraph/lab-a7260-01.t0-116.xml
+++ b/ansible/minigraph/lab-a7260-01.t0-116.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/24</a:PeersRange>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/24</Subnets>
+          <Subnets>192.168.0.0/21</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/24</Prefix>
+          <Prefix>192.168.0.1/21</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/minigraph/lab-s6000-01.t0.xml
+++ b/ansible/minigraph/lab-s6000-01.t0.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/24</a:PeersRange>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/24</Subnets>
+          <Subnets>192.168.0.0/21</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/24</Prefix>
+          <Prefix>192.168.0.1/21</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/minigraph/lab-s6100-01.t0-64.xml
+++ b/ansible/minigraph/lab-s6100-01.t0-64.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/24</a:PeersRange>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/24</Subnets>
+          <Subnets>192.168.0.0/21</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/24</Prefix>
+          <Prefix>192.168.0.1/21</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/minigraph/str-msn2700-01.t0.xml
+++ b/ansible/minigraph/str-msn2700-01.t0.xml
@@ -124,7 +124,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/24</a:PeersRange>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
@@ -227,7 +227,7 @@
           <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/24</Subnets>
+          <Subnets>192.168.0.0/21</Subnets>
         </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
@@ -274,7 +274,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/24</Prefix>
+          <Prefix>192.168.0.1/21</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -58,7 +58,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>192.168.0.0/24</a:PeersRange>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
 {% endif %}
         </a:Peers>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -67,7 +67,7 @@
           <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>192.168.0.0/24</Subnets>
+          <Subnets>192.168.0.0/21</Subnets>
         </VlanInterface>
 {% endif %}
       </VlanInterfaces>
@@ -96,7 +96,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>192.168.0.1/24</Prefix>
+          <Prefix>192.168.0.1/21</Prefix>
         </IPInterface>
 {% endif %}
       </IPInterfaces>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Extended all DUT vlan network prefix lengths from /24 to /21. The FastReboot test requires to run it with 2000 vlan hosts (current test has a default to 500 devices).  We need greater network size to put all required devices.

How did you verify/test it?
Run the fast-reboot test with the changes, It will show 
```
From upper layer number of packets: 500
```
Instead of 
```
From upper layer number of packets: 253
```
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
