### PR TITLE
[crm] Error handler for 'ip neigh show' command

### DIFF
--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
@@ -13,6 +13,10 @@
     - name: Get NH IP
       command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
+
+    - fail: msg="Get Next Hop IP failed. Neighbour not found"
+      when: out.stdout == ""
+
     - set_fact: nh_ip="{{out.stdout.split()[0]}}"
 
     - name: Add IPv4 route

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
@@ -11,8 +11,17 @@
     - set_fact: crm_stats_ipv6_route_available={{out.stdout}}
 
     - name: Get NH IP
-      shell: ip -6 neigh show dev {{crm_intf}} nud reachable nud stale | grep -v fe80
+      shell: ip -6 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
+
+    - name: Grep NH IP
+      shell: echo {{ out.stdout }} | grep -v fe80
+      register: out
+      ignore_errors: yes
+
+    - fail: msg="Get Next Hop IP failed. Neighbour not found"
+      when: out.stdout == ""
+
     - set_fact: nh_ip="{{out.stdout.split()[0]}}"
 
     - name: Add IPv6 route

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
@@ -13,11 +13,19 @@
     - name: Get NH IP 1
       command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
+
+    - fail: msg="Get Next Hop IP failed. Neighbour not found"
+      when: out.stdout == ""
+
     - set_fact: nh_ip1="{{out.stdout.split()[0]}}"
 
     - name: Get NH IP 2
       command: ip -4 neigh show dev {{crm_intf1}} nud reachable nud stale
       register: out
+
+    - fail: msg="Get Next Hop IP failed. Neighbour not found"
+      when: out.stdout == ""
+
     - set_fact: nh_ip2="{{out.stdout.split()[0]}}"
 
     - name: Add nexthop group

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
@@ -13,11 +13,19 @@
     - name: Get NH IP 1
       command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
       register: out
+
+    - fail: msg="Get Next Hop IP failed. Neighbour not found"
+      when: out.stdout == ""
+
     - set_fact: nh_ip1="{{out.stdout.split()[0]}}"
 
     - name: Get NH IP 2
       command: ip -4 neigh show dev {{crm_intf1}} nud reachable nud stale
       register: out
+
+    - fail: msg="Get Next Hop IP failed. Neighbour not found"
+      when: out.stdout == ""
+
     - set_fact: nh_ip2="{{out.stdout.split()[0]}}"
 
     - name: Add nexthop group members


### PR DESCRIPTION
Signed-off-by: Roman Kachur <romankac@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Make CRM test more informative when failed
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
When Ansible performs _ip -4 neigh show_, it presumes that the returned value is always valid,
and manipulates on it without validation. 
If the returned value is empty, it results in ambiguous error value like 
_"ERROR! list object has no element 0"_

I added conditional fail operator, to make the failure more informative:
```
    - fail: msg="Get Next Hop IP failed. Neighbour not found"
      when: out.stdout == ""
```
#### How did you verify/test it?
Run CRM test with both: all neighbors are Reachable, and some neighbours are Failed.

Now when the command fails, it returns more informative error:
`"msg": "Get Next Hop IP failed. Neighbor not found"`

Instead of previous:
`"ERROR! list object has no element 0"`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
