### PR TITLE
[fdb] Add FDB learning during config reload test

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_test.py
@@ -1,12 +1,13 @@
-import fdb
+import time
 import subprocess
+import logging
 
 from ipaddress import ip_address
-
 import ptf
-
 from ptf.base_tests import BaseTest
 from ptf.testutils import *
+
+import fdb
 
 class FdbTest(BaseTest):
 
@@ -82,4 +83,53 @@ class FdbTest(BaseTest):
 
                     for dummy_mac in self.dummy_mac_table[dst]:
                         self.test_l2_forwarding(arp_table[src], dummy_mac, src, dst)
+    #--------------------------------------------------------------------------
+
+
+class FdbConfigReloadTest(BaseTest):
+
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = test_params_get()
+    #--------------------------------------------------------------------------
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.router_mac = self.test_params["router_mac"]
+        self.vlan_ports = self.test_params["vlan_ports"].split()
+        self.lag_ports = self.test_params["lag_ports"].split()
+        self.dummy_mac_prefix = self.test_params["dummy_mac_prefix"]
+        self.vlan_port_idx = 0
+        self.lag_port_idx = 0
+    #--------------------------------------------------------------------------
+
+    def runTest(self):
+        max_time = 200  # seconds
+        i = 0
+        start_time = time.time()
+        while i < 0xffff - 128 and time.time() - start_time < max_time:
+            # Send frame to vlan and lag port in interleaved way
+            if i % 2 == 0:
+                port = self.vlan_ports[self.vlan_port_idx]
+                self.vlan_port_idx += 1
+                if self.vlan_port_idx >= len(self.vlan_ports):
+                    self.vlan_port_idx = 0
+            else:
+                port = self.lag_ports[self.lag_port_idx]
+                self.lag_port_idx += 1
+                if self.lag_port_idx >= len(self.lag_ports):
+                    self.lag_port_idx = 0
+
+            field_0 = i % 256
+            field_1 = i / 256
+            dummy_mac = self.dummy_mac_prefix + ":{:02x}:{:02x}".format(field_1, field_0)
+            pkt = simple_eth_packet(eth_dst=self.router_mac,
+                                    eth_src=dummy_mac,
+                                    eth_type=0x1234)
+            logging.debug("Send packet to port %s, src mac: %s" % (str(port), dummy_mac))
+            send(self, port, pkt)
+            i += 1
+
+            if i % len(self.lag_ports)*2 == 0:
+                time.sleep(0.1)
     #--------------------------------------------------------------------------

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -73,3 +73,83 @@
   always:
     - name: clear FDB table
       command: sonic-clear fdb all
