### PR TITLE
[acl]: Revisit ACL test

### DIFF
--- a/ansible/roles/test/tasks/acl/acltb_test_rules.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules.json
@@ -8,7 +8,7 @@
                             "1": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -23,7 +23,7 @@
                             "2": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -38,11 +38,26 @@
                             "3": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 3
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "172.16.2.0/32"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
                                 },
                                 "transport": {
                                     "config": {
@@ -50,33 +65,18 @@
                                     }
                                 }
                             },
-                            "4": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "DROP"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 4
-                                },
-                                "ip": {
-                                    "config": {
-                                        "protocol": 126
-                                    }
-                                }
-                            },
                             "5": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 5
                                 },
-                                "transport": {
+                                "ip": {
                                     "config": {
-                                        "tcp-flags": ["TCP_ACK", "TCP_SYN"]
+                                        "protocol": 126
                                     }
                                 }
                             },
@@ -89,9 +89,9 @@
                                 "config": {
                                     "sequence-id": 6
                                 },
-                                "ip": {
+                                "transport": {
                                     "config": {
-                                        "source-ip-address": "10.0.0.3/32"
+                                        "tcp-flags": ["TCP_ACK", "TCP_SYN"]
                                     }
                                 }
                             },
@@ -113,11 +113,26 @@
                             "8": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 8
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "10.0.0.3/32"
+                                    }
+                                }
+                            },
+                            "9": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 9
                                 },
                                 "transport": {
                                     "config": {
@@ -125,25 +140,10 @@
                                     }
                                 }
                             },
-                            "9": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "DROP"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 9
-                                },
-                                "l2": {
-                                    "config": {
-                                        "ethertype": "4660"
-                                    }
-                                }
-                            },
                             "10": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -158,7 +158,7 @@
                             "11": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -179,21 +179,6 @@
                                 "config": {
                                     "sequence-id": 12
                                 },
-                                "l2": {
-                                    "config": {
-                                        "ethertype": "ETHERTYPE_IPV4"
-                                    }
-                                }
-                            },
-                            "13": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "DROP"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 13
-                                },
                                 "ip": {
                                     "config": {
                                         "protocol":1,
@@ -201,14 +186,14 @@
                                     }
                                 }
                             },
-                            "14": {
+                            "13": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
-                                    "sequence-id": 14
+                                    "sequence-id": 13
                                 },
                                 "ip": {
                                     "config": {

--- a/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json
@@ -8,7 +8,7 @@
                             "1": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "ACCEPT"
+                                        "forwarding-action": "DROP"
                                     }
                                 },
                                 "config": {
@@ -23,7 +23,7 @@
                             "2": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "ACCEPT"
+                                        "forwarding-action": "DROP"
                                     }
                                 },
                                 "config": {
@@ -38,7 +38,7 @@
                             "3": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "ACCEPT"
+                                        "forwarding-action": "DROP"
                                     }
                                 },
                                 "config": {
@@ -50,18 +50,50 @@
                                     }
                                 }
                             },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 126
+                                    }
+                                }
+                            },
                             "13": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "ACCEPT"
+                                        "forwarding-action": "DROP"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 13
                                 },
-                                "l2": {
+                                "ip": {
                                     "config": {
-                                        "ethertype": "ETHERTYPE_IPV4"
+                                        "protocol":1,
+                                        "source-ip-address": "10.0.0.2/32"
+                                    }
+                                }
+                            },
+                            "14": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 14
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol":17,
+                                        "source-ip-address": "10.0.0.2/32"
                                     }
                                 }
                             }

--- a/ansible/roles/test/tasks/acl/acltb_test_rules_part_2.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules_part_2.json
@@ -8,7 +8,7 @@
                             "1": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -23,7 +23,7 @@
                             "2": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -38,11 +38,26 @@
                             "3": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 3
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "172.16.2.0/32"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
                                 },
                                 "transport": {
                                     "config": {
@@ -50,33 +65,18 @@
                                     }
                                 }
                             },
-                            "4": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "DROP"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 4
-                                },
-                                "ip": {
-                                    "config": {
-                                        "protocol": 126
-                                    }
-                                }
-                            },
                             "5": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 5
                                 },
-                                "transport": {
+                                "ip": {
                                     "config": {
-                                        "tcp-flags": ["TCP_ACK", "TCP_SYN"]
+                                        "protocol": 126
                                     }
                                 }
                             },
@@ -89,9 +89,9 @@
                                 "config": {
                                     "sequence-id": 6
                                 },
-                                "ip": {
+                                "transport": {
                                     "config": {
-                                        "source-ip-address": "10.0.0.3/32"
+                                        "tcp-flags": ["TCP_ACK", "TCP_SYN"]
                                     }
                                 }
                             },
@@ -113,11 +113,26 @@
                             "8": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
                                     "sequence-id": 8
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "10.0.0.3/32"
+                                    }
+                                }
+                            },
+                            "9": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 9
                                 },
                                 "transport": {
                                     "config": {
@@ -125,25 +140,10 @@
                                     }
                                 }
                             },
-                            "9": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "DROP"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 9
-                                },
-                                "l2": {
-                                    "config": {
-                                        "ethertype": "4660"
-                                    }
-                                }
-                            },
                             "10": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -158,7 +158,7 @@
                             "11": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
@@ -179,21 +179,6 @@
                                 "config": {
                                     "sequence-id": 12
                                 },
-                                "l2": {
-                                    "config": {
-                                        "ethertype": "ETHERTYPE_IPV4"
-                                    }
-                                }
-                            },
-                            "13": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "DROP"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 13
-                                },
                                 "ip": {
                                     "config": {
                                         "protocol":1,
@@ -201,14 +186,14 @@
                                     }
                                 }
                             },
-                            "14": {
+                            "13": {
                                 "actions": {
                                     "config": {
-                                        "forwarding-action": "DROP"
+                                        "forwarding-action": "ACCEPT"
                                     }
                                 },
                                 "config": {
-                                    "sequence-id": 14
+                                    "sequence-id": 13
                                 },
                                 "ip": {
                                     "config": {


### PR DESCRIPTION
1. The current ACL loader will insert a default DROP rule that
   whatever doesn't match any rules will fall into this slot and
   get dropped. Thus the current DROP rules inserted during the
   test cannot be used to inspect if a rule is successfully
   inserted or not. Thus I modified the rule file to make it test
   if a packet is forwarded and received.

2. A test #0 is added to make sure that if a packet doesn't fall into
   any slots it will be dropped by default.

3. Remove the current EtherType match rule since whatever ethertypes
   that are not IP or IPv6 would be dropped. A TODO task is to add
   rules that matches IPv4/IPv6 separately and determine if the field
   works or not.

Signed-off-by: Shuotian Cheng <stcheng_89@hotmail.com>