### PR TITLE
[vlan] Bring up LAGs after shutdown them for vlan test configuration

### DIFF
--- a/ansible/roles/test/tasks/vlan_configure.yml
+++ b/ansible/roles/test/tasks/vlan_configure.yml
@@ -52,4 +52,13 @@
   become: true
 
 - name: sleep for some time
+  pause: seconds=30
+
+- name: Bring up LAGs
+  shell: ifconfig {{ item.attachto }} up
+  with_items:
+    - "{{ minigraph_portchannel_interfaces }}"
+  become: true
+
+- name: sleep for some time
   pause: seconds=10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

In vlan_configuration.yml, the LAGs are shutdown for loading
/etc/sonic/vlan_configuration.json. Need to bring them back after the
configuration is loaded. Otherwise, the LAGs will remain down and PTF
test would fail.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Bring back the LAGs after loaded configuration for VLAN testing.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
