### PR TITLE
[Mellanox SimX] upstream scripts for SimX virtual testbed management

### DIFF
--- a/ansible/roles/test/files/helpers/simx/lldp.py
+++ b/ansible/roles/test/files/helpers/simx/lldp.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python
+
+import time
+import binascii
+
+from scapy.all import Ether
+from scapy.all import sendp
+
+SEND_TIMEOUT = 30
+PORT_RANGE = 32
+
+LLDP_MAC = '01:80:c2:00:00:0e'
+LLDP_ETHERTYPE = 0x88cc
+
+TLV_TYPE_CHASSIS_ID = '\x02\x07\x04'
+
+TLV_TYPE_PORT_ID = '\x04\x0a\x05'
+TLV_VALUE_PORT_ID = 'Ethernet1'
+
+TLV_TYPE_TIME_TO_LIVE = '\x06\x02'
+TLV_VALUE_TIME_TO_LIVE = '\x00\x78'
+
+TLV_TYPE_SYSTEM_NAME = '\x0a\x0a'
+
+TLV_TYPE_SYSTEM_DESCRIPTION = '\x0c\x46'
+TLV_VALUE_SYSTEM_DESCRIPTION = 'Arista Networks EOS version 4.16.6M running on an Arista Networks vEOS'
+
+ETHERNET_ARISTA_MAP = {
+    'et0':  'ARISTA01T2',
+    'et1':  'ARISTA02T2',
+    'et2':  'ARISTA03T2',
+    'et3':  'ARISTA04T2',
+    'et4':  'ARISTA05T2',
+    'et5':  'ARISTA06T2',
+    'et6':  'ARISTA07T2',
+    'et7':  'ARISTA08T2',
+    'et8':  'ARISTA09T2',
+    'et9':  'ARISTA10T2',
+    'et10': 'ARISTA11T2',
+    'et11': 'ARISTA12T2',
+    'et12': 'ARISTA13T2',
+    'et13': 'ARISTA14T2',
+    'et14': 'ARISTA15T2',
+    'et15': 'ARISTA16T2',
+    'et16': 'ARISTA01T0',
+    'et17': 'ARISTA02T0',
+    'et18': 'ARISTA03T0',
+    'et19': 'ARISTA04T0',
+    'et20': 'ARISTA05T0',
+    'et21': 'ARISTA06T0',
+    'et22': 'ARISTA07T0',
+    'et23': 'ARISTA08T0',
+    'et24': 'ARISTA09T0',
+    'et25': 'ARISTA10T0',
+    'et26': 'ARISTA11T0',
+    'et27': 'ARISTA12T0',
+    'et28': 'ARISTA13T0',
+    'et29': 'ARISTA14T0',
+    'et30': 'ARISTA15T0',
+    'et31': 'ARISTA16T0'
+}
+
+LLDP_PAYLOAD = '{TLV_TYPE_CHASSIS_ID}{TLV_VALUE_CHASSIS_ID}' + \
+'{TLV_TYPE_PORT_ID}{TLV_VALUE_PORT_ID}' + \
+'{TLV_TYPE_TIME_TO_LIVE}{TLV_VALUE_TIME_TO_LIVE}' + \
+'{TLV_TYPE_SYSTEM_NAME}{TLV_VALUE_SYSTEM_NAME}' + \
+'{TLV_TYPE_SYSTEM_DESCRIPTION}{TLV_VALUE_SYSTEM_DESCRIPTION}' + \
+'\x0e\x04\x00\x14\x00\x14\x10\x0c\x05\x01\x0a\xd5\x56\x3d\x02\x00' + \
+'\x0f\x3e\x59\x00\xfe\x06\x00\x80\xc2\x01\x00\x00\xfe\x09\x00\x12' + \
+'\x0f\x03\x01\x00\x00\x00\x00\xfe\x06\x00\x12\x0f\x04\x24\x14\x00' + \
+'\x00'
+
+
+def get_mac(iface):
+    with open('/sys/class/net/{}/address'.format(iface)) as mac:
+        return mac.read().strip()
+
+
+def get_payload(iface):
+    return LLDP_PAYLOAD.format(
+        TLV_TYPE_CHASSIS_ID=TLV_TYPE_CHASSIS_ID,
+        TLV_VALUE_CHASSIS_ID=binascii.unhexlify(get_mac(iface).replace(':', '')),
+        TLV_TYPE_PORT_ID=TLV_TYPE_PORT_ID,
+        TLV_VALUE_PORT_ID=TLV_VALUE_PORT_ID,
+        TLV_TYPE_TIME_TO_LIVE=TLV_TYPE_TIME_TO_LIVE,
+        TLV_VALUE_TIME_TO_LIVE=TLV_VALUE_TIME_TO_LIVE,
+        TLV_TYPE_SYSTEM_NAME=TLV_TYPE_SYSTEM_NAME,
+        TLV_VALUE_SYSTEM_NAME=ETHERNET_ARISTA_MAP[iface],
+        TLV_TYPE_SYSTEM_DESCRIPTION=TLV_TYPE_SYSTEM_DESCRIPTION,
+        TLV_VALUE_SYSTEM_DESCRIPTION=TLV_VALUE_SYSTEM_DESCRIPTION
+    )
+
+
+def create_lldp(iface):
+    print 'Creating LLDP: dst=' + LLDP_MAC + ', src=' + get_mac(iface)
+
+    pkt = Ether(dst=LLDP_MAC, src=get_mac(iface), type=LLDP_ETHERTYPE)
+    pkt = pkt / get_payload(iface)
+
+    return pkt
+
+
+def main():
+    while True:
+        for iface in ['et{}'.format(i) for i in xrange(PORT_RANGE)]:
+            lldp = create_lldp(iface)
+            sendp(lldp, iface=iface)
+            print 'Sent LLDP: iface = ' + iface
+
+        time.sleep(SEND_TIMEOUT)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -11,6 +11,26 @@
     msg: "Reboot type {{ reboot_type }} is invalid. Must be one of {{ reboot_types }}"
   when: reboot_type not in reboot_types
 
