### PR TITLE
[pytest] Improve infra and update the platform scripts to use the new infra

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1,0 +1,195 @@
+"""
+Classes for various devices that may be used in testing.
+
+There are other options for interacting with the devices used in testing, for example netmiko, fabric.
+We have a big number of customized ansible modules in the sonic-mgmt/ansible/library folder. To reused these
+modules, we have no other choice, at least for interacting with SONiC, localhost and PTF.
+
+We can consider using netmiko for interacting with the VMs used in testing.
+"""
+import json
+import logging
+from multiprocessing import Process, Queue
+
+from errors import RunAnsibleModuleFail
+from errors import UnsupportedAnsibleModule
+
+class AnsibleHostBase(object):
+    """
+    @summary: The base class for various objects.
+
+    This class filters an object from the ansible_adhoc fixture by hostname. The object can be considered as an
+    ansible host object although it is not under the hood. Anyway, we can use this object to run ansible module
+    on the host.
+    """
+
+    def __init__(self, ansible_adhoc, hostname):
+        if hostname == 'localhost':
+            self.host = ansible_adhoc(inventory='localhost', connection='local', host_pattern=hostname)[hostname]
+        else:
+            self.host = ansible_adhoc(become=True)[hostname]
+        self.hostname = hostname
+
+    def __getattr__(self, item):
+        if self.host.has_module(item):
+            self.module_name = item
+            self.module = getattr(self.host, item)
+
+            return self._run
+        else:
+            raise UnsupportedAnsibleModule("Unsupported module")
+
+    def _run(self, *module_args, **complex_args):
+        module_ignore_errors = complex_args.pop('module_ignore_errors', False)
+        module_async = complex_args.pop('module_async', False)
+
+        if module_async:
+            q = Queue()
+            def run_module(queue, module_args, complex_args):
+                res = self.module(*module_args, **complex_args)
+                q.put(res[self.hostname])
+            p = Process(target=run_module, args=(q, module_args, complex_args))
+            p.start()
+            return p, q
+
+        res = self.module(*module_args, **complex_args)[self.hostname]
+        if res.is_failed and not module_ignore_errors:
+            raise RunAnsibleModuleFail("run module {} failed, errmsg {}".format(self.module_name, res))
+
+        return res
+
+
+class Localhost(AnsibleHostBase):
+    """
+    @summary: Class for localhost
+
+    For running ansible module on localhost
+    """
+    def __init__(self, ansible_adhoc):
+        AnsibleHostBase.__init__(self, ansible_adhoc, "localhost")
+
+
+class PTFHost(AnsibleHostBase):
+    """
+    @summary: Class for PTF
+
+    Instance of this class can run ansible modules on the PTF host.
+    """
+    def __init__(self, ansible_adhoc, hostname):
+        AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
+
+    # TODO: Add a method for running PTF script
+
+
+class SonicHost(AnsibleHostBase):
+    """
+    @summary: Class for SONiC switch
+
+    For running ansible module on the SONiC switch
+    """
+    CRITICAL_SERVICES = ["swss", "syncd", "database", "teamd", "bgp", "pmon", "lldp"]
+
+    def __init__(self, ansible_adhoc, hostname, gather_facts=False):
+        AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
+        if gather_facts:
+            self.gather_facts()
+
+    def _platform_info(self):
+        platform_info = self.command("show platform summary")["stdout_lines"]
+        for line in platform_info:
+            if line.startswith("Platform:"):
+                self.facts["platform"] = line.split(":")[1].strip()
+            elif line.startswith("HwSKU:"):
+                self.facts["hwsku"] = line.split(":")[1].strip()
+            elif line.startswith("ASIC:"):
+                self.facts["asic_type"] = line.split(":")[1].strip()
+
+    def gather_facts(self):
+        """
+        @summary: Gather facts of the SONiC switch and store the gathered facts in the dict type 'facts' attribute.
+        """
+        self.facts = {}
+        self._platform_info()
+        logging.debug("SonicHost facts: %s" % json.dumps(self.facts))
+
+    def get_service_props(self, service, props=["ActiveState", "SubState"]):
+        """
+        @summary: Use 'systemctl show' command to get detailed properties of a service. By default, only get
+            ActiveState and SubState of the service.
+        @param service: Service name.
+        @param props: Properties of the service to be shown.
+        @return: Returns a dictionary containing properties of the specified service, for example:
+            {
+                "ActivateState": "active",
+                "SubState": "running"
+            }
+        """
+        props = " ".join(["-p %s" % prop for prop in props])
+        output = self.command("systemctl %s show %s" % (props, service))
+        result = {}
+        for line in output["stdout_lines"]:
+            fields = line.split("=")
+            if len(fields) >= 2:
+                result[fields[0]] = fields[1]
+        return result
+
+    def is_service_fully_started(self, service):
+        """
+        @summary: Check whether a SONiC specific service is fully started.
+
+        The last step in the starting script of all SONiC services is to run "docker wait <service_name>". This command
+        will not exit unless the docker container of the service is stopped. We use this trick to determine whether
+        a SONiC service has completed starting.
+
+        @param service: Name of the SONiC service
+        """
+        try:
+            output = self.command('pgrep -f "docker wait %s"' % service)
+            if output["stdout_lines"]:
+                return True
+            else:
+                return False
+        except:
+            return False
+
+    def critical_services_fully_started(self):
+        """
+        @summary: Check whether all the SONiC critical services have started
+        """
+        result = {}
+        for service in self.CRITICAL_SERVICES:
+            result[service] = self.is_service_fully_started(service)
+
+        logging.debug("Status of critical services: %s" % str(result))
+        return all(result.values())
+
+
+    def get_crm_resources(self):
+        """
+        @summary: Run the "crm show resources all" command and parse its output
+        """
+        result = {"main_resources": {}, "acl_resources": [], "table_resources": []}
+        output = self.command("crm show resources all")["stdout_lines"]
+        current_table = 0   # Totally 3 tables in the command output
+        for line in output:
+            if len(line.strip()) == 0:
+                continue
+            if "---" in line:
+                current_table += 1
+                continue
+            if current_table == 1:      # content of first table, main resources
+                fields = line.split()
+                if len(fields) == 3:
+                    result["main_resources"][fields[0]] = {"used": int(fields[1]), "available": int(fields[2])}
+            if current_table == 2:      # content of the second table, acl resources
+                fields = line.split()
+                if len(fields) == 5:
+                    result["acl_resources"].append({"stage": fields[0], "bind_point": fields[1],
+                        "resource_name": fields[2], "used_count": int(fields[3]), "available_count": int(fields[4])})
+            if current_table == 3:      # content of the third table, table resources
+                fields = line.split()
+                if len(fields) == 4:
+                    result["table_resources"].append({"table_id": fields[0], "resource_name": fields[1],
+                        "used_count": int(fields[2]), "available_count": int(fields[3])})
+
+        return result

