### PR TITLE
[everflow]: Remove unused variables

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/get_port_info.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/get_port_info.yml
@@ -20,10 +20,6 @@
   with_dict: "{{ minigraph_neighbors }}"
   when: "'T0' in item.value.name"
 
-- name: Sort tor ports by name.
-  set_fact:
-      tor_port: "{{ tor_ports|sort }}"
-
 - name: Print tor ports
   debug: msg="{{ tor_ports }}"
 
@@ -32,10 +28,6 @@
       spine_ports: "{{ spine_ports + [item.key]  }}"
   with_dict: "{{ minigraph_neighbors }}"
   when: "'T2' in item.value.name"
-
-- name: Sort tor ports by name.
-  set_fact:
-      tor_port: "{{ spine_ports|sort }}"
 
 - name: Print spine ports
   debug: msg="{{ spine_ports }}"


### PR DESCRIPTION
Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

the variable `tor_port` is not used, and is wrongly set on two sections