+- name: "SimX workaround: Set zebra template config facts"
+  set_fact:
+    zebra_orig_config: "/usr/share/sonic/templates/zebra.conf.j2_orig"
+    zebra_simx_config: "/usr/share/sonic/templates/zebra.conf.j2_simx"
+    zebra_config: "/usr/share/sonic/templates/zebra.conf.j2"
+
+- block:
+  - name: "SimX workaround: Check for backuped original zebra template config"
+    shell: "docker exec bgp bash -c '[ -f {{ zebra_orig_config }} ] && echo 'yes' || echo 'no''"
+    register: "stat_result"
+
+  - name: "SimX workaround: Restore default BGP config to speed up system boot"
+    shell: "{{ item }}"
+    become: "yes"
+    with_items:
+      - "docker exec bgp bash -c 'cp -f {{ zebra_orig_config }} {{ zebra_config }}'"
+    when: "stat_result.stdout == 'yes'"
+
+  when: "simx is defined and simx == 'yes'"
+
 - name: "rebooting {{ inventory_hostname }} : {{ ansible_host }} with {{ reboot_type }}..."
   command: "{{ reboot_type }}"
   async: 300
@@ -59,3 +79,22 @@
 
 - name: wait for 2 minute for prcesses and interfaces to be stable
   pause: seconds=120
+
+- block:
+  - name: "SimX workaround: Check for backuped SimX zebra template config"
+    shell: "docker exec bgp bash -c '[ -f {{ zebra_simx_config }} ] && echo 'yes' || echo 'no''"
+    register: "stat_result"
+
+  - name: "SimX workaround: Apply BGP static routes"
+    shell: "{{ item }}"
+    become: "yes"
+    with_items:
+      - "docker exec bgp bash -c 'cp -f {{ zebra_simx_config }} {{ zebra_config }}'"
+      - "service bgp restart"
+    when: "stat_result.stdout == 'yes'"
+
+  - name: "SimX workaround: Wait for 1 minute for BGP to be stable"
+    pause: minutes=1
+    when: "stat_result.stdout == 'yes'"
+
+  when: "simx is defined and simx == 'yes'"

--- a/ansible/roles/test/tasks/common_tasks/update_supervisor.yml
+++ b/ansible/roles/test/tasks/common_tasks/update_supervisor.yml
@@ -1,0 +1,12 @@
+- fail: msg="supervisor_host is not defined"
+  when: "supervisor_host is not defined"
+
+- name: "Reread supervisor configuration"
+  shell: "supervisorctl reread"
+  become: "yes"
+  delegate_to: "{{ supervisor_host }}"
+
+- name: "Update supervisor configuration"
+  shell: "supervisorctl update"
+  become: "yes"
+  delegate_to: "{{ supervisor_host }}"

