### PR TITLE
[fdb_mac_expire.yml]: FDB MAC Expire test case.

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb_mac_expire_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_mac_expire_test.py
@@ -1,0 +1,37 @@
+import fdb
+
+import ptf
+import ptf.packet as scapy
+import ptf.dataplane as dataplane
+
+from ptf import config
+from ptf.base_tests import BaseTest
+from ptf.testutils import *
+
+class FdbMacExpireTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = test_params_get()
+    #--------------------------------------------------------------------------
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.router_mac = self.test_params['router_mac']
+        self.dummy_mac_prefix = self.test_params['dummy_mac_prefix']
+        self.fdb_info = self.test_params['fdb_info']
+    #--------------------------------------------------------------------------
+    def populateFdb(self):
+        self.fdb = fdb.Fdb(self.fdb_info)
+        vlan_table = self.fdb.get_vlan_table()
+        for vlan in vlan_table:
+            for member in vlan_table[vlan]:
+                mac = self.dummy_mac_prefix + ":" + "{:02X}".format(member)
+                # Send a packet to switch to populate the layer 2 table
+                pkt = simple_eth_packet(eth_dst=self.router_mac,
+                                        eth_src=mac,
+                                        eth_type=0x1234)
+                send(self, member, pkt)
+    #--------------------------------------------------------------------------
+    def runTest(self):
+        self.populateFdb()
+	return
+    #--------------------------------------------------------------------------

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -22,7 +22,7 @@
   template: src=roles/test/templates/fdb.j2 dest=/root/fdb_info.txt
   delegate_to: "{{ ptf_host }}"
 
-- name: sonic-clear fdb all
+- name: Clear FDB table
   shell: sonic-clear fdb all
 
   # Change the config, populate fdb and observe expire time
@@ -110,6 +110,6 @@
       when: "show_mac_after_wait|int == 0"
 
   always:
-    - name: sonic-clear fdb all
+    - name: Clear FDB table
       shell: sonic-clear fdb all
 

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -23,6 +23,22 @@
 - name: clear fdb all
   shell: clear fdb all
 
+- name: copy current switch.json from docker to host
+  shell: docker cp swss:/etc/swss/config.d/switch.json .
+
+- name: set fdb value to "{{fdb_aging_time}}"
+  replace:
+    dest: switch.json
+    regexp: '"fdb_aging_time": ".*"'
+    replace: '"fdb_aging_time": "{{fdb_aging_time}}"'
+  become: true
+
+- name: copy current switch.json from docker to host
+  shell: docker cp switch.json swss:/etc/swss/config.d/switch.json
+
+- name: run swssconfig switch.json command in container swss
+  shell: docker exec -it swss bash -c "swssconfig /etc/swss/config.d/switch.json"
+
 - name: set dummy mac prefix to look for in mac table
   set_fact: dummy_mac_prefix="00:11:22:33:44"
 
@@ -55,34 +71,37 @@
 
 - debug: msg="{{show_mac_output}}"
 
-- name: wait for 300 secs
-  pause: seconds=300
+- name: wait for "{{fdb_aging_time}}" secs
+  pause: seconds="{{fdb_aging_time}}"
 
-# check mac table after > 300 secs wait
 - name: check entries in mac table after wait
   shell: show mac | grep {{dummy_mac_prefix}} | wc -l
-  register: show_mac_after_300s
+  register: show_mac_after_wait
 
-- debug: msg="{{show_mac_after_300s}}"
+- debug: msg="{{show_mac_after_wait}}"
 
-# wait in slot of 15 secs (after 300 secs) to find when MAC expires
+- name: set extra wait time period
+  set_fact:
+    extra_retries: "{{fdb_aging_time|int / 15}}"
+
+# wait in slot of 15 secs to find when MAC expires
 - block:
-    - name: check in mac table after 300 secs to find exact time (300-600 secs)
+    - name: check in mac table after "{{fdb_aging_time}}" secs to find exact time
       shell: show mac | grep {{dummy_mac_prefix}} | wc -l
-      register: show_mac_300_600s
-      until: "show_mac_300_600s.stdout|int == 0"
-      retries: 20
+      register: show_mac_after_more_wait
+      until: "show_mac_after_more_wait.stdout|int == 0"
+      retries: "{{extra_retries|int}}"
       delay: 15
 
     - fail:
         msg: "MAC Entires are not cleaned even after 600+ secs"
-      when: "show_mac_300_600s.stdout|int > 0"
+      when: "show_mac_after_more_wait.stdout|int > 0"
 
-    - debug: msg="MAC Entires are Cleared within 300-600 secs."
-  when: "show_mac_after_300s|int > 0"
+    - debug: msg="MAC Entires are Cleared within 2*"{{fdb_aging_time}}" secs."
+  when: "show_mac_after_wait|int > 0"
 
