### PR TITLE
[logAnalyzer] Fix the issue of unmatched start and end mark

### DIFF
--- a/ansible/roles/test/tasks/acl/acl_traffic_test/run_ping_test.yml
+++ b/ansible/roles/test/tasks/acl/acl_traffic_test/run_ping_test.yml
@@ -2,6 +2,9 @@
 # Execute ping and check the log.
 #-----------------------------------------
 
+- name: Get an unique timestamp to feed to testname_unique
+  set_fact:
+    unique_timestamp: "{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
 - include_vars: "vars/run_ping_test_vars.yml"
 
 - name: Start log analyser

--- a/ansible/roles/test/tasks/acl/acl_traffic_test/run_ptf_test.yml
+++ b/ansible/roles/test/tasks/acl/acl_traffic_test/run_ptf_test.yml
@@ -2,6 +2,9 @@
 # Send some TCP packets.
 #-----------------------------------------
 
+- name: Get an unique timestamp to feed to testname_unique
+  set_fact:
+    unique_timestamp: "{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
 - include_vars: "vars/run_ptf_test_vars.yml"
 
 - block:

--- a/ansible/roles/test/tasks/run_command_with_log_analyzer.yml
+++ b/ansible/roles/test/tasks/run_command_with_log_analyzer.yml
@@ -5,6 +5,9 @@
 #   3) Run cleanup if needed.
 #-----------------------------------------
 
+- name: Get an unique timestamp to feed to testname_unique
+  set_fact:
+    unique_timestamp: "{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 - include_vars: "vars/run_config_test_vars.yml"
 
 - block:

--- a/ansible/roles/test/tasks/run_loganalyzer.yml
+++ b/ansible/roles/test/tasks/run_loganalyzer.yml
@@ -3,6 +3,9 @@
 # or analyze-phase of loganalyzer.
 #-----------------------------------------
 
+- name: Get an unique timestamp to feed to testname_unique
+  set_fact:
+    unique_timestamp: "{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 - include_vars: "vars/run_loganalyzer_vars.yml"
 
 - name: Initialize loganalizer. Put start marker to log file.

--- a/ansible/vars/run_config_test_vars.yml
+++ b/ansible/vars/run_config_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+testname_unique: "{{ testname }}.{{ unique_timestamp }}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 loganalyzer_init: roles/test/files/tools/loganalyzer/loganalyzer_init.yml

--- a/ansible/vars/run_loganalyzer_vars.yml
+++ b/ansible/vars/run_loganalyzer_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+testname_unique: "{{ testname }}.{{ unique_timestamp }}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 loganalyzer_init: roles/test/files/tools/loganalyzer/loganalyzer_init.yml

--- a/ansible/vars/run_ping_test_vars.yml
+++ b/ansible/vars/run_ping_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+testname_unique: "{{ testname }}.{{ unique_timestamp }}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 summary_file: "summary.loganalysis.{{ testname_unique }}.log"

--- a/ansible/vars/run_ptf_test_vars.yml
+++ b/ansible/vars/run_ptf_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+testname_unique: "{{ testname }}.{{ unique_timestamp }}"
 
 test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
 summary_file: "summary.loganalysis.{{ testname_unique }}.log"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Previous PR #822 broke the log analyzer. This commit is to fix the issue
introduced by PR #822.

PR #822 is to replace the method of getting timestamp from
ansible_date_time to the pipe plugin. Log analyzer needs a variable
testname_unique to have timestamp in its value.

Script run_command_with_log_analyzer.yml uses include_vars to include
variables defined in vars/run_config_test_vars.yml. Ansible includes
variables dynamically when 'include_vars' is used. Consequence is that
the testname_unique variable defined in the vars/run_config_test_vars.yml
is re-evaluated when it is referenced. This caused log analyzer to use
inconsistent start and end mark.

To fix this issue, a unique timestamp is always generated before
include_vars. Then the timestamp is feed to the testname_unique
defined in the vars file. This approach can guarantee consistent
run id for each log analyzer execution. And the run id would also
be different for different log analyzer execution.

The other scripts changed in this commit have the similar issue.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Ansible include_vars is dynamic. To avoid the pipe for variable testname_unique in vars file being repeatedly evaluated, a unique_timestamp variable is initialized before include_vars. And in vars file, replace the pipe plugin with the variable unique_timestamp just initialized.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
