### PR TITLE
[warm-reboot] Add Preboot n BGP member down and n Lag down tests

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -344,6 +344,12 @@ class ReloadTest(BaseTest):
         self.get_neigh_port_info()
         self.get_portchannel_info()
 
+    def populate_fail_info(self, fails):
+        for key in fails:
+            if key not in self.fails:
+                self.fails[key] = set()
+            self.fails[key] |= fails[key]
+
     def setUp(self):
         self.fails['dut'] = set()
         self.port_indices = self.read_port_indices()
@@ -376,14 +382,12 @@ class ReloadTest(BaseTest):
         if self.preboot_oper is not None:
             self.log("Preboot Operations:")
             self.pre_handle = sp.PrebootTest(self.preboot_oper, self.ssh_targets, self.portchannel_ports, self.vm_dut_map, self.test_params, self.dut_ssh)
-            (self.ssh_targets, self.portchannel_ports, self.neigh_vm), (log_info, fails_dut, fails_vm) = self.pre_handle.setup()
-            self.fails['dut'] |= fails_dut
-            self.fails[self.neigh_vm] = fails_vm
+            (self.ssh_targets, self.portchannel_ports, self.neigh_vm), (log_info, fails) = self.pre_handle.setup()
+            self.populate_fail_info(fails)
             for log in log_info:
                 self.log(log)
-            log_info, fails_dut, fails_vm = self.pre_handle.verify()
-            self.fails['dut'] |= fails_dut
-            self.fails[self.neigh_vm] |= fails_vm
+            log_info, fails = self.pre_handle.verify()
+            self.populate_fail_info(fails)
             for log in log_info:
                 self.log(log)
             self.log(" ")
@@ -418,7 +422,9 @@ class ReloadTest(BaseTest):
         self.generate_arp_ping_packet()
 
         if self.reboot_type == 'warm-reboot':
-            self.log("Preboot Oper: %s" % self.preboot_oper)
+            (oper_type, cnt) = self.preboot_oper.split(':') if self.preboot_oper and ':' in self.preboot_oper else (self.preboot_oper, 1)
+            if self.preboot_oper:
+                self.log("Preboot Oper: %s Number down: %s" % (oper_type, cnt))
             # Pre-generate list of packets to be sent in send_in_background method.
             generate_start = datetime.datetime.now()
             self.generate_bidirectional()
@@ -736,9 +742,8 @@ class ReloadTest(BaseTest):
             if self.reboot_type == 'warm-reboot' and self.preboot_oper is not None:
                 if self.pre_handle is not None:
                     self.log("Postboot checks:")
-                    log_info, fails_dut, fails_vm = self.pre_handle.verify(pre_check=False)
-                    self.fails[self.neigh_vm] |= fails_vm
-                    self.fails['dut'] |= fails_dut
+                    log_info, fails = self.pre_handle.verify(pre_check=False)
+                    self.populate_fail_info(fails)
                     for log in log_info:
                         self.log(log)
                     self.log(" ")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -143,7 +143,7 @@ class ReloadTest(BaseTest):
         self.check_param('warm_up_timeout_secs', 300, required=False)
         self.check_param('dut_stabilize_secs', 30, required=False)
         self.check_param('preboot_files', None, required = False)