--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -1,0 +1,8 @@
+"""
+Customize exceptions
+"""
+class UnsupportedAnsibleModule(Exception):
+    pass
+
+class RunAnsibleModuleFail(Exception):
+    pass

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1,0 +1,142 @@
+
+SPC1_HWSKUS = ["ACS-MSN2700", "Mellanox-SN2700", "ACS-MSN2740", "ACS-MSN2100", "ACS-MSN2410", "ACS-MSN2010"]
+SPC2_HWSKUS = ["ACS-MSN3700", "ACS-MSN3700C", "ACS-MSN3800"]
+SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS
+
+SWITCH_MODELS = {
+    "ACS-MSN2700": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": True
+        },
+        "fans": {
+            "number": 4,
+            "hot_swappable": True
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": True
+        }
+    },
+    "ACS-MSN2740": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 4,
+            "hot_swappable": True
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": True
+        }
+    },
+    "ACS-MSN2410": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": True
+        },
+        "fans": {
+            "number": 4,
+            "hot_swappable": True
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": True
+        }
+    },
+    "ACS-MSN2100": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 4,
+            "hot_swappable": False
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": False
+        }
+    },
+    "ACS-MSN2100": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 4,
+            "hot_swappable": False
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": False
+        }
+    },
+    "ACS-MSN3800": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 3,
+            "hot_swappable": False
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": False
+        }
+    },
+    "ACS-MSN3700": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 6,
+            "hot_swappable": False
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": False
+        }
+    },
+    "ACS-MSN3700C": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 4,
+            "hot_swappable": False
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": False
+        }
+    },
+    "ACS-MSN3510": {
+        "reboot": {
+            "cold_reboot": True,
+            "fast_reboot": True,
+            "warm_reboot": False
+        },
+        "fans": {
+            "number": 6,
+            "hot_swappable": False
+        },
+        "psus": {
+            "number": 2,
+            "hot_swappable": False
+        }
+    }
+}

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -49,7 +49,7 @@ SWITCH_MODELS = {
             "hot_swappable": True
         }
     },
-    "ACS-MSN2100": {
+    "ACS-MSN2010": {
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -87,11 +87,11 @@ SWITCH_MODELS = {
         },
         "fans": {
             "number": 3,
-            "hot_swappable": False
+            "hot_swappable": True
         },
         "psus": {
             "number": 2,
-            "hot_swappable": False
+            "hot_swappable": True
         }
     },
     "ACS-MSN3700": {
@@ -102,11 +102,11 @@ SWITCH_MODELS = {
         },
         "fans": {
             "number": 6,
-            "hot_swappable": False
+            "hot_swappable": True
         },
         "psus": {
             "number": 2,
-            "hot_swappable": False
+            "hot_swappable": True
         }
     },
     "ACS-MSN3700C": {
@@ -117,11 +117,11 @@ SWITCH_MODELS = {
         },
         "fans": {
             "number": 4,
-            "hot_swappable": False
+            "hot_swappable": True
         },
         "psus": {
             "number": 2,
-            "hot_swappable": False
+            "hot_swappable": True
         }
     },
     "ACS-MSN3510": {
@@ -132,11 +132,11 @@ SWITCH_MODELS = {
         },
         "fans": {
             "number": 6,
-            "hot_swappable": False
+            "hot_swappable": True
         },
         "psus": {
             "number": 2,
-            "hot_swappable": False
+            "hot_swappable": True
         }
     }
 }

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -4,6 +4,17 @@ Utility functions can re-used in testing scripts.
 import time
 import logging
 
