### PR TITLE
[port-toggle.yml] Correct the commmand for shutdown/startup interface

### DIFF
--- a/ansible/roles/test/tasks/port_toggle.yml
+++ b/ansible/roles/test/tasks/port_toggle.yml
@@ -1,8 +1,8 @@
 - name: build shell command string
-  debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface shutdown $port; done"
+  debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface $port shutdown; done"
 
 - name: turn off all ports on device
-  shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface shutdown $port; done
+  shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface $port shutdown; done
   become: yes
 
 - name: Get interface facts
@@ -13,10 +13,10 @@
 
 - always:
   - name: build shell command string
-    debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface startup $port; done"
+    debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface $port startup; done"
 
-  - name: turn off all ports on device
-    shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface startup $port; done
+  - name: turn on all ports on device
+    shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface $port startup; done
     become: yes
 
   - name: wait 1 minute for ports to come up


### PR DESCRIPTION
Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
The syntax of CLI commands for shutting down and bringing up interfaces is wrong.
Changed commands from:
    config interface shutdown <interface_name>
    config interface startup <interface_name>
to:
    config interface <interface_name> shutdown
    config interface <interface_name> startup

Summary:
Fixes # (issue)

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Changed the command syntax in port-toggle.yml file

#### How did you verify/test it?
Test run the script on multiple topologies of Mellanox SONiC platforms. The script passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
