### PR TITLE
[fdb] Extend the FDB scripts to cover more MACs

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_test.py
@@ -10,8 +10,6 @@ from ptf.testutils import *
 
 class FdbTest(BaseTest):
 
-    DUMMY_MAC_NUMBER = 10
-
     def __init__(self):
         BaseTest.__init__(self)
         self.test_params = test_params_get()
@@ -34,6 +32,7 @@ class FdbTest(BaseTest):
         self.fdb = fdb.Fdb(self.test_params['fdb_info'])
         self.vlan_ip = ip_address(unicode(self.test_params['vlan_ip']))
         self.dummy_mac_prefix = self.test_params["dummy_mac_prefix"]
+        self.dummy_mac_number = int(self.test_params["dummy_mac_number"])
         self.dummy_mac_table = {}
 
         self.setUpFdb()
@@ -55,7 +54,7 @@ class FdbTest(BaseTest):
                 # Send packets to switch to populate the layer 2 table with dummy MACs for each port
                 # Totally 10 dummy MACs for each port, send 1 packet for each dummy MAC
                 dummy_macs = [self.dummy_mac_prefix + ":{:02x}:{:02x}".format(member, i)
-                              for i in range(self.DUMMY_MAC_NUMBER)]
+                              for i in range(self.dummy_mac_number)]
                 self.dummy_mac_table[member] = dummy_macs
                 for dummy_mac in dummy_macs:
                     pkt = simple_eth_packet(eth_dst=self.test_params['router_mac'],

--- a/ansible/roles/test/files/ptftests/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_test.py
@@ -15,6 +15,9 @@ from ptf.base_tests import BaseTest
 from ptf.testutils import *
 
 class FdbTest(BaseTest):
+
+    DUMMY_MAC_NUMBER = 10
+
     def __init__(self):
         BaseTest.__init__(self)
         self.test_params = test_params_get()
@@ -36,16 +39,10 @@ class FdbTest(BaseTest):
         self.dataplane = ptf.dataplane_instance
         self.fdb = fdb.Fdb(self.test_params['fdb_info'])
         self.vlan_ip = ip_address(unicode(self.test_params['vlan_ip']))
+        self.dummy_mac_prefix = self.test_params["dummy_mac_prefix"]
+        self.dummy_mac_table = {}
 
         self.setUpFdb()
-
-        self.log("Start arp_responder")
-        self.shell(["supervisorctl", "start", "arp_responder"])
-    #--------------------------------------------------------------------------
-
-    def tearDown(self):
-        self.log("Stop arp_responder")
-        self.shell(["supervisorctl", "stop", "arp_responder"])
     #--------------------------------------------------------------------------
 
     def setUpFdb(self):
@@ -55,27 +52,22 @@ class FdbTest(BaseTest):
                 mac = self.dataplane.get_mac(0, member)
                 self.fdb.insert(mac, member)
 
-                # Send a packet to switch to populate the layer 2 table
+                # Send a packet to switch to populate the layer 2 table with MAC of PTF interface
                 pkt = simple_eth_packet(eth_dst=self.test_params['router_mac'],
                                         eth_src=mac,
                                         eth_type=0x1234)
                 send(self, member, pkt)
-    #--------------------------------------------------------------------------
 
-    def setUpArpResponder(self):
-        vlan_table = self.fdb.get_vlan_table()
-        arp_table = self.fdb.get_arp_table()
-        d = defaultdict(list)
-        for vlan in vlan_table:
-            network = ip_network(vlan)
-            length = int(network[-1]) - int(network[0])
-            index = 1
-            for member in vlan_table[vlan]:
-                iface = "eth%d" % member
-                index = index + 1 if network[index + 1] != self.vlan_ip else index + 2
-                d[iface].append(str(network[index]))
-        with open('/tmp/from_t1.json', 'w') as file:
-            json.dump(d, file)
+                # Send packets to switch to populate the layer 2 table with dummy MACs for each port
+                # Totally 10 dummy MACs for each port, send 1 packet for each dummy MAC
+                dummy_macs = [self.dummy_mac_prefix + ":{:02x}:{:02x}".format(member, i)
+                              for i in range(self.DUMMY_MAC_NUMBER)]
+                self.dummy_mac_table[member] = dummy_macs
+                for dummy_mac in dummy_macs:
+                    pkt = simple_eth_packet(eth_dst=self.test_params['router_mac'],
+                                            eth_src=dummy_mac,
+                                            eth_type=0x1234)
+                    send(self, member, pkt)
     #--------------------------------------------------------------------------
 
     def check_route(self, src_mac, dst_mac, src_port, dst_port):
@@ -94,4 +86,7 @@ class FdbTest(BaseTest):
             for src in vlan_table[vlan]:
                 for dst in [i for i in vlan_table[vlan] if i != src]:
                     self.check_route(arp_table[src], arp_table[dst], src, dst)
+
+                    for dummy_mac in self.dummy_mac_table[dst]:
+                        self.check_route(arp_table[src], dummy_mac, src, dst)
     #--------------------------------------------------------------------------

--- a/ansible/roles/test/files/ptftests/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_test.py
@@ -1,16 +1,10 @@
 import fdb
-import json
-import logging
 import subprocess
 
-from collections import defaultdict
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address
 
 import ptf
-import ptf.packet as scapy
-import ptf.dataplane as dataplane
 
-from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.testutils import *
 
@@ -70,7 +64,7 @@ class FdbTest(BaseTest):
                     send(self, member, pkt)
     #--------------------------------------------------------------------------
 
-    def check_route(self, src_mac, dst_mac, src_port, dst_port):
+    def test_l2_forwarding(self, src_mac, dst_mac, src_port, dst_port):
         pkt = simple_eth_packet(eth_dst=dst_mac,
                                 eth_src=src_mac,
                                 eth_type=0x1234)
@@ -85,8 +79,8 @@ class FdbTest(BaseTest):
         for vlan in vlan_table:
             for src in vlan_table[vlan]:
                 for dst in [i for i in vlan_table[vlan] if i != src]:
-                    self.check_route(arp_table[src], arp_table[dst], src, dst)
+                    self.test_l2_forwarding(arp_table[src], arp_table[dst], src, dst)
 
                     for dummy_mac in self.dummy_mac_table[dst]:
-                        self.check_route(arp_table[src], dummy_mac, src, dst)
+                        self.test_l2_forwarding(arp_table[src], dummy_mac, src, dst)
     #--------------------------------------------------------------------------

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -4,60 +4,49 @@
 - fail: msg="testbed_type {{test_type}} is invalid"
   when: testbed_type not in ['t0', 't0-64', 't0-116']
 
-- include_vars: "vars/topo_{{testbed_type}}.yml"
-
-- name: Expand properties into props
-  set_fact: props="{{configuration_properties['common']}}"
-
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}
 