-- debug: msg="MAC Entires are Cleared around 300secs."
-  when: "show_mac_after_300s|int == 0"
+- debug: msg="MAC Entires are Cleared "{{fdb_aging_time}}" secs."
+  when: "show_mac_after_more_wait|int == 0"
 
 - always:
     - name: clear fdb all

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -94,13 +94,13 @@
       delay: 15
 
     - fail:
-        msg: "MAC Entires are not cleaned even after 2*"{{fdb_aging_time}}" secs"
+        msg: "MAC Entires are not cleaned even after {{2*fdb_aging_time|int}} secs"
       when: "show_mac_after_more_wait.stdout|int > 0"
 
-    - debug: msg="MAC Entires are Cleared within 2*"{{fdb_aging_time}}" secs."
+    - debug: msg="MAC Entires are Cleared within {{2*fdb_aging_time|int}} secs."
   when: "show_mac_after_wait|int > 0"
 
-- debug: msg="MAC Entires are Cleared "{{fdb_aging_time}}" secs."
+- debug: msg="MAC Entires are Cleared {{fdb_aging_time}} secs."
   when: "show_mac_after_more_wait|int == 0"
 
 - always:

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -4,10 +4,12 @@
 - fail: msg="testbed_type {{test_type}} is invalid"
   when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116']
 
-- include_vars: "vars/topo_{{testbed_type}}.yml"
+- name: set fdb_aging_time to default if no user input
+  set_fact:
+    fdb_aging_time: 60
+  when: fdb_aging_time is not defined
 
-- name: Expand properties into props
-  set_fact: props="{{configuration_properties['common']}}"
+- include_vars: "vars/topo_{{testbed_type}}.yml"
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}
@@ -20,90 +22,94 @@
   template: src=roles/test/templates/fdb.j2 dest=/root/fdb_info.txt
   delegate_to: "{{ ptf_host }}"
 
-- name: clear fdb all
-  shell: clear fdb all
+- name: sonic-clear fdb all
+  shell: sonic-clear fdb all
 
-- name: copy current switch.json from docker to host
-  shell: docker cp swss:/etc/swss/config.d/switch.json .
-
-- name: set fdb value to "{{fdb_aging_time}}"
-  replace:
-    dest: switch.json
-    regexp: '"fdb_aging_time": ".*"'
-    replace: '"fdb_aging_time": "{{fdb_aging_time}}"'
-  become: true
-
-- name: copy current switch.json from host to docker
-  shell: docker cp switch.json swss:/etc/swss/config.d/switch.json
-
-- name: run swssconfig switch.json command in container swss
-  shell: docker exec -it swss bash -c "swssconfig /etc/swss/config.d/switch.json"
-
-- name: set dummy mac prefix to look for in mac table
-  set_fact: dummy_mac_prefix="00:11:22:33:44"
-
-- name: check entries in mac table before adding dummy mac
-  shell: show mac | grep {{dummy_mac_prefix}} | wc -l
-  register: show_mac_output
-  failed_when: "show_mac_output.stdout|int > 0"
-
-- debug: msg="{{show_mac_output.stdout}}"
-
-- name: "Start PTF runner"
-  include: ptf_runner.yml
-  vars:
-    ptf_test_name: FDB Mac Expire test
-    ptf_test_dir: ptftests
-    ptf_test_path: fdb_mac_expire_test.FdbMacExpireTest
-    ptf_platform: remote
-    ptf_platform_dir: ptftests
-    ptf_test_params:
-      - testbed_type='{{testbed_type}}'
-      - router_mac='{{ansible_Ethernet0['macaddress']}}'
-      - fdb_info='/root/fdb_info.txt'
-      - dummy_mac_prefix='{{dummy_mac_prefix}}'
-    ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_mac_expire_test.FdbMacExpireTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
-
-- name: check entries in mac table after adding dummy mac
-  shell: show mac | grep {{dummy_mac_prefix}} | wc -l
-  register: show_mac_output
-  failed_when: "show_mac_output.stdout|int == 0"
-
-- debug: msg="{{show_mac_output}}"
-
-- name: wait for "{{fdb_aging_time}}" secs
-  pause: seconds="{{fdb_aging_time}}"
-
-- name: check entries in mac table after wait
-  shell: show mac | grep {{dummy_mac_prefix}} | wc -l
-  register: show_mac_after_wait
-
-- debug: msg="{{show_mac_after_wait}}"
-
-- name: set extra wait time period
-  set_fact:
-    extra_retries: "{{fdb_aging_time|int / 15}}"
-
-# wait in slot of 15 secs to find when MAC expires
+  # Change the config, populate fdb and observe expire time
 - block:
