### PR TITLE
[copp]: Add UDLD test in COPP test suite

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -275,7 +275,29 @@ class LLDPTest(NoPolicyTest):
                        eth_src=src_mac,
                        eth_type=0x88cc
                  )
+        return packet
 
+# SONIC configuration has no policer limiting for UDLD
+class UDLDTest(NoPolicyTest):
+    def __init__(self):
+        NoPolicyTest.__init__(self)
+
+    def runTest(self):
+        self.log("UDLDTest")
+        self.run_suite()
+
+    # UDLD uses Ethernet multicast address 01-00-0c-cc-cc-cc
+    # as its destination MAC address. eth_type is to indicate
+    # the length of the data in Ethernet 802.3 frame. pktlen
+    # = 117 = 103 (0x67) + 6 (dst MAC) + 6 (dst MAC) + 2 (len)
+    def contruct_packet(self, port_number):
+        src_mac = self.my_mac[port_number]
+        packet = simple_eth_packet(
+                       pktlen=117,
+                       eth_dst='01:00:0c:cc:cc:cc',
+                       eth_src=src_mac,
+                       eth_type=0x0067
+                 )
         return packet
 
 # SONIC configuration has no policer limiting for BGP

--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -41,6 +41,7 @@
         ptf_extra_options: "--device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://{{ ansible_eth0['ipv4']['address'] }}:10900"
       with_items:
         - ARPTest
+        - UDLDTest
         - DHCPTest
         - LLDPTest
         - BGPTest


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5171

The UDLD protocol runs on top of the LLC sub-layer of the data link
layer of the OSI model. It uses a specially assigned multicast
destination MAC address 01-00-0C-CC-CC-CC.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
