### PR TITLE
Use lookup('pipe', 'date +%H:%M:%S') in place of ansible_date_time.time

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
@@ -8,7 +8,7 @@
   copy: src="{{ loganalyzer_location }}/loganalyzer.py" dest="{{ run_dir }}"
 
 - set_fact:
-    testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ lookup('pipe', 'date +%H:%M:%S') }}"
+    testname_unique: "{{ testname }}.{{ lookup('pipe', 'date +%Y-%m-%d.%H:%M:%S') }}"
   when: testname_unique is not defined or (testname_unique_gen is defined and testname_unique_gen == true)
 
 - debug: msg="starting loganalyzer_init.py"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
@@ -8,8 +8,8 @@
   copy: src="{{ loganalyzer_location }}/loganalyzer.py" dest="{{ run_dir }}"
 
 - set_fact:
-    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
-  when: testname_unique is not defined
+    testname_unique: "{{ testname }}.{{ ansible_date_time.date }}.{{ lookup('pipe', 'date +%H:%M:%S') }}"
+  when: testname_unique is not defined or (testname_unique_gen is defined and testname_unique_gen == true)
 
 - debug: msg="starting loganalyzer_init.py"
 - debug: msg="python {{ run_dir }}/loganalyzer.py --action init --run_id {{ testname_unique }}"


### PR DESCRIPTION
Infrastructure change taken out of https://github.com/Azure/sonic-mgmt/pull/834

ansible_date_time.time uses cached time for a certain period of time https://github.com/ansible/ansible/issues/22561

Tested on regular pfc watchdog without break.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
