### PR TITLE
[reboot_sonic] Fix reboot task

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -13,13 +13,37 @@
 
 - name: "rebooting {{ inventory_hostname }} : {{ ansible_host }} with {{ reboot_type }}..."
   command: "{{ reboot_type }}"
-  async: 1
+  async: 300
   poll: 0
   become: yes
+  register: reboot_task
   ignore_errors: true
 
-- name: pause for 1 minute before check
-  pause: minutes=1
+- block:
+  - name: "Wait for switch to shutdown"
+    become: false
+    local_action: wait_for
+    args:
+      host: "{{ ansible_host }}"
+      port: 22
+      state: absent
+      search_regex: "OpenSSH_[\\w\\.]+ Debian"
+      delay: 10
+      timeout: 180
+    changed_when: false
+
+  rescue:
+
+  - name: 'Poll reboot task status'
+    become: yes
+    async_status:
+      jid: "{{ reboot_task.ansible_job_id }}"
+    register: reboot_result
+    ignore_errors: true
+
+  - name: 'Fail if {{ reboot_type }} failed'
+    fail:
+       msg: "{{ reboot_result.stderr }}"
 
 - name: Wait for switch to come back
   become: false


### PR DESCRIPTION
Increase async task timeout since reboot may take more than 1 sec
Wait for SSH to shutdown, if timeout exceed poll reboot task status 
If reboot failed ansible will fail with error message extracted from reboot

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
