### PR TITLE
[ warm-reboot ] adapted advanced-reboot for warm-reboot 

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -862,7 +862,7 @@ class ReloadTest(BaseTest):
                 examine_start = datetime.datetime.now()
                 self.log("Packet flow examine started %s after the reboot" % str(examine_start - self.reboot_start))
                 self.examine_flow()
-                self.log("Packet flow examine finished %s after" % str(datetime.datetime.now() - examine_start))
+                self.log("Packet flow examine finished after %s" % str(datetime.datetime.now() - examine_start))
 
                 if self.lost_packets:
                     no_routing_stop, no_routing_start = datetime.datetime.fromtimestamp(self.no_routing_stop), datetime.datetime.fromtimestamp(self.no_routing_start)

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1038,7 +1038,7 @@ class ReloadTest(BaseTest):
         if not packets_list:
             packets_list = self.packets_list
         sender_start = datetime.datetime.now()
-        self.log("Sender started %s at" % str(sender_start))
+        self.log("Sender started at %s" % str(sender_start))
         for entry in packets_list:
             time.sleep(interval)
             testutils.send_packet(self, *entry)
@@ -1053,7 +1053,7 @@ class ReloadTest(BaseTest):
         if not wait:
             wait = self.time_to_listen + 30
         sniffer_start = datetime.datetime.now()
-        self.log("Sniffer started %s at" % str(sniffer_start))
+        self.log("Sniffer started at %s" % str(sniffer_start))
         filename = '/tmp/capture.pcap'
         sniff_filter = "udp and udp dst port 5000 and udp src port 1234 and not icmp"
         self.packets = scapyall.sniff(timeout = wait, filter = sniff_filter)

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -145,7 +145,7 @@
         - verbose=False
         - dut_username=\"{{ ansible_ssh_user }}\"
         - dut_hostname=\"{{ ansible_host }}\"
-        - reboot_limit_in_seconds=30
+        - reboot_limit_in_seconds={{ reboot_limit }}
         - reboot_type=\"{{ reboot_type }}\"
         - portchannel_ports_file=\"/tmp/portchannel_interfaces.json\"
         - vlan_ports_file=\"/tmp/vlan_interfaces.json\"
@@ -161,6 +161,13 @@
     - name: Copy test results from ptf to the local box /tmp/reboot.log
       fetch: src='/tmp/reboot.log' dest='/tmp/' flat=true fail_on_missing=false
       delegate_to: "{{ ptf_host }}"
+
+    - name: Copy pcap files from ptf to the local box /tmp/
+      fetch: src={{ item }} dest='/tmp/' flat=true fail_on_missing=false
+      delegate_to: "{{ ptf_host }}"
+      with_items:
+        - "/tmp/capture.pcap"
+        - "/tmp/capture_filtered.pcap"
 
     - name: Remove existing ip from ptf host
       script: roles/test/files/helpers/remove_ip.sh

--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -7,4 +7,3 @@
   include: advanced-reboot.yml
   vars:
       reboot_type: fast-reboot
-      reboot_limit: reboot_limit

--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -1,5 +1,10 @@
+- name: set default reboot_limit in seconds
+  set_fact:
+      reboot_limit: 30
+  when: reboot_limit is not defined
+
 - name: Fast-reboot test
   include: advanced-reboot.yml
   vars:
       reboot_type: fast-reboot
-
+      reboot_limit: reboot_limit

--- a/ansible/roles/test/tasks/warm-reboot.yml
+++ b/ansible/roles/test/tasks/warm-reboot.yml
@@ -7,4 +7,3 @@
   include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
-      reboot_limit: reboot_limit

--- a/ansible/roles/test/tasks/warm-reboot.yml
+++ b/ansible/roles/test/tasks/warm-reboot.yml
@@ -1,5 +1,10 @@
+- name: set default reboot_limit in seconds
+  set_fact:
+      reboot_limit: 0
+  when: reboot_limit is not defined
+
 - name: Warm-reboot test
   include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
-
+      reboot_limit: reboot_limit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Support of warm-reboot for the advanced-reboot test.
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Advanced reboot now may be called from ansible playbook as next:
_ansible-playbook ... -e testcase_name=[ warm-reboot | fast-reboot ] [ -e reboot_limit=1 ]_ 

_warm-reboot.yml_ and _fast-reboot.yml_ now both call _advanced-reboot.yml_ with values: 
- **reboot_type** (fast-reboot or warm-reboot, defined in _fast-reboot.yml_ and _warm-reboot.yml_, accordingly).
- **reboot_limit** (time in seconds, which defines the limit in which the chosen reboot must fit),
    Default value (if not given explicitly by ansible-playbook) are: **30** for fast_reboot, **0** for warm-reboot (defined in _fast-reboot.yml_ and _warm-reboot.yml_, accordingly).

_advanced-reboot.yml_ calls _advanced-reboot.py_ with the above values (**reboot_type**, **reboot_limit**).

_advanced-reboot.py_ for the warm-reboot has now different flow (switched from the previous fast-reboot flow by _if_).

The flow of warm-reboot is next:
**577:** During the setUp phase, pre-generate a bidirectional list of packets (t1<->vlan) to be sent later in background. IP address randomization is the same as in _generate_from_t1_.
The beforehand pre-generation will save a time for the PTF docker later, and focus it on fast sending of ready packets.
Functionality implemented in line 722.

RunTest phase:
1. **823:** Switch the generic flow to fast-reboot only.
Fast-reboot implementation has not been affected neither changed.
2. **856:** Switch the generic flow to warm-reboot:
- Stop the watcher (it was used to detect Control Plane down, and not needed further in warm-reboot flow).
- Start two background threads for 180 seconds:
     One sending pre-generated packet list (implementation in line 1032).
     Another - captures in/out traffic on PTF, and dump it to a pcap file for later debugging (implementation in line 1047).
- Examine the captured traffic (implementation in line 1105):
      Identify the longest (by continuous packets losses and duration) disruption.
      Calculate total packets looses and total duration of all disruptions.
3. **875:** back to generic flow.

#### How did you verify/test it?

1. I ran the playbook with -e testcase_name=warm-reboot
2. I ran the playbook with -e testcase_name=fast-reboot
3. I ran the playbook with -e testcase_name=fast-reboot being directed to warm-reboot flow
(to check if warm-reboot flow is suitable for fast reboot as well).
4. I ran the playbook with -e testcase_name=warm-reboot being redirected to the temporary flow without reboot
(to check if the test shows no disruptions when a reboot actually does not happen).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
I ran the test only on T0 topology.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
