### PR TITLE
[linkstate]: Fix copy of fanout_listener in up.yml

### DIFF
--- a/ansible/linkstate/up.yml
+++ b/ansible/linkstate/up.yml
@@ -66,7 +66,7 @@
     - name: Copy script
       copy:
         src: "{{ fanout_listener | default('scripts/fanout_listener.py') }}"
-        dest: /root
+        dest: /root/
     - name: Run the script
       shell: nohup python fanout_listener.py {{ ptf_host }} > /tmp/fanout_listener.console.txt 2>&1 &
       when: '"python fanout_listener.py" not in out.stdout'


### PR DESCRIPTION
The 'dest' is a folder and ought to end with '/'.
Otherwise Ansible 'copy' fails, unable to overwrite the existing file.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
The copy's 'dest' parameter is a folder, and ought to end with '/'.
Otherwise Ansible 'copy' fails, if the file to be copied already exists in the destination folder.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added '/' to the end of destination directory name.
#### How did you verify/test it?
Verified that Copy can overwrite a file, if the file to be copied already exists in the destination directory.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
