### PR TITLE
[vxlan-decap]: Improvements of the test

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -195,27 +195,27 @@ class Vxlan(BaseTest):
             raise AssertionError(err)
 
     def Vxlan(self, test):
-        for n in self.net_ports:
-            for a in test['acc_ports']:
+        for i, n in enumerate(self.net_ports):
+            for j, a in enumerate(test['acc_ports']):
                 res, out = self.checkVxlan(a, n, test)
                 if not res:
-                    return False, out
+                    return False, out + " | net_port_rel=%d acc_port_rel=%d" % (i, j)
         return True, ""
 
     def RegularLAGtoVLAN(self, test):
-        for n in self.net_ports:
-            for a in test['acc_ports']:
+        for i, n in enumerate(self.net_ports):
+            for j, a in enumerate(test['acc_ports']):
                 res, out = self.checkRegularRegularLAGtoVLAN(a, n, test)
                 if not res:
-                    return False, out
+                    return False, out + " | net_port_rel=%d acc_port_rel=%d" % (i, j)
         return True, ""
 
     def RegularVLANtoLAG(self, test):
-        for dst, ports in self.pc_info:
-            for a in test['acc_ports']:
+        for i, (dst, ports) in enumerate(self.pc_info):
+            for j, a in enumerate(test['acc_ports']):
                 res, out = self.checkRegularRegularVLANtoLAG(a, ports, dst, test)
                 if not res:
-                    return False, out
+                    return False, out + " | pc_info_rel=%d acc_port_rel=%d" % (i, j)
         return True, ""
 
     def checkRegularRegularVLANtoLAG(self, acc_port, pc_ports, dst_ip, test):

--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -279,7 +279,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
-        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.2)
+        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.5)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
@@ -311,7 +311,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.2)
+        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.5)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
@@ -348,7 +348,7 @@ class Vxlan(BaseTest):
                  )
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.2)
+        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.5)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -65,7 +65,7 @@
     - name: Configure vxlan decap tunnel
       shell: sonic-cfggen -j /tmp/vxlan_db.tunnel.json --write-to-db
 
-    - name: Configure vxlan decap tunnel map for {{ item }}
+    - name: Configure vxlan decap tunnel maps
       shell: sonic-cfggen -j /tmp/vxlan_db.maps.{{ item }}.json --write-to-db
       with_items: minigraph_vlans
 
@@ -82,9 +82,9 @@
         - config_file='/tmp/vxlan_decap.json'
         - count=1
 
-    - name: Remove vxlan tunnel map configuration for {{ item }}
+    - name: Remove vxlan tunnel maps configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map{{ item }}"
-      with_items: minigraph_vlans
+      with_items: "{{ minigraph_vlans }}"
 
     - name: Remove vxlan tunnel configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"
@@ -104,9 +104,9 @@
 
 
 - always:
-    - name: Remove vxlan tunnel map configuration for {{ item }}
+    - name: Remove vxlan tunnel maps configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map{{ item }}"
-      with_items: minigraph_vlans
+      with_items: "{{ minigraph_vlans }}"
 
     - name: Remove vxlan tunnel configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. Added: Output offset of the test properties when the test failed. It does make sense when we need to understand was the port the number one for test or not
2. Added: Add warm-up before the test
3. Changed: Increase packet timeout time to 0.5 sec, to make sure python received a packet.

#### How did you verify/test it?
Run ansible test against my DUT
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
