### PR TITLE
Adding  iface_naming_mode  scripts for few more commands

### DIFF
--- a/ansible/roles/test/tasks/iface_naming_mode/iface_naming_mode_tests.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/iface_naming_mode_tests.yml
@@ -30,9 +30,6 @@
     - name: Test show interface status, counter,description,summary output  in {{mode}}  mode
       include: "roles/test/tasks/iface_naming_mode/show_interface.yml"
 
-    - name: Test config interface <Interface> in {{mode}} mode 
-      include: "roles/test/tasks/iface_naming_mode/interface_config.yml"
-
   become_user: '{{uname1}}'
   become: yes
 
@@ -46,6 +43,19 @@
 
   - name: Test show ip/ipv6 route in {{mode}}  mode
     include: "roles/test/tasks/iface_naming_mode/show_ip_route.yml"
+
+  - name: Test config interface <Interface> in {{mode}} mode
+    include: "roles/test/tasks/iface_naming_mode/interface_config.yml"
+
+  - name: Test show lldp in {{mode}}  mode
+    include: "roles/test/tasks/iface_naming_mode/show_lldp.yml"
+
+  - name: show ndp in {{mode}} mode
+    include: "roles/test/tasks/iface_naming_mode/show_ndp.yml"
+
+  - name: show ndp in {{mode}} mode
+    include: "roles/test/tasks/iface_naming_mode/show_priority_group.yml"
+
 
   when: testbed_type in ['t1']
   become_user: '{{uname1}}'

--- a/ansible/roles/test/tasks/iface_naming_mode/iface_naming_mode_tests.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/iface_naming_mode_tests.yml
@@ -27,8 +27,6 @@
     - name: Test show queue counters output in {{mode}} mode 
       include: "roles/test/tasks/iface_naming_mode/show_queue_counters.yml"
 
-    - name: Test show interface status, counter,description,summary output  in {{mode}}  mode
-      include: "roles/test/tasks/iface_naming_mode/show_interface.yml"
 
   become_user: '{{uname1}}'
   become: yes
@@ -46,6 +44,9 @@
 
   - name: Test config interface <Interface> in {{mode}} mode
     include: "roles/test/tasks/iface_naming_mode/interface_config.yml"
+
+  - name: Test show interface status, counter,description,summary output  in {{mode}}  mode
+    include: "roles/test/tasks/iface_naming_mode/show_interface.yml"
 
   - name: Test show lldp in {{mode}}  mode
     include: "roles/test/tasks/iface_naming_mode/show_lldp.yml"

--- a/ansible/roles/test/tasks/iface_naming_mode/interface_config.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/interface_config.yml
@@ -8,6 +8,40 @@
 
 - block: 
 
+    - name: config  interface {{intf}}  ip  remove in  {{mode}} mode
+      shell: sudo config interface ip remove  {{intf}} 10.0.0.0/31
+      failed_when: out.rc != 0
+
+    - pause: seconds=3
+
+    - name:  Get  show ip interface after rmeoving ip address
+      shell: show ip interface
+      register: show_ip_intf
+
+    - debug: var=show_ip_intf.stdout_lines
+
+    - name: Check  whether the ip is removed in {{mode}} mode
+      assert:
+        that:
+          - not ( show_ip_intf.stdout | search("{{intf}}\s+10.0.0.0/31"))
+
+    - name: config  interface {{intf}}  ip  add in  {{mode}} mode
+      shell: sudo config interface ip add  {{intf}} 10.0.0.0/31
+      failed_when: out.rc != 0
+
+    - pause: seconds=3
+
+    - name:  Get  show ip interface in after adding ip address
+      shell: show ip interface
+      register: show_ip_intf
+
+    - debug: var=show_ip_intf.stdout_lines
+
+    - name: Check  whether the ip is removed in {{mode}} mode
+      assert:
+        that:
+          -  show_ip_intf.stdout | search("{{intf}}\s+10.0.0.0/31")
+
     - name: shutdown the interface {{intf}} in {{mode}} mode 
       shell: sudo config interface shutdown {{intf}}
       register: out

--- a/ansible/roles/test/tasks/iface_naming_mode/show_interface.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/show_interface.yml
@@ -1,5 +1,46 @@
 - block:
 
