### PR TITLE
[vnet]: Wait for VNET routes to be applied to the HW

### DIFF
--- a/ansible/roles/test/tasks/vnet_vxlan.yml
+++ b/ansible/roles/test/tasks/vnet_vxlan.yml
@@ -125,6 +125,9 @@
         - name: Apply route json configuration
           shell: docker exec swss sh -c "swssconfig /vnet.route.json"
 
+        - name: sleep for some time
+          pause: seconds=3
+
     - include: ptf_runner.yml
       vars:
         ptf_test_name: Vnet vxlan test


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach
#### How did you do it?
From time to time test could fail due to sending traffic when VNET config is not yet applied, so before sending any packet need to make sure that config is already applied.
To fix this just added ```sleep``` after configuring VNET routes in order to wait config to be applied to HW before sending traffic.
#### How did you verify/test it?
Ran ansible test few times and verified that it passed.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
