### PR TITLE
fix test break in t1-lag-64 topology, make the search more restrict

### DIFF
--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -80,7 +80,7 @@
     assert: { that: "arptable.v4[v4_nei]['macaddress'] | lower ==  v4_mac2" }
 
   - name: Get the SONiC Asic DB key holding neighbour MAC for {{ v4_nei }}
-    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep {{ v4_nei }}
+    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep '\"{{ v4_nei }}\"'
     register: neighbour_key
     failed_when: neighbour_key.rc != 0
 
@@ -137,7 +137,7 @@
     assert: { that: "arptable.v6[v6_nei]['macaddress'] | lower == v6_mac2" }
 
   - name: Get the SONiC DB key holding neighbour MAC for {{ v6_nei }}
-    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep {{ v6_nei }}
+    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep '\"{{ v6_nei }}\"'
     register: neighbour_key
     failed_when: neighbour_key.rc != 0
 

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -80,7 +80,7 @@
     assert: { that: "arptable.v4[v4_nei]['macaddress'] | lower ==  v4_mac2" }
 
   - name: Get the SONiC Asic DB key holding neighbour MAC for {{ v4_nei }}
-    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep '\"{{ v4_nei }}\"'
+    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep -Fe '"{{ v4_nei }}"'
     register: neighbour_key
     failed_when: neighbour_key.rc != 0
 
@@ -137,7 +137,7 @@
     assert: { that: "arptable.v6[v6_nei]['macaddress'] | lower == v6_mac2" }
 
   - name: Get the SONiC DB key holding neighbour MAC for {{ v6_nei }}
-    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep '\"{{ v6_nei }}\"'
+    shell: docker exec database redis-cli -n 1 KEYS ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY* | grep -Fe '"{{ v6_nei }}"'
     register: neighbour_key
     failed_when: neighbour_key.rc != 0
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test fail in one topology

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
make the grep search more restrict to avoid test fail. 

#### How did you verify/test it?
verified in my local testbed t1-lag-64, it was failed before, and pass now.
Also verified in t1 topology

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
