### PR TITLE
fix arptest fail if using ptf-docker created by t1-64-lag

### DIFF
--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -13,7 +13,7 @@
       set_fact:
         index: "{{ ports | sort }}"
 
-    - name: select 1&2 two interfaces for test
+    - name: select port index 0&1 two interfaces for test
       set_fact:
         intf1: "Ethernet{{ index[0] }}"
         intf2: "Ethernet{{ index[1] }}"

--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -15,8 +15,8 @@
 
     - name: select 1&2 two interfaces for test
       set_fact:
-        intf1: "Ethernet{{ index[1] }}"
-        intf2: "Ethernet{{ index[2] }}"
+        intf1: "Ethernet{{ index[0] }}"
+        intf2: "Ethernet{{ index[1] }}"
 
     - name: figure out selected interface inices
       set_fact:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

The arpest fail if trying to use ptf-dockers created by t1-64-lag 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
change arptest running interfaces

#### How did you verify/test it?
locally tested for both 32 interface and 64 interfaces topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
