### PR TITLE
Add NH routes to VNET, clear fdb before vlan change

### DIFF
--- a/ansible/roles/test/tasks/vnet_vxlan.yml
+++ b/ansible/roles/test/tasks/vnet_vxlan.yml
@@ -70,6 +70,9 @@
     - name: Render DUT VNet Switch configuration
       template: src=vnet_switch.j2 dest=/tmp/vnet.switch.json
 
+    - name: clear FDB table
+      command: sonic-clear fdb all
+
     - name: Delete Vlan membership from config DB
       shell: docker exec -i database redis-cli -n 4 del "VLAN_MEMBER|{{ minigraph_vlan_interfaces[0]['attachto'] }}|{{ item.1 }}"
       with_indexed_items: "{{ minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'] }}"

--- a/ansible/roles/test/templates/vnet.j2
+++ b/ansible/roles/test/templates/vnet.j2
@@ -8,6 +8,7 @@
     "dut_mac": {{ ansible_Ethernet0['macaddress'] | to_nice_json }},
     "vnet_interfaces": {{ vnet_intf_list | to_nice_json }},
     "vnet_routes": {{ vnet_route_list | to_nice_json }},
+    "vnet_local_routes": {{ vnet_local_routes | to_nice_json }},
     "vnet_neighbors": {{ vnet_nbr_list | to_nice_json }},
     "vnet_peers": {{ vnet_peer_list | to_nice_json }}
 }

--- a/ansible/roles/test/templates/vnet_config.j2
+++ b/ansible/roles/test/templates/vnet_config.j2
@@ -50,6 +50,19 @@ vnet_nbr_list:
   - ifname: {{ minigraph_vlans[topo_vlan].members[0] }}
     ip: '10.10.10.102'
 
+vnet_local_routes:
+  - Vnet1_route_list:
+      - pfx: '50.1.1.0/24'
+        nh: '1.1.10.101'
+        ifname: 'Vlan2001'
+      - pfx: '50.2.2.0/24'
+        nh: '1.1.10.102'
+        ifname: 'Vlan2001'
+  - Vnet2_route_list:
+      - pfx: '60.1.1.0/24'
+        nh: '2.2.10.101'
+        ifname: 'Vlan2002'
+
 vnet_route_list:
   - Vnet1_route_list:
       - pfx: '1.1.1.10/32'

--- a/ansible/roles/test/templates/vnet_routes.j2
+++ b/ansible/roles/test/templates/vnet_routes.j2
@@ -41,6 +41,25 @@
 {% endfor %}
 {% endfor %}
 
+{% for vnet in vnet_id_list %}
+{% for routes in vnet_local_routes %}
+{% set route_list = vnet + '_route_list' %}
+{% if routes.keys()[0] == route_list %}
+{% for key,entries in routes.items() %}
+{% for route in entries %}
+    {
+        "VNET_ROUTE_TABLE:{{ vnet }}:{{ route.pfx }}" : {
+            "nexthop": "{{ route.nh }}",
+            "ifname": "{{ route.ifname }}"
+        },
+        "OP": "{{ op }}"
+    },
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+
 {% for intf in intf_list %}
 {% set outloop = loop %}
 {% for vnet_intf in vnet_intf_list %}


### PR DESCRIPTION
Summary:
Add test to have NH routes for VNETs. 

Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Add NH routes to config file

#### How did you do it?

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t0 variants

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
