### PR TITLE
Added become for removing fdb.json file from DUT

### DIFF
--- a/ansible/roles/test/tasks/crm/crm_test_fdb_entry.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_fdb_entry.yml
@@ -80,6 +80,7 @@
       command: fdbclear
 
     - name: Remove FDB JSON config from switch.
+      become: yes
       command: rm /tmp/fdb.json
 
     - name: Remove FDB JSON config from SWSS container


### PR DESCRIPTION
# Description of PR
- CRM testsuite was failing because of permission issue
- Playbook was trying to delete the fdb.json file from DUT and because of permission issue it was not able to delete the json file
- That's why added become=yes for removing the json file

### Type of change

- [ü] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
- Added become=yes in the file:-
roles/test/tasks/crm/crm_test_fdb_entry.yml

#### How did you verify/test it?
verified in my local testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 

