### PR TITLE
[link_flap_helper.yml] Fix assert syntax to prevent templating errors

### DIFF
--- a/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
+++ b/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
@@ -51,10 +51,10 @@
       when: ansible_interface_link_down_ports | length > 0
 
     - name: Verify interfaces are up correctly
-      assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
+      assert: { that: "ansible_interface_link_down_ports | length == 0" }
 
     - name: Verify {{intfs_to_exclude}} is down correctly
-      assert: { that: "'{{ ansible_interface_facts[intfs_to_exclude]['active'] }}' == 'False'" }
+      assert: { that: "ansible_interface_facts[intfs_to_exclude]['active'] == False" }
 
   always:
     - name: Bring up neighbor interface {{neighbor_interface}} on {{peer_host}}
@@ -80,4 +80,4 @@
       when: ansible_interface_link_down_ports | length > 0
 
     - name: Verify all interfaces are up
-      assert: { that: "{{ ansible_interface_link_down_ports }}|length == 0" }
+      assert: { that: "ansible_interface_link_down_ports | length == 0" }


### PR DESCRIPTION
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

Remove curly braces from inside assert statement to prevent the potential of receiving templating error messages like the following:

```
FAILED! => {"failed": true, "msg": "ERROR! The conditional check ''ansible_interface_facts[intfs_to_exclude]['active']' == 'False'' failed. The error was: ERROR! template error while templating string: expected token 'end of statement block', got 'active'"}
```