### PR TITLE
[warm reboot] always save the configuration

### DIFF
--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -155,6 +155,7 @@
     - include: ptf_runner_reboot.yml
       with_items: "{{ preboot_list }}"
 
+  always:
     # When new image is defined, test removed /host/config_db.json
     # before warm rebooting. So after the device boots up, it will
     # miss /etc/sonic/config_db.json. It is not an issue for the
@@ -175,7 +176,6 @@
     - fail: msg="/etc/sonic/config_db.json is missing"
       when: not stat_result.stat.exists
 
-  always:
     - name: Remove existing ip from ptf host
       script: roles/test/files/helpers/remove_ip.sh
       delegate_to: "{{ ptf_host }}"


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

When test failed due to dataplane disruption issue, config save would be
skipped and leaving the device in vulnerable state. Move config save to
the always block.