+
+def wait(seconds, msg=""):
+    """
+    @summary: Pause specified number of seconds
+    @param seconds: Number of seconds to pause
+    @param msg: Optional extra message for pause reason
+    """
+    logging.debug("Pause %d seconds, reason: %s" % (seconds, msg))
+    time.sleep(seconds)
+
+
 def wait_until(timeout, interval, condition, *args, **kwargs):
     """
     @summary: Wait until the specified condition is True or timeout.

--- a/tests/platform/check_critical_services.py
+++ b/tests/platform/check_critical_services.py
@@ -6,63 +6,7 @@ This script contains re-usable functions for checking status of critical service
 import time
 import logging
 
-from utilities import wait_until
-
-critical_services = ["swss", "syncd", "database", "teamd", "bgp", "pmon", "lldp"]
-
-
-def get_service_status(dut, service):
-    """
-    @summary: Get the ActiveState and SubState of a service. This function uses the systemctl tool to get the
-        ActiveState and SubState of specified service.
-    @param dut: The AnsibleHost object of DUT. For interacting with DUT.
-    @param service: Service name.
-    @return: Returns a dictionary containing ActiveState and SubState of the specified service, for example:
-        {
-            "ActivateState": "active",
-            "SubState": "running"
-        }
-    """
-    output = dut.command("systemctl -p ActiveState -p SubState show %s" % service)
-    result = {}
-    for line in output["stdout_lines"]:
-        fields = line.split("=")
-        if len(fields) >= 2:
-            result[fields[0]] = fields[1]
-    return result
-
-
-def service_fully_started(dut, service):
-    """
-    @summary: Check whether the specified service is fully started on DUT. According to the SONiC design, the last
-        instruction in service starting script is to run "docker wait <service_name>". This function take advantage
-        of this design to check whether a service has been fully started. The trick is to check whether
-        "docker wait <service_name>" exists in current running processes.
-    @param dut: The AnsibleHost object of DUT. For interacting with DUT.
-    @param service: Service name.
-    @return: Return True if the specified service is fully started. Otherwise return False.
-    """
-    try:
-        output = dut.command('pgrep -f "docker wait %s"' % service)
-        if output["stdout_lines"]:
-            return True
-        else:
-            return False
-    except:
-        return False
-
-
-def critical_services_fully_started(dut):
-    """
-    @summary: Check whether all the critical service have been fully started.
-    @param dut: The AnsibleHost object of DUT. For interacting with DUT.
-    @return: Return True if all the critical services have been fully started. Otherwise return False.
-    """
-    result = {}
-    for service in critical_services:
-        result[service] = service_fully_started(dut, service)
-    logging.debug("Status of critical services: %s" % str(result))
-    return all(result.values())
+from common.utilities import wait_until
 
 
 def check_critical_services(dut):
@@ -72,11 +16,11 @@ def check_critical_services(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     logging.info("Wait until all critical services are fully started")
-    assert wait_until(300, 20, critical_services_fully_started, dut), "Not all critical services are fully started"
+    assert wait_until(300, 20, dut.critical_services_fully_started), "Not all critical services are fully started"
 
     logging.info("Check critical service status")
-    for service in critical_services:
-        status = get_service_status(dut, service)
+    for service in dut.CRITICAL_SERVICES:
+        status = dut.get_service_props(service)
         assert status["ActiveState"] == "active", \
             "ActiveState of %s is %s, expected: active" % (service, status["ActiveState"])
         assert status["SubState"] == "running", \

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -31,7 +31,7 @@ def check_sysfs(dut):
     except:
         assert False, "Bad content in /var/run/hw-management/thermal/asic: %s" % file_asic["stdout"]
 
-    dut_hwsku = dut.command("sonic-cfggen -d -v 'DEVICE_METADATA[\"localhost\"][\"hwsku\"]'")["stdout"]
+    dut_hwsku = dut.facts["hwsku"]
     from common.mellanox_data import SWITCH_MODELS
     fan_count = SWITCH_MODELS[dut_hwsku]["fans"]["number"]
 

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -35,10 +35,11 @@ def check_sysfs(dut):
     from common.mellanox_data import SWITCH_MODELS
     fan_count = SWITCH_MODELS[dut_hwsku]["fans"]["number"]
 
-    fan_status_list = ["/var/run/hw-management/thermal/fan%d_status" % fan_id for fan_id in range(1, fan_count + 1)]
-    for fan_status in fan_status_list:
-        fan_status_content = dut.command("cat %s" % fan_status)
-        assert fan_status_content["stdout"] == "1", "Content of %s is not 1" % fan_status
+    if SWITCH_MODELS[dut_hwsku]["fans"]["hot_swappable"]:
+        fan_status_list = ["/var/run/hw-management/thermal/fan%d_status" % fan_id for fan_id in range(1, fan_count + 1)]
+        for fan_status in fan_status_list:
+            fan_status_content = dut.command("cat %s" % fan_status)
+            assert fan_status_content["stdout"] == "1", "Content of %s is not 1" % fan_status
 
     fan_fault_list = ["/var/run/hw-management/thermal/fan%d_fault" % fan_id for fan_id in range(1, fan_count + 1)]
     for fan_fault in fan_fault_list:

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -29,7 +29,7 @@ def check_sysfs(dut):
         asic_temp = float(file_asic["stdout"]) / 1000
         assert asic_temp > 0 and asic_temp < 85, "Abnormal ASIC temperature: %s" % file_asic["stdout"]
     except:
-        assert "Bad content in /var/run/hw-management/thermal/asic: %s" % file_asic["stdout"]
+        assert False, "Bad content in /var/run/hw-management/thermal/asic: %s" % file_asic["stdout"]
 
     dut_hwsku = dut.command("sonic-cfggen -d -v 'DEVICE_METADATA[\"localhost\"][\"hwsku\"]'")["stdout"]
     from common.mellanox_data import SWITCH_MODELS
@@ -52,7 +52,7 @@ def check_sysfs(dut):
             fan_min_speed = int(fan_min_content["stdout"])
             assert fan_min_speed > 0, "Bad fan minimum speed: %s" % str(fan_min_speed)
         except Exception as e:
-            assert "Get content from %s failed, exception: %s" % (fan_min, repr(e))
+            assert False, "Get content from %s failed, exception: %s" % (fan_min, repr(e))
 
     fan_max_list = ["/var/run/hw-management/thermal/fan%d_max" % fan_id for fan_id in range(1, fan_count + 1)]
     for fan_max in fan_max_list:
@@ -61,7 +61,7 @@ def check_sysfs(dut):
             fan_max_speed = int(fan_max_content["stdout"])
             assert fan_max_speed > 10000, "Bad fan maximum speed: %s" % str(fan_max_speed)
         except Exception as e:
-            assert "Get content from %s failed, exception: %s" % (fan_max, repr(e))
+            assert False, "Get content from %s failed, exception: %s" % (fan_max, repr(e))
 
     fan_speed_get_list = ["/var/run/hw-management/thermal/fan%d_speed_get" % fan_id for fan_id in range(1, fan_count + 1)]
     for fan_speed_get in fan_speed_get_list:
@@ -70,7 +70,7 @@ def check_sysfs(dut):
             fan_speed = int(fan_speed_get_content["stdout"])
             assert fan_speed > 1000, "Bad fan speed: %s" % str(fan_speed)
         except Exception as e:
-            assert "Get content from %s failed, exception: %s" % (fan_speed_get, repr(e))
+            assert False, "Get content from %s failed, exception: %s" % (fan_speed_get, repr(e))
 
     fan_speed_set_list = ["/var/run/hw-management/thermal/fan%d_speed_set" % fan_id for fan_id in range(1, fan_count + 1)]
     for fan_speed_set in fan_speed_set_list:

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -5,6 +5,7 @@ This script contains re-usable functions for checking status of hw-management re
 """
 import logging
 
