### PR TITLE
[copp] fix hard coding for arp test

### DIFF
--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -20,13 +20,13 @@
       script: roles/test/files/helpers/add_ip.sh
       delegate_to: "{{ ptf_host }}"
 
-    - name: set default nn_target_port if it's not defined
-      set_fact: nn_target_port="3"
-      when: nn_target_port is undefined
-
     - name: set default nn_target_interface if it's not defined
-      set_fact: nn_target_interface="Ethernet12"
+      set_fact: nn_target_interface="{{ minigraph_ports.keys()[3] }}"
       when: nn_target_interface is undefined
+
+    - name: set default nn_target_port if it's not defined
+      set_fact: nn_target_port="{{ minigraph_port_indices[nn_target_interface] }}"
+      when: nn_target_port is undefined
 
     - name: Update ptf_nn_agent configuration inside ptf
       template: src=ptf_nn_agent.conf.ptf.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
@@ -115,3 +115,4 @@
       with_items:
         - lldpd
         - lldp-syncd
+


### PR DESCRIPTION
### Description of PR
When perform the Copp ARP test, there are hard coding for selected port interface 3 and port interface's name "Ethernet12". For some devices, its interface 3's name is "Ethernet3" instead of "Ethernet12", therefore, the patch is changed to use minigarph to gather correct port interfaces name.

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)
 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
