### PR TITLE
[arp ping] add VLAN arp ping to warm/fast reboot test

### DIFF
--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -89,7 +89,11 @@ class ARPResponder(object):
         if len(data) > self.ARP_PKT_LEN:
             return
 
-        remote_mac, remote_ip, request_ip = self.extract_arp_info(data)
+        remote_mac, remote_ip, request_ip, op_type = self.extract_arp_info(data)
+
+        # Don't send ARP response if the ARP op code is response
+        if op_type == 2:
+            return
 
         request_ip_str = socket.inet_ntoa(request_ip)
         if request_ip_str not in self.ip_sets[interface.name()]:
@@ -106,7 +110,8 @@ class ARPResponder(object):
         return
         
     def extract_arp_info(self, data):
-        return data[6:12], data[28:32], data[38:42] # remote_mac, remote_ip, request_ip
+        # remote_mac, remote_ip, request_ip, op_type
+        return data[6:12], data[28:32], data[38:42], (ord(data[20]) * 256 + ord(data[21]))
 
     def generate_arp_reply(self, local_mac, remote_mac, local_ip, remote_ip, vlan_id):
         eth_hdr = remote_mac + local_mac

--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -76,6 +76,7 @@ class Poller(object):
 
 class ARPResponder(object):
     ARP_PKT_LEN = 60
+    ARP_OP_REQUEST = 1
     def __init__(self, ip_sets):
         self.arp_chunk = binascii.unhexlify('08060001080006040002') # defines a part of the packet for ARP Reply
         self.arp_pad = binascii.unhexlify('00' * 18)
@@ -91,8 +92,8 @@ class ARPResponder(object):
 
         remote_mac, remote_ip, request_ip, op_type = self.extract_arp_info(data)
 
-        # Don't send ARP response if the ARP op code is response
-        if op_type == 2:
+        # Don't send ARP response if the ARP op code is not request
+        if op_type != self.ARP_OP_REQUEST:
             return
 
         request_ip_str = socket.inet_ntoa(request_ip)


### PR DESCRIPTION
Summary:

The purpose of adding the VLAN APR ping, is to make sure that during warm/fast reboot, the servers on the VLAN can still resolve addresses of each other.

Because currently SONiC default behavior is to trap ARP packets to CPU, ARP requests within VLAN get dropped during warm/fast reboot. As result, the arp_ping is added but not used as success criteria.

This test enables testing the change of SONiC behavior from "trap to cpu" to "copy to cpu". 

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
- Enhance ARP responder to ignore ARP responses.
- Randomly choose 2 ports to run arp_ping during fast/warm reboot.

#### How did you verify/test it?
- Warm reboot and Fast reboot
- Binary don't support VLAN ARP flooding and binary supports VLAN ARP flooding.

Following is log while testing with a binary with VLAN ARP flooding support. Note that before fast reboot, we received double ping responses, because one ping request went to cpu, one went to VLAN, they both eventually reached the arp_responder and got response. When reboot started, the control plane is down, then there is only 1 response from VLAN flooding.

2019-03-08 04:10:25 : Send   100 Received   100 servers->t1
2019-03-08 04:10:27 : Send   500 Received   500 t1->servers
2019-03-08 04:10:27 : Send    10 Received    10 ping DUT
2019-03-08 04:10:28 : Send     1 Received     2 arp ping
2019-03-08 04:10:29 : Send   100 Received   100 servers->t1
2019-03-08 04:10:31 : Send   500 Received   500 t1->servers
2019-03-08 04:10:31 : Send    10 Received     0 ping DUT
2019-03-08 04:10:31 : Control plane state transition from up to down
2019-03-08 04:10:32 : Dut reboots: reboot start 2019-03-08 04:10:32.439384
2019-03-08 04:10:32 : Check that device is still forwarding data plane traffic
2019-03-08 04:10:32 : Send     1 Received     1 arp ping
2019-03-08 04:10:33 : Send   100 Received   100 servers->t1
2019-03-08 04:10:35 : Send   500 Received   500 t1->servers
2019-03-08 04:10:35 : Send    10 Received     0 ping DUT
2019-03-08 04:10:36 : Send     1 Received     1 arp ping
