### PR TITLE
Ignore TTL for encap packet, revised safe limit check for ARP packets

### DIFF
--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -86,7 +86,7 @@ class ARPResponder(object):
 
     def action(self, interface):
         data = interface.recv()
-        if len(data) >= self.ARP_PKT_LEN:
+        if len(data) > self.ARP_PKT_LEN:
             return
 
         remote_mac, remote_ip, request_ip = self.extract_arp_info(data)

--- a/ansible/roles/test/files/ptftests/vnet_vxlan.py
+++ b/ansible/roles/test/files/ptftests/vnet_vxlan.py
@@ -330,6 +330,7 @@ class VNET(BaseTest):
             masked_exp_pkt = Mask(encap_pkt)
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
             masked_exp_pkt.set_do_not_care_scapy(scapy.UDP, "sport")
 
             log_str = "Sending packet from port " + str('eth%d' % test['port']) + " to " + test['dst']


### PR DESCRIPTION
### Description of PR

- Ignore TTL for encap packet for Vxlan tunnel. 
- Revised the check to discard ARP packets exceeding the default length

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach

#### How did you do it?

#### How did you verify/test it?
Run ansible test

#### Any platform specific information?
Different platforms (MLNX, BF) encode different outer TTL values (64, 255..) if not configured. This is to ignore explicitly checking for outer TTL for different platforms. 

#### Supported testbed topology if it's a new test case?
T0 and variants

### Documentation 

