### PR TITLE
[crm]: Fix multiple CRM test cases

### DIFF
--- a/ansible/roles/test/tasks/crm/crm_test_acl_counter.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_acl_counter.yml
@@ -31,7 +31,7 @@
     - set_fact: acl_tbl_key={{"CRM:ACL_TABLE_STATS:{0}".format(out.stdout|replace("oid:", ""))}}
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_acl_counter_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_used
@@ -60,7 +60,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_acl_counter_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_used

--- a/ansible/roles/test/tasks/crm/crm_test_acl_entry.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_acl_entry.yml
@@ -11,7 +11,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get ACL entry keys
       command: bash -c "docker exec -i database redis-cli --raw -n 1 KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*"
@@ -34,7 +34,7 @@
     - set_fact: acl_tbl_key={{"CRM:ACL_TABLE_STATS:{0}".format(out.stdout|replace("oid:", ""))}}
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_acl_entry_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_entry_used
@@ -63,7 +63,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_acl_entry_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_entry_used

--- a/ansible/roles/test/tasks/crm/crm_test_fdb_entry.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_fdb_entry.yml
@@ -28,7 +28,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_fdb_entry_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_used

--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_neighbor.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_neighbor.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv4_neighbor_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv4_neighbor_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_used

--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_nexthop.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_nexthop.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv4_nexthop_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv4_nexthop_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_used

--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv4_route_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_used
@@ -31,14 +31,14 @@
       assert: {that: "{{new_crm_stats_ipv4_route_used|int - crm_stats_ipv4_route_used|int == 1}}"}
 
     - name: Verify "crm_stats_ipv4_route_available" counter was decremented
-      assert: {that: "{{crm_stats_ipv4_route_available|int - new_crm_stats_ipv4_route_available|int == 1}}"}
+      assert: {that: "{{crm_stats_ipv4_route_available|int - new_crm_stats_ipv4_route_available|int >= 1}}"}
 
     - name: Remove IPv4 route
       command: ip route del 2.2.2.0/24 via 10.0.0.57
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv4_route_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_used

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_neighbor.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_neighbor.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv6_neighbor_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv6_neighbor_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_used

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_nexthop.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_nexthop.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv6_nexthop_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv6_nexthop_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_used

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv6_route_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_ipv6_route_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_used

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_nexthop_group_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_nexthop_group_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_used

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
@@ -15,7 +15,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_nexthop_group_member_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_used
@@ -38,7 +38,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=1
+      pause: seconds=2
 
     - name: Get new "crm_stats_nexthop_group_member_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_used


### PR DESCRIPTION
* Increase timeout for all test cases to 2 seconds
* Correct condition for checking IPv4 route available counter

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

### Description of PR
Increase timeout for waiting counters update to 2 seconds for all test cases. It is needed because polling interval is set to 1 second and sometimes it is not enough to check counters after 1 second, so at least 2 seconds are needed.

Correct condition for checking IPv4 route available counter to verify whether it was decreased on 1 or more entries when we add a route instead of checking whether it was decreased exactly on 1. According to observations on some platforms available counter is decreased on more than 1 entries. It is because entries can be calculated dynamically based on free memory and memory can be shared between few resources, so need to handle such case in the test as well.

### Type of change
- [* ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Increased timeout for all test cases to 2 seconds
Corrected condition for checking IPv4 route available counter
#### How did you verify/test it?
Ran CRM test and observed that all test cases passed.
#### Any platform specific information?
### Supported testbed topology if it's a new test case?

### Documentation 