+  - name:  Get  show ip interface
+    shell: show ip interface
+    register: show_ip_intf
+
+  - debug: var=show_ip_intf
+
+  - name: Check intf name and ip address in show ip interface output in alias  mode
+    assert:
+      that:
+        -  show_ip_intf.stdout | search("{{port_name_map[item['attachto']]}}\s+{{item['addr']}}")
+    with_items: minigraph_interfaces
+    when:  item.addr|ipv4 and mode=='alias'
+
+  - name: Check intf name and ip address in show ip interface output in  default  mode
+    assert:
+      that:
+        -  show_ip_intf.stdout | search("{{item['attachto']}}\s+{{item['addr']}}")
+    with_items: minigraph_interfaces
+    when:  item.addr|ipv4 and mode=='default'
+
+  - name:  Get  show ipv6 interface output
+    shell: show ipv6 interface
+    register: show_ipv6_intf
+
+  - debug: var=show_ipv6_intf
+
+  - name: Check intf name and ipv6 address in show ip interface output in alias  mode
+    assert:
+      that:
+        -  show_ipv6_intf.stdout | search("{{port_name_map[item['attachto']]}}\s+{{item['addr']}}")
+    with_items: minigraph_interfaces
+    when:  item.addr|ipv6 and mode=='alias'
+
+  - name: Check intf name and ip address in show ip interface output in default  mode
+    assert:
+      that:
+        -  show_ipv6_intf.stdout | search("{{item['attachto']}}\s+{{item['addr']}}")
+    with_items: minigraph_interfaces
+    when:  item.addr|ipv6 and mode=='default'
+
+
   # show interface status 
   - name: show interface status in {{mode}} mode 
     show_interface:  interfaces={{intf}} command='status'

--- a/ansible/roles/test/tasks/iface_naming_mode/show_lldp.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/show_lldp.yml
@@ -1,0 +1,44 @@
+- name: Get the output of show lldp table command in {{mode}} mode
+  shell: show lldp table
+  register:  lldp_table
+  environment:
+    SONIC_CLI_IFACE_MODE: "{{ifmode}}"
+
+- debug: var=lldp_table
+
+- name: Check the output shows alias names in alias mode 
+  assert:
+    that:
+    - lldp_table.stdout | search("{{item}}.*\s+{{minigraph_neighbors[port_alias_map[item]]["name"]}}")
+  with_items: "{{upport_alias_list}}"
+  when: mode =='alias'
+
+- name: Check the output shows default interface names in default mode 
+  assert:
+    that:
+    - lldp_table.stdout | search("{{item}}.*\s+{{minigraph_neighbors[item]["name"]}}")
+  with_items: "{{up_ports}}"
+  when: mode =='default'
+
+- name: Get the output of show lldp neighbor {{intf}} command in {{mode}} mode
+  shell: show lldp neighbor {{intf}}
+  register:  lldp_neighbor
+  environment:
+    SONIC_CLI_IFACE_MODE: "{{ifmode}}"
+
+- debug: var=lldp_neighbor
+
+- name:  Check the output shows alias names of interface  in alias mode
+  assert:
+    that:
+    - lldp_neighbor.stdout | search("Interface:\s+{{intf}},\svia:\sLLDP,")
+    - lldp_neighbor.stdout | search("SysName:\s+{{minigraph_neighbors[port_alias_map[intf]]["name"]}}")
+  when: mode =='alias'
+
+- name: Check the output shows default interface names in default mode
+  assert:
+    that:
+    - lldp_neighbor.stdout | search("Interface:\s+{{intf}},\svia:\sLLDP,")
+    - lldp_neighbor.stdout | search("SysName:\s+{{minigraph_neighbors[intf]["name"]}}")
+  when: mode =='default'
+

