### PR TITLE
[platform/reboot] Fix the reboot stuck issue

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -9,7 +9,7 @@ We can consider using netmiko for interacting with the VMs used in testing.
 """
 import json
 import logging
-from multiprocessing import Process, Queue
+from multiprocessing.pool import ThreadPool
 
 from errors import RunAnsibleModuleFail
 from errors import UnsupportedAnsibleModule
@@ -44,13 +44,11 @@ class AnsibleHostBase(object):
         module_async = complex_args.pop('module_async', False)
 
         if module_async:
-            q = Queue()
-            def run_module(queue, module_args, complex_args):
-                res = self.module(*module_args, **complex_args)
-                q.put(res[self.hostname])
-            p = Process(target=run_module, args=(q, module_args, complex_args))
-            p.start()
-            return p, q
+            def run_module(module_args, complex_args):
+                return self.module(*module_args, **complex_args)[self.hostname]
+            pool = ThreadPool()
+            result = pool.apply_async(run_module, (module_args, complex_args))
+            return pool, result
 
         res = self.module(*module_args, **complex_args)[self.hostname]
         if res.is_failed and not module_ignore_errors:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test_reboot.py script may stuck like for ever while rebooting the SONiC switch.

Reason:
Some switch may need more time to go down after the reboot
command is issued. If switch does not go down in time, terminating the
multiprocessing.Process could stuck. The terminate() call sends SIGTERM
which is not able to terminate the asynchronous process.

The fix:
1. Increase the timeout to wait for switch to go down.
2. Replace multiprocessing.Process with multiprocessing.pool.ThreadPool.
3. Try to kill any reboot process on the switch if switch does not go down
in time.
4. On switch that reboot fast, the wait_for module may fail to detect
that the switch was down for rebooting. Ignore the error of waiting
for switch to go down.
5. Use uptime to verify whether switch has rebooted.
### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
1. Increase the timeout to wait for switch to go down.
2. Replace multiprocessing.Process with multiprocessing.pool.ThreadPool.
3. Try to kill any reboot process on the switch if switch does not go down
in time.
4. On switch that reboot fast, the wait_for module may fail to detect
that the switch was down for rebooting. Ignore the error of waiting
for switch to go down.
5. Use uptime to verify whether switch has rebooted.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
