### PR TITLE
Fix the exit code return issue in shell scripts - 201811

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-for i in $(ifconfig | grep eth | cut -f 1 -d ' ')
-do
+set -euo pipefail
+
+INTF_LIST=$(ifconfig | grep eth | cut -f 1 -d ' ')
+
+for i in ${INTF_LIST}; do
   prefix=$(ifconfig $i | grep HWaddr | cut -c39-53)
   suffix=$( printf "%02x" ${i##eth})
-  mac=$prefix$suffix  
+  mac=$prefix$suffix
   echo $i $mac
   ifconfig $i hw ether $mac
 done

--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-for i in `cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}'`; do
+INTF_IDX_LIST=$(cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}')
+
+for i in ${INTF_IDX_LIST}; do
+  echo "Flush eth${i} IP address"
   ip address flush dev eth$i
 done

--- a/tests/scripts/change_mac.sh
+++ b/tests/scripts/change_mac.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-for INTF in $(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}'); do
-    ADDR="$(ip -br link show dev ${INTF} | awk '{print $3}')"
-    PREFIX="$(cut -c1-15 <<< ${ADDR})"
-    SUFFIX="$(printf "%02x" ${INTF##eth})"
-    MAC="${PREFIX}${SUFFIX}"
+INTF_LIST=$(ifconfig | grep eth | cut -f 1 -d ' ')
 
-    echo "Update ${INTF} MAC address: ${ADDR}->$MAC"
-    ip link set dev ${INTF} address ${MAC}
+for i in ${INTF_LIST}; do
+  prefix=$(ifconfig $i | grep HWaddr | cut -c39-53)
+  suffix=$( printf "%02x" ${i##eth})
+  mac=$prefix$suffix
+  echo $i $mac
+  ifconfig $i hw ether $mac
 done

--- a/tests/scripts/remove_ip.sh
+++ b/tests/scripts/remove_ip.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-for i in `cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}'`; do
+INTF_IDX_LIST=$(cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}')
+
+for i in ${INTF_IDX_LIST}; do
+  echo "Flush eth${i} IP address"
   ip address flush dev eth$i
 done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to pick the change of https://github.com/Azure/sonic-mgmt/pull/1107 into 201811 branch because of merging conflict.

In shell script, by default exit code of the last command
in commands connected by pipe is returned. If previous
command returned none zero exit code, the error is
not captured. If ansible run such script in playbook, the
script issue is ignored and ansible is not aware of it.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
The fix is to add "set -o pipefail" in shell scripts. And
put the commands embedded in for loop statement
to a separate statement.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
