### PR TITLE
[advanced-reboot] help switch to populate fdb table before test

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -26,6 +26,7 @@
         - preboot_oper='{{ item }}'
         - allow_vlan_flooding='{{ allow_vlan_flooding }}'
         - sniff_time_incr={{ sniff_time_incr }}
+        - setup_fdb_before_test=True
 
   always:
 


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

Start fast reboot test on clean switch with clean FDB table (tested on Mellanox 201803):

```
2019-07-26 13:40:22 : Converted addresses VMs: ['10.213.84.184', '10.213.84.183', '10.213.84.182', '10.213.84.181']
2019-07-26 13:40:22 : Test params:
2019-07-26 13:40:22 : DUT ssh: admin@arc-switch1025
2019-07-26 13:40:22 : DUT reboot limit in seconds: 0:00:30
2019-07-26 13:40:22 : DUT mac address: 50:6b:4b:8f:ce:40
2019-07-26 13:40:22 : From server src addr: 192.168.0.253
2019-07-26 13:40:22 : From server src port: 14
2019-07-26 13:40:22 : From server dst addr: 192.168.130.212
2019-07-26 13:40:22 : From server dst ports: [28, 30, 29, 31]
2019-07-26 13:40:22 : From upper layer number of packets: 500
2019-07-26 13:40:22 : VMs: ['10.213.84.184','10.213.84.183','10.213.84.182','10.213.84.181']
2019-07-26 13:40:22 : Reboot type is fast-reboot
2019-07-26 13:40:24 : ARP ping: src idx 9 port 10 mac e4:1d:2d:ca:c7:0a addr 192.168.0.9
2019-07-26 13:40:24 : ARP ping: dst idx 6 port 7 addr 192.168.0.6
2019-07-26 13:40:24 : Enabling arp_responder
2019-07-26 13:40:25 : Run some server traffic to populate FDB table...
2019-07-26 13:40:28 : Starting reachability state watch thread...
2019-07-26 13:40:29 : Send   100 Received     0 servers->t1
2019-07-26 13:40:30 : Send   500 Received   500 t1->servers
2019-07-26 13:40:30 : Data plane state transition from init to down (500)
2019-07-26 13:40:31 : Send    10 Received    10 ping DUT
2019-07-26 13:40:31 : Control plane state transition from init to up
2019-07-26 13:40:31 : Send     1 Received     1 arp ping
2019-07-26 13:40:31 : VLAN ARP state transition from init to up
2019-07-26 13:40:32 : Send   100 Received   100 servers->t1
2019-07-26 13:40:33 : Check that device is alive and pinging
2019-07-26 13:40:34 : Send   500 Received   500 t1->servers
2019-07-26 13:40:34 : Data plane state transition from down to up (500)
2019-07-26 13:40:34 : Send    10 Received    10 ping DUT
2019-07-26 13:40:35 : Send     1 Received     1 arp ping
2019-07-26 13:40:36 : Send   100 Received   100 servers->t1
2019-07-26 13:40:37 : Send   500 Received   500 t1->servers
2019-07-26 13:40:38 : Send    10 Received    10 ping DUT
2019-07-26 13:40:38 : Send     1 Received     1 arp ping
2019-07-26 13:40:39 : Send   100 Received   100 servers->t1
2019-07-26 13:40:40 : Send   500 Received   500 t1->servers
2019-07-26 13:40:41 : Send    10 Received    10 ping DUT
2019-07-26 13:40:41 : Send     1 Received     1 arp ping
2019-07-26 13:40:42 : Send   100 Received   100 servers->t1
2019-07-26 13:40:44 : Send   500 Received   500 t1->servers

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
