### PR TITLE
[bgp-gr-helper] Add script for testing the BGP graceful restart helper function

### DIFF
--- a/ansible/group_vars/eos/eos.yml
+++ b/ansible/group_vars/eos/eos.yml
@@ -1,4 +1,4 @@
 # snmp variables
 snmp_rocommunity: strcommunity
 snmp_location: str
-
+bgp_gr_timer: 700

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -100,6 +100,9 @@ interface {{ bp_ifname }}
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  !
+ graceful-restart restart-time {{ bgp_gr_timer }}
+ graceful-restart
+ !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -92,6 +92,9 @@ interface {{ bp_ifname }}
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  !
+ graceful-restart restart-time {{ bgp_gr_timer }}
+ graceful-restart
+ !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}

--- a/ansible/roles/eos/templates/t1-tor.j2
+++ b/ansible/roles/eos/templates/t1-tor.j2
@@ -92,6 +92,9 @@ interface {{ bp_ifname }}
 router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  !
+ graceful-restart restart-time {{ bgp_gr_timer }}
+ graceful-restart
+ !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -5,7 +5,7 @@
 - fail: msg="testbed_type is not defined."
   when: testbed_type is not defined
 
-- fail: msg="testbed_type {{testbed_type}} is invalid."
+- fail: msg="testbed_type {{testbed_type}} is unsupported."
   when: testbed_type not in ['t1', 't1-lag', 't1-64-lag']
 
 - name: Get VM info.

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -16,7 +16,7 @@
 
 - name: Get VM GR timer.
   set_fact:
-      bgp_gr_timer: "{{ bgp_neighbors[peer_ip]['capabilities']['peer restart timer'] }}"
+      bgp_gr_timer: "{{ bgp_neighbors[peer_ipv4]['capabilities']['peer restart timer'] }}"
 
 - name: Set default value for GR simulation time in seconds.
   set_fact:
@@ -71,11 +71,17 @@
     - name: Gather facts from bgp container.
       bgp_facts:
 
-    - name: Verify bgp session is established
-      assert: { that: "'{{ bgp_neighbors[peer_ip]['state'] }}' == 'established'" }
+    - name: Verify IPv4 bgp session is established
+      assert: { that: "'{{ bgp_neighbors[peer_ipv4]['state'] }}' == 'established'" }
+
+    - name: Verify IPv6 bgp session is established
+      assert: { that: "'{{ bgp_neighbors[peer_ipv6]['state'] }}' == 'established'" }
 
     - name: Verify that IPv4 unicast routes were preserved during GR.
-      assert: { that: "'{{ bgp_neighbors[peer_ip]['capabilities']['peer af ipv4 unicast'] }}' == 'preserved'" }
+      assert: { that: "'{{ bgp_neighbors[peer_ipv4]['capabilities']['peer af ipv4 unicast'] }}' == 'preserved'" }
+
+    - name: Verify that IPv6 unicast routes were preserved during GR.
+      assert: { that: "'{{ bgp_neighbors[peer_ipv6]['capabilities']['peer af ipv6 unicast'] }}' == 'preserved'" }
 
     - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
       vars:
@@ -110,11 +116,17 @@
     - name: Gather facts from bgp container.
       bgp_facts:
 
-    - name: Verify bgp session is established
-      assert: { that: "'{{ bgp_neighbors[peer_ip]['state'] }}' == 'established'" }
+    - name: Verify IPv4 bgp session is established
+      assert: { that: "'{{ bgp_neighbors[peer_ipv4]['state'] }}' == 'established'" }
+
+    - name: Verify IPv6 bgp session is established
+      assert: { that: "'{{ bgp_neighbors[peer_ipv6]['state'] }}' == 'established'" }
 
     - name: Verify that IPv4 unicast routes were not preserved during GR. FIB should be updated.
