### PR TITLE
Configurable MTU for FIB test

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -87,6 +87,7 @@ class FibTest(BaseTest):
         self.dataplane = ptf.dataplane_instance
         self.fib = fib.Fib(self.test_params['fib_info'])
         self.router_mac = self.test_params['router_mac']
+        self.pktlen = self.test_params['testbed_mtu']
 
         self.test_ipv4 = self.test_params.get('ipv4', True)
         self.test_ipv6 = self.test_params.get('ipv6', True)
@@ -173,6 +174,7 @@ class FibTest(BaseTest):
         src_mac = self.dataplane.get_mac(0, 0)
 
         pkt = simple_tcp_packet(
+                            pktlen=self.pktlen,
                             eth_dst=self.router_mac,
                             eth_src=src_mac,
                             ip_src=ip_src,
@@ -181,6 +183,7 @@ class FibTest(BaseTest):
                             tcp_dport=dport,
                             ip_ttl=64)
         exp_pkt = simple_tcp_packet(
+                            self.pktlen,
                             eth_src=self.router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
@@ -211,6 +214,7 @@ class FibTest(BaseTest):
         src_mac = self.dataplane.get_mac(0, 0)
 
         pkt = simple_tcpv6_packet(
+                                pktlen=self.pktlen,
                                 eth_dst=self.router_mac,
                                 eth_src=src_mac,
                                 ipv6_dst=ip_dst,
@@ -219,6 +223,7 @@ class FibTest(BaseTest):
                                 tcp_dport=dport,
                                 ipv6_hlim=64)
         exp_pkt = simple_tcpv6_packet(
+                                pktlen=self.pktlen,
                                 eth_src=self.router_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,

--- a/ansible/roles/test/tasks/simple-fib.yml
+++ b/ansible/roles/test/tasks/simple-fib.yml
@@ -6,6 +6,9 @@
 
 - debug : msg="Start FIB Test"
 
+- set_fact: mtu=9114
+  when: mtu is not defined
+
 - name: "Start PTF runner"
   include: ptf_runner.yml
   vars:
@@ -20,4 +23,5 @@
       - fib_info='/root/fib_info.txt'
       - ipv4={{ipv4}}
       - ipv6={{ipv6}}
-    ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
+      - testbed_mtu={{mtu}}
+    ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log --socket-recv-size 16384"


### PR DESCRIPTION
Summary:
Default to use jumbo frames for this test. MTU is configurable for any smaller values

Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Use configured MTU for running FIB test

#### How did you do it?
Modify PTF test and pass MTU as a variable

#### How did you verify/test it?
Run the ansible test, Verify MTU value being passed to PTF:
`"ptf --test-dir ptftests fib_test.FibTest   --platform-dir ptftests  --platform remote  -t \"testbed_type='t1-lag';router_mac='90:b1:1c:f4:9d:40';fib_info='/root/fib_info.txt';ipv4=True;ipv6=True;testbed_mtu=9114\"  --relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.True.ipv6.True.2019-06-10-20:16:08.log --socket-recv-size 16384 2>&1"`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
