### PR TITLE
[loganalyzer] Fix the match_file_list accumulating issue

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
@@ -32,15 +32,16 @@
     match_file_option: "-m "
     ignore_file_option: "-i {{ ignore_file }}"
     expect_file_option: "-e {{ expect_file }}"
+    match_file_list: []
 
 - name: Collect list of match files - common_match
   set_fact:
-      match_file_list: "{{ match_file_list | default([]) }} + {{ [match_file] }}"
+      match_file_list: "{{ match_file_list + [match_file] }}"
   when: skip_common_match is not defined
 
 - name: Collect list of match files - test_match
   set_fact:
-      match_file_list: "{{ match_file_list | default([]) }} + {{ [test_match_file] }}"
+      match_file_list: "{{ match_file_list + [test_match_file] }}"
   when: test_match_file is defined
 
 - name: Add mmatch file option

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
@@ -44,7 +44,7 @@
       match_file_list: "{{ match_file_list + [test_match_file] }}"
   when: test_match_file is defined
 
-- name: Add mmatch file option
+- name: Add match file option
   set_fact:
       match_file_option: "{{ match_file_option }}{{ match_file_list | join(',') }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The match_file_list is not initialized to empty list when it is used.
The side effect is that when the log analyzer is called multiple times,
test match file used in earlier analysis will be used in later analysis
and cause issue. The fix is to initialize match_file_list to empty list
before using it.

Related PRs: 
* https://github.com/Azure/sonic-mgmt/pull/994 [loganalyzer] Fix the IOError of opening match file
* https://github.com/Azure/sonic-mgmt/pull/970 Add new test case to verify MAC address is correct after SONiC to SONiC update

### Type of change

- [X] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Initilize the match_file_list to empty list before using it.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
