### PR TITLE
add t0-64-32 topology to shared-fib test

### DIFF
--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -18,7 +18,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0', 't0-56', 't0-64', 't0-116']
+  when: testbed_type in ['t0', 't0-56', 't0-64', 't0-64-32', 't0-116']
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
when deploy the topo: t0-62-32 and run the fib test case, it causes the error: ERROR! 'props' is undefined
It's because that loss of t0-62-32 in the dictionary.
Summary:
Fixes # (issue)

### Type of change

-  Test case(improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
