### PR TITLE
Remove duplicated dict about become within the same block

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/testcase_2.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_2.yml
@@ -40,7 +40,6 @@
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
-  become: yes
 
   always:
     - name: Remove route.

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_3.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_3.yml
@@ -40,7 +40,6 @@
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
-  become: yes
 
   always:
     - name: Remove route.

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_4.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_4.yml
@@ -27,7 +27,6 @@
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
-  become: yes
 
   always:
     - name: Remove neighbor MAC.

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_7.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_7.yml
@@ -56,7 +56,6 @@
         chdir: /root
       delegate_to: "{{ ptf_host }}"
       register: out
-  become: yes
 
   always:
     - name: Remove route {{session_prefix_1}}


### PR DESCRIPTION
Signed-off-by: huharri@celestica.com

Description of PR
   Remove duplicated dict about become within the same block

Type of change
   【】Bug
Approach
How did you do it?
  Remove the duplicated dict of "become"
How did you verify/test it?
   passed the everflow_testbed testcase. and no duplicated dict is warned.
Any platform specific information?
N/A
Supported testbed topology if it's a new test case?
N/A
Documentation
N/A