### PR TITLE
Fix the exit code return issue in shell scripts

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
-for INTF in $(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}'); do
+INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+
+for INTF in ${INTF_LIST}; do
     ADDR="$(ip -br link show dev ${INTF} | awk '{print $3}')"
     PREFIX="$(cut -c1-15 <<< ${ADDR})"
     SUFFIX="$(printf "%02x" ${INTF##eth})"

--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
 INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
 

--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
-for INTF in $(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}'); do
+INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+
+for INTF in ${INTF_LIST}; do
     echo "Flush ${INTF} IP address"
     ip addr flush dev ${INTF}
 done

--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
 INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
 

--- a/tests/scripts/change_mac.sh
+++ b/tests/scripts/change_mac.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
-for INTF in $(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}'); do
+INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+
+for INTF in ${INTF_LIST}; do
     ADDR="$(ip -br link show dev ${INTF} | awk '{print $3}')"
     PREFIX="$(cut -c1-15 <<< ${ADDR})"
     SUFFIX="$(printf "%02x" ${INTF##eth})"

--- a/tests/scripts/change_mac.sh
+++ b/tests/scripts/change_mac.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
 INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
 

--- a/tests/scripts/remove_ip.sh
+++ b/tests/scripts/remove_ip.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
-INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+INTF_IDX_LIST=$(cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}')
 
-for INTF in ${INTF_LIST}; do
-    echo "Flush ${INTF} IP address"
-    ip addr flush dev ${INTF}
+for i in $INTF_IDX_LIST; do
+  ip address flush dev eth$i
 done

--- a/tests/scripts/remove_ip.sh
+++ b/tests/scripts/remove_ip.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
-for i in `cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}'`; do
-  ip address flush dev eth$i
+INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+
+for INTF in ${INTF_LIST}; do
+    echo "Flush ${INTF} IP address"
+    ip addr flush dev ${INTF}
 done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

In shell script, by default exit code of the last command
in commands connected by pipe is returned. If previous
command returned none zero exit code, the error is
not captured. If ansible run such script in playbook, the
script issue is ignored and ansible is not aware of it.

For example, block in fdb.yml:
```
  - name: Remove existing IPs from PTF host
    script: roles/test/files/helpers/remove_ip.sh
    delegate_to: "{{ptf_host}}" 
```

fails to detect issue which looks in log like this:
```
02:09:48 TASK [test : Remove existing IPs from PTF host] ********************************
02:09:48 task path: /builds2/jenkins2/workspace/SONiC_Test-FDB/ansible/roles/test/tasks/fdb.yml:11
02:09:48 Thursday 25 July 2019  23:09:48 +0000 (0:00:00.297)       0:00:13.829 ********* 
02:09:48 <10.213.103.5> ESTABLISH SSH CONNECTION FOR USER: root
02:09:48 <10.213.103.5> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)
02:09:48 <10.213.103.5> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
02:09:48 <10.213.103.5> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User=root)
02:09:48 <10.213.103.5> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=30)
02:09:48 <10.213.103.5> SSH: PlayContext set ssh_common_args: ()
02:09:48 <10.213.103.5> SSH: PlayContext set ssh_extra_args: ()
02:09:48 <10.213.103.5> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
02:09:48 <10.213.103.5> SSH: EXEC sshpass -d14 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=30 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r -tt 10.213.103.5 'mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1564096188.49-246685053741557 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1564096188.49-246685053741557 )"'
02:10:11 <10.213.103.5> PUT /builds2/jenkins2/workspace/SONiC_Test-FDB/ansible/roles/test/files/helpers/remove_ip.sh TO /root/.ansible/tmp/ansible-tmp-1564096188.49-246685053741557/remove_ip.sh
02:10:11 <10.213.103.5> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)
02:10:11 <10.213.103.5> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
02:10:11 <10.213.103.5> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User=root)
02:10:11 <10.213.103.5> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=30)
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_common_args: ()
02:10:11 <10.213.103.5> SSH: PlayContext set sftp_extra_args: ()
02:10:11 <10.213.103.5> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
02:10:11 <10.213.103.5> SSH: EXEC sshpass -d14 sftp -b - -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=30 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r '[10.213.103.5]'
02:10:11 <10.213.103.5> ESTABLISH SSH CONNECTION FOR USER: root
02:10:11 <10.213.103.5> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)
02:10:11 <10.213.103.5> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
02:10:11 <10.213.103.5> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User=root)
02:10:11 <10.213.103.5> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=30)
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_common_args: ()
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_extra_args: ()
02:10:11 <10.213.103.5> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
02:10:11 <10.213.103.5> SSH: EXEC sshpass -d14 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=30 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r -tt 10.213.103.5 'chmod +rx /root/.ansible/tmp/ansible-tmp-1564096188.49-246685053741557/remove_ip.sh'
02:10:11 <10.213.103.5> ESTABLISH SSH CONNECTION FOR USER: root
02:10:11 <10.213.103.5> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)
02:10:11 <10.213.103.5> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
02:10:11 <10.213.103.5> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User=root)
02:10:11 <10.213.103.5> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=30)
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_common_args: ()
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_extra_args: ()
02:10:11 <10.213.103.5> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
02:10:11 <10.213.103.5> SSH: EXEC sshpass -d14 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=30 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r -tt 10.213.103.5 'LANG=C LC_ALL=C LC_MESSAGES=C /root/.ansible/tmp/ansible-tmp-1564096188.49-246685053741557/remove_ip.sh '
02:10:11 <10.213.103.5> ESTABLISH SSH CONNECTION FOR USER: root
02:10:11 <10.213.103.5> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)
02:10:11 <10.213.103.5> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
02:10:11 <10.213.103.5> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User=root)
02:10:11 <10.213.103.5> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=30)
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_common_args: ()
02:10:11 <10.213.103.5> SSH: PlayContext set ssh_extra_args: ()
02:10:11 <10.213.103.5> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
02:10:11 <10.213.103.5> SSH: EXEC sshpass -d14 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=30 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r -tt 10.213.103.5 'rm -f -r /root/.ansible/tmp/ansible-tmp-1564096188.49-246685053741557/ > /dev/null 2>&1'
02:10:11 changed: [r-anaconda-10-t0 -> 10.213.103.5] => {"changed": true, "invocation": {"module_args": {"_raw_params": "roles/test/files/helpers/remove_ip.sh"}, "module_name": "script"}, "rc": 0, "stderr": "OpenSSH_7.2p2 Ubuntu-4ubuntu2.4, OpenSSL 1.0.2g  1 Mar 2016\r\ndebug1: Reading configuration data /root/.ssh/config\r\ndebug1: /root/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 43070\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\nShared connection to 10.213.103.5 closed.\r\n", "stdout": "Option \"-br\" is unknown, try \"ip -help\".\r\n", "stdout_lines": ["Option \"-br\" is unknown, try \"ip -help\"."]}
02:10:11 
02:10:11 TASK [test : Set unique MACs to PTF interfaces] ********************************
02:10:11 task path: /builds2/jenkins2/workspace/SONiC_Test-FDB/ansible/roles/test/tasks/fdb.yml:15
...
```
Error message is "Option "-br" is unknown, try "ip -help". But test continues because return code of the script is 0.

The fix is to add "set -o pipefail" in shell scripts. And put the commands embedded in for loop statement to a separate statement. Then the script can exit early and return none zero exit code if the "ip" command failed.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
The fix is to add "set -o pipefail" in shell scripts. And
put the commands embedded in for loop statement
to a separate statement.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