-      assert: { that: "'{{ bgp_neighbors[peer_ip]['capabilities']['peer af ipv4 unicast'] }}' == 'not preserved'" }
+      assert: { that: "'{{ bgp_neighbors[peer_ipv4]['capabilities']['peer af ipv4 unicast'] }}' == 'not preserved'" }
+
+    - name: Verify that IPv6 unicast routes were not preserved during GR. FIB should be updated.
+      assert: { that: "'{{ bgp_neighbors[peer_ipv6]['capabilities']['peer af ipv6 unicast'] }}' == 'not preserved'" }
 
     - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
       vars:

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -1,0 +1,127 @@
+#-----------------------------------------
+# Run BGP GR helper mode test and Perform log analysis.
+#-----------------------------------------
+
+- fail: msg="testbed_type is not defined."
+  when: testbed_type is not defined
+
+- fail: msg="testbed_type {{testbed_type}} is invalid."
+  when: testbed_type not in ['t1-lag', 't1']
+
+- name: Get VM info.
+  include: "roles/test/tasks/bgp_gr_helper/get_vm_info.yml"
+
+- name: Gather facts from bgp container.
+  bgp_facts:
+
+- name: Get VM GR timer.
+  set_fact:
+      bgp_gr_timer: "{{ bgp_neighbors[peer_ip]['capabilities']['peer restart timer'] }}"
+
+- name: Set default value for GR simulation time in seconds.
+  set_fact:
+      bgp_gr_simulation_timer: 100
+
+- set_fact:
+    testname: "bgp_gr_helper"
+    run_dir: /tmp
+    out_dir: /tmp/ansible-loganalyzer-results
+    tests_location: "{{ 'roles/test/tasks' }}"
+
+- block:
+    - set_fact:
+        testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+
+    - set_fact:
+        test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+      vars:
+        test_match_file: routes_update_match.txt
+
+    - name: Set log level to INFO bo be able to catch route update messages from orchagent
+      command: "swssloglevel -l INFO -c orchagent"
+
+    - name: Define stalepath time. Should be at least 30 seconds grater than graceful restart time.
+      set_fact:
+        bgp_gr_stalepath_timer: "{{ (bgp_gr_timer|int + 30) }}"
+
+    - name: Set bgp stalepath timer.
+      command: vtysh -c "conf t" -c "router bgp {{ minigraph_bgp_asn }}" -c "bgp graceful-restart stalepath-time {{ bgp_gr_stalepath_timer }}"
+
+    # When RIBD up and send bgp open message it will set F bit to 1. Which means that during restart
+    # all routes were preserved in FIB. When DUT receives open message with F bit set to 1 it also
+    # should preserve all routes (no route update should happens).
+    - name: Force stop RIBD to simulate GR.
+      shell: "killall -9 ribd; sleep 0.5; ifconfig et1 down"
+      delegate_to: "{{ vm_ip }}"
+
+    - name: Simulate GR.
+      pause:
+        seconds: "{{ bgp_gr_simulation_timer if (bgp_gr_timer|int - 30) > bgp_gr_simulation_timer else (bgp_gr_timer|int - 30) }}"
+
+    - name: Up interface to allow RIBD to send open message. End of GR.
+      command: ifconfig et1 up
+      delegate_to: "{{ vm_ip }}"
+
+    - name: Wait for BGP session state update.
+      pause:
+        seconds: 10
+
+    - name: Gather facts from bgp container.
+      bgp_facts:
+
+    - name: Verify bgp session is established
+      assert: { that: "'{{ bgp_neighbors[peer_ip]['state'] }}' == 'established'" }
+
+    - name: Verify that IPv4 unicast routes were preserved during GR.
+      assert: { that: "'{{ bgp_neighbors[peer_ip]['capabilities']['peer af ipv4 unicast'] }}' == 'preserved'" }
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+      vars:
+        test_match_file: routes_update_match.txt
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+
+    - set_fact:
+        testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+
+    - set_fact:
+        test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+      vars:
+        test_expect_file: routes_update_expect.txt
+
+    - name: Restart the VM
+      shell: killall -9 ribd ; reboot
+      delegate_to: "{{ vm_ip }}"
+
+    - name: Wait for the VM to go down
+      pause: 
+        seconds: 90
+
+    - local_action: wait_for port=22 host="{{ vm_ip }}" delay=20 timeout="{{ bgp_gr_timer|int - 90 }}" state=started
+
+    - name: Wait for BGP session state update.
+      pause:
+        seconds: 30
+
+    - name: Gather facts from bgp container.
+      bgp_facts:
+
+    - name: Verify bgp session is established
+      assert: { that: "'{{ bgp_neighbors[peer_ip]['state'] }}' == 'established'" }
+
+    - name: Verify that IPv4 unicast routes were not preserved during GR. FIB should be updated.
+      assert: { that: "'{{ bgp_neighbors[peer_ip]['capabilities']['peer af ipv4 unicast'] }}' == 'not preserved'" }
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+      vars:
+        test_expect_file: routes_update_expect.txt
+
+    - include: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+  
+  always:
+    - name: Set log level back to NOTICE
+      command: "swssloglevel -l NOTICE -c orchagent"

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -6,7 +6,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1']
+  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag']
 
 - name: Get VM info.
   include: "roles/test/tasks/bgp_gr_helper/get_vm_info.yml"