-    - name: check in mac table after "{{fdb_aging_time}}" secs to find exact time
+    - name: copy current switch.json from docker to host
+      shell: docker cp swss:/etc/swss/config.d/switch.json .
+
+    - name: set fdb value to "{{fdb_aging_time}}"
+      replace:
+        dest: switch.json
+        regexp: '"fdb_aging_time": ".*"'
+        replace: '"fdb_aging_time": "{{fdb_aging_time}}"'
+      become: true
+
+    - name: copy current switch.json from host to docker
+      shell: docker cp switch.json swss:/etc/swss/config.d/switch.json
+
+    - name: run swssconfig switch.json command in container swss
+      shell: docker exec swss bash -c "swssconfig /etc/swss/config.d/switch.json"
+
+    - name: set dummy mac prefix to look for in mac table
+      set_fact: dummy_mac_prefix="00:11:22:33:44"
+
+    - name: check entries in mac table before adding dummy mac
       shell: show mac | grep {{dummy_mac_prefix}} | wc -l
-      register: show_mac_after_more_wait
-      until: "show_mac_after_more_wait.stdout|int == 0"
-      retries: "{{extra_retries|int}}"
-      delay: 15
+      register: show_mac_output
+      failed_when: "show_mac_output.stdout|int > 0"
 
-    - fail:
-        msg: "MAC Entires are not cleaned even after {{2*fdb_aging_time|int}} secs"
-      when: "show_mac_after_more_wait.stdout|int > 0"
+    - debug: msg="{{show_mac_output.stdout}}"
 
-    - debug: msg="MAC Entires are Cleared within {{2*fdb_aging_time|int}} secs."
-  when: "show_mac_after_wait|int > 0"
+    - name: "Start PTF runner"
+      include: ptf_runner.yml
+      vars:
+        ptf_test_name: FDB Mac Expire test
+        ptf_test_dir: ptftests
+        ptf_test_path: fdb_mac_expire_test.FdbMacExpireTest
+        ptf_platform: remote
+        ptf_platform_dir: ptftests
+        ptf_test_params:
+          - testbed_type='{{testbed_type}}'
+          - router_mac='{{ansible_Ethernet0['macaddress']}}'
+          - fdb_info='/root/fdb_info.txt'
+          - dummy_mac_prefix='{{dummy_mac_prefix}}'
+        ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_mac_expire_test.FdbMacExpireTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
-- debug: msg="MAC Entires are Cleared {{fdb_aging_time}} secs."
-  when: "show_mac_after_more_wait|int == 0"
+    - name: check entries in mac table after adding dummy mac
+      shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+      register: show_mac_output
+      failed_when: "show_mac_output.stdout|int == 0"
 
-- always:
-    - name: clear fdb all
-      shell: clear fdb all
+    - debug: msg="{{show_mac_output}}"
+
+    - name: wait for "{{fdb_aging_time}}" secs
+      pause: seconds="{{fdb_aging_time}}"
+
+    - name: check entries in mac table after wait
+      shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+      register: show_mac_after_wait
+
+    - debug: msg="{{show_mac_after_wait}}"
+
+    - name: set extra wait time period
+      set_fact:
+        extra_retries: "{{fdb_aging_time|int / 15 + 1}}"
+
+    - debug: msg="{{extra_retries}}"
+
+      # wait in slot of 15 secs to find when MAC expires
+    - block:
+        - name: check in mac table after "{{fdb_aging_time}}" secs to find exact time
+          shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+          register: show_mac_after_more_wait
+          until: "show_mac_after_more_wait.stdout|int == 0"
+          retries: "{{extra_retries|int}}"
+          delay: 15
+
+        - fail:
+            msg: "MAC Entires are not cleaned even after {{2*fdb_aging_time|int}} secs"
+          when: "show_mac_after_more_wait.stdout|int > 0"
+
+        - debug: msg="MAC Entires are Cleared within {{2*fdb_aging_time|int}} secs."
+      when: "show_mac_after_wait|int > 0"
+
+    - debug: msg="MAC Entires are Cleared {{fdb_aging_time}} secs."
+      when: "show_mac_after_wait|int == 0"
+
+  always:
+    - name: sonic-clear fdb all
+      shell: sonic-clear fdb all
 

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -33,7 +33,7 @@
     replace: '"fdb_aging_time": "{{fdb_aging_time}}"'
   become: true
 
-- name: copy current switch.json from docker to host
+- name: copy current switch.json from host to docker
   shell: docker cp switch.json swss:/etc/swss/config.d/switch.json
 
 - name: run swssconfig switch.json command in container swss
@@ -94,7 +94,7 @@
       delay: 15
 
     - fail:
