### PR TITLE
[everflow/policer] remove route after session is removed

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/testcase_8.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_8.yml
@@ -47,11 +47,6 @@
       ptf_extra_options: "--relax --debug info"
 
   always:
-    - name: Remove route
-      shell: vtysh -e "conf t" -e "no ip route {{ session_prefix_1 }} {{ neighbor_info_1['addr'] }}"
-      ignore_errors: yes
-      become: yes
-
     - name: Remove the rule with DSCP value and mask
       shell: |
         redis-cli -n 4 del "ACL_RULE|{{dscp_table_name}}|RULE_1"
@@ -72,6 +67,11 @@
     - name: Remove policer
       shell: |
         redis-cli -n 4 del "POLICER|{{policer_name}}"
+      ignore_errors: yes
+      become: yes
+
+    - name: Remove route
+      shell: vtysh -e "conf t" -e "no ip route {{ session_prefix_1 }} {{ neighbor_info_1['addr'] }}"
       ignore_errors: yes
       become: yes
 


### PR DESCRIPTION
On Mellanox SPC there are 3 maximum mirror sessions or 2 mirror sessions if session attribute update is performed

to avoid no resource error remove first a session and then route, otherwise session will be updated with changed dest mac of default route next hop

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
