### PR TITLE
Using the latest sonic command of interface startup and shutdown

### DIFF
--- a/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
+++ b/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
@@ -42,7 +42,7 @@
 
     - name: Shutting down neighbor interface {{neighbor_interface}} on {{peer_host}}
       become: true
-      shell: ip link set {{port_alias_map[neighbor_interface]}} down
+      shell: config interface shutdown {{neighbor_interface}}
       delegate_to: "{{peer_host}}"
       when: peer_type == "FanoutLeafSonic"
 
@@ -76,7 +76,7 @@
 
     - name: Bring up neighbor interface {{neighbor_interface}} on {{peer_host}}
       become: true
-      shell: ip link set {{port_alias_map[neighbor_interface]}} up
+      shell: config interface startup {{neighbor_interface}}
       delegate_to: "{{peer_host}}"
       when: peer_type == "FanoutLeafSonic"
 


### PR DESCRIPTION
Description of PR
     In the latest sonic.  Setting interface to up/down is supported.  Using the command to trigger link flap for the peer type of FanoutLeafSonic.
Summary:
Fixes # (issue)
Type of change
  Bug fix

Approach
   Change the command of " ip link set" to "config interface"
How did you verify/test it?
   Pass the testcase of link_flap with the peer host of the latest sonic.