-        self.check_param('preboot_oper', None, required = False)
+        self.check_param('preboot_oper', None, required = False) # preboot sad path to inject before warm-reboot
         self.check_param('allow_vlan_flooding', False, required = False)
         self.check_param('sniff_time_incr', 60, required = False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
@@ -422,9 +422,14 @@ class ReloadTest(BaseTest):
         self.generate_arp_ping_packet()
 
         if self.reboot_type == 'warm-reboot':
-            (oper_type, cnt) = self.preboot_oper.split(':') if self.preboot_oper and ':' in self.preboot_oper else (self.preboot_oper, 1)
+            # get the number of members down for sad path
             if self.preboot_oper:
-                self.log("Preboot Oper: %s Number down: %s" % (oper_type, cnt))
+                if ':' in self.preboot_oper:
+                    oper_type, cnt = self.preboot_oper.split(':')
+                else:
+                    oper_type, cnt = self.preboot_oper, 1
+                 self.log("Preboot Oper: %s Number down: %s" % (oper_type, cnt))
+
             # Pre-generate list of packets to be sent in send_in_background method.
             generate_start = datetime.datetime.now()
             self.generate_bidirectional()

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -428,7 +428,7 @@ class ReloadTest(BaseTest):
                     oper_type, cnt = self.preboot_oper.split(':')
                 else:
                     oper_type, cnt = self.preboot_oper, 1
-                 self.log("Preboot Oper: %s Number down: %s" % (oper_type, cnt))
+                self.log("Preboot Oper: %s Number down: %s" % (oper_type, cnt))
 
             # Pre-generate list of packets to be sent in send_in_background method.
             generate_start = datetime.datetime.now()

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -42,11 +42,11 @@ class SadPath(object):
         self.portchannel_ports = portchannel_ports
         self.vm_dut_map = vm_dut_map
         self.test_args = test_args
-        self.neigh_vm = []
-        self.neigh_name = dict()
-        self.vm_handle = dict()
-        self.neigh_bgp = dict()
-        self.dut_bgp = dict()
+        self.neigh_vms = []
+        self.neigh_names = dict()
+        self.vm_handles = dict()
+        self.neigh_bgps = dict()
+        self.dut_bgps = dict()
         self.log = []
         self.fails = dict()
         self.fails['dut'] = set()
@@ -65,58 +65,58 @@ class SadPath(object):
         self.vm_list.sort()
         vm_len = len(self.vm_list)
         # use the day of the month to select start VM from the list for the sad pass operation
-        # neigh_vm list will contain cnt number of VMs starting from the start VM. vm_list will have the rest of the VMs
+        # neigh_vms list will contain cnt number of VMs starting from the start VM. vm_list will have the rest of the VMs
         vm_index = datetime.datetime.now().day % vm_len
         exceed_len = vm_index + self.cnt - vm_len
         if exceed_len <= 0:
-            self.neigh_vm.extend(self.vm_list[vm_index:vm_index+self.cnt])
+            self.neigh_vms.extend(self.vm_list[vm_index:vm_index+self.cnt])
             self.vm_list = self.vm_list[0:vm_index] + self.vm_list[vm_index+self.cnt:]
         else:
-            self.neigh_vm.extend(self.vm_list[vm_index:])
-            self.neigh_vm.extend(self.vm_list[0:exceed_len])
+            self.neigh_vms.extend(self.vm_list[vm_index:])
+            self.neigh_vms.extend(self.vm_list[0:exceed_len])
             self.vm_list = self.vm_list[exceed_len:vm_len - self.cnt]
 
     def get_neigh_name(self):
         for key in self.vm_dut_map:
-            for neigh_vm in self.neigh_vm:
+            for neigh_vm in self.neigh_vms:
                 if self.vm_dut_map[key]['mgmt_addr'] == neigh_vm:
-                    self.neigh_name[neigh_vm] = key   # VM address to name mapping
+                    self.neigh_names[neigh_vm] = key   # VM address to name mapping
                     break
 
     def down_neigh_port(self):
         # extract ptf ports for the selected VMs and mark them down
-        for neigh_name in self.neigh_name.values():
+        for neigh_name in self.neigh_names.values():
             for port in self.vm_dut_map[neigh_name]['ptf_ports']:
                 self.portchannel_ports.remove(port)
 
     def vm_connect(self):
-        for neigh_vm in self.neigh_vm:
-            self.vm_handle[neigh_vm] = Arista(neigh_vm, None, self.test_args)
-            self.vm_handle[neigh_vm].connect()
+        for neigh_vm in self.neigh_vms:
+            self.vm_handles[neigh_vm] = Arista(neigh_vm, None, self.test_args)
+            self.vm_handles[neigh_vm].connect()
 
     def __del__(self):
         self.vm_disconnect()
 
     def vm_disconnect(self):
-        for vm in self.vm_handle:
-            self.vm_handle[vm].disconnect()
+        for vm in self.vm_handles:
+            self.vm_handles[vm].disconnect()
 
     def setup(self):
         self.select_vm()
         self.get_neigh_name()
         self.down_neigh_port()
         self.vm_connect()
-        for vm in self.vm_handle:
-            self.neigh_bgp[vm], self.dut_bgp[vm] = self.vm_handle[vm].get_bgp_info()
+        for vm in self.vm_handles:
+            self.neigh_bgps[vm], self.dut_bgps[vm] = self.vm_handles[vm].get_bgp_info()
             self.fails[vm] = set()
-            self.log.append('Neighbor AS: %s' % self.neigh_bgp[vm]['asn'])
-            self.log.append('BGP v4 neighbor: %s' % self.neigh_bgp[vm]['v4'])
-            self.log.append('BGP v6 neighbor: %s' % self.neigh_bgp[vm]['v6'])
-            self.log.append('DUT BGP v4: %s' % self.dut_bgp[vm]['v4'])
-            self.log.append('DUT BGP v6: %s' % self.dut_bgp[vm]['v6'])
+            self.log.append('Neighbor AS: %s' % self.neigh_bgps[vm]['asn'])
+            self.log.append('BGP v4 neighbor: %s' % self.neigh_bgps[vm]['v4'])
+            self.log.append('BGP v6 neighbor: %s' % self.neigh_bgps[vm]['v6'])
+            self.log.append('DUT BGP v4: %s' % self.dut_bgps[vm]['v4'])
+            self.log.append('DUT BGP v6: %s' % self.dut_bgps[vm]['v6'])
 
     def retreive_test_info(self):
-        return self.vm_list, self.portchannel_ports, self.neigh_vm
+        return self.vm_list, self.portchannel_ports, self.neigh_vms
 
     def retreive_logs(self):
         return self.log, self.fails
@@ -133,21 +133,21 @@ class SadOper(SadPath):
         self.msg_prefix = ['Postboot', 'Preboot']
 
     def populate_bgp_state(self):
-        [self.dut_needed.setdefault(vm, self.dut_bgp[vm]) for vm in self.neigh_vm]
+        [self.dut_needed.setdefault(vm, self.dut_bgps[vm]) for vm in self.neigh_vms]
         if self.oper_type == 'neigh_bgp_down':
-            self.neigh_bgp['changed_state'] = 'down'
-            self.dut_bgp['changed_state'] = 'Active'
-            [self.dut_needed.update({vm:None}) for vm in self.neigh_vm]
+            self.neigh_bgps['changed_state'] = 'down'
+            self.dut_bgps['changed_state'] = 'Active'
+            [self.dut_needed.update({vm:None}) for vm in self.neigh_vms]
         elif self.oper_type == 'dut_bgp_down':
-            self.neigh_bgp['changed_state'] = 'Active'
-            self.dut_bgp['changed_state'] = 'Idle'
+            self.neigh_bgps['changed_state'] = 'Active'
+            self.dut_bgps['changed_state'] = 'Idle'
         elif self.oper_type == 'neigh_lag_down':
             # on the DUT side, bgp states are different pre and post boot. hence passing multiple values
-            self.neigh_bgp['changed_state'] = 'Idle'
-            self.dut_bgp['changed_state'] = 'Connect,Active,Idle'
+            self.neigh_bgps['changed_state'] = 'Idle'
+            self.dut_bgps['changed_state'] = 'Connect,Active,Idle'
         elif self.oper_type == 'dut_lag_down':
-            self.neigh_bgp['changed_state'] = 'Idle'
-            self.dut_bgp['changed_state'] = 'Active,Connect,Idle'
+            self.neigh_bgps['changed_state'] = 'Idle'
+            self.dut_bgps['changed_state'] = 'Active,Connect,Idle'
 
     def sad_setup(self, is_up=True):
         self.log = []
@@ -159,21 +159,21 @@ class SadOper(SadPath):
                 self.populate_lag_state()
 
         if 'bgp' in self.oper_type:
-            self.log.append('BGP state change will be for %s' % ", ".join(self.neigh_vm))
+            self.log.append('BGP state change will be for %s' % ", ".join(self.neigh_vms))
             if self.oper_type == 'neigh_bgp_down':
-                for vm in self.neigh_vm:
-                    self.log.append('Changing state of AS %s to shut' % self.neigh_bgp[vm]['asn'])
-                    self.vm_handle[vm].change_bgp_neigh_state(self.neigh_bgp[vm]['asn'], is_up=is_up)
+                for vm in self.neigh_vms:
+                    self.log.append('Changing state of AS %s to shut' % self.neigh_bgps[vm]['asn'])
+                    self.vm_handles[vm].change_bgp_neigh_state(self.neigh_bgps[vm]['asn'], is_up=is_up)
             elif self.oper_type == 'dut_bgp_down':
                 self.change_bgp_dut_state(is_up=is_up)
             time.sleep(30)
 
         elif 'lag' in self.oper_type:
-            self.log.append('LAG state change will be for %s' % ", ".join(self.neigh_vm))
+            self.log.append('LAG state change will be for %s' % ", ".join(self.neigh_vms))
             if self.oper_type == 'neigh_lag_down':
-                for vm in self.neigh_vm:
-                    self.log.append('Changing state of LAG %s to shut' % self.vm_dut_map[self.neigh_name[vm]]['neigh_portchannel'])
-                    self.vm_handle[vm].change_neigh_lag_state(self.vm_dut_map[self.neigh_name[vm]]['neigh_portchannel'], is_up=is_up)
+                for vm in self.neigh_vms:
+                    self.log.append('Changing state of LAG %s to shut' % self.vm_dut_map[self.neigh_names[vm]]['neigh_portchannel'])
+                    self.vm_handles[vm].change_neigh_lag_state(self.vm_dut_map[self.neigh_names[vm]]['neigh_portchannel'], is_up=is_up)
             elif self.oper_type == 'dut_lag_down':
                 self.change_dut_lag_state(is_up=is_up)
             # wait for sometime for lag members state to sync
@@ -181,29 +181,29 @@ class SadOper(SadPath):
 
     def change_bgp_dut_state(self, is_up=True):
         state = ['shutdown', 'startup']
-        for vm in self.neigh_vm:
-            for key in self.neigh_bgp[vm].keys():
+        for vm in self.neigh_vms:
+            for key in self.neigh_bgps[vm].keys():
                 if key not in ['v4', 'v6']:
                     continue
 
-                self.log.append('Changing state of BGP peer %s from DUT side to %s' % (self.neigh_bgp[vm][key], state[is_up]))
-                stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'sudo config bgp %s neighbor %s' % (state[is_up], self.neigh_bgp[vm][key])])
+                self.log.append('Changing state of BGP peer %s from DUT side to %s' % (self.neigh_bgps[vm][key], state[is_up]))
+                stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'sudo config bgp %s neighbor %s' % (state[is_up], self.neigh_bgps[vm][key])])
                 if return_code != 0:
