### PR TITLE
[config_test]: Add pause during cleanup section

### DIFF
--- a/ansible/roles/test/tasks/config.yml
+++ b/ansible/roles/test/tasks/config.yml
@@ -101,6 +101,8 @@
       become: yes
       when: add_tmp_portchannel_ip
 
+    - pause: seconds=30
+
     - name: Remove {{ portchannel_members }} from {{ tmp_portchannel }}
       shell: config portchannel member del {{ tmp_portchannel }} {{ item }}
       become: yes
@@ -111,6 +113,8 @@
       shell: config portchannel del {{ tmp_portchannel }}
       become: yes
       when: create_tmp_portchannel
+
+    - pause: seconds=30
 
     - name: Add {{ portchannel_ip }} to {{ portchannel }}
       shell: config interface ip add {{ portchannel }} {{ portchannel_ip }}/31


### PR DESCRIPTION
Ansible is executing all the cleanup commands too fast
and it causes reordering of the operations in orchagent,
which leads to crash.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>