### PR TITLE
[testbed-cli] flush ip neighbor after add_topo

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -113,6 +113,9 @@ function add_topo
 
   ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$dut" $@
 
+  # Delete the obsoleted arp entry for the PTF IP
+  ip neighbor flush $ptf_ip
+
   echo Done
 }
 


### PR DESCRIPTION
Change-Id: Ie9b461efee2fa458c53a28eb8fac1c8f5043bc96
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Sometimes test may fail with "ptf unreachable" ansible error. Happens when the test is run shortly after the topo is changed and prf docker redeployed.
### Type of change

- [] Bug fix
- [ X ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
Delete the obsoleted arp entry for the PTF IP
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