-- name: Remove existing IPs from PTF host
-  script: roles/test/files/helpers/remove_ip.sh
-  delegate_to: "{{ptf_host}}"
+- block:
+  - name: Remove existing IPs from PTF host
+    script: roles/test/files/helpers/remove_ip.sh
+    delegate_to: "{{ptf_host}}"
 
-- name: Set unique MACs to PTF interfaces
-  script: roles/test/files/helpers/change_mac.sh
-  delegate_to: "{{ptf_host}}"
+  - name: Set unique MACs to PTF interfaces
+    script: roles/test/files/helpers/change_mac.sh
+    delegate_to: "{{ptf_host}}"
 
-- name: Copy tests to PTF
-  copy: src=roles/test/files/ptftests dest=/root
-  delegate_to: "{{ptf_host}}"
+  - name: Copy tests to PTF
+    copy: src=roles/test/files/ptftests dest=/root
+    delegate_to: "{{ptf_host}}"
 
-- name: Copy ARP responder to PTF
-  copy: src=roles/test/files/helpers/arp_responder.py dest=/opt
-  delegate_to: "{{ptf_host}}"
+  - name: Copy FDB information file to PTF
+    template: src=roles/test/templates/fdb.j2 dest=/root/fdb_info.txt
+    delegate_to: "{{ ptf_host }}"
 
-- name: Copy arp responder supervisor configuration to the PTF container
-  template: src=arp_responder.conf.j2 dest=/etc/supervisor/conf.d/arp_responder.conf
-  vars:
-    - arp_responder_args: ''
-  delegate_to: "{{ ptf_host }}"
+  - name: clear FDB table
+    command: sonic-clear fdb all
 
-- name: Reread supervisor configuration
-  shell: supervisorctl reread
-  delegate_to: "{{ptf_host}}"
+  - name: Define dummy MAC prefix
+    set_fact:
+      dummy_mac_prefix: "02:11:22:33"
 
