### PR TITLE
[fdb] Improve robustness of checking PTF PID after config reload

### DIFF
--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -127,10 +127,12 @@
     command: "pgrep -f '/usr/bin/python /usr/bin/ptf'"
     register: ptf_script_pid
     delegate_to: "{{ ptf_host }}"
+    ignore_errors: yes
 
   - name: Wait until the PTF script completed execution
     shell: "tail --pid={{ ptf_script_pid.stdout }} -f /dev/null"
     delegate_to: "{{ ptf_host }}"
+    when: ptf_script_pid.rc == 0
 
   - name: Wait some extra time to ensure that all FDB entries are in DB
     pause: seconds=10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In case the config reload operation takes longer than the PTF
script's running time, checking PTF script PID after config reload
may fail. This change is to improve the robustness of checking
PTF script PID after config reload.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add "ignore_errors: yes" for the step checking PTF PID after config reload. If a PTF PID is found, then wait for the PTF script to complete running.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
At this point, it is Mellanox specific change.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
