### PR TITLE
[VLAN] Add ptf_platform_dir: ptftests to enable more than 32 ports testbed.

### DIFF
--- a/ansible/roles/test/tasks/vlan_test.yml
+++ b/ansible/roles/test/tasks/vlan_test.yml
@@ -35,6 +35,7 @@
         ptf_test_dir: ptftests
         ptf_test_path: vlan_test.VlanTest
         ptf_platform: remote
+        ptf_platform_dir: ptftests
         ptf_test_params:
           - vlan_ports_list = \"{{ vlan_ports_list }}\"
           - vlan_intf_list = \"{{ vlan_intf_list }}\"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Add ptf_platform_dir: ptftests to enable more than 32 ports testbed.

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
This will enable using the remote.py platform in the ptftest folder
instead of using the default remote.py platform file in ptf package,
#### How did you verify/test it?
To run vlan case on all supported topology. No failed items.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
Signed-off-by: kelly_chen@edge-core.com