### PR TITLE
Fixed the warm-reboot testcase pingDut script leading the DUT fdb-entrys flapping issue.

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -2,7 +2,14 @@
 
 set -e
 
+ppm_map_file="/tmp/ptf_ports_mmp.json"
+echo -n "{" > $ppm_map_file
 for INTF in $(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}'); do
+    if [ ${INTF##eth} != 0 ]
+    then
+        echo -n "," >> $ppm_map_file
+    fi
+    
     ADDR="$(ip -br link show dev ${INTF} | awk '{print $3}')"
     PREFIX="$(cut -c1-15 <<< ${ADDR})"
     SUFFIX="$(printf "%02x" ${INTF##eth})"
@@ -10,4 +17,7 @@ for INTF in $(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}'
 
     echo "Update ${INTF} MAC address: ${ADDR}->$MAC"
     ip link set dev ${INTF} address ${MAC}
+    
+    echo -n "\"${INTF##eth}\": \"${MAC}\"" >> $ppm_map_file
 done
+echo -n "}" >> $ppm_map_file

--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -16,6 +16,7 @@
         - portchannel_ports_file=\"/tmp/portchannel_interfaces.json\"
         - vlan_ports_file=\"/tmp/vlan_interfaces.json\"
         - ports_file=\"/tmp/ports.json\"
+        - ports_mmp_file=\"/tmp/ptf_ports_mmp.json\"
         - dut_mac='{{ dut_mac }}'
         - dut_vlan_ip='192.168.0.1'
         - default_ip_range='192.168.0.0/16'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The advanced-reboot.py script pingDut() function leaded the DUT fdb-entrys flapping in running the warm-reboot testing, that maybe have some disturbing to the warm-reboot. 
### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [√] Test case(new/improvement)

### Approach
#### How did you do it?
Change the ping packet's src mac address to the same mac address of the sending ptf's port.
#### How did you verify/test it?
Running the warm-reboot testing on our testbed environment.
TASK [test : debug] ************************************************************
task path: /var/clsnet/git-sw-csa/sonic-mgmt/mymgmt/sonic-mgmt/ansible/roles/test/tasks/test_sonic_by_testname.yml:44
Thursday 05 September 2019  08:48:06 +0000 (0:00:00.227)       0:08:40.862 ****
ok: [cel-seastone-01] => {
    "msg": [
        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
        "!!!!!!!!!!!!!!!!!!!! end running test warm-reboot !!!!!!!!!!!!!!!!!!!!!!",
        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
    ]
}

TASK [test : include] **********************************************************
task path: /var/clsnet/git-sw-csa/sonic-mgmt/mymgmt/sonic-mgmt/ansible/roles/test/tasks/main.yml:8
Thursday 05 September 2019  08:48:06 +0000 (0:00:00.034)       0:08:40.896 ****
skipping: [cel-seastone-01] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

PLAY ***************************************************************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
cel-seastone-01            : ok=88   changed=22   unreachable=0    failed=0

Thursday 05 September 2019  08:48:06 +0000 (0:00:00.033)       0:08:40.931 ****
===============================================================================
TASK: test : command -------------------------------------------------- 488.83s
TASK: test : set authorized key taken from file ------------------------- 2.76s
TASK: test : Copy tests to the PTF container ---------------------------- 1.91s
TASK: test : gather system version information -------------------------- 1.81s
TASK: setup ------------------------------------------------------------- 0.99s
TASK: test : Verify port channel interfaces are up correctly ------------ 0.95s
TASK: test : Warm-reboot test ------------------------------------------- 0.92s
TASK: test : Copy pcap files from ptf to the local box /tmp/ ------------ 0.88s
TASK: test : Get interface facts ---------------------------------------- 0.81s
TASK: test : Get interface facts ---------------------------------------- 0.78s
TASK: test : validate all interfaces are up after test ------------------ 0.75s
TASK: test : Fetch result files from switch to ansible machine ---------- 0.70s
TASK: test : debug ------------------------------------------------------ 0.66s
TASK: test : Verify port channel interfaces are up correctly ------------ 0.64s
TASK: test : Get process information in syncd docker -------------------- 0.63s
TASK: test : Get process information in syncd docker -------------------- 0.60s
TASK: test : Update supervisor configuration ---------------------------- 0.55s
TASK: test : Reread supervisor configuration ---------------------------- 0.54s
TASK: test : validate all interfaces are up ----------------------------- 0.52s
TASK: test : Extract all syslog entries since the last reboot ----------- 0.51s

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
