### PR TITLE
[vnet]: Change VxLAN encap TTL value

### DIFF
--- a/ansible/roles/test/files/ptftests/vnet_vxlan.py
+++ b/ansible/roles/test/files/ptftests/vnet_vxlan.py
@@ -359,7 +359,7 @@ class VNET(BaseTest):
                     ip_id=0,
                     ip_src=self.loopback_ipv4,
                     ip_dst=test['host'],
-                    ip_ttl=64,
+                    ip_ttl=128,
                     udp_sport=udp_sport,
                     udp_dport=udp_dport,
                     with_udp_chksum=False,


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach
#### How did you do it?
Changed VxLAN encap TTL value for "VNET" test according to changes in PR https://github.com/Azure/sonic-swss/pull/980
#### How did you verify/test it?
Executed "VNET" test and verified it passed
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