@@ -98,7 +98,7 @@
       delegate_to: "{{ vm_ip }}"
 
     - name: Wait for the VM to go down
-      pause: 
+      pause:
         seconds: 90
 
     - local_action: wait_for port=22 host="{{ vm_ip }}" delay=20 timeout="{{ bgp_gr_timer|int - 90 }}" state=started
@@ -121,7 +121,7 @@
         test_expect_file: routes_update_expect.txt
 
     - include: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
-  
+
   always:
     - name: Set log level back to NOTICE
       command: "swssloglevel -l NOTICE -c orchagent"

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -28,6 +28,7 @@
     out_dir: /tmp/ansible-loganalyzer-results
     tests_location: "{{ 'roles/test/tasks' }}"
 
+# Test case 1: Verify that routes are preserved when peer performed graceful restart
 - block:
     - set_fact:
         testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
@@ -41,13 +42,6 @@
 
     - name: Set log level to INFO bo be able to catch route update messages from orchagent
       command: "swssloglevel -l INFO -c orchagent"
-
-    - name: Define stalepath time. Should be at least 30 seconds grater than graceful restart time.
-      set_fact:
-        bgp_gr_stalepath_timer: "{{ (bgp_gr_timer|int + 30) }}"
-
-    - name: Set bgp stalepath timer.
-      command: vtysh -c "conf t" -c "router bgp {{ minigraph_bgp_asn }}" -c "bgp graceful-restart stalepath-time {{ bgp_gr_stalepath_timer }}"
 
     # When RIBD up and send bgp open message it will set F bit to 1. Which means that during restart
     # all routes were preserved in FIB. When DUT receives open message with F bit set to 1 it also
@@ -83,12 +77,19 @@
     - name: Verify that IPv6 unicast routes were preserved during GR.
       assert: { that: "'{{ bgp_neighbors[peer_ipv6]['capabilities']['peer af ipv6 unicast'] }}' == 'preserved'" }
 
+    # Analyze syslog, no log message related with routes update should be observed
     - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
       vars:
         test_match_file: routes_update_match.txt
 
     - include: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
 
+  always:
+    - name: Set log level back to NOTICE
+      command: "swssloglevel -l NOTICE -c orchagent"
+
+# Test case 2: Verify that routes are not preserved when peer performed normal reboot
+- block:
     - set_fact:
         testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
 
@@ -99,7 +100,11 @@
       vars:
         test_expect_file: routes_update_expect.txt
 
-    - name: Restart the VM
+    - name: Set log level to INFO bo be able to catch route update messages from orchagent
+      command: "swssloglevel -l INFO -c orchagent"
+
+    # Reboot the VM, this is not a graceful restart
+    - name: Reboot the VM
       shell: killall -9 ribd ; reboot
       delegate_to: "{{ vm_ip }}"
 
@@ -107,7 +112,8 @@
       pause:
         seconds: 90
 
-    - local_action: wait_for port=22 host="{{ vm_ip }}" delay=20 timeout="{{ bgp_gr_timer|int - 90 }}" state=started
+    - name: Wait for the VM to come back
+      local_action: wait_for port=22 host="{{ vm_ip }}" delay=20 timeout="{{ bgp_gr_timer|int - 90 }}" state=started
 
     - name: Wait for BGP session state update.
       pause:
@@ -128,6 +134,7 @@
     - name: Verify that IPv6 unicast routes were not preserved during GR. FIB should be updated.
       assert: { that: "'{{ bgp_neighbors[peer_ipv6]['capabilities']['peer af ipv6 unicast'] }}' == 'not preserved'" }
 
+    # Analyze syslog, log messages related with routes update are expected
     - include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
       vars:
         test_expect_file: routes_update_expect.txt

--- a/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
@@ -8,20 +8,27 @@
       vm_name: ""
       vm_intf: ""
       vm_ip: ""
