### PR TITLE
[linkstate] Align up.yml and down.yml with new EOS login/password variable names

### DIFF
--- a/ansible/linkstate/down.yml
+++ b/ansible/linkstate/down.yml
@@ -44,6 +44,8 @@
 - hosts: eos
   gather_facts: no
   tasks:
+    - name: Set ansible login user name and password
+      set_fact: ansible_user="root" ansible_password={{ eos_root_password }}
     - name: Check list of processes
       command: ps ax
       changed_when: False

--- a/ansible/linkstate/up.yml
+++ b/ansible/linkstate/up.yml
@@ -3,6 +3,8 @@
 - hosts: eos
   gather_facts: no
   tasks:
+    - name: Set ansible login user name and password
+      set_fact: ansible_user="root" ansible_password={{ eos_root_password }}
     - name: Check list of processes
       command: ps ax
       changed_when: False


### PR DESCRIPTION
Linkstate playbooks were broken after https://github.com/Azure/sonic-mgmt/commit/a88042adc7bfd8235f4d7e8626c2d13c08c70fe1 was merged. This fixes the playbooks by aligning them with the new EOS login/password variable names.