### PR TITLE
[vxlan-decap]: Add extended statistics output for vxlan-decap test

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -24,7 +24,9 @@ from ptf.dataplane import match_exp_pkt
 from ptf.mask import Mask
 import datetime
 import subprocess
+import traceback
 from pprint import pprint
+from pprint import pformat
 
 class Vxlan(BaseTest):
     def __init__(self):
@@ -162,49 +164,66 @@ class Vxlan(BaseTest):
 
     def runTest(self):
         print
-        for test in self.tests:
-            print test['name']
-            res_v = self.Vxlan(test)
-            print "  Vxlan            = ", res_v
-            res_f = self.RegularLAGtoVLAN(test)
-            print "  RegularLAGtoVLAN = ", res_f
-            res_t = self.RegularVLANtoLAG(test)
-            print "  RegularVLANtoLAG = ", res_t
+        err = ''
+        trace = ''
+        ret = 0
+        try:
+            for test in self.tests:
+                print test['name']
+                res_v, out_v = self.Vxlan(test)
+                print "  Vxlan            = ", res_v
+                res_f, out_f = self.RegularLAGtoVLAN(test)
+                print "  RegularLAGtoVLAN = ", res_f
+                res_t, out_t = self.RegularVLANtoLAG(test)
+                print "  RegularVLANtoLAG = ", res_t
+                print
+                if self.vxlan_enabled:
+                    self.assertTrue(res_v, "VxlanTest failed:\n  %s\n\ntest:\n%s"  % (out_v, pformat(test)))
+                else:
+                    self.assertFalse(res_v, "VxlanTest: vxlan works, but it must have been disabled!\n\ntest:%s" % pformat(test))
+                self.assertTrue(res_f, "RegularLAGtoVLAN test failed:\n  %s\n\ntest:\n%s" % (out_f, pformat(test)))
+                self.assertTrue(res_t, "RegularVLANtoLAG test failed:\n  %s\n\ntest:\n%s" % (out_t, pformat(test)))
+        except AssertionError as e:
+            err = str(e)
+            trace = traceback.format_exc()
+            ret = -1
+        if ret != 0:
+            print "The test failed"
             print
-            if self.vxlan_enabled:
-                self.assertTrue(res_v, "VxlanTest failed")
-            else:
-                self.assertFalse(res_v, "VxlanTest must be disabled")
-            self.assertTrue(res_f, "RegularLAGtoVLAN test failed")
-            self.assertTrue(res_t, "RegularVLANtoLAG test failed")
+            print "Error: %s" % err
+            print
+            print trace
+        else:
+            print "The test was successful"
+        sys.stdout.flush()
+        if ret != 0:
+            raise AssertionError(err)
 
     def Vxlan(self, test):
-        rv = True
         for n in self.net_ports:
             for a in test['acc_ports']:
-                res = self.checkVxlan(a, n, test)
-                rv = rv and res
-
-        return rv
+                res, out = self.checkVxlan(a, n, test)
+                if not res:
+                    return False, out
+        return True, ""
 
     def RegularLAGtoVLAN(self, test):
-        rv = True
         for n in self.net_ports:
             for a in test['acc_ports']:
-                res = self.checkRegularRegularLAGtoVLAN(a, n, test)
-                rv = rv and res
-        return rv
+                res, out = self.checkRegularRegularLAGtoVLAN(a, n, test)
+                if not res:
+                    return False, out
+        return True, ""
 
     def RegularVLANtoLAG(self, test):
-        rv = True
         for dst, ports in self.pc_info:
             for a in test['acc_ports']:
-                res = self.checkRegularRegularVLANtoLAG(a, ports, dst, test)
-                rv = rv and res
-        return rv
+                res, out = self.checkRegularRegularVLANtoLAG(a, ports, dst, test)
+                if not res:
+                    return False, out
+        return True, ""
 
     def checkRegularRegularVLANtoLAG(self, acc_port, pc_ports, dst_ip, test):
-        rv = True
         src_mac = self.ptf_mac_addrs['eth%d' % acc_port]
         dst_mac = self.dut_mac
         src_ip = test['vlan_ip_prefix'] % acc_port
@@ -228,13 +247,16 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
-        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.2)
-        rv = rv and (nr_rcvd == self.nr)
-        return rv
+        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.5)
+        rv = nr_rcvd == self.nr
+        out = ""
+        if not rv:
+            arg = self.nr, nr_rcvd, str(acc_port), str(pc_ports), src_mac, dst_mac, src_ip, dst_ip
+            out = "sent = %d rcvd = %d | src_port=%s dst_ports=%s | src_mac=%s dst_mac=%s src_ip=%s dst_ip=%s" % arg
+        return rv, out
 
 
     def checkRegularRegularLAGtoVLAN(self, acc_port, net_port, test):
-        rv = True
         src_mac = self.random_mac
         dst_mac = self.dut_mac
         src_ip = test['src_ip']
@@ -257,12 +279,15 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.2)
-        rv = rv and (nr_rcvd == self.nr)
-        return rv
+        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.5)
+        rv = nr_rcvd == self.nr
+        out = ""
+        if not rv:
+            arg = self.nr, nr_rcvd, str(net_port), str(acc_port), src_mac, dst_mac, src_ip, dst_ip
+            out = "sent = %d rcvd = %d | src_port=%s dst_port=%s | src_mac=%s dst_mac=%s src_ip=%s dst_ip=%s" % arg
+        return rv, out
 
     def checkVxlan(self, acc_port, net_port, test):
-        rv = True
         inner_dst_mac = self.ptf_mac_addrs['eth%d' % acc_port]
         inner_src_mac = self.dut_mac
         inner_src_ip = test['vlan_gw']
@@ -291,8 +316,12 @@ class Vxlan(BaseTest):
                  )
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.2)
-        rv = rv and (nr_rcvd == self.nr)
-        return rv
+        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.5)
+        rv = nr_rcvd == self.nr
+        out = ""
+        if not rv:
+            arg = self.nr, nr_rcvd, str(net_port), str(acc_port), src_mac, dst_mac, test['src_ip'], ip_dst, inner_src_mac, inner_dst_mac, inner_src_ip, inner_dst_ip, test['vni']
+            out = "sent = %d rcvd = %d | src_port=%s dst_port=%s | src_mac=%s dst_mac=%s src_ip=%s dst_ip=%s | Inner: src_mac=%s dst_mac=%s src_ip=%s dst_ip=%s vni=%s" % arg
+        return rv, out
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. Added detailed statistics showing the reason why the test case is failing
2. Flushed stdout before exit to print output from the test. Otherwise we can see only traceback

#### How did you verify/test it?
I tested it on my DUT.

#### Any platform specific information?
no

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
