### PR TITLE
[vxlan-decap]: Generate mapping between vlan member ports and vlan ip address robustly

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -157,7 +157,7 @@ callback_whitelist = profile_tasks
 # current IP information.
 fact_caching = jsonfile
 fact_caching_connection = ~/.ansible/cache
-fact_caching_timeout = 1200
+fact_caching_timeout = 86400
 
 
 # retry files

--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -25,6 +25,8 @@ from ptf.mask import Mask
 import datetime
 import subprocess
 import traceback
+import socket
+import struct
 from pprint import pprint
 from pprint import pformat
 
@@ -57,13 +59,39 @@ class Vxlan(BaseTest):
     def generate_ArpResponderConfig(self):
         config = {}
         for test in self.tests:
-            for port in test['acc_ports']:
-                config['eth%d' % port] = [test['vlan_ip_prefix'] % port]
+            for port, ip in test['vlan_ip_prefixes'].items():
+                config['eth%d' % port] = [ip]
 
         with open('/tmp/vxlan_arpresponder.conf', 'w') as fp:
             json.dump(config, fp)
 
         return
+
+    def generate_VlanPrefixes(self, gw, prefixlen, acc_ports):
+        res = {}
+        n_hosts = 2**(32 - prefixlen) - 3
+        nr_of_dataplane_ports = len(self.dataplane.ports)
+
+        if nr_of_dataplane_ports > n_hosts:
+            raise Exception("The prefix len size is too small for the test")
+
+        gw_addr_n = struct.unpack(">I", socket.inet_aton(gw))[0]
+        mask = (2**32 - 1) ^ (2**(32 - prefixlen) - 1)
+        net_addr_n = gw_addr_n & mask
+
+        addr = 1
+        for port in acc_ports:
+            while True:
+                host_addr_n = net_addr_n + addr
+                host_ip = socket.inet_ntoa(struct.pack(">I", host_addr_n))
+                if host_ip != gw:
+                    break
+                else:
+                    addr += 1 # skip gw
+            res[port] = host_ip
+            addr += 1
+
+        return res
 
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
@@ -117,20 +145,13 @@ class Vxlan(BaseTest):
             for d in graph['minigraph_vlan_interfaces']:
                 if d['attachto'] == name:
                     gw = d['addr']
-                    prefixlen = d['prefixlen']
+                    prefixlen = int(d['prefixlen'])
                     break
             else:
                 raise Exception("Vlan '%s' is not found" % name)
 
             test['vlan_gw'] = gw
-
-            number_of_dataplane_ports = len(self.dataplane.ports)
-            if number_of_dataplane_ports > 256:
-                raise Exception("Too much dataplane ports for the test")
-            if prefixlen > 24:
-                raise Exception("The prefix len size is too small for the test")
-
-            test['vlan_ip_prefix'] = '.'.join(gw.split('.')[0:3])+".%d"
+            test['vlan_ip_prefixes'] = self.generate_VlanPrefixes(gw, prefixlen, test['acc_ports'])
 
             self.tests.append(test)
 
@@ -150,11 +171,14 @@ class Vxlan(BaseTest):
 
         self.generate_ArpResponderConfig()
 
+        self.cmd(["supervisorctl", "restart", "arp_responder"])
+
         self.dataplane.flush()
 
         return
 
     def tearDown(self):
+        self.cmd(["supervisorctl", "stop", "arp_responder"])
         return
 
     def warmup(self):
@@ -258,7 +282,7 @@ class Vxlan(BaseTest):
     def checkRegularRegularVLANtoLAG(self, acc_port, pc_ports, dst_ip, test):
         src_mac = self.ptf_mac_addrs['eth%d' % acc_port]
         dst_mac = self.dut_mac
-        src_ip = test['vlan_ip_prefix'] % acc_port
+        src_ip = test['vlan_ip_prefixes'][acc_port]
 
         packet = simple_tcp_packet(
                          eth_dst=dst_mac,
@@ -279,7 +303,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
-        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.5)
+        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.2)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
@@ -292,7 +316,7 @@ class Vxlan(BaseTest):
         src_mac = self.random_mac
         dst_mac = self.dut_mac
         src_ip = test['src_ip']
