### PR TITLE
Set hostname in dhcp_relay container

### DIFF
--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -28,6 +28,10 @@
   copy: src=roles/test/files/ptftests dest=/root
   delegate_to: "{{ ptf_host }}"
 
+- name: Set hostname for 'dhcp_relay' container
+  become: true
+  shell: "docker exec -t dhcp_relay bash -c \"hostname {{ inventory_hostname }}\""
+
 # Run the DHCP relay PTF test
 - include: ptf_runner.yml
   vars:


### PR DESCRIPTION
Summary:

dhcp_relay testcase expects to see {{ inventory_hostname }} as a part of `Option82::Agent Circuit ID` but, inside docker container the hostname is `sonic`. That's why the testcase failed.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
execute remote shell to set hostname in the container

#### How did you verify/test it?
run `dhcp_relay` testacase, checked status

#### Any platform specific information?
no

@lguohan, @yxieca: please review and merge this.