### PR TITLE
Change warm-reboot time limit to 1 second

### DIFF
--- a/ansible/roles/test/tasks/warm-reboot.yml
+++ b/ansible/roles/test/tasks/warm-reboot.yml
@@ -1,6 +1,6 @@
 - name: set default reboot_limit in seconds
   set_fact:
-      reboot_limit: 0
+      reboot_limit: 1
   when: reboot_limit is not defined
 
 - name: Warm-reboot test


### PR DESCRIPTION
Tested with Mellanox DUT.
By definition, warm-reboot data plane disruption should be less than 1 second. If some platform implementation achieve better, we could override it specially.