### PR TITLE
[connection] overwrite pexpect 30s default timeout

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -71,7 +71,7 @@ class Connection(ConnectionBase):
                 self._display.vvv("SSH: EXEC {0}".format(' '.join(cmd)),
                               host=self.host)
                 last_user = user
-                client = pexpect.spawn(' '.join(cmd), env={'TERM': 'dumb'})
+                client = pexpect.spawn(' '.join(cmd), env={'TERM': 'dumb'}, timeout=60)
                 i = client.expect(['[Pp]assword:', pexpect.EOF])
                 if i == 1:
                     self._display.vvv("Server closed the connection, retry in %d seconds" % self.connection_retry_interval, host=self.host)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

Sometimes when connecting to VM, it takes a lot of time and we get a timeout exception like this: 
 
```
TIMEOUT: Timeout exceeded.
06:24:32 <pexpect.spawn object at 0x7fd4639fbc10>
. . .
06:24:32 searcher: <pexpect.searcher_re object at 0x7fd463cf4510>
06:24:32 buffer (last 100 chars): ' \r\nLast login: Mon May 21 03:23:28 2018 from . . . .\r\r\n'
06:24:32 before (last 100 chars): ' \r\nLast login: Mon May 21 03:23:28 2018 from . . . . \r\r\n'
06:24:32 after: <class 'pexpect.TIMEOUT'>
. . .
06:24:32 timeout: 30
. . .
```

timeout: 30 is a default timeout from pexpect python library. 
This commit overwrites it.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Specified timeout for pexpect object.
How did you verify/test it?
Run a test that uses switch connection plugin
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