-        dst_ip = test['vlan_ip_prefix'] % acc_port
+        dst_ip = test['vlan_ip_prefixes'][acc_port]
 
         packet = simple_tcp_packet(
                          eth_dst=dst_mac,
@@ -311,7 +335,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.5)
+        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.2)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
@@ -323,7 +347,7 @@ class Vxlan(BaseTest):
         inner_dst_mac = self.ptf_mac_addrs['eth%d' % acc_port]
         inner_src_mac = self.dut_mac
         inner_src_ip = test['vlan_gw']
-        inner_dst_ip = test['vlan_ip_prefix'] % acc_port
+        inner_dst_ip = test['vlan_ip_prefixes'][acc_port]
         dst_mac = self.dut_mac
         src_mac = self.random_mac
         ip_dst = self.loopback_ip
@@ -348,7 +372,7 @@ class Vxlan(BaseTest):
                  )
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.5)
+        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.2)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -89,7 +89,7 @@
 
     - name: Remove vxlan tunnel maps configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map{{ item }}"
-      with_items: "{{ minigraph_vlans }}"
+      with_items: minigraph_vlans
 
     - name: Remove vxlan tunnel configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"
@@ -110,7 +110,7 @@
 - always:
     - name: Remove vxlan tunnel maps configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map{{ item }}"
-      with_items: "{{ minigraph_vlans }}"
+      with_items: minigraph_vlans
 
     - name: Remove vxlan tunnel configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -31,10 +31,6 @@
       vars:
         supervisor_host: "{{ ptf_host }}"
 
-    - name: Start arpresponder
-      supervisorctl: state=restarted name=arp_responder
-      delegate_to: "{{ ptf_host }}"
-
     - name: Restart DUT. Wait 240 seconds after SONiC started ssh
       include: reboot.yml
       vars:
@@ -50,9 +46,6 @@
     - name: Render DUT vxlan configuration. Tunnel Maps
       template: src=vxlan_db.maps.json.j2 dest=/tmp/vxlan_db.maps.{{ item }}.json
       with_items: minigraph_vlans
-
-    - name: Wait for some time until arp cache is ready
-      pause: seconds=50
 
     - include: ptf_runner.yml
       vars:
@@ -114,7 +107,3 @@
 
     - name: Remove vxlan tunnel configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"
-
-    - name: Stop arpresponder
-      supervisorctl: state=stopped name=arp_responder
-      delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -96,9 +96,16 @@
    - net.bridge.bridge-nf-call-ip6tables
    - net.bridge.bridge-nf-call-iptables
 
-- name: Set sysctl RCVBUF parameter for testbed
+- name: Set sysctl RCVBUF max parameter for testbed
   sysctl:
     name: "net.core.rmem_max"
+    value: 509430500
+    sysctl_set: yes
+  become: yes
+
+- name: Set sysctl RCVBUF default parameter for testbed
+  sysctl:
+    name: "net.core.rmem_default"
     value: 509430500
     sysctl_set: yes
   become: yes

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -96,16 +96,9 @@
    - net.bridge.bridge-nf-call-ip6tables
    - net.bridge.bridge-nf-call-iptables
 
-- name: Set sysctl RCVBUF max parameter for testbed
+- name: Set sysctl RCVBUF parameter for testbed
   sysctl:
     name: "net.core.rmem_max"
-    value: 509430500
-    sysctl_set: yes
-  become: yes
-
-- name: Set sysctl RCVBUF default parameter for testbed
-  sysctl:
-    name: "net.core.rmem_default"
     value: 509430500
     sysctl_set: yes
   become: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. Generate ip addresses for vlan member ports in robust way.
2. Increase fact cache timeout to a day. Otherwise ansible forget variables during the test
3. Remove quotes around minigraph_vlans which were introduced to fix Item.2
4. Start/stop the arp_responder from ptf test, when the information was generated properly.
5. Wait 0.2 sec for every packet series.

#### How did you verify/test it?
run a test on your dut

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

