### PR TITLE
Added a task to lldp test case for testing the LLDP timing/buffer issue

### DIFF
--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -43,7 +43,7 @@
     set_fact:
       dut_system_description: "{{ result.stdout }}"
 
-###TODO: fix this lldp_neighbor validation, this part is not running 
+###TODO: fix this lldp_neighbor validation, this part is not running
 - name: Iterate through each LLDP neighbor and verify the information received by neighbor is correct
   add_host:
     name: "{{ lldp[item]['chassis']['mgmt-ip'] }}"
@@ -59,3 +59,81 @@
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"
 
+################Test Cases for LLDP bug fixes #######################
+- block:
+    - debug: msg="Deployment Specific Test Cases, Test LLDP timing/buffer issue."
+
+    # create the config_db.json (test specific)
+    - name: collect SONiC current configuration info (to find macaddress)
+      setup:
+
+    - name: saved original config_db.json in SONiC DUT (ignore errors when file does not exist)
+      shell: cp /etc/sonic/config_db.json /etc/sonic/config_db.json.orig
+      become: true
+      ignore_errors: true
+
+    - name: copy test specific lldp_config_db.json to Sonic DUT
+      become: true
+      copy:
+        src: roles/test/files/test_specific_configs/lldp_config_db.json
+        dest: /etc/sonic/config_db.json
+
+    - name: update mac hostname and speed in config_db.json
+      become: true
+      replace:
+        dest: /etc/sonic/config_db.json
+        regexp: "{{ item.regexp}}"
+        replace: "{{ item.line }}"
+      with_items:
+        - { regexp: '"hostname": ".*"', line: '"hostname": "{{ testbed_facts["dut"] }}"' }
+
+    - name: execute cli "config reload -l -y" to merge the system info on device
+      become: true
+      shell: config reload -l -y
+
+    - name: wait 60 seconds for completion of "config reload" command.
+      pause: seconds=60
+
+    - name: Ensure LLDP Daemon is runing and Enabled
+      become: true
+      service: name=lldpd
+               state=running
+               enabled=yes
+      vars:
+        ansible_shell_type: docker
+        ansible_python_interpreter: docker exec -i lldp python
+
+    - name: Get total number of interfaces from config_db.json file
+      shell: sonic-cfggen -j /etc/sonic/config_db.json -v "PORT.keys() | length"
+      register: interface_num
+
+    - name: Restart swss service and check lldpcli show statistics 10 times in a loop
+      shell: |
+         service swss restart & sleep 15s
+         docker exec -it lldp bash -c "lldpcli show statistics | grep Ethernet | wc -l"
+      register: lldpcli_output
+      failed_when: lldpcli_output.stdout != interface_num.stdout
+      with_sequence: start=0 end=10 stride=1
+
+  always:
+    - name: Restore the original config_db.json
+      shell: mv /etc/sonic/config_db.json.orig /etc/sonic/config_db.json
+      become: true
+      ignore_errors: true
+
+    - name: execute cli "config reload -y" to apply restored config_db.json
+      become: true
+      shell: config reload -y
+
+    - name: reboot
+      include: common_tasks/reboot_sonic.yml
+
+    - name: validate all interfaces are up after test
+      include: interface.yml
+
+    - name: wait for interfaces to come up
+      interface_facts: up_ports={{minigraph_ports}}
+      until: "{{ ansible_interface_link_down_ports | length }} == 0"
+      retries: 10
+      delay: 15
+## End of Test Cases for LLDP bug fixes ###


### PR DESCRIPTION

### Description of PR
Added a task to **LLDP** test case for testing the **LLDP timing/buffer issue**

Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

### Type of change

- [] New Task in existing LLDP Test case

### Approach
#### Any platform specific information?
- Not Platform specific. However, before the test, add **_test specific config_db.json_** named **_"lldp_config_db.json"_** under **_ansible/roles/test/files/test_specific_configs_**. As the task will be excuted against that config_db.json

#### How did you do it?

#### How did you verify/test it?
Tested in our Jenkins Server. Added the config.db json as it's a deployment specific test case.

