### PR TITLE
[everflow] Check asic_type rather than hwsku for Mellanox platform

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_tb_test.py
+++ b/ansible/roles/test/files/acstests/everflow_tb_test.py
@@ -142,7 +142,7 @@ class EverflowTest(BaseTest):
 
         payload = str(scapy_pkt[scapy.GRE].payload)
 
-        if self.hwsku in ["ACS-MSN2700", "ACS-MSN2100", "ACS-MSN2410", "ACS-MSN2740", "Mellanox-SN2700"]:
+        if self.asic_type in ["mellanox"]:
             payload = str(scapy_pkt[scapy.GRE].payload)[22:]
         if self.asic_type in ["barefoot"]:
             payload = str(scapy_pkt[scapy.GRE].payload)[12:]


### PR DESCRIPTION
The current logic of determining Mellanox platform by checking hwsku
against a hardcoded list of platforms is not flexible enough. Use
asic_type to determine platform type is more flexible. When a new
hwsku is added, just need to add the new hwsku into a central place:
ansible/group_vars/sonic/vars

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The current logic of determining Mellanox platform by checking hwsku
against a hardcoded list of platforms is not flexible enough. Use
asic_type to determine platform type is more flexible. When a new
hwsku is added, just need to add the new hwsku into a central place:
ansible/group_vars/sonic/vars

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replace checking hwsku against a hard coded list of models with checking asic_type.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
