### PR TITLE
update ecn testcase to use sudo privilege for ecnconfig command

### DIFF
--- a/ansible/roles/test/tasks/ecn_wred.yml
+++ b/ansible/roles/test/tasks/ecn_wred.yml
@@ -42,6 +42,7 @@
 
   always:
     - name: Restore original value
+      become: yes
       shell: ecnconfig -p AZURE_LOSSY -rmin {{ red_min_threshold }}
       register: ecn_restore
       failed_when: ecn_restore.rc != 0

--- a/ansible/roles/test/tasks/ecn_wred_worker.yml
+++ b/ansible/roles/test/tasks/ecn_wred_worker.yml
@@ -3,6 +3,7 @@
 
 # Set value...
 - name: Set WRED value {{ item }}
+  become: yes
   shell: ecnconfig -p AZURE_LOSSY -rmin {{ item }}
   register: rc
   failed_when: rc.rc != 0


### PR DESCRIPTION
### Description of PR
ecnconfig command now requires root privilege.  Updating ecn test cases with correct privilege

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Ran the update testcase against Barefoot device built with Azure buildimage master branch

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
