### PR TITLE
Added SKU sensor data for et6448m

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2483,3 +2483,37 @@ sensors_checks:
       - pmbus-i2c-5-58/Power supply 2 sensor/temp3_input
 
     psu_skips: {}
+
+  et6448m:
+    alarms:
+      fan:
+      - adt7473-i2c-0-2e/rear fan 1/fan1_alarm
+      - adt7473-i2c-0-2e/rear fan 2/fan2_alarm
+      power:
+      - adt7473-i2c-0-2e/+3.3V/in2_alarm
+      temp:
+      - adt7473-i2c-0-2e/temp1/temp1_alarm
+      - adt7473-i2c-0-2e/temp1/temp1_fault
+      - adt7473-i2c-0-2e/Board Temp/temp2_alarm
+      - adt7473-i2c-0-2e/temp3/temp3_alarm
+      - adt7473-i2c-0-2e/temp3/temp3_fault
+    compares:
+      fan: []
+      power:
+      - - adt7473-i2c-0-2e/+3.3V/in2_input
+        - adt7473-i2c-0-2e/+3.3V/in2_max
+      temp:
+      - - adt7473-i2c-0-2e/temp1/temp1_input
+        - adt7473-i2c-0-2e/temp1/temp1_crit
+      - - adt7473-i2c-0-2e/Board Temp/temp2_input
+        - adt7473-i2c-0-2e/Board Temp/temp2_crit
+      - - adt7473-i2c-0-2e/temp3/temp3_input
+        - adt7473-i2c-0-2e/temp3/temp3_crit
+    non_zero:
+      fan:
+      - adt7473-i2c-0-2e/rear fan 1/fan1_input
+      - adt7473-i2c-0-2e/rear fan 2/fan2_input
+      power:
+      - adt7473-i2c-0-2e/+3.3V/in2_input
+      temp: []
+    psu_skips: {}


### PR DESCRIPTION
### Description of PR
Added SKU sensor data for et6448m

### Type of change

- [] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
updated the group_vars/sonic/sku-sensors-data.yml file

#### How did you verify/test it?
testcases are passing with the following changes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
