### PR TITLE
Improve lag_2 test case suit "Sonic" as the fanout . 

### DIFF
--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -51,16 +51,8 @@
   delegate_to: "{{ ptf_host }}"
 
 - name: Include testbed topology configuration (to get LAG IP and PTF docker interfaces, that are behind LAG VMs).
-  include_vars: vars/topo_t1-lag.yml
-  when: testbed_type == 't1-lag'
-
-- name: Include testbed topology configuration (to get LAG IP and PTF docker interfaces, that are behind LAG VMs).
-  include_vars: vars/topo_t0.yml
-  when: testbed_type == 't0'
-
-- name: Include testbed topology configuration (to get LAG IP and PTF docker interfaces, that are behind LAG VMs).
-  include_vars: vars/topo_t0-116.yml
-  when: testbed_type == 't0-116'
+  include_vars: "vars/topo_{{ testbed_type }}.yml"
+  when: testbed_type in ['t1-lag','t0','t0-116']
 
 - set_fact:
     dut_mac: "{{ ansible_Ethernet0['macaddress'] }}"

--- a/ansible/roles/test/tasks/lag_minlink.yml
+++ b/ansible/roles/test/tasks/lag_minlink.yml
@@ -6,11 +6,18 @@
 
 - block:
     - name: Shut down neighbor interface {{ neighbor_interface }} on {{ peer_device }} ({{ peer_host }})
+      become: true
+      shell: ip link set {{ neighbor_interface }} down
+      delegate_to: "{{peer_host}}"
+      when: peer_type == "FanoutLeafSonic"
+
+    - name: Shut down neighbor interface {{ neighbor_interface }} on {{ peer_device }} ({{ peer_host }})
       action: apswitch template=neighbor_interface_shut_single.j2
       args:
         host: "{{peer_host}}"
         login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
       connection: switch
+      when: peer_type != "FanoutLeafSonic"
     
     - pause:
         seconds: "{{ wait_down_time }}"
@@ -37,12 +44,19 @@
 
   ### always bring back port in case test error and left testbed in unknow stage
   always:
+    - name: Bring up neighbor interface {{ neighbor_interface }} on {{ peer_device}} ({{ peer_host }})
+      become: true
+      shell: ip link set {{ neighbor_interface }} up
+      delegate_to: "{{peer_host}}"
+      when: peer_type == "FanoutLeafSonic"
+  
     - name: Bring up neighbor interface {{ neighbor_interface }} on {{ peer_device }} ({{ peer_host }})
       action: apswitch template=neighbor_interface_no_shut_single.j2
       args:
         host: "{{peer_host}}"
         login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
       connection: switch
+      when: peer_type != "FanoutLeafSonic"
     
     - pause:
         seconds: 35

--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -27,6 +27,7 @@
 - set_fact:
     peer_host: "{{ device_info['mgmtip'] }}"
     peer_hwsku: "{{ device_info['HwSku'] }}"
+    peer_type: "{{ device_info['Type']}}"
 
 - name: test fanout interface (physical) flap and lacp keep correct po status follow minimum links requirement
   include: lag_minlink.yml
@@ -38,6 +39,7 @@
     peer_device: "{{vm_neighbors[flap_intf]['name']}}"
     neighbor_interface: "{{vm_neighbors[flap_intf]['port']}}"
     peer_hwsku: 'Arista-VM'
+    peer_type: 'Arista'
 
 - set_fact:
     peer_host: "{{ minigraph_devices[peer_device]['mgmt_addr'] }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

If no have Arista as the fanout, we could use SONiC instead to test the Lag_2 case. 

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [√] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
verified it on our testbed topology.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