-        msg: "MAC Entires are not cleaned even after 600+ secs"
+        msg: "MAC Entires are not cleaned even after 2*"{{fdb_aging_time}}" secs"
       when: "show_mac_after_more_wait.stdout|int > 0"
 
     - debug: msg="MAC Entires are Cleared within 2*"{{fdb_aging_time}}" secs."

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -1,0 +1,90 @@
+- fail: msg="testbed_type is not defined"
+  when: testbed_type is not defined
+
+- fail: msg="testbed_type {{test_type}} is invalid"
+  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116']
+
+- include_vars: "vars/topo_{{testbed_type}}.yml"
+
+- name: Expand properties into props
+  set_fact: props="{{configuration_properties['common']}}"
+
+- name: Gather minigraph facts about the device
+  minigraph_facts: host={{inventory_hostname}}
+
+- name: Copy tests to PTF
+  copy: src=roles/test/files/ptftests dest=/root
+  delegate_to: "{{ptf_host}}"
+
+- name: Copy FDB information file to PTF
+  template: src=roles/test/templates/fdb.j2 dest=/root/fdb_info.txt
+  delegate_to: "{{ ptf_host }}"
+
+- name: clear fdb all
+  shell: clear fdb all
+
+- name: set dummy mac prefix to look for in mac table
+  set_fact: dummy_mac_prefix="00:11:22:33:44"
+
+- name: check entries in mac table before adding dummy mac
+  shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+  register: show_mac_output
+  failed_when: "show_mac_output.stdout|int > 0"
+
+- debug: msg="{{show_mac_output.stdout}}"
+
+- name: "Start PTF runner"
+  include: ptf_runner.yml
+  vars:
+    ptf_test_name: FDB Mac Expire test
+    ptf_test_dir: ptftests
+    ptf_test_path: fdb_mac_expire_test.FdbMacExpireTest
+    ptf_platform: remote
+    ptf_platform_dir: ptftests
+    ptf_test_params:
+      - testbed_type='{{testbed_type}}'
+      - router_mac='{{ansible_Ethernet0['macaddress']}}'
+      - fdb_info='/root/fdb_info.txt'
+      - dummy_mac_prefix='{{dummy_mac_prefix}}'
+    ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_mac_expire_test.FdbMacExpireTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
+
+- name: check entries in mac table after adding dummy mac
+  shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+  register: show_mac_output
+  failed_when: "show_mac_output.stdout|int == 0"
+
+- debug: msg="{{show_mac_output}}"
+
+- name: wait for 300 secs
+  pause: seconds=300
+
+# check mac table after > 300 secs wait
+- name: check entries in mac table after wait
+  shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+  register: show_mac_after_300s
+
+- debug: msg="{{show_mac_after_300s}}"
+
+# wait in slot of 15 secs (after 300 secs) to find when MAC expires
+- block:
+    - name: check in mac table after 300 secs to find exact time (300-600 secs)
+      shell: show mac | grep {{dummy_mac_prefix}} | wc -l
+      register: show_mac_300_600s
+      until: "show_mac_300_600s.stdout|int == 0"
+      retries: 20
+      delay: 15
+
+    - fail:
+        msg: "MAC Entires are not cleaned even after 600+ secs"
+      when: "show_mac_300_600s.stdout|int > 0"
+
+    - debug: msg="MAC Entires are Cleared within 300-600 secs."
+  when: "show_mac_after_300s|int > 0"
+
+- debug: msg="MAC Entires are Cleared around 300secs."
+  when: "show_mac_after_300s|int == 0"
+
+- always:
+    - name: clear fdb all
+      shell: clear fdb all
+

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -109,6 +109,7 @@ testcases:
       filename: fdb_mac_expire.yml
       topologies: [t0, t0-64, t0-64-32, t0-116]
       required_vars:
+          fdb_aging_time:
           ptf_host:
           testbed_type:
 

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -105,6 +105,13 @@ testcases:
           ptf_host:
           testbed_type:
 
+    fdb_mac_expire:
+      filename: fdb_mac_expire.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116]
+      required_vars:
+          ptf_host:
+          testbed_type:
+
     dir_bcast:
       filename: dir_bcast.yml
       topologies: [t0, t0-16, t0-64, t0-64-32, t0-116]


### PR DESCRIPTION
[fdb_mac_expire.yml]: FDB MAC Expire test case.
[fdb_mac_expire_test.py]: PTF helper to add Mac in L2 table.
[fdb.yml]: include fdb_mac_expire.yml.

This test case verifies that MAC expires within 10 mins if traffic
is not flowing using it.

Signed-off-by: Praveen Chaudhary<pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Test Case for https://github.com/Azure/sonic-buildimage/pull/2365
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Added new file fdb_mac_expire.yml to keep FDB MAC Expire test case separate.
[fdb_mac_expire_test.py]: PTF helper to add dummy Macs in L2 table. I used separate ptf file to generate traffic for dummy mac.
[fdb.yml]: include fdb_mac_expire.yml. I included fdb_mac_expire.yml with condition when parameter run_fdb_mac_expire is set to True.

Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [.] Test case(new/improvement)

