### PR TITLE
[Mellanox]Don't check psu thermal files when PSU is power off

### DIFF
--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -123,7 +123,7 @@ def check_sysfs(dut):
     for psu_id in range(1, psu_count + 1):
         if SWITCH_MODELS[dut_hwsku]["psus"]["hot_swappable"]:
 
-            # if the PSU if poweroff, all thermal related sensors of the PSU is removed.
+            # If the PSU is poweroff, all PSU thermal related sensors are not available.
             # In that case, just skip the following tests
             psu_status_file = "/var/run/hw-management/thermal/psu{}_status".format(psu_id)
             psu_status_output = dut.command("cat %s" % psu_status_file)

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -122,6 +122,23 @@ def check_sysfs(dut):
     psu_count = SWITCH_MODELS[dut_hwsku]["psus"]["number"]
     for psu_id in range(1, psu_count + 1):
         if SWITCH_MODELS[dut_hwsku]["psus"]["hot_swappable"]:
+
+            # if the PSU if poweroff, all thermal related sensors of the PSU is removed.
+            # In that case, just skip the following tests
+            psu_status_file = "/var/run/hw-management/thermal/psu{}_status".format(psu_id)
+            psu_status_output = dut.command("cat %s" % psu_status_file)
+            psu_status = int(psu_status_output["stdout"])
+            if not psu_status:
+                logging.info("PSU %d doesn't exist, skipped".format(psu_id))
+                continue
+
+            psu_pwr_status_file = "/var/run/hw-management/thermal/psu{}_pwr_status".format(psu_id)
+            psu_pwr_status_output = dut.command("cat %s" % psu_pwr_status_file)
+            psu_pwr_status = int(psu_pwr_status_output["stdout"])
+            if not psu_pwr_status:
+                logging.info("PSU %d isn't poweron, skipped".format(psu_id))
+                continue
+
             psu_temp_file = "/var/run/hw-management/thermal/psu{}_temp".format(psu_id)
             psu_temp_file_output = dut.command("cat %s" % psu_temp_file)
             psu_temp = float(psu_temp_file_output["stdout"])/1000


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Don't check PSU thermal files when PSU is power off or not present

#### How did you verify/test it?
Verify platform/test_reboot

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
