### PR TITLE
[bgp_speaker] Flush secondary IP address assigned to PTF interface in BGP speaker testing

### DIFF
--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -213,5 +213,5 @@
       with_items: "{{vlan_ips}}"
 
     - name: Remove Assigned IPs
-      shell: ip addr flush dev eth{{ '%d' % (minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][0] | replace("Ethernet", "") | int / 4)}}
+      shell: ip addr flush dev eth{{ '%d' % (minigraph_port_indices[minigraph_vlans[minigraph_vlan_interfaces[0]['attachto']]['members'][0]])}}
       delegate_to: "{{ptf_host}}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The BGP speaker testing need to assign two secondary IP addresses to a
PTF interface. The cleanup section tries to flush the previously
assigned IP addresses. However, it flushes the wrong interface.

After BGP speaker testing, on PTF container there are two extra interfaces eth1:0 and eth:1

```
root@418f371fd1b3:~# ifconfig | grep eth | cut -f 1 -d ' '
eth0
eth1
eth1:0
eth1:1
eth2
eth3
eth4
eth5
eth6
eth7
eth8
eth9
eth10
eth11
eth12
eth13
eth14
eth15
eth16
eth17
eth18
eth19
eth20
eth21
eth22
eth23
eth24
eth25
eth26
eth27
eth28
eth29
eth30
eth31
```

These two interfaces are corresponding to the secondary IP addresses assigned to eth1. They are created by a script used by exabgp on PTF:
```
root@418f371fd1b3:~/exabgp# cat start.sh
ifconfig eth1 192.168.0.2/21
ifconfig eth1:0 10.154.239.129/26
ifconfig eth1:1 10.154.239.130/26

ifconfig eth2 192.168.0.3/21
i=0; until [$i -eq 10] || ping 192.168.0.1 -I eth2 -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &

ifconfig eth3 192.168.0.4/21
i=0; until [$i -eq 10] || ping 192.168.0.1 -I eth3 -c 1 >/dev/null 2>&1; do i=`expr $i + 1`; done &

ip route flush 10.1.0.32/32
ip route add 10.1.0.32/32 via 192.168.0.1
env exabgp.daemon.user=root exabgp /root/exabgp/config_1.ini >/dev/null 2>&1 &
env exabgp.daemon.user=root exabgp /root/exabgp/config_2.ini >/dev/null 2>&1 &
env exabgp.daemon.user=root exabgp /root/exabgp/config_3.ini >/dev/null 2>&1 &
```

In the cleanup section of BGP speaker testing, a different algorithm is used to find out PTF interface index with secondary IP addresses assigned. And, the cleanup code clears the wrong interface.

```
21:50:21 TASK [test : Remove Assigned IPs] **********************************************
21:50:21 task path: /builds2/jenkins2/workspace/SONiC_Test-BGP-Speaker/ansible/roles/test/tasks/bgp_speaker.yml:214
21:50:21 Wednesday 25 September 2019  18:50:21 +0000 (0:00:01.229)       0:01:25.382 *** 
21:50:21 <10.213.84.98> ESTABLISH SSH CONNECTION FOR USER: root
21:50:21 <10.213.84.98> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)
21:50:21 <10.213.84.98> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
21:50:21 <10.213.84.98> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User=root)
21:50:21 <10.213.84.98> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=10)
21:50:21 <10.213.84.98> SSH: PlayContext set ssh_common_args: ()
21:50:21 <10.213.84.98> SSH: PlayContext set ssh_extra_args: ()
21:50:21 <10.213.84.98> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
21:50:21 <10.213.84.98> SSH: EXEC sshpass -d14 ssh -C -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r 10.213.84.98 'LANG=C LC_ALL=C LC_MESSAGES=C /usr/bin/python'
21:50:21 changed: [arc-switch1029-t0 -> 10.213.84.98] => {"changed": true, "cmd": "ip addr flush dev eth0", "delta": "0:00:00.066348", "end": "2019-09-25 18:50:21.553968", "invocation": {"module_args": {"_raw_params": "ip addr flush dev eth0", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 0, "start": "2019-09-25 18:50:21.487620", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
```

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
This fix is use the same algorith to identify the PTF interface with secondary IP address. This ensures that secondary IP address flushing is performed on the correct interface.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
