### PR TITLE
[sonic upgrade] Improve sonic upgrade script

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -74,6 +74,9 @@ def reduce_installed_sonic_images(module, disk_used_pcent):
         pcent = get_disk_used_percent(module, "/host")
         if pcent < disk_used_pcent:
             break
+        # Randomly choose an old image to remove. On a system with
+        # developer built images and offical build images mix-installed
+        # it is hard to compare image tag to find 'oldest' image.
         img = images.pop()
         exec_command(module, cmd="sonic_installer remove %s -y" % img,
                      ignore_error=True)

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -4,7 +4,7 @@ DOCUMENTATION = '''
 module:  reduce_and_add_sonic_images
 version_added:  "1.0"
 
-short_description: remove excessive sonic images install new image if specified
+short_description: remove excessive sonic images and install new image if specified
 description: remove excessive sonic images from the target device.
 Note that this version doesn't guarantee to remove older images. Images
 in the 'Available' list that are not 'Current' or 'Next' wil subject to
@@ -33,7 +33,7 @@ def exec_command(module, cmd, ignore_error=False, msg="executing command"):
     return out
 
 
-def get_sonic_image_list(module):
+def get_sonic_image_removal_candidates(module):
     keep   = set()
     images = set()
 
@@ -67,8 +67,8 @@ def get_disk_used_percent(module, partition):
     return pcent
 
 
-def reduce_sonic_image_copies(module, disk_used_pcent):
-    images = get_sonic_image_list(module)
+def reduce_installed_sonic_images(module, disk_used_pcent):
+    images = get_sonic_removal_candidates(module)
 
     while len(images) > 0:
         pcent = get_disk_used_percent(module, "/host")
@@ -121,7 +121,7 @@ def main():
     new_image_url   = module.params['new_image_url']
 
     try:
-        reduce_sonic_image_copies(module, disk_used_pcent)
+        reduce_installed_sonic_images(module, disk_used_pcent)
         install_new_sonic_image(module, new_image_url)
     except:
         err = str(sys.exc_info())

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+
+DOCUMENTATION = '''
+module:  reduce_and_add_sonic_images
+version_added:  "1.0"
+
+short_description: remove excessive sonic images install new image if specified
+description: remove excessive sonic images from the target device.
+Note that this version doesn't guarantee to remove older images. Images
+in the 'Available' list that are not 'Current' or 'Next' wil subject to
+removal.
+
+Options:
+    - option-name: disk_used_pcent
+      description: maximum disk used percentage after removing old images
+      required: False
+      Default: 50
+    - option-name: new_image_url
+      description: url pointing to the new image
+      required: False
+      Default: None
+
+'''
+
+import sys
+from ansible.module_utils.basic import *
+
+def exec_command(module, cmd, ignore_error=False, msg="executing command"):
+    rc, out, err = module.run_command(cmd)
+    if not ignore_error and rc != 0:
+        module.fail_json(msg="Failed %s: rc=%d, out=%s, err=%s" %
+                         (msg, rc, out, err))
+    return out
+
+
+def get_sonic_image_list(module):
+    keep   = set()
+    images = set()
+
+    out = exec_command(module, cmd="sonic_installer list",
+                       msg="listing sonic images")
+
+    lines = out.split('\n')
+    for line in lines:
+        line = line.strip()
+        if line.startswith("Current:") or line.startswith("Next:"):
+            keep.add(line.split()[1].strip())
+        elif line != "Available:" and len(line) > 0:
+            images.add(line)
+
+    return (images - keep)
+
+
+def get_disk_free_size(module, partition):
+    out   = exec_command(module, cmd="df -BM --output=avail %s" % partition,
+                         msg="checking disk available size")
+    avail = int(out.split('\n')[1][:-1])
+
+    return avail
+
+
+def get_disk_used_percent(module, partition):
+    out   = exec_command(module, cmd="df -BM --output=pcent %s" % partition,
+                         msg="checking disk available percent")
+    pcent = int(out.split('\n')[1][:-1])
+
+    return pcent
+
+
+def reduce_sonic_image_copies(module, disk_used_pcent):
+    images = get_sonic_image_list(module)
+
+    while len(images) > 0:
+        pcent = get_disk_used_percent(module, "/host")
+        if pcent < disk_used_pcent:
+            break
+        img = images.pop()
+        exec_command(module, cmd="sonic_installer remove %s -y" % img,
+                     ignore_error=True)
+
+
+def install_new_sonic_image(module, new_image_url):
+    if not new_image_url:
+        return
+
+    avail = get_disk_free_size(module, "/host")
+    if avail >= 1500:
+        # There is enough space to install directly
+        exec_command(module,
+                     cmd="sonic_installer install %s -y" % new_image_url,
+                     msg="installing new image")
+    else:
+        # Create a tmpfs partition to download image to install
+        exec_command(module, cmd="mkdir -p /tmp/tmpfs", ignore_error=True)
+        exec_command(module, cmd="umount /tmp/tmpfs", ignore_error=True)
+
+        exec_command(module,
+                     cmd="mount -t tmpfs -o size=1000M tmpfs /tmp/tmpfs",
+                     msg="mounting tmpfs")
+        exec_command(module,
+                     cmd="curl -o /tmp/tmpfs/sonic-image %s" % new_image_url,
+                     msg="downloading new image")
+        exec_command(module,
+                     cmd="sonic_installer install /tmp/tmpfs/sonic-image -y",
+                     msg="installing new image")
+
+        exec_command(module, cmd="sync", ignore_error=True)
+        exec_command(module, cmd="umount /tmp/tmpfs", ignore_error=True)
+        exec_command(module, cmd="rm -rf /tmp/tmpfs", ignore_error=True)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            disk_used_pcent=dict(required=False, type='int', default=8),
+            new_image_url=dict(required=False, type='str', default=None),
+        ),
+        supports_check_mode=False)
+
+    disk_used_pcent = module.params['disk_used_pcent']
+    new_image_url   = module.params['new_image_url']
+
+    try:
+        reduce_sonic_image_copies(module, disk_used_pcent)
+        install_new_sonic_image(module, new_image_url)
+    except:
+        err = str(sys.exc_info())
+        module.fail_json(msg="Error: %s" % err)
+
+    module.exit_json()
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -68,7 +68,7 @@ def get_disk_used_percent(module, partition):
 
 
 def reduce_installed_sonic_images(module, disk_used_pcent):
-    images = get_sonic_removal_candidates(module)
+    images = get_sonic_image_removal_candidates(module)
 
     while len(images) > 0:
         pcent = get_disk_used_percent(module, "/host")

--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -45,15 +45,21 @@
 
       when: upgrade_type == "onie"
 
+    - name: define disk_used_pcent if not defined
+      set_fact:
+        disk_used_pcent: 50
+      when: disk_used_pcent is not defined
+
     - block:
         - fail: msg="image_url is not defined"
           when: image_url is not defined
 
-        - name: Install the target image from {{ image_url }}
+        - name: Remove some old sonic image(s) and install new image
+          reduce_and_add_sonic_images:
           become: true
-          shell: sonic_installer install -y {{ image_url }}
-          register: output
-          failed_when: output.rc != 0
+          args:
+            disk_used_pcent: '{{disk_used_pcent}}'
+            new_image_url: '{{ image_url }}'
 
         - name: Reboot the switch {{ inventory_hostname }}
           become: true
@@ -85,3 +91,9 @@
     - name: save bgp admin-up states
       become: true
       shell: config save -y
+
+    - name: Remove some old sonic image(s) after installing new image
+      reduce_and_add_sonic_images:
+      become: true
+      args:
+        disk_used_pcent: '{{disk_used_pcent}}'


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
- Before upgrading sonic device, reduce sonic images to make space
  for the new image if neccessary.
- Use tmpfs to download and install sonic image if harddirve space
  is limited.
- Reduce sonic images again after installation to make space for
  applications.

How did you verify/test it?
- Tested on 7260cx3 with large disk, able to keep up to 9 images.
- Tested on 7060 with limited disk, able to keep up to 2 images.
- Tested on 7050 with very small disk, able to keep only 1 image after installing and will trigger tmpfs download.