### PR TITLE
[warm-reboot] Fix the issue where BGP info was not being extracted from neigh logs

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -234,7 +234,7 @@ class Arista(object):
         # for fast-reboot, we expect to have both the bgp and portchannel events in the logs. for warm-reboot, portchannel events might not be present in the logs all the time.
         if self.reboot_type == 'fast-reboot' and (initial_time_bgp == -1 or initial_time_if == -1):
             return result
-        elif self.reboot_type == 'warm-reboot' and (initial_time_bgp == -1 and initial_time_if == -1):
+        elif self.reboot_type == 'warm-reboot' and initial_time_bgp == -1:
             return result
 
         for events in result_bgp.values():

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -159,8 +159,8 @@ class Arista(object):
             log_output = self.do_cmd("show log | begin %s" % log_first_line)
             log_lines = log_output.split("\r\n")[1:-1]
             log_data = self.parse_logs(log_lines)
-            if (self.reboot_type == 'fast-reboot' and\
-                any(k.startswith('BGP') for k in log_data) and any(k.startswith('PortChannel') for k in log_data))\
+            if (self.reboot_type == 'fast-reboot' and \
+                any(k.startswith('BGP') for k in log_data) and any(k.startswith('PortChannel') for k in log_data)) \
                     or (self.reboot_type == 'warm-reboot' and any(k.startswith('BGP') for k in log_data)):
                 log_present = True
                 break

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -158,6 +158,7 @@ class Arista(object):
             log_output = self.do_cmd("show log | begin %s" % log_first_line)
             log_lines = log_output.split("\r\n")[1:-1]
             log_data = self.parse_logs(log_lines)
+            # log_data will always have 1 key (route_timeout)
             if len(log_data) > 1:
                 break
             time.sleep(1) # wait until logs are populated
@@ -227,6 +228,7 @@ class Arista(object):
 
         result['route_timeout'] = result_rt
 
+        # for fast-reboot, we expect to have both the bgp and portchannel events in the logs. for warm-reboot, portchannel events might not be present in the logs all the time.
         if self.reboot_type == 'fast-reboot' and (initial_time_bgp == -1 or initial_time_if == -1):
             return result
         elif self.reboot_type == 'warm-reboot' and (initial_time_bgp == -1 and initial_time_if == -1):
@@ -242,6 +244,7 @@ class Arista(object):
                 assert(events[0][1] != 'Established')
 
             assert(events[-1][1] == 'Established')
+            # TODO assert if the peer down to established time is more than 165s
 
         # verify establishment time between v4 and v6 peer is not more than 20s
         if self.reboot_type == 'warm-reboot':


### PR DESCRIPTION
### Description of PR
In warm reboot case, portchannel up/down event might not be recorded in the Arista logs all the time. With the check we had in place, no neigh logs were being printed.  With the changes in this PR, we should see BGP info being printed in the neigh logs all the time and portchannel info if it exists in the Arista logs.

### Type of change
- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added reboot_type var to determine if the portchannel info can be optional while parsing logs

#### How did you verify/test it?
Ran warm-reboot and fast reboot tests on T0-64 topology on 7260 and verified logs are getting printed in both cases
