### PR TITLE
Added additional timeout for Marvell M0 sonic device

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -7,6 +7,11 @@
     reboot_type: "reboot"
   when: reboot_type is not defined
 
+- name: set default value for Marvell M0 sonic ready timeout
+  set_fact:
+    ready_timeout: 240
+  when: hwsku == 'et6448m'
+
 - name: set default value for sonic ready timeout
   set_fact:
     ready_timeout: 180

--- a/ansible/roles/test/tasks/restart_swss.yml
+++ b/ansible/roles/test/tasks/restart_swss.yml
@@ -8,6 +8,11 @@
   pause:
     seconds: 120
 
+- name: Wait for additional 120 seconds for Marvell M0 sonic swss service to recover
+  pause:
+    seconds: 120
+  when: hwsku == 'et6448m'
+
 - name: check basic sanity of the device
   include: base_sanity.yml
   vars:

--- a/ansible/roles/test/tasks/restart_syncd.yml
+++ b/ansible/roles/test/tasks/restart_syncd.yml
@@ -14,6 +14,11 @@
   pause:
     seconds: 10
 
+- name: Wait for additional 20 seconds for Marvell M0 sonic syncd to quit
+  pause:
+    seconds: 20
+  when: hwsku == 'et6448m'
+
 - name: Look for syncd process
   shell: pgrep "\<syncd\>" -a
   register: syncd_out
@@ -47,6 +52,11 @@
 - name: wait for 2 minutes for swss service to recover
   pause:
     seconds: 120
+
+- name: Wait for additional 120 seconds for Marvell M0 sonic swss service to recover
+  pause:
+    seconds: 120
+  when: hwsku == 'et6448m'
 
 - name: check basic sanity of the device
   include: base_sanity.yml


### PR DESCRIPTION
### Description of PR
Added additional timeout for Marvell M0 sonic device

### Type of change
- [] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
Added conditional check for hwsku=et6448m

#### How did you verify/test it?
tested it on local testbed

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
