### PR TITLE
[fib]: Add IPv6 default route check

### DIFF
--- a/ansible/roles/test/files/ptftests/fib.py
+++ b/ansible/roles/test/files/ptftests/fib.py
@@ -17,7 +17,6 @@ EXCLUDE_IPV4_PREFIXES = [
 ]
 
 EXCLUDE_IPV6_PREFIXES = [
-        '::/0',                 # Currently no IPv6 default route
         '::/128',               # Unspecified           RFC 4291
         '::1/128',              # Loopback              RFC 4291
         'ff00::/8'              # Multicast             RFC 4291

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -1,13 +1,17 @@
 {# defualt route#}
 {% if testbed_type == 't1' %}
 0.0.0.0/0 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
+::/0 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 {% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-64-32' %}
 0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
+::/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 {% elif testbed_type == 't1-64-lag' %}
 0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
+::/0 [0 1] [4 5] [16 17] [20 21]
 {% elif testbed_type == 't0-116' %}
 0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
+::/0 [24 25] [26 27] [28 29] [30 31]
 {% endif %}
 
 {#routes to uplink#}
@@ -17,21 +21,15 @@
 {% for subnet in range(0, props.tor_subnet_number) %}
 {% if testbed_type == 't1' %}
 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
-
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for ifname, v in minigraph_neighbors.iteritems() %}{% if "T2" in v.name %}{{ '[%d]' %  minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
-
 {% elif testbed_type == 't1-lag' %}
 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
-
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
-
 {% elif testbed_type == 't1-64-lag' %}
 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 [0 1] [4 5] [16 17] [20 21]
-
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
-
 {% elif testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't0-64-32' %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
@@ -45,9 +43,7 @@
 {# Skip 192.168.0.0 as it is in Vlan1000 subnet  #}
 {% if octet2 != 168 and octet3 != 0 and octet4 != 0 %}
 {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
-
 {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
-
 {% endif %}
 {% elif testbed_type == 't0-116' %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
@@ -74,9 +70,7 @@
 {% if "T0" in v.name %}
 {% for subnet in range(0, props_tor.tor_subnet_number) %}
 172.16.{{ v.name|replace("ARISTA", "")|replace("T0", "")|int }}.{{ subnet }}/32 {{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}
-
 20AC:10{{ '%02X' % v.name|replace("ARISTA", "")|replace("T0", "")|int }}:0:{{ '%02X' % subnet }}::/64 {{ '[%d] ' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}
-
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
IPv6 default route is learned and has the same behavior
as the IPv4 default route.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>