### PR TITLE
Improved error handling when not all Interfaces are up

### DIFF
--- a/ansible/roles/test/tasks/check_fanout_interfaces.yml
+++ b/ansible/roles/test/tasks/check_fanout_interfaces.yml
@@ -1,0 +1,18 @@
+- block:
+  - name: Gathering lab graph facts about the device
+    conn_graph_facts: host={{ inventory_hostname }}
+    connection: local
+
+  - name: Fanout hostname
+    set_fact: fanout_switch={{ device_conn['Ethernet0']['peerdevice'] }}
+
+  - name: Check Fanout interfaces
+    local_action: shell ansible-playbook -i lab fanout.yml -l {{ fanout_switch }} --tags check_interfaces_status
+    ignore_errors: yes
+    register: fanout_interfaces_status
+
+  - name: Debug Fanout interfaces
+    debug: msg={{ fanout_interfaces_status }}
+    when: fanout_interfaces_status is defined
+
+  when: check_fanout is defined

--- a/ansible/roles/test/tasks/check_sw_vm_interfaces.yml
+++ b/ansible/roles/test/tasks/check_sw_vm_interfaces.yml
@@ -1,24 +1,4 @@
 - block:
-  - name: Gathering lab graph facts about the device
-    conn_graph_facts: host={{ inventory_hostname }}
-    connection: local
-
-  - name: Fanout hostname
-    set_fact: fanout_switch={{ device_conn['Ethernet0']['peerdevice'] }}
-
-  - name: Check Fanout interfaces
-    local_action: shell ansible-playbook -i lab fanout.yml -l {{ fanout_switch }} --tags check_interfaces_status
-    ignore_errors: yes
-    register: fanout_interfaces_status
-
-  - name: Debug Fanout interfaces
-    debug: msg={{ fanout_interfaces_status }}
-    when: fanout_interfaces_status is defined
-
-  when:
-    - check_fanout is defined
-
-- block:
   - name: Get Portchannel status
     shell: show interfaces portchannel
     register: portchannel_status

--- a/ansible/roles/test/tasks/check_testbed_interfaces.yml
+++ b/ansible/roles/test/tasks/check_testbed_interfaces.yml
@@ -1,0 +1,77 @@
+- block:
+  - name: Gathering lab graph facts about the device
+    conn_graph_facts: host={{ inventory_hostname }}
+    connection: local
+
+  - name: Fanout hostname
+    set_fact: fanout_switch={{ device_conn['Ethernet0']['peerdevice'] }}
+
+  - name: Check Fanout interfaces
+    local_action: shell ansible-playbook -i lab fanout.yml -l {{ fanout_switch }} --tags check_interfaces_status
+    ignore_errors: yes
+    register: fanout_interfaces_status
+
+  - name: Debug Fanout interfaces
+    debug: msg={{ fanout_interfaces_status }}
+    when: fanout_interfaces_status is defined
+
+  when:
+    - check_fanout is defined
+
+- block:
+  - name: Get Portchannel status
+    shell: show interfaces portchannel
+    register: portchannel_status
+    ignore_errors: yes
+
+  - name: Get teamd dump
+    shell: teamdctl '{{ item }}' state dump
+    with_items: "{{ minigraph_portchannels }}"
+    ignore_errors: yes
+    register: teamd_dump
+    when:
+      - minigraph_portchannels is defined
+
+  - name: Debug teamd dump
+    debug: msg={{ teamd_dump }}
+    when: teamd_dump is defined
+
+  - name: Define testbed_name when not obtained
+    set_fact:
+      testbed_name: "{{ inventory_hostname + '-' + topo }}"
+    when: testbed_name is not defined
+
+  - name: Gathering testbed information
+    test_facts: testbed_name="{{ testbed_name }}"
+    connection: local
+    ignore_errors: yes
+
+  - name: Gather vm list from Testbed server
+    local_action: shell ansible-playbook testbed_vm_status.yml -i veos -l "{{ testbed_facts['server'] }}"
+    ignore_errors: yes
+    register: testbed_vm_list
+
+  - name: Debug VM list on Testbed
+    debug: msg={{ testbed_vm_list }}
+    when: testbed_vm_list is defined
+
+  - set_fact:
+      vms: "{{ minigraph_devices }}"
+      peer_hwsku: 'Arista-VM'
+
+  - name: Gather Port-Channel status from VMs
+    action: apswitch template=roles/vm_set/templates/show_int_portchannel_status.j2
+    args:
+      host: "{{ vms[item]['mgmt_addr'] }}"
+      login: "{{ switch_login[hwsku_map[peer_hwsku]] }}"
+    connection: switch
+    ignore_errors: yes
+    when: vms["{{ item }}"]['hwsku'] == 'Arista-VM'
+    with_items: vms
+    register: vm_portchannel_status
+
+  - name: Debug Port-Channel on VMs
+    debug: msg={{ vm_portchannel_status }}
+    when: vm_portchannel_status is defined
+
+  when: check_vms is defined

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -36,10 +36,10 @@
   - name: Verify interfaces are up correctly
     assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
   rescue:
