### PR TITLE
[logAnalyzer] Avoid logAnalyzer logs being overwritten

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
@@ -18,7 +18,7 @@
   when: expect_file is not defined
 
 - set_fact:
-    testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ ansible_date_time.time }}"
+    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
   when: testname_unique is not defined
 
 - set_fact:

--- a/ansible/roles/test/tasks/acltb_ranges_test.yml
+++ b/ansible/roles/test/tasks/acltb_ranges_test.yml
@@ -27,7 +27,7 @@
 
 # Separate set_fact is required to be able to use 'testname' fact.
 - set_fact:
-    testname_unique: "{{ testname }}.{{ ansible_date_time.date}}.{{ ansible_date_time.hour}}-{{ ansible_date_time.minute}}-{{ ansible_date_time.second}}"
+    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
 # Separate set_fact is required to be able to use 'testname_unique' fact.
 - set_fact:

--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -103,7 +103,7 @@
 
   # Separate set_fact is required to be able to use 'testname' fact.
   - set_fact:
-      testname_unique: "{{ testname }}.{{ ansible_date_time.date}}.{{ ansible_date_time.hour}}-{{ ansible_date_time.minute}}-{{ ansible_date_time.second}}"
+      testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
   - debug: msg="generated run id:{{testname_unique}}"
 

--- a/ansible/roles/test/tasks/lag.yml
+++ b/ansible/roles/test/tasks/lag.yml
@@ -33,7 +33,7 @@
 
 # Separate set_fact is required to be able to use 'testname' fact.
 - set_fact:
-    testname_unique: "{{ testname }}.{{ ansible_date_time.date}}.{{ ansible_date_time.hour}}-{{ ansible_date_time.minute}}-{{ ansible_date_time.second}}"
+    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
 # Separate set_fact is required to be able to use 'testname_unique' fact.
 - set_fact:

--- a/ansible/vars/run_config_test_vars.yml
+++ b/ansible/vars/run_config_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ ansible_date_time.time }}"
+testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 loganalyzer_init: roles/test/files/tools/loganalyzer/loganalyzer_init.yml

--- a/ansible/vars/run_loganalyzer_vars.yml
+++ b/ansible/vars/run_loganalyzer_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ ansible_date_time.time }}"
+testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 loganalyzer_init: roles/test/files/tools/loganalyzer/loganalyzer_init.yml

--- a/ansible/vars/run_ping_test_vars.yml
+++ b/ansible/vars/run_ping_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ ansible_date_time.time }}"
+testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 summary_file: "summary.loganalysis.{{ testname_unique }}.log"

--- a/ansible/vars/run_ptf_test_vars.yml
+++ b/ansible/vars/run_ptf_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ ansible_date_time.time }}"
+testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 summary_file: "summary.loganalysis.{{ testname_unique }}.log"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In logAnalyzer related scripts, ansible_date_time is used for generating
testname_unique which will be used as folder name for storing
logAnalyzer results. The drawback is that ansible_date_time is fixed
in single ansible playbook execution. If logAnalyzer is called
multiple times, the earlier results could be overwritten by the latest
results.

The fix is to replace ansible_date_time with:
{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}

There are two differences:
1. Each time the lookup plugin is called, the returned date and time
   would be different (interval of two calls longer than 1 second)
2. The lookup plugin gets date and time of the sonic-mgmt container,
   not date and time of DUT.

After this change, filename of logAnalyzer result files would be almost the same. The only tiny difference is the separator char in timestamp. An example filename:
summary.loganalysis.functional_test.2019-03-08-10:30:18.log

Usually sonic-mgmt container and DUT are synched to same NTP server.
The timestamps should still be useful for debugging.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replaced occurance of ansible_date_time with "{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"

#### How did you verify/test it?
Tested on Mellanox platform

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
