### PR TITLE
Fix decap summary table output

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -321,8 +321,8 @@ class DecapPacketTest(BaseTest):
         for outer_pkt_type in outer_pkt_types:
             for inner_pkt_type in inner_pkt_types:
 
-                encap_combination = "{}in{}".format(outer_pkt_type.replace('ip', 'IP'),
-                                                    inner_pkt_type.replace('ip', 'IP'))
+                encap_combination = "{}in{}".format(inner_pkt_type.replace('ip', 'IP'),
+                                                    outer_pkt_type.replace('ip', 'IP'))
 
                 logging.info('----------------------------------------------------------------------')
                 logging.info("{} test started".format(encap_combination))


### PR DESCRIPTION
Inner IP version was mixed with outer IP version

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:

IP inner version was mixed with IP outer version

Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
