### PR TITLE
Fix testbed_mtu for tasks that invoke fib_test

### DIFF
--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -199,6 +199,7 @@
           - fib_info='/root/bgp_speaker_route.txt'
           - ipv4={{ ipv4|default(false) }}
           - ipv6={{ ipv6|default(false) }}
+          - testbed_mtu={{ mtu|default(9114) }}
         ptf_extra_options: "--relax --debug info --log-file /tmp/bgp_speaker_test.FibTest.log"
   always:
     - name: Kill exabgp instances

--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -200,7 +200,7 @@
           - ipv4={{ ipv4|default(false) }}
           - ipv6={{ ipv6|default(false) }}
           - testbed_mtu={{ mtu|default(9114) }}
-        ptf_extra_options: "--relax --debug info --log-file /tmp/bgp_speaker_test.FibTest.log"
+        ptf_extra_options: "--relax --debug info --log-file /tmp/bgp_speaker_test.FibTest.log --socket-recv-size 16384"
   always:
     - name: Kill exabgp instances
       shell: pkill exabgp

--- a/ansible/roles/test/tasks/warm-reboot-fib.yml
+++ b/ansible/roles/test/tasks/warm-reboot-fib.yml
@@ -19,6 +19,7 @@
       - fib_info='/root/fib_info.txt'
       - ipv4={{ipv4}}
       - ipv6={{ipv6}}
+      - testbed_mtu={{ mtu|default(9114) }}
     ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
 
 - name: "Show ptf params PTF Test - {{ ptf_test_name }}"

--- a/ansible/roles/test/tasks/warm-reboot-fib.yml
+++ b/ansible/roles/test/tasks/warm-reboot-fib.yml
@@ -20,7 +20,7 @@
       - ipv4={{ipv4}}
       - ipv6={{ipv6}}
       - testbed_mtu={{ mtu|default(9114) }}
-    ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
+    ptf_extra_options: "--relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.{{ipv4}}.ipv6.{{ipv6}}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log --socket-recv-size 16384"
 
 - name: "Show ptf params PTF Test - {{ ptf_test_name }}"
   debug: msg="ptf --test-dir {{ ptf_test_dir }} {{ ptf_test_path }} {% if ptf_qlen is defined %} --qlen={{ ptf_qlen }} {% endif %} {% if ptf_platform_dir is defined %} --platform-dir {{ ptf_platform_dir }} {% endif %} --platform {{ ptf_platform }} {% if ptf_test_params is defined %} -t \"{{ ptf_test_params | default([]) | join(';') }}\" {% endif %} {{ ptf_extra_options | default(\"\")}} --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre 2>&1"


### PR DESCRIPTION
### Description of PR
FIB test now accepts configurable mtu as part of [PR](https://github.com/Azure/sonic-mgmt/pull/946). Fixing bgp_speaker and warmboot tests which uses fib_test.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
Fix applied to bgp_speaker/warmboot yml

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
