### PR TITLE
Ignore snmp physical table test ,snmp pfc counter test and snmp PSU test when marvell hwsku=et6448m

### DIFF
--- a/ansible/roles/test/tasks/snmp.yml
+++ b/ansible/roles/test/tasks/snmp.yml
@@ -13,18 +13,21 @@
 
     - name: inlcude snmp physical table test
       include: roles/test/tasks/snmp/phys_table.yml
+      when: hwsku != 'et6448m'
 
     - name: include snmp interfaces test
       include: roles/test/tasks/snmp/interfaces.yml
 
     - name: include snmp pfc counter test
       include: roles/test/tasks/snmp/pfc_counters.yml
+      when: hwsku != 'et6448m'
 
     - name: include snmp queues test
       include: roles/test/tasks/snmp/queues.yml
 
     - name: include snmp PSU test
       include: roles/test/tasks/snmp/psu.yml
+      when: hwsku != 'et6448m'
 
     - name: include snmp lldp test
       include: roles/test/tasks/snmp/lldp.yml


### PR DESCRIPTION

### Description of PR
Ignore snmp physical table test ,snmp pfc counter test and snmp PSU test when marvell hwsku=et6448m

Summary:
Fixes # (issue)

### Type of change

- [] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
Added conditional support for hwsku et6448m in the file given below:-
roles/test/tasks/snmp.yml

#### How did you verify/test it?
tested in local testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

