### PR TITLE
[minigraph_facts.py]: Add support for creation of port_alias_mapping for

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -510,6 +510,19 @@ def parse_xml(filename, hostname):
     elif hwsku == "Accton-AS7712-32X":
         for i in range(1, 33):
             port_alias_map["hundredGigE%d" % i] = "Ethernet%d" % ((i - 1) * 4)
+    elif hwsku == "Seastone-DX010":
+        for i in range(0, 128, 4):
+            port_alias_map["Eth%d" % (i/4 + 1)] = "Ethernet%d" % i
+    elif hwsku == "Seastone-DX010-50":
+        for i in range(0,128, 2):
+            port_alias_map["Eth%d/%d" % (i/4 + 1, (i%4)/2 + 1)] = "Ethernet%d" % i
+    elif hwsku == "Seastone-DX010-10-50":
+        # from port 0 - 95 are 10G
+        for i in range(0, 96):
+            port_alias_map["Eth%d/%d" % (i/4 + 1, i%4 + 1)] = "Ethernet%d" % i
+        # from port 96 - 126 are 50G
+        for i in range(96, 128, 2):
+            port_alias_map["Eth%d/%d" % (i/4 + 1, (i%4)/2+1)] = "Ethernet%d" % i
     else:
         for i in range(0, 128, 4):
             port_alias_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
[minigraph_facts.py]: Add support for creation of port_alias_mapping for
Seastone-DX010, Seastone-DX010-50 and Seastone-DX010-10-50.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ -] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
How did you do it?
Added static code inline with current code for Seastone-DX010, Seastone-DX010-50 and Seastone-DX010-10-50

How did you verify/test it?
LLDP passes below only if correct port mapping is created.
http://172.25.11.20:8080/job/Run_Test_Cases_Msft_Ansible/63/console
Summary:
----------------------------------------------------------------------------------------------------
TestSuite: arp                  Pass: 96                   Fail: 0                   
TestSuite: continuous_reboot    Pass: 110                  Fail: 0                   
TestSuite: everflow_testbed     Pass: 491                  Fail: 0                   
TestSuite: lldp                 Pass: 60                   Fail: 0        <<<<<<<<<<<<<           
TestSuite: mem_check            Pass: 54                   Fail: 0                   
TestSuite: port_toggle          Pass: 59                   Fail: 0                   
TestSuite: reboot               Pass: 67                   Fail: 0                   
TestSuite: repeat_harness       Pass: 59                   Fail: 0                   
TestSuite: restart_swss         Pass: 51                   Fail: 0                   
TestSuite: restart_swss_service Pass: 67                   Fail: 0                   
TestSuite: sensors              Pass: 57                   Fail: 0                   
TestSuite: syslog               Pass: 77                   Fail: 0 

From: DUT
admin@falco-test-dut02:~$ sudo find / -iname port_config.ini | grep Seastone
/usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010/port_config.ini
/usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-10-50/port_config.ini
/usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-50/port_config.ini

admin@falco-test-dut02:~$ cat /usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010/port_config.ini
# name          lanes                 alias     index   speed
Ethernet0       65,66,67,68           Eth1      0       100000
Ethernet4       69,70,71,72           Eth2      1       100000
Ethernet8       73,74,75,76           Eth3      2       100000
Ethernet12      77,78,79,80           Eth4      3       100000
Ethernet16      33,34,35,36           Eth5      4       100000
Ethernet20      37,38,39,40           Eth6      5       100000
Ethernet24      41,42,43,44           Eth7      6       100000
Ethernet28      45,46,47,48           Eth8      7       100000
Ethernet32      49,50,51,52           Eth9      8       100000
Ethernet36      53,54,55,56           Eth10     9       100000
Ethernet40      57,58,59,60           Eth11     10      100000
Ethernet44      61,62,63,64           Eth12     11      100000
Ethernet48      81,82,83,84           Eth13     12      100000
Ethernet52      85,86,87,88           Eth14     13      100000
Ethernet56      89,90,91,92           Eth15     14      100000
Ethernet60      93,94,95,96           Eth16     15      100000
Ethernet64      97,98,99,100          Eth17     16      100000
Ethernet68      101,102,103,104       Eth18     17      100000
Ethernet72      105,106,107,108       Eth19     18      100000
Ethernet76      109,110,111,112       Eth20     19      100000
Ethernet80      1,2,3,4               Eth21     20      100000
Ethernet84      5,6,7,8               Eth22     21      100000
Ethernet88      9,10,11,12            Eth23     22      100000
Ethernet92      13,14,15,16           Eth24     23      100000
Ethernet96      17,18,19,20           Eth25     24      100000
Ethernet100     21,22,23,24           Eth26     25      100000
Ethernet104     25,26,27,28           Eth27     26      100000
Ethernet108     29,30,31,32           Eth28     27      100000
Ethernet112     113,114,115,116       Eth29     28      100000
Ethernet116     117,118,119,120       Eth30     29      100000
Ethernet120     121,122,123,124       Eth31     30      100000
Ethernet124     125,126,127,128       Eth32     31      100000