-                    self.fails['dut'].add('State change not successful from DUT side for peer %s' % self.neigh_bgp[vm][key])
+                    self.fails['dut'].add('State change not successful from DUT side for peer %s' % self.neigh_bgps[vm][key])
                     self.fails['dut'].add('Return code: %d' % return_code)
                     self.fails['dut'].add('Stderr: %s' % stderr)
 
     def verify_bgp_dut_state(self, state='Idle'):
         states = state.split(',')
         bgp_state = {}
-        for vm in self.neigh_vm:
+        for vm in self.neigh_vms:
             bgp_state[vm] = dict()
             bgp_state[vm]['v4'] = bgp_state[vm]['v6'] = False
-            for key in self.neigh_bgp[vm].keys():
+            for key in self.neigh_bgps[vm].keys():
                 if key not in ['v4', 'v6']:
                     continue
-                self.log.append('Verifying if the DUT side BGP peer %s is %s' % (self.neigh_bgp[vm][key], states))
-                stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'show ip bgp neighbor %s' % self.neigh_bgp[vm][key]])
+                self.log.append('Verifying if the DUT side BGP peer %s is %s' % (self.neigh_bgps[vm][key], states))
+                stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'show ip bgp neighbor %s' % self.neigh_bgps[vm][key]])
                 if return_code == 0:
                     for line in stdout.split('\n'):
                         if 'BGP state' in line:
@@ -211,23 +211,23 @@ class SadOper(SadPath):
                             bgp_state[vm][key] = (curr_state in states)
                             break
                 else:
-                    self.fails['dut'].add('Retreiving BGP info for peer %s from DUT side failed' % self.neigh_bgp[vm][key])
+                    self.fails['dut'].add('Retreiving BGP info for peer %s from DUT side failed' % self.neigh_bgps[vm][key])
                     self.fails['dut'].add('Return code: %d' % return_code)
                     self.fails['dut'].add('Stderr: %s' % stderr)
         return bgp_state
 
     def sad_bgp_verify(self):
         self.log = []
-        for vm in self.neigh_vm:
-            fails_vm, bgp_state = self.vm_handle[vm].verify_bgp_neigh_state(dut=self.dut_needed[vm], state=self.neigh_bgp['changed_state'])
+        for vm in self.neigh_vms:
+            fails_vm, bgp_state = self.vm_handles[vm].verify_bgp_neigh_state(dut=self.dut_needed[vm], state=self.neigh_bgps['changed_state'])
             self.fails[vm] |= fails_vm
             if bgp_state['v4'] and bgp_state['v6']:
                 self.log.append('BGP state down as expected for %s' % vm)
             else:
                 self.fails[vm].add('BGP state not down for %s' % vm)
