### PR TITLE
Replace shutdown with reboot

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -63,7 +63,7 @@
 
         - name: Reboot the switch {{ inventory_hostname }}
           become: true
-          shell: shutdown -r now "Reboot"
+          shell: reboot
           async: 1
           poll: 0
           ignore_errors: true
@@ -77,7 +77,7 @@
         port: 22
         state: started
         search_regex: "OpenSSH"
-        delay: 30
+        delay: 180
         timeout: 600
       changed_when: false
 

--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -61,15 +61,18 @@
             disk_used_pcent: '{{disk_used_pcent}}'
             new_image_url: '{{ image_url }}'
 
+        # Reboot may need some time to update firmware firstly.
+        # Increasing the async time to 300 seconds to avoid reboot being interrupted.
         - name: Reboot the switch {{ inventory_hostname }}
           become: true
           shell: reboot
-          async: 1
+          async: 300
           poll: 0
           ignore_errors: true
 
       when: upgrade_type == "sonic"
 
+    # Delay 180 seconds to wait for firmware updating before reboot, then start polling switch
     - name: Wait for switch {{ inventory_hostname }} to come back (to SONiC)
       local_action: wait_for
       args:


### PR DESCRIPTION
The reboot command can do some additional work like firmware update.
Replaced the shutdown command with reboot. Increased the delay time
for checking switch connectivity after reboot to 3 minutes because of
potential firmware update.

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replaced the "shutdown -r now" command with "reboot". Increased the delay time for checking switch connectivity.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
