### PR TITLE
[pytest] Improve ansible_host

### DIFF
--- a/tests/ansible_host.py
+++ b/tests/ansible_host.py
@@ -1,3 +1,9 @@
+from ansible.plugins import callback_loader
+
+def dump_ansible_results(results, stdout_callback='yamll'):
+    cb = callback_loader.get(stdout_callback)
+    return cb._dump_results(results) if cb else results
+
 class ansible_host():
     
     def __init__(self, ansible_adhoc, hostname, is_local = False):
@@ -17,6 +23,6 @@ class ansible_host():
    
         res = self.module(*module_args, **complex_args)[self.hostname]
         if res.is_failed:
-            raise Exception("run module {} failed, errmsg {}".format(self.module_name, res))
+            raise Exception("run module {} failed, errmsg {}".format(self.module_name, dump_ansible_results(res)))
 
         return res

--- a/tests/ansible_host.py
+++ b/tests/ansible_host.py
@@ -1,8 +1,20 @@
 from ansible.plugins import callback_loader
+from ansible.errors import AnsibleError
 
 def dump_ansible_results(results, stdout_callback='yaml'):
     cb = callback_loader.get(stdout_callback)
     return cb._dump_results(results) if cb else results
+
+class AnsibleModuleException(AnsibleError):
+
+    """Sub-class AnsibleError when module exceptions occur."""
+
+    def __init__(self, msg, results=None):
+        super(AnsibleModuleException, self).__init__(msg)
+        self.results = results
+
+    def __str__(self):
+        return "{}\nAnsible Results => {}".format(self.message, dump_ansible_results(self.results))
 
 class ansible_host():
     
@@ -21,10 +33,10 @@ class ansible_host():
 
     def _run(self, *module_args, **complex_args):
    
-        ignore_errors = complex_args.pop('ignore_errors', False)
+        module_ignore_errors = complex_args.pop('module_ignore_errors', False)
 
         res = self.module(*module_args, **complex_args)[self.hostname]
-        if res.is_failed and not ignore_errors:
-            raise Exception("run module {} failed, errmsg {}".format(self.module_name, dump_ansible_results(res)))
+        if res.is_failed and not module_ignore_errors:
+            raise AnsibleModuleException("run module {} failed".format(self.module_name), res)
 
         return res

--- a/tests/ansible_host.py
+++ b/tests/ansible_host.py
@@ -21,8 +21,10 @@ class ansible_host():
 
     def _run(self, *module_args, **complex_args):
    
+        ignore_errors = complex_args.pop('ignore_errors', False)
+
         res = self.module(*module_args, **complex_args)[self.hostname]
-        if res.is_failed:
+        if res.is_failed and not ignore_errors:
             raise Exception("run module {} failed, errmsg {}".format(self.module_name, dump_ansible_results(res)))
 
         return res

--- a/tests/ansible_host.py
+++ b/tests/ansible_host.py
@@ -1,6 +1,6 @@
 from ansible.plugins import callback_loader
 
-def dump_ansible_results(results, stdout_callback='yamll'):
+def dump_ansible_results(results, stdout_callback='yaml'):
     cb = callback_loader.get(stdout_callback)
     return cb._dump_results(results) if cb else results
 


### PR DESCRIPTION
[pytest] adding ability to use stdout callback plugin when running ansible module
[pytest ansible_host] Support 'module_ignore_errors' option

Signed-off-by: Zhiqian Wu <zhiqian.wu@nephosinc.com>

### Description of PR
Summary:
1.  stdout callback
With stdout callback plugin, we could get pretty-printed output of ansible module results.
It is simple and convenient to read the outputs or print dict/list objects. 

So i add a function `dump_ansible_results` to do that. 'yaml' is the default stdout callback plugin, back port from ansible 2.5 in  PR #1005 , you may choose another plugin whenever calling `dump_ansible_results`.

2. module_ignore_errors
We need to ignore errors when execute some cmds with non-zero return codes.

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add `dump_ansible_results` , it loads stdout callback plugin and return pretty-printed results. If load failed, nothing changed.
Add class `AnsibleModuleException` with pretty-printed ansible module results by overriding __str__. Raise it whenever module failed.

In `ansible_host`, add a `module_ignore_errors` argument.

#### How did you verify/test it?
assume to execute a simple cmd with shell module `echo hello && false`

**without stdout callback plugin, output is like:**
```
# py.test  --inventory veos --host-pattern all --user admin   --testbed vms-t0 --testbed_file testbed.csv   --show-capture=stdout test_fixtures.py::test2
...<omit some outputs>

    def test2(duthost):
>       duthost.shell("echo hello && false")

test_fixtures.py:20: 

...<omit some outputs>

    def _run(self, *module_args, **complex_args):
    
        ignore_errors = complex_args.pop('ignore_errors', False)
        res = self.module(*module_args, **complex_args)[self.hostname]
        if res.is_failed and not ignore_errors:
>           raise Exception("run module {} failed, errmsg {}".format(self.module_name, dump_ansible_results(res)))
E           Exception: run module shell failed, errmsg {u'changed': True, u'end': u'2019-07-12 09:30:43.029062', '_ansible_no_log': False, u'stdout': u'hello', u'cmd': u'echo hello && false', u'rc': 1, 'failed': True, u'stderr': u'', u'delta': u'0:00:00.002947', 'invocation': {'module_name': u'command', u'module_args': {u'creates': None, u'executable': None, u'chdir': None, u'_raw_params': u'echo hello && false', u'removes': None, u'warn': True, u'_uses_shell': True}}, 'stdout_lines': [u'hello'], u'start': u'2019-07-12 09:30:43.026115', u'warnings': []}

ansible_host.py:27: Exception
```

**with stdout callback plugin, output is like:**
```
py.test  --inventory veos --host-pattern all --user admin -vvvv  --testbed vms-t0 --testbed_file testbed.csv   --show-capture=stdout test_fixtures.py::test2
...<omit some outputs>

    def test2(duthost):
>       duthost.shell("echo hello && false")

test_fixtures.py:20: 

...<omit some outputs>

    def _run(self, *module_args, **complex_args):
    
        module_ignore_errors = complex_args.pop('module_ignore_errors', False)
    
        res = self.module(*module_args, **complex_args)[self.hostname]
        if res.is_failed and not module_ignore_errors:
>           raise AnsibleModuleException("run module {} failed".format(self.module_name), res)
E           AnsibleModuleException: ERROR! run module shell failed
E           Ansible Results => changed=true 
E             cmd: echo hello && false
E             delta: '0:00:00.003753'
E             end: '2019-07-25 03:37:11.906237'
E             failed: true
E             rc: 1
E             start: '2019-07-25 03:37:11.902484'
E             stderr: ''
E             stdout: hello
E             stdout_lines: <omitted>
E             warnings: []

```