### PR TITLE
[lag_rate] Restore lag setting on VMs in case of failure in test

### DIFF
--- a/ansible/roles/test/tasks/single_lag_lacp_rate_test.yml
+++ b/ansible/roles/test/tasks/single_lag_lacp_rate_test.yml
@@ -47,36 +47,53 @@
     neighbor_lag_intfs: "{{ neighbor_lag_intfs }} + [ '{{ vm_neighbors[item]['port'] }}' ]"
   with_items: "{{ po_interfaces }}"
 
-# make sure portchannel peer rate is set to fast
-- name: make sure all lag members on VM are set to fast
-  action: apswitch template=neighbor_lag_rate_fast.j2
-  args:
-    host: "{{peer_host}}"
-    login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
-  connection: switch
+- block:
+    # make sure portchannel peer rate is set to fast
+    - name: make sure all lag members on VM are set to fast
+      action: apswitch template=neighbor_lag_rate_fast.j2
+      args:
+        host: "{{peer_host}}"
+        login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
+      connection: switch
 
-- pause:
-    seconds: 5
+    - set_fact:
+        lag_rate_current_setting: "fast"
 
-- name: test lacp packet sending rate is 1 seconds
-  include: lag_lacp_timing_test.yml
-  vars:
-    vm_name: "{{ peer_device }}"
-    lacp_timer: 1
+    - pause:
+        seconds: 5
 
-# make sure portchannel peer rate is set to slow
-- name: make sure all lag members on VM are set to slow
-  action: apswitch template=neighbor_lag_rate_slow.j2
-  args:
-    host: "{{peer_host}}"
-    login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
-  connection: switch
+    - name: test lacp packet sending rate is 1 seconds
+      include: lag_lacp_timing_test.yml
+      vars:
+        vm_name: "{{ peer_device }}"
+        lacp_timer: 1
 
-- pause:
-    seconds: 5
+    # make sure portchannel peer rate is set to slow
+    - name: make sure all lag members on VM are set to slow
+      action: apswitch template=neighbor_lag_rate_slow.j2
+      args:
+        host: "{{peer_host}}"
+        login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
+      connection: switch
 
-- name: test lacp packet sending rate is 30 seconds
-  include: lag_lacp_timing_test.yml
-  vars:
-    vm_name: "{{ peer_device }}"
-    lacp_timer: 30
+    - set_fact:
+        lag_rate_current_setting: "slow"
+
+    - pause:
+        seconds: 5
+
+    - name: test lacp packet sending rate is 30 seconds
+      include: lag_lacp_timing_test.yml
+      vars:
+        vm_name: "{{ peer_device }}"
+        lacp_timer: 30
+
+  always:
+    - name: Restore lag rate setting on VM in case of failure
+      action: apswitch template=neighbor_lag_rate_slow.j2
+      args:
+        host: "{{peer_host}}"
+        login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
+        timeout: 300
+      connection: switch
+      when: "lag_rate_current_setting is defined and lag_rate_current_setting == 'fast'"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The existing script does not restore lag rate setting on VMs in case
of failure. This improvement is to restore lag setting on VMs if the
testing failed.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Wrap the lag rate testing code in `block`. Add `always` section to restore VMs settings in case the settings are not restored in testing.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
