### PR TITLE
[fast/warm reboot] improve fast/warm reboot handling code

### DIFF
--- a/ansible/roles/test/tasks/advanced_reboot/reboot-image-handle.yml
+++ b/ansible/roles/test/tasks/advanced_reboot/reboot-image-handle.yml
@@ -47,3 +47,7 @@
     - name: Installing new SONiC image
       shell: sonic_installer install -y {{ new_image_location }}
       become: true
+
+    - name: Remove config_db.json so the new image will reload minigraph
+      file: path=/host/old_config/config_db.json state=absent
+      become: true


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

- Improve the data test warm up code:
  Let the data plane IO stablize for 30 seconds before testing.
  We observed ptf instability causing the test to fail.
- Remove config_db.json when fast-reboot into a new image.
  We want the new image to reload minigraph in this case.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
#### How did you verify/test it?

