### PR TITLE
[restart_swss] Increase wait timeout to 120 seconds

### DIFF
--- a/ansible/roles/test/tasks/run_config_cleanup.yml
+++ b/ansible/roles/test/tasks/run_config_cleanup.yml
@@ -9,4 +9,4 @@
 
 - name: Wait for orchagent initialization
   pause:
-    seconds: 35
+    seconds: 120


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn vsenchyshyn@barefootnetworks.com


### Description of PR
Increased wait timeout to 120 seconds in restart_swss test case

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach
#### How did you do it?
Increased wait timeout for swss service bring up to 120 seconds like this is done in [restart_syncd](https://github.com/Azure/sonic-mgmt/blob/master/ansible/roles/test/tasks/restart_syncd.yml#L49) test case. Sometimes port up events are handled too slowly in SONiC which very often causes this test to fail. 

#### How did you verify/test it?
restart_swss TC has passed on BFN platform 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
