### PR TITLE
Add portchannel interface changing event count in test

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -42,6 +42,7 @@ import subprocess
 from ptf.mask import Mask
 import socket
 import ptf.packet as scapy
+import thread
 import threading
 import os
 import signal
@@ -664,124 +665,126 @@ class ReloadTest(BaseTest):
         self.log("Check that device is alive and pinging")
         self.assertTrue(self.check_alive(), 'DUT is not stable')
 
-        self.log("Schedule to reboot the remote switch in %s sec" % self.reboot_delay)
-        thr.start()
+        try:
+            self.log("Schedule to reboot the remote switch in %s sec" % self.reboot_delay)
+            thr.start()
 
-        self.log("Wait until VLAN and CPU port down")
-        self.timeout(self.task_timeout, "DUT hasn't shutdown in %d seconds" % self.task_timeout)
-        self.wait_until_vlan_cpu_port_down()
-        self.cancel_timeout()
+            self.log("Wait until VLAN and CPU port down")
+            self.timeout(self.task_timeout, "DUT hasn't shutdown in %d seconds" % self.task_timeout)
+            self.wait_until_vlan_cpu_port_down()
+            self.cancel_timeout()
 
-        self.reboot_start = datetime.datetime.now()
-        self.log("Dut reboots: reboot start %s" % str(self.reboot_start))
+            self.reboot_start = datetime.datetime.now()
+            self.log("Dut reboots: reboot start %s" % str(self.reboot_start))
 
-        self.log("Check that device is still forwarding Data plane traffic")
-        self.assertTrue(self.check_alive(), 'DUT is not stable')
+            self.log("Check that device is still forwarding Data plane traffic")
+            self.assertTrue(self.check_alive(), 'DUT is not stable')
 
-        self.log("Wait until VLAN and CPU port up")
-        self.timeout(self.task_timeout, "DUT hasn't bootup in %d seconds" % self.task_timeout)
-        self.wait_until_vlan_cpu_port_up()
-        self.cancel_timeout()
+            self.log("Wait until VLAN and CPU port up")
+            self.timeout(self.task_timeout, "DUT hasn't bootup in %d seconds" % self.task_timeout)
+            self.wait_until_vlan_cpu_port_up()
+            self.cancel_timeout()
 
-        self.log("Wait until ASIC stops")
-        self.timeout(self.task_timeout, "DUT hasn't stopped in %d seconds" % self.task_timeout)
-        no_routing_start, upper_replies = self.check_forwarding_stop()
-        self.cancel_timeout()
+            self.log("Wait until ASIC stops")
+            self.timeout(self.task_timeout, "DUT hasn't stopped in %d seconds" % self.task_timeout)
+            no_routing_start, upper_replies = self.check_forwarding_stop()
+            self.cancel_timeout()
 
-        self.log("ASIC was stopped, Waiting until it's up. Stop time: %s" % str(no_routing_start))
-        self.timeout(self.task_timeout, "DUT hasn't started to work for %d seconds" % self.task_timeout)
-        no_routing_stop, _ = self.check_forwarding_resume()
-        self.cancel_timeout()
+            self.log("ASIC was stopped, Waiting until it's up. Stop time: %s" % str(no_routing_start))
+            self.timeout(self.task_timeout, "DUT hasn't started to work for %d seconds" % self.task_timeout)
+            no_routing_stop, _ = self.check_forwarding_resume()
+            self.cancel_timeout()
 
-        # wait until all bgp session are established
-        self.log("Wait until bgp routing is up on all devices")
-        for _, q in self.ssh_jobs:
-            q.put('quit')
-
-        self.timeout(self.task_timeout, "SSH threads haven't finished for %d seconds" % self.task_timeout)
-        while any(thr.is_alive() for thr, _ in self.ssh_jobs):
+            # wait until all bgp session are established
+            self.log("Wait until bgp routing is up on all devices")
             for _, q in self.ssh_jobs:
-                q.put('go')
-            time.sleep(self.TIMEOUT)
+                q.put('quit')
 
