### PR TITLE
[CRM] Wait more time for CRM stats to update

### DIFF
--- a/ansible/roles/test/tasks/crm.yml
+++ b/ansible/roles/test/tasks/crm.yml
@@ -16,12 +16,13 @@
 
    - set_fact:
         ansible_date_time: "{{ansible_date_time}}"
+        crm_update_time: 4
 
    - name: Set polling interval
      command: crm config polling interval 1
 
    - name: Make sure CRM counters updated
-     pause: seconds=300
+     pause: seconds=30
 
    - name: Run test case "CRM IPv4 route resource"
      include: roles/test/tasks/crm/crm_test_ipv4_route.yml

--- a/ansible/roles/test/tasks/crm/crm_test_acl_counter.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_acl_counter.yml
@@ -7,7 +7,7 @@
       copy: src=roles/test/tasks/crm/acl.json dest=/tmp
 
     - name: Get original "crm_stats_acl_counter_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_available
+      command: redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_available
       register: out
     - set_fact: original_crm_stats_acl_counter_available={{out.stdout}}
 
@@ -16,12 +16,12 @@
       become: yes
 
     - name: Get ACL entry keys
-      command: bash -c "docker exec -i database redis-cli --raw -n 1 KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*"
+      command: redis-cli --raw -n 1 KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*
       register: out
     - set_fact: acl_tbl_keys={{out.stdout.split()}}
 
     - name: Get ethertype for ACL entry in order to match ACL which was configured
-      command: bash -c "docker exec -i database redis-cli -n 1 HGET {{item}} SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE"
+      command: redis-cli -n 1 HGET {{item}} SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE
       with_items: "{{acl_tbl_keys}}"
       register: out
 
@@ -31,22 +31,19 @@
       when: item.stdout|search("2048")
 
     - name: Get ACL table key
-      command: bash -c "docker exec -i database redis-cli -n 1 HGET {{key}} SAI_ACL_ENTRY_ATTR_TABLE_ID"
+      command: redis-cli -n 1 HGET {{key}} SAI_ACL_ENTRY_ATTR_TABLE_ID
       register: out
     - set_fact: acl_tbl_key={{"CRM:ACL_TABLE_STATS:{0}".format(out.stdout|replace("oid:", ""))}}
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_acl_counter_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_used
+    - name: Get new "crm_stats_acl_counter" used and available counter value
+      command: redis-cli --raw -n 2 HMGET {{acl_tbl_key}} crm_stats_acl_counter_used crm_stats_acl_counter_available
       register: out
-    - set_fact: new_crm_stats_acl_counter_used={{out.stdout}}
-
-    - name: Get new "crm_stats_acl_counter_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_available
-      register: out
-    - set_fact: new_crm_stats_acl_counter_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_acl_counter_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_acl_counter_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_acl_counter_used" counter was incremented
       assert: {that: "{{new_crm_stats_acl_counter_used|int - crm_stats_acl_counter_used|int == 2}}"}
@@ -65,17 +62,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_acl_counter_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_used
+    - name: Get new "crm_stats_acl_counter" used and available counter value
+      command: redis-cli --raw -n 2 HMGET {{acl_tbl_key}} crm_stats_acl_counter_used crm_stats_acl_counter_available
       register: out
