### PR TITLE
[minigraph]: Add ERSPANV6 ACL slot

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -113,6 +113,11 @@
           <Type>Everflow</Type>
         </AclInterface>
         <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>


### PR DESCRIPTION
Create MIRRORV6 ACL table by default

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>