### PR TITLE
Add 't0-64-32' testbed_type for FibTest.

### DIFF
--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -1,7 +1,7 @@
 {# defualt route#}
 {% if testbed_type == 't1' %}
 0.0.0.0/0 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
-{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' %}
+{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-64-32' %}
 0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 {% elif testbed_type == 't1-64-lag' %}
@@ -32,7 +32,7 @@
 
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
 
-{% elif testbed_type == 't0' or testbed_type == 't0-64' %}
+{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't0-64-32' %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}


### PR DESCRIPTION
Summary:
Fixes #966 

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### How did you do it?
Add 't0-64-32' testbed_type for FibTest.
#### How did you verify/test it?
Tested on the broadcom platform.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

