### PR TITLE
[add-topo] Add support for specifying PTF docker image tag

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -1,10 +1,24 @@
+
+# The PTF image built from different branches may be incompatible. The ptf_imagetag variable added here is to
+# support using different PTF images for different branches. When the ptf_imagetag variable is not specified,
+# the PTF image with default "201811" tag will be used in this sonic-mgmt 201811 branch. When a different PTF
+# image version is required, we can specify a different value for the ptf_imagetag variable somewhere to
+# override the default value, for example, specify from command line:
+#    ./testbed-cli.sh add-topo <testbed_name>-<topo> vault -e ptf_imagetag=myversion
+# By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
+# And we suggest to add tag "201811" for PTF image built from the 201811 branch.
+- name: Set default value for ptf_imagetag
+  set_fact:
+    ptf_imagetag: "201811"
+  when: ptf_imagetag is not defined
+
 - name: Create a docker container ptf_{{ vm_set_name }}
   docker:
     registry: "{{ docker_registry_host }}"
     username: "{{ docker_registry_username }}"
     password: "{{ docker_registry_password }}"
     name: ptf_{{ vm_set_name }}
-    image: "{{ docker_registry_host }}/{{ ptf_imagename }}"
+    image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
     pull: always
     state: reloaded
     net: none

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -34,6 +34,8 @@ function usage
   echo "        $0 start-vms server-name vault-password-file -e autostart=yes"
   echo "To stop VMs on a server:  $0 stop-vms 'server-name' ~/.password"
   echo "To deploy a topology on a server: $0 add-topo 'topo-name' ~/.password"
+  echo "    Optional argument for add-topo:"
+  echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"
   echo "To remove a topology on a server: $0 remove-topo 'topo-name' ~/.password"
   echo "To renumber a topology on a server: $0 renumber-topo 'topo-name' ~/.password"
   echo "To connect a topology: $0 connect-topo 'topo-name' ~/.password"


### PR DESCRIPTION
Signed-off-by: Xin Wang <xinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This is a sister PR of https://github.com/Azure/sonic-mgmt/pull/1045 
In PR#1045, an ansible variable ptf_imagetag is added. When deploy a toplogy, this variable can be used to specify the PTF image tag for creating PTF container. But in sonic-mgmt master branch, default value for the ptf_imagetag variable is set to "latest".

In this PR, default value for the ptf_imagetag is set to "201811". Because it is a good practice to use PTF and sonic-mgmt to test SONiC image from the same branch. So, it would be better to test 201811 SONiC build using PTF and sonic-mgmt from branch 201811 too.

If the PTF image built from 201811 was tagged with "201811" in docker registry, with this PR, then we do not need to explicitly specify PTF image tag in command line arguments of testbed-cli.sh when deploy a topology. By default PTF container will be created using PTF image with tag "201811":
    ./testbed-cli.sh add-topo <testbed>-<topo> vault

This PR is 201811 branch specific. It should only go to the 201811 branch.

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add a ptf_imagetag ansible variable in add_topo.yml. Set its default value to "201811".

#### How did you verify/test it?
* Add different tags for PTF image in docker registry
* Checkout sonic-mgmt 201811 branch.
* Run testbed-cli.sh add-topo without specifying ptf_imagetag, check the created PTF container on test server, PTF container is created using PTF image of "201811" tag.
* Run testbed-cli.sh add-topo with "-e ptf_imagetag=myversion", check the created PTF container on test server, PTF container is created using PTF image of "myversion" tag (Assume PTF image tag "myversion" is added in registry).

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