-        bgp_state = self.verify_bgp_dut_state(state=self.dut_bgp['changed_state'])
+        bgp_state = self.verify_bgp_dut_state(state=self.dut_bgps['changed_state'])
         state = True
-        for vm in self.neigh_vm:
+        for vm in self.neigh_vms:
             state &= bgp_state[vm]['v4'] and bgp_state[vm]['v6']
         if state:
             self.log.append('BGP state down as expected on DUT')
@@ -240,14 +240,14 @@ class SadOper(SadPath):
         elif self.oper_type == 'dut_lag_down':
             self.neigh_lag_state = 'notconnect'
 
-        for neigh_name in self.neigh_name.values():
+        for neigh_name in self.neigh_names.values():
             # build portchannel to down members mapping
             po_name = self.vm_dut_map[neigh_name]['dut_portchannel']
             self.lag_members_down[po_name] = self.vm_dut_map[neigh_name]['dut_ports']
 
     def change_dut_lag_state(self, is_up=True):
         state = ['shutdown', 'startup']
-        for neigh_name in self.neigh_name.values():
+        for neigh_name in self.neigh_names.values():
             dut_portchannel = self.vm_dut_map[neigh_name]['dut_portchannel']
             if not re.match('(PortChannel|Ethernet)\d+', dut_portchannel): continue
             self.log.append('Changing state of %s from DUT side to %s' % (dut_portchannel, state[is_up]))
@@ -282,10 +282,10 @@ class SadOper(SadPath):
 
         # get list of down portchannels and build portchannel to neigh mapping
         po_list = []
-        for vm in self.neigh_vm:
-            po_name = self.vm_dut_map[self.neigh_name[vm]]['dut_portchannel']
+        for vm in self.neigh_vms:
+            po_name = self.vm_dut_map[self.neigh_names[vm]]['dut_portchannel']
             po_list.append(po_name)
-            self.po_neigh_map[po_name] = self.neigh_name[vm]
+            self.po_neigh_map[po_name] = self.neigh_names[vm]
 
         stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'show interfaces portchannel'])
         if return_code == 0:
@@ -304,8 +304,8 @@ class SadOper(SadPath):
             self.fails['dut'].add('%s: Stderr: %s' % (self.msg_prefix[pre_check], stderr))
 
     def sad_lag_verify(self, pre_check=True):
-        for vm in self.neigh_vm:
-            fails_vm, lag_state = self.vm_handle[vm].verify_neigh_lag_state(self.vm_dut_map[self.neigh_name[vm]]['neigh_portchannel'], state=self.neigh_lag_state, pre_check=pre_check)
+        for vm in self.neigh_vms:
+            fails_vm, lag_state = self.vm_handles[vm].verify_neigh_lag_state(self.vm_dut_map[self.neigh_names[vm]]['neigh_portchannel'], state=self.neigh_lag_state, pre_check=pre_check)
             self.fails[vm] |= fails_vm
             if lag_state:
                 self.log.append('LAG state down as expected for %s' % vm)

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -66,7 +66,7 @@ class SadPath(object):
         vm_len = len(self.vm_list)
         # use the day of the month to select start VM from the list for the sad pass operation
         # neigh_vms list will contain cnt number of VMs starting from the start VM. vm_list will have the rest of the VMs
-        vm_index = datetime.datetime.now().day % vm_len
+        vm_index = datetime.datetime.now().day % vm_len if vm_len > 0 else 0
         exceed_len = vm_index + self.cnt - vm_len
         if exceed_len <= 0:
             self.neigh_vms.extend(self.vm_list[vm_index:vm_index+self.cnt])
@@ -278,6 +278,7 @@ class SadOper(SadPath):
         return success
 
     def verify_dut_lag_state(self, pre_check=True):
+        # pattern match eg: '0001  PortChannel0001  LACP(A)(Up)  Ethernet0(S) Ethernet4(S)'. extract the portchannel name and members
         pat = re.compile("\s+\d+\s+(\w+\d+)\s+LACP\(A\)\(Dw\)\s+(.*)")
 
         # get list of down portchannels and build portchannel to neigh mapping

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -36,16 +36,17 @@ class PrebootTest(object):
 
 class SadPath(object):
     def __init__(self, oper_type, vm_list, portchannel_ports, vm_dut_map, test_args):
-        self.oper_type = oper_type
+        (self.oper_type, self.cnt) = oper_type.split(':') if ':' in oper_type else (oper_type, 1)
+        self.cnt = int(self.cnt)
         self.vm_list = vm_list
         self.portchannel_ports = portchannel_ports
         self.vm_dut_map = vm_dut_map
         self.test_args = test_args
-        self.neigh_vm = None
-        self.neigh_name = None
-        self.vm_handle = None
-        self.neigh_bgp = None
-        self.dut_bgp = None
+        self.neigh_vm = []
+        self.neigh_name = dict()
+        self.vm_handle = dict()
+        self.neigh_bgp = dict()
+        self.dut_bgp = dict()
         self.log = []
         self.fails = dict()
         self.fails['dut'] = set()
@@ -62,78 +63,91 @@ class SadPath(object):
 
     def select_vm(self):
         self.vm_list.sort()
-        # use the day of the month to select a VM from the list for the sad pass operation
-        vm_index = datetime.datetime.now().day % len(self.vm_list)
-        self.neigh_vm = self.vm_list.pop(vm_index)
+        vm_len = len(self.vm_list)
+        # use the day of the month to select start VM from the list for the sad pass operation
+        # neigh_vm list will contain cnt number of VMs starting from the start VM. vm_list will have the rest of the VMs
+        vm_index = datetime.datetime.now().day % vm_len
+        exceed_len = vm_index + self.cnt - vm_len
+        if exceed_len <= 0:
+            self.neigh_vm.extend(self.vm_list[vm_index:vm_index+self.cnt])
+            self.vm_list = self.vm_list[0:vm_index] + self.vm_list[vm_index+self.cnt:]
+        else:
+            self.neigh_vm.extend(self.vm_list[vm_index:])
+            self.neigh_vm.extend(self.vm_list[0:exceed_len])
+            self.vm_list = self.vm_list[exceed_len:vm_len - self.cnt]
 
     def get_neigh_name(self):
