### PR TITLE
Allow log analyzer to take a specified start marker

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -79,9 +79,10 @@ class AnsibleLogAnalyzer:
         return logger
     #---------------------------------------------------------------------
 
-    def __init__(self, run_id, verbose):
+    def __init__(self, run_id, verbose, start_marker = None):
         self.run_id = run_id
         self.verbose = verbose
+        self.start_marker = start_marker
     #---------------------------------------------------------------------
 
     def print_diagnostic_message(self, message):
@@ -92,7 +93,10 @@ class AnsibleLogAnalyzer:
     #---------------------------------------------------------------------
 
     def create_start_marker(self):
-        return self.start_marker_prefix + "-" + self.run_id
+        if (self.start_marker is None) or (len(self.start_marker) == 0):
+            return self.start_marker_prefix + "-" + self.run_id
+        else:
+            return self.start_marker
 
     #---------------------------------------------------------------------
 
@@ -576,6 +580,7 @@ def main(argv):
 
     action = None
     run_id = None
+    start_marker = None
     log_files_in = ""
     out_dir = None
     match_files_in = None
@@ -584,7 +589,7 @@ def main(argv):
     verbose = False
 
     try:
-        opts, args = getopt.getopt(argv, "a:r:l:o:m:i:e:vh", ["action=", "run_id=", "logs=", "out_dir=", "match_files_in=", "ignore_files_in=", "expect_files_in=", "verbose", "help"])
+        opts, args = getopt.getopt(argv, "a:r:s:l:o:m:i:e:vh", ["action=", "run_id=", "start_marker=", "logs=", "out_dir=", "match_files_in=", "ignore_files_in=", "expect_files_in=", "verbose", "help"])
 
     except getopt.GetoptError:
         print "Invalid option specified"
@@ -601,6 +606,9 @@ def main(argv):
 
         elif (opt in ("-r", "--run_id")):
             run_id = arg
+
+        elif (opt in ("-s", "--start_marker")):
+            start_marker = arg
 
         elif (opt in ("-l", "--logs")):
             log_files_in = arg
@@ -624,7 +632,7 @@ def main(argv):
         usage()
         sys.exit(err_invalid_input)
 
-    analyzer = AnsibleLogAnalyzer(run_id, verbose)
+    analyzer = AnsibleLogAnalyzer(run_id, verbose, start_marker)
 
     log_file_list = filter(None, log_files_in.split(tokenizer))
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
@@ -113,7 +113,7 @@
       extract_log:
         directory: '/var/log'
         file_prefix: 'syslog'
-        start_string: 'start-LogAnalyzer-{{ testname_unique }}'
+        start_string: "{% if start_marker is defined %}{{ start_marker }}{% else %}start-LogAnalyzer-{{ testname_unique }}{% endif %}"
         target_filename: "/tmp/syslog"
       become: yes
 
@@ -122,7 +122,7 @@
       shell: sed -i 's/^#//g' /etc/cron.d/logrotate
       become: yes
 
-- set_fact: cmd="python {{ run_dir }}/loganalyzer.py --action analyze --logs {{ tmp_log_file }} --run_id {{ testname_unique }} --out_dir {{ test_out_dir }} {{ match_file_option }} {{ ignore_file_option }} {{ expect_file_option }} -v"
+- set_fact: cmd="python {{ run_dir }}/loganalyzer.py --action analyze --logs {{ tmp_log_file }} --run_id {{ testname_unique }} {% if start_marker is defined %}--start_marker '{{ start_marker }}'{% endif %} --out_dir {{ test_out_dir }} {{ match_file_option }} {{ ignore_file_option }} {{ expect_file_option }} -v"
 
 - debug: msg={{cmd}}
 


### PR DESCRIPTION
Infrastructure change taken out of https://github.com/Azure/sonic-mgmt/pull/834

For device that uses in-memory syslog, start marker placed before warm-reboot is gone. We use a specified message in the warm-reboot syslog as the anchor point/ start marker.

This PR provides us with such a capability.

Tested on regular pfc watchdog test without break.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
