### PR TITLE
Make link flap timeout configurable for link_flap test case

### DIFF
--- a/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
+++ b/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
@@ -10,6 +10,10 @@
     - name: Set default link timeout
       set_fact:
         link_timeout: 20
+      when: link_timeout is not defined
+
+    - name: Set default link delay
+      set_fact:
         link_delay: 5
 
     - set_fact:
@@ -50,7 +54,7 @@
       interface_facts: up_ports="[ '{{ interface }}' ]"
       register: out
       until: out.ansible_facts.ansible_interface_link_down_ports | length > 0
-      retries: "{{ (link_timeout / link_delay) | round(0, 'ceil') | int }}"
+      retries: "{{ ((link_timeout | int) / link_delay) | round(0, 'ceil') | int }}"
       delay: "{{ link_delay }}"
       when: "interface in minigraph_ports.keys()"
 
@@ -84,7 +88,7 @@
       interface_facts: up_ports="[ '{{ interface }}' ]"
       register: out
       until: out.ansible_facts.ansible_interface_link_down_ports | length == 0
-      retries: "{{ (link_timeout / link_delay) | round(0, 'ceil') | int }}"
+      retries: "{{ ((link_timeout | int) / link_delay) | round(0, 'ceil') | int }}"
       delay: "{{ link_delay }}"
       when: "interface in minigraph_ports.keys()"
 


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Make link flap timeout configurable for link_flap test case
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### How did you do it?
Make it possible to pass "link_timeout" parameter from console. Default "link_timeout" is unchanged and is equal to 20 sec.
Example:
-e link_timeout=30

#### How did you verify/test it?
Tested by running "link_flap" test on several platforms.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
