### PR TITLE
Improve vxlan decap test. Make a test after vxlan removal

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -228,7 +228,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
-        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.1)
+        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.2)
         rv = rv and (nr_rcvd == self.nr)
         return rv
 
@@ -257,7 +257,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.1)
+        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.2)
         rv = rv and (nr_rcvd == self.nr)
         return rv
 
@@ -291,7 +291,7 @@ class Vxlan(BaseTest):
                  )
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.1)
+        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.2)
         rv = rv and (nr_rcvd == self.nr)
         return rv
 

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -73,11 +73,11 @@
         - count=1
 
     - name: Remove vxlan tunnel map configuration for {{ item }}
-      shell: redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnel{{ item }}|map1"
+      shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnel{{ item }}|map1"
       with_items: minigraph_vlans
 
     - name: Remove vxlan tunnel configuration for {{ item }}
-      shell: redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnel{{ item }}"
+      shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnel{{ item }}"
       with_items: minigraph_vlans
 
     - include: ptf_runner.yml

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -44,7 +44,7 @@
 
     - include: ptf_runner.yml
       vars:
-        ptf_test_name: Vxlan decap test
+        ptf_test_name: Vxlan decap test - No vxlan configuration
         ptf_test_dir: ptftests
         ptf_test_path: vxlan-decap.Vxlan
         ptf_platform: remote
@@ -61,7 +61,7 @@
 
     - include: ptf_runner.yml
       vars:
-        ptf_test_name: Vxlan decap test
+        ptf_test_name: Vxlan decap test - vxlan configuration applied
         ptf_test_dir: ptftests
         ptf_test_path: vxlan-decap.Vxlan
         ptf_platform: remote
@@ -71,3 +71,24 @@
         - vxlan_enabled=True
         - config_file='/tmp/vxlan_decap.json'
         - count=1
+
+    - name: Remove vxlan tunnel map configuration for {{ item }}
+      shell: redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnel{{ item }}|map1"
+      with_items: minigraph_vlans
+
+    - name: Remove vxlan tunnel configuration for {{ item }}
+      shell: redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnel{{ item }}"
+      with_items: minigraph_vlans
+
+    - include: ptf_runner.yml
+      vars:
+        ptf_test_name: Vxlan decap test - vxlan configuration removed
+        ptf_test_dir: ptftests
+        ptf_test_path: vxlan-decap.Vxlan
+        ptf_platform: remote
+        ptf_platform_dir: ptftests
+        ptf_qlen: 1000
+        ptf_test_params:
+        - vxlan_enabled=False
+        - config_file='/tmp/vxlan_decap.json'
+        - repetitions=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. Add one extra test case: remove vxlan configuration and check that data plane made the change
2. Adjusted timeout parameter. Sometimes we lost first packet, because SONiC takes more than 0.1 second to insert FDB entry.

#### How did you verify/test it?
`ansible-playbook test_sonic.yml -i str --limit sonic-device --vault-password-file password.txt -e testcase_name=vxlan_decap -e testbed_name=testbed-1`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
