### PR TITLE
[warm-reboot] Add lag flap check after warm boot

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -875,10 +875,10 @@ class ReloadTest(BaseTest):
         for neigh in self.ssh_targets:
             self.neigh_handle = Arista(neigh, None, self.test_params)
             self.neigh_handle.connect()
-            fails, is_flap, flap_cnt = self.neigh_handle.verify_neigh_lag_no_flap()
+            fails, flap_cnt = self.neigh_handle.verify_neigh_lag_no_flap()
             self.neigh_handle.disconnect()
             self.fails[neigh] |= fails
-            if not is_flap:
+            if not flap_cnt:
                 self.log("No LAG flaps seen on %s after warm boot" % neigh)
             else:
                 self.fails[neigh].add("LAG flapped %s times on %s after warm boot" % (flap_cnt, neigh))

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -777,14 +777,18 @@ class ReloadTest(BaseTest):
             if self.reboot_type == 'fast-reboot' and no_cp_replies < 0.95 * self.nr_vl_pkts:
                 self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (no_cp_replies, self.nr_vl_pkts))
 
-            if self.reboot_type == 'warm-reboot' and self.preboot_oper is not None:
-                if self.pre_handle is not None:
+            if self.reboot_type == 'warm-reboot':
+                if self.preboot_oper is not None and self.pre_handle is not None:
                     self.log("Postboot checks:")
                     log_info, fails = self.pre_handle.verify(pre_check=False)
                     self.populate_fail_info(fails)
                     for log in log_info:
                         self.log(log)
                     self.log(" ")
+
+                else:
+                    # verify there are no interface flaps after warm boot
+                    self.neigh_lag_status_check()
 
         except Exception as e:
             self.fails['dut'].add(e)
@@ -863,6 +867,21 @@ class ReloadTest(BaseTest):
             self.log("="*50)
 
             self.assertTrue(is_good, errors)
