### PR TITLE
[mlnx] upstream mellanox pfc storm dockers and playbooks to check/deploy on fa…

### DIFF
--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -30,3 +30,17 @@
   - include: rootfanout_connect.yml
       deploy_leaf=true
   when: sw_type == 'FanoutLeaf'
+
+ ###################################################################
+ # build, deploy and start docker images for the PFC WD test       #
+ ###################################################################
+- include: mlnx/deploy_pfcwd_fanout.yml
+  when: peer_hwsku == "MLNX-OS"
+  tags: deploy,pfcwd_config
+
+ ###################################################################
+ # check and recover docker images for the PFC WD test             #
+ ###################################################################
+- include: mlnx/check_pfcwd_fanout.yml
+  when: peer_hwsku == "MLNX-OS"
+  tags: check_pfcwd_config

--- a/ansible/roles/fanout/tasks/mlnx/check_pfcwd_fanout.yml
+++ b/ansible/roles/fanout/tasks/mlnx/check_pfcwd_fanout.yml
@@ -1,0 +1,22 @@
+##############################################################################################
+### sub-playbook to deploy the docker images needed for the pfcwd test to fanout swtich
+### to run separately:
+### ansible-playbook -i lab fanout.yml -l ${FANOUT} --become --tags check_pfcwd_config -vvvv
+################################################################################################
+
+- name: Load and start dockers
+  action: apswitch template=mlnx_check_pfcwd_fanout.j2
+  connection: switch
+  register: output
+  args:
+    login: "{{ switch_login['MLNX-OS'] }}"
+
+- set_fact:
+    dockers_running: "{{output.stdout|search(\"args *storm_args\")|bool}}"
+    dockers_installed: "{{output.stdout|search(\"pfc_storm\") and output.stdout|search(\"storm_args\")|bool}}"
+
+- debug:
+    msg: "Dockers installed{{':'}} {{dockers_installed}}"
+
+- debug:
+    msg: "Dockers running  {{':'}} {{dockers_running}}"

--- a/ansible/roles/fanout/tasks/mlnx/deploy_pfcwd_fanout.yml
+++ b/ansible/roles/fanout/tasks/mlnx/deploy_pfcwd_fanout.yml
@@ -1,0 +1,54 @@
+##############################################################################################
+### sub-playbook to deploy the docker images needed for the pfcwd test to fanout swtich
+### to run separately:
+### ansible-playbook -i lab fanout.yml -l ${FANOUT} --become --tags pfcwd_config -vvvv
+### Optionally "-e pfcwd_dockers_url=<www_path>" can be specified to fetch dockers without
+### building them. This is useful to save time or run task in sonic-mgmt docker.
+### E.g.
+### ansible-playbook -i lab fanout.yml -l ${FANOUT} -e pfcwd_dockers_url=http://arc-build-server/sonic/ --become --tags pfcwd_config -vvvv
+################################################################################################
+
+- set_fact:
+    fanout_addr: "{{device_info['mgmtip']}}"
+    ansible_ssh_user: "{{fanout_root_user}}"
+    ansible_ssh_pass: "{{fanout_root_pass}}"
+    pfcwd_dockers: "['roles/test/files/mlnx/docker-tests-pfcgen/pfc_storm.tgz', 'roles/test/files/mlnx/docker-tests-saveargs/storm_args.tgz']"
+    fanout_img_path: "/var/opt/tms/images/"
+
+- name: Build containers to save storm arguments and to run storm
+  command: make
+  args:
+    chdir: "{{item | dirname}}"
+  with_items: pfcwd_dockers
+  delegate_to: localhost
+  when: pfcwd_dockers_url is not defined
+
+- name: Copy test match and ignore files to switch
+  copy:
+      src: "{{ item }}"
+      dest: "{{fanout_img_path}}"
+  with_items: pfcwd_dockers
+  when: pfcwd_dockers_url is not defined
+
+- name: Download pre-built pfcwd dockers if path specified
+  get_url: url={{pfcwd_dockers_url}}{{item | basename}} dest={{fanout_img_path}}/{{item | basename}}
+  with_items: pfcwd_dockers
+  when: pfcwd_dockers_url is defined
+
+- block:
+    - name: Mount FS to read-write
+      command: mount -o remount, rw /
+
+    - name: Update storage driver for Docker
+      command: 'sed -i s/\"storage-driver\":\ \"vfs\",/\"storage-driver\":\ \"devicemapper\",\\n\ \ \ \ \"storage-opts\":\ [\\n\ \ \ \ \ \ \ \ \"dm.fs=ext4\"\\n\ \ \ \ ],\/g /opt/tms/bin/docker_config.json'
+
+  always:
+    - name: Remount FS back to read-only
+      command: mount -r -o remount /
+
+- name: Load and start dockers
+  action: apswitch template=mlnx_deploy_pfcwd_fanout.j2
+  connection: switch
+  args:
+    timeout: 600
+    login: "{{ switch_login['MLNX-OS'] }}"

--- a/ansible/roles/test/files/mlnx/docker-tests-pfcgen/Dockerfile
+++ b/ansible/roles/test/files/mlnx/docker-tests-pfcgen/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:2.7-jessie
+
+COPY ["start.sh", "pfc_gen.py", "/root/"]
+
+CMD ["/root/start.sh"]

--- a/ansible/roles/test/files/mlnx/docker-tests-pfcgen/Makefile
+++ b/ansible/roles/test/files/mlnx/docker-tests-pfcgen/Makefile
@@ -1,0 +1,9 @@
+all: save
+
+build: Dockerfile
+	cp ../../helpers/pfc_gen.py .
+	docker build -t pfc_storm .
+	rm ./pfc_gen.py
+
+save: build
+	docker save pfc_storm:latest | gzip >pfc_storm.tgz

--- a/ansible/roles/test/files/mlnx/docker-tests-pfcgen/start.sh
+++ b/ansible/roles/test/files/mlnx/docker-tests-pfcgen/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/root/pfc_gen.py `cat /storm/args`

--- a/ansible/roles/test/files/mlnx/docker-tests-saveargs/Dockerfile
+++ b/ansible/roles/test/files/mlnx/docker-tests-saveargs/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:jessie
+
+COPY ./save_args.sh /root/

--- a/ansible/roles/test/files/mlnx/docker-tests-saveargs/Makefile
+++ b/ansible/roles/test/files/mlnx/docker-tests-saveargs/Makefile
@@ -1,0 +1,7 @@
+all: save
+
+build: Dockerfile
+	docker build -t storm_args .
+
+save: build
+	docker save storm_args:latest | gzip >storm_args.tgz

--- a/ansible/roles/test/files/mlnx/docker-tests-saveargs/save_args.sh
+++ b/ansible/roles/test/files/mlnx/docker-tests-saveargs/save_args.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $@ >/storm/args


### PR DESCRIPTION
…nout

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
ansible-playbook -i lab fanout.yml -l ${FANOUT} --become --tags check_pfcwd_config -vvvv
ansible-playbook -i lab fanout.yml -l ${FANOUT} --become --tags pfcwd_config -vvvv

#### Any platform specific information?
Specific for Mellanox fanout

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

