### PR TITLE
[sensors_create_metadata.yml]: playbook to create sensors meta data f…

### DIFF
--- a/ansible/library/sensors_meta_data.py
+++ b/ansible/library/sensors_meta_data.py
@@ -1,0 +1,237 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+from ansible.module_utils.basic import *
+
+DOCUMENTATION = '''
+---
+module: sensors_meta_data
+version_added:
+author: Praveen Chaudhary (pchaudhary@linkedin.com)
+short description: Generate file with sensors meta data which can be used with
+sensors test suite. Without this module user has to go through tedious process
+for creating this Meta data manually.
+
+description:
+    - sensors_raw input dictionary defines fields which will be part of sonic
+      meta data.
+    - create a predefined format similar to file sku-sensors-data.yml for result
+      dictionary.
+    - fill result dictionary with complete key string on basis of keys in
+      sensors_facts.
+    - write all non-classifiable strings in [others] keys.
+    - write output in file with same format as file sku-sensors-data.yml
+
+Post work items:
+    - Manually classify string listed in [others]
+    - paste the data in sku-sensors-data.yml to use it for sensors test suite
+'''
+
+EXAMPLES = '''
+ - name: create sensors meta data file
+    sensors_meta_data: sensors_raw={{ sensors['raw'] }} file={{ file }} hwsku={{ hwsku }}
+    connection: local
+    register: sensors_metadata
+'''
+
+class SensorsMetaData(object):
+    def __init__(self):
+        self.module = AnsibleModule(
+            argument_spec=dict(
+              sensors_raw=dict(required=True, type='dict'),
+              file_name =dict(required=True, type='str'),
+              hwsku=dict(required=True, type='str'),
+            ),
+            supports_check_mode=True)
+
+        self.rawDict = self.module.params['sensors_raw']
+        self.file    = self.module.params['file_name']
+        self.hwsku   = self.module.params['hwsku']
+        self.sensorsMetaData  = {self.hwsku: {}}
+        self.facts   =  {'sensors_meta_data': self.sensorsMetaData}
+
+        return
+
+    def run(self):
+        """
+            Main method of the class
+
+        """
+        self.init()
+
+        keyStr=""
+        for key in self.rawDict.keys():
+            keyStr = (key+"/")
+            self.generateSensorsMetaData(self.rawDict[key],
+                self.sensorsMetaData[self.hwsku], keyStr)
+
+        # print resultant dictionary in the file
+        with open(self.file,'w') as outputFile:
+            self.writeResultInFile(self.sensorsMetaData, "  ", outputFile)
+
+        self.module.exit_json(ansible_facts=self.facts)
+
+        return
+
+    def fillDictResultAlarms(self, keyStr, subResult):
+        """
+            fill Alarms section of result
+        """
+
+        if "fan" in keyStr:
+            subResult["alarms"]["fan"].append(keyStr)
+        elif "cpu" in keyStr or "CPU" in keyStr or "Psu" in keyStr:
+            subResult["alarms"]["power"].append(keyStr)
+        elif "temp" in keyStr:
+            subResult["alarms"]["temp"].append(keyStr)
+        else:
+            subResult["alarms"]["power"].append(keyStr)
+
+        return
+
+    def findDictKeyFromStr(self, keyStr):
+        '''
+            find key for compare section by string parsing
+        '''
+
+        if "fan" in keyStr:
+            dictKey = "fan"
+        elif "cpu" in keyStr or "CPU" in keyStr or "Psu" in keyStr:
+            dictKey = "power"
+        elif "temp" in keyStr:
+            dictKey = "temp"
+        else:
+            dictKey = "power"
+
+        return dictKey
+
+    def fillCompares(self, keyStr, compareStr, subResult, dictKey):
+        '''
+            fill compares section of result
+        '''
+        keyStr     = "- " + keyStr
+        compareStr = "  " + compareStr
+        subResult["compares"][dictKey].append(keyStr)
+        subResult["compares"][dictKey].append(compareStr)
+
+        return
+
+    def fillDictResultCompares(self, keyStr, subResult, rawDict):
+        '''
+            find compare string and fill compares section
+        '''
+        compareStr = ""
+        for keys in rawDict.keys():
+                if "input" in keys:
+                    idx = keyStr.rfind("/")
+                    compareStr =  keyStr[0:idx+1]
+                    compareStr += keys
+
+        if compareStr == "":
+            # no input item in this dict"
+            subResult["others"].append(keyStr)
+            return
+
+        dictKey = self.findDictKeyFromStr(keyStr)
+
+        if "min" in keyStr or "lcrit" in keyStr:
+            self.fillCompares(keyStr, compareStr, subResult, dictKey)
+        else:
+            self.fillCompares(compareStr, keyStr, subResult, dictKey)
+
+        return
+
+    def fillDictResult(self, keyStr, subResult, rawDict):
+        '''
+            find relavent section of result to fill
+        '''
+
+        keyStr = "- " + keyStr
+
+        if "alarm" in keyStr or "fault" in keyStr:
+            self.fillDictResultAlarms(keyStr, subResult)
+
+        elif "crit" in keyStr or "max" in keyStr or "min" in keyStr:
+            self.fillDictResultCompares(keyStr, subResult, rawDict)
+
+        elif "input" in keyStr:
+            dictKey = self.findDictKeyFromStr(keyStr)
+            subResult["non-zero"][dictKey].append(keyStr)
+        else:
+            subResult["others"].append(keyStr)
+
+        return
+
+    def generateSensorsMetaData(self, rawDict, subResult, keyStr):
+        '''
+            generate key strings meta data from sensors_raw by parsing it
+            recursively
+        '''
+
+        for keys in rawDict.keys():
+
+            if type(rawDict[keys]) == type(rawDict):
+                newStr = keyStr + (keys+"/")
+                self.generateSensorsMetaData(rawDict[keys], subResult, newStr)
+
+            else:
+                newStr = keyStr + keys
+                self.fillDictResult(newStr, subResult, rawDict)
+        return
+
+    def writeResultInFile(self, result, tabStr, outputFile):
+        '''
+            print result dictionary recursively in outputfile
+        '''
+        for keys in result.keys():
+            print(tabStr, end="", file=outputFile)
+
+            if type(result[keys]) == type(result):
+                print("{}:".format(keys), file=outputFile)
+                self.writeResultInFile(result[keys], "  " + tabStr, outputFile)
+
+            else: # it is a list of string
+                if len(result[keys]) == 0:
+                    print("{}:".format(keys), end="", file=outputFile)
+                    print(" []", file=outputFile)
+                else:
+                    print("{}:".format(keys), file=outputFile)
+                    for item in result[keys]:
+                        print(tabStr, end="", file=outputFile)
+                        print(item, file=outputFile)
+        return
+
+    def init(self):
+        '''
+            create skelaton of result dictionary
+        '''
+        sensorsDict = self.sensorsMetaData[self.hwsku]
+
+        sensorsDict["alarms"] = dict()
+        sensorsDict["compares"] = dict()
+        sensorsDict["non-zero"] = dict()
+        sensorsDict["psu_skips"] = dict()
+        sensorsDict["others"] = list()
+
+        sensorsDict["alarms"]["fan"] = list()
+        sensorsDict["alarms"]["power"] = list()
+        sensorsDict["alarms"]["temp"] = list()
+
+        sensorsDict["compares"]["fan"] = list()
+        sensorsDict["compares"]["power"] = list()
+        sensorsDict["compares"]["temp"] = list()
+
+        sensorsDict["non-zero"]["fan"] = list()
+        sensorsDict["non-zero"]["power"] = list()
+        sensorsDict["non-zero"]["temp"] = list()
+
+        return
+
+def main():
+    sensorsMetaData = SensorsMetaData()
+    sensorsMetaData.run()
+
+    return
+
+if __name__ == "__main__":
+    main()