--- a/ansible/roles/test/tasks/iface_naming_mode/show_ndp.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/show_ndp.yml
@@ -1,0 +1,29 @@
+- name: get arp , ndp facts
+  switch_arptable:
+
+- debug: var=arptable['v6']
+
+# As the ansible work in non interactive mode, it doesnt read the environmental varaiable set in bashrc file. Hence as a workaround, the variable is  extracted through check_userifmode.yml and manually set the variable 'SONIC_CLI_IFACE_MODE' to take effect.
+
+- name: Get the output of show ndp command in {{mode}} mode
+  shell: show ndp
+  register: ndp_output
+  environment:
+    SONIC_CLI_IFACE_MODE: "{{ifmode}}"
+
+- debug: var=ndp_output
+
+- name: Check the output shows default interface  names corresponding to the neighbor
+  assert:
+    that:
+    - ndp_output.stdout | search("{{item}}.*\s+{{arptable['v6'][item]['interface']}}")
+  with_items: arptable['v6']
+  when: arptable['v6'][item]['interface']!='eth0' and mode=='default'
+
+- name: Check the output shows alias interface  names corresponding to the neighbor
+  assert:
+    that:
+    - ndp_output.stdout | search("{{item}}.*\s+{{port_name_map[arptable['v6'][item]['interface']]}}")
+  with_items: arptable['v6']
+  when: arptable['v6'][item]['interface']!='eth0' and mode =='alias'
+

--- a/ansible/roles/test/tasks/iface_naming_mode/show_priority_group.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/show_priority_group.yml
@@ -1,0 +1,87 @@
+- block:
+
+    - name:  show priority-group persistent-watermark shared  in {{mode}} mode
+      shell:  show priority-group persistent-watermark shared
+      register: show_pg
+
+    - debug: var=show_pg.stdout_lines
+
+    - name: Check "show priority-group persistent-watermark shared" in alias  mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: upport_alias_list
+      when:  mode=='alias'
+
+    - name: Check "show priority-group persistent-watermark shared" in default mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: up_ports
+      when:  mode=='default'
+
+    - name:  show priority-group persistent-watermark headroom in {{mode}} mode
+      shell:  show priority-group persistent-watermark headroom
+      register: show_pg
+
+    - debug: var=show_pg.stdout_lines
+
+    - name: Check "show priority-group persistent-watermark headroom" in alias  mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: upport_alias_list
+      when:  mode=='alias'
+
+    - name: Check "show priority-group persistent-watermark headroom" in default mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: up_ports
+      when:  mode=='default'
+
+
+    - name:  show priority-group watermark shared  in {{mode}} mode
+      shell:  show priority-group watermark shared
+      register: show_pg
+
+    - debug: var=show_pg.stdout_lines
+
+    - name: Check "show priority-group watermark shared" in alias  mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: upport_alias_list
+      when:  mode=='alias'
+
+    - name: Check "show priority-group watermark shared" in default mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: up_ports
+      when:  mode=='default'
+
+    - name:  show priority-group watermark headroom in {{mode}} mode
+      shell:  show priority-group watermark headroom
+      register: show_pg
+
+    - debug: var=show_pg.stdout_lines
+
+    - name: Check "show priority-group watermark headroom" in alias  mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: upport_alias_list
+      when:  mode=='alias'
+
+    - name: Check "show priority-group watermark headroom" in default mode
+      assert:
+        that:
+          - show_pg.stdout | search("{{item}}.*")
+      with_items: up_ports
+      when:  mode=='default'
+
+# As the ansible work in non interactive mode, it doesnt read the environmental varaiable set in bashrc file. Hence as a workaround, the variable is  extracted through check_userifmode.yml and manually set the variable 'SONIC_CLI_IFACE_MODE' to take effect.
+
+  environment:
+      SONIC_CLI_IFACE_MODE: "{{ifmode}}"

--- a/ansible/roles/test/tasks/iface_naming_mode/show_queue_counters.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/show_queue_counters.yml
@@ -8,7 +8,7 @@
     - name: Check the {{mode}}  interface name is present in output when mode is set to {{mode}}
       assert:
         that:
-        - queue_counter.stdout |  search("{{intf}}\s+[U|M]C{{item}}\s+\d+\s+\d+\s+\d+\s+\d+")
+        - queue_counter.stdout |  search("{{intf}}\s+[U|M]C{{item}}\s+\S+\s+\S+\s+\S+\s+\S+")
       with_sequence: start=0 end=9
 
     - name: show queue counters for all interfaces
@@ -20,16 +20,98 @@
     - name: Check default interface name is present in output when mode is  is set to default 
       assert:
         that:
-        - queue_counter.stdout |  search("{{item}}\s+[UC|MC\d]+\s+\d+\s+\d+\s+\d+\s+\d+") and '{{port_name_map[item]}}' not in queue_counter.stdout
+        - queue_counter.stdout |  search("{{item}}\s+[UC|MC\d]+\s+\S+\s+\S+\s+\S+\s+\S+") and '{{port_name_map[item]}}' not in queue_counter.stdout
       with_items: default_interfaces 
       when: mode=='default'
 
     - name: Check alias interface name is present in output when mode is set to alias
       assert:
         that:
