### PR TITLE
loganalyzer_end: add the capability to check if the number of exact matches is equal to the target number

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_end.yml
@@ -20,8 +20,23 @@
   shell: grep "TOTAL EXPECTED MISSING MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL EXPECTED MISSING MATCHES:[[:space:]]*//p"
   register: expected_missing_matches
 
+- debug: msg={{expected_missing_matches}}
+
+- name: Check if loganalyzer gets the exact number of expected messages
+  shell: grep "TOTAL EXPECTED MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL EXPECTED MATCHES:[[:space:]]*//p"
+  register: expected_matches
+  when: expected_matches_target is defined and expected_matches_target != ""
+
+- debug: msg={{expected_matches}}
+  when: expected_matches_target is defined and expected_matches_target != ""
+
 - set_fact:
     fail_in_logs: "{{ errors_found.stdout  != \"0\" or expected_missing_matches.stdout != \"0\" }}"
+  when: expected_matches_target is not defined or expected_matches_target == ""
+
+- set_fact:
+    fail_in_logs: "{{ errors_found.stdout  != \"0\" or expected_missing_matches.stdout != \"0\" or expected_matches.stdout != expected_matches_target|string }}"
+  when: expected_matches_target is defined and expected_matches_target != ""
 
 - set_fact:
     dump_since: '1 hour ago'


### PR DESCRIPTION
Infrastructure change taken out of #834

Tested on regular pfc watchdog without break.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
