### PR TITLE
Fix log extraction module

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -199,7 +199,7 @@ def calculate_files_to_copy(filenames, file_with_latest_line):
 def combine_logs_and_save(directory, filenames, start_string, target_filename):
     do_copy = False
     with open(target_filename, 'w') as fp:
-        for filename in filenames:
+        for filename in reversed(filenames):
             path = os.path.join(directory, filename)
             file = None
             if 'gz' in path:


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
After trying to optimize performance of extract_log module I broke the module's functionality:
filenames in combine_logs_and_save function are the files to copy for log analysis. Finding start line in ordered filenames list caused only the last file to copy. Now, it starts from the last and copies all the rest files as well.

#### How did you verify/test it?
Simulated a lot of logs to achive situation where start marker and end marker are in seperate log files and run CRM test which uses loganalyzer.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
