### PR TITLE
[sku-sensors-data.yml]: Add Sensor meta data for Seastone-DX010.

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -1697,3 +1697,291 @@ sensors_checks:
         side: left
         skip_list:
         - ym2651-i2c-11-5b
+  Seastone-DX010:
+    alarms:
+      fan:
+      - dps460-i2c-10-5a/fan1/fan1_alarm
+      - dps460-i2c-10-5a/fan1/fan1_fault
+      - dps460-i2c-11-5b/fan1/fan1_alarm
+      - dps460-i2c-11-5b/fan1/fan1_fault
+      - emc2305-i2c-13-2e/fan1/fan2_alarm
+      - emc2305-i2c-13-2e/fan1/fan2_fault
+      - emc2305-i2c-13-2e/fan2/fan1_alarm
+      - emc2305-i2c-13-2e/fan2/fan1_fault
+      - emc2305-i2c-13-2e/fan3/fan4_alarm
+      - emc2305-i2c-13-2e/fan3/fan4_fault
+      - emc2305-i2c-13-2e/fan4/fan5_alarm
+      - emc2305-i2c-13-2e/fan4/fan5_fault
+      - emc2305-i2c-13-2e/fan5/fan3_alarm
+      - emc2305-i2c-13-2e/fan5/fan3_fault
+      - emc2305-i2c-13-4d/fan1/fan2_alarm
+      - emc2305-i2c-13-4d/fan1/fan2_fault
+      - emc2305-i2c-13-4d/fan2/fan4_alarm
+      - emc2305-i2c-13-4d/fan2/fan4_fault
+      - emc2305-i2c-13-4d/fan3/fan5_alarm
+      - emc2305-i2c-13-4d/fan3/fan5_fault
+      - emc2305-i2c-13-4d/fan4/fan3_alarm
+      - emc2305-i2c-13-4d/fan4/fan3_fault
+      - emc2305-i2c-13-4d/fan5/fan1_alarm
+      - emc2305-i2c-13-4d/fan5/fan1_fault
+      power:
+      - dps460-i2c-10-5a/iin/curr1_crit_alarm
+      - dps460-i2c-10-5a/iin/curr1_max_alarm
+      - dps460-i2c-10-5a/iout1/curr2_crit_alarm
+      - dps460-i2c-10-5a/iout1/curr2_lcrit_alarm
+      - dps460-i2c-10-5a/iout1/curr2_max_alarm
+      - dps460-i2c-10-5a/pin/power1_alarm
+      - dps460-i2c-10-5a/pout1/power2_cap_alarm
+      - dps460-i2c-10-5a/pout1/power2_crit_alarm
+      - dps460-i2c-10-5a/pout1/power2_max_alarm
+      - dps460-i2c-10-5a/vin/in1_crit_alarm
+      - dps460-i2c-10-5a/vin/in1_lcrit_alarm
+      - dps460-i2c-10-5a/vin/in1_max_alarm
+      - dps460-i2c-10-5a/vin/in1_min_alarm
+      - dps460-i2c-10-5a/vout1/in3_crit_alarm
+      - dps460-i2c-10-5a/vout1/in3_lcrit_alarm
+      - dps460-i2c-10-5a/vout1/in3_max_alarm
+      - dps460-i2c-10-5a/vout1/in3_min_alarm
+      - dps460-i2c-11-5b/iin/curr1_crit_alarm
+      - dps460-i2c-11-5b/iin/curr1_max_alarm
+      - dps460-i2c-11-5b/iout1/curr2_crit_alarm
+      - dps460-i2c-11-5b/iout1/curr2_lcrit_alarm
+      - dps460-i2c-11-5b/iout1/curr2_max_alarm
+      - dps460-i2c-11-5b/pin/power1_alarm
+      - dps460-i2c-11-5b/pout1/power2_cap_alarm
+      - dps460-i2c-11-5b/pout1/power2_crit_alarm
+      - dps460-i2c-11-5b/pout1/power2_max_alarm
+      - dps460-i2c-11-5b/vin/in1_crit_alarm
+      - dps460-i2c-11-5b/vin/in1_lcrit_alarm
+      - dps460-i2c-11-5b/vin/in1_max_alarm
+      - dps460-i2c-11-5b/vin/in1_min_alarm
+      - dps460-i2c-11-5b/vout1/in3_crit_alarm
+      - dps460-i2c-11-5b/vout1/in3_lcrit_alarm
+      - dps460-i2c-11-5b/vout1/in3_max_alarm
+      - dps460-i2c-11-5b/vout1/in3_min_alarm
+      temp:
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_lcrit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_max_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_min_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_lcrit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_max_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_min_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_lcrit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_max_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_min_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_crit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_lcrit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_max_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_min_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_crit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_lcrit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_max_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_min_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_crit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_lcrit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_max_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_min_alarm
+    compares:
+      fan: []
+      power:
+      - - dps460-i2c-10-5a/iin/curr1_input
+        - dps460-i2c-10-5a/iin/curr1_crit
+      - - dps460-i2c-10-5a/iin/curr1_input
+        - dps460-i2c-10-5a/iin/curr1_max
+      - - dps460-i2c-10-5a/iout1/curr2_input
+        - dps460-i2c-10-5a/iout1/curr2_crit
+      - - dps460-i2c-10-5a/iout1/curr2_lcrit
+        - dps460-i2c-10-5a/iout1/curr2_input
+      - - dps460-i2c-10-5a/iout1/curr2_input
+        - dps460-i2c-10-5a/iout1/curr2_max
+      - - dps460-i2c-10-5a/pin/power1_input
+        - dps460-i2c-10-5a/pin/power1_max
+      - - dps460-i2c-10-5a/pout1/power2_input
+        - dps460-i2c-10-5a/pout1/power2_crit
+      - - dps460-i2c-10-5a/pout1/power2_input
+        - dps460-i2c-10-5a/pout1/power2_max
+      - - dps460-i2c-10-5a/vin/in1_input
+        - dps460-i2c-10-5a/vin/in1_crit
+      - - dps460-i2c-10-5a/vin/in1_lcrit
+        - dps460-i2c-10-5a/vin/in1_input
+      - - dps460-i2c-10-5a/vin/in1_input
+        - dps460-i2c-10-5a/vin/in1_max
+      - - dps460-i2c-10-5a/vin/in1_min
+        - dps460-i2c-10-5a/vin/in1_input
+      - - dps460-i2c-10-5a/vout1/in3_input
+        - dps460-i2c-10-5a/vout1/in3_crit
+      - - dps460-i2c-10-5a/vout1/in3_lcrit
+        - dps460-i2c-10-5a/vout1/in3_input
+      - - dps460-i2c-10-5a/vout1/in3_input
+        - dps460-i2c-10-5a/vout1/in3_max
+      - - dps460-i2c-10-5a/vout1/in3_min
+        - dps460-i2c-10-5a/vout1/in3_input
+      - - dps460-i2c-11-5b/iin/curr1_input
+        - dps460-i2c-11-5b/iin/curr1_crit
+      - - dps460-i2c-11-5b/iin/curr1_input
+        - dps460-i2c-11-5b/iin/curr1_max
+      - - dps460-i2c-11-5b/iout1/curr2_input
+        - dps460-i2c-11-5b/iout1/curr2_crit
+      - - dps460-i2c-11-5b/iout1/curr2_lcrit
+        - dps460-i2c-11-5b/iout1/curr2_input
+      - - dps460-i2c-11-5b/iout1/curr2_input
+        - dps460-i2c-11-5b/iout1/curr2_max
+      - - dps460-i2c-11-5b/pin/power1_input
+        - dps460-i2c-11-5b/pin/power1_max
+      - - dps460-i2c-11-5b/pout1/power2_input
+        - dps460-i2c-11-5b/pout1/power2_crit
+      - - dps460-i2c-11-5b/pout1/power2_input
+        - dps460-i2c-11-5b/pout1/power2_max
+      - - dps460-i2c-11-5b/vin/in1_input
+        - dps460-i2c-11-5b/vin/in1_crit
+      - - dps460-i2c-11-5b/vin/in1_lcrit
+        - dps460-i2c-11-5b/vin/in1_input
+      - - dps460-i2c-11-5b/vin/in1_input
+        - dps460-i2c-11-5b/vin/in1_max
+      - - dps460-i2c-11-5b/vin/in1_min
+        - dps460-i2c-11-5b/vin/in1_input
+      - - dps460-i2c-11-5b/vout1/in3_input
+        - dps460-i2c-11-5b/vout1/in3_crit
+      - - dps460-i2c-11-5b/vout1/in3_lcrit
+        - dps460-i2c-11-5b/vout1/in3_input
+      - - dps460-i2c-11-5b/vout1/in3_input
+        - dps460-i2c-11-5b/vout1/in3_max
+      - - dps460-i2c-11-5b/vout1/in3_min
+        - dps460-i2c-11-5b/vout1/in3_input
+      temp:
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_max
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_max
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_max
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_crit
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_lcrit
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_min
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_crit
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_lcrit
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_min
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_crit
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_lcrit
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_min
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_crit
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_lcrit
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_max
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_min
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_crit
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_lcrit
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_max
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_min
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_crit
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_lcrit
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_max
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_min
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+      - - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_max
+      - - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_max_hyst
+      - - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_max
+      - - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_max_hyst
+      - - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_max
+      - - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_max_hyst
+      - - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_max
+      - - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_max_hyst
+      - - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
+        - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_max
+      - - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
+        - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_max_hyst
+    non_zero:
+      fan:
+      - dps460-i2c-10-5a/fan1/fan1_input
+      - dps460-i2c-11-5b/fan1/fan1_input
+      - emc2305-i2c-13-2e/fan1/fan2_input
+      - emc2305-i2c-13-2e/fan2/fan1_input
+      - emc2305-i2c-13-2e/fan3/fan4_input
+      - emc2305-i2c-13-2e/fan4/fan5_input
+      - emc2305-i2c-13-2e/fan5/fan3_input
+      - emc2305-i2c-13-4d/fan1/fan2_input
+      - emc2305-i2c-13-4d/fan2/fan4_input
+      - emc2305-i2c-13-4d/fan3/fan5_input
+      - emc2305-i2c-13-4d/fan4/fan3_input
+      - emc2305-i2c-13-4d/fan5/fan1_input
+      power:
+      - dps460-i2c-10-5a/iin/curr1_input
+      - dps460-i2c-10-5a/iout1/curr2_input
+      - dps460-i2c-10-5a/pin/power1_input
+      - dps460-i2c-10-5a/pout1/power2_input
+      - dps460-i2c-10-5a/vin/in1_input
+      - dps460-i2c-10-5a/vout1/in3_input
+      - dps460-i2c-11-5b/iin/curr1_input
+      - dps460-i2c-11-5b/iout1/curr2_input
+      - dps460-i2c-11-5b/pin/power1_input
+      - dps460-i2c-11-5b/pout1/power2_input
+      - dps460-i2c-11-5b/vin/in1_input
+      - dps460-i2c-11-5b/vout1/in3_input
+      temp:
+      - coretemp-isa-0000/Core 0/temp2_input
+      - coretemp-isa-0000/Core 1/temp3_input
+      - coretemp-isa-0000/Core 2/temp4_input
+      - coretemp-isa-0000/Core 3/temp5_input
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+      - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_input
+      - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_input
+      - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_input
+      - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
+      - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
+    psu_skips: {}
+


