### PR TITLE
[minigraph] allow generating minigraph without data plane acl defined

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -122,6 +122,7 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
+{%- if enable_data_plane_acl is defined and enable_data_plane_acl|bool %}
         <AclInterface>
           <AttachTo>
 {%- for index in range(vms_number) %}
@@ -138,6 +139,7 @@ PortChannel{{ ((index+1) |string).zfill(4) }}{% if not loop.last %};{% endif %}
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
+{% endif -%}
       </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -122,7 +122,7 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
-{%- if enable_data_plane_acl is defined and enable_data_plane_acl|bool %}
+{%- if enable_data_plane_acl|default('true')|bool %}
         <AclInterface>
           <AttachTo>
 {%- for index in range(vms_number) %}

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -41,9 +41,10 @@ function usage
   echo "To configure a VM on a server: $0 config-vm 'topo-name' 'vm-name' ~/.password"
   echo "To generate minigraph for DUT in a topology: $0 gen-mg 'topo-name' 'inventory' ~/.password"
   echo "To deploy minigraph to DUT in a topology: $0 deploy-mg 'topo-name' 'inventory' ~/.password"
-  echo "    gen-mg, deploy-mg, test-mg supports enabling data ACL with parameter"
+  echo "    gen-mg, deploy-mg, test-mg supports enabling/disabling data ACL with parameter"
   echo "        -e enable_data_plane_acl=true"
-  echo "        by default, data acl is not enabled"
+  echo "        -e enable_data_plane_acl=false"
+  echo "        by default, data acl is enabled"
   echo
   echo "You should define your topology in testbed CSV file"
   echo

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -41,6 +41,9 @@ function usage
   echo "To configure a VM on a server: $0 config-vm 'topo-name' 'vm-name' ~/.password"
   echo "To generate minigraph for DUT in a topology: $0 gen-mg 'topo-name' 'inventory' ~/.password"
   echo "To deploy minigraph to DUT in a topology: $0 deploy-mg 'topo-name' 'inventory' ~/.password"
+  echo "    gen-mg, deploy-mg, test-mg supports enabling data ACL with parameter"
+  echo "        -e enable_data_plane_acl=true"
+  echo "        by default, data acl is not enabled"
   echo
   echo "You should define your topology in testbed CSV file"
   echo
@@ -195,33 +198,54 @@ function disconnect_vms
 
 function generate_minigraph
 {
-  echo "Generating minigraph '$1'"
+  topology=$1
+  inventory=$2
+  passfile=$3
+  shift
+  shift
+  shift
 
-  read_file $1
+  echo "Generating minigraph '$topology'"
 
-  ansible-playbook -i "$2" config_sonic_basedon_testbed.yml --vault-password-file="$3" -l "$dut" -e testbed_name="$1" -e testbed_file=$tbfile -v
+  read_file $topology
+
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e local_minigraph=true $@
 
   echo Done
 }
 
 function deploy_minigraph
 {
-  echo "Deploying minigraph '$1'"
+  topology=$1
+  inventory=$2
+  passfile=$3
+  shift
+  shift
+  shift
 
-  read_file $1
+  echo "Deploying minigraph '$topology'"
 
-  ansible-playbook -i "$2" config_sonic_basedon_testbed.yml --vault-password-file="$3" -l "$dut" -e testbed_name="$1" -e testbed_file=$tbfile -e deploy=true -e save=true
+  read_file $topology
+
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e deploy=true -e save=true $@
 
   echo Done
 }
 
 function test_minigraph
 {
-  echo "Test minigraph generation '$1'"
+  topology=$1
+  inventory=$2
+  passfile=$3
+  shift
+  shift
+  shift
 
-  read_file $1
+  echo "Test minigraph generation '$topology'"
 
-  ansible-playbook -i "$2" --diff --connection=local --check config_sonic_basedon_testbed.yml --vault-password-file="$3" -l "$dut" -e testbed_name="$1" -e testbed_file=$tbfile -e local_minigraph=true
+  read_file $topology
+
+  ansible-playbook -i "$inventory" --diff --connection=local --check config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e local_minigraph=true $@
 
   echo Done
 }


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Allow minigraph to be generated with or without data plane acl. Default without.

#### How did you verify/test it?
Generate minigraph without specifying enable_data_plane_acl
Generate minigraph with specifying enable_data_plane_acl=false
Generate minigraph with specifying enable_data_plane_acl=true