### PR TITLE
[test] Add lacp fallback test cases

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -212,10 +212,10 @@ def parse_dpg(dpg, hname):
             for i, member in enumerate(pcmbr_list):
                 pcmbr_list[i] = port_alias_to_name_map[member]
                 ports[port_alias_to_name_map[member]] = {'name': port_alias_to_name_map[member], 'alias': member}
-            if pcintf.find(str(QName(ns, "Fallback"))) != None:
-		pcs[pcintfname] = {'name': pcintfname, 'fallback': pcintf.find(str(QName(ns, "Fallback"))).text, 'members': pcmbr_list}
-            else:
-		pcs[pcintfname] = {'name': pcintfname, 'members': pcmbr_list}
+            pcs[pcintfname] = {'name': pcintfname, 'members': pcmbr_list}
+            fallback_node = pcintf.find(str(QName(ns, "Fallback")))
+            if  fallback_node is not None:
+                pcs[pcintfname]['fallback'] = fallback_node.text
             ports.pop(pcintfname)
 
         vlanintfs = child.find(str(QName(ns, "VlanInterfaces")))

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -212,7 +212,10 @@ def parse_dpg(dpg, hname):
             for i, member in enumerate(pcmbr_list):
                 pcmbr_list[i] = port_alias_to_name_map[member]
                 ports[port_alias_to_name_map[member]] = {'name': port_alias_to_name_map[member], 'alias': member}
-            pcs[pcintfname] = {'name': pcintfname, 'members': pcmbr_list}
+            if pcintf.find(str(QName(ns, "Fallback"))) != None:
+		pcs[pcintfname] = {'name': pcintfname, 'fallback': pcintf.find(str(QName(ns, "Fallback"))).text, 'members': pcmbr_list}
+            else:
+		pcs[pcintfname] = {'name': pcintfname, 'members': pcmbr_list}
             ports.pop(pcintfname)
 
         vlanintfs = child.find(str(QName(ns, "VlanInterfaces")))

--- a/ansible/minigraph/switch-t0.xml
+++ b/ansible/minigraph/switch-t0.xml
@@ -172,11 +172,13 @@
       <PortChannelInterfaces>
         <PortChannel>
           <Name>PortChannel01</Name>
+          <Fallback>true</Fallback>
           <AttachTo>fortyGigE0/112</AttachTo>
           <SubInterface/>
         </PortChannel>
         <PortChannel>
           <Name>PortChannel02</Name>
+          <Fallback>false</Fallback>
           <AttachTo>fortyGigE0/116</AttachTo>
           <SubInterface/>
         </PortChannel>

