### PR TITLE
[vlan_trunk] stabilize vlan trunk test

### DIFF
--- a/ansible/roles/test/tasks/vlan_cleanup.yml
+++ b/ansible/roles/test/tasks/vlan_cleanup.yml
@@ -1,17 +1,17 @@
 - name: Restore all IP addresses on the LAGs
-  shell: ip addr add {{ (item.addr ~ "/" ~ item.mask)|ipaddr() }} dev {{ item.attachto }}
+  shell: config interface ip add {{ item.attachto }} {{ (item.addr ~ "/" ~ item.mask)|ipaddr()|upper }}
   with_items:
     - "{{ minigraph_portchannel_interfaces }}"
   become: true
 
 - name: Bring up LAGs
-  shell: ifconfig {{ item.attachto }} up
+  shell: config interface startup {{ item.attachto }}
   with_items:
     - "{{ minigraph_portchannel_interfaces }}"
   become: true
 
 - name: Remove configuration for test
-  file: 
+  file:
     state: absent
     path: /etc/sonic/vlan_configuration.json
   become: true

--- a/ansible/roles/test/tasks/vlan_configure.yml
+++ b/ansible/roles/test/tasks/vlan_configure.yml
@@ -1,7 +1,8 @@
 - fail: msg="Please set ptf_host variable"
   when: ptf_host is not defined
 
-- fail: msg="Invalid testbed_type value '{{testbed_type}}'"
+- fail:
+    msg: "Invalid testbed_type value '{{testbed_type}}'"
   when: testbed_type not in [ 't0', 't0-116' ]
 
 - debug: var=minigraph_portchannels
@@ -21,27 +22,25 @@
 - debug: var=vlan_ports_list
 - debug: var=vlan_intf_list
 
-- name: Flush all IP addresses on the LAGs
-  shell: ip addr flush {{ item.attachto }}
-  with_items:
-    - "{{ minigraph_portchannel_interfaces }}"
-  become: true
-
-- name: Delete all IP addresses on the LAGs in config DB
-  shell: docker exec -i database redis-cli -n 4 del "PORTCHANNEL_INTERFACE|{{ item.attachto }}|{{ (item.addr ~ '/' ~ item.mask)|ipaddr()|upper() }}"
-  with_items:
-    - "{{ minigraph_portchannel_interfaces }}"
-  become: true
-
 - name: Shutdown LAGs
-  shell: ifconfig {{ item.attachto }} down
+  shell: config interface shutdown {{ item.attachto }}
   with_items:
     - "{{ minigraph_portchannel_interfaces }}"
   become: true
 
-- name: sleep for some time
-  pause: seconds=10
+- name: Flush all IP addresses on the LAGs
+  shell: config interface ip remove {{ item.attachto }} {{ (item.addr ~ "/" ~ item.mask)|ipaddr()|upper }}
+  with_items:
+    - "{{ minigraph_portchannel_interfaces }}"
+  become: true
 
+# wait some time for route, neighbor, next hop groups to be removed,
+# otherwise PortChannel RIFs are still referenced and won't be removed
+# cause below vlan_configuration.json fail to apply
+- name: sleep for some time
+  pause: seconds=90
+
+# TODO: convert VLAN configuration into CLI commands
 - name: Generate nessesary configuration for test
   template: src=roles/test/templates/vlan_configuration.j2
             dest=/etc/sonic/vlan_configuration.json
@@ -52,10 +51,10 @@
   become: true
 
 - name: sleep for some time
-  pause: seconds=30
+  pause: seconds=10
 
 - name: Bring up LAGs
-  shell: ifconfig {{ item.attachto }} up
+  shell: config interface startup {{ item.attachto }}
   with_items:
     - "{{ minigraph_portchannel_interfaces }}"
   become: true

--- a/ansible/roles/test/tasks/vlan_configure.yml
+++ b/ansible/roles/test/tasks/vlan_configure.yml
@@ -38,7 +38,7 @@
 # otherwise PortChannel RIFs are still referenced and won't be removed
 # cause below vlan_configuration.json fail to apply
 - name: sleep for some time
-  pause: seconds=90
+  pause: seconds=10
 
 # TODO: convert VLAN configuration into CLI commands
 - name: Generate nessesary configuration for test

--- a/ansible/roles/test/tasks/vlan_test.yml
+++ b/ansible/roles/test/tasks/vlan_test.yml
@@ -39,6 +39,6 @@
           - vlan_ports_list = \"{{ vlan_ports_list }}\"
           - vlan_intf_list = \"{{ vlan_intf_list }}\"
           - router_mac = \"{{ ansible_Ethernet0['macaddress'] }}\"
-        ptf_extra_options: "--relax --debug info --log-file /tmp/vlan_test.log" 
+        ptf_extra_options: "--relax --debug info --log-file /tmp/vlan_test.log"
   rescue:
     - debug: msg="PTF test raise error"

--- a/ansible/roles/test/templates/vlan_configuration.j2
+++ b/ansible/roles/test/templates/vlan_configuration.j2
@@ -9,6 +9,9 @@
     },
     "VLAN_INTERFACE": {
 {% for vlan_intf in vlan_intf_list %}
+        "Vlan{{ vlan_intf.vlan_id }}": {},
+{% endfor %}
+{% for vlan_intf in vlan_intf_list %}
         "Vlan{{ vlan_intf.vlan_id }}|{{ vlan_intf.ip }}": {}{{ "," if not loop.last else "" }}
 {% endfor %}
     },


### PR DESCRIPTION
- use 'config' commands to brind down/up interfaces
- generate 'Vlan<VID>': {} in config to specify this interface belongs to global vrf as it is required (TODO: use config CLI instead);
- wait longer time after LAG shutdown;
  Test tries to configure LAG as part of VLAN interface which will fail if LAG is a RIF.
  Since RIF in SONiC is removed only when the ref_count becomes 0, we'll have to wait for orchagent
  to remove all routes, next hop groups, neighbors that reference those LAG RIFs.
  The time is required is not very deterministic and can differ between platforms but it is assumed 90 sec is enough.
  One other way to do this test is to create seperate PortChannels.
  Also, it looks that master has significantly slower performence to remove routes, next hops then 201811 branch.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Continuous test on master mellanox platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
