### PR TITLE
Make the copp test target port configurable

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -28,7 +28,7 @@ import threading
 
 
 class ControlPlaneBaseTest(BaseTest):
-    MAX_PORTS = 32
+    MAX_PORTS = 128
     PPS_LIMIT = 600
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
     PPS_LIMIT_MAX = PPS_LIMIT * 1.1
@@ -48,7 +48,7 @@ class ControlPlaneBaseTest(BaseTest):
             self.pkt_tx_count = self.PKT_TX_COUNT
         self.pkt_rx_limit = self.pkt_tx_count * 0.90
 
-        target_port_str = test_params.get('target_port', TARGET_PORT)
+        target_port_str = test_params.get('target_port', self.TARGET_PORT)
         self.target_port = int(target_port_str)
 
         self.timeout_thr = None

--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -1,4 +1,6 @@
-# ptf --test-dir saitests copp_tests  --qlen=100000 --platform nn -t "verbose=True;pkt_tx_count=100000" --device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://10.3.147.47:10900
+# ptf --test-dir saitests copp_tests  --qlen=100000 --platform nn -t "verbose=True;pkt_tx_count=100000;target_port=3" --device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://10.3.147.47:10900
+# or
+# ptf --test-dir saitests copp_tests  --qlen=100000 --platform nn -t "verbose=True;pkt_tx_count=100000;target_port=10" --device-socket 0-10@tcp://127.0.0.1:10900 --device-socket 1-10@tcp://10.3.147.47:10900
 #
 # copp_test.${name_test}
 #
@@ -32,6 +34,7 @@ class ControlPlaneBaseTest(BaseTest):
     PPS_LIMIT_MAX = PPS_LIMIT * 1.1
     NO_POLICER_LIMIT = PPS_LIMIT * 1.4
     PKT_TX_COUNT = 100000
+    TARGET_PORT = "3"  # historically we have port 3 as a target port
     TASK_TIMEOUT = 300 # Wait up to 5 minutes for tasks to complete
 
     def __init__(self):
@@ -44,6 +47,9 @@ class ControlPlaneBaseTest(BaseTest):
         if self.pkt_tx_count == 0:
             self.pkt_tx_count = self.PKT_TX_COUNT
         self.pkt_rx_limit = self.pkt_tx_count * 0.90
+
+        target_port_str = test_params.get('target_port', TARGET_PORT)
+        self.target_port = int(target_port_str)
 
         self.timeout_thr = None
 
@@ -161,7 +167,7 @@ class ControlPlaneBaseTest(BaseTest):
 
     def run_suite(self):
         self.timeout(self.TASK_TIMEOUT, "The test case hasn't been completed in %d seconds" % self.TASK_TIMEOUT) # FIXME: better make it decorator
-        self.one_port_test(3)
+        self.one_port_test(self.target_port)
         self.cancel_timeout()
 
     def printStats(self, pkt_send_count, total_rcv_pkt_cnt, time_delta, tx_pps, rx_pps):

--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -24,6 +24,34 @@
       script: roles/test/files/helpers/add_ip.sh
       delegate_to: "{{ ptf_host }}"
 
+    - name: set default nn_target_port if it's not defined
+      set_fact: nn_target_port="3"
+      when: nn_target_port is undefined
+
+    - name: set default nn_target_interface if it's not defined
+      set_fact: nn_target_interface="Ethernet12"
+      when: nn_target_interface is undefined
+
+    - name: Update ptf_nn_agent configuration inside ptf
+      template: src=ptf_nn_agent.conf.ptf.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Restart ptf_nn_agent inside ptf
+      supervisorctl: state=restarted name=ptf_nn_agent
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Update ptf_nn_agent configuration inside dut
+      template: src=ptf_nn_agent.conf.dut.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
+      vars:
+        ansible_shell_type: docker
+        ansible_python_interpreter: docker exec -i syncd python
+
+    - name: Restart ptf_nn_agent inside dut
+      supervisorctl: state=restarted name=ptf_nn_agent
+      vars:
+        ansible_shell_type: docker
+        ansible_python_interpreter: docker exec -i lldp python
+
     - name: copy the test to ptf container
       copy: src=roles/test/files/ptftests dest=/root
       delegate_to: "{{ ptf_host }}"
