### PR TITLE
[fast/warm reboot] check the existence of correct file as stated

### DIFF
--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -72,7 +72,7 @@
       delegate_to: "{{ ptf_host }}"
 
     - name: Check that file /root/.ssh/known_hosts exists
-      stat: path=/etc/shorewall/rules
+      stat: path=/root/.ssh/known_hosts
       delegate_to: "{{ ptf_host }}"
       register: known_hosts
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

The check is to gate removing a line in known_hosts file, so the check
needs to be checking /root/.ssh/known_hosts.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Noticed some nightly tests failed because not able to reboot the DUT because the known_hosts has conflicting entry.

Executed some test locally.