### PR TITLE
[fdb] More strict checking of FDB entry count

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_test.py
@@ -106,7 +106,7 @@ class FdbConfigReloadTest(BaseTest):
     #--------------------------------------------------------------------------
 
     def runTest(self):
-        max_time = 200  # seconds
+        max_time = 300  # seconds
         i = 0
         start_time = time.time()
         while i < 0xffff - 128 and time.time() - start_time < max_time:

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -161,3 +161,7 @@
     when: sdk_fdb_count.stdout != show_mac_output.stdout
 
   when: sonic_asic_type == 'mellanox'
+
+  always:
+    - name: clear FDB table
+      command: sonic-clear fdb all

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -120,8 +120,9 @@
     poll: 0
 
   - name: Reload config
-    command: config reload -y
-    become: yes
+    include: "roles/test/tasks/common_tasks/reload_config.yml"
+    vars:
+      config_source: "config_db"
 
   - name: Get PID of the PTF script
     command: "pgrep -f '/usr/bin/python /usr/bin/ptf'"
@@ -152,6 +153,9 @@
   - name: clear FDB table when test case pass
     command: sonic-clear fdb all
     when: sdk_fdb_count.stdout == show_mac_output.stdout
+
+  - fail: msg="No FDB is learned, something wrong with the switch"
+    when: sdk_fdb_count.stdout | int == 0 or show_mac_output.stdout | int == 0
 
   - fail: msg="In consistent number MAC entries between SDK and DB"
     when: sdk_fdb_count.stdout != show_mac_output.stdout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In the FdbConfigReloadTest, we observed that the SDK
FDB count and number of MACs in "show mac" output
may be 0. And the test still passed because of "0 == 0".

This fix is to have more strict checking of the FDB entry
number. If any of the FDB count is 0, fail the test.

What's more, the reason of 0 FDB count is that config
reloading takes longer than before. The PTF script has
stopped running when FDB was cleared during config
reloading. The fix is to increase the PTF script running
time from 200 seconds to 300 seconds.

The third change is to replace raw config reloading
command with calling common_tasks/reload_config.yml


### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
* Increae PTF running time from 200s to 300s.
* Replace executing config reload command with calling a task to do config reload.
* Check the number of FDB entries learned after reboot. Fail the test if the number is 0.

#### How did you verify/test it?
Tested on Mellanox platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
