### PR TITLE
[FromVM -> Server] Inner packet with global Vxlan MAC as dst mac

### DIFF
--- a/ansible/roles/test/files/ptftests/vnet_vxlan.py
+++ b/ansible/roles/test/files/ptftests/vnet_vxlan.py
@@ -238,7 +238,7 @@ class VNET(BaseTest):
 
         for net_port in self.net_ports:
             pkt = simple_tcp_packet(
-                eth_dst=self.dut_mac,
+                eth_dst=self.vxlan_router_mac,
                 eth_src=self.random_mac,
                 ip_dst=test['src'],
                 ip_src=test['dst'],


### PR DESCRIPTION
### Description of PR
FromVM to Server, the packets can have inner destination mac as the global Vxlan router Mac. 

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
N/A

#### How did you verify/test it?
Run ansible test

#### Any platform specific information?
Vxlan supported platforms

#### Supported testbed topology if it's a new test case?
All T0 topology

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