-        for key in self.vm_dut_map.keys():
-            if self.vm_dut_map[key]['mgmt_addr'] == self.neigh_vm:
-                self.neigh_name = key
-                break
+        for key in self.vm_dut_map:
+            for neigh_vm in self.neigh_vm:
+                if self.vm_dut_map[key]['mgmt_addr'] == neigh_vm:
+                    self.neigh_name[neigh_vm] = key   # VM address to name mapping
+                    break
 
     def down_neigh_port(self):
-        # extract ptf ports for the selected VM and mark them down
-        for port in self.vm_dut_map[self.neigh_name]['ptf_ports']:
-            self.portchannel_ports.remove(port)
+        # extract ptf ports for the selected VMs and mark them down
+        for neigh_name in self.neigh_name.values():
+            for port in self.vm_dut_map[neigh_name]['ptf_ports']:
+                self.portchannel_ports.remove(port)
 
     def vm_connect(self):
-        self.vm_handle = Arista(self.neigh_vm, None, self.test_args)
-        self.vm_handle.connect()
+        for neigh_vm in self.neigh_vm:
+            self.vm_handle[neigh_vm] = Arista(neigh_vm, None, self.test_args)
+            self.vm_handle[neigh_vm].connect()
 
     def __del__(self):
         self.vm_disconnect()
 
     def vm_disconnect(self):
-        self.vm_handle.disconnect()
+        for vm in self.vm_handle:
+            self.vm_handle[vm].disconnect()
 
     def setup(self):
         self.select_vm()
         self.get_neigh_name()
         self.down_neigh_port()
         self.vm_connect()
-        self.neigh_bgp, self.dut_bgp = self.vm_handle.get_bgp_info()
-        self.fails[self.neigh_vm] = set()
-        self.log.append('Neighbor AS: %s' % self.neigh_bgp['asn'])
-        self.log.append('BGP v4 neighbor: %s' % self.neigh_bgp['v4'])
-        self.log.append('BGP v6 neighbor: %s' % self.neigh_bgp['v6'])
-        self.log.append('DUT BGP v4: %s' % self.dut_bgp['v4'])
-        self.log.append('DUT BGP v6: %s' % self.dut_bgp['v6'])
+        for vm in self.vm_handle:
+            self.neigh_bgp[vm], self.dut_bgp[vm] = self.vm_handle[vm].get_bgp_info()
+            self.fails[vm] = set()
+            self.log.append('Neighbor AS: %s' % self.neigh_bgp[vm]['asn'])
+            self.log.append('BGP v4 neighbor: %s' % self.neigh_bgp[vm]['v4'])
+            self.log.append('BGP v6 neighbor: %s' % self.neigh_bgp[vm]['v6'])
+            self.log.append('DUT BGP v4: %s' % self.dut_bgp[vm]['v4'])
+            self.log.append('DUT BGP v6: %s' % self.dut_bgp[vm]['v6'])
 
     def retreive_test_info(self):
         return self.vm_list, self.portchannel_ports, self.neigh_vm
 
     def retreive_logs(self):
-        return self.log, self.fails['dut'], self.fails[self.neigh_vm]
+        return self.log, self.fails
 
 
 class SadOper(SadPath):
     def __init__(self, oper_type, vm_list, portchannel_ports, vm_dut_map, test_args, dut_ssh):
         super(SadOper, self).__init__(oper_type, vm_list, portchannel_ports, vm_dut_map, test_args)
         self.dut_ssh = dut_ssh
-        self.dut_needed = None
-        self.lag_members_down = None
+        self.dut_needed = dict()
+        self.lag_members_down = dict()
         self.neigh_lag_state = None
+        self.po_neigh_map = dict()
         self.msg_prefix = ['Postboot', 'Preboot']
 
     def populate_bgp_state(self):
+        [self.dut_needed.setdefault(vm, self.dut_bgp[vm]) for vm in self.neigh_vm]
         if self.oper_type == 'neigh_bgp_down':
             self.neigh_bgp['changed_state'] = 'down'
             self.dut_bgp['changed_state'] = 'Active'
-            self.dut_needed = None
+            [self.dut_needed.update({vm:None}) for vm in self.neigh_vm]
         elif self.oper_type == 'dut_bgp_down':
             self.neigh_bgp['changed_state'] = 'Active'
             self.dut_bgp['changed_state'] = 'Idle'
-            self.dut_needed = self.dut_bgp
         elif self.oper_type == 'neigh_lag_down':
             # on the DUT side, bgp states are different pre and post boot. hence passing multiple values
             self.neigh_bgp['changed_state'] = 'Idle'
             self.dut_bgp['changed_state'] = 'Connect,Active,Idle'
-            self.dut_needed = self.dut_bgp
         elif self.oper_type == 'dut_lag_down':
             self.neigh_bgp['changed_state'] = 'Idle'
             self.dut_bgp['changed_state'] = 'Active,Connect,Idle'
-            self.dut_needed = self.dut_bgp
 
     def sad_setup(self, is_up=True):
         self.log = []
@@ -145,18 +159,21 @@ class SadOper(SadPath):
                 self.populate_lag_state()
 
         if 'bgp' in self.oper_type:
-            self.log.append('BGP state change will be for %s' % self.neigh_vm)
+            self.log.append('BGP state change will be for %s' % ", ".join(self.neigh_vm))
             if self.oper_type == 'neigh_bgp_down':
-                self.log.append('Changing state of AS %s to shut' % self.neigh_bgp['asn'])
-                self.vm_handle.change_bgp_neigh_state(self.neigh_bgp['asn'], is_up=is_up)
+                for vm in self.neigh_vm:
+                    self.log.append('Changing state of AS %s to shut' % self.neigh_bgp[vm]['asn'])
+                    self.vm_handle[vm].change_bgp_neigh_state(self.neigh_bgp[vm]['asn'], is_up=is_up)
             elif self.oper_type == 'dut_bgp_down':
                 self.change_bgp_dut_state(is_up=is_up)
             time.sleep(30)