--- a/ansible/roles/sonicv2/templates/teamd.j2
+++ b/ansible/roles/sonicv2/templates/teamd.j2
@@ -3,8 +3,12 @@
     "runner": {
         "name": "lacp",
         "active": true,
+{% if PORTCHANNEL[pc]['fallback'] and ((PORTCHANNEL[pc]['members'] | length) == 1) %}
+        "fallback": {{ PORTCHANNEL[pc]['fallback'] }},
+{% else %}
 {# Use 75% links upperbound as min-links #}
         "min_ports": {{item['members'] | length * 0.75 | round(0, 'ceil') | int}},
+{% endif %}
         "tx_hash": ["eth", "ipv4", "ipv6"]
     },
     "link_watch": {

--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -72,12 +72,12 @@
 - name: test each lag interface minimum links and rate
   include: single_lag_test.yml
   with_items: lag_facts.names
-  when: lag_facts.lags[item]['po_config']['runner']['min_ports'] is defined
+  when: lag_facts.lags[item]['po_config']['runner']['min_ports'] is defined and test_minlink|bool == true
 
 - name: test each lag interface LACP DU rate
   include: single_lag_lacp_rate_test.yml
   with_items: lag_facts.names
-  when: lag_facts.lags[item]['po_config']['runner']['min_ports'] is defined
+  when: lag_facts.lags[item]['po_config']['runner']['min_ports'] is defined and test_rate|bool == true
 
 - name: test each lag interface with fallback config
   include: lag_fallback.yml

--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -72,9 +72,14 @@
 - name: test each lag interface minimum links and rate
   include: single_lag_test.yml
   with_items: lag_facts.names
-  when: test_minlink|bool == true
+  when: lag_facts.lags[item]['po_config']['runner']['min_ports'] is defined
 
 - name: test each lag interface LACP DU rate
   include: single_lag_lacp_rate_test.yml
   with_items: lag_facts.names
-  when: test_rate|bool == true
+  when: lag_facts.lags[item]['po_config']['runner']['min_ports'] is defined
+
+- name: test each lag interface with fallback config
+  include: lag_fallback.yml
+  with_items: lag_facts.names
+  when: lag_facts.lags[item]['po_config']['runner']['fallback'] is defined

--- a/ansible/roles/test/tasks/lag_fallback.yml
+++ b/ansible/roles/test/tasks/lag_fallback.yml
@@ -1,0 +1,86 @@
+### This playbook is part of lag_2.yml test
+### It is to test LACP fallback functionality when neighbor is not sending LACPDU.
+### The lag_fallback test cases flap the link from VM side while keeping the
+### physical link up, this is to simulate the situation where the remote end
+### stops sending LACP DU. If fallback is enabled, the port should still be selected,
+### and LAG should be kept up. Otherwise, the LAG should be brought down.
+### Then bring up the remote interface to make sure Port channel interface
+### should be kept up if fallback is enabled
+
+- set_fact:
+    po: "{{ item }}"
+    po_interfaces: "{{ lag_facts.lags[item]['po_config']['ports'] }}"
+    po_intf_num: "{{ lag_facts.lags[item]['po_config']['ports']|length }}"
+
+- set_fact:
+    flap_intf: "{{ lag_facts.lags[item]['po_config']['ports'].keys()[0] }}"
+    po_fallback: "{{ lag_facts.lags[item]['po_config']['runner']['fallback'] }}"
+
+### Now figure out remote VM and interface info for the falpping lag member and run fallback test
+- set_fact:
+    peer_device: "{{vm_neighbors[flap_intf]['name']}}"
+    neighbor_interface: "{{vm_neighbors[flap_intf]['port']}}"
+    peer_hwsku: 'Arista-VM'
+
+- set_fact:
+    peer_host: "{{ lldp[flap_intf]['chassis']['mgmt-ip'] }}"
+    wait_down_time: 120
+
+- block:
+    - name: Shut down neighbor interface {{ neighbor_interface }} on {{ peer_device }}
+      action: apswitch template=neighbor_interface_shut_single.j2
+      args:
+        host: "{{peer_host}}"
+        login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
+      connection: switch
+
+    - pause:
+        seconds: "{{ wait_down_time }}"
+
+    - lag_facts: host={{ inventory_hostname }}
+
+    - name: Display teamshow result
+      shell: teamshow
+      become: true
+      register: teamshow_result
+
+    - debug: var=teamshow_result.stdout_lines
+
+    - name: Verify all other lag member interfaces are marked selected
+      assert: { that: "'{{ lag_facts.lags[po]['po_stats']['ports'][item]['runner']['selected'] }}' == 'True'" }
+      with_items: "{{ po_interfaces.keys() }}"
+      when: item != "{{ flap_intf }}"
+
+    - name: Verify {{ flap_intf}}  lag member interfaces are marked as deselected for the shutdown port
+      assert: { that: "'{{ lag_facts.lags[po]['po_stats']['ports'][item]['runner']['selected'] }}' == 'False'" }
+      with_items: "{{ po_interfaces.keys() }}"
+      when: item == "{{ flap_intf }}"
+
+    - name: verify port-channel {{ po }} interface are marked down correctly if portchannel should down
+      assert: { that: "'{{ lag_facts.lags[po]['po_intf_stat'] }}' == 'Down' "}
+      when: po_fallback != True
+
+    - name: verify port-channel {{ po }} interface are marked Up correctly if portchannel should keepup
+      assert: { that: "'{{ lag_facts.lags[po]['po_intf_stat'] }}' == 'Up' "}
+      when: po_fallback == True
+
+  ### always bring back port in case test error and left testbed in unknow stage
+  always:
+    - name: Bring up neighbor interface {{ neighbor_interface }} on {{ peer_host }}
+      action: apswitch template=neighbor_interface_no_shut_single.j2
+      args:
+        host: "{{peer_host}}"
+        login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
+      connection: switch
+
+    - pause:
+        seconds: 30
+
+    - lag_facts: host={{ inventory_hostname }}
+
+    - name: Verify all interfaces in port_channel  are marked up
+      assert: { that: "'{{ lag_facts.lags[po]['po_stats']['ports'][item]['link']['up'] }}' == 'True'" }
+      with_items: "{{ po_interfaces.keys() }}"
+
+    - name: verify port-channel {{ po }} interface are marked up correctly
+      assert: { that: "'{{ lag_facts.lags[po]['po_intf_stat'] }}' == 'Up' "}


### PR DESCRIPTION
Signed-off-by: Haiyang Zheng <haiyang.z@alibaba-inc.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
1. Run lag_fallback test cases if fallback is configure on lags with only 1 member port
2. Run lag_minlink test cases only if min_ports is configured on lags with more than 2 member ports

**Please note min_port and fallback configure are mutual exclusive for each lag.**

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

The lag_fallback test cases flap the link from VM side while keeping the physical link up, this is to simulate the situation where the remote end stops sending LACP DU. If fallback is enabled, the port should still be selected, and LAG should be kept up. Otherwise, the member port should be unselected, and LAG should be brought down.

#### How did you verify/test it?
ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=lag_2 -e testbed_name={TESTBED_NAME}

#### Any platform specific information?

no
#### Supported testbed topology if it's a new test case?

t0 topo

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

https://github.com/Azure/SONiC/blob/master/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md
