### PR TITLE
[dhcp_relay] skip teamd restart test in dhcp_relay test

### DIFF
--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -48,6 +48,13 @@
       - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
     ptf_extra_options: "--relax"
 
+
+# FIXME: don't run teamd service restart tests until teamd supports restart
+- debug: msg="end play here until SONiC supports teamd restart."
+
+- action: skip
+
+
 # Service restart and service stop -> start exhibited different behaviors.
 # Therefore testing them separately.
 - name: Restart teamd on DUT


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Approach
#### How did you do it?
SONiC is currently not supporting teamd restart. Skip the test until the support is in place.

#### How did you verify/test it?
Passed dhcp_relay test on my dut with the change.