--- a/ansible/sensors_create_metadata.yml
+++ b/ansible/sensors_create_metadata.yml
@@ -1,0 +1,59 @@
+# This Playbook is used to generate Sensors Meta Data for new platforms for SONIC.
+# Sensors Meta Data can be appended in ansible/group_vars/sonic/sku-sensors-data.yml
+# to use it for sensors test suite.
+#
+# Without this playbook user has to go through tedious process for creating this Meta
+# data Manually.
+#
+# How it works:
+# This playbook uses sensors_facts module to collect the data from sonic device.
+#   - Argument to sensors_facts module will be an empty dictionary.
+# Then it uses sensors_meta_data module to generate a file with meta data.
+# Meta data will be in same format as in file ansible/group_vars/sonic/sku-sensors-data.yml
+# Caveat: file will also have a field [others] for non classified sensors. User has to
+# classify this part manually.
+#
+# Usage:
+# ansible-playbook -i lab -l falco-test-dut02 sensors_create_metadata.yml
+# -e "file=/tmp/praveen/sensorsMetaData.txt hwsku=Seastone-DX010"
+#
+# args:
+# -l sonic_dut          Sonic device
+# -e file               output file
+# -e hwsku              platform hwsku such as Seastone-DX010
+
+- hosts: sonic
+  remote_user: admin
+
+  tasks:
+  - name: Get platform monitor docker name
+    shell: docker ps -a --format '{{'{{'}}.Image{{'}} {{'}}.Names{{'}}'}}' | grep 'platform' | awk '{print $2}'
+    register: pmon_ps
+
+  - debug:
+      var: pmon_ps
+
+  - set_fact:
+      ansible_python_interpreter: "docker exec -i {{ pmon_ps.stdout }} python"
+
+  - set_fact:
+      checks: {'alarms': {}, 'compares': {}, 'non_zero': {}, 'psu_skips': {}}
+
+  - name: Gather sensors
+    sensors_facts: checks={{ checks }}
+    vars:
+      ansible_shell_type: docker
+
+  - set_fact:
+     ansible_python_interpreter: "/usr/bin/python"
+
+  - name: print variables
+    debug:
+      msg: "sensors_raw: {{ sensors['raw'] }}; file: {{ file }}; hwsku: {{ hwsku }}"
+
+  - name: create sensors meta data file
+    sensors_meta_data: sensors_raw={{ sensors['raw'] }} file_name={{ file }} hwsku={{ hwsku }}
+    connection: local
+    register: sensors_metadata
+
+  - debug: msg="{{ sensors_metadata }}"


