### PR TITLE
Select only reachable or stale entries 

### DIFF
--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
@@ -11,7 +11,7 @@
     - set_fact: crm_stats_ipv4_route_available={{out.stdout}}
 
     - name: Get NH IP
-      command: ip -4 neigh show dev {{crm_intf}}
+      command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
     - set_fact: nh_ip="{{out.stdout.split()[0]}}"
 

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
@@ -11,7 +11,7 @@
     - set_fact: crm_stats_ipv6_route_available={{out.stdout}}
 
     - name: Get NH IP
-      command: ip -6 neigh show dev {{crm_intf}} nud reachable nud stale | grep -v "fe80"
+      shell: ip -6 neigh show dev {{crm_intf}} nud reachable nud stale | grep -v fe80
       register: out
     - set_fact: nh_ip="{{out.stdout.split()[0]}}"
 

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
@@ -11,7 +11,7 @@
     - set_fact: crm_stats_ipv6_route_available={{out.stdout}}
 
     - name: Get NH IP
-      command: ip -6 neigh show dev {{crm_intf}}
+      command: ip -6 neigh show dev {{crm_intf}} nud reachable nud stale | grep -v "fe80"
       register: out
     - set_fact: nh_ip="{{out.stdout.split()[0]}}"
 

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
@@ -11,12 +11,12 @@
     - set_fact: crm_stats_nexthop_group_available={{out.stdout}}
 
     - name: Get NH IP 1
-      command: ip -4 neigh show dev {{crm_intf}}
+      command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
     - set_fact: nh_ip1="{{out.stdout.split()[0]}}"
 
     - name: Get NH IP 2
-      command: ip -4 neigh show dev {{crm_intf1}}
+      command: ip -4 neigh show dev {{crm_intf1}} nud reachable nud stale
       register: out
     - set_fact: nh_ip2="{{out.stdout.split()[0]}}"
 

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
@@ -11,12 +11,12 @@
     - set_fact: crm_stats_nexthop_group_member_available={{out.stdout}}
 
     - name: Get NH IP 1
-      command: ip -4 neigh show dev {{crm_intf}}
+      command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
     - set_fact: nh_ip1="{{out.stdout.split()[0]}}"
 
     - name: Get NH IP 2
-      command: ip -4 neigh show dev {{crm_intf1}}
+      command: ip -4 neigh show dev {{crm_intf1}} nud reachable nud stale
       register: out
     - set_fact: nh_ip2="{{out.stdout.split()[0]}}"
 


### PR DESCRIPTION

### Description of PR
Sometimes CRM "nexthop group" test fails due to incorrect nexthop set for the route. This PR is to select only reachable or stale entries. This also overrides the changes as part of 
https://github.com/Azure/sonic-mgmt/pull/633

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Select only reachable or stale neighbor entries in show command

How did you verify/test it?
Execute CRM test on t0 topology

Any platform specific information?
N/A

Supported testbed topology if it's a new test case?

### Documentation 
N/A
