### PR TITLE
Fix fast-reboot test for Arista-7260CX3-D108C8

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -226,7 +226,7 @@ class Arista(object):
             return result
 
         for events in result_bgp.values():
-            if len(events) > 1 and events[-1][1] != 'Established':
+            if events[-1][1] != 'Established':
                 return result
 
         # first state is Idle, last state is Established

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -149,9 +149,10 @@ class Arista(object):
 
             if not run_once:
                 self.ipv4_gr_enabled, self.ipv6_gr_enabled, self.gr_timeout = self.parse_bgp_neighbor_once(bgp_neig_output)
-                log_first_line = "session_begins_%f" % cur_time
-                self.do_cmd("send log message %s" % log_first_line)
-                run_once = True
+                if self.gr_timeout is not None:
+                    log_first_line = "session_begins_%f" % cur_time
+                    self.do_cmd("send log message %s" % log_first_line)
+                    run_once = True
 
             data[cur_time] = info
             if self.DEBUG:
@@ -225,13 +226,16 @@ class Arista(object):
             return result
 
         for events in result_bgp.values():
-            if events[-1][1] != 'Established':
+            if len(events) > 1 and events[-1][1] != 'Established':
                 return result
 
         # first state is Idle, last state is Established
         for events in result_bgp.values():
-            assert(events[0][1] == 'Idle')
+            if len(events) > 1:
+                assert(events[0][1] != 'Established')
+
             assert(events[-1][1] == 'Established')
+
         # first state is down, last state is up
         for events in result_if.values():
             assert(events[0][1] == 'down')


### PR DESCRIPTION
1. Retry parse_bgp_neighbor if gr_timeout is not got
2. The BGP logging is not as expected as before, possible reason may be this SKU is high performance. Below shows a sample 'show logging' we observed on EOS VM.
```
Dec  3 18:53:48 ARISTA04T1 Rib: %BGP-5-ADJCHANGE: peer 10.0.0.38 (AS 4200065100) old state Established event Closed new state Idle
Dec  3 18:55:44 ARISTA04T1 Rib: %BGP-5-ADJCHANGE: peer 10.0.0.38 (AS 4200065100) old state OpenConfirm event RecvKeepAlive new state Established
```