### PR TITLE
[bgp-speaker]: Fix failure due to packets go through unexpected port

### DIFF
--- a/ansible/roles/test/templates/exabgp/start.j2
+++ b/ansible/roles/test/templates/exabgp/start.j2
@@ -2,11 +2,13 @@ ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_int
 ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][0]])}}:0 {{item.logical_ip_1}}
 ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][0]])}}:1 {{item.logical_ip_2}}
 
-ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][1]])}} {{item.mux_ip_1}}
-ping {{minigraph_vlan_interfaces[0]['addr']}} -I eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][1]])}} -c 4 >/dev/null 2>&1 &
+{% set intf = 'eth%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][1]]) %}
+ifconfig {{intf}} {{item.mux_ip_1}}
+i=0; until [$i -eq 10] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
 
-ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][2]])}} {{item.mux_ip_2}}
-ping {{minigraph_vlan_interfaces[0]['addr']}} -I eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][2]])}} -c 4 >/dev/null 2>&1 &
+{% set intf = 'eth%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][2]]) %}
+ifconfig {{intf}} {{item.mux_ip_2}}
+i=0; until [$i -eq 10] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
 
 ip route flush {{minigraph_lo_interfaces[0]['addr']}}/{{minigraph_lo_interfaces[0]['prefixlen']}}
 ip route add {{minigraph_lo_interfaces[0]['addr']}}/{{minigraph_lo_interfaces[0]['prefixlen']}} via {{ minigraph_vlan_interfaces[0]['addr']}}


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

### Description of PR
Sometimes BGP speaker test fails with the error that packets received on unexpected port.
It happens because appropriate neighbor entries sometimes are not installed on DUT, so all sent packets go through the default route.

BGP speaker test configures some IPs on PTF host and in order to force DUT to add neighbor entries it pings VLAN interface on DUT.
Currently there are 4 pings sent but sometimes it is not enough because it takes some time to bring up IP interface and add neighbor.

To fix the issue need to increase number of possible pings in order to make sure that required neighbor entries are added on DUT.

### Type of change
- [* ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
### How did you do it?
Added logic for sending ping up to 10 times and stop in case neighbor becomes reachable earlier.
#### How did you verify/test it?
Executed BGP speaker test and verified it passed.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
N/A
