### PR TITLE
[fanout] Use command 'configure t' to enter configure terminal

### DIFF
--- a/ansible/roles/test/templates/neighbor_interface_no_shut_single.j2
+++ b/ansible/roles/test/templates/neighbor_interface_no_shut_single.j2
@@ -1,4 +1,4 @@
-configure
+configure t
     interface {{ neighbor_interface }}
     no shutdown
     exit

--- a/ansible/roles/test/templates/neighbor_interface_shut_single.j2
+++ b/ansible/roles/test/templates/neighbor_interface_shut_single.j2
@@ -1,4 +1,4 @@
-configure
+configure t
     interface {{ neighbor_interface }}
     shutdown
     exit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
  The command templates for shutdown/bringup interface on fanout switch
  use just 'configure' command to enter configure terminal mode. On
  some fanout switches, for example Mellanox fanout switch, command
  'configure' does not work. Need to use more complete command
  'configure t'.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replace command 'configure' with more complete form 'configure t'.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
This change is required for flapping interface on Mellanox fanout switch.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
