### PR TITLE
[deploy_pfc_pktgen] Ensure destination directory exists before copying pfc_gen_file

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/deploy_pfc_pktgen.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/deploy_pfc_pktgen.yml
@@ -1,11 +1,22 @@
-- name: Create pfc generater file in case it doesn't exist.
-  file: path=/mnt/flash/{{pfc_gen_file}} state=touch
-  delegate_to: "{{peer_mgmt}}"
-  become: true
-  when: peer_hwsku | search("Arista") or peer_hwsku | search("arista")
+- block:
+  - name: Ensure destination directory exists on fanout
+    file:
+      path: "/mnt/flash/"
+      state: directory
+    delegate_to: "{{peer_mgmt}}"
+    become: true
 
-- name: Deploy PFC generator to the fanout switch
-  copy: src=roles/test/files/helpers/{{pfc_gen_file}} dest=/mnt/flash
-  delegate_to: "{{peer_mgmt}}"
-  become: true
+  - name: Create pfc generator file in case it doesn't exist.
+    file:
+      path: "/mnt/flash/{{pfc_gen_file}}"
+      state: touch
+    delegate_to: "{{peer_mgmt}}"
+    become: true
+
+  - name: Deploy PFC generator to the fanout switch
+    copy:
+      src: "roles/test/files/helpers/{{pfc_gen_file}}"
+      dest: "/mnt/flash"
+    delegate_to: "{{peer_mgmt}}"
+    become: true
   when: peer_hwsku | search("Arista") or peer_hwsku | search("arista")


### PR DESCRIPTION
This change ensures we successfully copy the pfc_gen_file on both EOS and SONiC fanout switches by first creating the `/mnt/flash` directory (which, by default, doesn't exist on SONiC devices). It should be a no-op on EOS devices, where the `/mnt/flash` directory should already exist.