### PR TITLE
[loganalyzer] Generate dump of log within 1 hour by default if test failed

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -616,9 +616,9 @@ def main(argv):
         analyzer.place_marker(log_file_list, analyzer.create_start_marker())
         return 0
     elif (action == "analyze"):
-        match_file_list = match_files_in.split(tokenizer);
-        ignore_file_list = ignore_files_in.split(tokenizer);
-        expect_file_list = expect_files_in.split(tokenizer);
+        match_file_list = match_files_in.split(tokenizer)
+        ignore_file_list = ignore_files_in.split(tokenizer)
+        expect_file_list = expect_files_in.split(tokenizer)
 
         analyzer.place_marker(log_file_list, analyzer.create_end_marker())
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_end.yml
@@ -21,10 +21,14 @@
   register: expected_missing_matches
 
 - set_fact:
-    fail_in_logs: "{{ errors_found.stdout  != \"0\" or expected_missing_matches.stdout != \"0\" }}" 
+    fail_in_logs: "{{ errors_found.stdout  != \"0\" or expected_missing_matches.stdout != \"0\" }}"
+
+- set_fact:
+    dump_since: '1 hour ago'
+  when: dump_since is not defined
 
 - name: Generate system dump
-  command: generate_dump
+  command: "generate_dump -s '{{ dump_since }}'"
   become: true
   register: generate_dump
   when: fail_in_logs


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

By default the log analyzer generate a dump which collects all the
available log files by default in case of failure. This is unnecessary and
the dump file could be too big.

This fix is to generate a dump to collect log within 1 hour by default.
If more log is needed, parameter 'dump_since' can be used.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add a new variable 'dump_since' in the loganalyzer_end.yml script. If the variable is not defined, assign default value '1 hour ago' to it. Then value of the variable will be used for the -s argument of the generate_dump command to limit log files to be collected.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
