### PR TITLE
Added DIP=SIP testcase.

### DIFF
--- a/ansible/roles/test/files/ptftests/dip_sip.py
+++ b/ansible/roles/test/files/ptftests/dip_sip.py
@@ -1,0 +1,158 @@
+'''
+Description:
+    This file contains the DIP=SIP test for SONiC
+
+    This test uses UDP packets to validate that HW supports routing of L3 packets with DIP=SIP
+
+Topologies:
+    Supports t0, t1 and t1-lag topology
+
+Parameters:
+    testbed_type   - testbed type
+    dst_host_mac   - destination host MAC address
+    src_host_mac   - source host MAC address
+    dst_router_mac - destination router MAC address
+    src_router_mac - source router MAC address
+    dst_router_ip  - destination router IPv4 address
+    src_router_ip  - source router IPv4 address
+    dst_port_ids   - destination port array of indices (when router has a members)
+    src_port_ids   - source port array of indices (when router has a members)
+
+Usage:
+    Example of how to start this script:
+        ptf --test-dir ptftests dip_sip.DipSipTest --platform-dir ptftests --platform remote \
+        -t "testbed_type='<testbed_type>'; \
+            dst_host_mac='<dst_host_mac>'; \
+            src_host_mac='<src_host_mac>'; \
+            dst_router_mac='<dst_router_mac>'; \
+            src_router_mac='<src_router_mac>'; \
+            dst_router_ip='<dst_router_ip>'; \
+            src_router_ip='<src_router_ip>'; \
+            dst_port_ids='<dst_port_ids>'; \
+            src_port_ids='<src_port_ids>'" \
+        --relax --debug info --log-file /tmp/dip_sip.DipSipTest.log \
+        --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
+
+Notes:
+    Please check the dip_sip.yml file to see the details of how this test works
+'''
+
+#-------------------------------------------------------------------------------
+# Global imports
+#-------------------------------------------------------------------------------
+
+import json
+import time
+import logging
+
+from collections import defaultdict
+from ipaddress import ip_address, ip_network
+
+import ptf
+import ptf.packet as scapy
+import ptf.dataplane as dataplane
+
+from ptf import config
+from ptf.base_tests import BaseTest
+from ptf.testutils import *
+
+#-------------------------------------------------------------------------------
+# Testcase
+#-------------------------------------------------------------------------------
+
+class PortLagRouterBasedTest:
+    def __init__(self, dipSipTest):
+        self.test = dipSipTest
+        self.testParams = dipSipTest.test_params
+    #--------------------------------------------------------------------------
+
+    def logParams(self):
+        self.test.log("Destination router mac is: " + self.dstRouterMac)
+        self.test.log("Destination router ip is:  " + self.dstRouterIp)
+
+        self.test.log("Destination host mac is:   " + self.dstHostMac)
+        self.test.log("Destination host ip is:    " + self.dstHostIp)
+
+        self.test.log("Source router mac is:      " + self.srcRouterMac)
+        self.test.log("Source router ip is:       " + self.srcRouterIp)
+
+        self.test.log("Source host mac is:        " + self.srcHostMac)
+        self.test.log("Source host ip is:         " + self.srcHostIp)
+
+        self.test.log("Destination port ids is:   " + str([int(portId) for portId in self.dstPortIds]))
+        self.test.log("Source port ids is:        " + str([int(portId) for portId in self.srcPortIds]))
+
+        self.test.log("Packet TTL is:             " + str(self.pktTtl))
+    #--------------------------------------------------------------------------
+
+    def setUpParams(self):
+        self.dstRouterMac = self.testParams['dst_router_mac']
+        self.dstRouterIp = self.testParams['dst_router_ip']
+
+        self.dstHostMac = self.testParams['dst_host_mac']
+        self.dstHostIp = str(ip_address(unicode(self.testParams['dst_router_ip'])) + 1)
+
+        self.srcRouterMac = self.testParams['src_router_mac']
+        self.srcRouterIp = self.testParams['src_router_ip']
+
+        self.srcHostMac = self.testParams['src_host_mac']
+        self.srcHostIp = str(ip_address(unicode(self.testParams['src_router_ip'])) + 1)
+
+        self.dstPortIds = self.testParams['dst_port_ids']
+        self.srcPortIds = self.testParams['src_port_ids']
+
+        self.pktTtl = 64 # Default packet TTL value
+    #--------------------------------------------------------------------------
+
+    def runTest(self):
+        self.setUpParams()
+        self.logParams()
+
+        pkt = simple_udp_packet(eth_dst=self.srcRouterMac,
+                                eth_src=self.srcHostMac,
+                                ip_src=self.dstHostIp,
+                                ip_dst=self.dstHostIp,
+                                ip_ttl=self.pktTtl)
+        send(self.test, int(self.srcPortIds[0]), pkt)
+
+        pkt = simple_udp_packet(eth_dst=self.dstHostMac,
+                                eth_src=self.dstRouterMac,
+                                ip_src=self.dstHostIp,
+                                ip_dst=self.dstHostIp,
+                                ip_ttl=self.pktTtl-1)
+
+        verify_packet_any_port(self.test, pkt, [int(port) for port in self.dstPortIds])
+    #--------------------------------------------------------------------------
+
+class DipSipTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+    #--------------------------------------------------------------------------
+
+    def log(self, message):
+        logging.info(message)
+    #--------------------------------------------------------------------------
+
+    def setUp(self):
+        self.log("SetUp testbed")
+
+        self.dataplane = ptf.dataplane_instance
+        self.test_params = test_params_get()
+        self.testbed_type = self.test_params['testbed_type']
+    #--------------------------------------------------------------------------
+
+    def tearDown(self):
+        self.log("TearDown testbed")
+    #--------------------------------------------------------------------------
+
+    def runTest(self):
+        if self.testbed_type in ['t0', 't1', 't1-lag']:
+            self.log("Run PORT/LAG-router based test")
+
+            test = PortLagRouterBasedTest(self)
+            test.runTest()
+
+            return
+
+        self.fail("Unexpected testbed type %s!" % (self.testbed_type))
+    #--------------------------------------------------------------------------

