### PR TITLE
[dhcp_relay] Correct to use port alias instead of port name

### DIFF
--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -1,11 +1,15 @@
 # We choose client port index to be index of first port on Vlan
+- name: Obtain client interface name
+  set_fact:
+    client_iface_name: "{{ minigraph_vlans[minigraph_vlans.keys()[0]]['members'][0] }}"
+
 - name: Obtain client interface alias
   set_fact:
-    client_iface_alias: "{{ minigraph_vlans[minigraph_vlans.keys()[0]]['members'][0] }}"
-
+    client_iface_alias: "{{ minigraph_port_name_to_alias_map[client_iface_name] }}"
+ 
 - name: Obtain client port index
   set_fact:
-    client_port_index: "{{ minigraph_port_indices[client_iface_alias] }}"
+    client_port_index: "{{ minigraph_port_indices[client_iface_name] }}"
 
 - name: Obtain leaf port indices
   set_fact:


### PR DESCRIPTION
### Description of PR
 #976  dhcp_relay daemon use port interface's alias to fill option82 circuit ID instead of using port inteface's name.
In current yml, use minigraph_vlans' member as client port alias name, but there are only port interface's name in minigraph_vlans. Therefore add to use minigraph_port_name_to_alias_map to obtain the port interface's alias

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
