### PR TITLE
Adding iface_naming_mode scripts for vlan and interface  neighbor

### DIFF
--- a/ansible/roles/test/tasks/iface_naming_mode/iface_naming_mode_tests.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/iface_naming_mode_tests.yml
@@ -68,6 +68,9 @@
   - name: verify show portchannel interface output in {{mode}}  mode
     include: "roles/test/tasks/iface_naming_mode/show_portchannel.yml"
 
+  - name: verify config and show vlan  output in {{mode}}  mode
+    include: "roles/test/tasks/iface_naming_mode/vlan_test.yml"
+
   become_user: '{{uname1}}'
   become: yes
   when: testbed_type in ['t0', 't0-64',  't0-64-32', 't0-116', ]

--- a/ansible/roles/test/tasks/iface_naming_mode/show_interface.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/show_interface.yml
@@ -1,5 +1,29 @@
 - block:
 
+  # show interface neighbor expectd
+
+  - name:    show  interface  neighbor exepcted in {{mode}} mode
+    shell:  show interfaces neighbor expected
+    register: show_int_neighbor
+
+  - debug: var=show_int_neighbor
+
+  - name: Check  show interfaces neighbor expected in alias  mode
+    assert:
+      that:
+        -  show_int_neighbor.stdout | search("{{port_name_map[item]}}\s+{{minigraph_neighbors[item]['name']}}")
+    with_items: minigraph_neighbors
+    when:  mode=='alias'
+
+  - name: Check  show interfaces neighbor expected in default  mode
+    assert:
+      that:
+        -  show_int_neighbor.stdout | search("{{item}}\s+{{minigraph_neighbors[item]['name']}}")
+    with_items: minigraph_neighbors
+    when:  mode=='default'
+
+  # show ip interfaces
+
   - name:  Get  show ip interface
     shell: show ip interface
     register: show_ip_intf

--- a/ansible/roles/test/tasks/iface_naming_mode/vlan_test.yml
+++ b/ansible/roles/test/tasks/iface_naming_mode/vlan_test.yml
@@ -1,0 +1,54 @@
+- block:
+  - set_fact:
+     vlan_interface: "{{minigraph_vlans[minigraph_vlans.keys()[0]]['members'][0]}}"
+  - set_fact:
+     vlan_interface_alias: "{{port_name_map[vlan_interface]}}"
+
+  - set_fact:
+      v_intf: "{{vlan_interface_alias if (mode=='alias') else vlan_interface}}"
+
+  # show vlan
+  - name: show vlan brief output
+    shell: sudo show vlan brief
+    register: show_vlan_brief
+
+  - debug: var=show_vlan_brief
+
+  - name: check interface names of minigraph vlan 1000  are shown  as alias names
+    assert:
+      that:
+        - show_vlan_brief.stdout | search("{{port_name_map[item]}}.*untagged")
+    with_items: minigraph_vlans['Vlan1000']['members']
+    when: mode=="alias"
+
+  - name: check interface names of minigraph vlan 1000  are shown  as default names
+    assert:
+      that:
+        - show_vlan_brief.stdout | search("{{item}}.*untagged")
+    with_items: minigraph_vlans['Vlan1000']['members']
+    when: mode=="default"
+  # add vlan 
+
+  - name:  create vlan 100
+    shell: sudo config vlan add 100
+
+  - name:  Add member {{v_intf}} to vlan 100
+    shell: sudo config vlan member add 100 {{v_intf}}
+  
+  - name: show vlan config
+    shell:  sudo show vlan config | grep -w "Vlan100"
+    register: show_vlan
+
+  - debug: var=show_vlan
+
+  - name: check whether {{v_intf}} is part of vlan
+    assert: {that: "'{{v_intf}}' in '{{show_vlan.stdout}}'"}
+
+# As the ansible work in non interactive mode, it doesnt read the environmental varaiable set in bashrc file. Hence as a workaround, the variable is  extracted through check_userifmode.yml and manually set the variable 'SONIC_CLI_IFACE_MODE' to take effect.
+
+  environment:
+      SONIC_CLI_IFACE_MODE: "{{ifmode}}"
+
+  always:
+    - name: General cleanup.
+      shell: sudo config vlan del 100


### PR DESCRIPTION

Summary:
Adding  iface_naming_mode  tests for vlan and "show interface  neighbor expected "

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Added iface_naming_mode  tests for the below commands 
- config vlan
- show vlan brief
- show vlan config
- show interface neighbor expected 

#### How did you verify/test it?
verified in T0/T1 topologies 
#### Any platform specific information?
Platform independent

#### Supported testbed topology if it's a new test case?
T0/T1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
