### PR TITLE
[service_acl] Don't fail if acl.json is not already present on device

### DIFF
--- a/ansible/roles/test/files/helpers/config_service_acls.sh
+++ b/ansible/roles/test/files/helpers/config_service_acls.sh
@@ -81,5 +81,5 @@ sleep 60
 # Delete the test ACL config file
 rm -rf /tmp/testacl.json
 
-# IMPORTANT! Restore original service ACLs, so that we restore SSH connectivity
-acl-loader update full /etc/sonic/acl.json
+# IMPORTANT! Delete the ACLs we just added in order to restore connectivity
+acl-loader delete

--- a/ansible/roles/test/tasks/service_acl.yml
+++ b/ansible/roles/test/tasks/service_acl.yml
@@ -1,10 +1,3 @@
-- name: Check for existence of /etc/sonic/acl.json (this also ensures we can successfully SSH to the DuT)
-  become: true
-  stat:
-    path: /etc/sonic/acl.json
-  register: file_stat
-  failed_when: not file_stat.stat.exists
-
 # Gather facts with SNMP version 2
 - name: Ensure we can gather basic SNMP facts from the device
   snmp_facts:
@@ -13,7 +6,7 @@
     community: "{{ snmp_rocommunity }}"
   connection: local
 
-- name: Copy config_service_acls.sh to the DuT
+- name: Copy config_service_acls.sh to the DuT (this also ensures we can successfully SSH to the DuT)
   become: true
   copy:
     src: roles/test/files/helpers/config_service_acls.sh


### PR DESCRIPTION
Service ACL test no longer expects acl.json to be present on the device before executing the test. This was causing erroneous test failures on devices which did not have an acl.json file present.