### PR TITLE
Improved vms config reload: trigger only on state changed

### DIFF
--- a/ansible/roles/eos/files/boot-config
+++ b/ansible/roles/eos/files/boot-config
@@ -1,2 +1,1 @@
 SWI=flash:/vEOS.swi
-

--- a/ansible/roles/eos/handlers/common_handlers/update_state.yml
+++ b/ansible/roles/eos/handlers/common_handlers/update_state.yml
@@ -1,0 +1,20 @@
+- name: Reboot the VM
+  command: /sbin/shutdown -r now "Ansible updates triggered"
+
+- name: Wait for VM to shutdown
+  wait_for:
+    host: "{{ ansible_ssh_host }}"
+    port: 22
+    state: stopped
+    delay: 10
+    timeout: 300
+  connection: local
+
+- name: Wait for VM to startup
+  wait_for:
+    host: "{{ ansible_ssh_host }}"
+    port: 22
+    state: started
+    delay: 10
+    timeout: 1200
+  connection: local

--- a/ansible/roles/eos/handlers/main.yml
+++ b/ansible/roles/eos/handlers/main.yml
@@ -1,0 +1,5 @@
+# Notify handlers are always run in the same order they are defined, not in the order listed in the notify-statement.
+# This is also the case for handlers using listen.
+
+- name: Update VM state
+  include: roles/eos/handlers/common_handlers/update_state.yml

--- a/ansible/roles/eos/tasks/main.yml
+++ b/ansible/roles/eos/tasks/main.yml
@@ -41,34 +41,21 @@
   set_fact: properties_list="{{ configuration[hostname]['properties'] }}"
   when: configuration and configuration[hostname] and configuration[hostname]['properties'] is defined
 
-- name: copy boot-config
-  copy: src=boot-config
-        dest=/mnt/flash/boot-config
-
 - name: Expand {{ hostname }} properties into props
   set_fact: props="{{ configuration_properties[item] | combine(props | default({})) }}"
   with_items: properties_list
   when: hostname in configuration and configuration_properties[item] is defined
 
-- name: build a startup config
+- name: copy boot-config
+  copy: src=boot-config
+        dest=/mnt/flash/boot-config
+  when: hostname in configuration
+  notify:
+    - Update VM state
+
+- name: update startup-config
   template: src="{{ topo }}-{{ props.swrole }}.j2"
             dest=/mnt/flash/startup-config
   when: hostname in configuration
-
-- name: Restart the box
-  command: /sbin/shutdown -r now "Ansible updates triggered"
-  when: hostname in configuration
-
-- name: Pause for reboot
-  pause: seconds=30
-  when: hostname in configuration
-
-- name: Wait for VM to come up
-  wait_for:
-    host: "{{ ansible_ssh_host }}"
-    port: 22
-    state: started
-    delay: 10
-    timeout: 600
-  connection: local
-  when: hostname in configuration
+  notify:
+    - Update VM state


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

### Description of PR
Improved vms config reload: trigger only on state changed

### Type of change
- Testbed and Framework improvement

### Approach
#### How did you do it?
* Improved vms config reload: added on change handler

#### How did you verify/test it?
1. Verified using topo change action

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
* N/A