### PR TITLE
[warm/fast reboot] refactoring advanced-reboot script

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -724,7 +724,7 @@ class ReloadTest(BaseTest):
         thr.setDaemon(True)
 
         try:
-            pool = ThreadPool(processes=10)
+            pool = ThreadPool(processes=5)
             self.log("Starting reachability state watch thread...")
             self.watching = True
             watcher = pool.apply_async(self.reachability_watcher)

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -927,12 +927,18 @@ class ReloadTest(BaseTest):
 
         return recorded_time, nr_from_upper_array
 
-    def ping_iteration(self):
+    def ping_data_plane(self, force=False):
         replies_from_servers = self.pingFromServers()
-        if replies_from_servers > 0:
+        if replies_from_servers > 0 or force:
             replies_from_upper = self.pingFromUpperTier()
         else:
             replies_from_upper = 0
+
+        return replies_from_servers, replies_from_upper
+
+    def ping_iteration(self):
+        replies_from_servers, replies_from_upper = self.ping_data_plane()
+
         return replies_from_servers > 0 and replies_from_upper > 0, replies_from_upper
 
     def check_alive(self):
@@ -964,8 +970,7 @@ class ReloadTest(BaseTest):
         return False                        # we still see extra replies
 
     def ping_alive(self):
-        nr_from_s = self.pingFromServers()
-        nr_from_l = self.pingFromUpperTier()
+        nr_from_s, nr_from_l = self.ping_data_plane(True)
 
         is_alive      = nr_from_s > self.nr_pc_pkts * 0.7 and nr_from_l > self.nr_vl_pkts * 0.7
         is_asic_weird = nr_from_s > self.nr_pc_pkts        or nr_from_l > self.nr_vl_pkts

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -556,7 +556,7 @@ class ReloadTest(BaseTest):
             self.dataplane.start_pcap(filename)
 
         self.log("Enabling arp_responder")
-        self.cmd(["supervisorctl", "start", "arp_responder"])
+        self.cmd(["supervisorctl", "restart", "arp_responder"])
 
         return
 

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1085,16 +1085,16 @@ class ReloadTest(BaseTest):
         # changes for future analysis
 
         while self.watching:
-            vlan_to_t1, t1_to_vlan = self.ping_data_plane(True)
+            vlan_to_t1, t1_to_vlan = self.ping_data_plane(self.light_ping)
             reachable              = (t1_to_vlan  > 0 and vlan_to_t1 > 0  and
                                       t1_to_vlan  > self.nr_vl_pkts * 0.7 and
                                       vlan_to_t1  > self.nr_pc_pkts * 0.7)
-            partial                = (t1_to_vlan  > 0 and vlan_to_t1 > 0  and
+            partial                = (reachable and
                                       (t1_to_vlan < self.nr_vl_pkts or
                                        vlan_to_t1 < self.nr_pc_pkts))
             self.asic_flooding     = (reachable and
                                       (t1_to_vlan  > self.nr_vl_pkts or
-                                      vlan_to_t1  > self.nr_pc_pkts))
+                                       vlan_to_t1  > self.nr_pc_pkts))
             self.log_asic_state_change(reachable, partial, t1_to_vlan)
             total_rcv_pkt_cnt      = self.pingDut()
             reachable              = total_rcv_pkt_cnt > 0 and total_rcv_pkt_cnt > self.ping_dut_pkts * 0.7

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -126,6 +126,8 @@ class Arista(object):
         run_once = False
         log_first_line = None
         quit_enabled = False
+        v4_routing_ok = False
+        v6_routing_ok = False
         routing_works = True
         self.connect()
 
@@ -684,6 +686,7 @@ class ReloadTest(BaseTest):
         self.reboot_start = None
         no_routing_start = None
         no_routing_stop = None
+        no_cp_replies = None
 
         arista_vms = self.test_params['arista_vms'][1:-1].split(",")
         ssh_targets = []

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -709,6 +709,7 @@ class ReloadTest(BaseTest):
         self.assertTrue(self.check_alive(), 'DUT is not stable')
 
         try:
