### PR TITLE
Wrong DIP on packet

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -53,12 +53,21 @@ class ControlPlaneBaseTest(BaseTest):
 
         self.timeout_thr = None
 
+        self.minig_bgp = test_params.get('minig_bgp', None)
+        idx = 0
         self.myip = {}
         self.peerip = {}
-        for i in xrange(self.MAX_PORTS):
-            self.myip[i] = "10.0.0.%d" % (i*2+1)
-            self.peerip[i] = "10.0.0.%d" % (i*2)
-
+      
+        for peer in self.minig_bgp:
+            if str(peer['peer_addr']).find('10.0.0') == 0:#filter IPv6 info.
+              self.myip[idx] = peer['addr']
+              self.peerip[idx] = peer['peer_addr']
+              idx = idx+1
+#if port number is out of the total of IPv4, take the last IPv4
+        if int(target_port_str) > idx-1:
+          self.myip[self.target_port] = self.myip[idx-1]
+          self.peerip[self.target_port] = self.peerip[idx-1]
+       
         return
 
     def log(self, message, debug=False):

--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -63,7 +63,7 @@ class ControlPlaneBaseTest(BaseTest):
               self.myip[idx] = peer['addr']
               self.peerip[idx] = peer['peer_addr']
               idx = idx+1
-#if port number is out of the total of IPv4, take the last IPv4
+        #if port number is out of the total of IPv4, take the last IPv4
         if int(target_port_str) > idx-1:
           self.myip[self.target_port] = self.myip[idx-1]
           self.peerip[self.target_port] = self.peerip[idx-1]

--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -67,6 +67,7 @@
         - verbose=False
         - pkt_tx_count={{ pkt_tx_count|default(0) }}
         - target_port={{ nn_target_port }}
+        - minig_bgp={{ minigraph_bgp }}
         ptf_extra_options: "--device-socket 0-{{ nn_target_port }}@tcp://127.0.0.1:10900 --device-socket 1-{{ nn_target_port }}@tcp://{{ ansible_eth0['ipv4']['address'] }}:10900"
       with_items:
         - ARPTest


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
it cannot receive BGP, SNMP, SSH IP2ME packet on t1-lag and the root cause is copp_test.py config wrong DIP on packet.

Getting correct DIP solution:
1.add the "- minig_bgp={{ minigraph_bgp }}" to  call ptf_runner.yml as input argument in the copp.yml
2.  Filter IPv6 of minigraph_bgp and  in copp_test.py.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [v] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
