### PR TITLE
Fix port alias mapping in minigraph_facts

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -566,6 +566,8 @@ def parse_xml(filename, hostname):
     port_index_map = {}
     for idx, val in enumerate(port_alias_list_sorted):
         port_index_map[val] = idx
+        if port_index_map.has_key(inverted_port_alias_map[val]):
+            continue
         port_index_map[inverted_port_alias_map[val]] = idx
 
     # Create maps:


### PR DESCRIPTION
In the case that port alias conflicts with the port name, e.g., a7050-qx-32s

Ethernet36      41,42,43,44       Ethernet14/1  14      40000
Ethernet124     5,6,7,8           Ethernet36    36      40000

Use port name, e.g., Ethernet36's index, as the definitive reference

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
