### PR TITLE
[loganalyzer] Fix the files not copied issue in run_command_with_log_analyzer.yml

### DIFF
--- a/ansible/roles/test/tasks/run_command_with_log_analyzer.yml
+++ b/ansible/roles/test/tasks/run_command_with_log_analyzer.yml
@@ -41,21 +41,24 @@
       register: expects_found
       when: errors_expected == true
 
-    - name: Check that expected error messages are found (negative tests only).
-      fail: msg="Expected error messages are not found while running {{ testname }} / {{ command_to_run }}"
-      when: errors_expected == true and expects_found.stdout == "0"
-
     - name: Get the total number of error messages.
       shell: grep "TOTAL MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL MATCHES:[[:space:]]*//p"
       register: errors_found
 
-    - name: Check the number of error messages (positive tests only).
-      fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }} / {{ command_to_run }}."
-      when: errors_expected == false and errors_found.stdout != "0"
-
     - name: Copy test data to host.
-      fetch: src={{ test_out_dir }}/{{ item }} dest=failed-test-data/{{ testname_unique }}/{{ item }}
+      fetch:
+        src: "{{ test_out_dir }}/{{ item }}"
+        dest: "test/{{ inventory_hostname }}/{{ item | basename }}"
+        flat: yes
       with_items:
           - "{{ summary_file }}"
           - "{{ result_file }}"
       when: (errors_expected == true and expects_found.stdout == "0") or (errors_expected == false and errors_found.stdout != "0")
+
+    - name: Check that expected error messages are found (negative tests only).
+      fail: msg="Expected error messages are not found while running {{ testname }} / {{ command_to_run }}"
+      when: errors_expected == true and expects_found.stdout == "0"
+
+    - name: Check the number of error messages (positive tests only).
+      fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }} / {{ command_to_run }}."
+      when: errors_expected == false and errors_found.stdout != "0"


### PR DESCRIPTION
The copy files task was after the fail tests. In case of failure, the
copy task would never get a chance to run. This commit
adjusted the task sequence. In case of failure, copy the files, then
fail the test.

The original copy task copies files with deep folder structure.
This issue was also fixed in this commit.

Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
This commit adjusted the task sequence. In case of failure, copy the files, then fail the test.

#### How did you verify/test it?
Verified on Mellanox platform.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