### PR DESCRIPTION
[sku-sensors-data.yml]: Add Sensor meta data for Seastone-DX010.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
[sku-sensors-data.yml]: Add Sensor meta data for Seastone-DX010.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ -] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Added Sensors data created from Seastone Sonic DUT.
More Details in verification section,
How did you verify/test it?
[Sensors Data from Seastone:]
            "coretemp-isa-0000": {
                "Core 0": {
                    "temp2_crit": "98.000", 
                    "temp2_crit_alarm": "0.000", 
                    "temp2_input": "28.000", 
                    "temp2_max": "98.000"
                }, 
                "Core 1": {
                    "temp3_crit": "98.000", 
                    "temp3_crit_alarm": "0.000", 
                    "temp3_input": "28.000", 
                    "temp3_max": "98.000"
                }, 
                "Core 2": {
                    "temp4_crit": "98.000", 
                    "temp4_crit_alarm": "0.000", 
                    "temp4_input": "28.000", 
                    "temp4_max": "98.000"
                }, 
                "Core 3": {
                    "temp5_crit": "98.000", 
                    "temp5_crit_alarm": "0.000", 
                    "temp5_input": "28.000", 
                    "temp5_max": "98.000"
                }
            }, 
            "dps460-i2c-10-5a": {
                "Power Supply 1 temp sensor 1": {
                    "temp1_crit": "-0.500", 
                    "temp1_crit_alarm": "0.000", 
                    "temp1_input": "33.000", 
                    "temp1_lcrit": "-0.500", 
                    "temp1_lcrit_alarm": "0.000", 
                    "temp1_max": "119.000", 
                    "temp1_max_alarm": "0.000", 
                    "temp1_min": "-0.500", 
                    "temp1_min_alarm": "0.000"
                }, 
                "Power Supply 1 temp sensor 2": {
                    "temp2_crit": "-0.500", 
                    "temp2_crit_alarm": "0.000", 
                    "temp2_input": "36.000", 
                    "temp2_lcrit": "-0.500", 
                    "temp2_lcrit_alarm": "0.000", 
                    "temp2_max": "119.000", 
                    "temp2_max_alarm": "0.000", 
                    "temp2_min": "-0.500", 
                    "temp2_min_alarm": "0.000"
                }, 
                "Power Supply 1 temp sensor 3": {
                    "temp3_crit": "-0.500", 
                    "temp3_crit_alarm": "0.000", 
                    "temp3_input": "35.000", 
                    "temp3_lcrit": "-0.500", 
                    "temp3_lcrit_alarm": "0.000", 
                    "temp3_max": "119.000", 
                    "temp3_max_alarm": "0.000", 
                    "temp3_min": "-0.500", 
                    "temp3_min_alarm": "0.000"
                }, 
                "fan1": {
                    "fan1_alarm": "0.000", 
                    "fan1_fault": "0.000", 
                    "fan1_input": "3984.000"
                }, 
                "iin": {
                    "curr1_crit": "7.000", 
                    "curr1_crit_alarm": "0.000", 
                    "curr1_input": "0.460", 
                    "curr1_max": "6.000", 
                    "curr1_max_alarm": "0.000"
                }, 
                "iout1": {
                    "curr2_crit": "80.000", 
                    "curr2_crit_alarm": "0.000", 
                    "curr2_input": "6.578", 
                    "curr2_lcrit": "-0.500", 
                    "curr2_lcrit_alarm": "0.000", 
                    "curr2_max": "76.000", 
                    "curr2_max_alarm": "0.000"
                }, 
                "pin": {
                    "power1_alarm": "0.000", 
                    "power1_input": "91.000", 
                    "power1_max": "1148.000"
                }, 
                "pout1": {
                    "power2_cap": "-0.500", 
                    "power2_cap_alarm": "0.000", 
                    "power2_crit": "1100.000", 
                    "power2_crit_alarm": "0.000", 
                    "power2_input": "79.500", 
                    "power2_max": "900.000", 
                    "power2_max_alarm": "0.000"
                }, 
                "vin": {
                    "in1_crit": "-0.500", 
                    "in1_crit_alarm": "0.000", 
                    "in1_input": "209.500", 
                    "in1_lcrit": "-0.500", 
                    "in1_lcrit_alarm": "0.000", 
                    "in1_max": "-0.500", 
                    "in1_max_alarm": "0.000", 
                    "in1_min": "-0.500", 
                    "in1_min_alarm": "0.000"
                }, 
                "vout1": {
                    "in3_crit": "14.199", 
                    "in3_crit_alarm": "0.000", 
                    "in3_input": "12.175", 
                    "in3_lcrit": "10.400", 
                    "in3_lcrit_alarm": "0.000", 
                    "in3_max": "127.998", 
                    "in3_max_alarm": "0.000", 
                    "in3_min": "127.998", 
                    "in3_min_alarm": "0.000"
                }
            }, 
            "dps460-i2c-11-5b": {
                "Power Supply 2 temp sensor 1": {
                    "temp1_crit": "-0.500", 
                    "temp1_crit_alarm": "0.000", 
                    "temp1_input": "38.000", 
                    "temp1_lcrit": "-0.500", 
                    "temp1_lcrit_alarm": "0.000", 
                    "temp1_max": "119.000", 
                    "temp1_max_alarm": "0.000", 
                    "temp1_min": "-0.500", 
                    "temp1_min_alarm": "0.000"
                }, 
                "Power Supply 2 temp sensor 2": {
                    "temp2_crit": "-0.500", 
                    "temp2_crit_alarm": "0.000", 
                    "temp2_input": "40.000", 
                    "temp2_lcrit": "-0.500", 
                    "temp2_lcrit_alarm": "0.000", 
                    "temp2_max": "119.000", 
                    "temp2_max_alarm": "0.000", 
                    "temp2_min": "-0.500", 
                    "temp2_min_alarm": "0.000"
                }, 
                "Power Supply 2 temp sensor 3": {
                    "temp3_crit": "-0.500", 
                    "temp3_crit_alarm": "0.000", 
                    "temp3_input": "39.000", 
                    "temp3_lcrit": "-0.500", 
                    "temp3_lcrit_alarm": "0.000", 
                    "temp3_max": "119.000", 
                    "temp3_max_alarm": "0.000", 
                    "temp3_min": "-0.500", 
                    "temp3_min_alarm": "0.000"
                }, 
                "fan1": {
                    "fan1_alarm": "0.000", 
                    "fan1_fault": "0.000", 
                    "fan1_input": "5536.000"
                }, 
                "iin": {
                    "curr1_crit": "7.000", 
                    "curr1_crit_alarm": "0.000", 
                    "curr1_input": "0.439", 
                    "curr1_max": "6.000", 
                    "curr1_max_alarm": "0.000"
                }, 
                "iout1": {
                    "curr2_crit": "80.000", 
                    "curr2_crit_alarm": "0.000", 
                    "curr2_input": "6.312", 
                    "curr2_lcrit": "-0.500", 
                    "curr2_lcrit_alarm": "0.000", 
                    "curr2_max": "76.000", 
                    "curr2_max_alarm": "0.000"
                }, 
                "pin": {
                    "power1_alarm": "0.000", 
                    "power1_input": "86.750", 
                    "power1_max": "1148.000"
                }, 
                "pout1": {
                    "power2_cap": "-0.500", 
                    "power2_cap_alarm": "0.000", 
                    "power2_crit": "1100.000", 
                    "power2_crit_alarm": "0.000", 
                    "power2_input": "76.625", 
                    "power2_max": "900.000", 
                    "power2_max_alarm": "0.000"
                }, 
                "vin": {
                    "in1_crit": "-0.500", 
                    "in1_crit_alarm": "0.000", 
                    "in1_input": "210.000", 
                    "in1_lcrit": "-0.500", 
                    "in1_lcrit_alarm": "0.000", 
                    "in1_max": "-0.500", 
                    "in1_max_alarm": "0.000", 
                    "in1_min": "-0.500", 
                    "in1_min_alarm": "0.000"
                }, 
                "vout1": {
                    "in3_crit": "14.199", 
                    "in3_crit_alarm": "0.000", 
                    "in3_input": "12.160", 
                    "in3_lcrit": "10.400", 
                    "in3_lcrit_alarm": "0.000", 
                    "in3_max": "127.998", 
                    "in3_max_alarm": "0.000", 
                    "in3_min": "127.998", 
                    "in3_min_alarm": "0.000"
                }
            }, 
            "dx010_lm75b-i2c-14-48": {
                "Rear-panel temp sensor 1": {
                    "temp1_input": "37.000", 
                    "temp1_max": "43.000", 
                    "temp1_max_hyst": "28.000"
                }
            }, 
            "dx010_lm75b-i2c-15-4e": {
                "Rear-panel temp sensor 2": {
                    "temp1_input": "35.250", 
                    "temp1_max": "43.000", 
                    "temp1_max_hyst": "28.000"
                }
            }, 
            "dx010_lm75b-i2c-5-48": {
                "Rear-panel temp sensor 1": {
                    "temp1_input": "32.875", 
                    "temp1_max": "43.000", 
                    "temp1_max_hyst": "28.000"
                }
            }, 
            "dx010_lm75b-i2c-6-49": {
                "Front-panel temp sensor 2": {
                    "temp1_input": "39.375", 
                    "temp1_max": "43.000", 
                    "temp1_max_hyst": "28.000"
                }
            }, 
            "dx010_lm75b-i2c-7-4a": {
                "ASIC temp sensor": {
                    "temp1_input": "40.375", 
                    "temp1_max": "43.000", 
                    "temp1_max_hyst": "28.000"
                }
            }, 
            "emc2305-i2c-13-2e": {
                 "fan1": {
                    "fan1_alarm": "0.000", 
                    "fan1_div": "4.000", 
                    "fan1_fault": "0.000", 
                    "fan1_input": "16316.000"
                }, 
                "fan2": {
                    "fan2_alarm": "0.000", 
                    "fan2_div": "4.000", 
                    "fan2_fault": "0.000", 
                    "fan2_input": "16248.000"
                }, 
                "fan3": {
                    "fan3_alarm": "0.000", 
                    "fan3_div": "4.000", 
                    "fan3_fault": "0.000", 
                    "fan3_input": "16181.000"
                }, 
                "fan4": {
                    "fan4_alarm": "0.000", 
                    "fan4_div": "4.000", 
                    "fan4_fault": "0.000", 
                    "fan4_input": "16248.000"
                }, 
                "fan5": {
                    "fan5_alarm": "0.000", 
                    "fan5_div": "4.000", 
                    "fan5_fault": "0.000", 
                    "fan5_input": "15984.000"
                }
	    },
            "emc2305-i2c-13-4d": {
                "fan1": {
                    "fan1_alarm": "0.000", 
                    "fan1_div": "4.000", 
                    "fan1_fault": "0.000", 
                    "fan1_input": "15360.000"
                }, 
                "fan2": {
                    "fan2_alarm": "0.000", 
                    "fan2_div": "4.000", 
                    "fan2_fault": "0.000", 
                    "fan2_input": "15542.000"
                }, 
                "fan3": {
                    "fan3_alarm": "0.000", 
                    "fan3_div": "4.000", 
                    "fan3_fault": "0.000", 
                    "fan3_input": "15420.000"
                }, 
                "fan4": {
                    "fan4_alarm": "0.000", 
                    "fan4_div": "4.000", 
                    "fan4_fault": "0.000", 
                    "fan4_input": "15300.000"
                }, 
                "fan5": {
                    "fan5_alarm": "0.000", 
                    "fan5_div": "4.000", 
                    "fan5_fault": "0.000", 
                    "fan5_input": "15665.000"
                }
            }