--- a/ansible/roles/test/files/ptftests/dip_sip.py
+++ b/ansible/roles/test/files/ptftests/dip_sip.py
@@ -5,7 +5,7 @@ Description:
     This test uses UDP packets to validate that HW supports routing of L3 packets with DIP=SIP
 
 Topologies:
-    Supports t0, t1 and t1-lag topology
+    Supports t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag and t1-64-lag topology
 
 Parameters:
     testbed_type    - testbed type
@@ -185,7 +185,7 @@ class DipSipTest(BaseTest):
     #--------------------------------------------------------------------------
 
     def runTest(self):
-        if self.testbed_type in ['t0', 't1', 't1-lag']:
+        if self.testbed_type in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1', 't1-lag', 't1-64-lag']:
             self.log("Run PORT/LAG-router based test")
 
             test = PortLagRouterBasedTest(self)

--- a/ansible/roles/test/tasks/dip_sip.yml
+++ b/ansible/roles/test/tasks/dip_sip.yml
@@ -1,24 +1,24 @@
 - fail: msg="testbed_type is not defined"
   when: testbed_type is not defined
 
-- fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't1', 't1-lag']
+- fail: msg="testbed_type {{ test_type }} is invalid"
+  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1', 't1-lag', 't1-64-lag']
 
-- include_vars: "vars/topo_{{testbed_type}}.yml"
+- include_vars: "vars/topo_{{ testbed_type }}.yml"
 
 - name: "Expand properties into props"
-  set_fact: props="{{configuration_properties['common']}}"
+  set_fact: props="{{ configuration_properties['common'] }}"
 
 - name: "Gather minigraph facts about the device"
-  minigraph_facts: host={{inventory_hostname}}
+  minigraph_facts: host={{ inventory_hostname }}
 
 - name: "Remove existing IPs from PTF host"
   script: roles/test/files/helpers/remove_ip.sh
