### PR TITLE
[pfcwd]: increase PFC pause packet number in storm all test

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
@@ -41,6 +41,7 @@
   connection: local
   become: no
 
+# pfc_frames_number intends to be large enough so that PFC storm keeps happenning until runs pfc_storm_stop command. 
 - name: Prepare variables required for PFC test
   set_fact:
     pfc_queue_index: 4

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
@@ -1,3 +1,4 @@
+# pfc_frames_number intends to be large enough so that PFC storm keeps happenning until runs pfc_storm_stop command. 
 - name: Prepare variables required for PFC test
   set_fact:
     pfc_queue_index: 4

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
@@ -1,7 +1,7 @@
 - name: Prepare variables required for PFC test
   set_fact:
     pfc_queue_index: 4
-    pfc_frames_number: 1000000
+    pfc_frames_number: 10000000
     pfc_wd_detect_time: 200
     pfc_wd_restore_time: 200
     pfc_wd_restore_time_large: 30000


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
Increase the maximum PFC pause frame to be sent in storm all test, to make sure the PFC frame keep sending until running pfc frame stop command.
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
