### PR TITLE
[ansible] increase ansible cache timeout to 20 minutes

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -157,7 +157,7 @@ callback_whitelist = profile_tasks
 # current IP information.
 fact_caching = jsonfile
 fact_caching_connection = ~/.ansible/cache
-fact_caching_timeout = 600
+fact_caching_timeout = 1200
 
 
 # retry files


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Ansible timeout internal variables in cache in 10 minutes by default. However, we have some playbooks run more more than 10 minutes and would lose some ansible variables during execution. The error message wasn't super clear. It would be something like following:

fatal: [host_name]: FAILED! => {"failed": true, "msg": "ERROR! 'ansible_Ethernet0' is undefined"}

And the line number would point at the next task after the task actually took too long.

Warm reboot test could take up to 11 minutes to complete and it triggered this caching issue sometimes.

#### How did you verify/test it?
warm reboot test fails before the change and passes after the change.