### PR TITLE
[test]: Change config interface command arguments order

### DIFF
--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -35,7 +35,7 @@
       when: po1 is defined
 
     - name: bring {{ intf1 }} up
-      shell: config interface {{ intf1 }} startup
+      shell: config interface startup {{ intf1 }}
       become: yes
       when: po1 is defined
 
@@ -51,16 +51,16 @@
       when: po2 is defined
 
     - name: bring {{ intf2 }} up
-      shell: config interface {{ intf2 }} startup
+      shell: config interface startup {{ intf2 }}
       become: yes
       when: po2 is defined
 
     - name: change SONiC DUT interface IP to test IP address
-      command: config interface {{ intf1 }} ip add 10.10.1.2/28
+      command: config interface ip add {{ intf1 }} 10.10.1.2/28
       become: yes
 
     - name: change SONiC DUT interface IP to test IP address
-      command: config interface {{ intf2 }} ip add 10.10.1.20/28
+      command: config interface ip add {{ intf2 }} 10.10.1.20/28
       become: yes
 
     - name: wait for interfaces to be up after removed from portchannel

--- a/ansible/roles/test/tasks/config.yml
+++ b/ansible/roles/test/tasks/config.yml
@@ -42,7 +42,7 @@
         remove_portchannel_members: true
 
     - name: Step 2 Remove {{ portchannel_ip }} from {{ portchannel }}
-      shell: config interface {{ portchannel }} ip remove {{ portchannel_ip }}/31
+      shell: config interface ip remove {{ portchannel }} {{ portchannel_ip }}/31
       become: yes
     - set_fact:
         remove_portchannel_ip: true
@@ -73,7 +73,7 @@
         add_tmp_portchannel_members: true
 
     - name: Step 5 Add {{ portchannel_ip }} to {{ tmp_portchannel }}
-      shell: config interface {{ tmp_portchannel }} ip add {{ portchannel_ip }}/31
+      shell: config interface ip add {{ tmp_portchannel }} {{ portchannel_ip }}/31
       become: yes
     - set_fact:
         add_tmp_portchannel_ip: true
@@ -97,7 +97,7 @@
 
   always:
     - name: Remove {{ portchannel_ip }} from {{ tmp_portchannel }}
-      shell: config interface {{ tmp_portchannel }} ip remove {{ portchannel_ip }}/31
+      shell: config interface ip remove {{ tmp_portchannel }} {{ portchannel_ip }}/31
       become: yes
       when: add_tmp_portchannel_ip
 
@@ -113,7 +113,7 @@
       when: create_tmp_portchannel
 
     - name: Add {{ portchannel_ip }} to {{ portchannel }}
-      shell: config interface {{ portchannel }} ip add {{ portchannel_ip }}/31
+      shell: config interface ip add {{ portchannel }} {{ portchannel_ip }}/31
       become: yes
       when: remove_portchannel_ip
 

--- a/ansible/roles/test/tasks/iface_naming_mode/interface_config.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/interface_config.yml
@@ -9,7 +9,7 @@
 - block: 
 
     - name: shutdown the interface {{intf}} in {{mode}} mode 
-      shell: sudo config interface {{intf}} shutdown
+      shell: sudo config interface shutdown {{intf}}
       register: out
       failed_when: out.rc != 0
 
@@ -24,7 +24,7 @@
       assert: {that: "'{{int_status[intf]['admin_state']}}' == 'down'"}
 
     - name: Bringup the interface  {{intf}} in {{mode}} mode
-      shell: sudo config interface {{intf}} startup
+      shell: sudo config interface startup {{intf}}
       register: out
       failed_when: out.rc != 0
     
@@ -39,7 +39,7 @@
 # check the  config interface speed
 
     - name: configure interface speed to 10G in {{mode}} mode
-      shell: sudo config interface {{intf}} speed 10000
+      shell: sudo config interface speed {{intf}} 10000
       register: out
       failed_when: out.rc != 0
 
@@ -53,7 +53,7 @@
       assert: {that: "'{{speed.stdout}}' == '10000'"}
 
     - name: chamge interface speed to native speed and check
-      shell: sudo config interface {{intf}} speed {{native_speed}}
+      shell: sudo config interface speed {{intf}} {{native_speed}}
       register: out
       failed_when: out.rc != 0
 
@@ -72,8 +72,8 @@
   always:
 
     - name: set the interface up 
-      shell:  sudo config interface {{intf}}  startup
+      shell:  sudo config interface startup {{intf}}
 
     - name: change interface speed to native speed and check
-      shell: sudo config interface {{intf}} speed {{native_speed}}
+      shell: sudo config interface speed {{intf}} {{native_speed}}
 

--- a/ansible/roles/test/tasks/neighbour-mac.yml
+++ b/ansible/roles/test/tasks/neighbour-mac.yml
@@ -12,7 +12,7 @@
 
 - name: Change DUT interface IP to test IP address
   become: yes
-  command: config interface {{ dut_if }} ip add {{ dut_ip }}/24
+  command: config interface ip add {{ dut_if }} {{ dut_ip }}/24
 
 - name: Change host interface IP to test IP address
   become: yes

--- a/ansible/roles/test/tasks/port_toggle.yml
+++ b/ansible/roles/test/tasks/port_toggle.yml
@@ -1,8 +1,8 @@
 - name: build shell command string
-  debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface $port shutdown; done"
+  debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface shutdown $port; done"
 
 - name: turn off all ports on device
-  shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface $port shutdown; done
+  shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface shutdown $port; done
   become: yes
 
 - name: Get interface facts
@@ -13,10 +13,10 @@
 
 - always:
   - name: build shell command string
-    debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface $port startup; done"
+    debug: msg="PORTS={{minigraph_ports.keys() | join(' ')}}; for port in $PORTS; do config interface startup $port; done"
 
   - name: turn on all ports on device
-    shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface $port startup; done
+    shell: PORTS="{{minigraph_ports.keys() | join(' ')}}"; for port in $PORTS; do config interface startup $port; done
     become: yes
 
   - name: wait 1 minute for ports to come up


### PR DESCRIPTION
https://github.com/Azure/sonic-utilities/pull/504

This is to make all the commands backwards compatible

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>