### PR TITLE
Update external_port.yml to make it success to set external_port's mtu value

### DIFF
--- a/ansible/roles/vm_set/tasks/external_port.yml
+++ b/ansible/roles/vm_set/tasks/external_port.yml
@@ -4,7 +4,10 @@
   become: yes
   register: external_port_cfg
 
+- name: Set temp var to the {{ external_port }} configure file
+  set_fact: conf_file="/etc/network/interfaces.d/external_port"
+
 - name: bring up external port
-  shell: /sbin/ifup {{ external_port }} --force
+  shell: /sbin/ifup {{ external_port }} --force -i {{ conf_file }}
   become: yes
   when: external_port_cfg.changed


### PR DESCRIPTION
Miss the config file for setting the external_port parameter, so the old version could not set the interface's mtu value correctly!

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [√] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Use our own testbed environment to run add-topo function , and succeed setting the mtu value.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
