### PR TITLE
Add 't0-64-32' and 't0-56' testbed_type for BcastTest.

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -54,12 +54,14 @@ class BcastTest(BaseTest):
         self.dataplane = ptf.dataplane_instance
         self.router_mac = self.test_params['router_mac']
         self.setUpVlan(self.test_params['vlan_info'])
-        if self.test_params['testbed_type'] == 't0':
+        if self.test_params['testbed_type'] == 't0' or self.test_params['testbed_type'] == 't0-64-32':
             self.src_ports = range(1, 25) + range(28, 32)
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
         if self.test_params['testbed_type'] == 't0-116':
             self.src_ports = range(24, 32)
+        if self.test_params['testbed_type'] == 't0-56':
+            self.src_ports = [0, 1, 4, 5, 8, 9] + range(12, 18) + [20, 21, 24, 25, 28, 29, 32, 33, 36, 37] + range(40, 46) + [48, 49, 52, 53]
 
     #---------------------------------------------------------------------
 


### PR DESCRIPTION
### Description of PR
I get a fail message when we run the test item of dir_bcast.

[
        "WARNING: No route found for IPv6 destination :: (no default route?)", 
        "dir_bcast_test.BcastTest ... ERROR", 
        "", 
        "======================================================================", 
        "ERROR: dir_bcast_test.BcastTest", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"ptftests/dir_bcast_test.py\", line 177, in runTest", 
        "    self.check_all_dir_bcast()", 
        "  File \"ptftests/dir_bcast_test.py\", line 86, in check_all_dir_bcast", 
        "    self.check_ip_dir_bcast(bcast_ip, dst_port_list)", 
        "  File \"ptftests/dir_bcast_test.py\", line 114, in check_ip_dir_bcast", 
        "    src_port = random.choice([port for port in self.src_ports if port not in dst_port_list])", 
        "AttributeError: 'BcastTest' object has no attribute 'src_ports'", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 0.007s", 
        "", 
        "FAILED (errors=1)"
    ]

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### How did you do it?
Add 't0-64-32' and 't0-56' testbed_type for BcastTest.
#### How did you verify/test it?
Tested on the broadcom platform.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