-  - include: check_testbed_interfaces.yml
+  - include: check_fanout_interfaces.yml
     vars:
       check_fanout: true
-  - fail: msg="Not all Interfaces are up"
+  - debug: msg="Not all Interfaces are up"
 
 - block:
   - name: Verify port channel interfaces are up correctly
@@ -47,10 +47,10 @@
     with_items: "{{ minigraph_portchannels.keys() }}"
 
   rescue:
-  - include: check_testbed_interfaces.yml
+  - include: check_sw_vm_interfaces.yml
     vars:
       check_vms: true
-  - fail: msg="Not all PortChannels are up '{{ portchannel_status['stdout_lines'] }}' "
+  - debug: msg="Not all PortChannels are up '{{ portchannel_status['stdout_lines'] }}' "
     when: portchannel_status is defined
 
 - name: Verify VLAN interfaces are up correctly

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -32,12 +32,26 @@
 - debug: msg="Found link down ports {{ansible_interface_link_down_ports}}"
   when: ansible_interface_link_down_ports | length > 0
 
-- name: Verify interfaces are up correctly
-  assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
+- block:
+  - name: Verify interfaces are up correctly
+    assert: { that: "{{ ansible_interface_link_down_ports | length }} == 0" }
+  rescue:
+  - include: check_testbed_interfaces.yml
+    vars:
+      check_fanout: true
+  - fail: msg="Not all Interfaces are up"
 
-- name: Verify port channel interfaces are up correctly
-  assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
-  with_items: "{{ minigraph_portchannels.keys() }}"
+- block:
+  - name: Verify port channel interfaces are up correctly
+    assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
+    with_items: "{{ minigraph_portchannels.keys() }}"
+
+  rescue:
+  - include: check_testbed_interfaces.yml
+    vars:
+      check_vms: true
+  - fail: msg="Not all PortChannels are up '{{ portchannel_status['stdout_lines'] }}' "
+    when: portchannel_status is defined
 
 - name: Verify VLAN interfaces are up correctly
   assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }

--- a/ansible/roles/vm_set/templates/show_int_portchannel_status.j2
+++ b/ansible/roles/vm_set/templates/show_int_portchannel_status.j2
@@ -1,0 +1,1 @@
+show interfaces Port-Channel 1-$ status

--- a/ansible/testbed_vm_status.yml
+++ b/ansible/testbed_vm_status.yml
@@ -1,0 +1,7 @@
+- hosts: servers:&vm_host
+  tasks:
+  - name: Get VM statuses from Testbed server
+    shell: virsh list
+    register: virsh_list
+  - name: Show VM statuses
+    debug: msg="{{ virsh_list['stdout_lines'] }}"


### PR DESCRIPTION
Recreated PR
https://github.com/Azure/sonic-mgmt/pull/815 which was merged and reverted

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Any test, that calls interface.yml, if encountered that some Interfaces/PortChannels are not up, will not just fail but will try to gather interfaces status from Fanout/VMs as well.
### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. Modified interface.yml to include check_testbed_interfaces.yml,
  when 'Verify interfaces are up' step fails.
2. check_testbed_interfaces.yml will gather interfaces status on:
  * DUT
  * Fanout (for MLNX only, filtered by check_interfaces_status tag)
  * Testbed server (by calling testbed_vm_status.yml playbook)
  * relevant VMs
3.  testbed_vm_status.yml palybook will connect to Testbed server and gather VMs status.
4. show_int_portchannel_status.j2 will connect to each relevant VM and gather Port-Channel status.
#### How did you verify/test it?
Any test that call interface.yml, in two cases:

1. Normal flow, when all interfaces are up.
   In this case nothing is changed.
2.  When Fanout has deliberately its ports down,
   In that cases, the test fails as usual, but gathers Interfaces status from Fanout.
3.  When some relevant VM has its Port-Channel deliberately down.
   In that cases, the test fails as usual, but gathers VMs status from Testbed server, and PortChannel status from VMs.
#### Any platform specific information?
Current implementation can enter Fanout switch, only if Fanout is MLNX type.
The _'Check Fanout interfaces'_ step in _check_testbed_interfaces.yml_ calls _fanout.yml_ (actually fanout role) with tag _'check_interfaces_status'_
In this case anyone can modify roles/fanout/tasks/main.yml to execute Fanout specific step with
_when: peer_hwsku == "<specific_fanout_type>" tags: check_interfaces_status_

Example:

```
 ###################################################################
 # Check Fanout interfaces status                                  #
 ###################################################################
- block:
  - name: Check Fanout interfaces status
    action: apswitch template=roles/fanout/templates/mlnx_interfaces_status.j2
    connection: switch
    register: fanout_interfaces
    args:
      login: "{{ switch_login['MLNX-OS'] }}"

  - debug:
      msg: "{{ fanout_interfaces.stdout.split('\n') }}"

  when: peer_hwsku == "MLNX-OS"
  tags: check_interfaces_status
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
