### PR TITLE
minigraph png add server links

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -13,6 +13,17 @@
       </DeviceLinkBase>
 {% endfor %}
 {% endfor %}
+{% if 'host_interfaces' in vm_topo_config %}
+{% for host_index in range(vlan_intfs | length) %}
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ vlan_intfs[host_index] }}</EndPort>
+        <StartDevice>Servers{{ host_index }}</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+{% endfor %}
+{% endif %}
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="{{ vm_topo_config['dut_type'] }}">
@@ -44,3 +55,4 @@
 {% endif %}
     </Devices>
   </PngDec>
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Feedback some test case may need png ports 

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
add server ports connection for t0 topology

####How did you verify/test it?
tested locally and it was Ok for minigraph parser
#### Any platform specific information?
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
