### PR TITLE
[pfcwd]: use median value to verify timer accuracy

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
@@ -30,7 +30,11 @@
 
     - name: Calculate detection and restoration timings
       include: roles/test/tasks/pfc_wd/functional_test/timer_test.yml
-      with_sequence: start=1 end=20
+      with_sequence: start=1 end=19
+
+    - set_fact:
+        detect_time_list: "{{detect_time_list | sort}}"
+        restore_time_list: "{{restore_time_list | sort}}"
 
     - debug:
         var: "{{item}}"
@@ -41,22 +45,22 @@
     - name: Verify that real detection time is not greater than configured
       fail:
         msg: Real detection time is greater than configured
-      when: "{{(detect_time_list | sum)/20 > pfc_wd_detect_time + pfc_wd_poll_time}}"
+      when: "{{(detect_time_list[9]) > pfc_wd_detect_time + pfc_wd_poll_time}}"
 
     - name: Verify that real detection time is not less than configured
       fail:
         msg: Real detection time is less than configured
-      when: "{{(detect_time_list | sum)/20  <  pfc_wd_detect_time}}"
+      when: "{{(detect_time_list[9])  <  pfc_wd_detect_time}}"
 
     - name: Verify that real restoration time is not less than configured
       fail:
           msg: Real restoration time is less than configured
-      when: "{{(restore_time_list | sum)/20 < pfc_wd_restore_time}}"
+      when: "{{(restore_time_list[9]) < pfc_wd_restore_time}}"
 
     - name: Verify that real restoration time is less than configured
       fail:
           msg: Real restoration time is greater than configured
-      when: "{{(restore_time_list | sum)/20 > pfc_wd_restore_time + pfc_wd_poll_time}}"
+      when: "{{(restore_time_list[9]) > pfc_wd_restore_time + pfc_wd_poll_time}}"
 
   always:
     - name: Clean up config


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