+
+    def neigh_lag_status_check(self):
+        """
+        Ensure there are no interface flaps after warm-boot
+        """
+        for neigh in self.ssh_targets:
+            self.neigh_handle = Arista(neigh, None, self.test_params)
+            self.neigh_handle.connect()
+            fails, is_flap, flap_cnt = self.neigh_handle.verify_neigh_lag_no_flap()
+            self.neigh_handle.disconnect()
+            self.fails[neigh] |= fails
+            if not is_flap:
+                self.log("No LAG flaps seen on %s after warm boot" % neigh)
+            else:
+                self.fails[neigh].add("LAG flapped %s times on %s after warm boot" % (flap_cnt, neigh))
 
     def extract_no_cpu_replies(self, arr):
       """

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -427,8 +427,7 @@ class Arista(object):
         return self.fails, lag_state
 
     def verify_neigh_lag_no_flap(self):
-        is_flap = True
-        flap_cnt = -1
+        flap_cnt = sys.maxint
         output = self.do_cmd('show interfaces Po1 | json')
         if 'Invalid' not in output:
             data = '\n'.join(output.split('\r\n')[1:-1])
@@ -437,13 +436,12 @@ class Arista(object):
             if 'interfaces' in obj and 'Port-Channel1' in obj['interfaces']:
                 intf_cnt_info = obj['interfaces']['Port-Channel1']['interfaceCounters']
                 flap_cnt = intf_cnt_info['linkStatusChanges']
-                is_flap = (flap_cnt != 0)
             else:
                 self.fails.add('Object missing in output for Port-Channel1')
-            return self.fails, is_flap, flap_cnt
+            return self.fails, flap_cnt
 
         self.fails.add('Invalid interface name - Po1')
-        return self.fails, is_flap, flap_cnt
+        return self.fails, flap_cnt
 
     def check_gr_peer_status(self, output):
         # [0] True 'ipv4_gr_enabled', [1] doesn't matter 'ipv6_enabled', [2] should be >= 120

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -137,6 +137,9 @@ class Arista(object):
             sample["po_changetime"] = json.loads(portchannel_output, strict=False)['interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
 
             if not run_once:
+                # clear Portchannel counters
+                self.do_cmd("clear counters Port-Channel 1")
+
                 self.ipv4_gr_enabled, self.ipv6_gr_enabled, self.gr_timeout = self.parse_bgp_neighbor_once(bgp_neig_output)
                 if self.gr_timeout is not None:
                     log_first_line = "session_begins_%f" % cur_time
@@ -422,6 +425,25 @@ class Arista(object):
 
         self.fails.add('%s: Invalid interface name' % msg_prefix[pre_check])
         return self.fails, lag_state
+
+    def verify_neigh_lag_no_flap(self):
+        is_flap = True
+        flap_cnt = -1
+        output = self.do_cmd('show interfaces Po1 | json')
+        if 'Invalid' not in output:
+            data = '\n'.join(output.split('\r\n')[1:-1])
+            obj = json.loads(data)
+
+            if 'interfaces' in obj and 'Port-Channel1' in obj['interfaces']:
+                intf_cnt_info = obj['interfaces']['Port-Channel1']['interfaceCounters']
+                flap_cnt = intf_cnt_info['linkStatusChanges']
+                is_flap = (flap_cnt != 0)
+            else:
+                self.fails.add('Object missing in output for Port-Channel1')
+            return self.fails, is_flap, flap_cnt
+
+        self.fails.add('Invalid interface name - Po1')
+        return self.fails, is_flap, flap_cnt
 
     def check_gr_peer_status(self, output):
         # [0] True 'ipv4_gr_enabled', [1] doesn't matter 'ipv6_enabled', [2] should be >= 120


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Verify that no LAG flaps are seen on the neighbors after warm-reboot

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Clear interface counters on the neighbors prior to warm boot
Verify that 'linkStatusChanges' counter on the neighbors after warm boot is still 0

#### How did you verify/test it?
Image with issue:
        "2019-08-09 17:45:33 : ", 
        "2019-08-09 17:45:35 : No LAG flaps seen on 10.64.247.207 after warm boot", 
        "2019-08-09 17:45:37 : No LAG flaps seen on 10.64.247.206 after warm boot", 
        "2019-08-09 17:45:40 : No LAG flaps seen on 10.64.247.204 after warm boot", 
        "2019-08-09 17:45:40 : ==================================================", 
        "2019-08-09 17:45:40 : Report:", 
        "2019-08-09 17:45:40 : ==================================================", 
        "2019-08-09 17:45:40 : LACP/BGP were down for (extracted from cli):", 
        "2019-08-09 17:45:40 : --------------------------------------------------", 
        "2019-08-09 17:45:40 :     10.64.247.204 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)", 
        "2019-08-09 17:45:40 :     10.64.247.205 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp FAIL", 
        "", 
        "======================================================================", 
        "FAIL: advanced-reboot.ReloadTest", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"ptftests/advanced-reboot.py\", line 869, in runTest", 
        "    self.assertTrue(is_good, errors)", 
        "AssertionError: ", 
        "", 
        "Something went wrong. Please check output below:", 
        "", 
        "FAILED:10.64.247.205:LAG flapped 2 times on 10.64.247.205 after warm boot"
        "----------------------------------------------------------------------", 
        "Ran 1 test in 643.229s", 
        "", 
        "FAILED (failures=1)", 

Image with fix:
        "2019-08-12 10:46:05 : No LAG flaps seen on 10.64.247.207 after warm boot", 
        "2019-08-12 10:46:07 : No LAG flaps seen on 10.64.247.206 after warm boot", 
        "2019-08-12 10:46:08 : No LAG flaps seen on 10.64.247.205 after warm boot", 
        "2019-08-12 10:46:10 : No LAG flaps seen on 10.64.247.204 after warm boot", 
        "2019-08-12 10:46:10 : ==================================================", 
        "2019-08-12 10:46:10 : Report:", 
        "2019-08-12 10:46:10 : ==================================================", 
        "2019-08-12 10:46:10 : LACP/BGP were down for (extracted from cli):", 
        "2019-08-12 10:46:10 : --------------------------------------------------", 
        "2019-08-12 10:46:10 :     10.64.247.204 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)", 
        "2019-08-12 10:46:10 :     10.64.247.205 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)", 
        "2019-08-12 10:46:10 :     10.64.247.206 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)", 
        "2019-08-12 10:46:10 :     10.64.247.207 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)", 
        "2019-08-12 10:46:10 : --------------------------------------------------", 
        "2019-08-12 10:46:10 : Extracted from VM logs:", 
        "2019-08-12 10:46:10 : -----------------------ok", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 667.161s", 
        "", 
        "OK", 
        "---------------------------", 
