### PR TITLE
Add SKU sensors data for Arista-7050-QX-32S

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2400,3 +2400,86 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+
+  Arista-7050-QX-32S:
+    alarms:
+      fan:
+      - pmbus-i2c-5-58/fan1/fan1_alarm
+      - pmbus-i2c-6-58/fan1/fan1_alarm
+
+      power:
+      - pmbus-i2c-5-58/iin/curr1_max_alarm
+      - pmbus-i2c-5-58/iout1/curr2_crit_alarm
+      - pmbus-i2c-5-58/iout1/curr2_max_alarm
+      - pmbus-i2c-5-58/iout2/curr3_crit_alarm
+      - pmbus-i2c-5-58/vin/in1_alarm
+      - pmbus-i2c-5-58/vout1/in2_crit_alarm
+      - pmbus-i2c-5-58/vout1/in2_lcrit_alarm
+
+      temp:
+      - max6658-i2c-2-4c/Board temp sensor/temp1_max_alarm
+      - max6658-i2c-2-4c/Board temp sensor/temp1_min_alarm
+      - max6658-i2c-2-4c/Board temp sensor/temp1_crit_alarm
+      - max6658-i2c-2-4c/Front panel temp sensor/temp2_max_alarm
+      - max6658-i2c-2-4c/Front panel temp sensor/temp2_min_alarm
+      - max6658-i2c-2-4c/Front panel temp sensor/temp2_crit_alarm
+      - max6658-i2c-3-4c/Cpu board temp sensor/temp1_max_alarm
+      - max6658-i2c-3-4c/Cpu board temp sensor/temp1_min_alarm
+      - max6658-i2c-3-4c/Cpu board temp sensor/temp1_crit_alarm
+      - max6658-i2c-3-4c/Back panel temp sensor/temp2_max_alarm
+      - max6658-i2c-3-4c/Back panel temp sensor/temp2_min_alarm
+      - max6658-i2c-3-4c/Back panel temp sensor/temp2_crit_alarm
+      - pmbus-i2c-5-58/Power supply 2 hotspot sensor/temp1_alarm
+      - pmbus-i2c-5-58/Power supply 2 inlet temp sensor/temp2_alarm
+      - pmbus-i2c-5-58/Power supply 2 sensor/temp3_alarm
+
+    compares:
+      fan: []
+      power:
+      - - pmbus-i2c-5-58/iin/curr1_input
+        - pmbus-i2c-5-58/iin/curr1_max
+      - - pmbus-i2c-5-58/iout1/curr2_input
+        - pmbus-i2c-5-58/iout1/curr2_max
+
+      temp:
+      - - k10temp-pci-00c3/Cpu temp sensor/temp1_input
+        - k10temp-pci-00c3/Cpu temp sensor/temp1_max
+      - - max6658-i2c-2-4c/Board temp sensor/temp1_input
+        - max6658-i2c-2-4c/Board temp sensor/temp1_max
+      - - max6658-i2c-2-4c/Front panel temp sensor/temp2_input
+        - max6658-i2c-2-4c/Front panel temp sensor/temp2_max
+      - - max6658-i2c-3-4c/Cpu board temp sensor/temp1_input
+        - max6658-i2c-3-4c/Cpu board temp sensor/temp1_max
+      - - max6658-i2c-3-4c/Back panel temp sensor/temp2_input
+        - max6658-i2c-3-4c/Back panel temp sensor/temp2_max
+
+    non_zero:
+      fan:
+      - crow_cpld-i2c-3-60/fan1/fan1_input
+      - crow_cpld-i2c-3-60/fan2/fan2_input
+      - crow_cpld-i2c-3-60/fan3/fan3_input
+      - crow_cpld-i2c-3-60/fan4/fan4_input
+      - pmbus-i2c-5-58/fan1/fan1_input
+      - pmbus-i2c-6-58/fan1/fan1_input
+
+      power:
+      - pmbus-i2c-5-58/iin/curr1_input
+      - pmbus-i2c-5-58/iout1/curr2_input
+      - pmbus-i2c-5-58/iout2/curr3_input
+      - pmbus-i2c-5-58/pin/power1_input
+      - pmbus-i2c-5-58/pout1/power2_input
+      - pmbus-i2c-5-58/pout2/power3_input
+      - pmbus-i2c-5-58/vin/in1_input
+      - pmbus-i2c-5-58/vout1/in2_input
+
+      temp:
+      - k10temp-pci-00c3/Cpu temp sensor/temp1_input
+      - max6658-i2c-2-4c/Board temp sensor/temp1_input
+      - max6658-i2c-2-4c/Front panel temp sensor/temp2_input
+      - max6658-i2c-3-4c/Cpu board temp sensor/temp1_input
+      - max6658-i2c-3-4c/Back panel temp sensor/temp2_input
+      - pmbus-i2c-5-58/Power supply 2 hotspot sensor/temp1_input
+      - pmbus-i2c-5-58/Power supply 2 inlet temp sensor/temp2_input
+      - pmbus-i2c-5-58/Power supply 2 sensor/temp3_input
+
+    psu_skips: {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes SKU sensors test data not existing for Arista-7050-QX-32S.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
