### PR TITLE
make the config reload wait time more flexible

### DIFF
--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -159,5 +159,19 @@
       shell: "config load_minigraph -y"
       become: yes
 
-    - name: wait for port channel interface to be up
+    - name: wait 60 seconds for ports to be up
+      pause: seconds=60
+
+    - name: check port status
+      interface_facts: up_ports={{ minigraph_ports }}
+
+    - name: wait again if still not up
+      pause: seconds=30
+      when: ansible_interface_link_down_ports | length != 0
+
+    - name: second chance to check
+      interface_facts: up_ports={{ minigraph_ports }}
+      when: ansible_interface_link_down_ports | length != 0
+
+    - name: last wait if still not up
       pause: seconds=30


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Adding more waiting time for interface to be up after reload config

#### How did you verify/test it?
test it locally

#### Any platform specific information?
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