+
         elif 'lag' in self.oper_type:
-            self.log.append('LAG state change will be for %s' % self.neigh_vm)
+            self.log.append('LAG state change will be for %s' % ", ".join(self.neigh_vm))
             if self.oper_type == 'neigh_lag_down':
-                self.log.append('Changing state of LAG %s to shut' % self.vm_dut_map[self.neigh_name]['neigh_portchannel'])
-                self.vm_handle.change_neigh_lag_state(self.vm_dut_map[self.neigh_name]['neigh_portchannel'], is_up=is_up)
+                for vm in self.neigh_vm:
+                    self.log.append('Changing state of LAG %s to shut' % self.vm_dut_map[self.neigh_name[vm]]['neigh_portchannel'])
+                    self.vm_handle[vm].change_neigh_lag_state(self.vm_dut_map[self.neigh_name[vm]]['neigh_portchannel'], is_up=is_up)
             elif self.oper_type == 'dut_lag_down':
                 self.change_dut_lag_state(is_up=is_up)
             # wait for sometime for lag members state to sync
@@ -164,48 +181,55 @@ class SadOper(SadPath):
 
     def change_bgp_dut_state(self, is_up=True):
         state = ['shutdown', 'startup']
-        for key in self.neigh_bgp.keys():
-            if key not in ['v4', 'v6']:
-                continue
+        for vm in self.neigh_vm:
+            for key in self.neigh_bgp[vm].keys():
+                if key not in ['v4', 'v6']:
+                    continue
 
-            self.log.append('Changing state of BGP peer %s from DUT side to %s' % (self.neigh_bgp[key], state[is_up]))
-            stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'sudo config bgp %s neighbor %s' % (state[is_up], self.neigh_bgp[key])])
-            if return_code != 0:
-                self.fails['dut'].add('State change not successful from DUT side for peer %s' % self.neigh_bgp[key])
-                self.fails['dut'].add('Return code: %d' % return_code)
-                self.fails['dut'].add('Stderr: %s' % stderr)
+                self.log.append('Changing state of BGP peer %s from DUT side to %s' % (self.neigh_bgp[vm][key], state[is_up]))
+                stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'sudo config bgp %s neighbor %s' % (state[is_up], self.neigh_bgp[vm][key])])
+                if return_code != 0:
+                    self.fails['dut'].add('State change not successful from DUT side for peer %s' % self.neigh_bgp[vm][key])
+                    self.fails['dut'].add('Return code: %d' % return_code)
+                    self.fails['dut'].add('Stderr: %s' % stderr)
 
     def verify_bgp_dut_state(self, state='Idle'):
         states = state.split(',')
         bgp_state = {}
-        bgp_state['v4'] = bgp_state['v6'] = False
-        for key in self.neigh_bgp.keys():
-            if key not in ['v4', 'v6']:
-                continue
-            self.log.append('Verifying if the DUT side BGP peer %s is %s' % (self.neigh_bgp[key], states))
-            stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'show ip bgp neighbor %s' % self.neigh_bgp[key]])
-            if return_code == 0:
-                for line in stdout.split('\n'):
-                    if 'BGP state' in line:
-                        curr_state = re.findall('BGP state = (\w+)', line)[0]
-                        bgp_state[key] = (curr_state in states)
-                        break
-            else:
-                self.fails['dut'].add('Retreiving BGP info for peer %s from DUT side failed' % self.neigh_bgp[key])
-                self.fails['dut'].add('Return code: %d' % return_code)
-                self.fails['dut'].add('Stderr: %s' % stderr)
+        for vm in self.neigh_vm:
+            bgp_state[vm] = dict()
+            bgp_state[vm]['v4'] = bgp_state[vm]['v6'] = False
+            for key in self.neigh_bgp[vm].keys():
+                if key not in ['v4', 'v6']:
+                    continue
+                self.log.append('Verifying if the DUT side BGP peer %s is %s' % (self.neigh_bgp[vm][key], states))
+                stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'show ip bgp neighbor %s' % self.neigh_bgp[vm][key]])
+                if return_code == 0:
+                    for line in stdout.split('\n'):
+                        if 'BGP state' in line:
+                            curr_state = re.findall('BGP state = (\w+)', line)[0]
+                            bgp_state[vm][key] = (curr_state in states)
+                            break
+                else:
+                    self.fails['dut'].add('Retreiving BGP info for peer %s from DUT side failed' % self.neigh_bgp[vm][key])
+                    self.fails['dut'].add('Return code: %d' % return_code)
+                    self.fails['dut'].add('Stderr: %s' % stderr)
         return bgp_state
 
     def sad_bgp_verify(self):
         self.log = []
-        fails_vm, bgp_state = self.vm_handle.verify_bgp_neigh_state(dut=self.dut_needed, state=self.neigh_bgp['changed_state'])
-        self.fails[self.neigh_vm] |= fails_vm
-        if bgp_state['v4'] and bgp_state['v6']:
-            self.log.append('BGP state down as expected for %s' % self.neigh_vm)
-        else:
-            self.fails[self.neigh_vm].add('BGP state not down for %s' % self.neigh_vm)
+        for vm in self.neigh_vm:
+            fails_vm, bgp_state = self.vm_handle[vm].verify_bgp_neigh_state(dut=self.dut_needed[vm], state=self.neigh_bgp['changed_state'])
+            self.fails[vm] |= fails_vm
+            if bgp_state['v4'] and bgp_state['v6']:
+                self.log.append('BGP state down as expected for %s' % vm)
+            else:
+                self.fails[vm].add('BGP state not down for %s' % vm)
         bgp_state = self.verify_bgp_dut_state(state=self.dut_bgp['changed_state'])
