### PR TITLE
[fast/warm reboot] improve new image installation code

### DIFF
--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -110,12 +110,8 @@
       when: new_sonic_image is defined
 
     - set_fact:
-        stay_in_target_image: false
-      when: stay_in_target_image is not defined
-
-    - set_fact:
-        cleanup_old_sonic_images: false
-      when: cleanup_old_sonic_images is not defined
+        stay_in_target_image:     "{{ stay_in_target_image     | default('false') | bool }}"
+        cleanup_old_sonic_images: "{{ cleanup_old_sonic_images | default('false') | bool }}"
 
     - block:
 
@@ -123,7 +119,7 @@
           shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
           register: current_sonic_image
           become: true
-          when: not stay_in_target_image|bool
+          when: not stay_in_target_image
 
         - name: Generate temp file name on target device
           shell: mktemp
@@ -145,7 +141,7 @@
         - name: Cleanup sonic images that is not current and/or next
           shell: sonic_installer cleanup -y
           become: true
-          when: cleanup_old_sonic_images|bool
+          when: cleanup_old_sonic_images
 
         - name: 'Setup restoring initial image {{ current_sonic_image }}'
           shell: /bin/true
@@ -153,7 +149,7 @@
           notify:
           - restore current image
           - reboot sonic
-          when: not stay_in_target_image|bool
+          when: not stay_in_target_image
 
         - name: Installing new SONiC image
           shell: sonic_installer install -y {{ new_image_location }}

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -109,15 +109,26 @@
     - debug: msg="Defined new sonic image url is {{ new_sonic_image }}"
       when: new_sonic_image is defined
 
+    - set_fact:
+        stay_in_target_image: false
+      when: stay_in_target_image is not defined
+
     - block:
 
         - name: Save image version
           shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
           register: current_sonic_image
           become: true
+          when: not stay_in_target_image
+
+        - name: Generate temp file name on target device
+          shell: mktemp
+          register: tempfile
+
+        - debug: msg='Setting image file name to {{ tempfile.stdout }}'
 
         - set_fact:
-            new_image_location: '/tmp/new_sonic_image.img'
+            new_image_location: tempfile.stdout
 
         - name: Download SONiC image.
           local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
@@ -127,14 +138,18 @@
             src: "{{ new_image_location }}"
             dest: "{{ new_image_location }}"
 
+        - name: Schedule to restore current image
+          shell: show version
+          notify:
+          - restore current image
+          - reboot sonic
+          when: not stay_in_target_image
+
         - name: Install a new SONiC image if requested
           shell: sonic_installer install -y {{ new_image_location }}
           become: true
-          notify:
-            - restore current image
-            - reboot sonic
 
-      when: new_sonic_image is defined and new_sonic_image|length > 0
+      when: new_sonic_image | default('') | length > 0
 
     - include: ptf_runner.yml
       vars:

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -106,6 +106,9 @@
         dest: /tmp/ports.json
       delegate_to: "{{ ptf_host }}"
 
+    - debug: msg="Defined new sonic image url is {{ new_sonic_image }}"
+      when: new_sonic_image is defined
+
     - block:
 
         - name: Save image version
@@ -114,7 +117,7 @@
           become: true
 
         - set_fact:
-            new_image_location: '/tmp/new_sonic_image.bin'
+            new_image_location: '/tmp/new_sonic_image.img'
 
         - name: Download SONiC image.
           local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
@@ -131,7 +134,7 @@
             - restore current image
             - reboot sonic
 
-      when: new_sonic_image is defined
+      when: new_sonic_image is defined and new_sonic_image|length > 0
 
     - include: ptf_runner.yml
       vars:

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -113,6 +113,10 @@
         stay_in_target_image: false
       when: stay_in_target_image is not defined
 
+    - set_fact:
+        cleanup_old_sonic_images: false
+      when: cleanup_old_sonic_images is not defined
+
     - block:
 
         - name: Save image version
@@ -137,6 +141,11 @@
           copy:
             src: "{{ new_image_location }}"
             dest: "{{ new_image_location }}"
+
+        - name: Cleanup sonic images that is not current and/or next
+          shell: sonic_installer cleanup -y
+          become: true
+          when: cleanup_old_sonic_images|bool
 
         - name: 'Setup restoring initial image {{ current_sonic_image }}'
           shell: /bin/true

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -119,16 +119,16 @@
           shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
           register: current_sonic_image
           become: true
-          when: not stay_in_target_image
+          when: not stay_in_target_image|bool
 
         - name: Generate temp file name on target device
           shell: mktemp
           register: tempfile
 
-        - debug: msg='Setting image file name to {{ tempfile.stdout }}'
-
         - set_fact:
-            new_image_location: tempfile.stdout
+            new_image_location: '{{ tempfile.stdout }}'
+
+        - debug: msg='Setting image file name to {{ new_image_location }}'
 
         - name: Download SONiC image.
           local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
@@ -138,14 +138,15 @@
             src: "{{ new_image_location }}"
             dest: "{{ new_image_location }}"
 
-        - name: Schedule to restore current image
-          shell: show version
+        - name: 'Setup restoring initial image {{ current_sonic_image }}'
+          shell: /bin/true
+          connection: local
           notify:
           - restore current image
           - reboot sonic
-          when: not stay_in_target_image
+          when: not stay_in_target_image|bool
 
-        - name: Install a new SONiC image if requested
+        - name: Installing new SONiC image
           shell: sonic_installer install -y {{ new_image_location }}
           become: true
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

- Allow new_sonic_image being defined as empty string. It causes skipping image installation.
- Rename new_image_location to a generic name.
- Display defined new image url.
- Added a knob to allow DUT to stay in the target release after warm/fast reboot.
- Added a knob to allow clean up old images on the target DUT.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
- Tested with a valid new image URL
- Tested with an empty new image URL
- Tested without defining new_sonic_image variable