### PR TITLE
[continuous-reboot] wait for warmboot-finalizer to finish if warm-reboot

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -59,3 +59,13 @@
 
 - name: wait for 2 minute for prcesses and interfaces to be stable
   pause: seconds=120
+
+- name: Wait for warmboot-finalizer service to finish
+  become: true
+  ignore_errors: true
+  shell: systemctl is-active warmboot-finalizer.service
+  register: status
+  until: status.stdout.find('inactive') != -1
+  delay: 10
+  retries: 30
+  when: reboot_type == 'warm-reboot'


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: [continuous-reboot] wait for warmboo-finalizer to finish if warm-reboot
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Wait until warmboot-finalizer service finishes because I have seen cases when orchagent was not ready after 2 min wait after start

#### How did you verify/test it?
Run warm reboot continuous test 10 times

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
