### PR TITLE
Workaround python2 bug on strptime with threading

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -5,6 +5,7 @@ import ptf.testutils as testutils
 from ptf.testutils import *
 from ptf.dataplane import match_exp_pkt
 import datetime
+import _strptime  # workaround python bug ref: https://stackoverflow.com/a/22476843/2514803
 import time
 import subprocess
 from ptf.mask import Mask


### PR DESCRIPTION
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "ptftests/advanced-reboot.py", line 769, in peer_state_check
    self.fails[ip], self.info[ip], self.cli_info[ip], self.logs_info[ip] = ssh.run()
  File "ptftests/arista.py", line 157, in run
    log_data = self.parse_logs(log_lines)
  File "ptftests/arista.py", line 218, in parse_logs
    result_bgp, initial_time_bgp = self.extract_from_logs(bgp_r, data)
  File "ptftests/arista.py", line 205, in extract_from_logs
    raw_data.append((datetime.datetime.strptime(m.group(1), "%b %d %X"), m.group(2), m.group(3)))
AttributeError: 'module' object has no attribute '_strptime'

```
