### PR TITLE
Modified clean up section to include acldel to tmp folder

### DIFF
--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -7,8 +7,6 @@
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
-  become: no
-  connection: local
 
 - name: Read port reverse alias mapping
   set_fact:
@@ -51,12 +49,18 @@
             dest=/root
       delegate_to: "{{ ptf_host }}"
 
+    - name: copy ptftests
+      copy: src=roles/test/files/ptftests
+            dest=/root
+      delegate_to: "{{ ptf_host }}"
+
     - name: Run the test
       include: ptf_runner.yml
       vars:
           ptf_test_name: ACL Test
           ptf_test_dir: acstests
           ptf_test_path: acltb_test.AclTest
+          ptf_platform_dir: ptftests
           ptf_platform: remote
           ptf_test_params:
             - verbose=True
@@ -88,6 +92,7 @@
           ptf_test_name: ACL Test
           ptf_test_dir: acstests
           ptf_test_path: acltb_test.AclTest
+          ptf_platform_dir: ptftests
           ptf_platform: remote
           ptf_test_params:
             - verbose=True
@@ -97,6 +102,7 @@
 
     - name: Save the applied ACL in ConfigDB
       command: config save -y
+      become: true
 
     - name: Reboot the switch
       include: common_tasks/reboot_sonic.yml
@@ -116,9 +122,9 @@
 
   always:
     # Copy ACL config to the switch
-    - name: Copy ACL del file to the DUT for clean up after reload
+    - name: Copy ACL config file to the DUT
       copy: src="roles/test/tasks/acl/acltb_test_rules-del.json" dest="/tmp/"
-
+    
     - name: Clean up ACL rules.
       vars:
         command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
@@ -127,3 +133,4 @@
 
     - name: Ensure ConfigDB is cleaned up
       command: config save -y
+      become: true

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -81,6 +81,25 @@
         command_to_run: "acl-loader update incremental /tmp/acltb_test_rules_part_2.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
+         
+    - name: Run the test
+      include: ptf_runner.yml
+      vars:
+          ptf_test_name: ACL Test
+          ptf_test_dir: acstests
+          ptf_test_path: acltb_test.AclTest
+          ptf_platform: remote
+          ptf_test_params:
+            - verbose=True
+            - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
+            - switch_info=\"/tmp/acltb_switch_info.txt\"
+            - testbed_type=\"{{ testbed_type }}\"
+            
+    - name: Save the applied ACL in ConfigDB
+      command: config save -y 			
+    
+    - name: Reboot the switch 
+      include: common_tasks/reboot_sonic.yml
 
     - name: Run the test
       include: ptf_runner.yml
@@ -94,10 +113,19 @@
             - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
-
+            
   always:
+    # Copy ACL config to the switch
+    - name: Copy ACL config file to the DUT
+      copy: src="roles/test/tasks/acl/{{ item }}" dest="/tmp/"
+      with_items:
+        - "acltb_test_rules-del.json"
+      
     - name: Clean up ACL rules.
       vars:
         command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
+
+    - name: Ensure ConfigDB is cleaned up 
+      command: config save -y 	      

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -81,7 +81,7 @@
         command_to_run: "acl-loader update incremental /tmp/acltb_test_rules_part_2.json"
         errors_expected: false
       include: roles/test/tasks/run_command_with_log_analyzer.yml
-         
+
     - name: Run the test
       include: ptf_runner.yml
       vars:
@@ -94,11 +94,11 @@
             - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
-            
+
     - name: Save the applied ACL in ConfigDB
-      command: config save -y 			
-    
-    - name: Reboot the switch 
+      command: config save -y
+
+    - name: Reboot the switch
       include: common_tasks/reboot_sonic.yml
 
     - name: Run the test
@@ -113,10 +113,13 @@
             - router_mac=\"{{ ansible_Ethernet0['macaddress'] }}\"
             - switch_info=\"/tmp/acltb_switch_info.txt\"
             - testbed_type=\"{{ testbed_type }}\"
-            
+
   always:
     - name: Clean up ACL rules.
-      command: acl-loader delete
+      vars:
+        command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
+        errors_expected: false
+      include: roles/test/tasks/run_command_with_log_analyzer.yml
 
-    - name: Ensure ConfigDB is cleaned up 
-      command: config save -y 	      
+    - name: Ensure ConfigDB is cleaned up
+      command: config save -y

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -115,17 +115,8 @@
             - testbed_type=\"{{ testbed_type }}\"
             
   always:
-    # Copy ACL config to the switch
-    - name: Copy ACL config file to the DUT
-      copy: src="roles/test/tasks/acl/{{ item }}" dest="/tmp/"
-      with_items:
-        - "acltb_test_rules-del.json"
-      
     - name: Clean up ACL rules.
-      vars:
-        command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"
-        errors_expected: false
-      include: roles/test/tasks/run_command_with_log_analyzer.yml
+      command: acl-loader delete
 
     - name: Ensure ConfigDB is cleaned up 
       command: config save -y 	      

--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -115,6 +115,10 @@
             - testbed_type=\"{{ testbed_type }}\"
 
   always:
+    # Copy ACL config to the switch
+    - name: Copy ACL del file to the DUT for clean up after reload
+      copy: src="roles/test/tasks/acl/acltb_test_rules-del.json" dest="/tmp/"
+
     - name: Clean up ACL rules.
       vars:
         command_to_run: "acl-loader update full /tmp/acltb_test_rules-del.json"


### PR DESCRIPTION
Modified the clean up section to copy "acltb_test_rules-del.json" file in clean up section so that after reload, the acl rules get removed without any issue. 

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