-      peer_ip: ""
+      peer_ipv4: ""
+      peer_ipv6: ""
 
 - name: Get neighbor VM info.
   set_fact:
       vm_name: "{{ item.value.name }}"
       vm_intf: "{{ item.key }}"
   with_dict: "{{ minigraph_neighbors }}"
-  when: "testbed_type in ['t1-lag', 't1'] and 'T0' in item.value.name and not vm_name"
+  when: "testbed_type in ['t1', 't1-lag', 't1-64-lag'] and 'T0' in item.value.name and not vm_name"
 
-- name: Get neighbor IP address.
+- name: Get neighbor IPv4 address.
   set_fact:
-      peer_ip: "{{ item.addr }}"
+      peer_ipv4: "{{ item.addr }}"
   with_items: "{{ minigraph_bgp }}"
   when: "item.name == vm_name and item.addr|ipv4"
+
+- name: Get neighbor IPv6 address.
+  set_fact:
+      peer_ipv6: "{{ item.addr|lower }}"
+  with_items: "{{ minigraph_bgp }}"
+  when: "item.name == vm_name and item.addr|ipv6"
 
 - name: Gather information from LLDP
   lldp:
@@ -43,4 +50,6 @@
 - debug:
     var: vm_intf
 - debug:
-    var: vm_ip
+    var: vm_ipv4
+- debug:
+    var: vm_ipv6

--- a/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
@@ -1,0 +1,46 @@
+- name: Gathering lab graph facts about the device
+  conn_graph_facts: host={{ ansible_host }}
+  connection: local
+  tags: always
+
+- name: Init variables.
+  set_fact:
+      vm_name: ""
+      vm_intf: ""
+      vm_ip: ""
+      peer_ip: ""
+
+- name: Get neighbor VM info.
+  set_fact:
+      vm_name: "{{ item.value.name }}"
+      vm_intf: "{{ item.key }}"
+  with_dict: "{{ minigraph_neighbors }}"
+  when: "testbed_type in ['t1-lag', 't1'] and 'T0' in item.value.name and not vm_name"
+
+- name: Get neighbor IP address.
+  set_fact:
+      peer_ip: "{{ item.addr }}"
+  with_items: "{{ minigraph_bgp }}"
+  when: "item.name == vm_name and item.addr|ipv4"
+
+- name: Gather information from LLDP
+  lldp:
+  vars:
+    ansible_shell_type: docker
+    ansible_python_interpreter: docker exec -i lldp python
+
+- name: Get VM IP address.
+  set_fact:
+      vm_ip: "{{ lldp[vm_intf]['chassis']['mgmt-ip'] }}"
+
+- name: Add host
+  add_host:
+    name: "{{ vm_ip }}"
+    groups: "lldp_neighbors,eos"
+
+- debug:
+    var: vm_name
+- debug:
+    var: vm_intf
+- debug:
+    var: vm_ip

--- a/ansible/roles/test/tasks/bgp_gr_helper/routes_update_expect.txt
+++ b/ansible/roles/test/tasks/bgp_gr_helper/routes_update_expect.txt
@@ -1,0 +1,1 @@
+r, ".*Create route.*"

--- a/ansible/roles/test/tasks/bgp_gr_helper/routes_update_match.txt
+++ b/ansible/roles/test/tasks/bgp_gr_helper/routes_update_match.txt
@@ -1,0 +1,3 @@
+r, ".*Remove route.*"
+r, ".*Create route.*"
+r, ".*Set route.*"

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -16,6 +16,9 @@ testcases:
       filename: bgp_fact.yml
       topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
 
+    bgp_gr_helper:
+      filename: bgp_gr_helper.yml
+      topologies: [t1, t1-lag, t1-64-lag]
 
     bgp_multipath_relax:
       filename: bgp_multipath_relax.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add script for testing the BGP graceful restart helper function.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Two scenarios are covered:
* Kill ribd, bring down/up interface on VM to simulate graceful restart. Verify that the DUT preserves the routes.
* Reboot the VM to perform a normal restart. Verify that the DUT does not preserve the routes.

#### How did you verify/test it?
Tested on Mellanox platform

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
[t1, t1-lag, t1-64-lag]

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
[bgp-gr-helper.log](https://github.com/Azure/sonic-mgmt/files/3365109/bgp-gr-helper.log)
