### PR TITLE
[lag] Increase wait time for LAG to change state to 35 seconds

### DIFF
--- a/ansible/roles/test/tasks/lag_minlink.yml
+++ b/ansible/roles/test/tasks/lag_minlink.yml
@@ -45,7 +45,7 @@
       connection: switch
     
     - pause:
-        seconds: 20
+        seconds: 35
     
     - lag_facts: host={{ inventory_hostname }}
     

--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -31,9 +31,9 @@
 - name: test fanout interface (physical) flap and lacp keep correct po status follow minimum links requirement
   include: lag_minlink.yml
   vars:
-    wait_down_time: 20
+    wait_down_time: 35
 
-### Now figure out remote VM and interface info for the falpping lag member and run minlink test 
+### Now figure out remote VM and interface info for the flapping lag member and run minlink test
 - set_fact:
     peer_device: "{{vm_neighbors[flap_intf]['name']}}"
     neighbor_interface: "{{vm_neighbors[flap_intf]['port']}}"


### PR DESCRIPTION
Some DuT/fanout combinations may require ~30 seconds for LAG to fully change state.