### PR TITLE
[warm-reboot] increase warm-reboot sniffing time

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -821,7 +821,7 @@ class ReloadTest(BaseTest):
         The native scapy.snif() is used as a background thread, to allow delayed start for the send_in_background().
         """
         if not wait:
-            wait = self.time_to_listen + 30
+            wait = self.time_to_listen + 60
         sniffer_start = datetime.datetime.now()
         self.log("Sniffer started at %s" % str(sniffer_start))
         sniff_filter = "tcp and tcp dst port 5000 and tcp src port 1234 and not icmp"


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

With the original wait time, we couldn't receive all 36000 fast probing packets sent by warm-reboot
test. If any packet were delayed/re-ordered by the test infrastructure, the test would mis-judge the
missing packets as dropped packets. Therefore causing false positives. Increase the wait time by 30
seconds, in my tests, all 36000 packet were received and therefore no false positives.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
