### PR TITLE
[acl]: Add ptf_platform_dir option in ACL test to support 64 ports platform

### DIFF
--- a/ansible/roles/test/tasks/acltb.yml
+++ b/ansible/roles/test/tasks/acltb.yml
@@ -113,6 +113,7 @@
           ptf_test_name: ACL Test
           ptf_test_dir: acstests
           ptf_test_path: acltb_test.AclTest
+          ptf_platform_dir: ptftests
           ptf_platform: remote
           ptf_test_params:
             - verbose=True


### PR DESCRIPTION

ptf_platform_dir: ptftests is needed in ptf_runner.yml for 64 ports platform

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>