### PR TITLE
[snmp] Improve the error handling of snmp pfc_counters check

### DIFF
--- a/ansible/roles/test/tasks/snmp/pfc_counters.yml
+++ b/ansible/roles/test/tasks/snmp/pfc_counters.yml
@@ -7,5 +7,9 @@
 # Ignore management ports, assuming the names starting with 'eth', eg. eth0
 - fail:
     msg: "Port {{ item.key }} does not have PFC counters"
-  when: (not item.value.name.startswith("eth")) and (not item.value.cpfcIfRequests or not item.value.cpfcIfIndications or not item.value.requestsPerPriority or not item.value.indicationsPerPriority)
+  when: "{{ (not item.value.name.startswith('eth')) and
+            ('cpfcIfRequests' not in item.value.keys() or
+             'cpfcIfIndications' not in item.value.keys() or
+             'requestsPerPriority' not in item.value.keys() or
+             'indicationsPerPriority' not in item.value.keys()) }}"
   with_dict: "{{ snmp_interfaces }}"


### PR DESCRIPTION
The snmp pfc_counter check is to validate if the interfaces have
expected attributes. However, when expected attributes are missing, the
script failed with error "'dict object' has no attribute". This change
improved the error handling using a more robust syntax.

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The snmp pfc_counter check is to validate if the interfaces have
expected attributes. However, when expected attributes are missing, the
script failed with error "'dict object' has no attribute". This change
improved the error handling using a more robust syntax.

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Improve the checking of expected interface attributes using a more robust syntax.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
