### PR TITLE
Improve the scripts for preparing PTF interfaces

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ls /sys/class/net | grep eth)
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
 
 for INTF in ${INTF_LIST}; do
     ADDR="$(ip link show ${INTF} | grep ether | awk '{print $2}')"

--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+INTF_LIST=$(ls /sys/class/net | grep eth)
 
 for INTF in ${INTF_LIST}; do
-    ADDR="$(ip -br link show dev ${INTF} | awk '{print $3}')"
+    ADDR="$(ip link show ${INTF} | grep ether | awk '{print $2}')"
     PREFIX="$(cut -c1-15 <<< ${ADDR})"
     SUFFIX="$(printf "%02x" ${INTF##eth})"
     MAC="${PREFIX}${SUFFIX}"

--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
 
 for INTF in ${INTF_LIST}; do
-    ADDR="$(ip link show ${INTF} | grep ether | awk '{print $2}')"
+    ADDR="$(cat /sys/class/net/${INTF}/address)"
     PREFIX="$(cut -c1-15 <<< ${ADDR})"
     SUFFIX="$(printf "%02x" ${INTF##eth})"
     MAC="${PREFIX}${SUFFIX}"

--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+INTF_LIST=$(ls /sys/class/net | grep eth)
 
 for INTF in ${INTF_LIST}; do
     echo "Flush ${INTF} IP address"

--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ls /sys/class/net | grep eth)
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
 
 for INTF in ${INTF_LIST}; do
     echo "Flush ${INTF} IP address"

--- a/tests/scripts/change_mac.sh
+++ b/tests/scripts/change_mac.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ls /sys/class/net | grep eth)
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
 
 for INTF in ${INTF_LIST}; do
     ADDR="$(ip link show ${INTF} | grep ether | awk '{print $2}')"

--- a/tests/scripts/change_mac.sh
+++ b/tests/scripts/change_mac.sh
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ip -br link show | grep 'eth' | awk '{sub(/@.*/,"",$1); print $1}')
+INTF_LIST=$(ls /sys/class/net | grep eth)
 
 for INTF in ${INTF_LIST}; do
-    ADDR="$(ip -br link show dev ${INTF} | awk '{print $3}')"
+    ADDR="$(ip link show ${INTF} | grep ether | awk '{print $2}')"
     PREFIX="$(cut -c1-15 <<< ${ADDR})"
     SUFFIX="$(printf "%02x" ${INTF##eth})"
     MAC="${PREFIX}${SUFFIX}"

--- a/tests/scripts/change_mac.sh
+++ b/tests/scripts/change_mac.sh
@@ -1,15 +1,1 @@
-#!/bin/bash
-
-set -euo pipefail
-
-INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
-
-for INTF in ${INTF_LIST}; do
-    ADDR="$(ip link show ${INTF} | grep ether | awk '{print $2}')"
-    PREFIX="$(cut -c1-15 <<< ${ADDR})"
-    SUFFIX="$(printf "%02x" ${INTF##eth})"
-    MAC="${PREFIX}${SUFFIX}"
-
-    echo "Update ${INTF} MAC address: ${ADDR}->$MAC"
-    ip link set dev ${INTF} address ${MAC}
-done
+../../ansible/roles/test/files/helpers/change_mac.sh

--- a/tests/scripts/remove_ip.sh
+++ b/tests/scripts/remove_ip.sh
@@ -1,10 +1,1 @@
-#!/bin/bash
-
-set -euo pipefail
-
-INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
-
-for INTF in ${INTF_LIST}; do
-    echo "Flush ${INTF} IP address"
-    ip addr flush dev ${INTF}
-done
+../../ansible/roles/test/files/helpers/remove_ip.sh

--- a/tests/scripts/remove_ip.sh
+++ b/tests/scripts/remove_ip.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ls /sys/class/net | grep eth)
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
 
 for INTF in ${INTF_LIST}; do
     echo "Flush ${INTF} IP address"

--- a/tests/scripts/remove_ip.sh
+++ b/tests/scripts/remove_ip.sh
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
-INTF_IDX_LIST=$(cat /proc/net/dev | grep eth | awk -F'eth|:' '{print $2}')
+INTF_LIST=$(ls /sys/class/net | grep eth)
 
-for i in $INTF_IDX_LIST; do
-  ip address flush dev eth$i
+for INTF in ${INTF_LIST}; do
+    echo "Flush ${INTF} IP address"
+    ip addr flush dev ${INTF}
 done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The BGP speaker test case has an issue of leaving a PTF interface with 
sub-interfaces not cleaned. (Fixed in https://github.com/Azure/sonic-mgmt/pull/1131)

In that case, two extra interfaces would remain on PTF container: eth1:0, eth1:1. 
If that happen, the change_mac.sh script may fail with error: 
"line 9: printf: 1:0: invalid number"

Detailed error info:
```
FAILED! => {"changed": true, "failed": true, "invocation": {"module_args": {"_raw_params": "roles/test/files/helpers/change_mac.sh"}, "module_name": "script"}, "rc": 1, "stderr": "OpenSSH_7.2p2 Ubuntu-4ubuntu2.4, OpenSSL 1.0.2g 1 Mar 2016\r\ndebug1: Reading configuration data /root/.ssh/config\r\ndebug1: /root/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 75519\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\nShared connection to 10.213.84.98 closed.\r\n", "stdout": "eth0 24:8a:07:1e:df:00\r\neth1 24:8a:07:1e:df:01\r\n/root/.ansible/tmp/ansible-tmp-1569439544.06-202105328505521/change_mac.sh: line 9: printf: 1:0: invalid number\r\n", "stdout_lines": ["eth0 24:8a:07:1e:df:00", "eth1 24:8a:07:1e:df:01", "/root/.ansible/tmp/ansible-tmp-1569439544.06-202105328505521/change_mac.sh: line 9: printf: 1:0: invalid number"]}
```

This fix improves the change_mac.sh and remove_ip.sh scripts to
ensure that when this kind of issue happen, the script will not
fail and is still able to successfully run.

After the remove_ip.sh script is executed on PTF, the uncleaned
sub-interfaces will be cleared.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Use a better way to get the list of interfaces on PTF to avoid the interference of un-cleaned sub-interfaces: `ls /sys/class/net | grep -E "^eth[0-9]+$"`

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