-        if bgp_state['v4'] and bgp_state['v6']:
+        state = True
+        for vm in self.neigh_vm:
+            state &= bgp_state[vm]['v4'] and bgp_state[vm]['v6']
+        if state:
             self.log.append('BGP state down as expected on DUT')
         else:
             self.fails['dut'].add('BGP state not down on DUT')
@@ -213,28 +237,35 @@ class SadOper(SadPath):
     def populate_lag_state(self):
         if self.oper_type == 'neigh_lag_down':
             self.neigh_lag_state = 'disabled'
-            self.lag_members_down = self.vm_dut_map[self.neigh_name]['dut_ports']
         elif self.oper_type == 'dut_lag_down':
-            self.lag_members_down = self.vm_dut_map[self.neigh_name]['dut_ports']
             self.neigh_lag_state = 'notconnect'
+
+        for neigh_name in self.neigh_name.values():
+            # build portchannel to down members mapping
+            po_name = self.vm_dut_map[neigh_name]['dut_portchannel']
+            self.lag_members_down[po_name] = self.vm_dut_map[neigh_name]['dut_ports']
 
     def change_dut_lag_state(self, is_up=True):
         state = ['shutdown', 'startup']
-        dut_portchannel = self.vm_dut_map[self.neigh_name]['dut_portchannel']
-        if not re.match('(PortChannel|Ethernet)\d+', dut_portchannel): return
-        self.log.append('Changing state of %s from DUT side to %s' % (dut_portchannel, state[is_up]))
-        stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'sudo config interface %s %s' % (state[is_up], dut_portchannel)])
-        if return_code != 0:
-            self.fails['dut'].add('%s: State change not successful from DUT side for %s' % (self.msg_prefix[1 - is_up], dut_portchannel))
-            self.fails['dut'].add('%s: Return code: %d' % (self.msg_prefix[1 - is_up], return_code))
-            self.fails['dut'].add('%s: Stderr: %s' % (self.msg_prefix[1 - is_up], stderr))
-        else:
-            self.log.append('State change successful on DUT')
+        for neigh_name in self.neigh_name.values():
+            dut_portchannel = self.vm_dut_map[neigh_name]['dut_portchannel']
+            if not re.match('(PortChannel|Ethernet)\d+', dut_portchannel): continue
+            self.log.append('Changing state of %s from DUT side to %s' % (dut_portchannel, state[is_up]))
+            stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'sudo config interface %s %s' % (state[is_up], dut_portchannel)])
+            if return_code != 0:
+                self.fails['dut'].add('%s: State change not successful from DUT side for %s' % (self.msg_prefix[1 - is_up], dut_portchannel))
+                self.fails['dut'].add('%s: Return code: %d' % (self.msg_prefix[1 - is_up], return_code))
+                self.fails['dut'].add('%s: Stderr: %s' % (self.msg_prefix[1 - is_up], stderr))
+            else:
+                self.log.append('%s: State change successful on DUT for %s' % (self.msg_prefix[1 - is_up], dut_portchannel))
 
-    def verify_dut_lag_member_state(self, lag_memb_output, pre_check=True):
+    def verify_dut_lag_member_state(self, match, pre_check=True):
         success = True
-        for member in self.vm_dut_map[self.neigh_name]['dut_ports']:
-            if self.lag_members_down is not None and member in self.lag_members_down:
+        po_name = match.group(1)
+        lag_memb_output = match.group(2)
+        neigh_name = self.po_neigh_map[po_name]
+        for member in self.vm_dut_map[neigh_name]['dut_ports']:
+            if po_name in self.lag_members_down and member in self.lag_members_down[po_name]:
                 search_str = '%s(D)' % member
             else:
                 search_str = '%s(S)' % member
@@ -247,30 +278,38 @@ class SadOper(SadPath):
         return success
 
     def verify_dut_lag_state(self, pre_check=True):
-        pat = re.compile(".*%s\s+LACP\(A\)\(Dw\)\s+(.*)" % self.vm_dut_map[self.neigh_name]['dut_portchannel'])
+        pat = re.compile("\s+\d+\s+(\w+\d+)\s+LACP\(A\)\(Dw\)\s+(.*)")
+
+        # get list of down portchannels and build portchannel to neigh mapping
+        po_list = []
+        for vm in self.neigh_vm:
+            po_name = self.vm_dut_map[self.neigh_name[vm]]['dut_portchannel']
+            po_list.append(po_name)
+            self.po_neigh_map[po_name] = self.neigh_name[vm]
+
         stdout, stderr, return_code = self.cmd(['ssh', '-oStrictHostKeyChecking=no', self.dut_ssh, 'show interfaces portchannel'])
         if return_code == 0:
             for line in stdout.split('\n'):
-                if self.vm_dut_map[self.neigh_name]['dut_portchannel'] in line:
+                if any(po_name in line for po_name in po_list):
                     is_match = pat.match(line)
-                    if is_match and self.verify_dut_lag_member_state(is_match.group(1), pre_check=pre_check):
-                        self.log.append('Lag state is down as expected on the DUT')
+                    if is_match and self.verify_dut_lag_member_state(is_match, pre_check=pre_check):
+                        self.log.append('Lag state is down as expected on the DUT for %s' % is_match.group(1))
                         self.log.append('Pattern check: %s' % line)
                     else:
-                        self.fails['dut'].add('%s: Lag state is not down on the DUT' % self.msg_prefix[pre_check])
+                        self.fails['dut'].add('%s: Lag state is not down on the DUT for %s' % (self.msg_prefix[pre_check], is_match.group(1)))
                         self.fails['dut'].add('%s: Obtained: %s' % (self.msg_prefix[pre_check], line))
-                    break
         else:
             self.fails['dut'].add('%s: Retreiving LAG info from DUT side failed' % self.msg_prefix[pre_check])
             self.fails['dut'].add('%s: Return code: %d' % (self.msg_prefix[pre_check], return_code))
             self.fails['dut'].add('%s: Stderr: %s' % (self.msg_prefix[pre_check], stderr))
 
     def sad_lag_verify(self, pre_check=True):