--- a/ansible/roles/test/tasks/simx/prepare_ptf.yml
+++ b/ansible/roles/test/tasks/simx/prepare_ptf.yml
@@ -1,0 +1,108 @@
+- name: "Set default action (topo_action=add) if no arguments provided"
+  set_fact:
+    topo_action: "add"
+  when: "topo_action is not defined"
+
+- fail: msg="topo_action is provided with invalid value"
+  when: "topo_action not in [ 'add', 'remove' ]"
+
+- name: "Set LLDP daemon facts"
+  set_fact:
+    lldp_daemon: "/opt/lldp.py"
+
+- block:
+  - name: "Gathering minigraph facts about the device"
+    minigraph_facts: host={{ inventory_hostname }}
+
+  - name: "Remove existing IPs from the PTF host"
+    script: "roles/test/files/helpers/remove_ip.sh"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: "Set unique MACs to the PTF interfaces"
+    script: "roles/test/files/helpers/change_mac.sh"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: "Delete macvlan devices on the PTF host"
+    shell: "ip link del et{{ item }}"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32) | list }}"
+    ignore_errors: "yes"
+
+  - name: "Generate macvlan devices on the PTF host"
+    shell: "ip link add et{{ item }} link eth{{ item }} type macvlan mode bridge"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32) | list }}"
+
+  - name: "Bring macvlan devices up on the PTF host"
+    shell: "ip link set dev et{{ item }} up"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32) | list }}"
+
+  - name: "Add IPv4 addresses on macvlan devices on the PTF host"
+    shell: "ip addr add 10.0.0.{{ item | int * 2 + 1 }}/31 dev et{{ item }}"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32) | list }}"
+
+  - name: "Add IPv6 addresses on macvlan devices on the PTF host"
+    shell: "ip addr add fc00::{{ '%x' | format(item | int * 4 + 2) }}/126 dev et{{ item }}"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32) | list }}"
+
+  - name: "Copy LLDP supervisor configuration to the PTF container"
+    template:
+      src: "roles/test/templates/simx/lldp.conf.j2"
+      dest: "/etc/supervisor/conf.d/lldp.conf"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: "Copy LLDP daemon to the PTF container"
+    copy:
+      src: "roles/test/files/helpers/simx/lldp.py"
+      dest: "{{ lldp_daemon }}"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: "Update supervisor configuration"
+    include: "roles/test/tasks/common_tasks/update_supervisor.yml"
+    vars:
+      supervisor_host: "{{ ptf_host }}"
+
+  - name: "Run LLDP daemon"
+    shell: "supervisorctl start lldp"
+    delegate_to: "{{ ptf_host }}"
+
+  - name: "Set MTU to 9100 on PTF eth ifaces"
+    shell: "ip link set dev eth{{ item }} mtu 9100"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32)| list }}"
+
+  - name: "Set MTU to 9100 on created PTF et ifaces"
+    shell: "ip link set dev et{{ item }} mtu 9100"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32)| list }}"
+
+  when: "topo_action is defined and topo_action == 'add'"
+
+- block:
+  - name: "Stop LLDP daemon"
+    shell: "supervisorctl stop lldp"
+    delegate_to: "{{ ptf_host }}"
+    ignore_errors: "yes"
+
+  - name: "Clean up supervisor configuration"
+    shell: "{{ item }}"
+    delegate_to: "{{ ptf_host }}"
+    with_items:
+      - "rm -f /etc/supervisor/conf.d/lldp.conf"
+      - "rm -f {{ lldp_daemon }}"
+
+  - name: "Update supervisor configuration"
+    include: "roles/test/tasks/common_tasks/update_supervisor.yml"
+    vars:
+      supervisor_host: "{{ ptf_host }}"
+
+  - name: "Delete macvlan devices on the PTF host"
+    shell: "ip link del et{{ item }}"
+    delegate_to: "{{ ptf_host }}"
+    with_items: "{{ range(32) | list }}"
+    ignore_errors: "yes"
+
+  when: "topo_action is defined and topo_action == 'remove'"

