### PR TITLE
Added to-52 topology support for fdb_mac_expire test suite

### DIFF
--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-52']
 
 - name: set fdb_aging_time to default if no user input
   set_fact:

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -138,7 +138,7 @@ testcases:
 
     fdb_mac_expire:
       filename: fdb_mac_expire.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-52]
       required_vars:
           fdb_aging_time:
           ptf_host:


### PR DESCRIPTION
### Description of PR
Added to-52 topology support for fdb_mac_expire test suite

### Type of change
- [-/] Test case(new/improvement)

### Approach
#### How did you do it?
Modified the 'ansible/roles/test/tasks/fdb_mac_expire.yml' and 'ansible/roles/test/vars/testcases.yml' file to add the t0-52 topo support

#### How did you verify/test it?
Tested in local testbed and script is passing 

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

