### PR TITLE
Make the VM reboot command async and ignore its errors

### DIFF
--- a/ansible/roles/eos/handlers/common_handlers/update_state.yml
+++ b/ansible/roles/eos/handlers/common_handlers/update_state.yml
@@ -1,5 +1,8 @@
 - name: Reboot the VM
   command: /sbin/shutdown -r now "Ansible updates triggered"
+  async: 300
+  poll: 0
+  ignore_errors: true
 
 - name: Wait for VM to shutdown
   wait_for:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The command for rebooting VM was executed synchronously.
Sometimes it could fail because the VM closed the SSH connection
before ansible finishes the reboot command. The fix is to make
the command async and ignore its errors.

Signed-off-by: Xin Wang <xinw@mellanox.com>

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Make the command for rebooting VM async and ignore its errors.

#### How did you verify/test it?
Tested using `testbed-cli.sh add-topo`.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
