### PR TITLE
Loading config before getting red_min_threshold value.

### DIFF
--- a/ansible/roles/test/tasks/ecn.json
+++ b/ansible/roles/test/tasks/ecn.json
@@ -1,0 +1,24 @@
+{
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS": {
+            "red_max_threshold": "32760",
+            "yellow_max_threshold": "32760",
+            "green_min_threshold": "4095",
+            "red_min_threshold": "4095",
+            "yellow_min_threshold": "4095",
+            "green_max_threshold": "32760",
+            "wred_yellow_enable": "true",
+            "wred_green_enable": "true"
+        }, 
+        "AZURE_LOSSY": {
+            "red_max_threshold": "32760",
+            "yellow_max_threshold": "32760",
+            "green_min_threshold": "4095",
+            "red_min_threshold": "4095",
+            "yellow_min_threshold": "4095",
+            "green_max_threshold": "32760",
+            "wred_yellow_enable": "true",
+            "wred_green_enable": "true"
+        }
+    }
+}

--- a/ansible/roles/test/tasks/ecn_wred.yml
+++ b/ansible/roles/test/tasks/ecn_wred.yml
@@ -11,6 +11,16 @@
     test_wred_values="[ '491520', '516096', '430080' ]"
   tags: always
 
+- name: Copy JSON config to switch.
+  copy: src=roles/test/tasks/ecn.json dest=/tmp
+
+- name: Add config
+  shell: config load /tmp/ecn.json -y
+  become: yes
+
+- name: Make sure config updated
+  pause: seconds=2
+
   # Read and store original rmin value for AZURE_LOSSY
 - name: Get red_min_threshold
   shell: ecnconfig -l | grep -A20 AZURE_LOSSY | grep red_min_threshold | awk '{print $2}'


### PR DESCRIPTION
### Description of PR
I get the two fail messages when we run the test item of ecn_wred .

1.TASK [test : Get WRED objects] *************************************************
task path: /var/sonic/sonic-mgmt/ansible/roles/test/tasks/ecn_wred_worker.yml:13
Thursday 04 July 2019  03:43:29 +0000 (0:00:00.362)       0:00:17.754 *********
<10.250.0.196> ESTABLISH SSH CONNECTION FOR USER: admin
<10.250.0.196> SSH: EXEC sshpass -d15 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -o StrictHostKeyChecking=no -o User=admin -o ConnectTimeout=10 -o ControlPath=/var/sonic/.ansible/cp/ansible-ssh-%h-%p-%r 10.250.0.196 'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python'
fatal: [as7816-64x]: FAILED! => {"changed": true, "cmd": "docker exec database redis-cli -n 1 --eval /tmp/get_red_min.lua , 516096 | grep 516096", "delta": "0:00:00.190708", "end": "2019-07-04 03:43:29.729493", "failed": true, "failed_when_result": true, "invocation": {"module_args": {"_raw_params": "docker exec database redis-cli -n 1 --eval /tmp/get_red_min.lua , 516096 | grep 516096", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 1, "start": "2019-07-04 03:43:29.538785", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

2.TASK [test : Restore original value] *******************************************
task path: /var/sonic/sonic-mgmt/ansible/roles/test/tasks/ecn_wred.yml:54
Thursday 04 July 2019  03:43:29 +0000 (0:00:00.460)       0:00:18.215 *********
<10.250.0.196> ESTABLISH SSH CONNECTION FOR USER: admin
<10.250.0.196> SSH: EXEC sshpass -d15 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -o StrictHostKeyChecking=no -o User=admin -o ConnectTimeout=10 -o ControlPath=/var/sonic/.ansible/cp/ansible-ssh-%h-%p-%r 10.250.0.196 '/bin/sh -c '"'"'sudo -H -S  -p "[sudo via ansible, key=usqgymmvtyzccitlfjlhvlkuusoyhsqa] password: " -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-usqgymmvtyzccitlfjlhvlkuusoyhsqa; LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python'"'"'"'"'"'"'"'"''"'"''
fatal: [as7816-64x]: FAILED! => {"changed": true, "cmd": "ecnconfig -p AZURE_LOSSY -rmin ", "delta": "0:00:00.090793", "end": "2019-07-04 03:43:30.075148", "failed": true, "failed_when_result": true, "invocation": {"module_args": {"_raw_params": "ecnconfig -p AZURE_LOSSY -rmin ", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 2, "start": "2019-07-04 03:43:29.984355", "stderr": "usage: ecnconfig [-h] [-v] [-l] [-p PROFILE] [-gmin GREEN_MIN]\n                 [-gmax GREEN_MAX] [-ymin YELLOW_MIN] [-ymax YELLOW_MAX]\n                 [-rmin RED_MIN] [-rmax RED_MAX] [-gdrop GREEN_DROP_PROB]\n                 [-ydrop YELLOW_DROP_PROB] [-rdrop RED_DROP_PROB] [-vv]\n                 [-q QUEUE]\n                 [{on,off}]\necnconfig: error: argument -rmin/--red-min: expected one argument", "stdout": "", "stdout_lines": [], "warnings": []}

I think the issue is caused by getting red_min_threshold value fail.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### How did you do it?
I load the configuration file before running the test with getting red_min_threshold value.
Add the test steps, the two issues can be fixed.
#### How did you verify/test it?
Tested on the broadcom platform.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
