### PR TITLE
[bgp_facts.py]: Exceptional handing to work both with quagga and FRR.

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -144,13 +144,16 @@ class BgpModule(object):
                         if regex_subnet.match(line): neighbor['subnet'] = regex_subnet.match(line).group(1)
 
                         if regex_stats.match(line):
-                            key, values = line.split(':')
-                            key = key.lstrip()
-                            sent, rcvd = values.split()
-                            value_dict = {}
-                            value_dict['sent'] = int(sent)
-                            value_dict['rcvd'] = int(rcvd)
-                            message_stats[key] = value_dict
+                            try:
+                                key, values = line.split(':')
+                                key = key.lstrip()
+                                sent, rcvd = values.split()
+                                value_dict = {}
+                                value_dict['sent'] = int(sent)
+                                value_dict['rcvd'] = int(rcvd)
+                                message_stats[key] = value_dict
+                            except Exception as e:
+                                print"NonFatal: line:'{}' should not have matched for sent/rcvd count".format(line)
 
                         if message_stats:
                             neighbor['message statistics'] = message_stats


### PR DESCRIPTION
    [bgp_facts.py]: Exceptional handing to work both with quagga and FRR.
    
    Adding exception handing with this fix, so that extra lines of FRR
    does not raise Exception till Ansible level. This way bgp_facts test
    suite will work with both Quagga and FRR.
    
        Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
   Adding exception handing with this fix, so that extra lines of FRR
    does not raise Exception till Ansible level. This way bgp_facts test
    suite will work with both Quagga and FRR.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [-] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added Exceptional Handing to suppress exception till Ansible Level.
#### How did you verify/test it?
Without Fix:

admin@falco-test-dut02:~/.ansible/tmp/ansible-tmp-1538586911.06-60809342469986$ python bgp_facts | more
{"msg": "too many values to unpack", "failed": true, "invocation": {"module_args": {}}}

With Fix:

admin@falco-test-dut02:~/.ansible/tmp/ansible-tmp-1538586911.06-60809342469986$ python bgp_facts | more
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
NonFatal: line:'    Hostname Capability: advertised (name: falco-test-dut02,domain name: n/a) not received' should no
t have matched for sent/rcvd count
{"invocation": {"module_args": {}}, "changed": false, "ansible_facts": {"bgp_statistics": {"ipv4_idle": 0, "ipv6_admi
n_down": 0, "ipv4_admin_down": 0, "ipv6_idle": 0, "ipv6": 32, "ipv4": 32}, "bgp_neighbors": {"10.0.0.61": {"remote AS
": 64015, "description": "ARISTA15T0", "admin": "up", "message statistics": {"Route Refresh": {"rcvd": 0, "sent": 0},
 "Capability": {"rcvd": 0, "sent": 0}, "Notifications": {"rcvd": 0, "sent": 0}, "Updates": {"rcvd": 3, "sent": 3238},
 "Keepalives": {"rcvd": 6556, "sent": 6555}, "Opens": {"rcvd": 1, "sent": 1}, "Total": {"rcvd": 6560, "sent": 9794}},
 "accepted prefixes": 6, "connections established": 1, "state": "established", "remote routerid": "100.1.0.31", "conn
ections dropped": 0, "mrai": 0, "ip_version": 4, "local AS": 65100}, "10.0.0.49": {"remote AS": 64009, "description":
 "ARISTA09T0", "admin": "up", "message statistics": {"Route Refresh": {"rcvd": 0, "sent": 0}, "Capability": {"rcvd":0, "sent": 0}, "Notifications": {"rcvd": 0, "sent": 0}, "Updates": {"rcvd": 3, "sent": 3249}, "Keepalives": {"rcvd": 
6558, "sent": 6557}, "Opens": {"rcvd": 1, "sent": 1}, "Total": {"rcvd": 6562, "sent": 9807}}, "accepted prefixes": 6,
 "connections established": 1, "state": "established", "remote routerid": "100.1.0.25", "connections dropped": 0, "mr
ai": 0, "ip_version": 4, "local AS": 65100}, "fc00::26": {"remote AS": 65200, "description": "ARISTA10T2", "admin": "
up", "message statistics": {"Route Refresh": {"rcvd": 0, "sent": 0}, "Capability": {"rcvd": 0, "sent": 0}, "Notificat
ions": {"rcvd": 0, "sent": 0}, "Updates": {"rcvd": 3204, "sent": 3251}, "Keepalives": {"rcvd": 6556, "sent": 6557}, "
Opens": {"rcvd": 1, "sent": 1}, "Total": {"rcvd": 9761, "sent": 9809}}, "accepted prefixes": 2, "connections establis
hed": 1, "state": "established", "remote routerid": "100.1.0.10", "connections dropped": 0, "mrai": 0, "ip_version": 
6, "local AS": 65100}, "fc00::22": {"remote AS": 65200, "description": "ARISTA09T2", "admin": "up", "message statisti
cs": {"Route Refresh": {"rcvd": 0, "sent": 0}, "Capability": {"rcvd": 0, "sent": 0}, "Notifications": {"rcvd": 0, "se
nt": 0}, "Updates": {"rcvd": 3204, "sent": 4252}, "Keepalives": {"rcvd": 6560, "sent": 6559}, "Opens": {"rcvd": 1, "s
ent": 1}, "Total": {"rcvd": 9765, "sent": 10812}}, "accepted prefixes": 2, "connections established": 1, "state": "es
tablished", "remote routerid": "100.1.0.9", "connections dropped": 0, "mrai": 0, "ip_version": 6, "local AS": 65100},
 "10.0.0.43": {"remote AS": 64006, "description":..............


#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
