### PR TITLE
[linkstate] fix linkstate scripts

### DIFF
--- a/ansible/linkstate/up.yml
+++ b/ansible/linkstate/up.yml
@@ -42,10 +42,7 @@
         src: "{{ item }}"
         dest: /root
       with_items:
-        - ../files/sonic_str_links.csv
-        - ../files/sonic_str_devices.csv
-        - ../files/sonic_lab_links.csv
-        - ../files/sonic_lab_devices.csv
+        - ../files/lab_connection_graph.xml
         - ../veos
         - scripts/ptf_proxy.py
         - ../vars/topo_{{ topo }}.yml


### PR DESCRIPTION
Fix linkstate ptf_proxy script which parsed sonic_str_links, etc files
which were removed. Now use lab_connection_graph.xml to get fanout ports
to dut to ptf to vms mappings.

Fix mlnx/fanout_listner.py script for split ports and correct names.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: [linkstate] fix linkstate scripts
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Read port mappings from lab_connection_graph.xml

#### How did you verify/test it?
Run linkstate scripts in mellanox lab with mellanox fanout
Shutdown ports on DUT, verify ports are shut down on VMs on T0
Startup ports on DUT, verify ports are up on VMs on T0

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
