### PR TITLE
[service_acl]: Pause for 20s to prevent timeout error which may happen when deleting config_service_acls.sh

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -47,7 +47,7 @@ sudo_exe = sudo
 #sudo_flags = -H
 
 # SSH timeout
-timeout = 10
+timeout = 30
 
 # default user to use for playbooks if user is not specified
 # (/usr/bin/ansible will use current user as default)

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -47,7 +47,7 @@ sudo_exe = sudo
 #sudo_flags = -H
 
 # SSH timeout
-timeout = 30
+timeout = 10
 
 # default user to use for playbooks if user is not specified
 # (/usr/bin/ansible will use current user as default)

--- a/ansible/roles/test/tasks/service_acl.yml
+++ b/ansible/roles/test/tasks/service_acl.yml
@@ -57,6 +57,10 @@
     search_regex: "OpenSSH"
     timeout: 90
 
+- name: Pause for 20s to prevent timeout error which may happen when deleting config_service_acls.sh
+  pause:
+    seconds: 20
+
 - name: Delete config_service_acls.sh from the DuT
   become: true
   file:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:

When running "service_acl" test, it may get SSH timeout issue.
By changing the timeout(SSH timeout) from 10s to 30s in sonic-mgmt/ansible/ansible.cfg, it can overcome this issue.

TASK [test : Delete config_service_acls.sh from the DuT] ***********************
task path: /var/sonic/sonic-mgmt/ansible/roles/test/tasks/service_acl.yml:60
Thursday 13 June 2019 01:26:40 +0000 (0:00:15.248) 0:01:15.616 *********
<10.250.0.193> ESTABLISH SSH CONNECTION FOR USER: admin
<10.250.0.193> SSH: EXEC sshpass -d15 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -o StrictHostKeyChecking=no -o User=admin -o ConnectTimeout=10 -o ControlPath=/var/sonic/.ansible/cp/ansible-ssh-%h-%p-%r 10.250.0.193 '/bin/sh -c '"'"'sudo -H -S -p "[sudo via ansible, key=zqexexcctdeyuozujacoeknxehbqjeiq] password: " -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-zqexexcctdeyuozujacoeknxehbqjeiq; LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python'"'"'"'"'"'"'"'"''"'"''
fatal: [str-dut-01]: FAILED! => {"failed": true, "msg": "ERROR! Timeout (12s) waiting for privilege escalation prompt: "}



### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [v] Test case(improvement)

### Approach
#### How did you do it?
Modifying the timeout(SSH timeout) from 10s to 30s in sonic-mgmt/ansible/ansible.cfg.

#### How did you verify/test it?
Run "service_acl" test again after modifying SSH timeout from 10s to 30s in ansible.cfg.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