-  delegate_to: "{{ptf_host}}"
+  delegate_to: "{{ ptf_host }}"
 
 - name: "Set unique MACs to PTF interfaces"
   script: roles/test/files/helpers/change_mac.sh
-  delegate_to: "{{ptf_host}}"
+  delegate_to: "{{ ptf_host }}"
 
 - name: "Gather information from LLDP"
   lldp:
@@ -28,7 +28,7 @@
 
 - name: "Copy tests to PTF"
   copy: src=roles/test/files/ptftests dest=/root
-  delegate_to: "{{ptf_host}}"
+  delegate_to: "{{ ptf_host }}"
 
 - block:
   - fail: msg="minigraph_interfaces is not defined or zero length"
@@ -36,11 +36,11 @@
 
   - name: "Set destination PORT name"
     set_fact:
-      dst_port: "{{minigraph_interfaces[0].attachto}}"
+      dst_port: "{{ minigraph_interfaces[0].attachto }}"
 
   - name: "Set source PORT name"
     set_fact:
-      src_port: "{{minigraph_interfaces[2].attachto}}"
+      src_port: "{{ minigraph_interfaces[2].attachto }}"
 
   - name: "Start PTF runner: '{{ testbed_type }}' designated"
     include: ptf_runner.yml
@@ -51,18 +51,18 @@
       ptf_platform: remote
       ptf_platform_dir: ptftests
       ptf_test_params:
-        - testbed_type='{{testbed_type}}'
-        - dst_host_mac='{{lldp[dst_port]['chassis'].mac}}'
-        - src_host_mac='{{lldp[src_port]['chassis'].mac}}'
-        - dst_router_mac='{{ansible_interface_facts[dst_port].macaddress}}'
-        - src_router_mac='{{ansible_interface_facts[src_port].macaddress}}'
-        - dst_router_ipv4='{{ansible_interface_facts[dst_port]['ipv4']['address']}}'
-        - src_router_ipv4='{{ansible_interface_facts[src_port]['ipv4']['address']}}'
-        - dst_router_ipv6='{{ansible_interface_facts[dst_port]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
-        - src_router_ipv6='{{ansible_interface_facts[src_port]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
-        - dst_port_ids=[{{minigraph_port_indices[dst_port]}}]
-        - src_port_ids=[{{minigraph_port_indices[src_port]}}]
-      ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"
+        - testbed_type='{{ testbed_type }}'
+        - dst_host_mac='{{ lldp[dst_port]['chassis'].mac }}'
+        - src_host_mac='{{ lldp[src_port]['chassis'].mac }}'
+        - dst_router_mac='{{ ansible_interface_facts[dst_port].macaddress }}'
+        - src_router_mac='{{ ansible_interface_facts[src_port].macaddress }}'
+        - dst_router_ipv4='{{ ansible_interface_facts[dst_port]['ipv4']['address'] }}'
+        - src_router_ipv4='{{ ansible_interface_facts[src_port]['ipv4']['address'] }}'
+        - dst_router_ipv6='{{ ansible_interface_facts[dst_port]['ipv6'] | selectattr("scope", "match", "^global$") | map(attribute='address') | list | first }}'
+        - src_router_ipv6='{{ ansible_interface_facts[src_port]['ipv6'] | selectattr("scope", "match", "^global$") | map(attribute='address') | list | first }}'
+        - dst_port_ids=[{{ minigraph_port_indices[dst_port] }}]
+        - src_port_ids=[{{ minigraph_port_indices[src_port] }}]
+      ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}.log"
 
   vars:
     dst_port: "default('')"
@@ -75,11 +75,11 @@
 
   - name: "Set destination LAG name"
     set_fact:
-      dst_lag: "{{minigraph_portchannel_interfaces[0].attachto}}"
+      dst_lag: "{{ minigraph_portchannel_interfaces[0].attachto }}"
 
   - name: "Set source LAG name"
     set_fact:
-      src_lag: "{{minigraph_portchannel_interfaces[2].attachto}}"
+      src_lag: "{{ minigraph_portchannel_interfaces[2].attachto }}"
 
   - name: "Gather destination port indices"
     set_fact:
