### PR TITLE
[warm-reboot] Update the expected route for ipv6 loopback interface

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -134,7 +134,7 @@ class ReloadTest(BaseTest):
         self.check_param('default_ip_range', '', required=True)
         self.check_param('vlan_ip_range', '', required=True)
         self.check_param('lo_prefix', '10.1.0.32/32', required=False)
-        self.check_param('lo_v6_prefix', 'fc00:1::/64', required=False)
+        self.check_param('lo_v6_prefix', 'fc00:1::32/128', required=False)
         self.check_param('arista_vms', [], required=True)
         self.check_param('min_bgp_gr_timeout', 15, required=False)
         self.check_param('warm_up_timeout_secs', 180, required=False)
@@ -158,7 +158,7 @@ class ReloadTest(BaseTest):
         #   Inter-packet interval, to be used in send_in_background method.
         #   Improve this interval to gain more precision of disruptions.
         self.send_interval = 0.0035
-        self.packets_to_send = min(int(self.time_to_listen / (self.send_interval + 0.0015)), 45000) # How many packets to be sent in send_in_background method 
+        self.packets_to_send = min(int(self.time_to_listen / (self.send_interval + 0.0015)), 45000) # How many packets to be sent in send_in_background method
 
         # Thread pool for background watching operations
         self.pool = ThreadPool(processes=3)
@@ -385,7 +385,7 @@ class ReloadTest(BaseTest):
                 dst_addr = server_ip
 
                 # generate source MAC address for traffic based on LAG_BASE_MAC_PATTERN
-                mac_addr = self.hex_to_mac(self.LAG_BASE_MAC_PATTERN.format(counter)) 
+                mac_addr = self.hex_to_mac(self.LAG_BASE_MAC_PATTERN.format(counter))
 
                 packet = simple_tcp_packet(eth_src=mac_addr,
                                            eth_dst=self.dut_mac,
@@ -1018,7 +1018,7 @@ class ReloadTest(BaseTest):
             ctrlplane = self.cpu_state.get()
             elapsed   = (datetime.datetime.now() - start_time).total_seconds()
             if dataplane == 'up' and ctrlplane == 'up' and elapsed > dut_stabilize_secs:
-                break;
+                break
             if elapsed > warm_up_timeout_secs:
                 raise Exception("Control plane didn't come up within warm up timeout")
             time.sleep(1)

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -175,7 +175,7 @@
         - dut_vlan_ip='192.168.0.1'
         - default_ip_range='192.168.0.0/16'
         - vlan_ip_range=\"{{ minigraph_vlan_interfaces[0]['subnet'] }}\"
-        - lo_v6_prefix=\"{{ minigraph_lo_interfaces | map(attribute='addr') | ipv6 | first | ipsubnet(64) }}\"
+        - lo_v6_prefix=\"{% for intf in minigraph_lo_interfaces if intf.addr | ipv6 %}{{intf.addr}}/{{intf.mask}}{% endfor %}\"
         - arista_vms=\"['{{ vm_hosts | list | join("','") }}']\"
 
   always:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

After quagga is replaced with frr on SONiC, the route for IPv6 loopback
interface advertised to peer has been changed from prefix to the exact
IPv6 address of the interface. The automation scripts need to be updated
accordingly, otherwise the arista.py script would stuck in a while loop
checking IP routes.

On older SONiC images using quagga for BGP, the ipv6 route advertised to peer is like:

```
ARISTA01T1#show ipv6 route bgp | json
{
    "routes": {
        "fc00:1::0/64": {
            "kernelProgrammed": true, 
            "directlyConnected": false, 
            "preference": 200, 
            "routeAction": "forward", 
            "vias": [
                {
                    "interface": "Port-Channel1", 
                    "nexthopAddr": "fc00::71"
                }
            ], 
            "metric": 0, 
            "hardwareProgrammed": true, 
            "routeType": "bgp"
        }
    }, 
    "allRoutesProgrammedKernel": true, 
    "routingDisabled": false, 
    "allRoutesProgrammedHardware": true, 
    "defaultRouteState": "notSet"
}
```

After quagga is replaced with frr, the IPv6 route advertised is like:
```
ARISTA01T1#show ipv6 route bgp | json
{
    "routes": {
        "fc00:1::32/128": {
            "kernelProgrammed": true, 
            "directlyConnected": false, 
            "preference": 200, 
            "routeAction": "forward", 
            "vias": [
                {
                    "interface": "Port-Channel1", 
                    "nexthopAddr": "fc00::71"
                }
            ], 
            "metric": 0, 
            "hardwareProgrammed": true, 
            "routeType": "bgp"
        }
    }, 
    "allRoutesProgrammedKernel": true, 
    "routingDisabled": false, 
    "allRoutesProgrammedHardware": true, 
    "defaultRouteState": "notSet"
}
```
The scripts need to updated to expect the new format IPv6 route. Otherwise the arista.py scritp would stuck in the while loop checking routes. And the script would fail with error:
```
"FAILED:dut:SSH threads haven't finished for 300 seconds",
```

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Change the expected IPv6 route to the new format advertised by frr.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