+from check_hw_mgmt_service import wait_until_fan_speed_set_to_default
 
 def check_sysfs(dut):
     """
@@ -17,11 +18,11 @@ def check_sysfs(dut):
 
     logging.info("Check content of some key files")
 
+    assert not wait_until_fan_speed_set_to_default(dut, timeout=120), \
+        "Content of /var/run/hw-management/thermal/pwm1 should be 153"
+
     file_suspend = dut.command("cat /var/run/hw-management/config/suspend")
     assert file_suspend["stdout"] == "1", "Content of /var/run/hw-management/config/suspend should be 1"
-
-    file_pwm1 = dut.command("cat /var/run/hw-management/thermal/pwm1")
-    assert file_pwm1["stdout"] == "153", "Content of /var/run/hw-management/thermal/pwm1 should be 153"
 
     file_asic = dut.command("cat /var/run/hw-management/thermal/asic")
     try:
@@ -30,18 +31,22 @@ def check_sysfs(dut):
     except:
         assert "Bad content in /var/run/hw-management/thermal/asic: %s" % file_asic["stdout"]
 
-    fan_status_list = dut.command("find /var/run/hw-management/thermal -name fan*_status")
-    for fan_status in fan_status_list["stdout_lines"]:
+    dut_hwsku = dut.command("sonic-cfggen -d -v 'DEVICE_METADATA[\"localhost\"][\"hwsku\"]'")["stdout"]
+    from common.mellanox_data import SWITCH_MODELS
+    fan_count = SWITCH_MODELS[dut_hwsku]["fans"]["number"]
+
+    fan_status_list = ["/var/run/hw-management/thermal/fan%d_status" % fan_id for fan_id in range(1, fan_count + 1)]
+    for fan_status in fan_status_list:
         fan_status_content = dut.command("cat %s" % fan_status)
         assert fan_status_content["stdout"] == "1", "Content of %s is not 1" % fan_status
 
-    fan_fault_list = dut.command("find /var/run/hw-management/thermal -name fan*_fault")
-    for fan_fault in fan_fault_list["stdout_lines"]:
+    fan_fault_list = ["/var/run/hw-management/thermal/fan%d_fault" % fan_id for fan_id in range(1, fan_count + 1)]
+    for fan_fault in fan_fault_list:
         fan_fault_content = dut.command("cat %s" % fan_fault)
         assert fan_fault_content["stdout"] == "0", "Content of %s is not 0" % fan_fault
 
-    fan_min_list = dut.command("find /var/run/hw-management/thermal -name fan*_min")
-    for fan_min in fan_min_list["stdout_lines"]:
+    fan_min_list = ["/var/run/hw-management/thermal/fan%d_min" % fan_id for fan_id in range(1, fan_count + 1)]
+    for fan_min in fan_min_list:
         try:
             fan_min_content = dut.command("cat %s" % fan_min)
             fan_min_speed = int(fan_min_content["stdout"])
@@ -49,8 +54,8 @@ def check_sysfs(dut):
         except Exception as e:
             assert "Get content from %s failed, exception: %s" % (fan_min, repr(e))
 
-    fan_max_list = dut.command("find /var/run/hw-management/thermal -name fan*_max")
-    for fan_max in fan_max_list["stdout_lines"]:
+    fan_max_list = ["/var/run/hw-management/thermal/fan%d_max" % fan_id for fan_id in range(1, fan_count + 1)]
+    for fan_max in fan_max_list:
         try:
             fan_max_content = dut.command("cat %s" % fan_max)
             fan_max_speed = int(fan_max_content["stdout"])
@@ -58,8 +63,8 @@ def check_sysfs(dut):
         except Exception as e:
             assert "Get content from %s failed, exception: %s" % (fan_max, repr(e))
 
-    fan_speed_get_list = dut.command("find /var/run/hw-management/thermal -name fan*_speed_get")
-    for fan_speed_get in fan_speed_get_list["stdout_lines"]:
+    fan_speed_get_list = ["/var/run/hw-management/thermal/fan%d_speed_get" % fan_id for fan_id in range(1, fan_count + 1)]
+    for fan_speed_get in fan_speed_get_list:
         try:
             fan_speed_get_content = dut.command("cat %s" % fan_speed_get)
             fan_speed = int(fan_speed_get_content["stdout"])
@@ -67,7 +72,7 @@ def check_sysfs(dut):
         except Exception as e:
             assert "Get content from %s failed, exception: %s" % (fan_speed_get, repr(e))
 
-    fan_speed_set_list = dut.command("find /var/run/hw-management/thermal -name fan*_speed_set")
-    for fan_speed_set in fan_speed_set_list["stdout_lines"]:
+    fan_speed_set_list = ["/var/run/hw-management/thermal/fan%d_speed_set" % fan_id for fan_id in range(1, fan_count + 1)]
+    for fan_speed_set in fan_speed_set_list:
         fan_speed_set_content = dut.command("cat %s" % fan_speed_set)
         assert fan_speed_set_content["stdout"] == "153", "Fan speed should be set to 60%, 153/255"

--- a/tests/platform/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform/mellanox/test_check_sfp_using_ethtool.py
@@ -1,0 +1,40 @@
+"""
+Check SFP using ethtool
+
+This script covers the test case 'Check SFP using ethtool' in the SONiC platform test plan:
+https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
+"""
+import logging
+import os
+import json
+
+from platform_fixtures import conn_graph_facts
+from check_hw_mgmt_service import check_hw_management_service
+
+
+def test_check_sfp_using_ethtool(testbed_devices, conn_graph_facts):
+    """This test case is to check SFP using the ethtool.
+    """
+    ans_host = testbed_devices["dut"]
+    ports_config = json.loads(ans_host.command("sudo sonic-cfggen -d --var-json PORT")["stdout"])
+
+    logging.info("Use the ethtool to check SFP information")
+    for intf in conn_graph_facts["device_conn"]:
+        intf_lanes = ports_config[intf]["lanes"]
+        sfp_id = int(intf_lanes.split(",")[0])/4 + 1
+
+        ethtool_sfp_output = ans_host.command("sudo ethtool -m sfp%s" % str(sfp_id))
+        assert ethtool_sfp_output["rc"] == 0, "Failed to read eeprom of sfp%s using ethtool" % str(sfp_id)
+        assert len(ethtool_sfp_output["stdout_lines"]) >= 5, \
+            "Does the ethtool output look normal? " + str(ethtool_sfp_output["stdout_lines"])
+        for line in ethtool_sfp_output["stdout_lines"]:
+            assert len(line.split(":")) >= 2, \
+                "Unexpected line %s in %s" % (line, str(ethtool_sfp_output["stdout_lines"]))
+
+    logging.info("Check interface status")
+    mg_facts = ans_host.minigraph_facts(host=ans_host.hostname)["ansible_facts"]
+    intf_facts = ans_host.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
+    assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
+        "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
+
+    check_hw_management_service(ans_host)

--- a/tests/platform/mellanox/test_check_sysfs.py
+++ b/tests/platform/mellanox/test_check_sysfs.py
@@ -1,0 +1,27 @@
+"""
+Check SYSFS
+
+This script covers the test case 'Check SYSFS' in the SONiC platform test plan:
+https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
+"""
+import logging
+
+from check_sysfs import check_sysfs
+
+
+def test_check_hw_mgmt_sysfs(testbed_devices):
+    """This test case is to check the symbolic links under /var/run/hw-management
+    """
+    ans_host = testbed_devices["dut"]
+    check_sysfs(ans_host)
+
+
+def test_hw_mgmt_sysfs_mapped_to_pmon(testbed_devices):
+    """This test case is to verify that the /var/run/hw-management folder is mapped to pmon container
+    """
+    ans_host = testbed_devices["dut"]
+
+    logging.info("Verify that the /var/run/hw-management folder is mapped to the pmon container")
+    files_under_dut = set(ans_host.command("find /var/run/hw-management")["stdout_lines"])
+    files_under_pmon = set(ans_host.command("docker exec pmon find /var/run/hw-management")["stdout_lines"])
+    assert files_under_dut == files_under_pmon, "Folder /var/run/hw-management is not mapped to pmon"

--- a/tests/platform/mellanox/test_hw_management_service.py
+++ b/tests/platform/mellanox/test_hw_management_service.py
@@ -1,0 +1,15 @@
+"""
+Verify that the hw-management service is running properly
+
+This script covers test case 'Ensure that the hw-management service is running properly' in the SONiC platform test
+plan: https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
+"""
+
+from check_hw_mgmt_service import check_hw_management_service
+
+
+def test_hw_management_service_status(testbed_devices):
+    """This test case is to verify that the hw-management service is running properly
+    """
+    ans_host = testbed_devices["dut"]
+    check_hw_management_service(ans_host)

--- a/tests/platform/platform_fixtures.py
+++ b/tests/platform/platform_fixtures.py
@@ -1,0 +1,11 @@
+import pytest
+
+@pytest.fixture(scope="module")
+def conn_graph_facts(testbed_devices):
+    dut = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
+
+    base_path = os.path.dirname(os.path.realpath(__file__))
+    lab_conn_graph_file = os.path.join(base_path, "../../ansible/files/lab_connection_graph.xml")
+    conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
+    return conn_graph_facts

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -15,42 +15,41 @@ import sys
 
 import pytest
 
-from ansible_host import AnsibleHost
-from utilities import wait_until
+from platform_fixtures import conn_graph_facts
+from common.utilities import wait_until
 from check_critical_services import check_critical_services
 from check_interface_status import check_interface_status
 from check_transceiver_status import check_transceiver_basic
 from check_transceiver_status import all_transceivers_detected
 
 
-def reboot_and_check(localhost, dut, reboot_type="cold"):
+def reboot_and_check(localhost, dut, interfaces, reboot_type="cold"):
     """
     Perform the specified type of reboot and check platform status.
     """
-    dut.command("show platform summary")
-    lab_conn_graph_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), \
-        "../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file).\
-        contacted['localhost']['ansible_facts']
-    interfaces = conn_graph_facts["device_conn"]
-    asic_type = dut.shell("show platform summary | awk '/ASIC: / {print$2}'")["stdout"].strip()
-
     logging.info("Run %s reboot on DUT" % reboot_type)
     if reboot_type == "cold":
-        reboot_cmd = "sudo reboot &"
+        reboot_cmd = "reboot"
         reboot_timeout = 300
     elif reboot_type == "fast":
-        reboot_cmd = "sudo fast-reboot &"
+        reboot_cmd = "fast-reboot"
         reboot_timeout = 180
     elif reboot_type == "warm":
-        reboot_cmd = "sudo warm-reboot &"
+        reboot_cmd = "warm-reboot"
         reboot_timeout = 180
     else:
         assert False, "Reboot type %s is not supported" % reboot_type
-    dut.shell(reboot_cmd)
+    process, queue = dut.command(reboot_cmd, module_async=True)
 
     logging.info("Wait for DUT to go down")
-    localhost.wait_for(host=dut.hostname, port=22, state="stopped", delay=10, timeout=120)
+    res = localhost.wait_for(host=dut.hostname, port=22, state="stopped", delay=10, timeout=120,
+        module_ignore_errors=True)
+    if "failed" in res:
+        if process.is_alive():
+            logging.error("Command '%s' is not completed" % reboot_cmd)
+            process.terminate()
+        logging.error("reboot result %s" % str(queue.get()))
+        assert False, "DUT did not go down"
 
     logging.info("Wait for DUT to come back")
     localhost.wait_for(host=dut.hostname, port=22, state="started", delay=10, timeout=reboot_timeout)
@@ -68,18 +67,14 @@ def reboot_and_check(localhost, dut, reboot_type="cold"):
     logging.info("Check transceiver status")
     check_transceiver_basic(dut, interfaces)
 
-    if asic_type in ["mellanox"]:
+    if dut.facts["asic_type"] in ["mellanox"]:
 
         current_file_dir = os.path.dirname(os.path.realpath(__file__))
         sub_folder_dir = os.path.join(current_file_dir, "mellanox")
         if sub_folder_dir not in sys.path:
             sys.path.append(sub_folder_dir)
         from check_hw_mgmt_service import check_hw_management_service
-        from check_hw_mgmt_service import wait_until_fan_speed_set_to_default
         from check_sysfs import check_sysfs
-
-        logging.info("Wait until fan speed is set to default")
-        wait_until_fan_speed_set_to_default(dut)
 
         logging.info("Check the hw-management service")
         check_hw_management_service(dut)
@@ -88,37 +83,37 @@ def reboot_and_check(localhost, dut, reboot_type="cold"):
         check_sysfs(dut)
 
 
-def test_cold_reboot(localhost, ansible_adhoc, testbed):
+def test_cold_reboot(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
+    ans_host = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
 
-    reboot_and_check(localhost, ans_host, reboot_type="cold")
+    reboot_and_check(localhost, ans_host, conn_graph_facts["device_conn"], reboot_type="cold")
 
 
-def test_fast_reboot(localhost, ansible_adhoc, testbed):
+def test_fast_reboot(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
+    ans_host = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
 
-    reboot_and_check(localhost, ans_host, reboot_type="fast")
+    reboot_and_check(localhost, ans_host, conn_graph_facts["device_conn"], reboot_type="fast")
 
 
-def test_warm_reboot(localhost, ansible_adhoc, testbed):
+def test_warm_reboot(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    asic_type = ans_host.shell("show platform summary | awk '/ASIC: / {print$2}'")["stdout"].strip()
+    ans_host = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
+    asic_type = ans_host.facts["asic_type"]
 
     if asic_type in ["mellanox"]:
         issu_capability = ans_host.command("show platform mlnx issu")["stdout"]
         if "disabled" in issu_capability:
             pytest.skip("ISSU is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, ans_host, reboot_type="warm")
+    reboot_and_check(localhost, ans_host, conn_graph_facts["device_conn"], reboot_type="warm")

--- a/tests/platform/test_reload_config.py
+++ b/tests/platform/test_reload_config.py
@@ -10,27 +10,21 @@ import os
 import time
 import sys
 
-from ansible_host import AnsibleHost
-from utilities import wait_until
+from platform_fixtures import conn_graph_facts
+from common.utilities import wait_until
 from check_critical_services import check_critical_services
 from check_interface_status import check_interface_status
 from check_transceiver_status import check_transceiver_basic
 from check_transceiver_status import all_transceivers_detected
 
 
-def test_reload_configuration(localhost, ansible_adhoc, testbed):
+def test_reload_configuration(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to reload the configuration and check platform status
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    ans_host.command("show platform summary")
-    lab_conn_graph_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), \
-        "../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=hostname, filename=lab_conn_graph_file).\
-        contacted['localhost']['ansible_facts']
+    ans_host = testbed_devices["dut"]
     interfaces = conn_graph_facts["device_conn"]
-    asic_type = ans_host.shell("show platform summary | awk '/ASIC: / {print$2}'")["stdout"].strip()
+    asic_type = ans_host.facts["asic_type"]
 
     logging.info("Reload configuration")
     ans_host.command("sudo config reload -y")

--- a/tests/platform/test_sequential_restart.py
+++ b/tests/platform/test_sequential_restart.py
@@ -10,25 +10,20 @@ import os
 import time
 import sys
 
-from ansible_host import AnsibleHost
-from utilities import wait_until
+import pytest
+
+from platform_fixtures import conn_graph_facts
+from common.utilities import wait_until
 from check_critical_services import check_critical_services
 from check_interface_status import check_interface_status
 from check_transceiver_status import check_transceiver_basic
 from check_transceiver_status import all_transceivers_detected
 
 
-def restart_service_and_check(localhost, dut, service):
+def restart_service_and_check(localhost, dut, service, interfaces):
     """
     Restart specified service and check platform status
     """
-    dut.command("show platform summary")
-    lab_conn_graph_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), \
-        "../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file).\
-        contacted['localhost']['ansible_facts']
-    interfaces = conn_graph_facts["device_conn"]
-    asic_type = dut.shell("show platform summary | awk '/ASIC: / {print$2}'")["stdout"].strip()
 
     logging.info("Restart the %s service" % service)
     dut.command("sudo systemctl restart %s" % service)
@@ -47,7 +42,7 @@ def restart_service_and_check(localhost, dut, service):
     logging.info("Check transceiver status")
     check_transceiver_basic(dut, interfaces)
 
-    if asic_type in ["mellanox"]:
+    if dut.facts["asic_type"] in ["mellanox"]:
 
         current_file_dir = os.path.dirname(os.path.realpath(__file__))
         sub_folder_dir = os.path.join(current_file_dir, "mellanox")
@@ -63,19 +58,20 @@ def restart_service_and_check(localhost, dut, service):
         check_sysfs(dut)
 
 
-def test_restart_swss(localhost, ansible_adhoc, testbed):
+def test_restart_swss(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to restart the swss service and check platform status
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    restart_service_and_check(localhost, ans_host, "swss")
+    dut = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
+    restart_service_and_check(localhost, dut, "swss", conn_graph_facts["device_conn"])
 
 
-def test_restart_syncd(localhost, ansible_adhoc, testbed):
+@pytest.mark.skip(reason="Restarting syncd is not supported yet")
+def test_restart_syncd(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to restart the syncd service and check platform status
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    restart_service_and_check(localhost, ans_host, "syncd")
+    dut = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
+    restart_service_and_check(localhost, dut, "syncd", conn_graph_facts["device_conn"])

--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -10,7 +10,9 @@ import os
 import time
 import copy
 
-from ansible_host import AnsibleHost
+import pytest
+
+from platform_fixtures import conn_graph_facts
 
 
 def parse_output(output_lines):
@@ -42,7 +44,7 @@ def parse_eeprom(output_lines):
     return res
 
 
-def test_check_sfp_status_and_configure_sfp(localhost, ansible_adhoc, testbed):
+def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     """
     @summary: Check SFP status and configure SFP
 
