### PR TITLE
Fix Asym PFC teardown: provide valid port OID

### DIFF
--- a/ansible/roles/test/files/saitests/pfc_asym.py
+++ b/ansible/roles/test/files/saitests/pfc_asym.py
@@ -113,7 +113,7 @@ class PfcAsymOffOnTxTest(PfcAsymBaseTest):
         sched_prof_id = sai_thrift_create_scheduler_profile(self.client, self.RELEASE_PORT_MAX_RATE)
         attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
         attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-        self.client.sai_thrift_set_port_attribute(int(self.non_server_port['index']),attr)
+        self.client.sai_thrift_set_port_attribute(port_list[int(self.non_server_port['index'])],attr)
 
         PfcAsymBaseTest.tearDown(self)
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

### Description of PR
Fixed Asym PFC teardown: provided valid port OID

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
* Added logic to obtain valid port OID

#### How did you verify/test it?
1. Ran Asym PFC testcase

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
* N/A