### Approach
#### How did you do it?
Added new file fdb_mac_expire.yml to keep FDB MAC Expire test case separate.
[fdb_mac_expire_test.py]: PTF helper to add Mac in L2 table. I used separate ptf file to generate traffic for dummy mac.
[fdb.yml]: include fdb_mac_expire.yml. I included fdb_mac_expire.yml with condition when parameter run_fdb_mac_expire is set to True.

#### How did you verify/test it?
Results:
Had T0 FDB run:
Snippet from Run:
```
TASK [test : Include fdb_mac_expire.yml] ***************************************

Friday 18 January 2019  19:48:31 +0000 (0:00:00.084)       0:00:29.393 ********

included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/fdb_mac_expire.yml for falco-test-dut01


TASK [test : clear fdb all] ****************************************************

Friday 18 January 2019  19:48:32 +0000 (0:00:00.678)       0:00:30.071 ********

changed: [falco-test-dut01]


TASK [test : set dummy mac prefix to look for in mac table] ********************

Friday 18 January 2019  19:48:33 +0000 (0:00:00.959)       0:00:31.031 ********

ok: [falco-test-dut01]


TASK [test : check entries in mac table before adding dummy mac] ***************

Friday 18 January 2019  19:48:33 +0000 (0:00:00.180)       0:00:31.211 ********

changed: [falco-test-dut01]


TASK [test : debug] ************************************************************Friday 18 January 2019  19:48:34 +0000 (0:00:01.208)       0:00:32.419 ********

ok: [falco-test-dut01] => {
    "msg": "0"
}


TASK [test : Start PTF runner] *************************************************

Friday 18 January 2019  19:48:35 +0000 (0:00:00.166)       0:00:32.585 ********

included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/ptf_runner.yml for falco-test-dut01


TASK [test : fail] *************************************************************

Friday 18 January 2019  19:48:35 +0000 (0:00:00.417)       0:00:33.003 ********

skipping: [falco-test-dut01]


TASK [test : PTF Test - FDB Mac Expire test] ***********************************

Friday 18 January 2019  19:48:35 +0000 (0:00:00.194)       0:00:33.198 ********

ok: [falco-test-dut01] => {
    "msg": "ptf --test-dir ptftests fdb_mac_expire_test.FdbMacExpireTest   --platform-dir ptftests  --platform remote  -t \"testbed_type='t0';router_mac='00:e0:ec:5a:7c:ac';fdb_info='/root/fdb_info.txt';dummy_mac_prefix='00:11:22:33:44'\"  --relax --debug info --log-file /tmp/fdb_mac_expire_test.FdbMacExpireTest.2019-01-18-19:48:35.log  --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre 2>&1"
}


TASK [test : command] **********************************************************

Friday 18 January 2019  19:48:35 +0000 (0:00:00.266)       0:00:33.464 ********

changed: [falco-test-dut01 -> 172.25.11.190]


TASK [test : debug] ************************************************************

Friday 18 January 2019  19:48:37 +0000 (0:00:01.357)       0:00:34.822 ********

ok: [falco-test-dut01] => {
    "out.stdout_lines": [
        "WARNING: No route found for IPv6 destination :: (no default route?)",
        "fdb_mac_expire_test.FdbMacExpireTest ... ok",
        "",
        "----------------------------------------------------------------------",
        "Ran 1 test in 0.018s",
        "",
        "OK"
    ]
}
TASK [test : fail] *************************************************************

Friday 18 January 2019  19:48:37 +0000 (0:00:00.252)       0:00:35.075 ********

skipping: [falco-test-dut01]


TASK [test : check entries in mac table after adding dummy mac] ****************

Friday 18 January 2019  19:48:37 +0000 (0:00:00.190)       0:00:35.266 ********

changed: [falco-test-dut01]


TASK [test : debug] ************************************************************

Friday 18 January 2019  19:48:38 +0000 (0:00:01.136)       0:00:36.402 ********

ok: [falco-test-dut01] => {
    "msg": {
        "changed": true,
        "cmd": "show mac | grep 00:11:22:33:44 | wc -l",
        "delta": "0:00:00.757353",
        "end": "2019-01-18 19:48:46.947363",
        "failed": false,
        "failed_when_result": false,
        "rc": 0,
        "start": "2019-01-18 19:48:46.190010",
        "stderr": "",
        "stdout": "1",        "stdout_lines": [
            "1"
        ],
        "warnings": []
    }
}


TASK [test : wait for 300 secs] ************************************************

Friday 18 January 2019  19:48:38 +0000 (0:00:00.108)       0:00:36.510 ********

Pausing for 300 seconds

(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)

ok: [falco-test-dut01]


TASK [test : check entries in mac table after wait] ****************************

Friday 18 January 2019  19:53:39 +0000 (0:05:00.121)       0:05:36.631 ********

changed: [falco-test-dut01]


TASK [test : debug] ************************************************************

Friday 18 January 2019  19:53:40 +0000 (0:00:01.256)       0:05:37.888 ********
ok: [falco-test-dut01] => {
    "msg": {
        "changed": true,
        "cmd": "show mac | grep 00:11:22:33:44 | wc -l",
        "delta": "0:00:00.769846",
        "end": "2019-01-18 19:53:48.449176",
        "rc": 0,
        "start": "2019-01-18 19:53:47.679330",
        "stderr": "",
        "stdout": "1",
        "stdout_lines": [
            "1"
        ],
        "warnings": []
    }
}


TASK [test : check in mac table after 300 secs to find exact time (300-600 secs)] ***

Friday 18 January 2019  19:53:40 +0000 (0:00:00.107)       0:05:37.995 ********

skipping: [falco-test-dut01]


TASK [test : fail] *************************************************************

Friday 18 January 2019  19:53:40 +0000 (0:00:00.128)       0:05:38.124 ********

skipping: [falco-test-dut01]

TASK [test : debug] ************************************************************

Friday 18 January 2019  19:53:40 +0000 (0:00:00.202)       0:05:38.327 ********

skipping: [falco-test-dut01]


TASK [test : debug] ************************************************************

Friday 18 January 2019  19:53:40 +0000 (0:00:00.115)       0:05:38.442 ********

ok: [falco-test-dut01] => {
    "msg": "MAC Entires are Cleared around 300secs."
}


TASK [test : clear fdb all] ****************************************************

Friday 18 January 2019  19:53:41 +0000 (0:00:00.151)       0:05:38.594 ********

changed: [falco-test-dut01]


TASK [test : do basic sanity check after each test] ****************************

Friday 18 January 2019  19:53:41 +0000 (0:00:00.920)       0:05:39.515 ********

included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/base_sanity.yml for falco-test-dut01


TASK [test : Get process information in syncd docker] **************************

Friday 18 January 2019  19:53:42 +0000 (0:00:00.690)       0:05:40.205 ********

changed: [falco-test-dut01]


TASK [test : debug] ************************************************************

Friday 18 January 2019  19:53:43 +0000 (0:00:00.600)       0:05:40.806 ********

ok: [falco-test-dut01] => {
    "ps_out.stdout_lines": [
        "root        20  0.0  0.0  41584  2740 ?        Sl   18:51   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -p /etc/sai.d/sai.profile",
        "root        30 12.2  4.7 1065684 193832 ?      Sl   18:51   7:36 /usr/bin/syncd --diag -p /etc/sai.d/sai.profile",
        "root        51  0.0  5.0 759364 202260 ?       S    18:51   0:02 /usr/bin/syncd --diag -p /etc/sai.d/sai.profile"
    ]
}


TASK [test : Get orchagent process information] ********************************

Friday 18 January 2019  19:53:43 +0000 (0:00:00.102)       0:05:40.908 ********

changed: [falco-test-dut01]



……………………….
………………
Friday 18 January 2019  19:53:55 +0000 (0:00:00.071)       0:05:52.710 ********

===============================================================================

TASK: test : wait for 300 secs ---------------------------------------- 300.12s

TASK: setup ------------------------------------------------------------- 5.78s

TASK: test : Get interface facts ---------------------------------------- 5.26s

TASK: test : Get interface facts ---------------------------------------- 5.21s

TASK: test : Copy tests to PTF ------------------------------------------ 3.72s

TASK: test : Verify port channel interfaces are up correctly ------------ 1.83s

TASK: test : gather system version information -------------------------- 1.40s

TASK: test : command ---------------------------------------------------- 1.36s

TASK: test : check entries in mac table after wait ---------------------- 1.26s

TASK: test : check entries in mac table before adding dummy mac --------- 1.21s

TASK: test : Verify port channel interfaces are up correctly ------------ 1.15s
TASK: test : check entries in mac table after adding dummy mac ---------- 1.14s

TASK: test : clear fdb all ---------------------------------------------- 0.96s

TASK: test : validate all interfaces are up after test ------------------ 0.94s

TASK: test : clear fdb all ---------------------------------------------- 0.92s

TASK: test : Get process information in syncd docker -------------------- 0.69s

TASK: test : do basic sanity check after each test ---------------------- 0.69s

TASK: test : Include fdb_mac_expire.yml --------------------------------- 0.68s

TASK: test : Get process information in syncd docker -------------------- 0.60s

TASK: test : run test case {{ testcases[testcase_name]['filename'] }} file --- 0.58s

Done

(82, 0)
----------------------------------------------------------------------------------------------------
Summary:
----------------------------------------------------------------------------------------------------
TestSuite: fdb       Pass: 82                   Fail: 0

----------------------------------------------------------------------------------------------------
```