@@ -54,13 +56,8 @@ def test_check_sfp_status_and_configure_sfp(localhost, ansible_adhoc, testbed):
     * show interface transceiver eeprom
     * sfputil reset <interface name>
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    localhost.command("who")
-    lab_conn_graph_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), \
-        "../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=hostname, filename=lab_conn_graph_file).\
-        contacted['localhost']['ansible_facts']
+
+    ans_host = testbed_devices["dut"]
 
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -110,7 +107,7 @@ def test_check_sfp_status_and_configure_sfp(localhost, ansible_adhoc, testbed):
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 
-def test_check_sfp_low_power_mode(localhost, ansible_adhoc, testbed):
+def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     """
     @summary: Check SFP low power mode
 
@@ -119,13 +116,7 @@ def test_check_sfp_low_power_mode(localhost, ansible_adhoc, testbed):
     * sfputil lpmode off
     * sfputil lpmode on
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    localhost.command("who")
-    lab_conn_graph_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), \
-        "../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=hostname, filename=lab_conn_graph_file).\
-        contacted['localhost']['ansible_facts']
+    ans_host = testbed_devices["dut"]
 
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_show_lpmode = "sudo sfputil show lpmode"

--- a/tests/platform/test_xcvr_info_in_db.py
+++ b/tests/platform/test_xcvr_info_in_db.py
@@ -8,52 +8,15 @@ import logging
 import re
 import os
 
-from ansible_host import AnsibleHost
 from check_transceiver_status import check_transceiver_status
+from platform_fixtures import conn_graph_facts
 
 
-def parse_transceiver_info(output_lines):
-    """
-    @summary: Parse the list of transceiver from DB table TRANSCEIVER_INFO content
-    @param output_lines: DB table TRANSCEIVER_INFO content output by 'redis' command
-    @return: Return parsed transceivers in a list
-    """
-    res = []
-    p = re.compile(r"TRANSCEIVER_INFO\|(Ethernet\d+)")
-    for line in output_lines:
-        m = p.match(line)
-        assert m, "Unexpected line %s" % line
-        res.append(m.group(1))
-    return res
-
-
-def parse_transceiver_dom_sensor(output_lines):
-    """
-    @summary: Parse the list of transceiver from DB table TRANSCEIVER_DOM_SENSOR content
-    @param output_lines: DB table TRANSCEIVER_DOM_SENSOR content output by 'redis' command
-    @return: Return parsed transceivers in a list
-    """
-    res = []
-    p = re.compile(r"TRANSCEIVER_DOM_SENSOR\|(Ethernet\d+)")
-    for line in output_lines:
-        m = p.match(line)
-        assert m, "Unexpected line %s" % line
-        res.append(m.group(1))
-    return res
-
-
-def test_xcvr_info_in_db(localhost, ansible_adhoc, testbed):
+def test_xcvr_info_in_db(testbed_devices, conn_graph_facts):
     """
     @summary: This test case is to verify that xcvrd works as expected by checking transceiver information in DB
     """
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
-    localhost.command("who")
-    lab_conn_graph_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), \
-        "../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=hostname, filename=lab_conn_graph_file).\
-        contacted['localhost']['ansible_facts']
-    interfaces = conn_graph_facts["device_conn"]
+    dut = testbed_devices["dut"]
 
     logging.info("Check transceiver status")
-    check_transceiver_status(ans_host, interfaces)
+    check_transceiver_status(dut, conn_graph_facts["device_conn"])


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Improvements:
* Add testbed_devices fixture
* Add common folder for reusable libraries
* Use OO design to abstract and encapsulate behavior for various devices in testbed
* Improve code reuse by the OO design and common libraries
* Add support to run ansible module asynchronously
* In devices.AnsibleHostBase, use the improvement of module_ignore_errors by dawnbeauty
* Update the platform scripts to use the improved pytest infrastructure
* Add a few Mellanox specific testing scripts for completeness and demonstration

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Added a `common` subfolder under `sonic-mgmt/tests` to hold common library modules. In the `sonic-mgmt/tests/common/devices.py`, added couple of classes to different devices may be used in testbed. The base class AnsibleHostBase encapsulate the behavior previously defined in ansible_host.py. Some other classes like SonicHost inherit from AnsibleHostBase. The SonicHost class can be extended with more methods for frequently used functions.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
The scripts under `sonic-mgmt/tests/platform/mellanox` are specific for Mellanox platforms. 

#### Supported testbed topology if it's a new test case?
The platform scripts support all the current topologies.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
