### PR TITLE
Let storm all test run on queue index 3

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
@@ -1,7 +1,7 @@
 # pfc_frames_number intends to be large enough so that PFC storm keeps happenning until runs pfc_storm_stop command. 
 - name: Prepare variables required for PFC test
   set_fact:
-    pfc_queue_index: 4
+    pfc_queue_index: 3
     pfc_frames_number: 10000000
     pfc_wd_detect_time: 200
     pfc_wd_restore_time: 200


### PR DESCRIPTION
This, together with the functional test, covers both queue index 3 and 4. This checks whether hardware resources are sufficient or not, confirmed by actual test run.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