+            pool = ThreadPool(processes=10)
             self.log("Schedule to reboot the remote switch in %s sec" % self.reboot_delay)
             thr.start()
 
@@ -724,7 +725,6 @@ class ReloadTest(BaseTest):
             self.assertTrue(self.check_alive(), 'DUT is not stable')
 
             self.log("Wait until CPU port up")
-            pool = ThreadPool(processes=10)
             async_cpu_up = pool.apply_async(self.wait_until_cpu_port_up)
 
             self.log("Wait until ASIC stops")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -739,7 +739,7 @@ class ReloadTest(BaseTest):
             self.log("Schedule to reboot the remote switch in %s sec" % self.reboot_delay)
             thr.start()
 
-            self.log("Wait until CPU port down")
+            self.log("Wait until Control plane down")
             self.timeout(self.task_timeout, "DUT hasn't shutdown in %d seconds" % self.task_timeout)
             self.wait_until_cpu_port_down()
             self.cancel_timeout()
@@ -747,13 +747,13 @@ class ReloadTest(BaseTest):
             self.reboot_start = datetime.datetime.now()
             self.log("Dut reboots: reboot start %s" % str(self.reboot_start))
 
-            self.log("Check that device is still forwarding Data plane traffic")
+            self.log("Check that device is still forwarding data plane traffic")
             self.assertTrue(self.check_alive(), 'DUT is not stable')
 
-            self.log("Wait until CPU port up")
+            self.log("Wait until control plane up")
             async_cpu_up = pool.apply_async(self.wait_until_cpu_port_up)
 
-            self.log("Wait until ASIC stops")
+            self.log("Wait until data plane stops")
             async_forward_stop = pool.apply_async(self.check_forwarding_stop)
 
             try:
@@ -764,9 +764,9 @@ class ReloadTest(BaseTest):
 
             try:
                 no_routing_start, upper_replies = async_forward_stop.get(timeout=self.task_timeout)
-                self.log("ASIC was stopped, Waiting until it's up. Stop time: %s" % str(no_routing_start))
+                self.log("Data plane was stopped, Waiting until it's up. Stop time: %s" % str(no_routing_start))
             except TimeoutError:
-                self.log("ASIC never stop")
+                self.log("Data plane never stop")
                 no_routing_start = datetime.min
 
             if no_routing_start is not None:
@@ -794,7 +794,7 @@ class ReloadTest(BaseTest):
                 thr.join()
             self.cancel_timeout()
 
-            self.log("ASIC works again. Start time: %s" % str(no_routing_stop))
+            self.log("Data plane works again. Start time: %s" % str(no_routing_stop))
             self.log("")
 
             no_cp_replies = self.extract_no_cpu_replies(upper_replies)
@@ -1063,7 +1063,7 @@ class ReloadTest(BaseTest):
         self.try_record_asic_vlan_recachability(t1_to_vlan)
 
         if old != state:
-            self.log("ASIC state transition from %s to %s (%d)" % (old, state, t1_to_vlan))
+            self.log("Data plane state transition from %s to %s (%d)" % (old, state, t1_to_vlan))
             self.set_asic_state(state)
 
 
@@ -1076,7 +1076,7 @@ class ReloadTest(BaseTest):
             state = 'down'
 
         if old != state:
-            self.log("CPU state transition from %s to %s" % (old, state))
+            self.log("Control plane state transition from %s to %s" % (old, state))
             self.set_cpu_state(state)
 
 

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -724,7 +724,7 @@ class ReloadTest(BaseTest):
         thr.setDaemon(True)
 
         try:
-            pool = ThreadPool(processes=5)
+            pool = ThreadPool(processes=3)
             self.log("Starting reachability state watch thread...")
             self.watching = True
             watcher = pool.apply_async(self.reachability_watcher)

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1085,7 +1085,7 @@ class ReloadTest(BaseTest):
         # changes for future analysis
 
         while self.watching:
