### PR TITLE
[simx vt] add infra to skip tests not suitable on virtual testbed

### DIFF
--- a/ansible/roles/test/tasks/snmp.yml
+++ b/ansible/roles/test/tasks/snmp.yml
@@ -8,12 +8,6 @@
   assert: { that: "ansible_sysname == '{{ inventory_hostname }}'" }
 
 - block:
-    - name: include snmp cpu test
-      include: roles/test/tasks/snmp/cpu.yml
-
-    - name: inlcude snmp physical table test
-      include: roles/test/tasks/snmp/phys_table.yml
-
     - name: include snmp interfaces test
       include: roles/test/tasks/snmp/interfaces.yml
 
@@ -21,11 +15,21 @@
       include: roles/test/tasks/snmp/pfc_counters.yml
 
     - name: include snmp queues test
-      include: roles/test/tasks/snmp/queues.yml
-
-    - name: include snmp PSU test
-      include: roles/test/tasks/snmp/psu.yml
+      include: roles/test/tasks/snmp/queues.yml 
 
     - name: include snmp lldp test
       include: roles/test/tasks/snmp/lldp.yml
   when: testcase_name is defined
+
+- block:
+    - name: include snmp cpu test
+      include: roles/test/tasks/snmp/cpu.yml 
+
+    - name: inlcude snmp physical table test
+      include: roles/test/tasks/snmp/phys_table.yml
+
+    - name: include snmp PSU test
+      include: roles/test/tasks/snmp/psu.yml 
+  when:
+   - testcase_name is defined
+   - hostvars[ansible_hostname]['type'] != 'simx' 

--- a/ansible/roles/test/tasks/test_sonic_by_testname.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_testname.yml
@@ -32,17 +32,38 @@
 - name: print system versions
   debug: var=versions.stdout_lines
 
+- set_fact:
+    skip_test: false
+
+- set_fact:
+    skip_test: true
+  when: 
+    - testcases[testcase_name]['vtestbed_compatible'] is defined
+    - hostvars[ansible_hostname]['type'] == 'kvm' or hostvars[ansible_hostname]['type'] == 'simx'
+    - not testcases[testcase_name]['vtestbed_compatible'] | bool
+
 - name: run test case {{ testcases[testcase_name]['filename'] }} file
   include: "{{ testcases[testcase_name]['filename'] }}"
+  when: not skip_test
 
 - name: do basic sanity check after each test
   include: base_sanity.yml
+  when: not skip_test
 
 - name: validate all interfaces are up after test
   include: interface.yml
+  when: not skip_test
+
+- debug:
+    msg:
+      - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      - "!!!!!!!!!!!!!!!!!!!! test {{ testcase_name }} was skipped !!!!!!!!!!!!!!!!!!!!!!"
+      - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  when: skip_test
 
 - debug:
     msg:
       - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
       - "!!!!!!!!!!!!!!!!!!!! end running test {{ testcase_name }} !!!!!!!!!!!!!!!!!!!!!!"
       - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  when: not skip_test

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -40,6 +40,7 @@ testcases:
 
     continuous_reboot:
       filename: continuous_reboot.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
 
     copp:
@@ -75,6 +76,7 @@ testcases:
 
     fast-reboot:
       filename: fast-reboot.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-56, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
@@ -82,6 +84,7 @@ testcases:
 
     warm-reboot:
       filename: warm-reboot.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
@@ -89,6 +92,7 @@ testcases:
 
     warm-reboot-sad:
       filename: warm-reboot-sad.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
@@ -96,6 +100,7 @@ testcases:
 
     warm-reboot-multi-sad:
       filename: warm-reboot-multi-sad.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
@@ -117,6 +122,7 @@ testcases:
 
     warm-reboot-fib:
       filename: warm-reboot-fib.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
       required_vars:
           ptf_host:
@@ -157,10 +163,12 @@ testcases:
 
     link_flap:
       filename: link_flap.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
     continuous_link_flap:
       filename: continuous_link_flap.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
 
     mem_check:
@@ -190,6 +198,7 @@ testcases:
 
     pfc_wd:
       filename: pfc_wd.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
     portstat:
@@ -198,6 +207,7 @@ testcases:
 
     port_toggle:
       filename: port_toggle.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
     qos:
@@ -230,6 +240,7 @@ testcases:
 
     sensors:
       filename: sensors_check.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
     service_acl:
@@ -264,18 +275,21 @@ testcases:
 
     vxlan_decap:
       filename: vxlan-decap.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
 
     wr_arp:
       filename: wr_arp.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:
 
     vnet_vxlan:
       filename: vnet_vxlan.yml
+      vtestbed_compatible: no
       topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116]
       required_vars:
           ptf_host:

--- a/tests/platform/conftest.py
+++ b/tests/platform/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.fixture(autouse=True, scope="module")
+def skip_on_simx(testbed_devices):
+    platform = testbed_devices["dut"].facts["platform"]
+    if "simx" in platform:
+        pytest.skip('skipped on this platform: {}'.format(platform))


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Related to #1157 

Some tests can not be run on a virtual topology, due to missing fanout(PFC for example) or those relying on platform stuff (sensors, platform). 
Need a way to skip execution of these tests.


### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
