### PR TITLE
[Config Test] swss exit after remove port channel due to SAI not found L3 interface

### DIFF
--- a/ansible/roles/test/tasks/config.yml
+++ b/ansible/roles/test/tasks/config.yml
@@ -101,11 +101,15 @@
       become: yes
       when: add_tmp_portchannel_ip
 
+    - pause: seconds=5
+
     - name: Remove {{ portchannel_members }} from {{ tmp_portchannel }}
       shell: config portchannel member del {{ tmp_portchannel }} {{ item }}
       become: yes
       when: add_tmp_portchannel_members
       with_items: "{{portchannel_members}}"
+
+    - pause: seconds=5
 
     - name: Remove {{ tmp_portchannel }}
       shell: config portchannel del {{ tmp_portchannel }}


### PR DESCRIPTION
### Description of PR
When executing the config test case, it has the possibility to cause swss exit. It is due to the intfOrch may be slower than portOrch 

#### When the issue not happens, the timeline would be
1. Playbook remove IP from port channel
intfOrch want to remove l3 intf, but neighOrch still have reference and the intfOrch will wait to next run

2. neighOrch decrease the reference count
neighOrch finish the reference count decrement and then intfOrch remove l3 intf to SAI

3. Playbook remove port channel
portOrch remove this port in SAI

#### When the issue happens, the timeline would be

1. Playbook remove IP from port channel
intfOrch want to remove l3 intf, but neighOrch still have reference and the intfOrch will wait to next run

2. Playbook remove port channel
portOrch remove this port and its l3 intf in SAI

3. neighOrch decrease the reference count
neighOrch finish the reference count decrement and then intfOrch remove l3 intf to SAI whcih was removed by step 2. Then the swss will exception

Summary:
Fixes # (issue)

### Type of change

- [v] Bug fix