+
+- block:
+  - name: clear FDB table
+    command: sonic-clear fdb all
+
+  - name: Get ports in portchannels
+    set_fact:
+      portchannel_members_all: []
+  - set_fact:
+      portchannel_members_all: "{{ portchannel_members_all + item['members'] }}"
+    with_items: "{{ minigraph_portchannels.values() }}"
+
+  - name: Get DUT ports info
+    set_fact:
+      vlan_ports: "{%for port in minigraph_vlans['Vlan1000']['members'] %}{{minigraph_port_indices[port]}}{%if not loop.last%} {%endif%}{%endfor%}"
+      lag_ports: "{%for port in portchannel_members_all %}{{minigraph_port_indices[port]}}{%if not loop.last%} {%endif%}{%endfor%}"
+
+  - name: Initialize variables
+    set_fact:
+      dummy_mac_prefix: "02:11:22:33"
+
+  - name: "Set ptf facts"
+    set_fact:
+      ptf_test_name: FDB test
+      ptf_test_dir: ptftests
+      ptf_test_path: fdb_test.FdbConfigReloadTest
+      ptf_platform: remote
+      ptf_platform_dir: ptftests
+      ptf_test_params:
+        - testbed_type='{{ testbed_type }}'
+        - vlan_ports='{{ vlan_ports }}'
+        - lag_ports='{{ lag_ports }}'
+        - router_mac='{{ ansible_interface_facts['Ethernet0']['macaddress'] }}'
+        - dummy_mac_prefix='{{ dummy_mac_prefix }}'
+      ptf_extra_options: "--relax --debug info --log-file /tmp/fdb_test.FdbTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
+
+  - debug: msg="ptf --test-dir {{ ptf_test_dir }} {{ ptf_test_path }} {% if ptf_qlen is defined %} --qlen={{ ptf_qlen }} {% endif %} {% if ptf_platform_dir is defined %} --platform-dir {{ ptf_platform_dir }} {% endif %} --platform {{ ptf_platform }} {% if ptf_test_params is defined %} -t \"{{ ptf_test_params | default([]) | join(';') }}\" {% endif %} {{ ptf_extra_options | default(\"\")}} 2>&1"
+
+  - name: Run PTF script to inject packets with different src MAC
+    shell: ptf --test-dir {{ ptf_test_dir }} {{ ptf_test_path }} {% if ptf_qlen is defined %} --qlen={{ ptf_qlen }} {% endif %} {% if ptf_platform_dir is defined %} --platform-dir {{ ptf_platform_dir }} {% endif %} --platform {{ ptf_platform }} {% if ptf_test_params is defined %} -t "{{ ptf_test_params | default([]) | join(';') }}" {% endif %} {{ ptf_extra_options | default("")}} 2>&1
+    args:
+      chdir: /root
+    delegate_to: "{{ ptf_host }}"
+    async: 300
+    poll: 0
+
+  - name: Reload config
+    command: config reload -y
+    become: yes
+
+  - name: Wait until the PTF script completed execution
+    shell: "ps -ef | grep /usr/bin/ptf | grep -v grep"
+    register: ptf_script_state
+    retries: 60
+    until: ptf_script_state.rc == 1
+    delay: 5
+    delegate_to: "{{ ptf_host }}"
+    ignore_errors: yes
+
+  - name: Wait some extra time to ensure that all FDB entries are in DB
+    pause: seconds=10
+
+  - name: Count FDB entries from SDK
+    shell: "docker exec syncd sx_api_fdb_dump.py | grep {{ dummy_mac_prefix }} | wc -l"
+    register: sdk_fdb_count
+
+  - debug: msg="{{ sdk_fdb_count.stdout_lines }}"
+
+  - name: Count FDB entries from 'show mac'
+    shell: "show mac | grep {{ dummy_mac_prefix }} | wc -l"
+    register: show_mac_output
+
+  - debug: msg="{{ show_mac_output.stdout_lines }}"
+
+  - fail: msg="In consistent number MAC entries between SDK and DB"
+    when: sdk_fdb_count.stdout != show_mac_output.stdout
+
+  always:
+    - name: clear FDB table
+      command: sonic-clear fdb all

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -136,13 +136,13 @@
     pause: seconds=10
 
   - name: Count FDB entries from SDK
-    shell: "docker exec syncd sx_api_fdb_dump.py | grep {{ dummy_mac_prefix }} | wc -l"
+    shell: "docker exec syncd sx_api_fdb_dump.py | grep AGEABLE | wc -l"
     register: sdk_fdb_count
 
   - debug: msg="{{ sdk_fdb_count.stdout_lines }}"
 
   - name: Count FDB entries from 'show mac'
-    shell: "show mac | grep {{ dummy_mac_prefix }} | wc -l"
+    shell: "show mac | grep Dynamic | wc -l"
     register: show_mac_output
 
   - debug: msg="{{ show_mac_output.stdout_lines }}"

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -124,7 +124,7 @@
     become: yes
 
   - name: Get PID of the PTF script
-    shell: "ps -ef | grep /usr/bin/ptf | grep -v grep | awk '{print $2}'"
+    command: "pgrep -f '/usr/bin/python /usr/bin/ptf'"
     register: ptf_script_pid
     delegate_to: "{{ ptf_host }}"
 

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -153,3 +153,5 @@
   always:
     - name: clear FDB table
       command: sonic-clear fdb all