[Meta_Data Based on this Sensors Data]:
+  Seastone-DX010:
+    alarms:
+      fan:
+      - dps460-i2c-10-5a/fan1/fan1_alarm
+      - dps460-i2c-10-5a/fan1/fan1_fault
+      - dps460-i2c-11-5b/fan1/fan1_alarm
+      - dps460-i2c-11-5b/fan1/fan1_fault
+      - emc2305-i2c-13-2e/fan1/fan2_alarm
+      - emc2305-i2c-13-2e/fan1/fan2_fault
+      - emc2305-i2c-13-2e/fan2/fan1_alarm
+      - emc2305-i2c-13-2e/fan2/fan1_fault
+      - emc2305-i2c-13-2e/fan3/fan4_alarm
+      - emc2305-i2c-13-2e/fan3/fan4_fault
+      - emc2305-i2c-13-2e/fan4/fan5_alarm
+      - emc2305-i2c-13-2e/fan4/fan5_fault
+      - emc2305-i2c-13-2e/fan5/fan3_alarm
+      - emc2305-i2c-13-2e/fan5/fan3_fault
+      - emc2305-i2c-13-4d/fan1/fan2_alarm
+      - emc2305-i2c-13-4d/fan1/fan2_fault
+      - emc2305-i2c-13-4d/fan2/fan4_alarm
+      - emc2305-i2c-13-4d/fan2/fan4_fault
+      - emc2305-i2c-13-4d/fan3/fan5_alarm
+      - emc2305-i2c-13-4d/fan3/fan5_fault
+      - emc2305-i2c-13-4d/fan4/fan3_alarm
+      - emc2305-i2c-13-4d/fan4/fan3_fault
+      - emc2305-i2c-13-4d/fan5/fan1_alarm
+      - emc2305-i2c-13-4d/fan5/fan1_fault
+      power:
+      - dps460-i2c-10-5a/iin/curr1_crit_alarm
+      - dps460-i2c-10-5a/iin/curr1_max_alarm
+      - dps460-i2c-10-5a/iout1/curr2_crit_alarm
+      - dps460-i2c-10-5a/iout1/curr2_lcrit_alarm
+      - dps460-i2c-10-5a/iout1/curr2_max_alarm
+      - dps460-i2c-10-5a/pin/power1_alarm
+      - dps460-i2c-10-5a/pout1/power2_cap_alarm
+      - dps460-i2c-10-5a/pout1/power2_crit_alarm
+      - dps460-i2c-10-5a/pout1/power2_max_alarm
+      - dps460-i2c-10-5a/vin/in1_crit_alarm
+      - dps460-i2c-10-5a/vin/in1_lcrit_alarm
+      - dps460-i2c-10-5a/vin/in1_max_alarm
+      - dps460-i2c-10-5a/vin/in1_min_alarm
+      - dps460-i2c-10-5a/vout1/in3_crit_alarm
+      - dps460-i2c-10-5a/vout1/in3_lcrit_alarm
+      - dps460-i2c-10-5a/vout1/in3_max_alarm
+      - dps460-i2c-10-5a/vout1/in3_min_alarm
+      - dps460-i2c-11-5b/iin/curr1_crit_alarm
+      - dps460-i2c-11-5b/iin/curr1_max_alarm
+      - dps460-i2c-11-5b/iout1/curr2_crit_alarm
+      - dps460-i2c-11-5b/iout1/curr2_lcrit_alarm
+      - dps460-i2c-11-5b/iout1/curr2_max_alarm
+      - dps460-i2c-11-5b/pin/power1_alarm
+      - dps460-i2c-11-5b/pout1/power2_cap_alarm
+      - dps460-i2c-11-5b/pout1/power2_crit_alarm
+      - dps460-i2c-11-5b/pout1/power2_max_alarm
+      - dps460-i2c-11-5b/vin/in1_crit_alarm
+      - dps460-i2c-11-5b/vin/in1_lcrit_alarm
+      - dps460-i2c-11-5b/vin/in1_max_alarm
+      - dps460-i2c-11-5b/vin/in1_min_alarm
+      - dps460-i2c-11-5b/vout1/in3_crit_alarm
+      - dps460-i2c-11-5b/vout1/in3_lcrit_alarm
+      - dps460-i2c-11-5b/vout1/in3_max_alarm
+      - dps460-i2c-11-5b/vout1/in3_min_alarm
+      temp:
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_lcrit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_max_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_min_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_lcrit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_max_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_min_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_crit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_lcrit_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_max_alarm
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_min_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_crit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_lcrit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_max_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_min_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_crit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_lcrit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_max_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_min_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_crit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_lcrit_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_max_alarm
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_min_alarm
+    compares:
+      fan: []
+      power:
+      - - dps460-i2c-10-5a/iin/curr1_input
+        - dps460-i2c-10-5a/iin/curr1_crit
+      - - dps460-i2c-10-5a/iin/curr1_input
+        - dps460-i2c-10-5a/iin/curr1_max
+      - - dps460-i2c-10-5a/iout1/curr2_input
+        - dps460-i2c-10-5a/iout1/curr2_crit
+      - - dps460-i2c-10-5a/iout1/curr2_lcrit
+        - dps460-i2c-10-5a/iout1/curr2_input
+      - - dps460-i2c-10-5a/iout1/curr2_input
+        - dps460-i2c-10-5a/iout1/curr2_max
+      - - dps460-i2c-10-5a/pin/power1_input
+        - dps460-i2c-10-5a/pin/power1_max
+      - - dps460-i2c-10-5a/pout1/power2_input
+        - dps460-i2c-10-5a/pout1/power2_crit
+      - - dps460-i2c-10-5a/pout1/power2_input
+        - dps460-i2c-10-5a/pout1/power2_max
+      - - dps460-i2c-10-5a/vin/in1_input
+        - dps460-i2c-10-5a/vin/in1_crit
+      - - dps460-i2c-10-5a/vin/in1_lcrit
+        - dps460-i2c-10-5a/vin/in1_input
+      - - dps460-i2c-10-5a/vin/in1_input
+        - dps460-i2c-10-5a/vin/in1_max
+      - - dps460-i2c-10-5a/vin/in1_min
+        - dps460-i2c-10-5a/vin/in1_input
+      - - dps460-i2c-10-5a/vout1/in3_input
+        - dps460-i2c-10-5a/vout1/in3_crit
+      - - dps460-i2c-10-5a/vout1/in3_lcrit
+        - dps460-i2c-10-5a/vout1/in3_input
+      - - dps460-i2c-10-5a/vout1/in3_input
+        - dps460-i2c-10-5a/vout1/in3_max
+      - - dps460-i2c-10-5a/vout1/in3_min
+        - dps460-i2c-10-5a/vout1/in3_input
+      - - dps460-i2c-11-5b/iin/curr1_input
+        - dps460-i2c-11-5b/iin/curr1_crit
+      - - dps460-i2c-11-5b/iin/curr1_input
+        - dps460-i2c-11-5b/iin/curr1_max
+      - - dps460-i2c-11-5b/iout1/curr2_input
+        - dps460-i2c-11-5b/iout1/curr2_crit
+      - - dps460-i2c-11-5b/iout1/curr2_lcrit
+        - dps460-i2c-11-5b/iout1/curr2_input
+      - - dps460-i2c-11-5b/iout1/curr2_input
+        - dps460-i2c-11-5b/iout1/curr2_max
+      - - dps460-i2c-11-5b/pin/power1_input
+        - dps460-i2c-11-5b/pin/power1_max
+      - - dps460-i2c-11-5b/pout1/power2_input
+        - dps460-i2c-11-5b/pout1/power2_crit
+      - - dps460-i2c-11-5b/pout1/power2_input
+        - dps460-i2c-11-5b/pout1/power2_max
+      - - dps460-i2c-11-5b/vin/in1_input
+        - dps460-i2c-11-5b/vin/in1_crit
+      - - dps460-i2c-11-5b/vin/in1_lcrit
+        - dps460-i2c-11-5b/vin/in1_input
+      - - dps460-i2c-11-5b/vin/in1_input
+        - dps460-i2c-11-5b/vin/in1_max
+      - - dps460-i2c-11-5b/vin/in1_min
+        - dps460-i2c-11-5b/vin/in1_input
+      - - dps460-i2c-11-5b/vout1/in3_input
+        - dps460-i2c-11-5b/vout1/in3_crit
+      - - dps460-i2c-11-5b/vout1/in3_lcrit
+        - dps460-i2c-11-5b/vout1/in3_input
+      - - dps460-i2c-11-5b/vout1/in3_input
+        - dps460-i2c-11-5b/vout1/in3_max
+      - - dps460-i2c-11-5b/vout1/in3_min
+        - dps460-i2c-11-5b/vout1/in3_input
+      temp:
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_max
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_max
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_max
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_crit
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_lcrit
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_min
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_crit
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_lcrit
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_min
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_crit
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_lcrit
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_max
+      - - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_min
+        - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_crit
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_lcrit
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_max
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_min
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_crit
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_lcrit
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_max
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_min
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_crit
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_lcrit
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_max
+      - - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_min
+        - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+      - - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_max
+      - - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_max_hyst
+      - - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_max
+      - - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_max_hyst
+      - - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_max
+      - - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_input
+        - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_max_hyst
+      - - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_max
+      - - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
+        - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_max_hyst
+      - - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
+        - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_max
+      - - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
+        - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_max_hyst
+    non_zero:
+      fan:
+      - dps460-i2c-10-5a/fan1/fan1_input
+      - dps460-i2c-11-5b/fan1/fan1_input
+      - emc2305-i2c-13-2e/fan1/fan2_input
+      - emc2305-i2c-13-2e/fan2/fan1_input
+      - emc2305-i2c-13-2e/fan3/fan4_input
+      - emc2305-i2c-13-2e/fan4/fan5_input
+      - emc2305-i2c-13-2e/fan5/fan3_input
+      - emc2305-i2c-13-4d/fan1/fan2_input
+      - emc2305-i2c-13-4d/fan2/fan4_input
+      - emc2305-i2c-13-4d/fan3/fan5_input
+      - emc2305-i2c-13-4d/fan4/fan3_input
+      - emc2305-i2c-13-4d/fan5/fan1_input
+      power:
+      - dps460-i2c-10-5a/iin/curr1_input
+      - dps460-i2c-10-5a/iout1/curr2_input
+      - dps460-i2c-10-5a/pin/power1_input
+      - dps460-i2c-10-5a/pout1/power2_input
+      - dps460-i2c-10-5a/vin/in1_input
+      - dps460-i2c-10-5a/vout1/in3_input
+      - dps460-i2c-11-5b/iin/curr1_input
+      - dps460-i2c-11-5b/iout1/curr2_input
+      - dps460-i2c-11-5b/pin/power1_input
+      - dps460-i2c-11-5b/pout1/power2_input
+      - dps460-i2c-11-5b/vin/in1_input
+      - dps460-i2c-11-5b/vout1/in3_input
+      temp:
+      - coretemp-isa-0000/Core 0/temp2_input
+      - coretemp-isa-0000/Core 1/temp3_input
+      - coretemp-isa-0000/Core 2/temp4_input
+      - coretemp-isa-0000/Core 3/temp5_input
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_input
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_input
+      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_input
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_input
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_input
+      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_input
+      - dx010_lm75b-i2c-14-48/Rear-panel temp sensor 1/temp1_input
+      - dx010_lm75b-i2c-15-4e/Rear-panel temp sensor 2/temp1_input
+      - dx010_lm75b-i2c-5-48/Rear-panel temp sensor 1/temp1_input
+      - dx010_lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
+      - dx010_lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
+    psu_skips: {}
+

Test Results on Seastone:

Any platform specific information?
For Seasone-DX010. 
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
