### PR TITLE
[vxlan_decap]: Fix import issue for the scapy module

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -15,6 +15,7 @@ import sys
 import os.path
 import json
 import ptf
+import ptf.packet as scapy
 from ptf.base_tests import BaseTest
 from ptf import config
 import ptf.testutils as testutils


### PR DESCRIPTION
Fix the following issue:
AttributeError: 'module' object has no attribute 'Ether'

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
