### PR TITLE
[dhcp_relay] Set Broadcast flag for all test packets

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -212,7 +212,8 @@ class DHCPTest(DataplaneBaseTest):
                     ip_gateway=self.relay_iface_ip,
                     netmask_client=self.client_subnet,
                     dhcp_lease=self.LEASE_TIME,
-                    padding_bytes=0)
+                    padding_bytes=0,
+                    set_broadcast_bit=True)
 
     def create_dhcp_offer_relayed_packet(self):
         my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
@@ -233,7 +234,7 @@ class DHCPTest(DataplaneBaseTest):
                     hops=0,
                     xid=0,
                     secs=0,
-                    flags=0,
+                    flags=0x8000,
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.client_ip,
                     siaddr=self.server_ip,
@@ -310,7 +311,8 @@ class DHCPTest(DataplaneBaseTest):
                     ip_gateway=self.relay_iface_ip,
                     netmask_client=self.client_subnet,
                     dhcp_lease=self.LEASE_TIME,
-                    padding_bytes=0)
+                    padding_bytes=0,
+                    set_broadcast_bit=True)
 
     def create_dhcp_ack_relayed_packet(self):
         my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
@@ -331,7 +333,7 @@ class DHCPTest(DataplaneBaseTest):
                     hops=0,
                     xid=0,
                     secs=0,
-                    flags=0,
+                    flags=0x8000,
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.client_ip,
                     siaddr=self.server_ip,

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -154,7 +154,7 @@ class DHCPTest(DataplaneBaseTest):
     """
 
     def create_dhcp_discover_packet(self):
-        return testutils.dhcp_discover_packet(eth_client=self.client_mac)
+        return testutils.dhcp_discover_packet(eth_client=self.client_mac, set_broadcast_bit=True)
 
     def create_dhcp_discover_relayed_packet(self):
         my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
@@ -183,7 +183,7 @@ class DHCPTest(DataplaneBaseTest):
                     hops=1,
                     xid=0,
                     secs=0,
-                    flags=0,
+                    flags=0x8000,
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.DEFAULT_ROUTE_IP,
                     siaddr=self.DEFAULT_ROUTE_IP,
@@ -258,7 +258,8 @@ class DHCPTest(DataplaneBaseTest):
     def create_dhcp_request_packet(self):
         return testutils.dhcp_request_packet(eth_client=self.client_mac,
                     ip_server=self.server_ip,
-                    ip_requested=self.client_ip)
+                    ip_requested=self.client_ip,
+                    set_broadcast_bit=True)
 
     def create_dhcp_request_relayed_packet(self):
         my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
@@ -280,7 +281,7 @@ class DHCPTest(DataplaneBaseTest):
                     hops=1,
                     xid=0,
                     secs=0,
-                    flags=0,
+                    flags=0x8000,
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.DEFAULT_ROUTE_IP,
                     siaddr=self.DEFAULT_ROUTE_IP,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The expected offer& ack package is broadcast
But get the package is Unicast.
So，we  need to set Broadcast flag  for dhcp offer&ack, 

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
dhcp relay test failed because   verified packet not correct.
### Type of change

- [√] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Modify file dhcp_relay_test.py
Add “set_broadcast_bit=True” in create_dhcp_offer_packet and  create_dhcp_ack_packet
 Set “flags=0x8000” in create_dhcp_offer_relayed_packet and  create_dhcp_ack_relayed_packet
#### How did you verify/test it?
testbed  dhcp_relay test

PLAY RECAP *********************************************************************
cel-e1031-01               : ok=58   changed=10   unreachable=0    failed=0

Wednesday 24 July 2019  09:41:45 +0000 (0:00:00.033)       0:00:30.786 ********
===============================================================================
TASK: test : command ---------------------------------------------------- 4.53s
TASK: test : gather system version information -------------------------- 2.49s
TASK: setup ------------------------------------------------------------- 1.72s
TASK: test : Copy tests to the PTF container ---------------------------- 1.67s
TASK: test : Get interface facts ---------------------------------------- 1.47s
TASK: test : Get interface facts ---------------------------------------- 1.43s
TASK: test : set_fact --------------------------------------------------- 1.28s
TASK: test : Get process information in syncd docker -------------------- 1.24s
TASK: test : Get process information in syncd docker -------------------- 1.11s
TASK: test : Verify port channel interfaces are up correctly ------------ 0.98s
TASK: test : validate all interfaces are up after test ------------------ 0.82s
TASK: test : Fetch result files from switch to ansible machine ---------- 0.65s
TASK: test : Verify port channel interfaces are up correctly ------------ 0.64s
TASK: test : Gather minigraph facts about the device -------------------- 0.64s
TASK: test : debug ------------------------------------------------------ 0.60s
TASK: test : Gather minigraph facts about the device -------------------- 0.58s
TASK: test : Gathering minigraph facts about the device ----------------- 0.57s
TASK: test : Get orchagent process information -------------------------- 0.52s
TASK: test : validate all interfaces are up ----------------------------- 0.49s
TASK: test : Get orchagent process information -------------------------- 0.49s

#### Any platform specific information?
cel_e1031&cel_seastone devices
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
