### PR TITLE
[acltb] Apply BGP ACL forward rules in acltb_test_rules_part_1.json

### DIFF
--- a/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json
+++ b/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json
@@ -96,6 +96,36 @@
                                         "source-ip-address": "10.0.0.2/32"
                                     }
                                 }
+                            },
+                            "15": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 27
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "179"
+                                    }
+                                }
+                            },
+                            "16": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 28
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "179"
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
After applying acltb_test_rules_part_1.json BGP sessions may go down
before we apply acltb_test_rules_part_2.json (which had BGP ACL forward
rules); This results in BGP flap during ptf test run;
It is safer to apply BGP ACL forward rules first to avoid BGP flapping.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
After applying acltb_test_rules_part_1.json BGP sessions may go down
before we apply acltb_test_rules_part_2.json (which had BGP ACL forward
rules); This results in BGP flap during ptf test run;
It is safer to apply BGP ACL forward rules first to avoid BGP flapping.
#### How did you do it?

#### How did you verify/test it?
Run ACL test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
