### PR TITLE
Vxlan Decap: Send vxlan encapsulated packets to access vlan interfaces

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -256,6 +256,12 @@ class Vxlan(BaseTest):
 
 
     def Vxlan(self, test, wu = False):
+        for i, n in enumerate(test['acc_ports']):
+            for j, a in enumerate(test['acc_ports']):
+                res, out = self.checkVxlan(a, n, test)
+                if not res and not wu:
+                    return False, out + " | net_port_rel(acc)=%d acc_port_rel=%d" % (i, j)
+
         for i, n in enumerate(self.net_ports):
             for j, a in enumerate(test['acc_ports']):
                 res, out = self.checkVxlan(a, n, test)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Added a new loop enabling sending encapsulated packets from vlan ports and expecting them decapsulated on vlan ports 

#### How did you verify/test it?
Using ansible

#### Any platform specific information?
Tested on broadcom

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
