### PR TITLE
Revert "[minigraph] change default vlan subnet to 100.100.0.0/21"

### DIFF
--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -58,7 +58,7 @@
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
             <a:Name>BGPVac</a:Name>
-            <a:PeersRange>100.100.0.0/21</a:PeersRange>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
 {% endif %}
         </a:Peers>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -67,7 +67,7 @@
           <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
-          <Subnets>100.100.0.0/21</Subnets>
+          <Subnets>192.168.0.0/21</Subnets>
         </VlanInterface>
 {% endif %}
       </VlanInterfaces>
@@ -96,7 +96,7 @@
         <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
-          <Prefix>100.100.0.1/21</Prefix>
+          <Prefix>192.168.0.1/21</Prefix>
         </IPInterface>
 {% endif %}
       </IPInterfaces>


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#706

There are tests that uses hard coded vlan IPs. We will have to change these tests first before we can change VLAN subnet.