### PR TITLE
Added sonic-cli to bring up/down the FanoutLeafSonic ports

### DIFF
--- a/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
+++ b/ansible/roles/test/tasks/link_flap/link_flap_helper.yml
@@ -46,7 +46,7 @@
 
     - name: Shutting down neighbor interface {{neighbor_interface}} on {{peer_host}}
       become: true
-      shell: ip link set {{port_alias_map[neighbor_interface]}} down
+      shell: config interface shutdown {{port_alias_map[neighbor_interface]}}
       delegate_to: "{{peer_host}}"
       when: peer_type == "FanoutLeafSonic"
 
@@ -80,7 +80,7 @@
 
     - name: Bring up neighbor interface {{neighbor_interface}} on {{peer_host}}
       become: true
-      shell: ip link set {{port_alias_map[neighbor_interface]}} up
+      shell: config interface startup {{port_alias_map[neighbor_interface]}}
       delegate_to: "{{peer_host}}"
       when: peer_type == "FanoutLeafSonic"
 


### PR DESCRIPTION
### Description of PR
Added sonic-cli to bring up/down the FanoutLeafSonic ports

### Type of change
- [] Test case(new/improvement)

### Approach
#### How did you do it?
* Added 'config interface startup/shutdown' sonic-li to the file 'ansible/roles/test/tasks/link_flap/link_flap_helper.yml'
* Replaced the 'ip link set port down/up' cli with sonic-cli 

#### How did you verify/test it?
Tested in local testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