@@ -110,20 +110,20 @@
       ptf_platform: remote
       ptf_platform_dir: ptftests
       ptf_test_params:
-        - testbed_type='{{testbed_type}}'
-        - dst_host_mac='{{lldp[minigraph_portchannels[dst_lag].members[0]]['chassis'].mac}}'
-        - src_host_mac='{{lldp[minigraph_portchannels[src_lag].members[0]]['chassis'].mac}}'
-        - dst_router_mac='{{ansible_interface_facts[dst_lag].macaddress}}'
-        - src_router_mac='{{ansible_interface_facts[src_lag].macaddress}}'
-        - dst_router_ipv4='{{ansible_interface_facts[dst_lag]['ipv4']['address']}}'
-        - src_router_ipv4='{{ansible_interface_facts[src_lag]['ipv4']['address']}}'
-        - dst_router_ipv6='{{ansible_interface_facts[dst_lag]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
-        - src_router_ipv6='{{ansible_interface_facts[src_lag]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
-        - dst_port_ids={{dst_port_ids}}
-        - src_port_ids={{src_port_ids}}
-      ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"
+        - testbed_type='{{ testbed_type }}'
+        - dst_host_mac='{{ lldp[minigraph_portchannels[dst_lag].members[0]]['chassis'].mac }}'
+        - src_host_mac='{{ lldp[minigraph_portchannels[src_lag].members[0]]['chassis'].mac }}'
+        - dst_router_mac='{{ ansible_interface_facts[dst_lag].macaddress }}'
+        - src_router_mac='{{ ansible_interface_facts[src_lag].macaddress }}'
+        - dst_router_ipv4='{{ ansible_interface_facts[dst_lag]['ipv4']['address'] }}'
+        - src_router_ipv4='{{ ansible_interface_facts[src_lag]['ipv4']['address'] }}'
+        - dst_router_ipv6='{{ ansible_interface_facts[dst_lag]['ipv6'] | selectattr("scope", "match", "^global$") | map(attribute='address') | list | first }}'
+        - src_router_ipv6='{{ ansible_interface_facts[src_lag]['ipv6'] | selectattr("scope", "match", "^global$") | map(attribute='address') | list | first }}'
+        - dst_port_ids={{ dst_port_ids }}
+        - src_port_ids={{ src_port_ids }}
+      ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}.log"
 
   vars:
     dst_lag: "default('')"
     src_lag: "default('')"
-  when: testbed_type in ['t0', 't1-lag']
+  when: testbed_type in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1-lag', 't1-64-lag']

