### PR TITLE
Adjusting the ntp waiting time to a reasonable value

### DIFF
--- a/ansible/roles/test/tasks/ntp.yml
+++ b/ansible/roles/test/tasks/ntp.yml
@@ -19,7 +19,7 @@
   shell: ntpstat
   register: ntpstat_result
   until: ntpstat_result.rc == 0
-  retries: 8
-  delay: 10
+  retries: 10
+  delay: 30
 
 - debug: msg="NTP Status {{ ntpstat_result.stdout }}"


### PR DESCRIPTION
Description of PR
      Two turnkey limits for NTP: 128 ms for stepping and 500 ppm (496 to 512 ppm) for locking and slewing. So the maximum allowed offset of 128 ms will be compensated at maximum slewing rate of 512 ppm in a matter of 250 seconds (4.17 minutes). In practice, however, this will probably take slightly longer, as slewing rate is gradually decreased when approaching the target time.
         At the same time. Even we used " ntpd -g". According to the actual testing result. We need to 
Adjust the waiting time to 300. It is more reasonable.

Summary:
Fixes # (issue)
Type of change
  Bug fix
Approach
   changed roles/test/tasks/ntp.yml

How did you verify/test it?
   passed ntp testcase.
