### PR TITLE
Add LLDP test case item in lldp.yml.

### DIFF
--- a/ansible/roles/test/tasks/lldp.yml
+++ b/ansible/roles/test/tasks/lldp.yml
@@ -59,3 +59,41 @@
   with_items: "{{ lldp.keys() }}"
   when: item != "eth0"
 
+- block:
+  - name: Disable LLDP from DUT
+    shell: "docker exec -i lldp lldpcli  configure lldp status disabled"
+
+  - name: Wait 120s to clear LLDP info (TTL  120s)
+    pause:
+      seconds: 120
+
+  - name: Print LLDP information and Check neigbour item.
+    shell: "lldpctl -f json"
+    register: lldptest
+    failed_when: '"Ethernet" in lldptest.stdout'
+
+  - name: Enable LLDP tx and rx
+    shell: "docker exec -i lldp lldpcli  configure lldp status rx-and-tx"
+
+  - name: Wait 30s to get LLDP info
+    pause:
+      seconds: 30
+
+  - name: Print LLDP information
+    debug: msg="{{ lldp }}"
+
+  - name: Verify LLDP information is available on most interfaces
+    assert: { that: "{{ lldp|length }} > {{ minigraph_lldp_nei|length * 0.8 }}"}
+
+    assert: { that: "'{{ lldp[item]['chassis']['name'] }}' == '{{ minigraph_lldp_nei[item]['name'] }}'" }
+    with_items: "{{ lldp.keys() }}"
+    when: item != "eth0"
+
+  - name: Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
+    assert: { that: "'{{ lldp[item]['port']['ifname'] }}' == '{{ minigraph_neighbors[item]['port'] }}'" }
+    with_items: "{{ lldp.keys() }}"
+    when: item != "eth0"
+
+  rescue:
+    - name: Restart LLDP if Failed
+      shell: "docker exec -i lldp lldpcli  configure lldp status rx-and-tx"


### PR DESCRIPTION
Add Disable and Enable LLDP test in lldp.yml

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [√] Test case(new/improvement)

### Approach
#### How did you do it?
Step:
1, Disable lldp  and read lldp info after 120s(neighbour TTL 120s)
2, Enable lldp  and  check lldp again after 30s        
#### How did you verify/test it?
PLAY RECAP *********************************************************************
cel-e1031-01               : ok=62   changed=12   unreachable=0    failed=0

Friday 05 July 2019  07:43:42 +0000 (0:00:00.031)       0:02:59.808 ***********
===============================================================================
TASK: test : Wait 120s to clear LLDP info (TTL  120s) ----------------- 120.06s
TASK: test : Wait 30s to get LLDP info --------------------------------- 30.06s
TASK: test : gather system version information -------------------------- 2.04s
TASK: test : Enable LLDP tx and rx -------------------------------------- 1.64s
TASK: setup ------------------------------------------------------------- 1.63s
TASK: test : Get interface facts ---------------------------------------- 1.44s
TASK: test : Get interface facts ---------------------------------------- 1.38s
TASK: test : Disable LLDP from DUT -------------------------------------- 1.30s
TASK: test : find minigraph lldp neighbor ------------------------------- 1.16s
TASK: test : Print LLDP information and Check neigbour item. ------------ 1.11s
TASK: test : Verify port channel interfaces are up correctly ------------ 1.10s
TASK: test : Get process information in syncd docker -------------------- 1.01s
TASK: test : Obtain the system description of the DUT chassis ----------- 0.98s
TASK: test : Gather information from LLDP ------------------------------- 0.93s
TASK: test : Get process information in syncd docker -------------------- 0.82s
TASK: test : Verify LLDP information is available on most interfaces ---- 0.67s
TASK: test : Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port) --- 0.66s
TASK: test : Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port) --- 0.65s
TASK: test : Iterate through each LLDP neighbor and verify the information received by neighbor is correct --- 0.64s
TASK: test : Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port) --- 0.61s

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
LLDP test case

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
