### PR TITLE
[FDB] BUG FIX introduce a 2-second delay between learning frame and test frame

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_test.py
@@ -62,6 +62,8 @@ class FdbTest(BaseTest):
                                             eth_src=dummy_mac,
                                             eth_type=0x1234)
                     send(self, member, pkt)
+
+        time.sleep(2)
     #--------------------------------------------------------------------------
 
     def test_l2_forwarding(self, src_mac, dst_mac, src_port, dst_port):


### PR DESCRIPTION
[FDB] introduce a 2-second delay between learning frame and test frame in order to avoid FDB test failure due to the DUT failing to have learnt the MAC before receiving the test frame.

MLNX bug 1717512, fdb test fails sporadically. 
we have investigated it and found that the failure is because the DUT fails to learn MAC address and then flood the packet in the vlan.

The working flow of fdb test contains two steps:
1. PTF docker sends the learning frame with a view to having the DUT learnt the source mac address of the frame.
2. PTF docker sends the test frame and checks whether the test frame is received from the port where the learning frame sent.
Typically the DUT requires a short period to have the MAC address learnt. However, there is no delay between step 1 and 2 above. There is a probability of 20% that when the DUT hasn't learnt the MAC address when it receives the test frame. In that case, the test frame will be flooded.
We introduce a short delay of 2 seconds between the above steps 1 and 2 in order to solve that problem and this issue doesn't occur with the delay.

Signed-off-by: Stephen Sun <stephens@mellanox.com>