### PR TITLE
Add 't0-56' testbed_type for fib_test.

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -100,7 +100,7 @@ class FibTest(BaseTest):
             self.src_ports = range(0, 32)
         if self.test_params['testbed_type'] == 't1-64-lag':
             self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
-        if self.test_params['testbed_type'] == 't0':
+        if self.test_params['testbed_type'] == 't0' or self.test_params['testbed_type'] == 't0-64-32':
             self.src_ports = range(1, 25) + range(28, 32)
         if self.test_params['testbed_type'] == 't0-56':
             self.src_ports = [0, 1, 4, 5, 8, 9] + range(12, 18) + [20, 21, 24, 25, 28, 29, 32, 33, 36, 37] + range(40, 46) + [48, 49, 52, 53]

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -96,11 +96,11 @@ class FibTest(BaseTest):
         self.balancing_test_ratio = self.test_params.get('balancing_test_ratio', self.DEFAULT_BALANCING_TEST_RATIO)
 
         # Provide the list of all UP interfaces with index in sequence order starting from 0
-        if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag':
+        if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag' or self.test_params['testbed_type'] == 't0-64-32':
             self.src_ports = range(0, 32)
         if self.test_params['testbed_type'] == 't1-64-lag':
             self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
-        if self.test_params['testbed_type'] == 't0' or self.test_params['testbed_type'] == 't0-64-32':
+        if self.test_params['testbed_type'] == 't0':
             self.src_ports = range(1, 25) + range(28, 32)
         if self.test_params['testbed_type'] == 't0-56':
             self.src_ports = [0, 1, 4, 5, 8, 9] + range(12, 18) + [20, 21, 24, 25, 28, 29, 32, 33, 36, 37] + range(40, 46) + [48, 49, 52, 53]

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -1,7 +1,7 @@
 {# defualt route#}
 {% if testbed_type == 't1' %}
 0.0.0.0/0 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
-{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' %}
+{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-56'%}
 0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 {% elif testbed_type == 't1-64-lag' %}
@@ -32,7 +32,7 @@
 
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
 
-{% elif testbed_type == 't0' or testbed_type == 't0-64' %}
+{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't0-56'%}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -1,7 +1,7 @@
 {# defualt route#}
 {% if testbed_type == 't1' %}
 0.0.0.0/0 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
-{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-56'%}
+{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-64-32' or testbed_type == 't0-56'%}
 0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 {% elif testbed_type == 't1-64-lag' %}
@@ -32,7 +32,7 @@
 
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
 
-{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't0-56'%}
+{% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't0-64-32' or testbed_type == 't0-56'%}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}


### PR DESCRIPTION
### Description of PR
It's the same issue with losing t0-56 testbed_type.
I base on #954 bug fix to test bgp_speaker and I get the a fail messages when we run the test item of bgp_speaker.

    "FAIL: fib_test.FibTest",
        "----------------------------------------------------------------------",
        "Traceback (most recent call last):",
        "  File \"ptftests/fib_test.py\", line 290, in runTest",
        "    self.check_ip_range()",
        "  File \"ptftests/fib_test.py\", line 138, in check_ip_range",
        "    self.check_ip_route(src_port, ip_range.get_last_ip(), exp_port_list, ipv4)",
        "  File \"ptftests/fib_test.py\", line 155, in check_ip_route",
        "    (matched_index, received) = self.check_ipv4_route(src_port, dst_ip_addr, dst_port_list)",
        "  File \"ptftests/fib_test.py\", line 200, in check_ipv4_route",
        "    return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)",
        "  File \"/usr/lib/python2.7/dist-packages/ptf/testutils.py\", line 2373, in verify_packet_any_port",
        "    % (ports, device_number, result.format()))",
        "AssertionError: Did not receive expected packet on any of ports [2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18, 19, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] for device 0.",

I move the  judgement of t0-64-32 to the self.src_ports = range(1, 25) + range(28, 32), and the test is success.
 
Summary:
Fixes  #966

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [v] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
add t0-56 testbed_type.
#### Any platform specific information?
Tested on the broadcom platform.

### Documentation 
