### PR TITLE
Fix ifconfig format for exabgp/start.sh script

### DIFF
--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -118,6 +118,7 @@
       template: src=roles/test/templates/exabgp/start.j2 dest={{exabgp_dir}}/{{item.file_name}} mode=u+rwx
       with_items:
         - {file_name: 'start.sh',
+           addr_family: '{{addr_family}}',
            config_file_1: 'config_1.ini',
            config_file_2: 'config_2.ini',
            config_file_3: 'config_3.ini',

--- a/ansible/roles/test/templates/exabgp/start.j2
+++ b/ansible/roles/test/templates/exabgp/start.j2
@@ -3,11 +3,11 @@ ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_int
 ifconfig eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][0]])}}:1 {{item.logical_ip_2}}
 
 {% set intf = 'eth%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][1]]) %}
-ifconfig {{intf}} add {{item.mux_ip_1}}
+ifconfig {{intf}} {% if item.addr_family=='ipv6' %} inet6 add {% endif %} {{item.mux_ip_1}}
 i=0; until [ $i -eq 10 ] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
 
 {% set intf = 'eth%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][2]]) %}
-ifconfig {{intf}} add {{item.mux_ip_2}}
+ifconfig {{intf}} {% if item.addr_family=='ipv6' %} inet6 add {% endif %} {{item.mux_ip_2}}
 i=0; until [ $i -eq 10 ] || ping {{minigraph_vlan_interfaces[0]['addr']}} -I {{intf}} -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &
 
 ip route flush {{minigraph_lo_interfaces[0]['addr']}}/{{minigraph_lo_interfaces[0]['prefixlen']}}


### PR DESCRIPTION
### Description of PR

This fix the regression after 44983442f4bb4df2a966ae0f530ab054814268b6 ([#876](https://github.com/Azure/sonic-mgmt/pull/876)).

@yxieca, I was wrong, `add` should not be used in case set IPv4 address. 

Current fix is applying configuration option only for IPv6 case.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
changed Jinja template, changed Ansible script

#### How did you verify/test it?

Tested bgp_speaker for  both v4 and v6 cases and also another cases like `fdb` in different sequence.
no regression found.

@yxieca please review this.