### PR TITLE
Fix the testcase of restart_syncd failed due to expecting message error

### DIFF
--- a/ansible/roles/test/tasks/restart_syncd.yml
+++ b/ansible/roles/test/tasks/restart_syncd.yml
@@ -15,7 +15,7 @@
     seconds: 10
 
 - name: Look for syncd process
-  shell: pgrep "\<syncd\>" -a
+  shell: docker exec -i syncd ps aux | grep /usr/bin/syncd
   register: syncd_out
   ignore_errors: yes
 


### PR DESCRIPTION
Description of PR
     Fix the testcase of restart_syncd failed due to expecting message error.
     1.  Through "docker exec -i syncd ps aux | grep /usr/bin/syncd", The info of syncd as following:
              admin@cel-seastone-01:~$ docker exec -i syncd ps aux | grep /usr/bin/syncd
                  root        42  0.0  0.0 107660  2820 pts/0    Sl   14:01   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /etc/sai.d/sai.profile
                  root        52 24.5  8.3 1528312 337004 pts/0  Sl   14:01  14:13 /usr/bin/syncd --diag -u -p /etc/sai.d/sai.profile

2.  Through "pgrep "\<syncd\>" -a", The info of syncd as following:
      admin@cel-seastone-01:~$ pgrep "\<syncd\>" -a
      13448 /usr/bin/syncd --diag -u -p /etc/sai.d/sai.profile
      13643 /bin/bash /usr/local/bin/syncd.sh wait
       13647 /bin/bash /usr/bin/syncd.sh wait
   In the second part. the info of "syncd.sh" will interfer the checking of "/usr/bin/syncd". When the syncd is shutdown. We Maybe find the exist of "syncd.sh". Then cause to the failure of the case of restart_syncd. Just as following:
        [cel-seastone-01] => {
    "msg": [
        "15920 /bin/bash /usr/local/bin/syncd.sh wait",
        "15924 /bin/bash /usr/bin/syncd.sh wait"
    ]
     


Summary:
Fixes # (issue)
Type of change
  [■]  Bug fix

Approach
How did you do it?
How did you verify/test it?
    passed the testcase of restart_syncd
Any platform specific information?
Supported testbed topology if it's a new test case?


