### PR TITLE
[link state] look up topology name until the separator char

### DIFF
--- a/ansible/linkstate/testbed_inv.py
+++ b/ansible/linkstate/testbed_inv.py
@@ -25,7 +25,7 @@ def read_config():
 def parse_testbed_configuration(filename, target):
     with open(filename) as fp:
         for line in fp:
-            if line.startswith(target):
+            if line.startswith(target + ','):
                 splitted_line = line.split(",")
                 ptf_name = splitted_line[1]
                 topo_name = splitted_line[2]


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

Otherwise, if 2 systems have names where one is prefix of the other one, parsing of the
shorter name will come up with 2 lines.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
both fast/warm reboot tests requires linkstate change before and after.