### PR TITLE
[connection_switch] Add an additional match for sku type mlnx_os

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -103,9 +103,9 @@ class Connection(ConnectionBase):
             self.sku = 'eos'
         elif 'Cisco' in client.before:
             self.sku = 'nxos'
-        if 'MLNX-OS' in client.before:
+        elif ('MLNX-OS' in client.before) or ('Onyx' in client.before):
             self.sku = 'mlnx_os'
-        if 'Dell' in client.before:
+        elif 'Dell' in client.before:
             self.sku = 'dell'
 
         if self.sku == 'mlnx_os':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For some version of Mellanox switch OS, string 'MLNX-OS' is not in output of `show version`. We can match string 'Onyx' to determine that the sku is 'mlnx_os'. BTW, I combined the independent `if` clauses into `if...elif`.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added an additional match for sku type mlnx_os.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
The change is specific for Mellanox fanout switch.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