-- name: Update supervisor configuration
-  shell: supervisorctl update
-  delegate_to: "{{ ptf_host }}"
+  - name: "Start PTF runner"
+    include: ptf_runner.yml
+    vars:
+      ptf_test_name: FDB test
+      ptf_test_dir: ptftests
+      ptf_test_path: fdb_test.FdbTest
+      ptf_platform: remote
+      ptf_platform_dir: ptftests
+      ptf_test_params:
+        - testbed_type='{{testbed_type}}'
+        - router_mac='{{ansible_Ethernet0['macaddress']}}'
+        - fdb_info='/root/fdb_info.txt'
+        - vlan_ip='{{minigraph_vlan_interfaces[0]['addr']}}'
+        - dummy_mac_prefix='{{ dummy_mac_prefix }}'
+      ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_test.FdbTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
-- name: Copy FDB information file to PTF
-  template: src=roles/test/templates/fdb.j2 dest=/root/fdb_info.txt
-  delegate_to: "{{ ptf_host }}"
-
-- name: "Start PTF runner"
-  include: ptf_runner.yml
-  vars:
-    ptf_test_name: FDB test
-    ptf_test_dir: ptftests
-    ptf_test_path: fdb_test.FdbTest
-    ptf_platform: remote
-    ptf_platform_dir: ptftests
-    ptf_test_params:
-      - testbed_type='{{testbed_type}}'
-      - router_mac='{{ansible_Ethernet0['macaddress']}}'
-      - fdb_info='/root/fdb_info.txt'
-      - vlan_ip='{{minigraph_vlan_interfaces[0]['addr']}}'
-    ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_test.FdbTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
-  
+  always:
+    - name: clear FDB table
+      command: sonic-clear fdb all

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -27,9 +27,11 @@
   - name: clear FDB table
     command: sonic-clear fdb all
 
-  - name: Define dummy MAC prefix
+  - name: Initialize variables
     set_fact:
       dummy_mac_prefix: "02:11:22:33"
+      dummy_mac_number: "10"
+      vlan_member_count: 0
 
   - name: "Start PTF runner"
     include: ptf_runner.yml
@@ -45,7 +47,28 @@
         - fdb_info='/root/fdb_info.txt'
         - vlan_ip='{{minigraph_vlan_interfaces[0]['addr']}}'
         - dummy_mac_prefix='{{ dummy_mac_prefix }}'
+        - dummy_mac_number='{{ dummy_mac_number }}'
       ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_test.FdbTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
+
+  - name: Get the output of 'show mac'
+    command: "show mac"
+    register: show_mac_output
+
+  - name: Count the total number of members of all VLANs
+    set_fact:
+      vlan_member_count: "{{ vlan_member_count|int + minigraph_vlans[item.key]['members']|length }}"
+    with_dict: "{{ minigraph_vlans }}"
+
+  - name: Set variables for expected number of MAC entries
+    set_fact:
+      expected_dummy_mac_number: "{{ dummy_mac_number|int * vlan_member_count|int }}"
+      expected_total_mac_number: "{{ dummy_mac_number|int * vlan_member_count|int + vlan_member_count|int }}"
+
+  - name: Verify that the number of dummy MAC entries is expected
+    assert: { that: "{{ show_mac_output.stdout_lines|select('search', dummy_mac_prefix)|list|length == expected_dummy_mac_number|int }}"}
+
+  - name: Verify that total number of MAC entries is expected
+    assert: { that: "{{ show_mac_output.stdout_lines|select('search', 'Dynamic')|list|length == expected_total_mac_number|int }}"}
 
   always:
     - name: clear FDB table


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The existing FDB scripts only send one packet on each PTF interface to populate MAC table on DUT. This update extends the FDB scripts to send 10 more packets from each PTF interface to DUT to populate MAC table with more entries. Each packet has an unique dummy MAC address. Then send packets from each PTF ports to remaining ports to verify that L2 forwarding works for these MAC addresses.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. Send 10 more packets from each PTF port to DUT switch to populate MAC table. Each packet has an unique MAC address.
2. Send packets from each PTF ports to remaining ports to verify that L2 forwarding is working as expected.

#### How did you verify/test it?
Tested on Mellanox platform using the latest master image.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Supported topologies are not changed: [t0, t0-16, t0-64, t0-64-32, t0-116]

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
