### PR TITLE
[acl] Add ACL rules to allow BGP traffic

### DIFF
--- a/ansible/roles/test/tasks/acl/acltb_test_rules.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules.json
@@ -201,6 +201,36 @@
                                         "source-ip-address": "10.0.0.2/32"
                                     }
                                 }
+                            },
+                            "14": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 27
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "179"
+                                    }
+                                }
+                            },
+                            "15": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 28
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "179"
+                                    }
+                                }
                             }
                         }
                     }

--- a/ansible/roles/test/tasks/acl/acltb_test_rules_part_2.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules_part_2.json
@@ -201,6 +201,36 @@
                                         "source-ip-address": "10.0.0.2/32"
                                     }
                                 }
+                            },
+                            "14": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 27
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "179"
+                                    }
+                                }
+                            },
+                            "15": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 28
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "179"
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The current set of ACL rules will block BGP traffic. All the routes
learned via BGP will timeout after the ACL rules are loaded. Then
there is no route for the PTF injected packets. Packets accepted by
ACL rules would not be forwarded anyway. This update is to add two
ACL rules to allow BGP traffic.

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The current set of ACL rules will block BGP traffic. All the routes
learned via BGP will timeout after the ACL rules are loaded. Then
there is no route for the PTF injected packets. Packets accepted by
ACL rules would not be forwarded anyway. This update is to add two
ACL rules to allow BGP traffic.

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add two ACL rules to always alow BGP traffic.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