TestCase Result Update after Changes done to address Review Comment:
snippet:

```
TASK [test : Gather minigraph facts about the device] ****

Thursday 10 January 2019  21:03:06 +0000 (0:00:00.101)       0:00:29.488 ** 

ok: [falco-test-dut01]


TASK [test : Copy tests to PTF] ********

Thursday 10 January 2019  21:03:07 +0000 (0:00:00.617)       0:00:30.105 ** 

ok: [falco-test-dut01 -> 172.25.11.190]


TASK [test : Copy FDB information file to PTF] *****

Thursday 10 January 2019  21:03:10 +0000 (0:00:03.259)       0:00:33.365 ** 

ok: [falco-test-dut01 -> 172.25.11.190]


TASK [test : clear fdb all] **********

Thursday 10 January 2019  21:03:10 +0000 (0:00:00.325)       0:00:33.691 ** 

changed: [falco-test-dut01]


TASK [test : set dummy mac prefix to look for in mac table] ****

Thursday 10 January 2019  21:03:12 +0000 (0:00:01.237)       0:00:34.928 ** 

ok: [falco-test-dut01]


TASK [test : check entries in mac table before adding dummy mac] ***

Thursday 10 January 2019  21:03:12 +0000 (0:00:00.111)       0:00:35.039 ** 

changed: [falco-test-dut01]


TASK [test : debug] ************

Thursday 10 January 2019  21:03:13 +0000 (0:00:01.568)       0:00:36.608 ** 

ok: [falco-test-dut01] => {
    "msg": "0"
}


TASK [test : Start PTF runner] *******

Thursday 10 January 2019  21:03:13 +0000 (0:00:00.091)       0:00:36.699 ** 

included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/ptf_runner.yml for falco-test-dut01


TASK [test : fail] *********

Thursday 10 January 2019  21:03:14 +0000 (0:00:00.321)       0:00:37.020 ** 

skipping: [falco-test-dut01]


TASK [test : PTF Test - FDB Mac Expire test] *****

Thursday 10 January 2019  21:03:14 +0000 (0:00:00.105)       0:00:37.125 ** 

ok: [falco-test-dut01] => {
    "msg": "ptf --test-dir ptftests fdb_mac_expire_test.FdbMacExpireTest   --platform-dir ptftests  --platform remote  -t \"testbed_type='t0';router_mac='00:e0:ec:5a:7c:ac';fdb_info='/root/fdb_info.txt';dummy_mac_prefix='00:11:22:33:44'\"  --relax --debug info --log-file /tmp/fdb_mac_expire_test.FdbMacExpireTest.2019-01-10-21:03:14.log  --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre 2>&1"
}


TASK [test : command] **********

Thursday 10 January 2019  21:03:14 +0000 (0:00:00.170)       0:00:37.296 ** 

changed: [falco-test-dut01 -> 172.25.11.190]


TASK [test : debug] ************

Thursday 10 January 2019  21:03:15 +0000 (0:00:01.224)       0:00:38.521 ** 

ok: [falco-test-dut01] => {
    "out.stdout_lines": [
        "WARNING: No route found for IPv6 destination :: (no default route?)", 
        "fdb_mac_expire_test.FdbMacExpireTest ... ok", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 0.012s", 
        "", 
        "OK"
    ]
}


TASK [test : fail] *********

Thursday 10 January 2019  21:03:15 +0000 (0:00:00.147)       0:00:38.668 ** 

skipping: [falco-test-dut01]


TASK [test : check entries in mac table after adding dummy mac] ****

Thursday 10 January 2019  21:03:15 +0000 (0:00:00.105)       0:00:38.773 ** 

changed: [falco-test-dut01]


TASK [test : debug] ************

Thursday 10 January 2019  21:03:17 +0000 (0:00:01.581)       0:00:40.355 ** 

ok: [falco-test-dut01] => {
    "msg": {
        "changed": true, 
        "cmd": "show mac | grep 00:11:22:33:44 | wc -l", 
        "delta": "0:00:01.164202", 
        "end": "2019-01-10 21:03:23.931254", 
        "failed": false, 
        "failed_when_result": false, 
        "rc": 0, 
        "start": "2019-01-10 21:03:22.767052", 
        "stderr": "", 
        "stdout": "1", 
        "stdout_lines": [
            "1"
        ], 
        "warnings": []
    }
}


TASK [test : wait for 303 secs] ********

Thursday 10 January 2019  21:03:17 +0000 (0:00:00.085)       0:00:40.440 ** 

Pausing for 303 seconds

(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)

ok: [falco-test-dut01]


TASK [test : check entries in mac table after wait] ****

Thursday 10 January 2019  21:08:20 +0000 (0:05:03.084)       0:05:43.525 ** 

changed: [falco-test-dut01]


TASK [test : debug] ************

Thursday 10 January 2019  21:08:22 +0000 (0:00:01.712)       0:05:45.237 ** 

ok: [falco-test-dut01] => {
    "msg": {
        "changed": true, 
        "cmd": "show mac | grep 00:11:22:33:44 | wc -l", 
        "delta": "0:00:01.161600", 
        "end": "2019-01-10 21:08:28.820977", 
        "rc": 0, 
        "start": "2019-01-10 21:08:27.659377", 
        "stderr": "", 
        "stdout": "1", 
        "stdout_lines": [
            "1"
        ], 
        "warnings": []
    }
}


TASK [test : check in mac table after failure to find exact time (300-600 secs)] ***

Thursday 10 January 2019  21:08:22 +0000 (0:00:00.080)       0:05:45.318 ** 

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (19 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:08:30.486417', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:08:29.325817', u'stderr': u'', u'delta': u'0:00:01.160600', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (18 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:08:47.002005', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:08:45.835631', u'stderr': u'', u'delta': u'0:00:01.166374', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (17 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:09:03.513023', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:09:02.353425', u'stderr': u'', u'delta': u'0:00:01.159598', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (16 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:09:20.030499', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:09:18.860738', u'stderr': u'', u'delta': u'0:00:01.169761', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (15 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:09:36.547583', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:09:35.381684', u'stderr': u'', u'delta': u'0:00:01.165899', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (14 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:09:53.062671', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:09:51.901323', u'stderr': u'', u'delta': u'0:00:01.161348', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (13 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:10:09.581060', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:10:08.413343', u'stderr': u'', u'delta': u'0:00:01.167717', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (12 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:10:26.100625', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:10:24.933232', u'stderr': u'', u'delta': u'0:00:01.167393', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

FAILED - RETRYING: TASK: test : check in mac table after failure to find exact time (300-600 secs) (11 retries left). Result was: {u'changed': True, u'end': u'2019-01-10 21:10:42.635189', u'stdout': u'1', u'cmd': u'show mac | grep 00:11:22:33:44 | wc -l', u'rc': 0, u'start': u'2019-01-10 21:10:41.453279', u'stderr': u'', u'delta': u'0:00:01.181910', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'show mac | grep 00:11:22:33:44 | wc -l', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'1'], u'warnings': []}

changed: [falco-test-dut01]


TASK [test : fail] *********

Thursday 10 January 2019  21:10:52 +0000 (0:02:30.380)       0:08:15.699 ** 

skipping: [falco-test-dut01]


TASK [test : clear fdb all] **********

Thursday 10 January 2019  21:10:52 +0000 (0:00:00.124)       0:08:15.823 ** 

changed: [falco-test-dut01]
```

