### PR TITLE
[docker] Use recommended CMD for getting docker GPG key

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -20,9 +20,7 @@
   when: host_distribution_version.stdout == "18.04"
 
 - name: Add docker official GPG key
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    state: present
+  shell: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -"
   become: yes
   environment: "{{ proxy_env | default({}) }}"
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

If use apt_key module for getting docker official GPG key, there would
be cert validation issue. 

```
TASK [vm_set : Add docker official GPG key] ************************************
task path: /var/johnar/code/sonic_mgmt/ansible/roles/vm_set/tasks/docker.yml:22
Tuesday 26 March 2019  06:29:38 +0000 (0:00:00.069)       0:00:03.344 ********* 
<dev-r730-03> ESTABLISH SSH CONNECTION FOR USER: root
<dev-r730-03> SSH: EXEC sshpass -d14 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r dev-r730-03 'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python'
fatal: [DEV-R730-03]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"data": null, "file": null, "id": null, "key": null, "keyring": null, "keyserver": null, "state": "present", "url": "https://download.docker.com/linux/ubuntu/gpg", "validate_certs": true}, "module_name": "apt_key"}, "msg": "Failed to validate the SSL certificate for download.docker.com:443. Make sure your managed systems have a valid CA certificate installed.  If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine.  You can use validate_certs=False if you do not need to confirm the server\\s identity but this is unsafe and not recommended Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"}
```

This change is to replace the apt_key module with 'curl' command 
recommended on docker official documentation site:

https://docs.docker.com/install/linux/docker-ce/ubuntu/

`$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -`

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replace apt_key module with recommended curl command.

#### How did you verify/test it?
Tested in Mellanox lab

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
