### PR TITLE
Install a new sonic image before fast-reboot test if requested

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -79,7 +79,7 @@
         flat: yes
       delegate_to: "{{ ptf_host }}"
 
-    - name: set authorized key took from file
+    - name: set authorized key taken from file
       authorized_key:
         user: "{{ ansible_ssh_user }}"
         state: present
@@ -102,6 +102,10 @@
         content: "{{ minigraph_port_indices | to_nice_json }}"
         dest: /tmp/ports.json
       delegate_to: "{{ ptf_host }}"
+
+    - name: Install a new sonic image if requested
+      shell: sonic_installer install -y {{ new_sonic_image }}
+      where: new_sonic_image is defined
 
     - include: ptf_runner.yml
       vars:


### PR DESCRIPTION
Don't merge. It's not tested properly.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR makes possible to install a new image right before the FastReboot test. It allows us to test FastReboot procedure with the image upgrade
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
How did you do it?
I've added a new parameter for the test: `new_sonic_image` When it's defined it will be used as an argument for sonic_install utility.
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
