### PR TITLE
[plugins/connection/switch] Use timeout from args rather than hard coded value

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -71,7 +71,7 @@ class Connection(ConnectionBase):
                 self._display.vvv("SSH: EXEC {0}".format(' '.join(cmd)),
                               host=self.host)
                 last_user = user
-                client = pexpect.spawn(' '.join(cmd), env={'TERM': 'dumb'}, timeout=60)
+                client = pexpect.spawn(' '.join(cmd), env={'TERM': 'dumb'}, timeout=self.timeout)
                 i = client.expect(['[Pp]assword:', pexpect.EOF])
                 if i == 1:
                     self._display.vvv("Server closed the connection, retry in %d seconds" % self.connection_retry_interval, host=self.host)
@@ -81,7 +81,6 @@ class Connection(ConnectionBase):
 
             self._display.vvv("Try password %s..." % login_passwd[0:4], host=self.host)
             client.sendline(login_passwd)
-            client.timeout = 60
             i = client.expect(['>', '#', '[Pp]assword:', pexpect.EOF])
             if i < 2:
                 break
@@ -184,13 +183,13 @@ class Connection(ConnectionBase):
         self.reboot   = kwargs['reboot']
         if kwargs['root']:
             self.login['user'] = 'root'
+        if kwargs['timeout']:
+            self.timeout = int(kwargs['timeout'])
+        else:
+            self.timeout = 60
         self._build_command()
 
         client = self._spawn_connect()
-
-        # Set command timeout after connection is spawned
-        if kwargs['timeout']:
-            client.timeout = int(kwargs['timeout'])
 
         # "%s>": non privileged prompt
         # "%s(\([a-z\-]+\))?#": privileged prompt including configure mode

--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -53,7 +53,7 @@ class Connection(ConnectionBase):
 
         self._ssh_command += ['-o', 'GSSAPIAuthentication=no',
                               '-o', 'PubkeyAuthentication=no']
-        self._ssh_command += ['-o', 'ConnectTimeout=60']
+        self._ssh_command += ['-o', 'ConnectTimeout=' + str(self.timeout)]
 
     def _spawn_connect(self):
         last_user = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

    The connection plugin 'switch' uses hard coded timeout value 60s for
    establishing SSH connection to target. After connection is spawned, then
    the timeout value for matching expected output is set to value passed in
    from keyword arguments.

    In practice, sometimes the hard coded 60s timeout is not enough for
    establishing SSH connection to targets. This improvement is to use value
    passed in from keyword arguments for connection timeout. Since the
    pexpect lib uses the same timeout value for establishing SSH connection
    and matching expected output, there is no need to set timeout for
    spawned connection in later code.

    With this change, we can pass in a longer timeout value from arguments
    when necessary.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replace hard coded timeout values with value passed in from arguments. When no timeout argument is passed in, use default 60s.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
