### PR TITLE
Fix extract log task in advanced-reboot test

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -188,6 +188,9 @@ def extract_latest_line_with_string(directory, filenames, start_string):
         if comparator(line, target) > 0:
             target = line
 
+    if target is None:
+        raise Exception("{} was not found in {}".format(start_string, directory))
+
     return target
 
 

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -170,7 +170,7 @@
       extract_log:
         directory: '/var/log'
         file_prefix: 'syslog'
-        start_string: 'Initializing cgroup subsys cpuset'
+        start_string: 'Linux version'
         target_filename: '/tmp/syslog'
       become: yes
 


### PR DESCRIPTION
1. Fix issue in extract_log.py module - raise specific
   exception when start_string was not found
2. After upgrade to 4.9 "Initialize cgroup subsys cpuset"
   is not present in syslog at startup. Replace with
   "Linux version" which should work for both debian 8/9

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix extract log task in advanced-reboot test
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
1. Fix issue in extract_log.py module - raise specific
   exception when start_string was not found
2. After upgrade to 4.9 "Initialize cgroup subsys cpuset"
   is not present in syslog at startup. Replace with
   "Linux version" which should work for both debian 8/9

Linux 4.9:
```
Jan 17 16:40:07.697449 mts-sonic-dut INFO systemd[1]: Stopping OpenBSD Secure Shell server...
Jan 17 16:46:33.787276 mts-sonic-dut INFO systemd-udevd[277]: Network interface NamePolicy= disabled on kernel command line, ignoring.
Jan 17 16:46:33.788464 mts-sonic-dut ERR systemd-udevd[277]: invalid key/value pair in file /lib/udev/rules.d/50-mellanox-system-event.rules on line 242, starting at character 120 (',')
Jan 17 16:46:33.788482 mts-sonic-dut ERR systemd-udevd[277]: invalid key/value pair in file /lib/udev/rules.d/50-mellanox-system-event.rules on line 243, starting at character 120 (',')
Jan 17 16:46:33.788491 mts-sonic-dut INFO systemd[1]: Starting Flush Journal to Persistent Storage...
Jan 17 16:46:33.788501 mts-sonic-dut INFO netfilter-persistent[276]: run-parts: executing /usr/share/netfilter-persistent/plugins.d/15-ip4tables start
Jan 17 16:46:33.788509 mts-sonic-dut INFO systemd[1]: Started Flush Journal to Persistent Storage.
Jan 17 16:46:33.788522 mts-sonic-dut INFO systemd[1]: Starting Create Volatile Files and Directories...
Jan 17 16:46:33.788533 mts-sonic-dut INFO systemd[1]: Started Create Volatile Files and Directories.
Jan 17 16:46:33.788542 mts-sonic-dut INFO systemd[1]: Reached target System Time Synchronized.
Jan 17 16:46:33.788550 mts-sonic-dut INFO netfilter-persistent[276]: run-parts: executing /usr/share/netfilter-persistent/plugins.d/25-ip6tables start
Jan 17 16:46:33.788559 mts-sonic-dut INFO systemd[1]: Starting Update UTMP about System Boot/Shutdown...
Jan 17 16:46:33.788567 mts-sonic-dut INFO netfilter-persistent[276]: Warning: skipping IPv6 (no rules to load)
Jan 17 16:46:33.788578 mts-sonic-dut INFO systemd[1]: Started netfilter persistent configuration.
Jan 17 16:46:33.788586 mts-sonic-dut INFO systemd[1]: Reached target Network (Pre).
Jan 17 16:46:33.788594 mts-sonic-dut INFO systemd[1]: Started Update UTMP about System Boot/Shutdown.
Jan 17 16:46:33.788602 mts-sonic-dut INFO systemd[1]: Started udev Coldplug all Devices.
Jan 17 16:46:33.788610 mts-sonic-dut INFO apparmor[274]: Starting AppArmor profiles:.
Jan 17 16:46:33.788618 mts-sonic-dut INFO systemd[1]: Started AppArmor initialization.
Jan 17 16:46:33.788629 mts-sonic-dut INFO systemd[1]: Starting Raise network interfaces...
Jan 17 16:46:33.788637 mts-sonic-dut INFO systemd[1]: Reached target System Initialization.
Jan 17 16:46:33.788645 mts-sonic-dut INFO systemd[1]: Started Delays snmp container until SONiC has started.
Jan 17 16:46:33.788652 mts-sonic-dut INFO systemd[1]: Started Daily Cleanup of Temporary Directories.
Jan 17 16:46:33.788660 mts-sonic-dut INFO systemd[1]: apt-daily.timer: Adding 5h 42min 43.904746s random time.
Jan 17 16:46:33.788667 mts-sonic-dut INFO systemd[1]: Started Daily apt download activities.
Jan 17 16:46:33.788675 mts-sonic-dut INFO systemd[1]: Listening on D-Bus System Message Bus Socket.
Jan 17 16:46:33.788686 mts-sonic-dut INFO systemd[1]: Reached target Sockets.
Jan 17 16:46:33.788694 mts-sonic-dut INFO systemd[1]: apt-daily-upgrade.timer: Adding 30min 53.184515s random time.
Jan 17 16:46:33.788701 mts-sonic-dut INFO systemd[1]: Started Daily apt upgrade and clean activities.
Jan 17 16:46:33.788709 mts-sonic-dut INFO systemd[1]: Reached target Timers.
Jan 17 16:46:33.788717 mts-sonic-dut INFO systemd[1]: Reached target Basic System.
Jan 17 16:46:33.788724 mts-sonic-dut INFO systemd[1]: Starting Login Service...
Jan 17 16:46:33.788732 mts-sonic-dut INFO systemd[1]: Starting LSB: Set sysfs variables from /etc/sysfs.conf...
Jan 17 16:46:33.788742 mts-sonic-dut INFO systemd[1]: Starting System Logging Service...
Jan 17 16:46:33.788750 mts-sonic-dut INFO systemd[1]: Starting LSB: service and resource monitoring daemon...
Jan 17 16:46:33.788758 mts-sonic-dut INFO systemd[1]: Started D-Bus System Message Bus.
Jan 17 16:46:33.787600 mts-sonic-dut INFO liblogging-stdlog:  [origin software="rsyslogd" swVersion="8.24.0" x-pid="355" x-info="http://www.rsyslog.com"] start
Jan 17 16:46:33.788325 mts-sonic-dut NOTICE kernel: [    0.000000] Linux version 4.9.0-8-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19)
Jan 17 16:46:33.788782 mts-sonic-dut INFO kernel: [    0.000000] Command line: BOOT_IMAGE=/image-develop.0-38bc3b8/boot/vmlinuz-4.9.0-8-amd64 root=/dev/sda3 rw console=tty0 console=ttyS0,9600n8 quiet net.ifnames=0 biosdevname=0 loop=image-develop.0-38bc3b8/fs.squashfs loopfstype=squashfs apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 acpi_enforce_resources=lax acpi=noirq

```

Linux 3.16
```
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] Initializing cgroup subsys cpuset
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] Initializing cgroup subsys cpu
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] Initializing cgroup subsys cpuacct
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] Linux version 3.16.0-6-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.2 (Debian 4.9.2-10+deb8u1) ) #1 SMP Debian 3.16.57-2 (2015-12-19)
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] Command line: BOOT_IMAGE=/image-HEAD.106-69d5d61/boot/vmlinuz-3.16.0-6-amd64 root=/dev/sda3 rw console=tty0 console=ttyS0,9600n8 quiet loop=image-HEAD.106-69d5d61/fs.squashfs loopfstype=squashfs apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 acpi_enforce_resources=lax acpi=noirq
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] e820: BIOS-provided physical RAM map:
Jan 15 09:35:30 mtbc-sonic-03-2700 kernel: [    0.000000] BIOS-e820: [mem 0x0000000000000000-0x0000000000099bff] usable

```

#### How did you verify/test it?
Run fast/warm-reboot tests and observe no failure in extract_log task

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
