### PR TITLE
[fast/warm-reboot] Avoid the FDB clear

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -22,9 +22,6 @@
       vars:
         supervisor_host: "{{ ptf_host }}"
 
-    - name: Clear FDB entries on the DUT
-      command: sonic-clear fdb all
-
     - include: ptf_runner.yml
       vars:
         ptf_test_name: Advanced-reboot test


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

Summary:
Fixes # (issue)
t1->server packet loss was seen. Do not clear FDB entries before fast/warm reboot

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

#### How did you verify/test it?
Ran warm-reboot, fast reboot and vlan port sad path case (clear FDB was introduced was this case). No longer seeing t1->servers packet loss
