### PR TITLE
[config_test]: Add config test to validate IP/LAG commands

### DIFF
--- a/ansible/roles/test/tasks/config.yml
+++ b/ansible/roles/test/tasks/config.yml
@@ -1,0 +1,139 @@
+- debug: msg="Configuration Test"
+
+- fail: msg="testbed_type {{testbed_type}} is not supported"
+  when: testbed_type not in ['t1-lag', 't1-64-lag']
+
+- name: Gather minigraph facts
+  minigraph_facts: host={{inventory_hostname}}
+
+- name: Gather interface facts
+  interface_facts:
+
+- name: Initialize portchannel
+  set_fact:
+    portchannel: "{{minigraph_portchannels | first}}"
+    tmp_portchannel: "PortChannel999"
+
+- name: Initialize portchannel_ip and portchannel_member
+  set_fact:
+    portchannel_ip: "{{ansible_interface_facts[portchannel]['ipv4']['address']}}"
+    portchannel_members: "{{minigraph_portchannels[portchannel]['members']}}"
+
+- name: Print variables
+  vars:
+    msg: |
+      portchannel: {{ portchannel }}
+      portchannel_ip: {{ portchannel_ip }}
+      portchannel_members: {{ portchannel_members }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Initialize flags
+  set_fact:
+    remove_portchannel_members: false
+    remove_portchannel_ip: false
+    create_tmp_portchannel: false
+    add_tmp_portchannel_members: false
+    add_tmp_portchannel_ip: false
+
+- block:
+    - name: Step 1 Remove {{ portchannel_members }} from {{ portchannel }}
+      shell: config portchannel member del {{ portchannel }} {{ item }}
+      become: yes
+      with_items: "{{portchannel_members}}"
+    - set_fact:
+        remove_portchannel_members: true
+
+    - name: Step 2 Remove {{ portchannel_ip }} from {{ portchannel }}
+      shell: config interface {{ portchannel }} ip remove {{ portchannel_ip }}/31
+      become: yes
+    - set_fact:
+        remove_portchannel_ip: true
+
+    - pause: seconds=30
+
+    - interface_facts:
+    - assert:
+        that:
+          - "{{ansible_interface_facts[portchannel]['link']}} == False"
+
+    - bgp_facts:
+    - assert:
+        that:
+          - "{{bgp_statistics['ipv4_idle']}} == 1"
+
+    - name: Step 3 Create {{ tmp_portchannel }}
+      shell: config portchannel add {{ tmp_portchannel }}
+      become: yes
+    - set_fact:
+        create_tmp_portchannel: true
+
+    - name: Step 4 Add {{ portchannel_members }} to {{ tmp_portchannel }}
+      shell: config portchannel member add {{ tmp_portchannel }} {{ item }}
+      become: yes
+      with_items: "{{portchannel_members}}"
+    - set_fact:
+        add_tmp_portchannel_members: true
+
+    - name: Step 5 Add {{ portchannel_ip }} to {{ tmp_portchannel }}
+      shell: config interface {{ tmp_portchannel }} ip add {{ portchannel_ip }}/31
+      become: yes
+    - set_fact:
+        add_tmp_portchannel_ip: true
+
+    - interface_facts:
+    - assert:
+        that:
+          - "'{{ansible_interface_facts[tmp_portchannel].ipv4.address}}' == '{{portchannel_ip}}'"
+
+    - pause: seconds=30
+
+    - interface_facts:
+    - assert:
+        that:
+          - "{{ansible_interface_facts[tmp_portchannel]['link']}} == True"
+
+    - bgp_facts:
+    - assert:
+        that:
+          - "{{bgp_statistics['ipv4_idle']}} == 0"
+
+  always:
+    - name: Remove {{ portchannel_ip }} from {{ tmp_portchannel }}
+      shell: config interface {{ tmp_portchannel }} ip remove {{ portchannel_ip }}/31
+      become: yes
+      when: add_tmp_portchannel_ip
+
+    - name: Remove {{ portchannel_members }} from {{ tmp_portchannel }}
+      shell: config portchannel member del {{ tmp_portchannel }} {{ item }}
+      become: yes
+      when: add_tmp_portchannel_members
+      with_items: "{{portchannel_members}}"
+
+    - name: Remove {{ tmp_portchannel }}
+      shell: config portchannel del {{ tmp_portchannel }}
+      become: yes
+      when: create_tmp_portchannel
+
+    - name: Add {{ portchannel_ip }} to {{ portchannel }}
+      shell: config interface {{ portchannel }} ip add {{ portchannel_ip }}/31
+      become: yes
+      when: remove_portchannel_ip
+
+    - name: Add {{ portchannel_members }} to {{ portchannel }}
+      shell: config portchannel member add {{ portchannel }} {{ item }}
+      become: yes
+      when: remove_portchannel_members
+      with_items: "{{portchannel_members}}"
+
+    - pause: seconds=30
+
+    - interface_facts:
+    - assert:
+        that:
+          - "{{ansible_interface_facts[portchannel]['link']}} == True"
+
+    - bgp_facts:
+    - assert:
+        that:
+          - "{{bgp_statistics['ipv4_idle']}} == 0"

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -31,6 +31,10 @@ testcases:
           ptf_host:
           testbed_type:
 
+    config:
+        filename: config.yml
+        topologies: [t1-lag, t1-64-lag, t0, t0-64]
+
     continuous_reboot:
       filename: continuous_reboot.yml
       topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]


### PR DESCRIPTION
This test runs on topologies configured with LAG.
The procedure of the test is:

1. Pick one LAG and remove all its members
2. Remove the IP configured on this LAG
3. Create a temporary LAG and add the original members to this new LAG
4. Add the IP to this temporary LAG
5. Verify BGP status

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
