### PR TITLE
[lag_2] use minigraph data(prev. lldp) to figure out neighbor host access info

### DIFF
--- a/ansible/roles/test/tasks/single_lag_lacp_rate_test.yml
+++ b/ansible/roles/test/tasks/single_lag_lacp_rate_test.yml
@@ -29,12 +29,8 @@
     neighbor_interface: "{{vm_neighbors[flap_intf]['port']}}"
     peer_hwsku: 'Arista-VM'
 
-##############################################################################################
-##### TODO:  use minigraph/and VM configuration to figure out neighbor host access info #####
-#####        try not using lldp dynamic info to find neighbor access
-##############################################################################################
 - set_fact:
-    peer_host: "{{ lldp[flap_intf]['chassis']['mgmt-ip'] }}"
+    peer_host: "{{ minigraph_devices[peer_device]['mgmt_addr'] }}"
 
 ### Now prepare for the remote VM interfaces that using PTF docker to check teh LACP DU packet rate is correct
 

--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -39,12 +39,8 @@
     neighbor_interface: "{{vm_neighbors[flap_intf]['port']}}"
     peer_hwsku: 'Arista-VM'
 
-##############################################################################################
-##### TODO:  use minigraph/and VM configuration to figure out neighbor host access info #####
-#####        try not using lldp dynamic info to find neighbor access
-##############################################################################################
 - set_fact:
-    peer_host: "{{ lldp[flap_intf]['chassis']['mgmt-ip'] }}"
+    peer_host: "{{ minigraph_devices[peer_device]['mgmt_addr'] }}"
 
 - name: test vm interface flap (no physical port down, more like remote port lock) that lag interface can change to correct po status follow minimum links requirement
   include: lag_minlink.yml


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)
In the test ansible previously discovered VMs mgmt IP through lldp facts.
Using minigraph seems more reliable. Also we encountered situations when 
test used wrong IP.


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
How did you do it?
Set peer host based on data from minigraph. 
How did you verify/test it?
Run the test, verify it used correct mgmt IPs to connect.
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
