### PR TITLE
[lag] To use the remote.py platform in the ptftest folder

### DIFF
--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -1,8 +1,8 @@
 ### this is the Lag_2 lag test that tests each Lag interface minimum link and rate of sending LACP DU packets
 ### this test could be consider as an additional/alternative lag test from existing lagall.yml.
 ### Due to some labs are using two layer fanout switches, and one DUT might connects to multiple fanoutleaf switches
-### so for minimum link test of lag member flaps, it requires to use lab connection facts to determine the fanout neighbor ports, 
-### Also, most of the traffic load balancing tests of LAG interface are covered in new FIB tests. so we are ignoring traffic test 
+### so for minimum link test of lag member flaps, it requires to use lab connection facts to determine the fanout neighbor ports,
+### Also, most of the traffic load balancing tests of LAG interface are covered in new FIB tests. so we are ignoring traffic test
 ### for lag member flaps for now, will consider add traffic back if required
 
 - fail: msg="Please define ptf_host"
@@ -15,7 +15,7 @@
   lag_facts: host={{ inventory_hostname }}
 
 - fail: msg="No lag configuration found in {{ inventory_hostname }}"
-  when: lag_facts.names == [] 
+  when: lag_facts.names == []
 
 - set_fact: test_minlink=true
   when: test_minlink is not defined
@@ -37,10 +37,10 @@
   connection: local
 
 - set_fact:
-    fanout_neighbors: "{{device_conn}}"   
+    fanout_neighbors: "{{device_conn}}"
 
 - set_fact:
-    vm_neighbors: "{{ minigraph_neighbors }}"   
+    vm_neighbors: "{{ minigraph_neighbors }}"
 
 - name: Copy PTF test into PTF-docker for test LACP DU.
   copy: src=roles/test/files/acstests/{{ item }} dest=/tmp/{{ item }}
@@ -48,6 +48,10 @@
     - lag_test.py
     - acs_base_test.py
     - router_utils.py
+  delegate_to: "{{ ptf_host }}"
+
+- name: Copy tests to the PTF container
+  copy: src=roles/test/files/ptftests dest=/root
   delegate_to: "{{ ptf_host }}"
 
 - name: Include testbed topology configuration (to get LAG IP and PTF docker interfaces, that are behind LAG VMs).
@@ -65,12 +69,12 @@
 - set_fact:
     dut_mac: "{{ ansible_Ethernet0['macaddress'] }}"
 
-- name: test each lag interface minimum links and rate 
+- name: test each lag interface minimum links and rate
   include: single_lag_test.yml
   with_items: lag_facts.names
   when: test_minlink|bool == true
 
-- name: test each lag interface LACP DU rate 
+- name: test each lag interface LACP DU rate
   include: single_lag_lacp_rate_test.yml
   with_items: lag_facts.names
   when: test_rate|bool == true

--- a/ansible/roles/test/tasks/lag_run_ptf.yml
+++ b/ansible/roles/test/tasks/lag_run_ptf.yml
@@ -8,7 +8,7 @@
 #-----------------------
 
 - name: Run lag_test.{{ lag_ptf_test_name }} on PTF docker.
-  shell: ptf --test-dir . --platform remote lag_test.{{ lag_ptf_test_name }} -t "{{ params }}"
+  shell: ptf --test-dir . --platform-dir /root/ptftests --platform remote lag_test.{{ lag_ptf_test_name }} -t "{{ params }}"
   args:
     chdir: "{{ change_dir }}"
   delegate_to: "{{ ptf_host }}"


### PR DESCRIPTION
The default remote.py platform file in ptf package only supports 32-port platforms.
To enable using the remote.py platform in the ptftest folder instead of using the the default one.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The lag_2 test case failed in t0-56/t1-64-lag topology because the default remote.py platform file in ptf package only define fixed eth0~eth31 remote interface mapping. 
### Type of change
- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- []Test case(new/improvement)

### Approach
#### How did you do it?
To enable using the remote.py platform in the ptftest folder instead of using the the default one.
#### How did you verify/test it?
To run lag_2 on t0-56 topology for as7326-56x device and t1-64-lag topology for  as7816-64x device. No failed items.

> 

    ansible-playbook -i lab --limit as7326-56x test_sonic.yml -e testbed_name=1-2_t0-56 -e testcase_name=lag_2 -vvvv
    ansible-playbook -i lab --limit as7816-64x test_sonic.yml -e testbed_name=2-1_t1-64-lag -e testcase_name=lag_2 -vvvv
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A

Signed-off-by: kelly_chen@edge-core.com