### PR TITLE
[eos]: Disable default task which runs "show tech-support" on hourly …

### DIFF
--- a/ansible/roles/eos/templates/t0-64-32-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-32-leaf.j2
@@ -1,5 +1,7 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t0-64-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-leaf.j2
@@ -1,5 +1,7 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -1,5 +1,7 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT
@@ -178,3 +180,4 @@ management api http-commands
  no shutdown
 !
 end
+s

--- a/ansible/roles/eos/templates/t1-64-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-spine.j2
@@ -1,5 +1,7 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -1,6 +1,8 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% set tornum = host['tornum'] %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -1,5 +1,7 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -1,6 +1,8 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% set tornum = host['tornum'] %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t1-spine.j2
+++ b/ansible/roles/eos/templates/t1-spine.j2
@@ -1,5 +1,7 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT

--- a/ansible/roles/eos/templates/t1-tor.j2
+++ b/ansible/roles/eos/templates/t1-tor.j2
@@ -1,6 +1,8 @@
 {% set host = configuration[hostname] %}
 {% set mgmt_ip = ansible_host %}
 {% set tornum = host['tornum'] %}
+no schedule tech-support
+!
 hostname {{ hostname }}
 !
 vrf definition MGMT


### PR DESCRIPTION
…basis

* Fixes issue: some LAGs go down from time to time
* Fixes issue: some EOS VMs become unaccecable via SSH from time to time

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Problem is that from time to time some VMs become unaccecable via SSH and some LAGs go down.

Arista EOS supports "schedule" feature which allows to run CLI command on e.g. hourly basis.
```
ARISTA01T1(config)#?
...
  schedule         Configure a CLI command to be run periodically
...
```
By default there is already configured hourly task for ```"show tech-support"``` CLI command.
```
ARISTA01T1(config)#show schedule summary
Maximum concurrent jobs  1
Name         At time Last  Inter\  Max    Logfile Location               Status
                     time   val    log
                           (mins)  files
------------ ------- ----- ------- ------ ------------------------------ ------
tech-support   now   10:38   60    100    flash:/schedule/tech-support/  Success
ARISTA01T1(config)#

```
In order to execute ```"show tech-support"``` command it takes some time and it utilizes quite a lot of CPU resources.
Due to this, sometimes some VMs get stuck for some period of time and as a result they are not available via SSH and some LAGs go down.
Also because of this some tests fail from time to time, e.g. IP-in-IP test could fail when some LAG is down, so packets are not going as expected.

### Type of change
- [*] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Disabled default "show tech-support" hourly task which causes the issues.
```
no schedule tech-support
```
#### How did you verify/test it?
Ran IP-in-IP test and observed that it passes each time and doesn't fail as before.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
