### PR TITLE
[warm reboot] save config after upgrading into new image

### DIFF
--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -154,6 +154,18 @@
     - include: ptf_runner_reboot.yml
       with_items: "{{ preboot_list }}"
 
+    # When new image is defined, test removed /host/config_db.json
+    # before warm rebooting. So after the device boots up, it will
+    # miss /etc/sonic/config_db.json. It is not an issue for the
+    # device to stay up. But it will be an issue when device reboot
+    # again (cold or fast).
+    - name: Save configuration when warm rebooting into new image
+      shell: config save -y
+      become: yes
+      when:
+        - new_sonic_image is defined
+        - reboot_type == "warm-reboot"
+
     - name: check /etc/sonic/config_db.json existence
       stat:
         path: /etc/sonic/config_db.json

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -154,6 +154,14 @@
     - include: ptf_runner_reboot.yml
       with_items: "{{ preboot_list }}"
 
+    - name: check /etc/sonic/config_db.json existence
+      stat:
+        path: /etc/sonic/config_db.json
+      register: stat_result
+
+    - fail: msg="/etc/sonic/config_db.json is missing"
+      when: stat_result.stat.exists == False
+
   always:
     - name: Remove existing ip from ptf host
       script: roles/test/files/helpers/remove_ip.sh

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -159,7 +159,7 @@
     # miss /etc/sonic/config_db.json. It is not an issue for the
     # device to stay up. But it will be an issue when device reboot
     # again (cold or fast).
-    - name: Save configuration when warm rebooting into new image
+    - name: Save configuration after warm rebooting into new image
       shell: config save -y
       become: yes
       when:
@@ -172,7 +172,7 @@
       register: stat_result
 
     - fail: msg="/etc/sonic/config_db.json is missing"
-      when: stat_result.stat.exists == False
+      when: not stat_result.stat.exists
 
   always:
     - name: Remove existing ip from ptf host


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

When new image is defined, test removed /host/config_db.json
before warm rebooting. So after the device boots up, it will
miss /etc/sonic/config_db.json. It is not an issue for the
device to stay up. But it will be an issue when device reboot
again (cold or fast).

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Invoke warm reboot test and specify a new target image with first commit only. test failed when detected missing /etc/sonic/config_db.json
Rerun test with both commits and the test passes.