admin@falco-test-dut02:~$ cat /usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-10-50/port_config.ini
# name          lanes        alias      index   speed
Ethernet0       65           Eth1/1     0       10000
Ethernet1       66           Eth1/2     0       10000
Ethernet2       67           Eth1/3     0       10000
Ethernet3       68           Eth1/4     0       10000
Ethernet4       69           Eth2/1     1       10000
Ethernet5       70           Eth2/2     1       10000
Ethernet6       71           Eth2/3     1       10000
Ethernet7       72           Eth2/4     1       10000
Ethernet8       73           Eth3/1     2       10000
Ethernet9       74           Eth3/2     2       10000
Ethernet10      75           Eth3/3     2       10000
Ethernet11      76           Eth3/4     2       10000
Ethernet12      77           Eth4/1     3       10000
Ethernet13      78           Eth4/2     3       10000
Ethernet14      79           Eth4/3     3       10000
Ethernet15      80           Eth4/4     3       10000
Ethernet16      33           Eth5/1     4       10000
.....
.....
Ethernet94      15           Eth24/3    23      10000
Ethernet95      16           Eth24/4    23      10000
Ethernet96      17,18        Eth25/1    24      50000
Ethernet98      19,20        Eth25/2    24      50000
Ethernet100     21,22        Eth26/1    25      50000
Ethernet102     23,24        Eth26/2    25      50000
Ethernet104     25,26        Eth27/1    26      50000
Ethernet106     27,28        Eth27/2    26      50000
Ethernet108     29,30        Eth28/1    27      50000
Ethernet110     31,32        Eth28/2    27      50000
Ethernet112     113,114      Eth29/1    28      50000
Ethernet114     115,116      Eth29/2    28      50000
Ethernet116     117,118      Eth30/1    29      50000
Ethernet118     119,120      Eth30/2    29      50000
Ethernet120     121,122      Eth31/1    30      50000
Ethernet122     123,124      Eth31/2    30      50000
Ethernet124     125,126      Eth32/1    31      50000
Ethernet126     127,128      Eth32/2    31      50000

admin@falco-test-dut02:~$ cat /usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-50/port_config.ini
# name          lanes           alias       index       speed
Ethernet0       65,66           Eth1/1      0           50000
Ethernet2       67,68           Eth1/2      0           50000
Ethernet4       69,70           Eth2/1      1           50000
Ethernet6       71,72           Eth2/2      1           50000
Ethernet8       73,74           Eth3/1      2           50000
Ethernet10      75,76           Eth3/2      2           50000
Ethernet12      77,78           Eth4/1      3           50000
Ethernet14      79,80           Eth4/2      3           50000
Ethernet16      33,34           Eth5/1      4           50000
Ethernet18      35,36           Eth5/2      4           50000
Ethernet20      37,38           Eth6/1      5           50000
Ethernet22      39,40           Eth6/2      5           50000
Ethernet24      41,42           Eth7/1      6           50000
.........
..........
Ethernet104     25,26           Eth27/1     26          50000
Ethernet106     27,28           Eth27/2     26          50000
Ethernet108     29,30           Eth28/1     27          50000
Ethernet110     31,32           Eth28/2     27          50000
Ethernet112     113,114         Eth29/1     28          50000
Ethernet114     115,116         Eth29/2     28          50000
Ethernet116     117,118         Eth30/1     29          50000
Ethernet118     119,120         Eth30/2     29          50000
Ethernet120     121,122         Eth31/1     30          50000
Ethernet122     123,124         Eth31/2     30          50000
Ethernet124     125,126         Eth32/1     31          50000
Ethernet126     127,128         Eth32/2     31          50000

Any platform specific information?
Only for Seastone-DX010

Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
