### PR TITLE
[arp] Ignore intermittent failure of "ip neigh flush all"

### DIFF
--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -73,7 +73,8 @@
       delegate_to: "{{ ptf_host }}"
 
     - name: Clear DUT arp cache
-      command: ip nei flush all
+      command: ip -stats neigh flush all
+      ignore_errors: yes
       become: yes
 
     - name: Start PTF runner and Send correct unicast arp packets (10.10.1.3 to 10.10.1.2 with src_mac=00:06:07:08:09:00)
@@ -99,7 +100,8 @@
           - "{{ arptable['v4']['10.10.1.3']['interface'] == intf1 }}"
 
     - name: Clear DUT arp cache
-      command: ip nei flush all
+      command: ip -stats neigh flush all
+      ignore_errors: yes
       become: yes
 
     # Send correct ARP request from correct interface, expecting normal behavior
@@ -127,7 +129,8 @@
 
     ## check DUT won't reply ARP and install ARP entry when ARP request coming from other interfaces
     - name: Clear DUT arp cache
-      command: ip nei flush all
+      command: ip -stats neigh flush all
+      ignore_errors: yes
       become: yes
 
     - name: Send correct arp packets from other interface expect no reply(10.10.1.4 to 10.10.1.2 with src_mac=00:02:07:08:09:0a)
@@ -154,7 +157,8 @@
 
     ## check DUT won't reply ARP and install ARP entry when src address is not in interface subnet range
     - name: Clear DUT arp cache
-      command: ip nei flush all
+      command: ip -stats neigh flush all
+      ignore_errors: yes
       become: yes
 
     - name: Send Src IP out of interface subnet range arp packets, expect no reply and no arp table entry (10.10.1.22 to 10.10.1.2 with src_mac=00:03:07:08:09:0a)
@@ -181,7 +185,8 @@
 
     ## Test Gratuitous ARP behavior, no Gratuitous ARP installed when arp was not resolved before
     - name: Clear DUT arp cache
-      command: ip nei flush all
+      command: ip -stats neigh flush all
+      ignore_errors: yes
       become: yes
 
     - name: Send  garp packets (10.10.1.7 to 10.10.1.7)


### PR DESCRIPTION
In ARP testing, the script needs to run "ip neigh flush all" couple of
times to clean up ARP table. Occasionally flushing ARP table may fail
with error "*** Flush not complete bailing out after 10 rounds" on ptf32
or ptf64 topology.

The reason is that BGP peers are configured on these topologies although
the PTF container does not have BGP running. From time to time, DUT will
try to contact the BGP peers. ARP requests are firstly sent out. This
will create some INCOMPLETE entries in ARP table for the BGP peers. If
"ip neigh flush all" is executed at the same moment, the command may
fail with "*** Flush not complete bailing out after 10 rounds".

The fix is to simply ignore the error of "ip neigh flush all". Purpose
of the "ip neigh flush all" command is to cleanup ARP entries generated
by previous testing. It doesn't matter when there are ARP entries
generated by other activities not flushed.

Meanwhile, I changed the command to "ip -stats neigh flush all" to
have more detailed output for debug in case of failure.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In ARP testing, the script needs to run "ip neigh flush all" couple of
times to clean up ARP table. Occasionally flushing ARP table may fail
with error "*** Flush not complete bailing out after 10 rounds" on ptf32
or ptf64 topology.

The reason is that BGP peers are configured on these topologies although
the PTF container does not have BGP running. From time to time, DUT will
try to contact the BGP peers. ARP requests are firstly sent out. This
will create some INCOMPLETE entries in ARP table for the BGP peers. If
"ip neigh flush all" is executed at the same moment, the command may
fail with "*** Flush not complete bailing out after 10 rounds".

The fix is to simply ignore the error of "ip neigh flush all". Purpose
of the "ip neigh flush all" command is to cleanup ARP entries generated
by previous testing. It doesn't matter when there are ARP entries
generated by other activities not flushed.

Meanwhile, I changed the command to "ip -stats neigh flush all" to
have more detailed output for debug in case of failure.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
* Add "ignore_errors: yes" for "ip neigh flush all" command.
* Replace the command with "ip -stats neigh flush all" to have more detailed output for debugging in case of failure.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