-        for thr, _ in self.ssh_jobs:
-            thr.join()
-        self.cancel_timeout()
+            self.timeout(self.task_timeout, "SSH threads haven't finished for %d seconds" % self.task_timeout)
+            while any(thr.is_alive() for thr, _ in self.ssh_jobs):
+                for _, q in self.ssh_jobs:
+                    q.put('go')
+                time.sleep(self.TIMEOUT)
 
-        self.log("ASIC works again. Start time: %s" % str(no_routing_stop))
-        self.log("")
+            for thr, _ in self.ssh_jobs:
+                thr.join()
+            self.cancel_timeout()
 
-        no_cp_replies = self.extract_no_cpu_replies(upper_replies)
+            self.log("ASIC works again. Start time: %s" % str(no_routing_stop))
+            self.log("")
 
-        self.fails['dut'] = set()
-        if no_routing_stop - no_routing_start > self.limit:
-            self.fails['dut'].add("Downtime must be less then %s seconds. It was %s" \
-                    % (self.test_params['reboot_limit_in_seconds'], str(no_routing_stop - no_routing_start)))
-        if no_routing_stop - self.reboot_start > datetime.timedelta(seconds=self.test_params['graceful_limit']):
-            self.fails['dut'].add("Fast-reboot cycle must be less than graceful limit %s seconds" % self.test_params['graceful_limit'])
-        if no_cp_replies < 0.95 * self.nr_vl_pkts:
-            self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (no_cp_replies, self.nr_vl_pkts))
+            no_cp_replies = self.extract_no_cpu_replies(upper_replies)
 
-        # Generating report
-        self.log("="*50)
-        self.log("Report:")
-        self.log("="*50)
+            self.fails['dut'] = set()
+            if no_routing_stop - no_routing_start > self.limit:
+                self.fails['dut'].add("Downtime must be less then %s seconds. It was %s" \
+                        % (self.test_params['reboot_limit_in_seconds'], str(no_routing_stop - no_routing_start)))
+            if no_routing_stop - self.reboot_start > datetime.timedelta(seconds=self.test_params['graceful_limit']):
+                self.fails['dut'].add("Fast-reboot cycle must be less than graceful limit %s seconds" % self.test_params['graceful_limit'])
+            if no_cp_replies < 0.95 * self.nr_vl_pkts:
+                self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (no_cp_replies, self.nr_vl_pkts))
 
-        self.log("LACP/BGP were down for (extracted from cli):")
-        self.log("-"*50)
-        for ip in sorted(self.cli_info.keys()):
-            self.log("    %s - lacp: %7.3f (%d) bgp v4: %7.3f (%d) bgp v6: %7.3f (%d)" \
-                     % (ip, self.cli_info[ip]['lacp'][1],   self.cli_info[ip]['lacp'][0], \
-                            self.cli_info[ip]['bgp_v4'][1], self.cli_info[ip]['bgp_v4'][0],\
-                            self.cli_info[ip]['bgp_v6'][1], self.cli_info[ip]['bgp_v6'][0]))
+        finally:
+            # Generating report
+            self.log("="*50)
+            self.log("Report:")
+            self.log("="*50)
 
-        self.log("-"*50)
-        self.log("Extracted from VM logs:")
-        self.log("-"*50)
-        for ip in sorted(self.logs_info.keys()):
-            self.log("Extracted log info from %s" % ip)
-            for msg in sorted(self.logs_info[ip].keys()):
-                if msg != 'error':
-                    self.log("    %s : %d" % (msg, self.logs_info[ip][msg]))
-                else:
-                    self.log("    %s" % self.logs_info[ip][msg])
+            self.log("LACP/BGP were down for (extracted from cli):")
             self.log("-"*50)
+            for ip in sorted(self.cli_info.keys()):
+                self.log("    %s - lacp: %7.3f (%d) bgp v4: %7.3f (%d) bgp v6: %7.3f (%d)" \
+                         % (ip, self.cli_info[ip]['lacp'][1],   self.cli_info[ip]['lacp'][0], \
+                                self.cli_info[ip]['bgp_v4'][1], self.cli_info[ip]['bgp_v4'][0],\
+                                self.cli_info[ip]['bgp_v6'][1], self.cli_info[ip]['bgp_v6'][0]))
 