```
TASK [test : debug] ********* Monday 15 April 2019 19:40:38 +0000 (0:00:08.923) 0:00:58.875 *
ok: [falco-test-dut01] => {
    "msg": "Deployment Specific Test Cases, Test LLDP timing/buffer issue."
}

TASK [test : collect SONiC current configuration info (to find macaddress)] * Monday 15 April 2019 19:40:38 +0000 (0:00:00.116) 0:00:58.991 *
ok: [falco-test-dut01]

TASK [test : saved original config_db.json in SONiC DUT (ignore errors when file does not exist)]  Monday 15 April 2019 19:40:43 +0000 (0:00:04.376) 0:01:03.367 *
changed: [falco-test-dut01]

TASK [test : copy test specific lldp_config_db.json to Sonic DUT] **
Monday 15 April 2019  19:40:43 +0000 (0:00:00.585)       0:01:03.953 ****
changed: [falco-test-dut01]

TASK [test : update mac hostname and speed in config_db.json] *** Monday 15 April 2019 19:40:44 +0000 (0:00:00.548) 0:01:04.501 *
changed: [falco-test-dut01] => (item={u'regexp': u'"hostname": ".*"', u'line': u'"hostname": "falco-test-dut01"'})

TASK [test : execute cli "config reload -l -y" to merge the system info on device]  Monday 15 April 2019 19:40:44 +0000 (0:00:00.647) 0:01:05.149 *
changed: [falco-test-dut01]

TASK [test : wait 60 seconds for completion of "config reload" command.] *
Monday 15 April 2019  19:41:58 +0000 (0:01:13.211)       0:02:18.361 ****
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [falco-test-dut01]

TASK [test : Ensure LLDP Daemon is runing and Enabled] **** Monday 15 April 2019 19:42:58 +0000 (0:01:00.126) 0:03:18.487 *
ok: [falco-test-dut01]

TASK [test : Get total number of interfaces from config_db.json file] * Monday 15 April 2019 19:43:00 +0000 (0:00:02.469) 0:03:20.957 *
changed: [falco-test-dut01]

TASK [test : Restart swss service and check lldpcli show statistics 10 times in a loop]  Monday 15 April 2019 19:43:01 +0000 (0:00:00.736) 0:03:21.693 *
changed: [falco-test-dut01] => (item=0)
changed: [falco-test-dut01] => (item=1)
changed: [falco-test-dut01] => (item=2)
changed: [falco-test-dut01] => (item=3)
changed: [falco-test-dut01] => (item=4)
changed: [falco-test-dut01] => (item=5)
changed: [falco-test-dut01] => (item=6)
changed: [falco-test-dut01] => (item=7)
changed: [falco-test-dut01] => (item=8)
changed: [falco-test-dut01] => (item=9)
changed: [falco-test-dut01] => (item=10)

TASK [test : Restore the original config_db.json] **** Monday 15 April 2019 19:45:54 +0000 (0:02:53.563) 0:06:15.257 **
changed: [falco-test-dut01]

TASK [test : execute cli "config reload -y" to apply restored config_db.json]  Monday 15 April 2019 19:45:55 +0000 (0:00:00.419) 0:06:15.676 **
changed: [falco-test-dut01]

TASK [test : reboot] ******** Monday 15 April 2019 19:47:28 +0000 (0:01:33.486) 0:07:49.163 *
included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml for falco-test-dut01

TASK [test : rebooting falco-test-dut01 : 172.25.11.56 ...] **** Monday 15 April 2019 19:47:29 +0000 (0:00:00.323) 0:07:49.487 **
ok: [falco-test-dut01]

TASK [test : pause for 1 minute before check] *** *** Monday 15 April 2019 19:47:30 +0000 (0:00:01.451) 0:07:50.939 **
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [falco-test-dut01]

TASK [test : Wait for switch to come back] ***** Monday 15 April 2019 19:48:30 +0000 (0:01:00.157) 0:08:51.096 ** ok: [falco-test-dut01 -> localhost]
TASK [test : wait for 2 minute for prcesses and interfaces to be stable] * Monday 15 April 2019 19:48:41 +0000 (0:00:10.258) 0:09:01.355 **** Pausing for 120 seconds (ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort) ok: [falco-test-dut01]
TASK [test : include] ******** Monday 15 April 2019 19:50:41 +0000 (0:02:00.160) 0:11:01.515 ** included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/interface.yml for falco-test-dut01
TASK [test : Gather minigraph facts about the device] **** Monday 15 April 2019 19:50:41 +0000 (0:00:00.364) 0:11:01.880 ** ok: [falco-test-dut01]
TASK [test : Get interface facts] ******* Monday 15 April 2019 19:50:42 +0000 (0:00:00.681) 0:11:02.562 * ok: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:46 +0000 (0:00:03.939) 0:11:06.502 * skipping: [falco-test-dut01]
TASK [test : reboot] ******** Monday 15 April 2019 19:50:46 +0000 (0:00:00.090) 0:11:06.593 * skipping: [falco-test-dut01]
TASK [test : figure out fanout switch port in case it was down] ** Monday 15 April 2019 19:50:46 +0000 (0:00:00.092) 0:11:06.685 ** skipping: [falco-test-dut01]
TASK [test : set_fact] ******** Monday 15 April 2019 19:50:46 +0000 (0:00:00.068) 0:11:06.753 *** skipping: [falco-test-dut01]
TASK [test : include] ******** Monday 15 April 2019 19:50:46 +0000 (0:00:00.083) 0:11:06.837 **
TASK [test : pause and wait interface to be up] ***** Monday 15 April 2019 19:50:46 +0000 (0:00:00.079) 0:11:06.917 * skipping: [falco-test-dut01]
TASK [test : Get interface facts] ******* Monday 15 April 2019 19:50:46 +0000 (0:00:00.097) 0:11:07.015 * skipping: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:46 +0000 (0:00:00.092) 0:11:07.107 * skipping: [falco-test-dut01]
TASK [test : Verify interfaces are up correctly] **** Monday 15 April 2019 19:50:46 +0000 (0:00:00.096) 0:11:07.203 * ok: [falco-test-dut01]
TASK [test : Verify port channel interfaces are up correctly] *** Monday 15 April 2019 19:50:47 +0000 (0:00:00.126) 0:11:07.329 *
TASK [test : Verify VLAN interfaces are up correctly] **** Monday 15 April 2019 19:50:47 +0000 (0:00:00.084) 0:11:07.414 **
TASK [test : wait for interfaces to come up] **** * Monday 15 April 2019 19:50:47 +0000 (0:00:00.085) 0:11:07.499 **** ok: [falco-test-dut01]
TASK [test : do basic sanity check after each test] **** Monday 15 April 2019 19:50:51 +0000 (0:00:03.910) 0:11:11.410 **** included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/base_sanity.yml for falco-test-dut01
TASK [test : Get process information in syncd docker] **** Monday 15 April 2019 19:50:51 +0000 (0:00:00.838) 0:11:12.248 ** changed: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:52 +0000 (0:00:00.607) 0:11:12.856 * ok: [falco-test-dut01] => { "ps_out.stdout_lines": [ "root 20 0.0 0.0 41584 2688 ? Sl 19:48 0:00 /usr/bin/dsserve /usr/bin/syncd --diag -p /etc/sai.d/sai.profile", "root 30 28.9 4.8 1066480 194372 ? Rl 19:48 0:39 /usr/bin/syncd --diag -p /etc/sai.d/sai.profile", "root 53 4.2 5.0 891068 203160 ? S 19:48 0:05 /usr/bin/syncd --diag -p /etc/sai.d/sai.profile" ] }
TASK [test : Get orchagent process information] ***** Monday 15 April 2019 19:50:52 +0000 (0:00:00.111) 0:11:12.967 * changed: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:53 +0000 (0:00:00.431) 0:11:13.398 * ok: [falco-test-dut01] => { "orch_out.stdout_lines": [ "3344 /usr/bin/orchagent -d /var/log/swss -b 8192 -m 00:e0:ec:5a:7c:ac" ] }
TASK [test : reboot] ******** Monday 15 April 2019 19:50:53 +0000 (0:00:00.108) 0:11:13.507 * skipping: [falco-test-dut01]
TASK [test : Get process information in syncd docker] **** Monday 15 April 2019 19:50:53 +0000 (0:00:00.085) 0:11:13.593 ** skipping: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:53 +0000 (0:00:00.089) 0:11:13.682 * skipping: [falco-test-dut01]
TASK [test : Verify that syncd process is running] **** Monday 15 April 2019 19:50:53 +0000 (0:00:00.083) 0:11:13.765 *** skipping: [falco-test-dut01]
TASK [test : Get orchagent process information] ***** Monday 15 April 2019 19:50:53 +0000 (0:00:00.085) 0:11:13.850 * skipping: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:53 +0000 (0:00:00.088) 0:11:13.939 * skipping: [falco-test-dut01]
TASK [test : Verify that orchagent process is running] **** Monday 15 April 2019 19:50:53 +0000 (0:00:00.081) 0:11:14.021 * skipping: [falco-test-dut01]
TASK [test : Get syslog error information] ***** Monday 15 April 2019 19:50:53 +0000 (0:00:00.074) 0:11:14.095 ** changed: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:54 +0000 (0:00:00.447) 0:11:14.542 * ok: [falco-test-dut01] => { "syslog_out.stdout_lines": [ "Apr 15 19:50:56.786842 falco-test-dut01 INFO ansible-command: Invoked with warn=True executable=None chdir=None _raw_params=cat /var/log/syslog |tail -n 5000 |grep -i error removes=None creates=None _uses_shell=True" ] }
TASK [test : validate all interfaces are up after test] *** Monday 15 April 2019 19:50:54 +0000 (0:00:00.110) 0:11:14.652 * included: /var/jenkins/sonic-mgmt/ansible/roles/test/tasks/interface.yml for falco-test-dut01
TASK [test : Gather minigraph facts about the device] **** Monday 15 April 2019 19:50:55 +0000 (0:00:00.930) 0:11:15.583 ** ok: [falco-test-dut01]
TASK [test : Get interface facts] ******* Monday 15 April 2019 19:50:55 +0000 (0:00:00.578) 0:11:16.162 * ok: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:50:59 +0000 (0:00:03.961) 0:11:20.123 * skipping: [falco-test-dut01]
TASK [test : reboot] ******** Monday 15 April 2019 19:50:59 +0000 (0:00:00.083) 0:11:20.207 * skipping: [falco-test-dut01]
TASK [test : figure out fanout switch port in case it was down] ** Monday 15 April 2019 19:51:00 +0000 (0:00:00.082) 0:11:20.289 ** skipping: [falco-test-dut01]
TASK [test : set_fact] ******** Monday 15 April 2019 19:51:00 +0000 (0:00:00.087) 0:11:20.377 *** skipping: [falco-test-dut01]
TASK [test : include] ******** Monday 15 April 2019 19:51:00 +0000 (0:00:00.085) 0:11:20.463 **
TASK [test : pause and wait interface to be up] ***** Monday 15 April 2019 19:51:00 +0000 (0:00:00.081) 0:11:20.544 * skipping: [falco-test-dut01]
TASK [test : Get interface facts] ******* Monday 15 April 2019 19:51:00 +0000 (0:00:00.090) 0:11:20.635 * skipping: [falco-test-dut01]
TASK [test : debug] ********* Monday 15 April 2019 19:51:00 +0000 (0:00:00.083) 0:11:20.718 * skipping: [falco-test-dut01]
TASK [test : Verify interfaces are up correctly] **** Monday 15 April 2019 19:51:00 +0000 (0:00:00.156) 0:11:20.875 * ok: [falco-test-dut01]
TASK [test : Verify port channel interfaces are up correctly] *** Monday 15 April 2019 19:51:00 +0000 (0:00:00.170) 0:11:21.046 *
TASK [test : Verify VLAN interfaces are up correctly] **** Monday 15 April 2019 19:51:00 +0000 (0:00:00.129) 0:11:21.175 **
TASK [test : debug] ********* Monday 15 April 2019 19:51:01 +0000 (0:00:00.180) 0:11:21.356 * ok: [falco-test-dut01] => { "msg": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" }
TASK [test : debug] ********* Monday 15 April 2019 19:51:01 +0000 (0:00:00.084) 0:11:21.440 * ok: [falco-test-dut01] => { "msg": "!!!!!!!!!!!!!!!!!!!! end running test lldp !!!!!!!!!!!!!!!!!!!!" }
TASK [test : debug] ********* Monday 15 April 2019 19:51:01 +0000 (0:00:00.080) 0:11:21.521 * ok: [falco-test-dut01] => { "msg": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" }
```


#### Supported testbed topology if it's a new test case?
 yes
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
--> N/A. Adding a task to lldp test case.
