### PR TITLE
[arp] Replace ifconfig cmd with config interface command

### DIFF
--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -35,7 +35,7 @@
       when: po1 is defined
 
     - name: bring {{ intf1 }} up
-      shell: ifconfig {{ intf1 }} up
+      shell: config interface {{ intf1 }} startup
       become: yes
       when: po1 is defined
 
@@ -51,16 +51,16 @@
       when: po2 is defined
 
     - name: bring {{ intf2 }} up
-      shell: ifconfig {{ intf2 }} up
+      shell: config interface {{ intf2 }} startup
       become: yes
       when: po2 is defined
 
     - name: change SONiC DUT interface IP to test IP address
-      command: /sbin/ifconfig  {{ intf1 }} 10.10.1.2 netmask 255.255.255.240
+      command: config interface {{ intf1 }} ip add 10.10.1.2/28
       become: yes
 
     - name: change SONiC DUT interface IP to test IP address
-      command: /sbin/ifconfig {{ intf2 }} 10.10.1.20 netmask 255.255.255.240
+      command: config interface {{ intf2 }} ip add 10.10.1.20/28
       become: yes
 
     - name: wait for interfaces to be up after removed from portchannel


### PR DESCRIPTION
If use ifconfig to configure IP address or startup interface,
the unicast ARP reply case may fail. Possibly interface was not in
proper state and failed to reply.

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The arp testcase failed ocassionally. Command `ifconfig` is used to startup and configure IP address for interfaces. The formal way is to use the `config interface` command. Possibly interface was not in proper status if it is configured by `ifconfig`.

This change replace the `ifconfig` command with more formal `config interface`.

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Changed `ifconfig` to more formal `config interface` for startup and configuring interfaces.

#### How did you verify/test it?
Run the script on Mellanox switches and the script passed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