-        self.log("Summary:")
-        self.log("-"*50)
-        self.log("Downtime was %s" % str(no_routing_stop - no_routing_start))
-        self.log("Reboot time was %s" % str(no_routing_stop - self.reboot_start))
-
-
-        self.log("How many packets were received back when control plane was down: %d Expected: %d" % (no_cp_replies, self.nr_vl_pkts))
-
-        has_info = any(len(info) > 0 for info in self.info.values())
-        if has_info:
             self.log("-"*50)
-            self.log("Additional info:")
+            self.log("Extracted from VM logs:")
             self.log("-"*50)
-            for name, info in self.info.items():
-                for entry in info:
-                    self.log("INFO:%s:%s" % (name, entry))
+            for ip in sorted(self.logs_info.keys()):
+                self.log("Extracted log info from %s" % ip)
+                for msg in sorted(self.logs_info[ip].keys()):
+                    if msg != 'error':
+                        self.log("    %s : %d" % (msg, self.logs_info[ip][msg]))
+                    else:
+                        self.log("    %s" % self.logs_info[ip][msg])
+                self.log("-"*50)
+
+            self.log("Summary:")
             self.log("-"*50)
+            self.log("Downtime was %s" % str(no_routing_stop - no_routing_start))
+            self.log("Reboot time was %s" % str(no_routing_stop - self.reboot_start))
 
-        is_good = all(len(fails) == 0 for fails in self.fails.values())
 
-        errors = ""
-        if not is_good:
-            self.log("-"*50)
-            self.log("Fails:")
-            self.log("-"*50)
+            self.log("How many packets were received back when control plane was down: %d Expected: %d" % (no_cp_replies, self.nr_vl_pkts))
 
-            errors = "\n\nSomething went wrong. Please check output below:\n\n"
-            for name, fails in self.fails.items():
-                for fail in fails:
-                    self.log("FAILED:%s:%s" % (name, fail))
-                    errors += "FAILED:%s:%s\n" % (name, fail)
+            has_info = any(len(info) > 0 for info in self.info.values())
+            if has_info:
+                self.log("-"*50)
+                self.log("Additional info:")
+                self.log("-"*50)
+                for name, info in self.info.items():
+                    for entry in info:
+                        self.log("INFO:%s:%s" % (name, entry))
+                self.log("-"*50)
 
-        self.log("="*50)
+            is_good = all(len(fails) == 0 for fails in self.fails.values())
 
-        self.assertTrue(is_good, errors)
+            errors = ""
+            if not is_good:
+                self.log("-"*50)
+                self.log("Fails:")
+                self.log("-"*50)
+
+                errors = "\n\nSomething went wrong. Please check output below:\n\n"
+                for name, fails in self.fails.items():
+                    for fail in fails:
+                        self.log("FAILED:%s:%s" % (name, fail))
+                        errors += "FAILED:%s:%s\n" % (name, fail)
+
+            self.log("="*50)
+
+            self.assertTrue(is_good, errors)
 
     def extract_no_cpu_replies(self, arr):
       """
@@ -806,6 +809,10 @@ class ReloadTest(BaseTest):
         if stderr != []:
             self.log("stderr from %s: %s" % (self.reboot_type, str(stderr)))
         self.log("return code from %s: %s" % (self.reboot_type, str(return_code)))
+
+        # Note: a timeout reboot in ssh session will return a 255 code
+        if return_code not in [0, 255]:
+            thread.interrupt_main()
 
         return
 


### PR DESCRIPTION
Sample output
```
2018-12-10 19:33:31 : LACP/BGP were down for (extracted from cli):
2018-12-10 19:33:31 : --------------------------------------------------
2018-12-10 19:33:31 :     10.10.247.196 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)
```

BTW, the underlying command I am using
```
ARISTA03T1#show interface port-Channel 1 | json
{
    "interfaces": {
        "Port-Channel1": {
            "lastStatusChangeTimestamp": 1544502263.8816288,
```