-            vlan_to_t1, t1_to_vlan = self.ping_data_plane(self.light_ping)
+            vlan_to_t1, t1_to_vlan = self.ping_data_plane(True)
             reachable              = (t1_to_vlan  > 0 and vlan_to_t1 > 0  and
                                       t1_to_vlan  > self.nr_vl_pkts * 0.7 and
                                       vlan_to_t1  > self.nr_pc_pkts * 0.7)

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -734,6 +734,7 @@ class ReloadTest(BaseTest):
 
             self.log("Check that device is alive and pinging")
             self.assertTrue(self.check_alive(), 'DUT is not stable')
+            self.assertTrue(self.get_cpu_state() == 'up' and self.get_asic_state() == 'up', 'DUT is not ready for test')
 
             self.log("Schedule to reboot the remote switch in %s sec" % self.reboot_delay)
             thr.start()

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -579,6 +579,10 @@ class ReloadTest(BaseTest):
     def tearDown(self):
         self.log("Disabling arp_responder")
         self.cmd(["supervisorctl", "stop", "arp_responder"])
+
+        # Stop watching DUT
+        self.watching = False
+
         if config["log_dir"] != None:
             self.dataplane.stop_pcap()
         self.log_fp.close()
@@ -809,6 +813,9 @@ class ReloadTest(BaseTest):
                 self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (no_cp_replies, self.nr_vl_pkts))
 
         finally:
+            # Stop watching DUT
+            self.watching = False
+
             # Generating report
             self.log("="*50)
             self.log("Report:")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1086,8 +1086,7 @@ class ReloadTest(BaseTest):
 
         while self.watching:
             vlan_to_t1, t1_to_vlan = self.ping_data_plane(True)
-            reachable              = (t1_to_vlan  > 0 and vlan_to_t1 > 0  and
-                                      t1_to_vlan  > self.nr_vl_pkts * 0.7 and
+            reachable              = (t1_to_vlan  > self.nr_vl_pkts * 0.7 and
                                       vlan_to_t1  > self.nr_pc_pkts * 0.7)
             partial                = (reachable and
                                       (t1_to_vlan < self.nr_vl_pkts or

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -803,7 +803,7 @@ class ReloadTest(BaseTest):
                 self.fails['dut'].add("Downtime must be less then %s seconds. It was %s" \
                         % (self.test_params['reboot_limit_in_seconds'], str(no_routing_stop - no_routing_start)))
             if no_routing_stop - self.reboot_start > datetime.timedelta(seconds=self.test_params['graceful_limit']):
-                self.fails['dut'].add("Fast-reboot cycle must be less than graceful limit %s seconds" % self.test_params['graceful_limit'])
+                self.fails['dut'].add("%s cycle must be less than graceful limit %s seconds" % (self.reboot_type, self.test_params['graceful_limit']))
             if no_cp_replies < 0.95 * self.nr_vl_pkts:
                 self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (no_cp_replies, self.nr_vl_pkts))
 

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -703,7 +703,7 @@ class ReloadTest(BaseTest):
             self.ssh_jobs.append((thr, q))
             thr.start()
 
-        thr = threading.Thread(target=self.background)
+        thr = threading.Thread(target=self.reboot_dut)
         thr.setDaemon(True)
         self.log("Check that device is alive and pinging")
         self.assertTrue(self.check_alive(), 'DUT is not stable')
@@ -855,7 +855,7 @@ class ReloadTest(BaseTest):
       else:
           return non_zero[-1]
 
-    def background(self):
+    def reboot_dut(self):
         time.sleep(self.reboot_delay)
 
         self.log("Rebooting remote side")


### PR DESCRIPTION
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
At high level, this change addresses a few issues I encountered when running fast-reboot test. As it stands now, the script hasn't been fully adapted to support warm-reboot yet.

Issues addressed:
- When having more than one thread sending data plane/control plane probes, they will all fail due to not getting all responses back.
- Some minor issues that shows up randomly.

Approach taking:
- Introduced a watcher thread to send probes and analyze results. Then update states accordingly.
- Other parties who requires information can start thread to wait for certain state change. But don't send probe IO themselves.

#### How did you verify/test it?
- passed fast-reboot test multiple times on one platform.