### PR TITLE
Fixes for bgp_speaket test in case run for IPv6

### DIFF
--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -138,7 +138,7 @@
       delegate_to: "{{ptf_host}}"
 
     - pause:
-        seconds: 5
+        seconds: 15
         prompt: "make sure dynamic bgp neighbors appear"
 
     - name: Announce the routes

--- a/ansible/roles/test/templates/bgp_speaker_route.j2
+++ b/ansible/roles/test/templates/bgp_speaker_route.j2
@@ -1,8 +1,8 @@
 {% if addr_family == 'ipv6' %}
-{{announce_prefix}} [{% for member in minigraph_portchannels[portchannel_name].members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}
+{{announce_prefix}} {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% elif addr_family == 'ipv4' %}
-0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+0.0.0.0/0           {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {{announce_prefix}} {% for vlan, v in minigraph_vlans.iteritems() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}
 {% endif %}

--- a/ansible/roles/test/templates/bgp_speaker_route.j2
+++ b/ansible/roles/test/templates/bgp_speaker_route.j2
@@ -2,7 +2,7 @@
 {{announce_prefix}} {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% elif addr_family == 'ipv4' %}
-0.0.0.0/0           {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {{announce_prefix}} {% for vlan, v in minigraph_vlans.iteritems() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}
 {% endif %}

--- a/ansible/roles/test/templates/exabgp/start.j2
+++ b/ansible/roles/test/templates/exabgp/start.j2
@@ -3,12 +3,12 @@ ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_int
 ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][0]])}}:1 {{item.logical_ip_2}}
 
 {% set intf = 'eth%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][1]]) %}
-ifconfig {{intf}} {{item.mux_ip_1}}
-i=0; until [$i -eq 10] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
+ifconfig {{intf}} add {{item.mux_ip_1}}
+i=0; until [ $i -eq 10 ] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
 
 {% set intf = 'eth%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][2]]) %}
-ifconfig {{intf}} {{item.mux_ip_2}}
-i=0; until [$i -eq 10] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
+ifconfig {{intf}} add {{item.mux_ip_2}}
+i=0; until [ $i -eq 10 ] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
 
 ip route flush {{minigraph_lo_interfaces[0]['addr']}}/{{minigraph_lo_interfaces[0]['prefixlen']}}
 ip route add {{minigraph_lo_interfaces[0]['addr']}}/{{minigraph_lo_interfaces[0]['prefixlen']}} via {{ minigraph_vlan_interfaces[0]['addr']}}


### PR DESCRIPTION
### Description of PR

- include all the LAG interfaces into ECMP group on which test packet can arrive
- fix 'ifconfig' arguments format in case set IPv6 address
- increase dynamic bgp neighbors appearing interval as 5sec not enough (seen random fails on different testbeds and even on the same testbed)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
changed Jinja templates used for configs generation

#### How did you verify/test it?
tested on the hardware in the lab

@lguohan, @yxieca  please review and merge this.