### PR TITLE
[warm-reboot] Preboot sad path automation for n lag members

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -396,16 +396,17 @@ class Arista(object):
                     self.fails.add('Verify BGP %s neighbor: Object missing in output' % ver)
         return self.fails, bgp_state
 
-    def change_neigh_lag_state(self, lag, is_up=True):
+    def change_neigh_lag_state(self, intfs, is_up=True):
         state = ['shut', 'no shut']
         self.do_cmd('configure')
-        is_match = re.match('(Port-Channel|Ethernet)\d+', lag)
-        if is_match:
-            output = self.do_cmd('interface %s' % lag)
-            if 'Invalid' not in output:
-                self.do_cmd(state[is_up])
-                self.do_cmd('exit')
-            self.do_cmd('exit')
+        for intf in intfs:
+            is_match = re.match('(Port-Channel|Ethernet)\d+', intf)
+            if is_match:
+                output = self.do_cmd('interface %s' % intf)
+                if 'Invalid' not in output:
+                    self.do_cmd(state[is_up])
+                    self.do_cmd('exit')
+        self.do_cmd('exit')
 
     def verify_neigh_lag_state(self, lag, state="connected", pre_check=True):
         lag_state = False

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -396,17 +396,20 @@ class Arista(object):
                     self.fails.add('Verify BGP %s neighbor: Object missing in output' % ver)
         return self.fails, bgp_state
 
-    def change_neigh_lag_state(self, intfs, is_up=True):
+    def change_neigh_lag_state(self, intf, is_up=True):
         state = ['shut', 'no shut']
         self.do_cmd('configure')
-        for intf in intfs:
-            is_match = re.match('(Port-Channel|Ethernet)\d+', intf)
-            if is_match:
-                output = self.do_cmd('interface %s' % intf)
-                if 'Invalid' not in output:
-                    self.do_cmd(state[is_up])
-                    self.do_cmd('exit')
+        is_match = re.match('(Port-Channel|Ethernet)\d+', intf)
+        if is_match:
+            output = self.do_cmd('interface %s' % intf)
+            if 'Invalid' not in output:
+                self.do_cmd(state[is_up])
+                self.do_cmd('exit')
         self.do_cmd('exit')
+
+    def change_neigh_intfs_state(self, intfs, is_up=True):
+        for intf in intfs:
+            self.change_neigh_lag_state(intf, is_up=is_up)
 
     def verify_neigh_lag_state(self, lag, state="connected", pre_check=True):
         states = state.split(',')

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -409,6 +409,7 @@ class Arista(object):
         self.do_cmd('exit')
 
     def verify_neigh_lag_state(self, lag, state="connected", pre_check=True):
+        states = state.split(',')
         lag_state = False
         msg_prefix = ['Postboot', 'Preboot']
         is_match = re.match('(Port-Channel|Ethernet)\d+', lag)
@@ -419,7 +420,7 @@ class Arista(object):
                 obj = json.loads(data)
 
                 if 'interfaces' in obj and lag in obj['interfaces']:
-                    lag_state = (obj['interfaces'][lag]['interfaceStatus'] == state)
+                    lag_state = (obj['interfaces'][lag]['interfaceStatus'] in states)
                 else:
                     self.fails.add('%s: Verify LAG %s: Object missing in output' % (msg_prefix[pre_check], lag))
                 return self.fails, lag_state

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -288,7 +288,7 @@ class SadOper(SadPath):
 
     def populate_lag_state(self):
         if 'neigh_lag' in self.oper_type:
-            self.neigh_lag_state = 'disabled'
+            self.neigh_lag_state = 'disabled,notconnect'
         elif 'dut_lag' in self.oper_type:
             self.neigh_lag_state = 'notconnect'
 

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -323,10 +323,15 @@ class SadOper(SadPath):
         lag_memb_output = match.group(2)
         neigh_name = self.po_neigh_map[po_name]
         for member in self.vm_dut_map[neigh_name]['dut_ports']:
-            if po_name in self.lag_members_down and member in self.lag_members_down[po_name]:
-                search_str = '%s(D)' % member
-            else:
-                search_str = '%s(S)' % member
+            # default state for the lag member
+            search_str = '%s(S)' % member
+
+            if po_name in self.lag_members_down:
+                 if member in self.lag_members_down[po_name]:
+                     search_str = '%s(D)' % member
+                 # single member case. state of non down member of the down portchannel
+                 elif self.tot_memb_cnt != self.memb_cnt:
+                     search_str = '%s(S*)' % member
 
             if lag_memb_output.find(search_str) != -1:
                 self.log.append('Lag member %s state as expected' % member)

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -212,7 +212,7 @@ class SadOper(SadPath):
                         down_intfs = [self.vm_dut_map[self.neigh_names[vm]]['neigh_portchannel']]
 
                     self.log.append('Changing state of LAG %s %s to shut' % (self.memb_str, ", ".join(down_intfs)))
-                    self.vm_handles[vm].change_neigh_lag_state(down_intfs, is_up=is_up)
+                    self.vm_handles[vm].change_neigh_intfs_state(down_intfs, is_up=is_up)
 
             elif 'dut_lag' in self.oper_type:
                 self.change_dut_lag_state(is_up=is_up)

--- a/ansible/roles/test/tasks/advanced_reboot/validate_preboot_list.yml
+++ b/ansible/roles/test/tasks/advanced_reboot/validate_preboot_list.yml
@@ -1,5 +1,5 @@
 - set_fact:
-    item_cnt: "{{ item.split(':')[1]|int }}"
+    item_cnt: "{{ item.split(':')[-1]|int }}"
     host_max_len: "{{ vm_hosts|length - 1 }}"
     member_max_cnt: "{{ minigraph_portchannels.values()[0]['members']|length }}"
 

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -3,9 +3,20 @@
       reboot_limit: 1
   when: reboot_limit is not defined
 
+# preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'. for non lag member cases, this parameter will be skipped
+- name: Set vars
+  set_fact:
+      pre_list: ['neigh_bgp_down:2', 'dut_bgp_down:3', 'dut_lag_down:2', 'neigh_lag_down:3', 'dut_lag_member_down:3:1', 'neigh_lag_member_down:2:1']
+      lag_memb_cnt: "{{ minigraph_portchannels.values()[0]['members']|length }}"
+
+- name: Add all lag member down case
+  set_fact:
+      pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
+  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+
 - name: Warm-reboot test
   include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
-      preboot_list: ['neigh_bgp_down:2', 'dut_bgp_down:3', 'dut_lag_down:2', 'neigh_lag_down:3']
+      preboot_list: "{{ pre_list }}"
       preboot_files: "peer_dev_info,neigh_port_info"


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Covers  cases where a single lag member or all lag members can be brought down from the neighbor end or DUT end before warm-reboot

Test case as follows
1) Bring down single/all lag members down from the neighbor or DUT end for the selected VMs as per the preboot_oper passed
2) Verify the BGP and LAG and lag member state for the selected VMs
3) Do a warm reboot
4) Verify the BGP and LAG and lag member state for the selected VMs and ensure they remain the same as preboot
5) Revert the preboot operation

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
* warm-reboot-multi-sad.yml
    - number of lag members down is appended with a ':' to the preboot oper type
*.py 
    - extended existing lag down case to bring down multiple interfaces
    - added necessary mapping to identify which lag members are down so that verification of lag member state can be done properly

#### How did you verify/test it?
Tested on T0 topology. Seeing some issues in the single lag member down case. Need investigation. 
