### PR TITLE
[bgp_fact]Add ip neighbor(arp/nd) displaying

### DIFF
--- a/ansible/roles/test/tasks/bgp_fact.yml
+++ b/ansible/roles/test/tasks/bgp_fact.yml
@@ -14,6 +14,14 @@
 - name: Print bgp facts
   debug: msg="{{ bgp_neighbors }}"
 
+- name: Prepare neighbor info
+  shell: ip neigh show
+  register: ip_neighbors
+  ignore_errors: yes
+
+- name: Print neighbor info
+  debug: msg="{{ip_neighbors.stdout_lines}}"
+
 - name: Verify bgp sessions are established
   assert: { that: "'{{ bgp_neighbors[item]['state'] }}' == 'established'" }
   with_items: "{{ bgp_neighbors.keys() }}"


### PR DESCRIPTION
### Description of PR
Summary:
Add ip neighbor(arp/nd) displaying prior to asserting BGP neighbor state.

### Type of change
- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Recently bgp test has failed due to non-established neighbor state frequently.
We highly suspect it is due to some topo deployment issue which causes DUT unable to learn arp/nd of its bgp neighbor.
By displaying ip neigh info we can easily distinguish this reason from others thus saving effort of diagnosing.
#### How did you do it?
register the output of "ip neigh show" to ip_neighbors and display it via "debug".
#### How did you verify/test it?
Run bgp_fact test on t1.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

Signed-off-by: Stephen Sun stephens@mellanox.com