### PR TITLE
[tests] if no ptf host in testbed.csv get it from inventory

### DIFF
--- a/tests/ptf_fixtures.py
+++ b/tests/ptf_fixtures.py
@@ -34,7 +34,7 @@ def get_ifaces(netdev_output):
 
 
 @pytest.fixture(scope='module')
-def ptfadapter(ansible_adhoc, testbed):
+def ptfadapter(ptfhost, testbed):
     """return ptf test adapter object.
     The fixture is module scope, because usually there is not need to
     restart PTF nn agent and reinitialize data plane thread on every
@@ -43,7 +43,6 @@ def ptfadapter(ansible_adhoc, testbed):
     to restart PTF before proceeding running other test modules
     """
 
-    ptfhost = AnsibleHost(ansible_adhoc, testbed['ptf'])
     # get the eth interfaces from PTF and initialize ifaces_map
     res = ptfhost.command('cat /proc/net/dev')
     ifaces = get_ifaces(res['stdout'])


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
```
02:08:09         "ansible_adhoc = <function init_host_mgr at 0x7f19ecd395f0>", 
02:08:09         "testbed = {'comment': 'Mellanox MTBC testbed', 'dut': 'mtbc-sonic-03-2700', 'group-name': 'vm-t1', 'ptf_image_name': 'docker-ptf-mlnx', ...}", 
02:08:09         "", 
02:08:09         "    @pytest.fixture(scope='module')", 
02:08:09         "    def ptfadapter(ansible_adhoc, testbed):", 
02:08:09         "        \"\"\"return ptf test adapter object.", 
02:08:09         "        The fixture is module scope, because usually there is not need to", 
02:08:09         "        restart PTF nn agent and reinitialize data plane thread on every", 
02:08:09         "        test class or test function/method. Session scope should also be Ok,", 
02:08:09         "        however if something goes really wrong in one test module it is safer", 
02:08:09         "        to restart PTF before proceeding running other test modules", 
02:08:09         "        \"\"\"", 
02:08:09         "    ", 
02:08:09         ">       ptfhost = AnsibleHost(ansible_adhoc, testbed['ptf'])", 
02:08:09         "E       KeyError: 'ptf'", 
```

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Get ptf_host from inventory

#### How did you verify/test it?
Run test with pdb and access ptf_host when no ptf in testbed.csv

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
