### PR TITLE
Port alias map seastone

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -510,6 +510,19 @@ def parse_xml(filename, hostname):
     elif hwsku == "Accton-AS7712-32X":
         for i in range(1, 33):
             port_alias_map["hundredGigE%d" % i] = "Ethernet%d" % ((i - 1) * 4)
+    elif hwsku == "Seastone-DX010":
+        for i in range(0, 128, 4):
+            port_alias_map["Eth%d" % (i/4 + 1)] = "Ethernet%d" % i
+    elif hwsku == "Seastone-DX010-50":
+        for i in range(0,128, 2):
+            port_alias_map["Eth%d/%d" % (i/4 + 1, (i%4)/2 + 1)] = "Ethernet%d" % i
+    elif hwsku == "Seastone-DX010-10-50":
+        # from port 0 - 95 are 10G
+        for i in range(0, 96):
+            port_alias_map["Eth%d/%d" % (i/4 + 1, i%4 + 1)] = "Ethernet%d" % i
+        # from port 96 - 126 are 50G
+        for i in range(96, 128, 2):
+            port_alias_map["Eth%d/%d" % (i/4 + 1, (i%4)/2+1)] = "Ethernet%d" % i
     else:
         for i in range(0, 128, 4):
             port_alias_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
[minigraph_facts.py]: Add support for creation of port_alias_mapping for
     Seastone-DX010, Seastone-DX010-50 and Seastone-DX010-10-50.
    
    Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ -] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Added static code inline with current code for Seastone-DX010, Seastone-DX010-50 and Seastone-DX010-10-50
How did you verify/test it?
LLDP passes below only if correct port mapping is created.
http://172.25.11.20:8080/job/Run_Test_Cases_Msft_Ansible/63/console
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
