### PR TITLE
Add 't0-56' testbed_type for decap.

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -99,6 +99,9 @@ class DecapPacketTest(BaseTest):
             self.src_ports = [0,  1,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 36, 37, 38, 39, 40, 41, 42, 48, 52, 53, 54, 55, 56, 57, 58]
         if self.test_params['testbed_type'] == 't0-116':
             self.src_ports = range(0, 24) + range(32, 120)
+        if self.test_params['testbed_type'] == 't0-56':
+            self.src_ports = [0, 1, 4, 5, 8, 9] + range(12, 18) + [20, 21, 24, 25, 28, 29, 32, 33, 36, 37] + range(40, 46) + [48, 49, 52, 53]
+
 
         # which type of tunneled trafic to test (IPv4 in IPv4, IPv6 in IPv4, IPv6 in IPv4, IPv6 in IPv6)
         self.test_outer_ipv4 = self.test_params.get('outer_ipv4', True)

--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -43,7 +43,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0', 't0-64', 't0-116']
+  when: testbed_type in ['t0', 't0-64', 't0-116', 't0-56']
 
 - name: Expand properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"


### PR DESCRIPTION
Description of PR
when deploy the topo: t0-56 and run the decap test case, it causes the error: ERROR! 'props' is undefined.

Type of change
[] Bug fix
[] Testbed and Framework(new/improvement)
[+] Test case(new/improvement)

Approach
How did you do it?
Add 't0-56' testbed_type for decap.

How did you verify/test it?
Tested on the broadcom platform.

Any platform specific information?
Supported testbed topology if it's a new test case?
Documentation