### PR TITLE
[simx vt] Add Mellanox SimX virtual testbed infra 

### DIFF
--- a/ansible/doc/README.testbed.SimXSetup.md
+++ b/ansible/doc/README.testbed.SimXSetup.md
@@ -20,9 +20,11 @@ SimX is a functional simulation of Mellanox PCI devices
 
 - Install Ubuntu 18.04 amd64 server. To setup a T0 topology, the server needs to have 10GB free memory.
 - Install bridge utils
+
 ```
 $ sudo apt-get install bridge-utils
 ```
+
 - Setup internal management network.
 
 ```
@@ -48,8 +50,8 @@ Instructions to set up sonic-mgmt docker [here](https://github.com/Azure/sonic-m
 
 - Download the SimX in Docker archive. Mellanox only provides it to it's customers. You need to contact the support team to get it.
 
-```
 - unzip the archive into ```~/sid/images/```
+
 ```
 $ mkdir -p ~/sid/images
 $ unzip simxindocker.gz
@@ -67,12 +69,14 @@ You should get something like:
 ```
 
 ```settings.ini``` file 
+
 ```
 [vlab-simx-01]
 chip = spectrum
 vm_image = ~/sid/disks/vlab-simx-01.img
 ip =  10.250.0.103, 255.255.255.0, 10.250.0.1
 ```
+
 You can execute ```./start.py``` to start one docker container, without applying a topology.
 
 ## Load the docker image

