### PR TITLE
Fix Asymmetric PFC testcase skip for vlan-less topologies

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -134,10 +134,21 @@
     - name: Test PFC WD extreme case when all ports have storm
       include: roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
 
+    - name: Vlan members initial value
+      set_fact:
+        vlan_members: []
+
+    - name: Set vlan members
+      set_fact:
+        vlan_members: "{{ minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members']}}"
+      when:
+        - minigraph_vlan_interfaces
+        - pfc_asym is defined
+
     - name: Enable asymmetric PFC on all server interfaces
       command: config interface pfc asymmetric on {{ item }}
       become: yes
-      with_items: "{{ minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'] }}"
+      with_items: "{{ vlan_members }}"
       when:
         - pfc_asym is defined
         - testbed_type in ['t0']
@@ -158,6 +169,6 @@
     - name: Disable asymmetric PFC on all server interfaces
       command: config interface pfc asymmetric on {{ item.dut_name }}
       become: yes
-      with_items: "{{ minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'] }}"
+      with_items: "{{ vlan_members }}"
       when:
-        - pfc_asym is defined        
+        - pfc_asym is defined


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

### Description of PR
Improved skipping of Asymmetric PFC test cases if not requested

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you do it?
No matter of "when:" condition Ansible analyses value specified in "with_items"
On topology without VLAN defined it caused an error.
Declared empty list for with_items when it is not needed

#### How did you verify/test it?
PFC_WD test on t1 topology does not fail

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
