### PR TITLE
EOS software image path is wrong in boot-config file

### DIFF
--- a/ansible/roles/eos/files/boot-config
+++ b/ansible/roles/eos/files/boot-config
@@ -1,1 +1,1 @@
-SWI=flash:/vEOS.swi
+SWI=flash:/EOS.swi


### PR DESCRIPTION
### Description of PR
- When the arista switch is powered on or rebooted, Aboot reads its configuration from boot-config on the internal flash and attempts to boot an EOS software image (with the extension .swi) automatically if one is configured.
- Arista veos vm's are going to Aboot shell mode while adding the topology and console is showing these messages
given below
===============
Press Control-C now to enter Aboot shell
Booting flash:/vEOS.swi
flash:/vEOS.swi not found or not a file
===================
- Load topology is failing because vEOS.swi file is not present in /mnt/flash directory

Summary:
Fixes # (issue)

### Type of change

- [.../] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Changed the roles/eos/files/boot-config file

#### How did you verify/test it?
verified it on local testbed

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
N/A
