### PR TITLE
[201811] backport #1026 to 201811

### DIFF
--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -40,6 +40,7 @@ RETURN = '''
                 "name": "Ethernet0"
                 "speed": "40G"
                 "alias": "fortyGigE1/1/1"
+                "vlan": "routed"
                 "oper_state": "down"
                 "admin_state": "up"
                 }
@@ -82,7 +83,7 @@ class ShowInterfaceModule(object):
         self.module.exit_json(ansible_facts=self.facts)
 
     def collect_interface_status(self):
-        regex_int = re.compile(r'(\S+)\s+[\d,]+\s+(\w+)\s+(\d+)\s+([\w\/]+)\s+(\w+)\s+(\w+)')
+        regex_int = re.compile(r'(\S+)\s+[\d,N\/A]+\s+(\w+)\s+(\d+)\s+([\w\/]+)\s+(\w+)\s+(\w+)\s+(\w+)')
         self.int_status = {}
         if self.m_args['interfaces'] is not None:
             for interface in self.m_args['interfaces']:
@@ -96,8 +97,9 @@ class ShowInterfaceModule(object):
                             self.int_status[interface]['name'] = regex_int.match(line).group(1)
                             self.int_status[interface]['speed'] = regex_int.match(line).group(2)
                             self.int_status[interface]['alias'] = regex_int.match(line).group(4)
-                            self.int_status[interface]['oper_state'] = regex_int.match(line).group(5)
-                            self.int_status[interface]['admin_state'] = regex_int.match(line).group(6)
+                            self.int_status[interface]['vlan'] = regex_int.match(line).group(5)
+                            self.int_status[interface]['oper_state'] = regex_int.match(line).group(6)
+                            self.int_status[interface]['admin_state'] = regex_int.match(line).group(7)
                     self.facts['int_status'] = self.int_status
                 except Exception as e:
                     self.module.fail_json(msg=str(e))
@@ -114,8 +116,9 @@ class ShowInterfaceModule(object):
                         self.int_status[interface]['name'] = interface
                         self.int_status[interface]['speed'] = regex_int.match(line).group(2)
                         self.int_status[interface]['alias'] = regex_int.match(line).group(4)
-                        self.int_status[interface]['oper_state'] = regex_int.match(line).group(5)
-                        self.int_status[interface]['admin_state'] = regex_int.match(line).group(6)
+                        self.int_status[interface]['vlan'] = regex_int.match(line).group(5)
+                        self.int_status[interface]['oper_state'] = regex_int.match(line).group(6)
+                        self.int_status[interface]['admin_state'] = regex_int.match(line).group(7)
                 self.facts['int_status'] = self.int_status
             except Exception as e:
                 self.module.fail_json(msg=str(e))

--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -31,32 +31,32 @@
   - name: init loganalyzer for later syslog analysis
     include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
 
-  - name: gather DUT arp table
-    switch_arptable:
+  - name: gather DUT interface table
+    show_interface: command='status'
+
+  # To pick an interface which is up and a routing interface for the test.
+  # For a routing interface, the item.value['vlan'] contains string 'routed'.
+  # The key name 'vlan' aligns with the title of column where its data comes.
+  # It doesn't mean to use a 'vlan' interface for the test.
+  - name: select A routing interface for testing
+    set_fact:
+      routing_interface: "{{ item.key }}"
+    with_dict: "{{int_status}}"
+    when:
+      - ('routed' in item.value['vlan'] and 'up' in item.value['oper_state'])
+      - int_status | length != 0
 
   ########## Test V4 mac address change #################
-  - name: pick IPv4 neighbor to test change mac behavior
+  - name: pick {{routing_interface}} to test change mac behavior
     set_fact:
-      v4_nei: "{{ item.key }}"
-      v4_intf: "{{ item.value['interface'] }}"
-    with_dict: "{{ arptable.v4 }}"
-    when:
-      - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
-      - arptable.v4 | length != 0
-
-  - name: select Ethernet0 if cannot find an v4 neighbor for test
-    set_fact:
-      v4_intf: "Ethernet0"
+      v4_intf: "{{routing_interface}}"
       v4_nei: "{{ v4_intf_nei }}"
-    when: v4_nei is not defined
 
-  - name: add an ip entry for Ethernet0
-    command: "/sbin/ifconfig Ethernet0 {{ v4_intf_ip }}"
-    when: v4_nei is not defined
+  - name: add an ip entry for {{v4_intf}}
+    command: "config interface ip add {{ v4_intf }} {{ v4_intf_ip }}"
 
-  - name: add neighbor of Ethernet0
-    command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev Ethernet0"
-    when: v4_nei is not defined
+  - name: add neighbor for {{v4_intf}}
+    command: "/sbin/ip neigh add {{ v4_intf_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
 
   - name: change v4 neighbor mac address 1st time
     command: "ip neigh change {{ v4_nei }} lladdr {{ v4_mac1 }} dev {{ v4_intf }}"
@@ -91,29 +91,16 @@
   - assert: { that: "neighbour_mac.stdout | lower == v4_mac2" }
 
   ############## Test V6 mac change   ##################
-  - name: pick IPv6 neighbor to test change mac address"
+  - name: pick {{routing_interface}} as test interface
     set_fact:
-      v6_nei: "{{ item.key }}"
-      v6_intf: "{{ item.value['interface'] }}"
-    with_dict: "{{ arptable.v6 }}"
-    when:
-       - "'fe80::' not in  item.key | lower"
-       - ('Ethernet' in item.value['interface']) or ('PortChannel' in item.value['interface'])
-       - arptable.v6 | length != 0
-
-  - name: pick Ethernet0 as test interface if cannot fine v6 neighbor to test
-    set_fact:
-      v6_intf: "Ethernet0"
+      v6_intf: "{{routing_interface}}"
       v6_nei: "{{ v6_intf_nei }}"
-    when: v6_nei is not defined
 
-  - name: add an ipv6 entry for Ethernet0 if not find v6 neighbor
-    command: "/sbin/ifconfig Ethernet0 inet6 add {{ v6_intf_ip }}"
-    when: v6_nei is not defined
+  - name: add an ipv6 entry for {{v6_intf}}
+    command: "config interface ip add {{v6_intf}} {{ v6_intf_ip }}"
 
-  - name: add an ipv6 neighbor of Ethernet0 if not find v6 neighbor to test
-    command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev Ethernet0"
-    when: v6_nei is not defined
+  - name: add an ipv6 neighbor for {{v6_intf}}
+    command: "/sbin/ip neigh add {{ v6_intf_nei }} lladdr {{ v6_mac1 }} dev {{v6_intf}}"
 
   - name: change v6 neighbor mac address 1st time
     command: "ip -6 neigh change {{ v6_nei }} lladdr {{ v6_mac1 }} dev {{ v6_intf }}"


### PR DESCRIPTION
[neighbour-mac-noptf] Fix issue 2414 by always using static arp/neighbour entry (#1026)

### Description of PR
Backport #1026 to 201811
Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