-        fails_vm, lag_state = self.vm_handle.verify_neigh_lag_state(self.vm_dut_map[self.neigh_name]['neigh_portchannel'], state=self.neigh_lag_state, pre_check=pre_check)
-        self.fails[self.neigh_vm] |= fails_vm
-        if lag_state:
-            self.log.append('LAG state down as expected for %s' % self.neigh_vm)
-        else:
-            self.fails[self.neigh_vm].add('%s: LAG state not down for %s' % (self.msg_prefix[pre_check], self.neigh_vm))
+        for vm in self.neigh_vm:
+            fails_vm, lag_state = self.vm_handle[vm].verify_neigh_lag_state(self.vm_dut_map[self.neigh_name[vm]]['neigh_portchannel'], state=self.neigh_lag_state, pre_check=pre_check)
+            self.fails[vm] |= fails_vm
+            if lag_state:
+                self.log.append('LAG state down as expected for %s' % vm)
+            else:
+                self.fails[vm].add('%s: LAG state not down for %s' % (self.msg_prefix[pre_check], vm))
         self.log.append('Verifying LAG state on the dut end')
         self.verify_dut_lag_state(pre_check=pre_check)

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -26,7 +26,7 @@
     - name: Validate preboot list
       include: roles/test/tasks/advanced_reboot/validate_preboot_list.yml
       with_items: "{{ preboot_list }}"
-      when: item and  item != 'None' and item.find(':') != -1
+      when: item and ':' in item
 
     - name: Preboot files initialization
       set_fact: preboot_files={% if preboot_files is not defined %}None{% else %}{{ preboot_files }}{% endif %}

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -23,6 +23,11 @@
     - name: Preboot-list initialization
       set_fact: preboot_list={% if preboot_list is not defined %}[None]{% else %}{{ preboot_list }}{% endif %}
 
+    - name: Validate preboot list
+      include: roles/test/tasks/advanced_reboot/validate_preboot_list.yml
+      with_items: "{{ preboot_list }}"
+      when: item and  item != 'None' and item.find(':') != -1
+
     - name: Preboot files initialization
       set_fact: preboot_files={% if preboot_files is not defined %}None{% else %}{{ preboot_files }}{% endif %}
 

--- a/ansible/roles/test/tasks/advanced_reboot/validate_preboot_list.yml
+++ b/ansible/roles/test/tasks/advanced_reboot/validate_preboot_list.yml
@@ -1,0 +1,13 @@
+- set_fact:
+    item_cnt: "{{ item.split(':')[1]|int }}"
+    host_max_len: "{{ vm_hosts|length - 1 }}"
+    member_max_cnt: "{{ minigraph_portchannels.values()[0]['members']|length }}"
+
+- fail: msg="Bgp neigh down count is greater than or equal to number of VM hosts. Current val = {{ item_cnt }} Max val = {{ host_max_len }}"
+  when: "{{ 'bgp_down' in item and item_cnt > host_max_len }}"
+
+- fail: msg="Lag count is greater than or equal to number of VM hosts. Current val = {{ item_cnt }} Max val = {{ host_max_len }}"
+  when: "{{ 'lag_down' in item and item_cnt > host_max_len }}"
+
+- fail: msg="Lag member count is greater than available number of lag members. Current val = {{ item_cnt }} Available cnt = {{ member_max_cnt }}"
+  when: "{{ 'lag_member_down' in item and item_cnt > member_max_cnt }}"

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -7,5 +7,5 @@
   include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
-      preboot_list: ['neigh_bgp_down:2', 'dut_bgp_down', 'dut_lag_down:2', 'neigh_lag_down:3']
+      preboot_list: ['neigh_bgp_down:2', 'dut_bgp_down:3', 'dut_lag_down:2', 'neigh_lag_down:3']
       preboot_files: "peer_dev_info,neigh_port_info"

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -7,5 +7,5 @@
   include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
-      preboot_list: ['neigh_bgp_down', 'dut_bgp_down', 'dut_lag_down', 'neigh_lag_down']
+      preboot_list: ['neigh_bgp_down:2', 'dut_bgp_down', 'dut_lag_down:2', 'neigh_lag_down:3']
       preboot_files: "peer_dev_info,neigh_port_info"

--- a/ansible/roles/test/tasks/warm-reboot-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad.yml
@@ -7,5 +7,5 @@
   include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
-      preboot_list: ['neigh_bgp_down', 'dut_bgp_down', 'dut_lag_down', 'neigh_lag_down']
+      preboot_list: ['neigh_bgp_down:2', 'dut_bgp_down', 'dut_lag_down:2', 'neigh_lag_down:3']
       preboot_files: "peer_dev_info,neigh_port_info"

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -91,6 +91,13 @@ testcases:
           ptf_host:
           vm_hosts:
 
+    warm-reboot-multi-sad:
+      filename: warm-reboot-multi-sad.yml
+      topologies: [t0, t0-64, t0-64-32, t0-116]
+      required_vars:
+          ptf_host:
+          vm_hosts:
+
     fib:
       filename: simple-fib.yml
       topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Extend the warm-reboot sad path BGP and LAG tests for bringing n BGP members or n lags down instead of a single one

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
* warm-reboot-sad.yml 
     - Added ':' separated parameter for each preboot operation which indicates the number of bgp members/lag down.  If no ':' separated parameter exists, the count is set to 1
* validate_preboot_list.yml 
     - Validate if the cnt for each preboot operation is within allowed limits. For bgp and lag down case, the max value is set to one less than the number of Vms. For lag member case, max allowed value is the total number of members in a lag
* sad_path.py
    - VM selection method is extended to select count number of VMs after picking a start VM.  
    - extend all cases to make changes for count number of VMs instead of a single VM

#### How did you verify/test it?
Ran the test on T0 topology and all cases passed
Regression run for fast-reboot and warm-reboot tests also passed
