### PR TITLE
Wait for switch reboot to be finished

### DIFF
--- a/ansible/roles/test/tasks/warm-reboot-fib.yml
+++ b/ansible/roles/test/tasks/warm-reboot-fib.yml
@@ -54,8 +54,7 @@
   when: warm_restart_docker is defined
 
 - name: reboot dut
-  shell: reboot
-  become: true
+  include: common_tasks/reboot_sonic.yml
   when: warm_restart_docker is not defined
 
 - name: check async_ptf status

--- a/ansible/roles/test/tasks/warm-reboot-fib.yml
+++ b/ansible/roles/test/tasks/warm-reboot-fib.yml
@@ -39,13 +39,13 @@
   become: true
   when: warm_restart_docker is defined
 
-- name: set config warm_restart enable system
-  shell: config warm_restart enable system
-  become: true
+- name: set restart type
+  set_fact:
+    reboot_type: "warm-reboot"
   when: warm_restart_docker is not defined
 
 - name: wait for 10 secs
-  pause: 
+  pause:
     seconds: 10
 
 - name: restart {{ warm_restart_docker}}


### PR DESCRIPTION
### Description of PR

While executing `warm-reboot-fib` testcase, in case undefined `warm_restart_docker` (which means `system`) the CT will fail as it doesn't wait for reboot end. That's why the test fails on final phase - checking the switch state (e.g. daemons and interfaces statuses)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Using 'common' functionality from `common_tasks/reboot_sonic.yml` which is waiting for reboot end.

#### How did you verify/test it?

ran the test on a hardware

@yxieca please review and merge this