### PR TITLE
[advanced-reboot] Fix the wait condition between iterations

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -149,5 +149,5 @@
 
 - name: Wait for the DUT to be ready for the next test
   pause: seconds=420
-  when: (preboot_list|length > 1) or
-        (inboot_list|length > 0 and 'None' not in inboot_list)
+  when: (preboot_list|length > 0 and None not in preboot_list) or
+          (inboot_list|length > 0 and None not in inboot_list)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
include a wait between iterations only for the preboot and inboot cases where multiple items are present

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

#### How did you verify/test it?
Verified running warm-boot and fast-reboot cases. No wait at the end of the test
