### PR TITLE
[crm]: Fix "nexthop group" test failure due to incorrect nexthop

### DIFF
--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
@@ -11,7 +11,7 @@
     - set_fact: crm_stats_ipv4_route_available={{out.stdout}}
 
     - name: Get NH IP
-      command: ip -4 neigh show dev {{crm_intf}}
+      command: ip -4 neigh show dev {{crm_intf}} nud reachable
       register: out
     - set_fact: nh_ip="{{out.stdout.split()[0]}}"
 

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
@@ -11,12 +11,12 @@
     - set_fact: crm_stats_nexthop_group_available={{out.stdout}}
 
     - name: Get NH IP 1
-      command: ip -4 neigh show dev {{crm_intf}}
+      command: ip -4 neigh show dev {{crm_intf}} nud reachable
       register: out
     - set_fact: nh_ip1="{{out.stdout.split()[0]}}"
 
     - name: Get NH IP 2
-      command: ip -4 neigh show dev {{crm_intf1}}
+      command: ip -4 neigh show dev {{crm_intf1}} nud reachable
       register: out
     - set_fact: nh_ip2="{{out.stdout.split()[0]}}"
 

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
@@ -11,12 +11,12 @@
     - set_fact: crm_stats_nexthop_group_member_available={{out.stdout}}
 
     - name: Get NH IP 1
-      command: ip -4 neigh show dev {{crm_intf}}
+      command: ip -4 neigh show dev {{crm_intf}} nud reachable
       register: out
     - set_fact: nh_ip1="{{out.stdout.split()[0]}}"
 
     - name: Get NH IP 2
-      command: ip -4 neigh show dev {{crm_intf1}}
+      command: ip -4 neigh show dev {{crm_intf1}} nud reachable
       register: out
     - set_fact: nh_ip2="{{out.stdout.split()[0]}}"
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Sometimes CRM "nexthop group" test fails due to incorrect nexthop set for the route.

Currently nexthop is retrieved using the command:
```
ip -4 neigh show dev {{crm_intf}}
```
Problem is that mentioned command returns all neighbors for the specified interface, including already deleted.
It happens because in Linux neighbor entries are not deleted immediately, they are moved to another state and after that once some timeout exceeded they are deleted.

Before "nexthop group" test there is "ipv4 nexhop" test which adds static neighbor and then deletes it.
According to described above when "nexthop group" test is running that deleted neighbor entry could still be present but with the state "incomplete/failed".
As a result *"ip neigh show"* returns both valid and invalid (deleted) entries, but test uses only first from the list and if first is that deleted neighbor then test fails.

To fix the issue need to modify *"ip neigh show"* command in order to get only valid and reachable neighbor entries:
```
ip -4 neigh show dev {{crm_intf}} nud reachable
```

### Type of change
- [*] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Modified *"ip neigh show"* command in order to get only valid and reachable neighbor entries:
```
ip -4 neigh show dev {{crm_intf}} nud reachable
```
#### How did you verify/test it?
Execute CRM test and verified that it passed.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
N/A
