### PR TITLE
Added conditional check for ptf32 topo in snmp.yml file

### DIFF
--- a/ansible/roles/test/tasks/snmp.yml
+++ b/ansible/roles/test/tasks/snmp.yml
@@ -28,4 +28,5 @@
 
     - name: include snmp lldp test
       include: roles/test/tasks/snmp/lldp.yml
+      when: testbed_type != "ptf32"
   when: testcase_name is defined


### PR DESCRIPTION
####Description of PR
snmp.yml 

- snmp lldp test case is failing with ptf32 topology
- PTF-32 topology is not using the arista-veos VM's.That's why this test case is 
not valid for ptf32 topology.Test-case will fail For remote values check.
- sonic DUT is not returning any lldp data with Ptf32 topology 
- Added condition to check the testbed_type != ptf32

Summary:
Fixes # (issue)

### Type of change

- [-/] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added conditional check in roles/test/tasks/snmp.yml file

#### How did you verify/test it?
tested in local testbed

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
N/A
