### PR TITLE
Set ptf_nn_agent sockets rcv/snd buffer size

### DIFF
--- a/ansible/roles/test/templates/ptf_nn_agent.conf.dut.j2
+++ b/ansible/roles/test/templates/ptf_nn_agent.conf.dut.j2
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-{{ nn_target_port }}@{{ nn_target_interface }} --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-{{ nn_target_port }}@{{ nn_target_interface }} --set-nn-rcv-buffer=109430400 --set-iface-rcv-buffer=109430400 --set-nn-snd-buffer=109430400 --set-iface-snd-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:

CoPP test sends/receive 100k packets using ptf_nn_agent.
What I could see in /tmp/copp.log ptf could capture only ~80k.

After increasing iface/nn socket snd/rcv buffers the test passes.


Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Set a large socket snd/rcv buffer size
#### How did you verify/test it?
Run CoPP test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
