### PR TITLE
[warm-reboot] Change no_routing_stop/start type to datetime

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -884,7 +884,7 @@ class ReloadTest(BaseTest):
                     self.log("Total disruptions count is %d. All disruptions lasted %.3f seconds. Total %d packet(s) lost" % \
                         (self.disrupts_count, self.total_disrupt_time, self.total_disrupt_packets))
                 else:
-                    no_routing_stop, no_routing_start = 0, 0
+                    no_routing_stop, no_routing_start = self.reboot_start, self.reboot_start
 
             # wait until all bgp session are established
             self.log("Wait until bgp routing is up on all devices")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Changed initialization of empty no_routing_stop, no_routing_start
from `no_routing_stop, no_routing_start = 0, 0`
to `no_routing_stop, no_routing_start = self.reboot_start, self.reboot_start`
In this case default (empty) _no_routing_stop_, _no_routing_start_ point to the same datetime  _self.reboot_start_, and no to _0_.

Exception happens when disruptions do not happen, and the test tries to compare
_no_reboot_start_ and _no_reboot_stop_ (which were integer) with _self.limit_ which is datetime.timedelta
`if no_routing_stop - no_routing_start > self.limit:", "TypeError: can't compare datetime.timedelta to int"`
#### How did you verify/test it?
Run warm-reboot test, specially when disruptions do not happen
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Tested on T0.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