--- a/ansible/doc/README.testbed.SimXSetup.md
+++ b/ansible/doc/README.testbed.SimXSetup.md
@@ -1,0 +1,226 @@
+# Testbed Setup
+
+This document describes the steps to setup the SimX in docker based testbed and deploy a topology. Mellanox only provides the simulator to it's customers. 
+
+## About SimX
+
+SimX is a functional simulation of Mellanox PCI devices
+ - It simulates 
+   - Mellanox NICs
+   - Switch: Spectrum-1, Spectrum-2, Spectrum-3
+- It simulates both FW and HW
+- All flows are supported (controll + data path)
+
+- Inside the VM, the OS is runnaing as is
+  - Running Mellanox SAI
+  - Running Mellanox SDK
+
+
+## Prepare testbed server
+
+- Install Ubuntu 18.04 amd64 server. To setup a T0 topology, the server needs to have 10GB free memory.
+- Install bridge utils
+```
+$ sudo apt-get install bridge-utils
+```
+- Setup internal management network.
+
+```
+$ sudo brctl addbr br0
+$ sudo ifconfig br0 10.250.0.1/24
+$ sudo ifconfig br0 up
+```
+
+- Download vEOS image from [arista](https://www.arista.com/en/support/software-download).
+- Copy below image files to ```~/veos-vm/images``` on your testbed server.
+   - ```Aboot-veos-serial-8.0.0.iso```
+   - ```vEOS-lab-4.15.9M.vmdk```
+
+## Setup docker registry for *PTF* docker
+
+Instructions to build or download pre-built docker-ptf [here](https://github.com/Azure/sonic-mgmt/blob/master/ansible/doc/README.testbed.VsSetup.md#setup-docker-registry-for-ptf-docker)
+
+## Build or download *sonic-mgmt* docker image
+
+Instructions to set up sonic-mgmt docker [here](https://github.com/Azure/sonic-mgmt/blob/master/ansible/doc/README.testbed.VsSetup.md#build-or-download-sonic-mgmt-docker-image)
+
+## Download SimX in Docker  
+
+- Download the SimX in Docker archive. Mellanox only provides it to it's customers. You need to contact the support team to get it.
+
+```
+- unzip the archive into ```~/sid/images/```
+```
+$ mkdir -p ~/sid/images
+$ unzip simxindocker.gz
+$ mv simixindocker/* ~/sid/images/
+```
+
+You should get something like:
+```
+|-- sid
+|   |-- images
+|   |   |-- settings.ini     - input values for start.py(SimX in Docker infra)
+|   |   |-- simx.tar         - docker image of SimX in Docker
+|   |   |-- sonic_spc.img   - vm disk image for the simx-qemu emulator
+|   |   `-- start.py         - script to start the simulator inside dcoker container(SiD infra)
+```
+
+```settings.ini``` file 
+```
+[vlab-simx-01]
+chip = spectrum
+vm_image = ~/sid/disks/vlab-simx-01.img
+ip =  10.250.0.103, 255.255.255.0, 10.250.0.1
+```
+You can execute ```./start.py``` to start one docker container, without applying a topology.
+
+## Load the docker image
+
+```
+$ docker load -i simx.tar
+```
+
+## Clone sonic-mgmt repo
+
+```
+$ git clone https://github.com/Azure/sonic-mgmt
+```
+
+### Modify sonic-mgmt
+
+Add host_vars file for the hypervisor
+
+ansible/host_vars/<HYPERVISOR_HOSTNAME>.yml:
+```
+mgmt_bridge: br0
+mgmt_prefixlen: 24
+mgmt_gw: 10.250.0.1
+vm_mgmt_gw: 10.250.0.1
+
+internal_mgmt_port: True
+```
+
+Change the veos.vtb:
+
+```
+[vm_host_1]
+<HYPERVISOR_HOSTNAME> ansible_host=<HYPERVISOR_IP> ansible_user=<use_own_value>
+
+[vm_host:children]
+vm_host_1
+
+[vms_1]
+VM0100 ansible_host=10.250.0.51
+VM0101 ansible_host=10.250.0.52
+VM0102 ansible_host=10.250.0.53
+VM0103 ansible_host=10.250.0.54
+
+
+[eos:children]
+vms_1
+
+## The groups below are helper to limit running playbooks to server_1, server_2 or server_3 only
+[server_1:children]
+vm_host_1
+vms_1
+
+[server_1:vars]
+host_var_file=host_vars/<HYPERVISOR_HOSTNAME>.yml
+
+[servers:children]
+server_1
+
+[servers:vars]
+topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+
+[sonic]
+vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000
+vlab-02 ansible_host=10.250.0.102 type=kvm hwsku=Force10-S6100
+vlab-simx-01 ansible_host=10.250.0.103 type=simx hwsku=MSN2700
+```
+
+Notice the _type=simx_ for the SimX device
+
+Add entry in vtestbed.csv
+
+```
+# conf-name,group-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,comment
+vms-kvm-t0,vms6-1,t0,docker-ptf-brcm,10.250.0.102/24,server_1,VM0100,vlab-01,Tests virtual switch vm
+vms-kvm-t0-64,vms6-1,t0-64,docker-ptf-brcm,10.250.0.102/24,server_1,VM0100,vlab-02,Tests virtual switch vm
+vms-kvm-t0,vms6-1,t0,docker-ptf-brcm,10.250.0.102/24,server_1,VM0100,vlab-simx-01,Tests virtual SimX vm
+```
+
+## Run sonic-mgmt docker
+
+```
+$ docker run -v $PWD:/data -it docker-sonic-mgmt bash
+```
+
+From now on, all steps are running inside the *sonic-mgmt* docker.
+
+## Setup Arista VMs in the server and deploy the topology
+
+```
+$ ./testbed-cli.sh -m veos.vtb start-vms server_1 password.txt
+
+$ ./testbed-cli.sh -t vtestbed.csv -m veos.vtb add-topo vms-kvm-t0 password.txt
+```
+
+## Verify the simulator running in the container(optional)
+
+```
+docker ps
+CONTAINER ID        IMAGE                                          COMMAND                  CREATED             STATUS              PORTS               NAMES
+3fb6b04aa28f        arc-build-server:5000/docker-ptf-mlnx:latest   "/usr/local/bin/supe…"   5 hours ago         Up 5 hours                              ptf_vms6-2
+be00ad20b505        simx                                           "/usr/sbin/init"         5 hours ago         Up 5 hours                              
+vlab-simx-01
+```
+
+Grep for the simulator process
+
+```
+root@dev-r-vrt-232:/images# docker exec be00ad20b505 ps aux | grep simx-qemu-system-x86_64 
+root      1144  160 21.7 24598832 7151752 ?    Sl   07:45 464:30 /opt/simx/bin/simx-qemu-system-x86_64
+```
+
+## Deploy minigraph on the DUT
+
+```
+$ ./testbed-cli.sh -t vtestbed.csv -m veos.vtb deploy-mg vms-kvm-t0 lab password.txt
+```
+
+You should be login into the SimX vm using IP: 10.250.0.103 using admin:YourPaSsWoRd.
+There is also a telnet connection: 
+
+```
+$ telnet localhost 1213
+```
+
+You should see BGP sessions up in SONiC.
+
+```
+admin@vlab-simx-01:~$ show ip bgp sum
+BGP router identifier 10.1.0.32, local AS number 65100
+RIB entries 12807, using 1401 KiB of memory
+Peers 8, using 36 KiB of memory
+Peer groups 2, using 112 bytes of memory
+
+Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.0.0.57       4 64600    3208      12        0    0    0 00:00:22     6400
+10.0.0.59       4 64600    3208     593        0    0    0 00:00:22     6400
+10.0.0.61       4 64600    3205     950        0    0    0 00:00:21     6400
+10.0.0.63       4 64600    3204     950        0    0    0 00:00:21     6400
+```
+At this point the DUT is ready to run some tests.
+
+## Troubleshooting
+
+Useful log files:
+If something went wrong during container startup:
+~/sid/images/autostart_<container_name>.log
+
+If something went wrong with the simulator:
+(in docker) /var/log/libvirt/qemu/d-switch-001.log
+
+No ssh connectivity to the VM - try ```telnet <hypervisor_ip> 1213```

--- a/ansible/roles/vm_set/library/mellanox_simx_port.py
+++ b/ansible/roles/vm_set/library/mellanox_simx_port.py
@@ -3,7 +3,7 @@
 from ansible.module_utils.basic import *
 
 DOCUMENTATION = '''
-module: simx_port
+module: mellanox_simx_port
 version_added: "0.1"
 author: Mykola Faryma (mykolaf@mellanox.com)
 short_description: Gather management and front panel ports from simx-based DUT
@@ -12,7 +12,7 @@ This is a stub, currently returns hardcoded values
 
 EXAMPLES = '''
 - name: Get front panel and mgmt port for SimX in Docker
-  simx_port:
+  mellanox_simx_port:
     vmname: "{{ dut_name }}"
 '''
 

--- a/ansible/roles/vm_set/library/simx_port.py
+++ b/ansible/roles/vm_set/library/simx_port.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import *
+
+DOCUMENTATION = '''
+module: simx_port
+version_added: "0.1"
+author: Mykola Faryma (mykolaf@mellanox.com)
+short_description: Gather management and front panel ports from simx-based DUT
+This is a stub, currently returns hardcoded values
+'''
+
+EXAMPLES = '''
+- name: Get front panel and mgmt port for SimX in Docker
+  simx_port:
+    vmname: "{{ dut_name }}"
+'''
+
+def main():
+
+    module = AnsibleModule(argument_spec=dict(
+        vmname = dict(required=False),
+    ))
+
+    mgmt_port = None
+    fp_ports = []
+    
+    for i in range(1,33):
+        fp_ports.append("tap{}".format(i))
+
+    mgmt_port = "tap0"
+
+    module.exit_json(changed=False, ansible_facts={'dut_mgmt_port': mgmt_port, 'dut_fp_ports': fp_ports})
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -195,3 +195,11 @@
 - name: Stop SONiC VM
   include: stop_sonic_vm.yml
   when: action == 'stop_sonic_vm' and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'kvm'
+
+- name: Start SID
+  include: start_sid.yml
+  when: action == 'start_sid' and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'simx'
+
+- name: Stop SID
+  include: stop_sid.yml
+  when: action == 'stop_sid' and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'simx'

--- a/ansible/roles/vm_set/tasks/set_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/set_dut_port.yml
@@ -14,5 +14,11 @@
 - name: Get front panel and mgmt port for kvm vm
   kvm_port:
     vmname: "{{ dut_name }}"
-  when: external_port is not defined
+  when: external_port is not defined and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'kvm'
+  become: yes
+
+- name: Get front panel and mgmt port for SID
+  simx_port:
+    vmname: "{{ dut_name }}"
+  when: external_port is not defined and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'simx'
   become: yes

--- a/ansible/roles/vm_set/tasks/set_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/set_dut_port.yml
@@ -18,7 +18,7 @@
   become: yes
 
 - name: Get front panel and mgmt port for SID
-  simx_port:
+  mellanox_simx_port:
     vmname: "{{ dut_name }}"
   when: external_port is not defined and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'simx'
   become: yes

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -7,7 +7,7 @@
 - include_vars: group_vars/sonic/vars
 
 - set_fact:
-    src_disk_image: "{{ home_path }}/sid/images/sonic_spc.img"
+    src_disk_image: "{{ home_path }}/sid/images/sonic.img"
     disk_image: "{{ home_path }}/sid/disks/{{ dut_name }}.img"
     simx_image: "{{ home_path }}/sid/images/simx:latest.tar"
     mgmt_ip_address: " {{ hostvars[dut_name]['ansible_host'] }}/{{ mgmt_prefixlen }}"
@@ -54,18 +54,3 @@
 - name: Wait for SID to start
   pause:
     seconds: 60
-
-- name: get rid of linux bridges
-  shell: brctl delif v000_port{{ item }} tap{{ item }}
-  with_sequence: start=1 end=32
-  ignore_errors: true
-
-- name: get rid of linux bridges
-  shell: ifconfig v000_port{{ item }} down
-  with_sequence: start=1 end=32
-  ignore_errors: true
-  
-- name: get rid of linux bridges
-  shell: brctl delbr v000_port{{ item }}
-  with_sequence: start=1 end=32
-  ignore_errors: true

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -6,7 +6,6 @@
 
 - include_vars: group_vars/sonic/vars
 
-# TODO: handle serial port
 - set_fact:
     src_disk_image: "{{ home_path }}/sid/images/sonic_spc.img"
     disk_image: "{{ home_path }}/sid/disks/{{ dut_name }}.img"
@@ -56,7 +55,6 @@
   pause:
     seconds: 60
 
-# Annoying linux bridges will be gone in later SimX versions
 - name: get rid of linux bridges
   shell: brctl delif v000_port{{ item }} tap{{ item }}
   with_sequence: start=1 end=32

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -1,0 +1,73 @@
+- name: Create directory for SimX in docker(SID) images and disk images 
+  file: path={{ item }} state=directory mode=0755
+  with_items:
+    - "sid/images"
+    - "sid/disks"
+
+- include_vars: group_vars/sonic/vars
+
+# TODO: handle serial port
+- set_fact:
+    src_disk_image: "{{ home_path }}/sid/images/sonic_spc.img"
+    disk_image: "{{ home_path }}/sid/disks/{{ dut_name }}.img"
+    simx_image: "{{ home_path }}/sid/images/simx:latest.tar"
+    mgmt_ip_address: " {{ hostvars[dut_name]['ansible_host'] }}/{{ mgmt_prefixlen }}"
+
+- name: Device debug output
+  debug: msg="hostname = {{ dut_name }} ip = {{ mgmt_ip_address }}"
+
+- name: Check destination file existance
+  stat: path={{ disk_image }}
+  register: file_stat
+
+- name: Copy sonic disk image for {{ dut_name }}
+  copy: src={{ src_disk_image }} dest={{ disk_image }} remote_src=True
+  when: not file_stat.stat.exists
+
+- set_fact:
+    sonic_hwsku: "{{ hostvars[dut_name]['hwsku'] }}"
+
+- fail: msg="sonic_hwsku is not defined"
+  when: "sonic_hwsku is not defined"
+
+- fail: msg="{{ item }} is not defined"
+  when: "{{ item }} is not defined"
+  with_items:
+    - mellanox_spc1_hwskus
+    - mellanox_spc2_hwskus
+
+- set_fact:
+    chip: "spectrum"
+  when: hostvars[dut_name]['hwsku'] in mellanox_spc1_hwskus
+
+- set_fact:
+    chip: "spectrum2"
+  when: hostvars[dut_name]['hwsku'] in mellanox_spc2_hwskus
+
+- name: Create SID startup config
+  template:
+    src: settings.ini.j2
+    dest: "{{ home_path }}/sid/images/settings.ini"
+
+- name: start SimX in docker container
+  shell: /usr/bin/env python {{ home_path }}/sid/images/start.py
+
+- name: Wait for SID to start
+  pause:
+    seconds: 60
+
+# Annoying linux bridges will be gone in later SimX versions
+- name: get rid of linux bridges
+  shell: brctl delif v000_port{{ item }} tap{{ item }}
+  with_sequence: start=1 end=32
+  ignore_errors: true
+
+- name: get rid of linux bridges
+  shell: ifconfig v000_port{{ item }} down
+  with_sequence: start=1 end=32
+  ignore_errors: true
+  
+- name: get rid of linux bridges
+  shell: brctl delbr v000_port{{ item }}
+  with_sequence: start=1 end=32
+  ignore_errors: true

--- a/ansible/roles/vm_set/tasks/stop_sid.yml
+++ b/ansible/roles/vm_set/tasks/stop_sid.yml
@@ -1,0 +1,5 @@
+- name: stop and remove docker container
+  docker:
+    name: "{{ dut_name }}"
+    state: absent
+    image: simx

--- a/ansible/roles/vm_set/templates/settings.ini.j2
+++ b/ansible/roles/vm_set/templates/settings.ini.j2
@@ -1,0 +1,4 @@
+[{{ dut_name }}]
+chip = {{ chip }}
+vm_image = {{ disk_image }}
+ip = {{ mgmt_ip_address | ipaddr('address') }}, {{ mgmt_ip_address | ipaddr('netmask') }}, {{ vm_mgmt_gw }}

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -73,6 +73,7 @@
 
   roles:
     - { role: vm_set, action: 'start_sonic_vm' }
+    - { role: vm_set, action: 'start_sid' }
     - { role: vm_set, action: 'add_topo' }
 
 - hosts: servers:&eos

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -56,5 +56,6 @@
 
   roles:
     - { role: vm_set, action: 'remove_topo' }
+    - { role: vm_set, action: 'stop_sid' }
     - { role: vm_set, action: 'stop_sonic_vm' }
 

--- a/ansible/veos.vtb
+++ b/ansible/veos.vtb
@@ -32,3 +32,4 @@ topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000
 vlab-02 ansible_host=10.250.0.102 type=kvm hwsku=Force10-S6100
 vlab-simx-01 ansible_host=10.250.0.103 type=simx hwsku=MSN2700
+vlab-simx-02 ansible_host=10.250.0.104 type=simx hwsku=MSN3700

--- a/ansible/veos.vtb
+++ b/ansible/veos.vtb
@@ -31,3 +31,4 @@ topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32
 [sonic]
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000
 vlab-02 ansible_host=10.250.0.102 type=kvm hwsku=Force10-S6100
+vlab-simx-01 ansible_host=10.250.0.103 type=simx hwsku=MSN2700


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Add a few playbooks which allow to use t0 virtual testbed with Mellanox SimX simulator.
SimX is a functional simulation of Mellanox PCI devices
 - It simulates 
   - Mellanox NICs
   - Switch: Spectrum-1, Spectrum-2, Spectrum-3
- It simulates both FW and HW
- All flows are supported (controll + data path)


Mellanox only provides the simulator to it's customers.
Without the simulator none of this scripts are relevant.

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add start/stop playbooks for new DUT type=simx.
The playbook starts the Simulator inside a docker container(for ease of deployment) and then wm-topology module can connect it to the topology.
#### How did you verify/test it?
```
$ ./testbed-cli.sh -m veos.vtb start-vms server_1 password.txt
$ ./testbed-cli.sh -t vtestbed.csv -m veos.vtb add-topo vms-kvm-t0 password.txt
```
- run BGP test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
