### PR TITLE
Improve "Verify all interfaces are up" error handling

### DIFF
--- a/ansible/roles/test/tasks/check_testbed_interfaces.yml
+++ b/ansible/roles/test/tasks/check_testbed_interfaces.yml
@@ -13,7 +13,6 @@
   when: 
     - check_fanout is defined
 
-
 - block:
   - name: Get Portchannel status 
     shell: show interfaces portchannel

--- a/ansible/roles/test/tasks/check_testbed_interfaces.yml
+++ b/ansible/roles/test/tasks/check_testbed_interfaces.yml
@@ -1,0 +1,58 @@
+- block:
+  - name: Gathering lab graph facts about the device
+    conn_graph_facts: host={{ inventory_hostname }}
+    connection: local
+
+  - name: Fanout hostname
+    set_fact: fanout_switch={{ device_conn['Ethernet0']['peerdevice'] }}
+
+  - name: Check Fanout interfaces
+    local_action: shell ansible-playbook -i lab fanout.yml -l {{ fanout_switch }} --tags check_interfaces_status
+    ignore_errors: yes
+
+  when: 
+    - check_fanout is defined
+
+
+- block:
+  - name: Get Portchannel status 
+    shell: show interfaces portchannel
+    register: portchannel_status
+    ignore_errors: yes
+
+  - name: Get teamd dump
+    shell: teamdctl '{{ item }}' state dump
+    with_items: "{{ minigraph_portchannels }}"
+    ignore_errors: yes
+    when:
+      - minigraph_portchannels is defined
+
+  - name: Define testbed_name when not obtained
+    set_fact:
+      testbed_name: "{{ inventory_hostname + '-' + topo }}"
+    when: testbed_name is not defined
+
+  - name: Gathering testbed information
+    test_facts: testbed_name="{{ testbed_name }}"
+    connection: local
+    ignore_errors: yes
+
+  - name: Gather vm list from Testbed server
+    local_action: shell ansible-playbook testbed_vm_status.yml -i veos -l "{{ testbed_facts['server'] }}"
+    ignore_errors: yes
+
+  - set_fact:
+      vms: "{{ minigraph_devices }}"
+      peer_hwsku: 'Arista-VM'
+
+  - name: Gather Port-Channel status from VMs
+    action: apswitch template=roles/vm_set/templates/show_int_portchannel_status.j2
+    args:
+      host: "{{ vms[item]['mgmt_addr'] }}"
+      login: "{{ switch_login[hwsku_map[peer_hwsku]] }}"
+    connection: switch
+    ignore_errors: yes
+    when: vms["{{ item }}"]['hwsku'] == 'Arista-VM'
+    with_items: vms
+
+  when: check_vms is defined

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -32,12 +32,27 @@
 - debug: msg="Found link down ports {{ansible_interface_link_down_ports}}"
   when: ansible_interface_link_down_ports | length > 0
 
-- name: Verify interfaces are up correctly
-  assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
+- block:
+  - name: Verify interfaces are up correctly
+    assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
+  rescue:
+  - include: check_testbed_interfaces.yml
+    vars:
+      check_fanout: true
+  - fail: msg="Not all Interfaces are up"
 
-- name: Verify port channel interfaces are up correctly
-  assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
-  with_items: "{{ minigraph_portchannels.keys() }}"
+- block:
+
+  - name: Verify port channel interfaces are up correctly
+    assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
+    with_items: "{{ minigraph_portchannels.keys() }}"
+
+  rescue:
+  - include: check_testbed_interfaces.yml
+    vars:
+      check_vms: true
+  - fail: msg="Not all PortChannels are up '{{ portchannel_status['stdout_lines'] }}' "
+    when: portchannel_status is defined
 
 - name: Verify VLAN interfaces are up correctly
   assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -42,7 +42,6 @@
   - fail: msg="Not all Interfaces are up"
 
 - block:
-
   - name: Verify port channel interfaces are up correctly
     assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
     with_items: "{{ minigraph_portchannels.keys() }}"

--- a/ansible/roles/vm_set/templates/show_int_portchannel_status.j2
+++ b/ansible/roles/vm_set/templates/show_int_portchannel_status.j2
@@ -1,0 +1,1 @@
+show interfaces Port-Channel 1-$ status

--- a/ansible/testbed_vm_status.yml
+++ b/ansible/testbed_vm_status.yml
@@ -1,0 +1,7 @@
+- hosts: servers:&vm_host
+  tasks:
+  - name: Get VM statuses from Testbed server
+    shell: virsh list
+    register: virsh_list
+  - name: Show VM statuses
+    debug: msg="{{ virsh_list['stdout_lines'] }}"

--- a/ansible/testbed_vm_status.yml
+++ b/ansible/testbed_vm_status.yml
@@ -1,3 +1,5 @@
+# Example:
+# ansible-playbook testbed_vm_status.yml -i veos -l server_1
 - hosts: servers:&vm_host
   tasks:
   - name: Get VM statuses from Testbed server


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
1. Modified interface.yml
2. Added check_testbed_interfaces.yml
3. Added testbed_vm_status.yml playbook
4. Added show_int_portchannel_status.j2

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
1. Modified interface.yml to include check_testbed_interfaces.yml,
   when 'Verify interfaces are up' fails.
2. Added check_testbed_interfaces.yml to gather interfaces status on:
   - DUT
   - Fanout (for MLNX only, filtered by check_interfaces_status tag)
   - Testbed server (by calling testbed_vm_status.yml playbook)
   - relevant VMs
3. Added testbed_vm_status.yml palybook to enter Testbed server and gather VMs status.
4. Added show_int_portchannel_status.j2 to enter each relevant VM and gather Port-Channel status.
### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
I changed interface.yml flow to gather more information from Testbed (DUT / Fanout / Server / VMS)
about the statuses of interfaces and Port-Channels.
Now, when 'Verify all interfaces are up' step when fail, playbook executes additional steps
to gather relevant information (interfaces statuses) from Testbed Server / DUT / Fanout / VMS.

#### How did you verify/test it?
I ran for example LLDP test (or any other test using interfaces.yml).
I used two cases:
1. Normal flow, when all interfaces are up.
   In this case nothing is changes
2. Bug flow, when Fanout has deliberately its ports down,
   or when some relevant VM has its Port-Channel deliberately down.
   In that cases, the test fails as usual, but gathers additional information through the Testbed.

#### Any platform specific information?
Current implementation can enter Fanout switch, only if Fanout is MLNX type.
The _'Check Fanout interfaces'_ step in _check_testbed_interfaces.yml_ calls _fanout.yml_ (actually fanout role) with tag _'check_interfaces_status'_
In this case anyone can modify roles/fanout/tasks/main.yml to execute Fanout specific step with
  _when: peer_hwsku == "<specific_fanout_type>"
  tags: check_interfaces_status_

Example:
```
 ###################################################################
 # Check Fanout interfaces status                                  #
 ###################################################################
- block:
  - name: Check Fanout interfaces status
    action: apswitch template=roles/fanout/templates/mlnx_interfaces_status.j2
    connection: switch
    register: fanout_interfaces
    args:
      login: "{{ switch_login['MLNX-OS'] }}"

  - debug:
      msg: "{{ fanout_interfaces.stdout.split('\n') }}"

  when: peer_hwsku == "MLNX-OS"
  tags: check_interfaces_status
```

#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A