+
+  when: sonic_asic_type == 'mellanox'

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -123,14 +123,14 @@
     command: config reload -y
     become: yes
 
-  - name: Wait until the PTF script completed execution
-    shell: "ps -ef | grep /usr/bin/ptf | grep -v grep"
-    register: ptf_script_state
-    retries: 60
-    until: ptf_script_state.rc == 1
-    delay: 5
+  - name: Get PID of the PTF script
+    shell: "ps -ef | grep /usr/bin/ptf | grep -v grep | awk '{print $2}'"
+    register: ptf_script_pid
     delegate_to: "{{ ptf_host }}"
-    ignore_errors: yes
+
+  - name: Wait until the PTF script completed execution
+    shell: "tail --pid={{ ptf_script_pid.stdout }} -f /dev/null"
+    delegate_to: "{{ ptf_host }}"
 
   - name: Wait some extra time to ensure that all FDB entries are in DB
     pause: seconds=10
@@ -147,11 +147,11 @@
 
   - debug: msg="{{ show_mac_output.stdout_lines }}"
 
+  - name: clear FDB table when test case pass
+    command: sonic-clear fdb all
+    when: sdk_fdb_count.stdout == show_mac_output.stdout
+
   - fail: msg="In consistent number MAC entries between SDK and DB"
     when: sdk_fdb_count.stdout != show_mac_output.stdout
-
-  always:
-    - name: clear FDB table
-      command: sonic-clear fdb all
 
   when: sonic_asic_type == 'mellanox'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This case is to verify that all the FDB entries learned by SDK are correctly reported to upper layer in the initialization process after config reload.

The added case in this PR is  to cover the issue fixed by SAI commit: https://github.com/Mellanox/SAI-Implementation/commit/fc5a8dd398dfb23b489d4cfd1e810ccb892f0205 

Steps performed by the scripts:
* Find out the list of ports in VLAN
* Find out the list of ports in PortChannel
* Start a PTF script in asynchronous. Keep it running and move on to next ansible task immediately. Details of the PTF script:
  * The PTF script keeps sending packets with unique src MAC address to different vlan ports and lag ports in interleaved way. The unique src MAC addresses have same pre-defined prefix.
  * Pause 0.1 second after sending 8 packets (4 sent to VLAN ports, 4 sent to LAG ports, interleaved)
  * Repeat the above steps for 200 seconds.
* Immediately execute “sudo config reload -y” after the PTF script is started.
* After config reload is completed (need around 90 seconds), keep waiting until the PTF script is completed executing.
* Check the number of learned FDB entries from SDK:
  * `docker exec syncd sx_api_fdb_dump.py | grep {{ dummy_mac_prefix }} | wc -l`
* Check the number of learned FDB entries from “show mac”:
  * `show mac | grep {{ dummy_mac_prefix }} | wc -l`
* Compare the number of learned FDB entries:
  * If SDK entries < “show mac” entries, issue reproduced
  * If SDK entries == “show mac” entries, verified OK

With the current tuning (send for 200 seconds, 8 packets in a batch, send to VLAN ports and LAG ports in interleaved pattern, 0.1s interval between batches), the issue could be reproduced 4 times in 6 tests.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Extended the existing FDB testing scripts. Please refer to the description for detailed steps.

#### How did you verify/test it?
Verified on Mellanox platform.

#### Any platform specific information?
The command for checking FDB entries learned from SDK is Mellanox specific.  It takes nearly 4 minutes to run this added test case. There is no point wasting time run the case and skip verification step for other vendors. Because of this, I set the whole new test case Mellanox specific for now.

If other vendors consider this test case useful, they need little effort to refactor this test case to make just the step for counting FDB entries learned in SDK vendor specific.

#### Supported testbed topology if it's a new test case?
['t0', 't0-64', 't0-116']

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
https://github.com/Azure/SONiC/wiki/FDB-Scale-Test-Plan
[fdb_test_ansible.log](https://github.com/Azure/sonic-mgmt/files/3121008/fdb_test_ansible.log)