### PR DESCRIPTION
[sensors_create_metadata.yml]: playbook to create sensors meta data for given hwsku.
[sensors_meta_data.py]: Ansible module to create sensors meta data.
    
Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
    
This playbook and module generates a file with sensors meta data which can be used with
sensors test suite. Without this module user has to go through tedious process for creating this Meta data manually.
    
[Review Note]: As of now sensors_create_metadata.yml is placed in main ansible directory.
Kindly suggest the best directory for it.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This playbook and module generates a file with sensors meta data which can be used with
sensors test suite. Without this module user has to go through tedious process for creating this Meta data manually.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
This playbook and module generates a file with sensors meta data which can be used with
sensors test suite. Without this module user has to go through tedious process for creating this Meta data manually.
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [-] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added new playbook and new ansible module. 

#### How did you verify/test it?
Verified for Seastone-DX010. 

$ ANSIBLE_KEEP_REMOTE_FILES=1 ansible-playbook -i lab -l falco-test-dut02 sensors_create_metadata.yml -e "file=/tmp/praveen/sensorsMetaData.txt hwsku=Seastone-DX010"

$ cat /tmp/praveen/sensorsMetaData.txt
  Seastone-DX010:
    alarms:
      fan:
      - dps460-i2c-11-5b/fan1/fan1_alarm
      - dps460-i2c-11-5b/fan1/fan1_fault
      - emc2305-i2c-13-4d/fan1/fan2_fault
      - emc2305-i2c-13-4d/fan1/fan2_alarm
      - emc2305-i2c-13-4d/fan3/fan5_alarm
      - emc2305-i2c-13-4d/fan3/fan5_fault
      - emc2305-i2c-13-4d/fan2/fan4_alarm
      - emc2305-i2c-13-4d/fan2/fan4_fault
      - emc2305-i2c-13-4d/fan5/fan1_alarm
      - emc2305-i2c-13-4d/fan5/fan1_fault
      - emc2305-i2c-13-4d/fan4/fan3_fault
      - emc2305-i2c-13-4d/fan4/fan3_alarm
      - dps460-i2c-10-5a/fan1/fan1_alarm
      - dps460-i2c-10-5a/fan1/fan1_fault
      - emc2305-i2c-13-2e/fan1/fan2_fault
      - emc2305-i2c-13-2e/fan1/fan2_alarm
      - emc2305-i2c-13-2e/fan3/fan4_alarm
      - emc2305-i2c-13-2e/fan3/fan4_fault
      - emc2305-i2c-13-2e/fan2/fan1_alarm
      - emc2305-i2c-13-2e/fan2/fan1_fault
      - emc2305-i2c-13-2e/fan5/fan3_fault
      - emc2305-i2c-13-2e/fan5/fan3_alarm
      - emc2305-i2c-13-2e/fan4/fan5_alarm
      - emc2305-i2c-13-2e/fan4/fan5_fault
      temp:
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_crit_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_max_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_min_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 2/temp2_lcrit_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_lcrit_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_crit_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_max_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 3/temp3_min_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_crit_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_lcrit_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_min_alarm
      - dps460-i2c-11-5b/Power Supply 2 temp sensor 1/temp1_max_alarm
      - coretemp-isa-0000/Core 3/temp5_crit_alarm
      - coretemp-isa-0000/Core 2/temp4_crit_alarm
      - coretemp-isa-0000/Core 1/temp3_crit_alarm
      - coretemp-isa-0000/Core 0/temp2_crit_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_crit_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_lcrit_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_min_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 1/temp1_max_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_lcrit_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_crit_alarm
            - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_max_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 3/temp3_min_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_crit_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_max_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_min_alarm
      - dps460-i2c-10-5a/Power Supply 1 temp sensor 2/temp2_lcrit_alarm
      power:
      - dps460-i2c-11-5b/pin/power1_alarm
      - dps460-i2c-11-5b/vin/in1_max_alarm
      - dps460-i2c-11-5b/vin/in1_crit_alarm
      - dps460-i2c-11-5b/vin/in1_min_alarm
      - dps460-i2c-11-5b/vin/in1_lcrit_alarm
      - dps460-i2c-11-5b/pout1/power2_max_alarm
      - dps460-i2c-11-5b/pout1/power2_crit_alarm
      - dps460-i2c-11-5b/pout1/power2_cap_alarm
      - dps460-i2c-11-5b/vout1/in3_crit_alarm
      - dps460-i2c-11-5b/vout1/in3_min_alarm
      - dps460-i2c-11-5b/vout1/in3_lcrit_alarm
      - dps460-i2c-11-5b/vout1/in3_max_alarm
      - dps460-i2c-11-5b/iout1/curr2_lcrit_alarm
      - dps460-i2c-11-5b/iout1/curr2_crit_alarm
      - dps460-i2c-11-5b/iout1/curr2_max_alarm
      - dps460-i2c-11-5b/iin/curr1_max_alarm
      - dps460-i2c-11-5b/iin/curr1_crit_alarm
      - dps460-i2c-10-5a/pin/power1_alarm
      - dps460-i2c-10-5a/vin/in1_max_alarm
      - dps460-i2c-10-5a/vin/in1_crit_alarm
      - dps460-i2c-10-5a/vin/in1_min_alarm
      - dps460-i2c-10-5a/vin/in1_lcrit_alarm
      - dps460-i2c-10-5a/pout1/power2_max_alarm
      - dps460-i2c-10-5a/pout1/power2_crit_alarm
      - dps460-i2c-10-5a/pout1/power2_cap_alarm
      - dps460-i2c-10-5a/vout1/in3_crit_alarm
      - dps460-i2c-10-5a/vout1/in3_min_alarm
      - dps460-i2c-10-5a/vout1/in3_lcrit_alarm
      - dps460-i2c-10-5a/vout1/in3_max_alarm
      - dps460-i2c-10-5a/iout1/curr2_lcrit_alarm
      - dps460-i2c-10-5a/iout1/curr2_crit_alarm
      - dps460-i2c-10-5a/iout1/curr2_max_alarm
      - dps460-i2c-10-5a/iin/curr1_max_alarm
      - dps460-i2c-10-5a/iin/curr1_crit_alarm
    non-zero:
      fan:
      - dps460-i2c-11-5b/fan1/fan1_input
      - emc2305-i2c-13-4d/fan1/fan2_input
      - emc2305-i2c-13-4d/fan3/fan5_input
      - emc2305-i2c-13-4d/fan2/fan4_input
      - emc2305-i2c-13-4d/fan5/fan1_input
      - emc2305-i2c-13-4d/fan4/fan3_input
      - dps460-i2c-10-5a/fan1/fan1_input
      ............
      ............
              - dps460-i2c-10-5a/iout1/curr2_max
      - - dps460-i2c-10-5a/iin/curr1_input
        - dps460-i2c-10-5a/iin/curr1_crit
      - - dps460-i2c-10-5a/iin/curr1_input
        - dps460-i2c-10-5a/iin/curr1_max
    psu_skips:
    others:
    - dps460-i2c-11-5b/pout1/power2_cap
    - emc2305-i2c-13-4d/fan1/fan2_div
    - emc2305-i2c-13-4d/fan3/fan5_div
    - emc2305-i2c-13-4d/fan2/fan4_div
    - emc2305-i2c-13-4d/fan5/fan1_div
    - emc2305-i2c-13-4d/fan4/fan3_div
    - dps460-i2c-10-5a/pout1/power2_cap
    - emc2305-i2c-13-2e/fan1/fan2_div
    - emc2305-i2c-13-2e/fan3/fan4_div
    - emc2305-i2c-13-2e/fan2/fan1_div
    - emc2305-i2c-13-2e/fan5/fan3_div
    - emc2305-i2c-13-2e/fan4/fan5_div
$

#### Any platform specific information?
No. This module is developed to create meta data for all platform.

#### Supported testbed topology if it's a new test case?
NA
### Documentation 
Let me know if it is needed, I can create one.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
