### PR TITLE
[fib_info] Avoid temp file on sonic-mgmt while templating fib_info.txt

### DIFF
--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -65,12 +65,7 @@
   debug: msg="Loopback IPs {{ lo_ip }}, {{ lo_ipv6 }}"
 
 # Generate file with BGP routes information
-- template: src=roles/test/templates/fib.j2 dest=/tmp/fib_info.txt
-  connection: local
-
-# Copy the fib_info to ptf container
-- template: src=/tmp/fib_info.txt dest=/root
-  connection: local
+- template: src=roles/test/templates/fib.j2 dest=/root/fib_info.txt
   delegate_to: "{{ ptf_host }}"
 
 - set_fact: outer_ipv4=True

--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -30,11 +30,7 @@
 # Generate route file
 - name: Generate route-port map information
   template: src=roles/test/templates/fib.j2
-            dest=/tmp/fib_info.txt
-  connection: local
-
-- name: copy the fib_info to ptf container
-  copy: src=/tmp/fib_info.txt dest=/root
+            dest=/root/fib_info.txt
   delegate_to: "{{ptf_host}}"
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The decap and fib test cases use two steps to generate fib_info.txt
file from template into PTF container for testing. The first step is to
generate temp file to /tmp/fib_info.txt on sonic-mgmt container. There
could be conflicts if two scripts use exactly the same location and same
filename for temp file.

This fix is to simplify the two steps templating into just one step and
avoid using temp file.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Simplify two steps templating into one step.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
