### PR TITLE
add t0-16 and t0-56 topology for dir_bcast.yml test

### DIFF
--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 

--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t0', 't0-64', 't0-116']
+  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Running the test case: dir_bcast with the topology: 't0-16' or't0-56', the error caused as below:
task path: /var/sonic/sonic-mgmt/ansible/roles/test/tasks/dir_bcast.yml:9

fatal: [str-dut-01]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"msg": "testbed_type t0-64-32 is invalid."}, "module_name": "fail"}, "msg": "testbed_type t0-56is invalid."}

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [v] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
