### PR TITLE
[fast-reboot] don't restore original image when no new image defined

### DIFF
--- a/ansible/roles/test/handlers/main.yml
+++ b/ansible/roles/test/handlers/main.yml
@@ -60,3 +60,10 @@
 - name: Clean up apt
   become: true
   shell: apt-get autoremove -y; apt-get autoclean -y; apt-get clean -y
+
+- name: restore current image
+  shell: 'sonic_installer set_default {{ current_sonic_image.stdout }}'
+  become: true
+
+- name: reboot sonic
+  include: roles/test/tasks/common_tasks/reboot_sonic.yml

--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -124,6 +124,9 @@
         - name: Install a new SONiC image if requested
           shell: sonic_installer install -y {{ new_image_location }}
           become: true
+          notify:
+            - restore current image
+            - reboot sonic
 
       when: new_sonic_image is defined
 
@@ -199,12 +202,5 @@
         dest: '/tmp/'
         flat: yes
 
-    - block:
-      - name: Set previous image as default
-        shell: 'sonic_installer set_default {{ current_sonic_image.stdout }}'
-        become: true
-
-      - name: reboot
-        include: roles/test/tasks/common_tasks/reboot_sonic.yml
-
-      when: new_sonic_image is defined
+    - name: make sure all handlers run
+      meta: flush_handlers

--- a/ansible/test_sonic.yml
+++ b/ansible/test_sonic.yml
@@ -18,6 +18,7 @@
     - vars/docker_registry.yml
   roles:
     - { role: test, scope: 'sonic' }
+  force_handlers: true
 
 - hosts: [lldp_neighbors]
   gather_facts: no


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
It appears taht ansible ignores 'when' condition for tasks under 'always' section.
When new image is not defined. The original image is not set. So when test executed
to always section trying to restore the origin image, an ansible error occurs.

Use notify/handler mechanism to make sure original image is restored when necessary,
even under failure conditions.


#### How did you verify/test it?
Tested fast-reboot on my local DUT. With vlan subnet fixed, the test passes, (not 100% pass yet, but better than 100% failure).