### PR TITLE
[decap]: Add default dscp_mode to decap test

### DIFF
--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -3,13 +3,10 @@
 #-----------------------------------------
 
 - block:
-  - name: Set dscp_mode for decap test for broadcom
+  - name: Set dscp_mode for decap test
     set_fact:
        dscp_mode: pipe
        ecn_mode: copy_from_outer
-    when:
-       - sonic_hwsku in broadcom_hwskus
-       - dscp_mode is not defined
 
   - name: Set dscp_mode var for decap test for mellanox
     set_fact:
@@ -17,7 +14,6 @@
        ecn_mode: standard
     when:
        - sonic_hwsku in mellanox_hwskus
-       - dscp_mode is not defined
 
   - name: Set ttl_mode var
     set_fact:


### PR DESCRIPTION
Description of PR
Set a default dscp/ecn mode in the Decap Ansible test. This will allow test to proceed if hw_sku is other than Mellanox/Broadcom.

Type of change: Enhancement/Fix

Approach
How did you do it?
Set the dscp_mode to pipe and ecn_mode to copy_from_outer by default 
How did you verify/test it?
Ansible test run on DUT
