### PR TITLE
Improve sonic installation before fast-reboot test

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -103,8 +103,28 @@
         dest: /tmp/ports.json
       delegate_to: "{{ ptf_host }}"
 
-    - name: Install a new sonic image if requested
-      shell: sonic_installer install -y {{ new_sonic_image }}
+    - block:
+
+        - name: Save image version
+          shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
+          register: current_sonic_image
+          become: true
+
+        - set_fact:
+            new_image_location: '/tmp/new_sonic_image.bin'
+
+        - name: Download SONiC image.
+          local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
+
+        - name: Upload SONiC image to device.
+          copy:
+            src: "{{ new_image_location }}"
+            dest: "{{ new_image_location }}"
+
+        - name: Install a new SONiC image if requested
+          shell: sonic_installer install -y {{ new_image_location }}
+          become: true
+
       when: new_sonic_image is defined
 
     - include: ptf_runner.yml
@@ -177,3 +197,13 @@
         src: '/tmp/swss.rec'
         dest: '/tmp/'
         flat: yes
+
+    - block:
+      - name: Set previous image as default
+        shell: 'sonic_installer set_default {{ current_sonic_image.stdout }}'
+        become: true
+
+      - name: reboot
+        include: roles/test/tasks/common_tasks/reboot_sonic.yml
+
+      when: new_sonic_image is defined


### PR DESCRIPTION


Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
1. sonic_installer requires root - added 'become: true'
2. download image to mgmt host and copy to the DUT, since
   DUT may not have internet connection
3. Reboot to previous image after the test

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
