### PR TITLE
[mlnx][fanout] disable mac learning on fanout

### DIFF
--- a/ansible/roles/fanout/templates/mlnx_fanout.j2
+++ b/ansible/roles/fanout/templates/mlnx_fanout.j2
@@ -98,6 +98,12 @@ protocol openflow
 
 {% for i in range(1, eth_ports|length) %}
 interface ethernet {{ eth_ports[i] }} openflow mode hybrid
+
+# Disable mac learning to avoid issue when VM MAC address appears on DUT port during SONiC port flap or restart and also issue in FDB reload test for which rules matching 0x1234 ethertype were introduces.
+# The idea is that forwarding is controlled by openflow rules.
+# For normal openflow rule since there are only two ports in same vlan (one access port connected to DUT, one trunk port connected to server)
+# - one is always a source port and one is always a destination port, so no flooding actually occurs.
+interface ethernet {{ eth_ports[i] }} mac-learning disable
 {% endfor %}
 
 {% set of_counter = 0 -%}
@@ -149,7 +155,10 @@ openflow add-flows {{ of_counter + i }} table={{ open_flow_tableid }},priority={
 openflow add-flows {{ of_counter + i }} table={{ open_flow_tableid }},priority={{ dut_to_server_flow_priority }},dl_type={{ eth_typ_test }},in_port={{ of_ports[i] }},actions=output:{{ of_ports[uplink_port_id] }}
 {% endfor %}
 
-openflow add-flows {{ last_flowid }} table={{ open_flow_tableid }},priority={{ low_priority }},actions=normal
+{% set of_counter = of_counter + eth_ports|length-2 -%}
+
+# apply normal openflow rule
+openflow add-flows {{ of_counter + 1 }} table={{ open_flow_tableid }},priority={{ low_priority }},actions=normal
 
 docker
 no shutdown


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Disable MAC learning on Mellanox fanout to avoid an Onyx OS bug when MAC of VM can appear on port connected to DUT
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

Manually continuously toggled ports on DUT and verified BGP sessions did not stuck in 'connect' state and ping to VM works almost immediately after port/LAG becomes up.
Basic manual check - LAGs, BGPs Run FIB/ACL automation tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