@@ -38,6 +66,7 @@
         ptf_test_params:
         - verbose=False
         - pkt_tx_count={{ pkt_tx_count|default(0) }}
+        - target_port={{ nn_target_port }}
         ptf_extra_options: "--device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://{{ ansible_eth0['ipv4']['address'] }}:10900"
       with_items:
         - ARPTest
@@ -53,6 +82,32 @@
     - name: Remove existing ip from ptf host
       script: roles/test/files/helpers/remove_ip.sh
       delegate_to: "{{ ptf_host }}"
+
+    - name: set default nn_target_port
+      set_fact: nn_target_port="3"
+
+    - name: set default nn_target_interface
+      set_fact: nn_target_interface="Ethernet12"
+
+    - name: Update ptf_nn_agent configuration inside ptf
+      template: src=ptf_nn_agent.conf.ptf.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Restart ptf_nn_agent inside ptf
+      supervisorctl: state=restarted name=ptf_nn_agent
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Update ptf_nn_agent configuration inside dut
+      template: src=ptf_nn_agent.conf.dut.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
+      vars:
+        ansible_shell_type: docker
+        ansible_python_interpreter: docker exec -i syncd python
+
+    - name: Restart ptf_nn_agent inside dut
+      supervisorctl: state=restarted name=ptf_nn_agent
+      vars:
+        ansible_shell_type: docker
+        ansible_python_interpreter: docker exec -i lldp python
 
     - name: Restore LLDP Daemon
       become: yes

--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -50,7 +50,7 @@
       supervisorctl: state=restarted name=ptf_nn_agent
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i lldp python
+        ansible_python_interpreter: docker exec -i syncd python
 
     - name: copy the test to ptf container
       copy: src=roles/test/files/ptftests dest=/root
@@ -67,7 +67,7 @@
         - verbose=False
         - pkt_tx_count={{ pkt_tx_count|default(0) }}
         - target_port={{ nn_target_port }}
-        ptf_extra_options: "--device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://{{ ansible_eth0['ipv4']['address'] }}:10900"
+        ptf_extra_options: "--device-socket 0-{{ nn_target_port }}@tcp://127.0.0.1:10900 --device-socket 1-{{ nn_target_port }}@tcp://{{ ansible_eth0['ipv4']['address'] }}:10900"
       with_items:
         - ARPTest
         - DHCPTest
@@ -107,7 +107,7 @@
       supervisorctl: state=restarted name=ptf_nn_agent
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i lldp python
+        ansible_python_interpreter: docker exec -i syncd python
 
     - name: Restore LLDP Daemon
       become: yes

--- a/ansible/roles/test/templates/ptf_nn_agent.conf.dut.j2
+++ b/ansible/roles/test/templates/ptf_nn_agent.conf.dut.j2
@@ -1,0 +1,10 @@
+[program:ptf_nn_agent]
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-{{ nn_target_port }}@{{ nn_target_interface }} --set-iface-rcv-buffer=109430400
+process_name=ptf_nn_agent
+stdout_logfile=/tmp/ptf_nn_agent.out.log
+stderr_logfile=/tmp/ptf_nn_agent.err.log
+redirect_stderr=false
+autostart=true
+autorestart=true
+startsecs=1
+numprocs=1

--- a/ansible/roles/test/templates/ptf_nn_agent.conf.ptf.j2
+++ b/ansible/roles/test/templates/ptf_nn_agent.conf.ptf.j2
@@ -1,0 +1,10 @@
+[program:ptf_nn_agent]
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 0@tcp://127.0.0.1:10900 -i 0-{{ nn_target_port }}@eth{{ nn_target_port }}
+process_name=ptf_nn_agent
+stdout_logfile=/tmp/ptf_nn_agent.out.log
+stderr_logfile=/tmp/ptf_nn_agent.err.log
+redirect_stderr=false
+autostart=true
+autorestart=true
+startsecs=1
+numprocs=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
I've added additional parameters for copp test. Now you can specify nn_target_port, nn_target_interface. Previously the values were "3" and "Ethernet12" which doesn't work for all devices.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
I've added additional parameters for copp test. Now you can specify nn_target_port, nn_target_interface. Previously the values were "3" and "Ethernet12" which doesn't work for all devices.

How did you verify/test it?
Run copp test for some dut

Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
