### PR TITLE
[minigraph] always generate neighbor device information

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -56,7 +56,7 @@
     connection: local
 
   - set_fact:
-      VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
+      VM_topo: "True"
       remote_dut: "{{ ansible_ssh_host }}"
 
   - name: gather testbed VM informations


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix

### Approach
#### How did you do it?
sonic master branch code requires neighbor device presence when
parsing minigraph. Without neighbor device information, the
minigraph load would fail and leave nightly testbed in bad state
if ptf topology was tested in the last step of the test sequence.


#### How did you verify/test it?
My nightly testbed has been failure recently with PTF topology due to minigraph issue. With the change. the newly generated minigraph is loaded properly.