### PR TITLE
when deploy topo:t0-16,t0-56,t0-64-32, it caused error: testbed_type is invalid

### DIFF
--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-116']
+  when: testbed_type not in [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116]
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
when deploy topo:t0-16,t0-56,t0-64-32, it caused error: testbed_type is invalid!
it should sync with the topologies of testcases.yml as below:
fdb:
      filename: fdb.yml
      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116]
      required_vars:
          ptf_host:
          testbed_type:

Summary:
Fixes # (issue)

### Type of change

- Test case(improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
we have verified it by deploying the t0-64-32 and run the fdb test case.  
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