--- a/ansible/roles/test/tasks/dip_sip.yml
+++ b/ansible/roles/test/tasks/dip_sip.yml
@@ -1,0 +1,125 @@
+- fail: msg="testbed_type is not defined"
+  when: testbed_type is not defined
+
+- fail: msg="testbed_type {{test_type}} is invalid"
+  when: testbed_type not in ['t0', 't1', 't1-lag']
+
+- include_vars: "vars/topo_{{testbed_type}}.yml"
+
+- name: "Expand properties into props"
+  set_fact: props="{{configuration_properties['common']}}"
+
+- name: "Gather minigraph facts about the device"
+  minigraph_facts: host={{inventory_hostname}}
+
+- name: "Remove existing IPs from PTF host"
+  script: roles/test/files/helpers/remove_ip.sh
+  delegate_to: "{{ptf_host}}"
+
+- name: "Set unique MACs to PTF interfaces"
+  script: roles/test/files/helpers/change_mac.sh
+  delegate_to: "{{ptf_host}}"
+
+- name: "Gather information from LLDP"
+  lldp:
+  vars:
+    ansible_shell_type: docker
+    ansible_python_interpreter: docker exec -i lldp python
+
+- name: "Copy tests to PTF"
+  copy: src=roles/test/files/ptftests dest=/root
+  delegate_to: "{{ptf_host}}"
+
+- block:
+  - fail: msg="minigraph_interfaces is not defined or zero length"
+    when: minigraph_interfaces is not defined or (minigraph_interfaces | length == 0)
+
+  - name: "Set destination PORT name"
+    set_fact:
+      dst_port: "{{minigraph_interfaces[0].attachto}}"
+
+  - name: "Set source PORT name"
+    set_fact:
+      src_port: "{{minigraph_interfaces[2].attachto}}"
+
+  - name: "Start PTF runner: '{{ testbed_type }}' designated"
+    include: ptf_runner.yml
+    vars:
+      ptf_test_name: DipSip test
+      ptf_test_dir: ptftests
+      ptf_test_path: dip_sip.DipSipTest
+      ptf_platform: remote
+      ptf_platform_dir: ptftests
+      ptf_test_params:
+        - testbed_type='{{testbed_type}}'
+        - dst_host_mac='{{lldp[dst_port]['chassis'].mac}}'
+        - src_host_mac='{{lldp[src_port]['chassis'].mac}}'
+        - dst_router_mac='{{ansible_interface_facts[dst_port].macaddress}}'
+        - src_router_mac='{{ansible_interface_facts[src_port].macaddress}}'
+        - dst_router_ip='{{ansible_interface_facts[dst_port]['ipv4']['address']}}'
+        - src_router_ip='{{ansible_interface_facts[src_port]['ipv4']['address']}}'
+        - dst_port_ids=[{{minigraph_port_indices[dst_port]}}]
+        - src_port_ids=[{{minigraph_port_indices[src_port]}}]
+      ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"
+
+  vars:
+    dst_port: "default('')"
+    src_port: "default('')"
+  when: testbed_type in ['t1']
+
+- block:
+  - fail: msg="minigraph_portchannel_interfaces is not defined or zero length"
+    when: minigraph_portchannel_interfaces is not defined or (minigraph_portchannel_interfaces | length == 0)
+
+  - name: "Set destination LAG name"
+    set_fact:
+      dst_lag: "{{minigraph_portchannel_interfaces[0].attachto}}"
+
+  - name: "Set source LAG name"
+    set_fact:
+      src_lag: "{{minigraph_portchannel_interfaces[2].attachto}}"
+
+  - name: "Gather destination port indices"
+    set_fact:
+      dst_port_ids: "{{ minigraph_port_indices[item] }}"
+    with_items: "{{ minigraph_portchannels[dst_lag].members }}"
+    register: dst_port_ids_result
+
+  - name: "Make a list from destination port indices"
+    set_fact:
+      dst_port_ids: "{{ dst_port_ids_result.results | map(attribute='ansible_facts.dst_port_ids') | list }}"
+
+  - name: "Gather source port indices"
+    set_fact:
+      src_port_ids: "{{ minigraph_port_indices[item] }}"
+    with_items: "{{ minigraph_portchannels[src_lag].members }}"
+    register: src_port_ids_result
+
+  - name: "Make a list from source port indices"
+    set_fact:
+      src_port_ids: "{{ src_port_ids_result.results | map(attribute='ansible_facts.src_port_ids') | list }}"
+
+  - name: "Start PTF runner: '{{ testbed_type }}' designated"
+    include: ptf_runner.yml
+    vars:
+      ptf_test_name: DipSip test
+      ptf_test_dir: ptftests
+      ptf_test_path: dip_sip.DipSipTest
+      ptf_platform: remote
+      ptf_platform_dir: ptftests
+      ptf_test_params:
+        - testbed_type='{{testbed_type}}'
+        - dst_host_mac='{{lldp[minigraph_portchannels[dst_lag].members[0]]['chassis'].mac}}'
+        - src_host_mac='{{lldp[minigraph_portchannels[src_lag].members[0]]['chassis'].mac}}'
+        - dst_router_mac='{{ansible_interface_facts[dst_lag].macaddress}}'
+        - src_router_mac='{{ansible_interface_facts[src_lag].macaddress}}'
+        - dst_router_ip='{{ansible_interface_facts[dst_lag]['ipv4']['address']}}'
+        - src_router_ip='{{ansible_interface_facts[src_lag]['ipv4']['address']}}'
+        - dst_port_ids={{dst_port_ids}}
+        - src_port_ids={{src_port_ids}}
+      ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"
+
+  vars:
+    dst_lag: "default('')"
+    src_lag: "default('')"
+  when: testbed_type in ['t0', 't1-lag']

