### PR TITLE
[ansible-plugin] back port stdout callback plugin 'yaml' from ansible2.5

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -115,7 +115,7 @@ deprecation_warnings = False
 
 # set plugin path directories here, separate with colons
 action_plugins     = plugins/action
-# callback_plugins   = /usr/share/ansible_plugins/callback_plugins
+callback_plugins   = plugins/callback
 connection_plugins = plugins/connection
 # lookup_plugins     = /usr/share/ansible_plugins/lookup_plugins
 # vars_plugins       = /usr/share/ansible_plugins/vars_plugins

--- a/ansible/plugins/callback/yaml.py
+++ b/ansible/plugins/callback/yaml.py
@@ -1,0 +1,123 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: yaml
+    type: stdout
+    short_description: yaml-ized Ansible screen output
+    version_added: 2.5
+    description:
+        - Ansible output that can be quite a bit easier to read than the
+          default JSON formatting.
+    extends_documentation_fragment:
+      - default_callback
+    requirements:
+      - set as stdout in configuration
+'''
+
+import yaml
+import json
+import re
+import string
+import sys
+from ansible.plugins.callback import CallbackBase, strip_internal_keys
+from ansible.plugins.callback.default import CallbackModule as Default
+
+# simple workaroud for using yaml callback plugin
+from ansible.vars.unsafe_proxy import AnsibleUnsafeText
+represent_unicode = yaml.representer.SafeRepresenter.represent_unicode
+from ansible.parsing.yaml.dumper import AnsibleDumper
+AnsibleDumper.add_representer(
+    AnsibleUnsafeText,
+    represent_unicode,
+)
+
+# from http://stackoverflow.com/a/15423007/115478
+def should_use_block(value):
+    """Returns true if string should be in block format"""
+    for c in u"\u000a\u000d\u001c\u001d\u001e\u0085\u2028\u2029":
+        if c in value:
+            return True
+    return False
+
+
+def my_represent_scalar(self, tag, value, style=None):
+    """Uses block style for multi-line strings"""
+    if style is None:
+        if should_use_block(value):
+            style = '|'
+            # we care more about readable than accuracy, so...
+            # ...no trailing space
+            value = value.rstrip()
+            # ...and non-printable characters
+            value = ''.join(x for x in value if x in string.printable)
+            # ...tabs prevent blocks from expanding
+            value = value.expandtabs()
+            # ...and odd bits of whitespace
+            value = re.sub(r'[\x0b\x0c\r]', '', value)
+            # ...as does trailing space
+            value = re.sub(r' +\n', '\n', value)
+        else:
+            style = self.default_style
+    node = yaml.representer.ScalarNode(tag, value, style=style)
+    if self.alias_key is not None:
+        self.represented_objects[self.alias_key] = node
+    return node
+
+
+class CallbackModule(Default):
+
+    """
+    Variation of the Default output which uses nicely readable YAML instead
+    of JSON for printing results.
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'yaml'
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        yaml.representer.BaseRepresenter.represent_scalar = my_represent_scalar
+
+    def _dump_results(self, result, indent=None, sort_keys=True, keep_invocation=False):
+        if result.get('_ansible_no_log', False):
+            return json.dumps(dict(censored="the output has been hidden due to the fact that 'no_log: true' was specified for this result"))
+
+        # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.
+        abridged_result = strip_internal_keys(result)
+
+        # remove invocation unless specifically wanting it
+        if not keep_invocation and self._display.verbosity < 3 and 'invocation' in result:
+            del abridged_result['invocation']
+
+        # remove diff information from screen output
+        if self._display.verbosity < 3 and 'diff' in result:
+            del abridged_result['diff']
+
+        # remove exception from screen output
+        if 'exception' in abridged_result:
+            del abridged_result['exception']
+
+        dumped = ''
+
+        # put changed and skipped into a header line
+        if 'changed' in abridged_result:
+            dumped += 'changed=' + str(abridged_result['changed']).lower() + ' '
+            del abridged_result['changed']
+
+        if 'skipped' in abridged_result:
+            dumped += 'skipped=' + str(abridged_result['skipped']).lower() + ' '
+            del abridged_result['skipped']
+
+        # if we already have stdout, we don't need stdout_lines
+        if 'stdout' in abridged_result and 'stdout_lines' in abridged_result:
+            abridged_result['stdout_lines'] = '<omitted>'
+
+        if abridged_result:
+            dumped += '\n'
+            dumped += yaml.dump(abridged_result,  Dumper=AnsibleDumper, allow_unicode=True, width=1000, default_flow_style=False)
+
+        # indent by a couple of spaces
+        dumped = '\n  '.join(dumped.split('\n')).rstrip()
+        return dumped


### PR DESCRIPTION
### Description of PR
With this plugin `yaml`, we could get pretty-printed stdout of ansible-playbook.
And don't need to put `debug` everywhere.

Summary:
* Adding the ability to use yaml plugin with stdout content

Signed-off-by: Zhiqian Wu <zhiqian.wu@nephosinc.com>

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
- Back port yaml plugin from ansible 2.5
- Enable plugin through `ansible.cfg`

#### How to use ?
exec `ansible-playbook` with `ANSIBLE_STDOUT_CALLBACK` or set default stdout callback to `yaml` through `ansible.cfg`

E.g.
```
ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -i lab -vvv --limit str-msn2700-01 test_sonic.yml -e "testcase_name=mem_check testbed_type=t0 testbed_name=vms-t1 ptf_host=10.250.0.178"
```
#### How did you verify/test it?
assume that we have a playbook include below tasks:
```
   - name: Get process information in syncd docker
     shell: docker exec -i syncd ps aux | grep /usr/bin/syncd
     register: ps_out
     ignore_errors: yes

   - debug: var=ps_out.stdout_lines
```
   
**without yaml plugin, the stdout is like:**
```
TASK [test : Get process information in syncd docker] **************************
task path: /var/root/sonic-mgmt-vrf/ansible/roles/test/tasks/base_sanity.yml:1
Friday 12 July 2019  08:11:23 +0000 (0:00:00.387)       0:00:10.390 *********** 
...
changed: [str-msn2700-01] => {"changed": true, "cmd": "docker exec -i syncd ps aux | grep /usr/bin/syncd", "delta": "0:00:00.226302", "end": "2019-07-12 08:11:23.601663", "invocation": {"module_args": {"_raw_params": "docker exec -i syncd ps aux | grep /usr/bin/syncd", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 0, "start": "2019-07-12 08:11:23.375361", "stderr": "", "stdout": "root        16  0.0  0.0  41584  2712 pts/0    Sl   Jul11   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile\nroot        25 12.8  0.3 1137728 59284 pts/0   Sl   Jul11 220:24 /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile", "stdout_lines": ["root        16  0.0  0.0  41584  2712 pts/0    Sl   Jul11   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile", "root        25 12.8  0.3 1137728 59284 pts/0   Sl   Jul11 220:24 /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile"], "warnings": []}

TASK [test : debug] ************************************************************
task path: /var/root/sonic-mgmt-vrf/ansible/roles/test/tasks/base_sanity.yml:6
Friday 12 July 2019  08:11:23 +0000 (0:00:00.394)       0:00:10.785 *********** 
ok: [str-msn2700-01] => {
    "ps_out.stdout_lines": [
        "root        16  0.0  0.0  41584  2712 pts/0    Sl   Jul11   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile", 
        "root        25 12.8  0.3 1137728 59284 pts/0   Sl   Jul11 220:24 /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile"
    ]
}
```

**with yaml plugin, the stdout is like:**
```
TASK [test : Get process information in syncd docker] **************************
task path: /var/root/sonic-mgmt-vrf/ansible/roles/test/tasks/base_sanity.yml:1
Friday 12 July 2019  08:17:45 +0000 (0:00:00.389)       0:00:10.965 *********** 
...
changed: [str-msn2700-01] => changed=true 
  cmd: docker exec -i syncd ps aux | grep /usr/bin/syncd
  delta: '0:00:00.214221'
  end: '2019-07-12 08:17:46.200908'
  invocation:
    module_args:
      _raw_params: docker exec -i syncd ps aux | grep /usr/bin/syncd
      _uses_shell: true
      chdir: null
      creates: null
      executable: null
      removes: null
      warn: true
    module_name: command
  rc: 0
  start: '2019-07-12 08:17:45.986687'
  stderr: ''
  stdout: |-
    root        16  0.0  0.0  41584  2712 pts/0    Sl   Jul11   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile
    root        25 12.8  0.3 1137728 59284 pts/0   Sl   Jul11 221:13 /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile
  stdout_lines: <omitted>
  warnings: []

TASK [test : debug] ************************************************************
task path: /var/root/sonic-mgmt-vrf/ansible/roles/test/tasks/base_sanity.yml:6
Friday 12 July 2019  08:17:46 +0000 (0:00:00.368)       0:00:11.333 *********** 
ok: [str-msn2700-01] => 
  ps_out.stdout_lines:
  - root        16  0.0  0.0  41584  2712 pts/0    Sl   Jul11   0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile
  - root        25 12.8  0.3 1137728 59284 pts/0   Sl   Jul11 221:13 /usr/bin/syncd --diag -u -p /usr/share/sonic/hwsku/sai.profile
```
