### PR TITLE
[advanced reboot] define default vnet vars for every advanced reboot test

### DIFF
--- a/ansible/roles/test/tasks/fast-reboot.yml
+++ b/ansible/roles/test/tasks/fast-reboot.yml
@@ -3,7 +3,14 @@
       reboot_limit: 30
   when: reboot_limit is not defined
 
+- name: set default values vnet variables
+  set_fact:
+      vnet: False
+      vnet_pkts: ''
+  when: (vnet is not defined) or (vnet_pkts is not defined)
+
 - name: Fast-reboot test
   include: advanced-reboot.yml
   vars:
       reboot_type: fast-reboot
+

--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -71,7 +71,7 @@
         - allow_vlan_flooding='{{ allow_vlan_flooding }}'
         - sniff_time_incr={{ sniff_time_incr }}
         - setup_fdb_before_test=True
-        - vnet='{{ vnet }}'
+        - vnet={{ vnet }}
         - vnet_pkts='{{ vnet_pkts }}'
 
   always:

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad-inboot.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad-inboot.yml
@@ -8,6 +8,12 @@
   set_fact:
       in_list: ['routing_del:50', 'routing_add:50']
 
+- name: set default values vnet variables
+  set_fact:
+      vnet: False
+      vnet_pkts: ''
+  when: (vnet is not defined) or (vnet_pkts is not defined)
+
 - name: Warm-reboot test
   include: advanced-reboot.yml
   vars:

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -14,6 +14,12 @@
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
   when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
 
+- name: set default values vnet variables
+  set_fact:
+      vnet: False
+      vnet_pkts: ''
+  when: (vnet is not defined) or (vnet_pkts is not defined)
+
 - name: Warm-reboot test
   include: advanced-reboot.yml
   vars:

--- a/ansible/roles/test/tasks/warm-reboot-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad.yml
@@ -3,6 +3,12 @@
       reboot_limit: 1
   when: reboot_limit is not defined
 
+- name: set default values vnet variables
+  set_fact:
+      vnet: False
+      vnet_pkts: ''
+  when: (vnet is not defined) or (vnet_pkts is not defined)
+
 - name: Warm-reboot test
   include: advanced-reboot.yml
   vars:


### PR DESCRIPTION

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

 FAILED! => {"failed": true, "msg": "ERROR! 'vnet' is undefined"}

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Run fast-reboot, warm-reboot
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