--- a/ansible/roles/test/tasks/dip_sip.yml
+++ b/ansible/roles/test/tasks/dip_sip.yml
@@ -56,8 +56,10 @@
         - src_host_mac='{{lldp[src_port]['chassis'].mac}}'
         - dst_router_mac='{{ansible_interface_facts[dst_port].macaddress}}'
         - src_router_mac='{{ansible_interface_facts[src_port].macaddress}}'
-        - dst_router_ip='{{ansible_interface_facts[dst_port]['ipv4']['address']}}'
-        - src_router_ip='{{ansible_interface_facts[src_port]['ipv4']['address']}}'
+        - dst_router_ipv4='{{ansible_interface_facts[dst_port]['ipv4']['address']}}'
+        - src_router_ipv4='{{ansible_interface_facts[src_port]['ipv4']['address']}}'
+        - dst_router_ipv6='{{ansible_interface_facts[dst_port]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
+        - src_router_ipv6='{{ansible_interface_facts[src_port]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
         - dst_port_ids=[{{minigraph_port_indices[dst_port]}}]
         - src_port_ids=[{{minigraph_port_indices[src_port]}}]
       ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"
@@ -113,8 +115,10 @@
         - src_host_mac='{{lldp[minigraph_portchannels[src_lag].members[0]]['chassis'].mac}}'
         - dst_router_mac='{{ansible_interface_facts[dst_lag].macaddress}}'
         - src_router_mac='{{ansible_interface_facts[src_lag].macaddress}}'
-        - dst_router_ip='{{ansible_interface_facts[dst_lag]['ipv4']['address']}}'
-        - src_router_ip='{{ansible_interface_facts[src_lag]['ipv4']['address']}}'
+        - dst_router_ipv4='{{ansible_interface_facts[dst_lag]['ipv4']['address']}}'
+        - src_router_ipv4='{{ansible_interface_facts[src_lag]['ipv4']['address']}}'
+        - dst_router_ipv6='{{ansible_interface_facts[dst_lag]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
+        - src_router_ipv6='{{ansible_interface_facts[src_lag]['ipv6'] | selectattr("scope", "equalto", "global") | map(attribute='address') | list | first }}'
         - dst_port_ids={{dst_port_ids}}
         - src_port_ids={{src_port_ids}}
       ptf_extra_options: "--relax --debug info --log-file /tmp/dip_sip.DipSipTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log"

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -195,7 +195,7 @@ testcases:
 
     dip_sip:
       filename: dip_sip.yml
-      topologies: [t0, t1, t1-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
       required_vars:
           ptf_host:
           testbed_type:

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -192,3 +192,10 @@ testcases:
     crm:
       filename: crm.yml
       topologies: [t1, t1-lag, t0, t0-56, t0-64, t0-116]
+
+    dip_sip:
+      filename: dip_sip.yml
+      topologies: [t0, t1, t1-lag]
+      required_vars:
+          ptf_host:
+          testbed_type:


### PR DESCRIPTION
### Description of PR
The purpose of this test is to validate that SONiC switch supports routing of L3 packets with DIP=SIP

### Type of change
- [DIP=SIP] Test case(new/improvement)

### Approach

#### How did you do it?
- N/A

#### How did you verify/test it?
sudo -H ansible-playbook test_sonic.yml -i inventory --limit arc-switch1025-t0 -e testbed_name=arc-switch1025-t0 -e testbed_type=t0 -e testcase_name=dip_sip -vvvvv

#### Any platform specific information?
- N/A

#### Supported testbed topology if it's a new test case?
- t0
- t0-16
- t0-56
- t0-64
- t0-64-32
- t0-116
- t1
- t1-lag
- t1-64-lag

### Documentation
- DIP=SIP HLD.md (https://github.com/Azure/SONiC/pull/224)