### PR TITLE
Extended port_alias config processing: added KVM platform

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -43,8 +43,10 @@ PORTMAP_FILE = 'port_config.ini'
 ALLOWED_HEADER = ['name', 'lanes', 'alias', 'index', 'speed']
 
 MACHINE_CONF = '/host/machine.conf'
-ONIE_PLATFORM = 'onie_platform'
-ABOOT_PLATFORM = 'aboot_platform'
+ONIE_PLATFORM_KEY = 'onie_platform'
+ABOOT_PLATFORM_KEY = 'aboot_platform'
+
+KVM_PLATFORM = 'x86_64-kvm_x86_64-r0'
 
 class SonicPortAliasMap():
     """
@@ -56,12 +58,14 @@ class SonicPortAliasMap():
         return
 
     def get_platform_type(self):
+        if not os.path.exists(MACHINE_CONF):
+            return KVM_PLATFORM
         with open(MACHINE_CONF) as machine_conf:
             for line in machine_conf:
                 tokens = line.split('=')
                 key = tokens[0].strip()
                 value = tokens[1].strip()
-                if key == ONIE_PLATFORM or key == ABOOT_PLATFORM:
+                if key == ONIE_PLATFORM_KEY or key == ABOOT_PLATFORM_KEY:
                     return value
         return None
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

### Description of PR
Extended port_alias config processing: added KVM platform

### Type of change
- Bug fix

### Approach
#### How did you do it?
* Changed port_config.ini path generation logic

#### How did you verify/test it?
* Executed relevant test cases

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation
* N/A