-    - set_fact: new_crm_stats_acl_counter_used={{out.stdout}}
-
-    - name: Get new "crm_stats_acl_counter_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_counter_available
-      register: out
-    - set_fact: new_crm_stats_acl_counter_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_acl_counter_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_acl_counter_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_acl_counter_used" counter was decremented
       assert: {that: "{{new_crm_stats_acl_counter_used|int - crm_stats_acl_counter_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_acl_entry.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_acl_entry.yml
@@ -11,15 +11,15 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
     - name: Get ACL entry keys
-      command: bash -c "docker exec -i database redis-cli --raw -n 1 KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*"
+      command: redis-cli --raw -n 1 KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*
       register: out
     - set_fact: acl_tbl_keys={{out.stdout.split()}}
 
     - name: Get ethertype for ACL entry in order to match ACL which was configured
-      command: bash -c "docker exec -i database redis-cli -n 1 HGET {{item}} SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE"
+      command: redis-cli -n 1 HGET {{item}} SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE
       with_items: "{{acl_tbl_keys}}"
       register: out
 
@@ -29,22 +29,19 @@
       when: item.stdout|search("2048")
 
     - name: Get ACL table key
-      command: bash -c "docker exec -i database redis-cli -n 1 HGET {{key}} SAI_ACL_ENTRY_ATTR_TABLE_ID"
+      command: redis-cli -n 1 HGET {{key}} SAI_ACL_ENTRY_ATTR_TABLE_ID
       register: out
     - set_fact: acl_tbl_key={{"CRM:ACL_TABLE_STATS:{0}".format(out.stdout|replace("oid:", ""))}}
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_acl_entry_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_entry_used
+    - name: Get new "crm_stats_acl_entry" used and available counter value
+      command: redis-cli --raw -n 2 HMGET {{acl_tbl_key}} crm_stats_acl_entry_used crm_stats_acl_entry_available
       register: out
-    - set_fact: new_crm_stats_acl_entry_used={{out.stdout}}
-
-    - name: Get new "crm_stats_acl_entry_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_entry_available
-      register: out
-    - set_fact: new_crm_stats_acl_entry_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_acl_entry_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_acl_entry_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_acl_entry_used" counter was incremented
       assert: {that: "{{new_crm_stats_acl_entry_used|int - crm_stats_acl_entry_used|int == 2}}"}
@@ -63,17 +60,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_acl_entry_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_entry_used
+    - name: Get new "crm_stats_acl_entry" used and available counter value
+      command: redis-cli --raw -n 2 HMGET {{acl_tbl_key}} crm_stats_acl_entry_used crm_stats_acl_entry_available
       register: out
-    - set_fact: new_crm_stats_acl_entry_used={{out.stdout}}
-
-    - name: Get new "crm_stats_acl_entry_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET {{acl_tbl_key}} crm_stats_acl_entry_available
-      register: out
-    - set_fact: new_crm_stats_acl_entry_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_acl_entry_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_acl_entry_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_acl_entry_used" counter was decremented
       assert: {that: "{{new_crm_stats_acl_entry_used|int - crm_stats_acl_entry_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_fdb_entry.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_fdb_entry.yml
@@ -1,14 +1,11 @@
 - block:
 
-    - name: Get "crm_stats_fdb_entry_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_used
+    - name: Get "crm_stats_fdb_entry" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available
       register: out
-    - set_fact: crm_stats_fdb_entry_used={{out.stdout}}
-
-    - name: Get "crm_stats_fdb_entry_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_available
-      register: out
-    - set_fact: crm_stats_fdb_entry_available={{out.stdout}}
+    - set_fact:
+        crm_stats_fdb_entry_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_fdb_entry_available: "{{ out.stdout_lines[1] }}"
 
     - name: Copy FDB JSON config to switch.
       copy: src=roles/test/tasks/crm/fdb.json dest=/tmp
@@ -28,17 +25,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_fdb_entry_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_used
+    - name: Get new "crm_stats_fdb_entry" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available
       register: out
-    - set_fact: new_crm_stats_fdb_entry_used={{out.stdout}}
-
-    - name: Get new "crm_stats_fdb_entry_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_available
-      register: out
-    - set_fact: new_crm_stats_fdb_entry_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_fdb_entry_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_fdb_entry_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_fdb_entry_used" counter was incremented
       assert: {that: "{{new_crm_stats_fdb_entry_used|int - crm_stats_fdb_entry_used|int == 1}}"}
@@ -57,17 +51,14 @@
       command: fdbclear
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_fdb_entry_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_used
+    - name: Get new "crm_stats_fdb_entry" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available
       register: out
-    - set_fact: new_crm_stats_fdb_entry_used={{out.stdout}}
-
-    - name: Get new "crm_stats_fdb_entry_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_fdb_entry_available
-      register: out
-    - set_fact: new_crm_stats_fdb_entry_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_fdb_entry_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_fdb_entry_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_fdb_entry_used" counter was decremented
       assert: {that: "{{new_crm_stats_fdb_entry_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_neighbor.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_neighbor.yml
@@ -1,31 +1,25 @@
 - block:
 
-    - name: Get "crm_stats_ipv4_neighbor_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_used
+    - name: Get "crm_stats_ipv4_neighbor" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_neighbor_used crm_stats_ipv4_neighbor_available
       register: out
-    - set_fact: crm_stats_ipv4_neighbor_used={{out.stdout}}
-
-    - name: Get "crm_stats_ipv4_neighbor_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_available
-      register: out
-    - set_fact: crm_stats_ipv4_neighbor_available={{out.stdout}}
+    - set_fact:
+        crm_stats_ipv4_neighbor_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_ipv4_neighbor_available: "{{ out.stdout_lines[1] }}"
 
     - name: Add IPv4 neighbor
       command: ip neigh replace 2.2.2.2 lladdr 11:22:33:44:55:66 dev {{crm_intf}}
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv4_neighbor_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_used
+    - name: Get new "crm_stats_ipv4_neighbor" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_neighbor_used crm_stats_ipv4_neighbor_available
       register: out
-    - set_fact: new_crm_stats_ipv4_neighbor_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv4_neighbor_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_available
-      register: out
-    - set_fact: new_crm_stats_ipv4_neighbor_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv4_neighbor_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv4_neighbor_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv4_neighbor_used" counter was incremented
       assert: {that: "{{new_crm_stats_ipv4_neighbor_used|int - crm_stats_ipv4_neighbor_used|int >= 1}}"}
@@ -38,17 +32,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv4_neighbor_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_used
+    - name: Get new "crm_stats_ipv4_neighbor" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_neighbor_used crm_stats_ipv4_neighbor_available
       register: out
-    - set_fact: new_crm_stats_ipv4_neighbor_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv4_neighbor_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_neighbor_available
-      register: out
-    - set_fact: new_crm_stats_ipv4_neighbor_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv4_neighbor_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv4_neighbor_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv4_neighbor_used" counter was decremented
       assert: {that: "{{new_crm_stats_ipv4_neighbor_used|int - crm_stats_ipv4_neighbor_used|int >= 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_nexthop.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_nexthop.yml
@@ -1,31 +1,25 @@
 - block:
 
-    - name: Get "crm_stats_ipv4_nexthop_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_used
+    - name: Get "crm_stats_ipv4_nexthop" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_nexthop_used crm_stats_ipv4_nexthop_available
       register: out
-    - set_fact: crm_stats_ipv4_nexthop_used={{out.stdout}}
-
-    - name: Get "crm_stats_ipv4_nexthop_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_available
-      register: out
-    - set_fact: crm_stats_ipv4_nexthop_available={{out.stdout}}
+    - set_fact:
+        crm_stats_ipv4_nexthop_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_ipv4_nexthop_available: "{{ out.stdout_lines[1] }}"
 
     - name: Add IPv4 nexthop
       command: ip neigh replace 2.2.2.2 lladdr 11:22:33:44:55:66 dev {{crm_intf}}
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv4_nexthop_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_used
+    - name: Get new "crm_stats_ipv4_nexthop" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_nexthop_used crm_stats_ipv4_nexthop_available
       register: out
-    - set_fact: new_crm_stats_ipv4_nexthop_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv4_nexthop_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_available
-      register: out
-    - set_fact: new_crm_stats_ipv4_nexthop_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv4_nexthop_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv4_nexthop_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv4_nexthop_used" counter was incremented
       assert: {that: "{{new_crm_stats_ipv4_nexthop_used|int - crm_stats_ipv4_nexthop_used|int >= 1}}"}
@@ -38,17 +32,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv4_nexthop_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_used
+    - name: Get new "crm_stats_ipv4_nexthop" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_nexthop_used crm_stats_ipv4_nexthop_available
       register: out
-    - set_fact: new_crm_stats_ipv4_nexthop_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv4_nexthop_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_nexthop_available
-      register: out
-    - set_fact: new_crm_stats_ipv4_nexthop_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv4_nexthop_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv4_nexthop_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv4_nexthop_used" counter was decremented
       assert: {that: "{{new_crm_stats_ipv4_nexthop_used|int - crm_stats_ipv4_nexthop_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv4_route.yml
@@ -1,14 +1,11 @@
 - block:
 
-    - name: Get "crm_stats_ipv4_route_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_used
+    - name: Get "crm_stats_ipv4_route" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_route_used crm_stats_ipv4_route_available
       register: out
-    - set_fact: crm_stats_ipv4_route_used={{out.stdout}}
-
-    - name: Get "crm_stats_ipv4_route_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_available
-      register: out
-    - set_fact: crm_stats_ipv4_route_available={{out.stdout}}
+    - set_fact:
+        crm_stats_ipv4_route_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_ipv4_route_available: "{{ out.stdout_lines[1] }}"
 
     - name: Get NH IP
       command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
@@ -24,17 +21,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=3
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv4_route_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_used
+    - name: Get new "crm_stats_ipv4_route" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_route_used crm_stats_ipv4_route_available
       register: out
-    - set_fact: new_crm_stats_ipv4_route_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv4_route_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_available
-      register: out
-    - set_fact: new_crm_stats_ipv4_route_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv4_route_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv4_route_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv4_route_used" counter was incremented
       assert: {that: "{{new_crm_stats_ipv4_route_used|int - crm_stats_ipv4_route_used|int == 1}}"}
@@ -47,17 +41,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=3
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv4_route_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_used
+    - name: Get new "crm_stats_ipv4_route" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_route_used crm_stats_ipv4_route_available
       register: out
-    - set_fact: new_crm_stats_ipv4_route_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv4_route_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv4_route_available
-      register: out
-    - set_fact: new_crm_stats_ipv4_route_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv4_route_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv4_route_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv4_route_used" counter was decremented
       assert: {that: "{{new_crm_stats_ipv4_route_used|int - crm_stats_ipv4_route_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_neighbor.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_neighbor.yml
@@ -1,31 +1,25 @@
 - block:
 
-    - name: Get "crm_stats_ipv6_neighbor_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_used
+    - name: Get "crm_stats_ipv6_neighbor" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_neighbor_used crm_stats_ipv6_neighbor_available
       register: out
-    - set_fact: crm_stats_ipv6_neighbor_used={{out.stdout}}
-
-    - name: Get "crm_stats_ipv6_neighbor_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_available
-      register: out
-    - set_fact: crm_stats_ipv6_neighbor_available={{out.stdout}}
+    - set_fact:
+        crm_stats_ipv6_neighbor_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_ipv6_neighbor_available: "{{ out.stdout_lines[1] }}"
 
     - name: Add IPv6 neighbor
       command: ip neigh replace 2001::1 lladdr 11:22:33:44:55:66 dev {{crm_intf}}
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv6_neighbor_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_used
+    - name: Get new "crm_stats_ipv6_neighbor" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_neighbor_used crm_stats_ipv6_neighbor_available
       register: out
-    - set_fact: new_crm_stats_ipv6_neighbor_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv6_neighbor_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_available
-      register: out
-    - set_fact: new_crm_stats_ipv6_neighbor_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv6_neighbor_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv6_neighbor_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv6_neighbor_used" counter was incremented
       assert: {that: "{{new_crm_stats_ipv6_neighbor_used|int - crm_stats_ipv6_neighbor_used|int >= 1}}"}
@@ -38,17 +32,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv6_neighbor_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_used
+    - name: Get new "crm_stats_ipv6_neighbor" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_neighbor_used crm_stats_ipv6_neighbor_available
       register: out
-    - set_fact: new_crm_stats_ipv6_neighbor_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv6_neighbor_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_neighbor_available
-      register: out
-    - set_fact: new_crm_stats_ipv6_neighbor_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv6_neighbor_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv6_neighbor_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv6_neighbor_used" counter was decremented
       assert: {that: "{{new_crm_stats_ipv6_neighbor_used|int - crm_stats_ipv6_neighbor_used|int >= 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_nexthop.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_nexthop.yml
@@ -1,30 +1,25 @@
 - block:
-    - name: Get "crm_stats_ipv6_nexthop_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_used
-      register: out
-    - set_fact: crm_stats_ipv6_nexthop_used={{out.stdout}}
 
-    - name: Get "crm_stats_ipv6_nexthop_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_available
+    - name: Get "crm_stats_ipv6_nexthop" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_nexthop_used crm_stats_ipv6_nexthop_available
       register: out
-    - set_fact: crm_stats_ipv6_nexthop_available={{out.stdout}}
+    - set_fact:
+        crm_stats_ipv6_nexthop_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_ipv6_nexthop_available: "{{ out.stdout_lines[1] }}"
 
     - name: Add IPv6 nexthop
       command: ip neigh replace 2001::1 lladdr 11:22:33:44:55:66 dev {{crm_intf}}
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv6_nexthop_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_used
+    - name: Get new "crm_stats_ipv6_nexthop" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_nexthop_used crm_stats_ipv6_nexthop_available
       register: out
-    - set_fact: new_crm_stats_ipv6_nexthop_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv6_nexthop_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_available
-      register: out
-    - set_fact: new_crm_stats_ipv6_nexthop_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv6_nexthop_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv6_nexthop_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv6_nexthop_used" counter was incremented
       assert: {that: "{{new_crm_stats_ipv6_nexthop_used|int - crm_stats_ipv6_nexthop_used|int == 1}}"}
@@ -37,17 +32,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv6_nexthop_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_used
+    - name: Get new "crm_stats_ipv6_nexthop" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_nexthop_used crm_stats_ipv6_nexthop_available
       register: out
-    - set_fact: new_crm_stats_ipv6_nexthop_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv6_nexthop_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_nexthop_available
-      register: out
-    - set_fact: new_crm_stats_ipv6_nexthop_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv6_nexthop_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv6_nexthop_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv6_nexthop_used" counter was decremented
       assert: {that: "{{new_crm_stats_ipv6_nexthop_used|int - crm_stats_ipv6_nexthop_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_ipv6_route.yml
@@ -1,14 +1,11 @@
 - block:
 
-    - name: Get "crm_stats_ipv6_route_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_used
+    - name: Get "crm_stats_ipv6_route" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_route_used crm_stats_ipv6_route_available
       register: out
-    - set_fact: crm_stats_ipv6_route_used={{out.stdout}}
-
-    - name: Get "crm_stats_ipv6_route_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_available
-      register: out
-    - set_fact: crm_stats_ipv6_route_available={{out.stdout}}
+    - set_fact:
+        crm_stats_ipv6_route_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_ipv6_route_available: "{{ out.stdout_lines[1] }}"
 
     - name: Get NH IP
       shell: ip -6 neigh show dev {{crm_intf}} nud reachable nud stale
@@ -29,17 +26,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv6_route_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_used
+    - name: Get new "crm_stats_ipv6_route" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_route_used crm_stats_ipv6_route_available
       register: out
-    - set_fact: new_crm_stats_ipv6_route_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv6_route_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_available
-      register: out
-    - set_fact: new_crm_stats_ipv6_route_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv6_route_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv6_route_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv6_route_used" counter was incremented
       assert: {that: "{{new_crm_stats_ipv6_route_used|int - crm_stats_ipv6_route_used|int >= 1}}"}
@@ -52,17 +46,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_ipv6_route_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_used
+    - name: Get new "crm_stats_ipv6_route" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv6_route_used crm_stats_ipv6_route_available
       register: out
-    - set_fact: new_crm_stats_ipv6_route_used={{out.stdout}}
-
-    - name: Get new "crm_stats_ipv6_route_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_ipv6_route_available
-      register: out
-    - set_fact: new_crm_stats_ipv6_route_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_ipv6_route_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_ipv6_route_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_ipv6_route_used" counter was decremented
       assert: {that: "{{new_crm_stats_ipv6_route_used|int - crm_stats_ipv6_route_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group.yml
@@ -1,14 +1,11 @@
 - block:
 
-    - name: Get "crm_stats_nexthop_group_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_used
+    - name: Get "crm_stats_nexthop_group" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_nexthop_group_used crm_stats_nexthop_group_available
       register: out
-    - set_fact: crm_stats_nexthop_group_used={{out.stdout}}
-
-    - name: Get "crm_stats_nexthop_group_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_available
-      register: out
-    - set_fact: crm_stats_nexthop_group_available={{out.stdout}}
+    - set_fact:
+        crm_stats_nexthop_group_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_nexthop_group_available: "{{ out.stdout_lines[1] }}"
 
     - name: Get NH IP 1
       command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
@@ -33,7 +30,7 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
     - name: Get new "crm_stats_nexthop_group_used" counter value
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_used
@@ -44,6 +41,13 @@
       command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_available
       register: out
     - set_fact: new_crm_stats_nexthop_group_available={{out.stdout}}
+
+    - name: Get new "crm_stats_nexthop_group" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_nexthop_group_used crm_stats_nexthop_group_available
+      register: out
+    - set_fact:
+        new_crm_stats_nexthop_group_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_nexthop_group_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_nexthop_group_used" counter was incremented
       assert: {that: "{{new_crm_stats_nexthop_group_used|int - crm_stats_nexthop_group_used|int == 1}}"}
@@ -56,17 +60,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_nexthop_group_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_used
+    - name: Get new "crm_stats_nexthop_group" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_nexthop_group_used crm_stats_nexthop_group_available
       register: out
-    - set_fact: new_crm_stats_nexthop_group_used={{out.stdout}}
-
-    - name: Get new "crm_stats_nexthop_group_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_available
-      register: out
-    - set_fact: new_crm_stats_nexthop_group_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_nexthop_group_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_nexthop_group_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_nexthop_group_used" counter was decremented
       assert: {that: "{{new_crm_stats_nexthop_group_used|int - crm_stats_nexthop_group_used|int == 0}}"}

--- a/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_nexthop_group_member.yml
@@ -1,14 +1,11 @@
 - block:
 
-    - name: Get "crm_stats_nexthop_group_member_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_used
+    - name: Get "crm_stats_nexthop_group_member" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_nexthop_group_member_used crm_stats_nexthop_group_member_available
       register: out
-    - set_fact: crm_stats_nexthop_group_member_used={{out.stdout}}
-
-    - name: Get "crm_stats_nexthop_group_member_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_available
-      register: out
-    - set_fact: crm_stats_nexthop_group_member_available={{out.stdout}}
+    - set_fact:
+        crm_stats_nexthop_group_member_used: "{{ out.stdout_lines[0] }}"
+        crm_stats_nexthop_group_member_available: "{{ out.stdout_lines[1] }}"
 
     - name: Get NH IP 1
       command: ip -4 neigh show dev {{crm_intf}} nud reachable nud stale
@@ -33,17 +30,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_nexthop_group_member_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_used
+    - name: Get new "crm_stats_nexthop_group_member" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_nexthop_group_member_used crm_stats_nexthop_group_member_available
       register: out
-    - set_fact: new_crm_stats_nexthop_group_member_used={{out.stdout}}
-
-    - name: Get new "crm_stats_nexthop_group_member_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_available
-      register: out
-    - set_fact: new_crm_stats_nexthop_group_member_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_nexthop_group_member_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_nexthop_group_member_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_nexthop_group_member_used" counter was incremented
       assert: {that: "{{new_crm_stats_nexthop_group_member_used|int - crm_stats_nexthop_group_member_used|int == 2}}"}
@@ -56,17 +50,14 @@
       become: yes
 
     - name: Make sure CRM counters updated
-      pause: seconds=2
+      pause: seconds={{ crm_update_time }}
 
-    - name: Get new "crm_stats_nexthop_group_member_used" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_used
+    - name: Get new "crm_stats_nexthop_group_member" used and available counter value
+      command: redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_nexthop_group_member_used crm_stats_nexthop_group_member_available
       register: out
-    - set_fact: new_crm_stats_nexthop_group_member_used={{out.stdout}}
-
-    - name: Get new "crm_stats_nexthop_group_member_available" counter value
-      command: docker exec -i database redis-cli -n 2 HGET CRM:STATS crm_stats_nexthop_group_member_available
-      register: out
-    - set_fact: new_crm_stats_nexthop_group_member_available={{out.stdout}}
+    - set_fact:
+        new_crm_stats_nexthop_group_member_used: "{{ out.stdout_lines[0] }}"
+        new_crm_stats_nexthop_group_member_available: "{{ out.stdout_lines[1] }}"
 
     - name: Verify "crm_stats_nexthop_group_member_used" counter was decremented
       assert: {that: "{{new_crm_stats_nexthop_group_member_used|int - crm_stats_nexthop_group_member_used|int == 0}}"}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

CRM testing may fail because CRM stats was not updated yet
while checking the counters. Main purpose of this change is
to increase the time waiting for CRM update from 2 seconds
to 4 seconds. 

Two other improvements made in this PR:

* Decrease the time waiting for CRM counters update from
300 seconds to 30 seconds. The 300 seconds waiting is
unnecessary.
* Use a single redis-cli command to get used and available
counters rather than two commands.

### Type of change

- [X] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
* Increase the time waiting for CRM counters update from 2 seconds to 4 seconds.
* Decrease the time waiting for CRM counters update from 300 seconds to 30 seconds.
* Use a single redis-cli command to get used and available counters rather than two commands.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