--- a/ansible/roles/test/tasks/simx/prepare_sonic.yml
+++ b/ansible/roles/test/tasks/simx/prepare_sonic.yml
@@ -1,0 +1,102 @@
+- name: "Set default action (topo_action=add) if no arguments provided"
+  set_fact:
+    topo_action: "add"
+  when: "topo_action is not defined"
+
+- fail: msg="topo_action is provided with invalid value"
+  when: "topo_action not in [ 'add', 'remove' ]"
+
+- name: "Set zebra template config facts"
+  set_fact:
+    zebra_orig_config: "/usr/share/sonic/templates/zebra.conf.j2_orig"
+    zebra_simx_config: "/usr/share/sonic/templates/zebra.conf.j2_simx"
+    zebra_config: "/usr/share/sonic/templates/zebra.conf.j2"
+
+- block:
+  - name: "Gathering minigraph facts about the device"
+    minigraph_facts: host={{ inventory_hostname }}
+
+  - name: "Set T1 topology"
+    set_fact:
+      testbed_type: "t1"
+
+  - name: "Include T1 topology variables"
+    include_vars: "vars/topo_t1.yml"
+
+  - name: "Expand properties into props"
+    set_fact:
+      props: "{{ configuration_properties['spine'] }}"
+      props_tor: "{{ configuration_properties['tor'] }}"
+
+  - name: "Generate route-port map information"
+    template:
+      src: "roles/test/templates/fib.j2"
+      dest: "/tmp/fib_info.txt"
+    connection: "local"
+
+  - name: "Generate FIB facts"
+    fib_facts:
+      fib: "/tmp/fib_info.txt"
+    connection: "local"
+
+  - name: "Generate zebra config"
+    template:
+      src: "roles/test/templates/simx/zebra_route_populate.conf.j2"
+      dest: "/tmp/zebra_route_populate.conf"
+
+  - name: "Check for backuped original zebra template config"
+    shell: "docker exec bgp bash -c '[ -f {{ zebra_orig_config }} ] && echo 'yes' || echo 'no''"
+    register: "stat_result"
+
+  - name: "Restore original zebra template config if backup exists"
+    shell: "docker exec bgp bash -c 'cp -f {{ zebra_orig_config }} {{ zebra_config }}'"
+    when: "stat_result.stdout == 'yes'"
+
+  - name: "Create original zebra template config backup if it doesn't exist"
+    shell: "docker exec bgp bash -c 'cp -f {{ zebra_config }} {{ zebra_orig_config }}'"
+    when: "stat_result.stdout == 'no'"
+
+  - name: "Copy zebra config to BGP container"
+    shell: "docker cp /tmp/zebra_route_populate.conf bgp:/zebra_route_populate.conf"
+
+  - name: "Append to existing zebra template config"
+    shell: "docker exec bgp bash -c 'cat /zebra_route_populate.conf >> {{ zebra_config }}'"
+
+  - name: "Clean up intermediate zebra config"
+    shell: "docker exec bgp bash -c 'rm -f /zebra_route_populate.conf'"
+
+  - name: "Check for backuped SimX zebra template config"
+    shell: "docker exec bgp bash -c '[ -f {{ zebra_simx_config }} ] && echo 'yes' || echo 'no''"
+    register: "stat_result"
+
+  - name: "Create SimX zebra template config backup if it doesn't exist"
+    shell: "docker exec bgp bash -c 'cp -f {{ zebra_config }} {{ zebra_simx_config }}'"
+    when: "stat_result.stdout == 'no'"
+
+  when: "topo_action is defined and topo_action == 'add'"
+
+- block:
+  - name: "Check for backuped original zebra template config"
+    shell: "docker exec bgp bash -c '[ -f {{ zebra_orig_config }} ] && echo 'yes' || echo 'no''"
+    register: "stat_result"
+
+  - name: "Restore original zebra template config if backup exists"
+    shell: "docker exec bgp bash -c 'cp -f {{ zebra_orig_config }} {{ zebra_config }}'"
+    when: "stat_result.stdout == 'yes'"
+
+  - name: "Clean up backuped zebra template config"
+    shell: "{{ item }}"
+    with_items:
+      - "docker exec bgp bash -c 'rm -f {{ zebra_orig_config }}'"
+      - "docker exec bgp bash -c 'rm -f {{ zebra_simx_config }}'"
+
+  when: "topo_action is defined and topo_action == 'remove'"
+
+- name: "Restart BGP docker"
+  service:
+    name: "bgp"
+    state: "restarted"
+  become: "yes"
+
+- name: "Wait for 1 minute for BGP to be stable"
+  pause: minutes=1

--- a/ansible/roles/test/templates/simx/lldp.conf.j2
+++ b/ansible/roles/test/templates/simx/lldp.conf.j2
@@ -1,0 +1,10 @@
+[program:lldp]
+command=/usr/bin/python {{ lldp_daemon }}
+process_name=lldp
+stdout_logfile=/tmp/lldp.out.log
+stderr_logfile=/tmp/lldp.err.log
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1

--- a/ansible/roles/test/templates/simx/zebra_route_populate.conf.j2
+++ b/ansible/roles/test/templates/simx/zebra_route_populate.conf.j2
@@ -1,0 +1,11 @@
+{% for prefix in fib %}
+{% for nexthop in fib[prefix] %}
+{% if prefix | ipv4 %}
+ip route {{ prefix | ipv4 }} {{ nexthop | ipv4 }}
+{% endif %}
+{% if prefix | ipv6 %}
+ipv6 route {{ prefix | ipv6 }} {{ nexthop | ipv6 }}
+{% endif %}
+!
+{% endfor %}
+{% endfor %}

--- a/ansible/testbed_prepare_simx.yml
+++ b/ansible/testbed_prepare_simx.yml
@@ -1,0 +1,4 @@
+- hosts: sonic
+  tasks:
+    - include: roles/test/tasks/simx/prepare_ptf.yml
+    - include: roles/test/tasks/simx/prepare_sonic.yml


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Upstream the scripts used for SimX virtual testbed management

This allows us to run t1 topology over ptf32(using only ptf docker and no VMs)
![ ](https://github.com/mykolaf/SONiC/blob/master/images/topo.PNG) 

It does several things:
 - Configure the routes for t1 topology
 - Start a LLDP script on ptf docker that emulates the lldp traffic from the VMs

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
