### PR TITLE
[logAnalyzer] Flush after extracted logs

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -215,6 +215,7 @@ def combine_logs_and_save(directory, filenames, start_string, target_filename):
                         do_copy = True
                     if do_copy:
                         fp.write(line)
+        fp.flush()
 
 
 def extract_log(directory, prefixname, target_string, target_filename):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Log analyzer extracts logs starting from the start_marker to /tmp/syslog. This is done by the ansible/roles/library/extract_log.py module. Then log analyzer will write an end_marker into /tmp/syslog and analyze the content between start&end markers. Ocassionally, the end marker is not written to the end of /tmp/syslog. This caused some key logs are not in the range of start and end marker.
Possible reason is that the extract_log module does not do flush operation after write content to /tmp/syslog.
The change is to add a flush operation to the extract_log module after all the lines are written to /tmp/syslog.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add a flush operation to the extract_log module after all the lines are written to /tmp/syslog.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
