### PR TITLE
Disabled IPv6 DAD: aligned with SONiC

### DIFF
--- a/ansible/roles/eos/files/rc.eos
+++ b/ansible/roles/eos/files/rc.eos
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo '# Disable IPv6 DAD' >> /etc/sysctl.conf
+
+echo 'net.ipv6.conf.all.accept_dad = 0' >> /etc/sysctl.conf
+echo 'net.ipv6.conf.default.accept_dad = 0' >> /etc/sysctl.conf
+
+/sbin/sysctl -p

--- a/ansible/roles/eos/tasks/main.yml
+++ b/ansible/roles/eos/tasks/main.yml
@@ -46,6 +46,13 @@
   with_items: properties_list
   when: hostname in configuration and configuration_properties[item] is defined
 
+- name: copy rc.eos
+  copy: src=rc.eos
+        dest=/mnt/flash/rc.eos
+  when: hostname in configuration
+  notify:
+    - Update VM state
+
 - name: copy boot-config
   copy: src=boot-config
         dest=/mnt/flash/boot-config


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Aligned IPv6 DAD with SONiC:
https://github.com/Azure/sonic-buildimage/blob/master/build_debian.sh
```
set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_dad 0
```

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
* Added new rc.eos config file

#### How did you verify/test it?
1. Checked sysctl settings
```bash
bash-4.1# sysctl -q net.ipv6.conf | grep po1
net.ipv6.conf.po1.accept_dad = 0
net.ipv6.conf.po1.accept_ra = 0
net.ipv6.conf.po1.accept_ra_defrtr = 0
net.ipv6.conf.po1.accept_ra_pinfo = 0
net.ipv6.conf.po1.accept_redirects = 0
net.ipv6.conf.po1.accept_source_route = 0
net.ipv6.conf.po1.autoconf = 0
net.ipv6.conf.po1.dad_transmits = 1
net.ipv6.conf.po1.disable_ipv6 = 0
net.ipv6.conf.po1.force_mld_version = 0
net.ipv6.conf.po1.force_tllao = 0
net.ipv6.conf.po1.forwarding = 1
net.ipv6.conf.po1.hop_limit = 64
net.ipv6.conf.po1.max_addresses = 16
net.ipv6.conf.po1.mc_forwarding = 0
net.ipv6.conf.po1.mtu = 1500
net.ipv6.conf.po1.proxy_ndp = 0
net.ipv6.conf.po1.router_solicitation_delay = 1
net.ipv6.conf.po1.router_solicitation_interval = 4
net.ipv6.conf.po1.router_solicitations = 0
```

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
* N/A