### PR TITLE
[deploy] increase ToR subnet size from 64 to 128

### DIFF
--- a/ansible/roles/eos/templates/t0-16-leaf.j2
+++ b/ansible/roles/eos/templates/t0-16-leaf.j2
@@ -34,7 +34,6 @@ route-map DEFAULT_ROUTES permit
 !
 {# #}
 {# NOTE: Using large enough values (e.g., podset_number = 200, #}
-{# max_tor_subnet_number = 16, tor_subnet_size = 64), will cause #}
 {# us to overflow the 192.168.0.0/16 private address space here. #}
 {# This should be fine for internal use, but may pose an issue if used otherwise #}
 {# #}
@@ -46,12 +45,14 @@ route-map DEFAULT_ROUTES permit
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
-ip route 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
-ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
+ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -63,14 +64,16 @@ ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64
 {% if podset != 0 or tor != 0 %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
 {% set prefixlen_v6 = (64 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
-ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
 ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
- seq 10 permit 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
+ seq 10 permit {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
 exit
 {% endif %}
 {% endfor %}

--- a/ansible/roles/eos/templates/t0-64-32-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-32-leaf.j2
@@ -32,7 +32,6 @@ route-map DEFAULT_ROUTES permit
 !
 {# #}
 {# NOTE: Using large enough values (e.g., podset_number = 200, #}
-{# max_tor_subnet_number = 16, tor_subnet_size = 64), will cause #}
 {# us to overflow the 192.168.0.0/16 private address space here. #}
 {# This should be fine for internal use, but may pose an issue if used otherwise #}
 {# #}
@@ -44,12 +43,14 @@ route-map DEFAULT_ROUTES permit
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
-ip route 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
-ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
+ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -61,14 +62,16 @@ ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64
 {% if podset != 0 or tor != 0 %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
 {% set prefixlen_v6 = (64 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
-ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
 ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
- seq 10 permit 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
+ seq 10 permit {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
 exit
 {% endif %}
 {% endfor %}

--- a/ansible/roles/eos/templates/t0-64-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-leaf.j2
@@ -32,7 +32,6 @@ route-map DEFAULT_ROUTES permit
 !
 {# #}
 {# NOTE: Using large enough values (e.g., podset_number = 200, #}
-{# max_tor_subnet_number = 16, tor_subnet_size = 64), will cause #}
 {# us to overflow the 192.168.0.0/16 private address space here. #}
 {# This should be fine for internal use, but may pose an issue if used otherwise #}
 {# #}
@@ -42,12 +41,14 @@ route-map DEFAULT_ROUTES permit
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
-ip route 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
-ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
+ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
 {% endfor %}
 {% endfor %}
 {% endfor %}
@@ -56,14 +57,16 @@ ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64
 {% for tor in range(0, props.tor_number) %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
 {% set prefixlen_v6 = (64 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
-ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
 ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
- seq 10 permit 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
+ seq 10 permit {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
 exit
 {% endfor %}
 {% endfor %}

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -36,7 +36,6 @@ route-map DEFAULT_ROUTES permit
 !
 {# #}
 {# NOTE: Using large enough values (e.g., podset_number = 200, #}
-{# max_tor_subnet_number = 16, tor_subnet_size = 64), will cause #}
 {# us to overflow the 192.168.0.0/16 private address space here. #}
 {# This should be fine for internal use, but may pose an issue if used otherwise #}
 {# #}
@@ -48,12 +47,14 @@ route-map DEFAULT_ROUTES permit
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
-ip route 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
-ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
+ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -65,14 +66,16 @@ ipv6 route 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64
 {% if podset != 0 or tor != 0 %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2))) % 256) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
 {% set octet3 = ((suffix // 256) % 256) %}
 {% set octet4 = (suffix % 256) %}
 {% set prefixlen_v4 = (32 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
 {% set prefixlen_v6 = (64 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
-ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit 192.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
 ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
- seq 10 permit 20C0:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
+ seq 10 permit {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
 exit
 {% endif %}
 {% endfor %}

--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -143,7 +143,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 4200064600
     tor_asn_start: 4200065100

--- a/ansible/vars/topo_t0-16.yml
+++ b/ansible/vars/topo_t0-16.yml
@@ -116,7 +116,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64600
     tor_asn_start: 65100

--- a/ansible/vars/topo_t0-52.yml
+++ b/ansible/vars/topo_t0-52.yml
@@ -75,7 +75,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64600
     tor_asn_start: 65100

--- a/ansible/vars/topo_t0-56.yml
+++ b/ansible/vars/topo_t0-56.yml
@@ -116,7 +116,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64600
     tor_asn_start: 65100

--- a/ansible/vars/topo_t0-64-32.yml
+++ b/ansible/vars/topo_t0-64-32.yml
@@ -55,7 +55,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64802
     tor_asn_start: 64601

--- a/ansible/vars/topo_t0-64.yml
+++ b/ansible/vars/topo_t0-64.yml
@@ -108,7 +108,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64802
     tor_asn_start: 64601

--- a/ansible/vars/topo_t0.yml
+++ b/ansible/vars/topo_t0.yml
@@ -60,7 +60,7 @@ configuration_properties:
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 64
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64600
     tor_asn_start: 65100


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
- Increase subnet size to 128, so each ToR will occupy 128 * 16 = 2k IP addresses.
  2K IP addresses is minimum requirement for fast-reboot test.
- After increasing tor subnet size, the routing entries overflow to 192.x.y.z and 20c1::
- Removed unused local variables.

#### How did you verify/test it?
Deployed on my T0 DUT. Verified expected number of routing entries present.
Also validated that routing entry 192.168.4.0/26 is no longer there.

NOTE: this change won't take effect until a DUT is redeployed with
testbed-cli.sh remove-topo ...
testbed-cli.sh add-topo ...