### PR TITLE
[t0-64 template] avoid deploying conflict routing entries on leaf switch

### DIFF
--- a/ansible/roles/eos/templates/t0-64-leaf.j2
+++ b/ansible/roles/eos/templates/t0-64-leaf.j2
@@ -38,6 +38,8 @@ route-map DEFAULT_ROUTES permit
 {% for podset in range(0, props.podset_number) %}
 {% for tor in range(0, props.tor_number) %}
 {% for subnet in range(0, props.tor_subnet_number) %}
+{# Skip tor 0 podset 0 #}
+{% if podset != 0 or tor != 0 %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}
@@ -49,6 +51,7 @@ route-map DEFAULT_ROUTES permit
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
 ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
 ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

192.168.0.0/21 belongs ot the vlan. Leaf switch should not advertise routes
in this segment to carve out IP address ranges from the VLAN. Doing so would
cause T1 to VLAN IO validation failure. fast/warm reboot tests depend on the
IO validation would also fail.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
warm-reboot on T0-64 topology.