### PR TITLE
Fix python crash in case data plane never stop on fast-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1193,7 +1193,6 @@ class ReloadTest(BaseTest):
     def pingFromServers(self):
         for i in xrange(self.nr_pc_pkts):
             testutils.send_packet(self, self.from_server_src_port, self.from_vlan_packet)
-            time.sleep(.001)
 
         total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.from_vlan_exp_packet, self.from_server_dst_ports, timeout=self.TIMEOUT)
 
@@ -1204,7 +1203,6 @@ class ReloadTest(BaseTest):
     def pingFromUpperTier(self):
         for entry in self.from_t1:
             testutils.send_packet(self, *entry)
-            time.sleep(.001)
 
         total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.from_t1_exp_packet, self.vlan_ports, timeout=self.TIMEOUT)
 

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -694,7 +694,7 @@ class ReloadTest(BaseTest):
 
             if no_routing_stop:
                 self.log("Downtime was %s" % str(no_routing_stop - no_routing_start))
-                if no_routing_stop != datetime.datetime.min:
+                if not routing_always:
                     self.log("Reboot time was %s" % str(no_routing_stop - self.reboot_start))
                 else:
                     self.log("Reboot time was minimal")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -694,10 +694,8 @@ class ReloadTest(BaseTest):
 
             if no_routing_stop:
                 self.log("Downtime was %s" % str(no_routing_stop - no_routing_start))
-                if not routing_always:
-                    self.log("Reboot time was %s" % str(no_routing_stop - self.reboot_start))
-                else:
-                    self.log("Reboot time was minimal")
+                reboot_time = "0:00:00" if routing_always else str(no_routing_stop - self.reboot_start)
+                self.log("Reboot time was %s" % reboot_time)
                 self.log("Expected downtime is less then %s" % self.limit)
 
             if self.reboot_type == 'fast-reboot' and no_cp_replies:

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -511,6 +511,7 @@ class ReloadTest(BaseTest):
         no_routing_stop = None
         no_cp_replies = None
         upper_replies = []
+        routing_always = False
 
         arista_vms = self.test_params['arista_vms'][1:-1].split(",")
         ssh_targets = []
@@ -591,15 +592,16 @@ class ReloadTest(BaseTest):
                     self.log("Data plane was stopped, Waiting until it's up. Stop time: %s" % str(no_routing_start))
                 except TimeoutError:
                     self.log("Data plane never stop")
-                    no_routing_start = datetime.datetime.min
+                    routing_always = True
                     upper_replies = [self.nr_vl_pkts]
 
-                if no_routing_start is not None and no_routing_start != datetime.datetime.min:
+                if no_routing_start is not None:
                     self.timeout(self.task_timeout, "DUT hasn't started to work for %d seconds" % self.task_timeout)
                     no_routing_stop, _ = self.check_forwarding_resume()
                     self.cancel_timeout()
                 else:
                     no_routing_stop = datetime.datetime.min
+                    no_routing_start = datetime.datetime.min
 
                 # Stop watching DUT
                 self.watching = False


### PR DESCRIPTION
If for some reason data plane never stop on fast reboot the script will
fail bc of some undefined variables.

### Description of PR
 - Do not crash in case data plane never stop on fast-reboot; 
 - Insert 1ms interpacket gap as on some platforms have seen that `swss` was not fast enough to insert all the FDB entries.

Have tested the CT with `ReloadTest::max_nr_vl_pkts == 1000` and verified that it passed.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
 Changed Python script

#### How did you verify/test it?
 Run `fast-reboot` CT and verify it will pass even in case `ReloadTest::max_nr_vl_pkts == 1000`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 


@yxieca please review and merge this