### PR TITLE
[platform]Optimize reboot-cause testcase for 201811

### DIFF
--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -35,22 +35,26 @@ REBOOT_TYPE_POWEROFF = "power off"
 reboot_ctrl_dict = {
     REBOOT_TYPE_POWEROFF: {
         "timeout": 300,
-        "cause": "Power Loss"
+        "cause": "Power Loss",
+        "test_reboot_cause_only": True
     },
     REBOOT_TYPE_COLD: {
         "command": "reboot",
         "timeout": 300,
-        "cause": "reboot"
+        "cause": "reboot",
+        "test_reboot_cause_only": False
     },
     REBOOT_TYPE_FAST: {
         "command": "fast-reboot",
         "timeout": 180,
-        "cause": "fast-reboot"
+        "cause": "fast-reboot",
+        "test_reboot_cause_only": False
     },
     REBOOT_TYPE_WARM: {
         "command": "warm-reboot",
         "timeout": 180,
-        "cause": "warm-reboot"
+        "cause": "warm-reboot",
+        "test_reboot_cause_only": False
     }
 }
 
@@ -122,6 +126,10 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
 
     logging.info("Check reboot cause")
     check_reboot_cause(dut, reboot_cause)
+
+    if reboot_ctrl_dict[reboot_type]["test_reboot_cause_only"]:
+        logging.info("Further checking skipped for {} test which intends to verify reboot-cause only".format(reboot_type))
+        return
 
     logging.info("Wait some time for all the transceivers to be detected")
     assert wait_until(300, 20, check_interface_information, dut, interfaces), \


### PR DESCRIPTION
### Description of PR
Summary:
Optimize reboot-cause testcase via checking reboot-cause only for power off and watchdog reboot.

The power off and watchdog reboot share the same working flow with cold reboot except that their reboot causes differ and the motivation of them is to verify whether the reboot cause is correct.
In this sense, it is unnecessary to do the full check for them. By doing so we can reduce a lot of minutes.

This is the backport of the [[platform]Optimize reboot-cause testcase #1167](https://github.com/Azure/sonic-mgmt/pull/1167) on master

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### How did you do it?
Skip checkings other than reboot-cause for power off and watchdog reboot.

#### How did you verify/test it?
Run platform test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
