### PR TITLE
[platform] Disable log analyzer for the reload and restart cases

### DIFF
--- a/tests/platform/test_reload_config.py
+++ b/tests/platform/test_reload_config.py
@@ -5,16 +5,18 @@ This script is to cover the test case 'Reload configuration' in the SONiC platfo
 https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
-import re
 import os
-import time
 import sys
+
+import pytest
 
 from platform_fixtures import conn_graph_facts
 from common.utilities import wait_until
 from check_critical_services import check_critical_services
 from check_transceiver_status import check_transceiver_basic
 from check_all_interface_info import check_interface_information
+
+pytestmark = [pytest.mark.disable_loganalyzer]
 
 
 def test_reload_configuration(testbed_devices, conn_graph_facts):

--- a/tests/platform/test_sequential_restart.py
+++ b/tests/platform/test_sequential_restart.py
@@ -5,9 +5,7 @@ This script is to cover the test case 'Sequential syncd/swss restart' in the SON
 https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
-import re
 import os
-import time
 import sys
 
 import pytest
@@ -17,6 +15,9 @@ from common.utilities import wait_until
 from check_critical_services import check_critical_services
 from check_transceiver_status import check_transceiver_basic
 from check_all_interface_info import check_interface_information
+
+pytestmark = [pytest.mark.disable_loganalyzer]
+
 
 def restart_service_and_check(localhost, dut, service, interfaces):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Log analyzer is automatically enabled for all test cases. It is inappropriate to have log analyzer
enabled for the config reload and service restart test case. This would cause some unnecessary
testing failures.

The change is to disable log analyzer for test_reload_config.py and test_sequential_restart.py.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Disabled log analyzer for test_reload_config.py and test_sequential_restart.py.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
