### PR TITLE
[neighbour-arp-noptf] fix: testcase fails when no arp/nd learnt on DUT

### DIFF
--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -44,24 +44,22 @@
       - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
       - arptable.v4 | length != 0
 
-  - name: select Ethernet0 if cannot find an v4 neighbor for test
-    set_fact:
-      v4_intf: "Ethernet0"
-      v4_nei: "{{ v4_intf_nei }}"
-      need_add_ip: True
+  - block:
+    - name: select Ethernet0 if cannot find an v4 neighbor for test
+      set_fact:
+        v4_intf: "Ethernet0"
+        v4_nei: "{{ v4_intf_nei }}"
+
+    - name: startup Ethernet0
+      command: "config interface startup Ethernet0"
+
+    - name: add an ip entry for Ethernet0
+      command: "config interface ip add Ethernet0 {{ v4_intf_ip }}"
+
+    - name: add neighbor of Ethernet0
+      command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev Ethernet0"
+
     when: v4_nei is not defined
-
-  - name: startup Ethernet0
-    command: "config interface startup Ethernet0"
-    when: need_add_ip is defined and need_add_ip == True
-
-  - name: add an ip entry for Ethernet0
-    command: "config interface ip add Ethernet0 {{ v4_intf_ip }}"
-    when: need_add_ip is defined and need_add_ip == True
-
-  - name: add neighbor of Ethernet0
-    command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev Ethernet0"
-    when: need_add_ip is defined and need_add_ip == True
 
   - name: change v4 neighbor mac address 1st time
     command: "ip neigh change {{ v4_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
@@ -106,24 +104,22 @@
        - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
        - arptable.v6 | length != 0
 
-  - name: pick Ethernet0 as test interface if cannot fine v6 neighbor to test
-    set_fact:
-      v6_intf: "Ethernet0"
-      v6_nei: "{{ v6_intf_nei }}"
-      need_add_ipv6: True
+  - block:
+    - name: pick Ethernet0 as test interface if cannot fine v6 neighbor to test
+      set_fact:
+        v6_intf: "Ethernet0"
+        v6_nei: "{{ v6_intf_nei }}"
+
+    - name: startup Ethernet0
+      command: "config interface startup Ethernet0"
+
+    - name: add an ipv6 entry for Ethernet0 if not find v6 neighbor
+      command: "config interface ip add Ethernet0 {{ v6_intf_ip }}"
+
+    - name: add an ipv6 neighbor of Ethernet0 if not find v6 neighbor to test
+      command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev Ethernet0"
+
     when: v6_nei is not defined
-
-  - name: startup Ethernet0
-    command: "config interface startup Ethernet0"
-    when: need_add_ipv6 is defined and need_add_ipv6 == True
-
-  - name: add an ipv6 entry for Ethernet0 if not find v6 neighbor
-    command: "config interface ip add Ethernet0 {{ v6_intf_ip }}"
-    when: need_add_ipv6 is defined and need_add_ipv6 == True
-
-  - name: add an ipv6 neighbor of Ethernet0 if not find v6 neighbor to test
-    command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev Ethernet0"
-    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: change v6 neighbor mac address 1st time
     command: "ip -6 neigh change {{ v6_nei }} lladdr {{ v6_mac1 }} dev {{ v6_intf }}"

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -45,7 +45,7 @@
       - arptable.v4 | length != 0
 
   - block:
-    - name: select Ethernet0 if cannot find an v4 neighbor for test
+    - name: select Ethernet0 if cannot find a v4 neighbor for test
       set_fact:
         v4_intf: "Ethernet0"
         v4_nei: "{{ v4_intf_nei }}"
@@ -105,7 +105,7 @@
        - arptable.v6 | length != 0
 
   - block:
-    - name: pick Ethernet0 as test interface if cannot fine v6 neighbor to test
+    - name: pick Ethernet0 as test interface if cannot find v6 neighbor to test
       set_fact:
         v6_intf: "Ethernet0"
         v6_nei: "{{ v6_intf_nei }}"
