### PR TITLE
Revert "[minigraph] always generate neighbor device information"

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -56,7 +56,7 @@
     connection: local
 
   - set_fact:
-      VM_topo: "True"
+      VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
       remote_dut: "{{ ansible_ssh_host }}"
 
   - name: gather testbed VM informations


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#757

There was flaw in my test. This change didn't fix the PTF topology minigraph loading issue. Sorry for the inconvenience.