### PR TITLE
Extend IP-in-IP test to check IPv6 in IPv4, IPv4 in IPv6, IPv6 in IP…

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -44,6 +44,19 @@ import pprint
 import fib
 
 class DecapPacketTest(BaseTest):
+    """ IP in IP decapsulation test """
+
+    # Default source IP to use for inner packet
+    DEFAULT_INNER_V4_PKT_SRC_IP = '1.1.1.1'
+    DEFAULT_INNER_V6_PKT_SRC_IP = '1::1'
+
+    # Default source and destination IPs to use
+    # for triple encapsulated packets
+    DEFAULT_INNER2_V4_PKT_SRC_IP = '4.4.4.4'
+    DEFAULT_INNER2_V6_PKT_SRC_IP = '4::4'
+    DEFAULT_INNER2_V4_PKT_DST_IP = '3.3.3.3'
+    DEFAULT_INNER2_V6_PKT_DST_IP = '3::3'
+
     def __init__(self):
         '''
         @summary: constructor
@@ -68,106 +81,214 @@ class DecapPacketTest(BaseTest):
             self.src_ports = [0,  1,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 36, 37, 38, 39, 40, 41, 42, 48, 52, 53, 54, 55, 56, 57, 58]
         if self.test_params['testbed_type'] == 't0-116':
             self.src_ports = range(0, 24) + range(32, 120)
+
+        # which type of tunneled trafic to test (IPv4 in IPv4, IPv6 in IPv4, IPv6 in IPv4, IPv6 in IPv6)
+        self.test_outer_ipv4 = self.test_params.get('outer_ipv4', True)
+        self.test_outer_ipv6 = self.test_params.get('outer_ipv6', True)
+        self.test_inner_ipv4 = self.test_params.get('inner_ipv4', True)
+        self.test_inner_ipv6 = self.test_params.get('inner_ipv6', True)
+
     #-----------------------------------------------------------------
-    
-    def send_and_verify(self, dst_ip, expected_ports, src_port, triple_encap = False):
-        '''
-        @summary: This function builds encap packet, send and verify their arrival.
-        @dst_ip: the destination ip for the inner IP header
-        @expected_ports: list of ports that a packet can arrived from 
-        @src_port: the physical port that the packet will be sent from 
-        @triple_encap: True to send triple encapsulated packet
-        '''
-        #setting parameters
+
+    def create_ipv4_inner_pkt_only(self, src_ip, dst_ip, tos, encap=False):
+        """Creates an IP only packet for the test
+        @param src_ip: source ip
+        @param dst_ip: destination ip
+        @param tos: type of service field
+        @param encap: build encapsulated packet.
+                      If @encap is True the return packet would be:
+                      IP(@src_ip, @dst_ip, @tos) / IP(dst_ip=4.4.4.4, src_ip=3.3.3.3) / TCP()
+        """
+
+        inner_pkt = simple_ip_only_packet(ip_dst=dst_ip, ip_src=src_ip, ip_ttl=64, ip_tos=tos)
+        if encap:
+            inner_pkt2 = self.create_ipv4_inner_pkt_only(self.DEFAULT_INNER2_V4_PKT_SRC_IP,
+                                                         self.DEFAULT_INNER2_V4_PKT_DST_IP,
+                                                         0)
+            inner_pkt = simple_ipv4ip_packet(ip_src=src_ip,
+                                             ip_dst=dst_ip,
+                                             ip_tos=tos,
+                                             ip_ttl=64,
+                                             inner_frame=inner_pkt2).getlayer(scapy.IP) # get only the IP layer
+
+        return inner_pkt
+
+    #-----------------------------------------------------------------
+
+    def create_ipv6_inner_pkt_only(self, src_ip, dst_ip, tc, encap=False):
+        """Creates an IPv6 only packet for the test
+        @param src_ip: source ip
+        @param dst_ip: destination ip
+        @param tc: traffic class
+        @param encap: build encapsulated packet.
+                      If @encap is True the return packet would be:
+                      IP(@src_ip, @dst_ip, @tc) / IP(dst_ip=4::4, src_ip=3::3) / TCP()
+        """
+
+        # no ptf function to build simple ipv6 only packet
+        # so use simple_tcpv6_packet function which builds the same packet
+        # with TCP header as simple_ip_only_packet but extract away Ethernet
+        inner_pkt = simple_tcpv6_packet(ipv6_dst=dst_ip, ipv6_src=src_ip, ipv6_hlim=64, ipv6_tc=tc).getlayer(scapy.IPv6)
+        if encap:
+            inner_pkt2 = self.create_ipv6_inner_pkt_only(self.DEFAULT_INNER2_V6_PKT_SRC_IP,
+                                                         self.DEFAULT_INNER2_V6_PKT_DST_IP,
+                                                         0)
+            inner_pkt = simple_ipv6ip_packet(ipv6_src=src_ip,
+                                             ipv6_dst=dst_ip,
+                                             ipv6_tc=tc,
+                                             ipv6_hlim=64,
+                                             inner_frame=inner_pkt2).getlayer(scapy.IPv6) # get only the IP layer
+
+        return inner_pkt
+
+    #-----------------------------------------------------------------
+
+    def create_encap_packet(self, dst_ip, outer_pkt='ipv4', triple_encap=False):
+        """Creates an IPv4/IPv6 encapsulated packet in @outer_pkt packet
+        @param dst_ip: Destination IP for inner packet. Depending @dst_ip IPv4 or IPv6 packet will be created
+        @param outer_pkt: Outer packet type to encapsulate inner packet in (ipv4/ipv6)
+        @param triple_encap: Whether to build triple encapsulated packet
+        @return: built packet and expected packet to match after decapsulation"""
+
         src_mac =  self.dataplane.get_mac(0, 0)
         dst_mac = '00:11:22:33:44:55'
-        inner_src_ip = '2.2.2.2'
         router_mac = self.test_params['router_mac']
         dscp_in = random.randint(0, 32)
-        tos_in = dscp_in << 2
+        # TC for IPv6, ToS for IPv4
+        tc_in = tos_in = dscp_in << 2
         dscp_out = random.randint(0, 32)
-        tos_out = dscp_out << 2
+        tc_out = tos_out = dscp_out << 2
         if ("pipe" == self.test_params['dscp_mode']):
-            exp_tos = tos_in
+            exp_tc = exp_tos = tc_in
         elif("uniform" == self.test_params['dscp_mode']):
-            exp_tos = tos_out
+            exp_tc = exp_tos = tc_out
         else:
             print("ERROR: no dscp is configured")
             exit()
 
-        default_packet_len = 100
-        default_packet_add_header_len = 114
+        if ipaddress.ip_address(unicode(dst_ip)).version == 6:
+            inner_src_ip = self.DEFAULT_INNER_V6_PKT_SRC_IP
+            # build inner packet, if triple_encap is True inner_pkt would be double encapsulated
+            inner_pkt = self.create_ipv6_inner_pkt_only(inner_src_ip, dst_ip, tos_in, triple_encap)
 
-        #building the packets  and the expected packets
-        if (not triple_encap):
-            #for the double encap packet we will use IP header with TCP header without mac    
-            inner_pkt = simple_ip_only_packet(ip_dst=dst_ip, ip_src=inner_src_ip, ip_ttl=64, ip_tos=tos_in)
-            #after the decap process the retuning packet will be normal tcp packet, The TTL is taked from the inner layer and redused by one
-            exp_pkt = simple_tcp_packet(pktlen=default_packet_add_header_len,
-                                        eth_dst=dst_mac,
-                                        eth_src=router_mac,
-                                        ip_dst=dst_ip,
-                                        ip_src=inner_src_ip,
-                                        ip_tos=exp_tos,
-                                        ip_ttl=63)
+            # build expected packet based on inner packet
+            # set the correct L2 fields
+            exp_pkt = scapy.Ether(dst=dst_mac, src=router_mac) / inner_pkt
+
+            # set expected TC value
+            exp_pkt['IPv6'].tc = exp_tc
+            # decrement TTL
+            exp_pkt['IPv6'].hlim -= 1
         else:
-            #Building triple encap packet with SCAPY, because there is no PTF function for it, I use the defualt values for the TCP header
-            tcp_hdr    = scapy.TCP(sport=1234, dport=80, flags="S", chksum=0)
-            inner_pkt2 = scapy.IP(src='4.4.4.4', dst='3.3.3.3', tos=0, ttl=64, id=1, ihl=None) / tcp_hdr
-            inner_pkt  = scapy.IP(src=inner_src_ip, dst=dst_ip, tos=tos_in, ttl=64, id=1, ihl=None,proto=4) / inner_pkt2
-            inner_pkt  = inner_pkt/("".join([chr(x) for x in xrange(default_packet_len - len(inner_pkt))]))
-            #The expected packet is also built by scapy, and the TTL is taked from the inner layer and redused by one
-            exp_pkt    = scapy.Ether(dst=dst_mac, src=router_mac)/inner_pkt   
-            exp_pkt['IP'].tos = exp_tos #this parameter is taken by the decap rule configuration 
-            exp_pkt['IP'].ttl = 63
+            inner_src_ip = self.DEFAULT_INNER_V4_PKT_SRC_IP
+            # build inner packet, if triple_encap is True inner_pkt would be double encapsulated
+            inner_pkt = self.create_ipv4_inner_pkt_only(inner_src_ip, dst_ip, tos_in, triple_encap)
 
-        pkt = simple_ipv4ip_packet(
-                            eth_dst=router_mac,
-                            eth_src=src_mac,
-                            ip_src='1.1.1.1',
-                            ip_dst=self.test_params['lo_ip'],
-                            ip_tos=tos_out,
-                            ip_ttl=random.randint(2, 63), 
-                            inner_frame=inner_pkt)
+            # build expected packet based on inner packet
+            # set the correct L2 fields
+            exp_pkt = scapy.Ether(dst=dst_mac, src=router_mac) / inner_pkt
+
+            # set expected ToS value
+            exp_pkt['IP'].tos = exp_tos
+            # decrement TTL
+            exp_pkt['IP'].ttl -= 1
+
+
+        if outer_pkt == 'ipv4':
+            pkt = simple_ipv4ip_packet(
+                                eth_dst=router_mac,
+                                eth_src=src_mac,
+                                ip_src='1.1.1.1',
+                                ip_dst=self.test_params['lo_ip'],
+                                ip_tos=tos_out,
+                                ip_ttl=random.randint(2, 63),
+                                inner_frame=inner_pkt)
+        elif outer_pkt == 'ipv6':
+            pkt = simple_ipv6ip_packet(
+                                eth_dst=router_mac,
+                                eth_src=src_mac,
+                                ipv6_src='1::1',
+                                ipv6_dst=self.test_params['lo_ipv6'],
+                                ipv6_tc=tc_out,
+                                ipv6_hlim=random.randint(2, 63),
+                                inner_frame=inner_pkt)
+        else:
+            raise Exception("ERROR: invalid outer packet type ", outer_pkt)
+
+
+        return pkt, exp_pkt
+
+    #-----------------------------------------------------------------
+
+    def send_and_verify(self, dst_ip, expected_ports, src_port, outer_pkt='ipv4', triple_encap=False):
+        '''
+        @summary: This function builds encap packet, send and verify their arrival.
+        @dst_ip: the destination ip for the inner IP header
+        @expected_ports: list of ports that a packet can arrived from
+        @src_port: the physical port that the packet will be sent from
+        @triple_encap: True to send triple encapsulated packet
+        '''
+
+        pkt, exp_pkt = self.create_encap_packet(dst_ip, outer_pkt, triple_encap)
         
-        #send and verify the return packets
         masked_exp_pkt = Mask(exp_pkt)
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+
+        #send and verify the return packets
         send_packet(self, src_port, pkt)
-        logging.info(".....Sending packet from port" + str(src_port) + " to " + dst_ip + ", Triple_encap: " + str(triple_encap))
-        (matched, received) = verify_packet_any_port(self, masked_exp_pkt, expected_ports)
+        logging.info(".....Sending packet from port" + str(src_port) + " to " +
+                     dst_ip + ", Triple_encap: " + str(triple_encap))
+        matched, received = verify_packet_any_port(self, masked_exp_pkt, expected_ports)
         assert received
-        return (matched, received)
+        return matched, received
+
     #-----------------------------------------------------------------
-    
+
     def runTest(self):
         """
         @summary: Send double and triple encapsulated packets for each range of IPv4 and
         expect the packet to be received from one of the expected ports
         """
-        # IPv4 Test
-        for ip_range in self.fib.ipv4_ranges():
-            # Get the expected list of ports that would receive the packets
-            exp_port_list = self.fib[ip_range.get_first_ip()].get_next_hop_list()
-            # Choose random one source port from all ports excluding the expected ones
-            src_port = random.choice([port for port in self.src_ports if port not in exp_port_list])
 
-            if not len(exp_port_list):
-                continue
+        ip_ranges = []
 
-            logging.info("Check IP range:" + str(ip_range) + " on " + str(exp_port_list) + "...")
-            # Send a packet with the first IP in the range
-            self.send_and_verify(ip_range.get_first_ip(), exp_port_list, src_port)
-            self.send_and_verify(ip_range.get_first_ip(), exp_port_list, src_port, True)
-            # Send a packet with the last IP in the range
-            if ip_range.length() > 1:
-                self.send_and_verify(ip_range.get_last_ip(), exp_port_list, src_port)
-                self.send_and_verify(ip_range.get_last_ip(), exp_port_list, src_port, True)
-            # Send a packet with a random IP in the range
-            if ip_range.length() > 2:
-                self.send_and_verify(ip_range.get_random_ip(), exp_port_list, src_port)
-                self.send_and_verify(ip_range.get_random_ip(), exp_port_list, src_port, True)
+        if self.test_inner_ipv4:
+            ip_ranges += self.fib.ipv4_ranges()
+        if self.test_inner_ipv6:
+            ip_ranges += self.fib.ipv6_ranges()
+
+        outer_pkt_family_type = []
+        if self.test_outer_ipv4:
+            outer_pkt_family_type.append('ipv4')
+        if self.test_outer_ipv6:
+            outer_pkt_family_type.append('ipv6')
+
+        # First test one tunnel with all ip ranges
+        for pkt_type in outer_pkt_family_type:
+            for ip_range in ip_ranges:
+                # Get the expected list of ports that would receive the packets
+                exp_port_list = self.fib[ip_range.get_first_ip()].get_next_hop_list()
+                # Choose random one source port from all ports excluding the expected ones
+                src_port = random.choice([port for port in self.src_ports if port not in exp_port_list])
+
+                if not len(exp_port_list):
+                    continue
+
+                logging.info("Check " + pkt_type.replace('ip', 'IP') + " tunneled traffic on IP range:" +
+                             str(ip_range) + " on " + str(exp_port_list) + "...")
+                # Send a packet with the first IP in the range
+                self.send_and_verify(ip_range.get_first_ip(), exp_port_list, src_port, pkt_type)
+                self.send_and_verify(ip_range.get_first_ip(), exp_port_list, src_port, pkt_type, True)
+                # Send a packet with the last IP in the range
+                if ip_range.length() > 1:
+                    self.send_and_verify(ip_range.get_last_ip(), exp_port_list, src_port, pkt_type)
+                    self.send_and_verify(ip_range.get_last_ip(), exp_port_list, src_port, pkt_type, True)
+                # Send a packet with a random IP in the range
+                if ip_range.length() > 2:
+                    self.send_and_verify(ip_range.get_random_ip(), exp_port_list, src_port, pkt_type)
+                    self.send_and_verify(ip_range.get_random_ip(), exp_port_list, src_port, pkt_type, True)
+
 #---------------------------------------------------------------------
 
     

--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -42,12 +42,16 @@
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}
 
-# Obtain loopback ip of the device
-- name: Obtain loopback ip of the device
-  set_fact: lo_ip="{{ minigraph_lo_interfaces[0]['addr'] }}"
+# Obtain loopback IPs of the device
 
-- name: print loopback ip
-  debug: msg="{{ lo_ip }}"
+- name: Obtain loopback IPv4 of the device
+  set_fact: lo_ip="{{ minigraph_lo_interfaces | map(attribute='addr') | ipv4 | first }}"
+
+- name: Obtain loopback IPv6 of the device
+  set_fact: lo_ipv6="{{ minigraph_lo_interfaces | map(attribute='addr') | ipv6 | first }}"
+
+- name: print loopback IPs
+  debug: msg="Loopback IPs {{ lo_ip }}, {{ lo_ipv6 }}"
 
 # Generate file with BGP routes information
 - template: src=roles/test/templates/fib.j2 dest=/tmp/fib_info.txt
@@ -58,33 +62,75 @@
   connection: local
   delegate_to: "{{ ptf_host }}"
 
-- set_fact:
-    testname: decap
+- set_fact: outer_ipv4=True
+  when: outer_ipv4 is not defined
 
-# Separate set_fact is required to be able to use 'testname' fact.
-- set_fact:
-    testname_unique: "{{ testname }}.{{ ansible_date_time.date}}.{{ ansible_date_time.hour}}-{{ ansible_date_time.minute}}-{{ ansible_date_time.second}}"
+- set_fact: outer_ipv6=True
+  when: outer_ipv6 is not defined
 
-- debug: msg="generated run id:{{testname_unique}}"
+- set_fact: inner_ipv4=True
+  when: inner_ipv4 is not defined
 
-- debug : msg="INVOKE DECAP TEST"
+- set_fact: inner_ipv6=True
+  when: inner_ipv6 is not defined
 
-- name: copy the test to ptf container
-  copy: src=roles/test/files/ptftests dest=/root
-  delegate_to: "{{ ptf_host }}"
+# Apply tunnel configuration
+- set_fact: op="SET"
 
-- name: "Running test {{ testname }}"
-  include: ptf_runner.yml
-  vars:
-    ptf_test_name: '{{ testname_unique }}'
-    ptf_test_dir: ptftests
-    ptf_test_path: IP_decap_test.DecapPacketTest
-    ptf_platform: remote
-    ptf_platform_dir: ptftests
-    ptf_test_params:
-      - testbed_type='{{ testbed_type }}'
-      - fib_info='/root/fib_info.txt'
-      - router_mac='{{ansible_Ethernet0['macaddress']}}'
-      - dscp_mode='{{ dscp_mode }}'
-      - lo_ip='{{ lo_ip }}'
-    ptf_extra_options:  "--relax --debug info --log-file /tmp/{{ testname_unique }}.log "
+- block:
+
+  - template: src=roles/test/templates/decap_conf.j2 dest=/tmp/decap_conf.json
+
+  - name: Copy configuration to swss container
+    shell: docker cp /tmp/decap_conf.json swss:/decap_conf.json
+
+  - name: Apply decap_conf.json configuration
+    shell: docker exec swss sh -c "swssconfig /decap_conf.json"
+
+  - set_fact:
+      testname: decap
+
+  # Separate set_fact is required to be able to use 'testname' fact.
+  - set_fact:
+      testname_unique: "{{ testname }}.{{ ansible_date_time.date}}.{{ ansible_date_time.hour}}-{{ ansible_date_time.minute}}-{{ ansible_date_time.second}}"
+
+  - debug: msg="generated run id:{{testname_unique}}"
+
+  - debug : msg="INVOKE DECAP TEST"
+
+  - name: copy the test to ptf container
+    copy: src=roles/test/files/ptftests dest=/root
+    delegate_to: "{{ ptf_host }}"
+
+  - name: "Running test {{ testname }}"
+    include: ptf_runner.yml
+    vars:
+      ptf_test_name: '{{ testname_unique }}'
+      ptf_test_dir: ptftests
+      ptf_test_path: IP_decap_test.DecapPacketTest
+      ptf_platform: remote
+      ptf_platform_dir: ptftests
+      ptf_test_params:
+        - testbed_type='{{ testbed_type }}'
+        - fib_info='/root/fib_info.txt'
+        - router_mac='{{ansible_Ethernet0['macaddress']}}'
+        - dscp_mode='{{ dscp_mode }}'
+        - lo_ip='{{ lo_ip }}'
+        - lo_ipv6='{{ lo_ipv6 }}'
+        - outer_ipv4={{ outer_ipv4 }}
+        - outer_ipv6={{ outer_ipv6 }}
+        - inner_ipv4={{ inner_ipv4 }}
+        - inner_ipv6={{ inner_ipv6 }}
+      ptf_extra_options:  "--relax --debug info --log-file /tmp/{{ testname_unique }}.log "
+
+  always:
+  # Delete the configuration
+  - set_fact: op="DEL"
+
+  - template: src=roles/test/templates/decap_conf.j2 dest=/tmp/decap_conf.json
+
+  - name: Copy configuration to swss container
+    shell: docker cp /tmp/decap_conf.json swss:/decap_conf.json
+
+  - name: Apply decap_conf.json configuration
+    shell: docker exec swss sh -c "swssconfig /decap_conf.json"

--- a/ansible/roles/test/templates/decap_conf.j2
+++ b/ansible/roles/test/templates/decap_conf.j2
@@ -1,13 +1,28 @@
 [
+{% if outer_ipv4 | bool %}
         {
-                "TUNNEL_DECAP_TABLE:NETBOUNCER" : {
+                "TUNNEL_DECAP_TABLE:IPINIP_V4_TUNNEL" : {
                         "tunnel_type":"IPINIP",
-                        "dst_ip":"{{lo_ip}}",
-                        "src_ip":"1.1.1.1",
-                        "dscp_mode":"{{dscp_mode}}",
+                        "dst_ip":"{{ lo_ip }}",
+                        "dscp_mode":"{{ dscp_mode }}",
                         "ecn_mode":"standard",
                         "ttl_mode":"pipe"
                 },
-                "OP": "SET"
+                "OP": "{{ op }}"
         }
+{% endif %}
+{% if outer_ipv6 | bool and outer_ipv4 | bool %} ,
+{% endif %}
+{% if outer_ipv6 | bool %}
+        {
+                "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+                        "tunnel_type":"IPINIP",
+                        "dst_ip":"{{ lo_ipv6 }}",
+                        "dscp_mode":"{{ dscp_mode }}",
+                        "ecn_mode":"standard",
+                        "ttl_mode":"pipe"
+                },
+                "OP": "{{ op }}"
+        }
+{% endif %}
 ]


### PR DESCRIPTION
…v6 decapsulation

Signed-off-by: stepanb <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Extend IP-in-IP decapsulation test to pass different combinations of tunneled traffic (IPv6 in IPv4, IPv4 in IPv6, IPv6 in IP…)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Extend PTF test

#### How did you verify/test it?
Run the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