-        - queue_counter.stdout |  search("{{item}}\s+[UC|MC\d]+\s+\d+\s+\d+\s+\d+\s+\d+") and '{{port_alias_map[item]}}'  not in queue_counter.stdout
+        - queue_counter.stdout |  search("{{item}}\s+[UC|MC\d]+\s+\S+\s+\S+\s+\S+\s+\S+") and '{{port_alias_map[item]}}'  not in queue_counter.stdout
       with_items: port_alias
       when: mode=='alias'
+
+    - name:    show queue watermark in {{mode}} mode
+      shell:   show queue watermark multicast
+      register: show_queue_wm_mcast
+
+    - debug: var=show_queue_wm_mcast.stdout_lines
+
+    - name: Check show queue watermark multicast in alias  mode
+      assert:
+        that:
+          - show_queue_wm_mcast.stdout | search("{{item}}")
+      with_items: port_alias
+      when:  mode=='alias'
+
+    - name: Check show queue watermark multicast in default mode
+      assert:
+        that:
+          - show_queue_wm_mcast.stdout | search("{{item}}")
+      with_items: default_interfaces
+      when:  mode=='default'
+
+    - name:    show queue watermark unicast in {{mode}} mode
+      shell:   show queue watermark unicast
+      register: show_queue_wm_ucast
+
+    - debug: var=show_queue_wm_ucast.stdout_lines
+
+    - name: Check show queue watermark unicast in alias  mode
+      assert:
+        that:
+          - show_queue_wm_ucast.stdout | search("{{item}}")
+      with_items: port_alias
+      when:  mode=='alias'
+
+    - name: Check show queue watermark multicast in default  mode
+      assert:
+        that:
+          - show_queue_wm_ucast.stdout | search("{{item}}")
+      with_items: default_interfaces
+      when:  mode=='default'
+
+    - name:    show queue persistent-watermark in {{mode}} mode
+      shell:   show queue persistent-watermark multicast
+      register: show_queue_wm_mcast
+
+    - debug: var=show_queue_wm_mcast.stdout_lines
+
+    - name: Check show queue persistent-watermark multicast in alias  mode
+      assert:
+        that:
+          - show_queue_wm_mcast.stdout | search("{{item}}")
+      with_items: port_alias
+      when:  mode=='alias'
+
+    - name: Check show queue persistent-watermark multicast in default mode
+      assert:
+        that:
+          - show_queue_wm_mcast.stdout | search("{{item}}")
+      with_items: default_interfaces
+      when:  mode=='default'
+
+    - name:    show queue persistent-watermark unicast in {{mode}} mode
+      shell:   show queue persistent-watermark unicast
+      register: show_queue_wm_ucast
+
+    - debug: var=show_queue_wm_ucast.stdout_lines
+
+    - name: Check show queue persistent-watermark unicast in alias  mode
+      assert:
+        that:
+          - show_queue_wm_ucast.stdout | search("{{item}}")
+      with_items: port_alias
+      when:  mode=='alias'
+
+    - name: Check show queue persistent-watermark multicast in default  mode
+      assert:
+        that:
+          - show_queue_wm_ucast.stdout | search("{{item}}")
+      with_items: default_interfaces
+      when:  mode=='default'
+
+
 # As the ansible work in non interactive mode, it doesnt read the environmental varaiable set in bashrc file. Hence as a workaround, the variable is  extracted through check_userifmode.yml and manually set the variable 'SONIC_CLI_IFACE_MODE' to take effect.
 
   environment:


### PR DESCRIPTION
Summary:
Adding iface_naming_mode script for  few more  commands 

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Added tests  for  the below 

show   lldp neigh
show lldp   table
config   interface   ip add
config   interface  ip remove
show ndp
show priority-group watermark headroom
show priority-group watermark shared
show priority-group persistent-watermark   headroom
show priority-group persistent-watermark   shared
show queue persistent-watermark multicast
show queue persistent-watermark unicast
show queue watermark multicast
show queue watermark unicast
show ip interface
show ipv6 interface

#### How did you verify/test it?
verified in t1 topology
#### Any platform specific information?
Platform independent
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
