### PR TITLE
[add-topo] Refresh ARP table of neighbors with new MAC of new PTF

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -43,3 +43,7 @@
     fp_mtu: "{{ fp_mtu_size }}"
     max_fp_num: "{{ max_fp_num }}"
   become: yes
+
+- name: Send arp ping packet to gw for flusing the ARP table
+  command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
+  become: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The PTF container will be destroyed if testbed-cli.sh remove-topo is
executed. Run testbed-cli.sh add-topo will add a new PTF conainer.
Usually the new PTF container will have a new MAC address. If add-topo
is executed immediately after remove-topo, ARP table of neighbor
switches and hosts may still have entry of the old PTF MAC address. This
would cause connectivity issue to the new PTF container for a while
until the old PTF MAC address is expired.

This workaround is to send out an ARPing from the PTF container querying
mgmt_gw after new PTF container is deployed and attached to network.
The ARPing request will be broadcasted to all neighbors on same LAN and
will refresh ARP table of neighbors with new MAC address of new PTF.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Send an ARPing request from the PTF container after it is deployed and attached to network.

#### How did you verify/test it?
Tested on Mellanox platform

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
