### PR TITLE
[add-topo] Add support for specifying PTF docker image tag

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -1,10 +1,22 @@
+
+# The PTF image built from different branches may be incompatible. The ptf_imagetag variable added here is to
+# support using different PTF images for different branches. When the ptf_imagetag variable is not specified,
+# the PTF image with default "latest" tag will be used. When a specific PTF image version is required, we can
+# specify a value for the ptf_imagetag variable somewhere, for example, specify from command line:
+#    ./testbed-cli.sh add-topo <testbed_name>-<topo> vault -e ptf_imagetag=201811
+# By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
+- name: Set default value for ptf_imagetag
+  set_fact:
+    ptf_imagetag: "latest"
+  when: ptf_imagetag is not defined
+
 - name: Create a docker container ptf_{{ vm_set_name }}
   docker:
     registry: "{{ docker_registry_host }}"
     username: "{{ docker_registry_username }}"
     password: "{{ docker_registry_password }}"
     name: ptf_{{ vm_set_name }}
-    image: "{{ docker_registry_host }}/{{ ptf_imagename }}"
+    image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
     pull: always
     state: reloaded
     net: none

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -34,6 +34,8 @@ function usage
   echo "        $0 start-vms server-name vault-password-file -e autostart=yes"
   echo "To stop VMs on a server:  $0 stop-vms 'server-name' ~/.password"
   echo "To deploy a topology on a server: $0 add-topo 'topo-name' ~/.password"
+  echo "    Optional argument for add-topo:"
+  echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"
   echo "To remove a topology on a server: $0 remove-topo 'topo-name' ~/.password"
   echo "To renumber a topology on a server: $0 renumber-topo 'topo-name' ~/.password"
   echo "To connect a topology: $0 connect-topo 'topo-name' ~/.password"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

PTF docker container is pulled and created while add-topo.
By default, the PTF container is always created from PTF image
with "latest" tag. This change added a variable for specifying PTF
image tag while add-topo. The variable value can be
specified via CLI option. If the variable value is not given,
default "latest" value will be used.
When this variable is specified, PTF container will be created
from PTF image with the specified tag.

For example:
./testbed-cli.sh add-topo <testbed_name>-<topo> vault -e ptf_imagetag=201811

By using this practice, we suggest to add different tags for different PTF image 
versions in docker registry.

There is no need to merge this PR to 201811 branch. There is a dedicated PR for 201811 (https://github.com/Azure/sonic-mgmt/pull/1046)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added a variable ptf_imagetag in add_topo.yml. 
When this variable is specified, PTF container will be created from PTF image with the specified tag.

#### How did you verify/test it?
* Add different tags for PTF image in docker registry
* Run testbed-cli.sh add-topo without specifying ptf_imagetag, check the created PTF container on test server, PTF container is created using PTF image of "latest" tag.
* Run testbed-cli.sh add-topo with "-e ptf_imagetag=201811", check the created PTF container on test server, PTF container is created using PTF image of "201811" tag.
 
#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
