### PR TITLE
[snmp-psu] update SNMP PSU test to ignore PSU working status check  

### DIFF
--- a/ansible/roles/test/tasks/snmp/psu.yml
+++ b/ansible/roles/test/tasks/snmp/psu.yml
@@ -3,10 +3,9 @@
   snmp_facts: host={{ ansible_host }} version=v2c community={{ snmp_rocommunity }}
   connection: local
 
-# We assume that all the PSUs tested should be in good status, otherwise, fix the PSU manually
 - fail:
     msg: "PSU index {{ item.key }} operstatus is not OK"
-  when: "{{ item.value.operstatus | int }} != 2"
+  when: not item.value.operstatus
   with_dict: "{{ snmp_psu }}"
 
 - name: Get the PSU count from command line


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Current SNMP PSU status is assuming DUT shall have two PSU and work properly. If PSU is not in 'OK' status the test will fail.  This test should focus on whether can get the PSU status via SNMP rather than judge the PSU working status.
So update the PSU test case to judge whether can successfully get the PSU status from SNMP and ignore whether the PSU is working well or not.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
change the test failure criteria to not able to get the PSU status from SNMP.

#### How did you verify/test it?
run test on mlnx platform testbed

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
