### PR TITLE
[mtu] optimizing mtu for configurable in testbed

### DIFF
--- a/ansible/roles/test/files/ptftests/mtu_test.py
+++ b/ansible/roles/test/files/ptftests/mtu_test.py
@@ -36,6 +36,7 @@ class MtuTest(BaseTest):
     #---------------------------------------------------------------------
     DEFAULT_PACKET_LEN = 9114
     ICMP_HDR_LEN = 8
+    pktlen = DEFAULT_PACKET_LEN
 
     def __init__(self):
         '''
@@ -50,6 +51,7 @@ class MtuTest(BaseTest):
         self.dataplane = ptf.dataplane_instance
         self.router_mac = self.test_params['router_mac']
         self.testbed_type = self.test_params['testbed_type']
+        self.testbed_mtu = self.test_params['testbed_mtu']
     
     #---------------------------------------------------------------------
 
@@ -61,7 +63,7 @@ class MtuTest(BaseTest):
         ip_dst = "10.0.0.0"
         src_mac = self.dataplane.get_mac(0, 0)
 
-        pktlen = self.DEFAULT_PACKET_LEN
+        pktlen = self.pktlen
 
         pkt = simple_icmp_packet(pktlen=pktlen,
                             eth_dst=self.router_mac,
@@ -107,14 +109,14 @@ class MtuTest(BaseTest):
         ip_dst = "10.0.0.63"
         src_mac = self.dataplane.get_mac(0, 0)
 
-        pkt = simple_ip_packet(pktlen=self.DEFAULT_PACKET_LEN,
+        pkt = simple_ip_packet(pktlen=self.pktlen,
                             eth_dst=self.router_mac,
                             eth_src=src_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
                             ip_ttl=64)
 
-        exp_pkt = simple_ip_packet(pktlen=self.DEFAULT_PACKET_LEN,
+        exp_pkt = simple_ip_packet(pktlen=self.pktlen,
                             eth_src=self.router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
@@ -148,5 +150,8 @@ class MtuTest(BaseTest):
         @summary: Send packet(Max MTU) to test on Ping request/response and unicast IP destination.
         Expect the packet to be received from one of the expected ports
         """
+        if self.testbed_mtu != 0 :
+           self.pktlen = self.testbed_mtu          
+
         self.check_icmp_mtu()
         self.check_ip_mtu()

--- a/ansible/roles/test/files/ptftests/mtu_test.py
+++ b/ansible/roles/test/files/ptftests/mtu_test.py
@@ -27,16 +27,14 @@ class MtuTest(BaseTest):
     back. It also sends a jumbo frame to a route destination for verifying the 
     forwarding functionality
     
-    For the device configured with IP-MTU=9100, PHY-MTU=9114,
+    By default.For the device configured with IP-MTU=9100, PHY-MTU=9114,
      - ICMP/IP frame, the packet-len is 9114 (This includes the 14 bytes Layer 2 Ethernet header)
     '''
 
     #---------------------------------------------------------------------
     # Class variables
     #---------------------------------------------------------------------
-    DEFAULT_PACKET_LEN = 9114
     ICMP_HDR_LEN = 8
-    pktlen = DEFAULT_PACKET_LEN
 
     def __init__(self):
         '''
@@ -62,7 +60,6 @@ class MtuTest(BaseTest):
         ip_src = "10.0.0.1"
         ip_dst = "10.0.0.0"
         src_mac = self.dataplane.get_mac(0, 0)
-
         pktlen = self.pktlen
 
         pkt = simple_icmp_packet(pktlen=pktlen,
@@ -150,8 +147,6 @@ class MtuTest(BaseTest):
         @summary: Send packet(Max MTU) to test on Ping request/response and unicast IP destination.
         Expect the packet to be received from one of the expected ports
         """
-        if self.testbed_mtu != 0 :
-           self.pktlen = self.testbed_mtu          
-
+        self.pktlen = self.testbed_mtu          
         self.check_icmp_mtu()
         self.check_ip_mtu()

--- a/ansible/roles/test/tasks/mtu.yml
+++ b/ansible/roles/test/tasks/mtu.yml
@@ -9,6 +9,12 @@
 - fail: msg="testbed_type {{testbed_type}} is invalid."
   when: testbed_type not in ['t1-lag', 't1', 't1-64-lag']
 
+- set_fact: mtu=0
+  when: mtu is not defined
+
+- name: Print testbed mtu
+  debug: msg="{{mtu}}"
+  
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 
 - name: Expand properties into props
@@ -37,4 +43,5 @@
     ptf_test_params:
       - testbed_type='{{testbed_type}}'
       - router_mac='{{ansible_Ethernet0['macaddress']}}'
+      - testbed_mtu={{mtu}} # 0 -- using default. The value includes the 14 bytes Layer 2 Ethernet header.
     ptf_extra_options: "--relax --debug info --log-file /tmp/mtu_test.MtuTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log --socket-recv-size 16384"

--- a/ansible/roles/test/tasks/mtu.yml
+++ b/ansible/roles/test/tasks/mtu.yml
@@ -9,7 +9,7 @@
 - fail: msg="testbed_type {{testbed_type}} is invalid."
   when: testbed_type not in ['t1-lag', 't1', 't1-64-lag']
 
-- set_fact: mtu=0
+- set_fact: mtu=9114   #using the default mtu,The value includes the 14 bytes Layer 2 Ethernet header
   when: mtu is not defined
 
 - name: Print testbed mtu
@@ -43,5 +43,5 @@
     ptf_test_params:
       - testbed_type='{{testbed_type}}'
       - router_mac='{{ansible_Ethernet0['macaddress']}}'
-      - testbed_mtu={{mtu}} # 0 -- using default. The value includes the 14 bytes Layer 2 Ethernet header.
+      - testbed_mtu={{mtu}} 
     ptf_extra_options: "--relax --debug info --log-file /tmp/mtu_test.MtuTest.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log --socket-recv-size 16384"


### PR DESCRIPTION
Summary:
### Type of change
- [] Test case(improvement)
  1. In roles/test/tasks/mtu.yml
        I have added the parameter of "testbed_mtu", Users can use the default value or set  their own mtu .
  2. In roles/test/files/ptftests/mtu_test.py
       The parameter of self.pktlen has been added. When inputing parameter of "testbed_mtu" isn't the default of 0.  It will be set with the value. otherwise. It will use the default value of DEFAULT_PACKET_LEN.


#### How did you verify/test it?
          I have set  “testbed_mtu” as the default of zero. to test the case of mtu. It works well.
          I have set "testbed_mtu" as 1514. to test the case of mtu. It works well.
#### Any platform specific information?
         No.