@@ -113,10 +113,10 @@
     - name: startup Ethernet0
       command: "config interface startup Ethernet0"
 
-    - name: add an ipv6 entry for Ethernet0 if not find v6 neighbor
+    - name: add an ipv6 entry for Ethernet0 if no v6 neighbor was found
       command: "config interface ip add Ethernet0 {{ v6_intf_ip }}"
 
-    - name: add an ipv6 neighbor of Ethernet0 if not find v6 neighbor to test
+    - name: add an ipv6 neighbor for Ethernet0 if no v6 neighbor was found
       command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev Ethernet0"
 
     when: v6_nei is not defined

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -48,15 +48,20 @@
     set_fact:
       v4_intf: "Ethernet0"
       v4_nei: "{{ v4_intf_nei }}"
+      need_add_ip: True
     when: v4_nei is not defined
 
+  - name: startup Ethernet0
+    command: "config interface startup Ethernet0"
+    when: need_add_ip is defined and need_add_ip == True
+
   - name: add an ip entry for Ethernet0
-    command: "/sbin/ifconfig Ethernet0 {{ v4_intf_ip }}"
-    when: v4_nei is not defined
+    command: "config interface ip add Ethernet0 {{ v4_intf_ip }}"
+    when: need_add_ip is defined and need_add_ip == True
 
   - name: add neighbor of Ethernet0
     command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev Ethernet0"
-    when: v4_nei is not defined
+    when: need_add_ip is defined and need_add_ip == True
 
   - name: change v4 neighbor mac address 1st time
     command: "ip neigh change {{ v4_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
@@ -87,7 +92,7 @@
   - name: Check if mac changed in DUT ASIC DB. Should be {{ v4_mac2 }}
     shell: docker exec database redis-cli -n 1 HGETALL '{{ neighbour_key.stdout }}' | grep "_ATTR_DST_MAC_ADDRESS" -A 1 | tail -1
     register: neighbour_mac
-        
+
   - assert: { that: "neighbour_mac.stdout | lower == v4_mac2" }
 
   ############## Test V6 mac change   ##################
@@ -105,15 +110,20 @@
     set_fact:
       v6_intf: "Ethernet0"
       v6_nei: "{{ v6_intf_nei }}"
+      need_add_ipv6: True
     when: v6_nei is not defined
 
+  - name: startup Ethernet0
+    command: "config interface startup Ethernet0"
+    when: need_add_ipv6 is defined and need_add_ipv6 == True
+
   - name: add an ipv6 entry for Ethernet0 if not find v6 neighbor
-    command: "/sbin/ifconfig Ethernet0 inet6 add {{ v6_intf_ip }}"
-    when: v6_nei is not defined
+    command: "config interface ip add Ethernet0 {{ v6_intf_ip }}"
+    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: add an ipv6 neighbor of Ethernet0 if not find v6 neighbor to test
     command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev Ethernet0"
-    when: v6_nei is not defined
+    when: need_add_ipv6 is defined and need_add_ipv6 == True
 
   - name: change v6 neighbor mac address 1st time
     command: "ip -6 neigh change {{ v6_nei }} lladdr {{ v6_mac1 }} dev {{ v6_intf }}"


### PR DESCRIPTION
### Description of PR
Fix the issue that testcase fails when no ARP/ND learnt on DUT.

Summary:
Fixes issue that testcase fails when no ARP/ND learnt on DUT.
The neighbour-mac-noptf test case is designed to test whether a newly updated ARP/ND can be propagated to SAI table. In case of no ARP/ND learnt on DUT it choice the Ethernet0 to do the test, assigning an address and then updating it. However, the script fails to assign the address ahead of updatding its ARP/ND, causing RTNETLINK error. This PR fix the issue.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
topo: t0
remove all ip addresses on PortChannels without notifying SONiC and then run the test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