----------------------------------------
Test results summary after commit 9:
----------------------------------------
```Thursday 11 April 2019  18:02:46 +0000 (0:00:00.055)       0:02:21.185 ******** 

=============================================================================== 

TASK: test : wait for "{{fdb_aging_time}}" secs ------------------------ 60.11s

TASK: test : check in mac table after "{{fdb_aging_time}}" secs to find exact time -- 32.81s

TASK: setup ------------------------------------------------------------- 4.84s

TASK: test : Get interface facts ---------------------------------------- 4.58s

TASK: test : Get interface facts ---------------------------------------- 4.39s

TASK: test : Copy tests to PTF ------------------------------------------ 2.97s

TASK: test : Verify port channel interfaces are up correctly ------------ 1.91s

TASK: test : command ---------------------------------------------------- 1.30s

TASK: test : gather system version information -------------------------- 1.19s

TASK: test : Verify port channel interfaces are up correctly ------------ 1.07s

TASK: test : check entries in mac table before adding dummy mac --------- 1.00s

TASK: test : check entries in mac table after adding dummy mac ---------- 0.99s

TASK: test : copy current switch.json from host to docker --------------- 0.99s

TASK: test : check entries in mac table after wait ---------------------- 0.99s

TASK: test : validate all interfaces are up after test ------------------ 0.93s

TASK: test : do basic sanity check after each test ---------------------- 0.85s

TASK: test : run test case {{ testcases[testcase_name]['filename'] }} file --- 0.84s

TASK: test : sonic-clear fdb all ---------------------------------------- 0.79s

TASK: test : sonic-clear fdb all ---------------------------------------- 0.78s

TASK: test : Get process information in syncd docker -------------------- 0.64s

Done

(93, 0)
----------------------------------------------------------------------------------------------------
Summary:
----------------------------------------------------------------------------------------------------
TestSuite: fdb_mac_expire       Pass: 93                   Fail: 0              
```

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
T0

### Documentation 
Part of FDB.
Related PR: https://github.com/Azure/sonic-buildimage/pull/2365
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->