### PR TITLE
Beautify minigraph generator: align code output

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -59,7 +59,7 @@
 {% set vlan_intf_str=';'.join(vlan_intfs) %}
         <VlanInterface>
           <Name>Vlan1000</Name>
-           <AttachTo>{{ vlan_intf_str }}</AttachTo>
+          <AttachTo>{{ vlan_intf_str }}</AttachTo>
           <NoDhcpRelay>False</NoDhcpRelay>
           <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
           <Type i:nil="true"/>
@@ -122,7 +122,7 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
-{%- if enable_data_plane_acl|default('true')|bool %}
+{% if enable_data_plane_acl|default('true')|bool %}
         <AclInterface>
           <AttachTo>
 {%- for index in range(vms_number) %}
@@ -130,7 +130,7 @@
 PortChannel{{ ((index+1) |string).zfill(4) }}{% if not loop.last %};{% endif %}
 {% endif %}
 {% endfor %}
-{%- for index in range(vms_number) %}
+{% for index in range(vms_number) %}
 {% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf']|lower %}
 {{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][0]] }}{% if not loop.last %};{% endif %}
 {% endif %}
@@ -139,7 +139,7 @@ PortChannel{{ ((index+1) |string).zfill(4) }}{% if not loop.last %};{% endif %}
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-{% endif -%}
+{% endif %}
       </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

### Description of PR
Improved minigraph config generator: aligned code output

### Type of change
- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
* Fixed jinja2 templates

#### How did you verify/test it?
* Tested with the next topologies: t0/t1/t1-lag/ptf32
```xml
diff --git a/test/sonic.ptf32.xml b/test/sonic.ptf32.xml
index c807734..62e5f1e 100644
--- a/test/sonic.ptf32.xml
+++ b/test/sonic.ptf32.xml
@@ -1364,12 +1364,13 @@
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
-        </AclInterface>        <AclInterface>
+        </AclInterface>
+        <AclInterface>
           <AttachTo>etp17a;etp1;etp17b;etp2;etp17c;etp3;etp17d;etp4;etp21a;etp5;etp21b;etp6;etp23;etp7;etp24;etp8;etp25;etp9;etp26;etp10;etp27;etp11;etp28;etp12;etp29;etp13;etp30;etp14;etp31;etp15;etp32;etp16</AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-</AclInterfaces>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
diff --git a/test/sonic.t0.xml b/test/sonic.t0.xml
index 3c4d64e..e437765 100644
--- a/test/sonic.t0.xml
+++ b/test/sonic.t0.xml
@@ -220,7 +220,7 @@
       <VlanInterfaces>
         <VlanInterface>
           <Name>Vlan1000</Name>
-           <AttachTo>etp2;etp3;etp4;etp5;etp6;etp7;etp8;etp9;etp10;etp11;etp12;etp13;etp14;etp15;etp16;etp17a;etp17b;etp17c;etp17d;etp21a;etp21b;etp23;etp24;etp25</AttachTo>
+          <AttachTo>etp2;etp3;etp4;etp5;etp6;etp7;etp8;etp9;etp10;etp11;etp12;etp13;etp14;etp15;etp16;etp17a;etp17b;etp17c;etp17d;etp21a;etp21b;etp23;etp24;etp25</AttachTo>
           <NoDhcpRelay>False</NoDhcpRelay>
           <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
           <Type i:nil="true"/>
@@ -298,12 +298,13 @@
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
-        </AclInterface>        <AclInterface>
+        </AclInterface>
+        <AclInterface>
           <AttachTo>PortChannel0001;PortChannel0002;PortChannel0003;PortChannel0004</AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-</AclInterfaces>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
diff --git a/test/sonic.t1-lag.xml b/test/sonic.t1-lag.xml
index ae20f7d..02b30ca 100644
--- a/test/sonic.t1-lag.xml
+++ b/test/sonic.t1-lag.xml
@@ -1084,12 +1084,13 @@
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
-        </AclInterface>        <AclInterface>
+        </AclInterface>
+        <AclInterface>
           <AttachTo>PortChannel0002;PortChannel0005;PortChannel0008;PortChannel0011;PortChannel0014;PortChannel0017;PortChannel0020;PortChannel0023;etp17a;etp17b;etp17c;etp17d;etp21a;etp21b;etp23;etp24;etp25;etp26;etp27;etp28;etp29;etp30;etp31;etp32</AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-</AclInterfaces>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
diff --git a/test/sonic.t1.xml b/test/sonic.t1.xml
index 9cfa9c9..196dbbf 100644
--- a/test/sonic.t1.xml
+++ b/test/sonic.t1.xml
@@ -1364,12 +1364,13 @@
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
-        </AclInterface>        <AclInterface>
+        </AclInterface>
+        <AclInterface>
           <AttachTo>etp17a;etp1;etp17b;etp2;etp17c;etp3;etp17d;etp4;etp21a;etp5;etp21b;etp6;etp23;etp7;etp24;etp8;etp25;etp9;etp26;etp10;etp27;etp11;etp28;etp12;etp29;etp13;etp30;etp14;etp31;etp15;etp32;etp16</AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-</AclInterfaces>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
```

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
* N/A