### PR TITLE
Add testcases for management port in SNMP test

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -190,6 +190,7 @@ def parse_dpg(dpg, hname):
         mgmtintfs = child.find(str(QName(ns, "ManagementIPInterfaces")))
         mgmt_intf = None
         for mgmtintf in mgmtintfs.findall(str(QName(ns1, "ManagementIPInterface"))):
+            intfname = mgmtintf.find(str(QName(ns, "AttachTo"))).text
             ipprefix = mgmtintf.find(str(QName(ns1, "PrefixStr"))).text
             mgmtipn = ipaddress.IPNetwork(ipprefix)
             # Ignore IPv6 management address
@@ -199,7 +200,7 @@ def parse_dpg(dpg, hname):
             prefix_len = str(mgmtipn.prefixlen)
             ipmask = mgmtipn.netmask
             gwaddr = ipaddress.IPAddress(int(mgmtipn.network) + 1)
-            mgmt_intf = {'addr': ipaddr, 'prefixlen': prefix_len, 'mask': ipmask, 'gwaddr': gwaddr}
+            mgmt_intf = {'addr': ipaddr, 'alias': intfname, 'prefixlen': prefix_len, 'mask': ipmask, 'gwaddr': gwaddr}
 
         pcintfs = child.find(str(QName(ns, "PortChannelInterfaces")))
         pc_intfs = []

--- a/ansible/roles/test/tasks/snmp/interfaces.yml
+++ b/ansible/roles/test/tasks/snmp/interfaces.yml
@@ -23,6 +23,10 @@
     mg_intf: "{{ mg_intf + [item.key] }}"
   with_dict: "{{ minigraph_portchannels }}"
 
+- name: Add management port into minigraph interfaces list
+  set_fact:
+    mg_intf: "{{ mg_intf + [minigraph_mgmt_interface.alias] }}"
+
 - debug: var=minigraph_map_sonic_to_ngs
 - debug: var=snmp_intf
 - debug: var=mg_intf

--- a/ansible/roles/test/tasks/snmp/lldp.yml
+++ b/ansible/roles/test/tasks/snmp/lldp.yml
@@ -34,7 +34,7 @@
 - set_fact:
     snmp_ports:  "{{ snmp_ports|default({}) | combine({ item.key : item.value}) }}"
   when: "{{ item.value.name is defined }}
-    and {{ item.value['name'].find('Ethernet') != -1 }}"
+    and ({{ item.value['name'].find('Ethernet') != -1 }} or {{ item.value['name'].find('eth') != -1 }})"
   with_dict: "{{ snmp_interfaces }}"
 
 # Check if lldpLocPortTable is present for all ports

--- a/ansible/roles/test/tasks/snmp/pfc_counters.yml
+++ b/ansible/roles/test/tasks/snmp/pfc_counters.yml
@@ -7,5 +7,5 @@
 # Ignore management ports, assuming the names starting with 'eth', eg. eth0
 - fail:
     msg: "Port {{ item.key }} does not have PFC counters"
-  when: (not item.value.name.startswith("eth")) and (item.value.cpfcIfRequests is not defined or not item.value.cpfcIfIndications or not item.value.requestsPerPriority or not item.value.indicationsPerPriority)
+  when: (not item.value.name.startswith("eth")) and (not item.value.cpfcIfRequests or not item.value.cpfcIfIndications or not item.value.requestsPerPriority or not item.value.indicationsPerPriority)
   with_dict: "{{ snmp_interfaces }}"

--- a/ansible/roles/test/tasks/snmp/pfc_counters.yml
+++ b/ansible/roles/test/tasks/snmp/pfc_counters.yml
@@ -6,6 +6,6 @@
 # Check PFC counters
 # Ignore management ports, assuming the names starting with 'eth', eg. eth0
 - fail:
-    msg: "Port {{ item.key }} does not has PFC counters"
-  when: (not item.value.name.startswith("eth")) and (not item.value.cpfcIfRequests or not item.value.cpfcIfIndications or not item.value.requestsPerPriority or not item.value.indicationsPerPriority)
+    msg: "Port {{ item.key }} does not have PFC counters"
+  when: (not item.value.name.startswith("eth")) and (item.value.cpfcIfRequests is not defined or not item.value.cpfcIfIndications or not item.value.requestsPerPriority or not item.value.indicationsPerPriority)
   with_dict: "{{ snmp_interfaces }}"

--- a/ansible/roles/test/tasks/snmp/queues.yml
+++ b/ansible/roles/test/tasks/snmp/queues.yml
@@ -4,6 +4,6 @@
   connection: local
 
 - fail:
-    msg: "Port {{ item.key }} does not has queue counters"
+    msg: "Port {{ item.key }} does not have queue counters"
   when: "{{ item.value.description | match('^Ethernet') }} and {{ item.value['queues'] is not defined }}"
   with_dict: "{{ snmp_interfaces }}"


### PR DESCRIPTION
NOTE 1: This changes depend on a fix: https://github.com/Azure/sonic-snmpagent/pull/91
Also on master sonic-snmpagent pointer is not updated to include management ports support
NOTE 2: I will cherry pick this change in 201803 branch and create a PR once this will be approved.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Added test cases for management port
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Split front panel ports, port channels and management ports by SNMP OID ranges

#### How did you verify/test it?
Run testbed test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
