### PR TITLE
[sensors] use platform string to index sensor test data

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -1,5 +1,5 @@
 sensors_checks:
-  Force10-S6100:
+  x86_64-dell_s6100_c2538-r0:
     alarms:
       fan:
       - SMF_S6100_ON-isa-0000/Tray1 Fan1/fan1_alarm
@@ -149,7 +149,7 @@ sensors_checks:
 
     psu_skips: {}
 
-  Force10-Z9100-C32:
+  x86_64-dell_z9100_c2538-r0:
     alarms:
       fan:
       - SMF_Z9100_ON-isa-0000/Tray1 Fan1/fan1_alarm
@@ -276,139 +276,7 @@ sensors_checks:
 
     psu_skips: {}
 
-  Force10-Z9100-C8D48:
-    alarms:
-      fan:
-      - SMF_Z9100_ON-isa-0000/Tray1 Fan1/fan1_alarm
-      - SMF_Z9100_ON-isa-0000/Tray1 Fan1/fan1_fault
-      - SMF_Z9100_ON-isa-0000/Tray1 Fan2/fan2_alarm
-      - SMF_Z9100_ON-isa-0000/Tray1 Fan2/fan2_fault
-      - SMF_Z9100_ON-isa-0000/Tray2 Fan1/fan3_alarm
-      - SMF_Z9100_ON-isa-0000/Tray2 Fan1/fan3_fault
-      - SMF_Z9100_ON-isa-0000/Tray2 Fan2/fan4_alarm
-      - SMF_Z9100_ON-isa-0000/Tray2 Fan2/fan4_fault
-      - SMF_Z9100_ON-isa-0000/Tray3 Fan1/fan5_alarm
-      - SMF_Z9100_ON-isa-0000/Tray3 Fan1/fan5_fault
-      - SMF_Z9100_ON-isa-0000/Tray3 Fan2/fan6_alarm
-      - SMF_Z9100_ON-isa-0000/Tray3 Fan2/fan6_fault
-      - SMF_Z9100_ON-isa-0000/Tray4 Fan1/fan7_alarm
-      - SMF_Z9100_ON-isa-0000/Tray4 Fan1/fan7_fault
-      - SMF_Z9100_ON-isa-0000/Tray4 Fan2/fan8_alarm
-      - SMF_Z9100_ON-isa-0000/Tray4 Fan2/fan8_fault
-      - SMF_Z9100_ON-isa-0000/Tray5 Fan1/fan9_alarm
-      - SMF_Z9100_ON-isa-0000/Tray5 Fan1/fan9_fault
-      - SMF_Z9100_ON-isa-0000/Tray5 Fan2/fan10_alarm
-      - SMF_Z9100_ON-isa-0000/Tray5 Fan2/fan10_fault
-      - SMF_Z9100_ON-isa-0000/Psu1 Fan/fan11_alarm
-      - SMF_Z9100_ON-isa-0000/Psu1 Fan/fan11_fault
-      - SMF_Z9100_ON-isa-0000/Psu2 Fan/fan12_alarm
-      - SMF_Z9100_ON-isa-0000/Psu2 Fan/fan12_fault
-      temp:
-      - coretemp-isa-0000/Core 0/temp2_crit_alarm
-      - coretemp-isa-0000/Core 1/temp3_crit_alarm
-      - coretemp-isa-0000/Core 2/temp4_crit_alarm
-      - coretemp-isa-0000/Core 3/temp5_crit_alarm
-      power:
-      - SMF_Z9100_ON-isa-0000/CPU XP3R3V_EARLY/in1_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP5R0V_CP/in2_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP3R3V_STD/in3_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP3R3V_CP /in4_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP3R3V_STD/in3_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP3R3V_CP /in4_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP0R75V_VTT_A/in5_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP0R75V_VTT_B/in6_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R07V_CPU/in7_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R0V_CPU/in8_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP12R0V/in9_alarm
-      - SMF_Z9100_ON-isa-0000/CPU VDDR_CPU_2/in10_alarm
-      - SMF_Z9100_ON-isa-0000/CPU VDDR_CPU_1/in11_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R5V_CLK/in12_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R35V_CPU/in13_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R8V_CPU/in14_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R0V_CPU_VNN/in15_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R0V_CPU_VCC/in16_alarm
-      - SMF_Z9100_ON-isa-0000/CPU XP1R5V_EARLY/in17_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP3R3V_MON/in19_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP1R8V_MON/in20_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP1R25V_MON/in21_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP1R2V_MON/in22_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP1R0V_SW_MON/in23_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP1R0V_ROV_SW_MON/in24_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP5V_MB_MON/in25_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP1R8V_FPGA_MON/in26_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP3R3V_FPGA_MON/in27_alarm
-      - SMF_Z9100_ON-isa-0000/SW XP3R3V_EARLY_MON/in28_alarm
-    compares:
-      temp:
-      - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_crit
-      - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_crit
-      - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_crit
-      - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_crit
-      power:
-      - - SMF_Z9100_ON-isa-0000/PSU1 Input  Power/power1_input
-        - SMF_Z9100_ON-isa-0000/PSU1 Input  Power/power1_max
-      - - SMF_Z9100_ON-isa-0000/PSU1 Output Power/power2_input
-        - SMF_Z9100_ON-isa-0000/PSU1 Output Power/power2_max
-      - - SMF_Z9100_ON-isa-0000/PSU2 Input  Power/power3_input
-        - SMF_Z9100_ON-isa-0000/PSU2 Input  Power/power3_max
-      - - SMF_Z9100_ON-isa-0000/PSU2 Output Power/power4_input
-        - SMF_Z9100_ON-isa-0000/PSU2 Output Power/power4_max
-      fan: []
-    non_zero:
-      fan:
-      - SMF_Z9100_ON-isa-0000/Tray1 Fan1/fan1_input
-      - SMF_Z9100_ON-isa-0000/Tray1 Fan2/fan2_input
-      - SMF_Z9100_ON-isa-0000/Tray2 Fan1/fan3_input
-      - SMF_Z9100_ON-isa-0000/Tray2 Fan2/fan4_input
-      - SMF_Z9100_ON-isa-0000/Tray3 Fan1/fan5_input
-      - SMF_Z9100_ON-isa-0000/Tray3 Fan2/fan6_input
-      - SMF_Z9100_ON-isa-0000/Tray4 Fan1/fan7_input
-      - SMF_Z9100_ON-isa-0000/Tray4 Fan2/fan8_input
-      - SMF_Z9100_ON-isa-0000/Tray5 Fan1/fan9_input
-      - SMF_Z9100_ON-isa-0000/Tray5 Fan2/fan10_input
-      - SMF_Z9100_ON-isa-0000/Psu1 Fan/fan11_input
-      - SMF_Z9100_ON-isa-0000/Psu2 Fan/fan12_input
-      power:
-      - SMF_Z9100_ON-isa-0000/PSU1 Input  Power/power1_input
-      - SMF_Z9100_ON-isa-0000/PSU1 Output Power/power2_input
-      - SMF_Z9100_ON-isa-0000/PSU2 Input  Power/power3_input
-      - SMF_Z9100_ON-isa-0000/PSU1 Output Power/power2_input
-      - SMF_Z9100_ON-isa-0000/PSU2 Input  Power/power3_input
-      - SMF_Z9100_ON-isa-0000/PSU2 Output Power/power4_input
-      - SMF_Z9100_ON-isa-0000/PSU1 VIN/in29_input
-      - SMF_Z9100_ON-isa-0000/PSU1 VOUT/in30_input
-      - SMF_Z9100_ON-isa-0000/PSU2 VIN/in31_input
-      - SMF_Z9100_ON-isa-0000/PSU2 VOUT/in32_input
-      - SMF_Z9100_ON-isa-0000/XP1R0V/curr21_input
-      - SMF_Z9100_ON-isa-0000/XP1R0V_ROV/curr22_input
-      - SMF_Z9100_ON-isa-0000/PSU1 Input  Current/curr601_input
-      - SMF_Z9100_ON-isa-0000/PSU1 Output Current/curr602_input
-      - SMF_Z9100_ON-isa-0000/PSU2 Input  Current/curr701_input
-      - SMF_Z9100_ON-isa-0000/PSU2 Output Current/curr702_input
-
-      temp:
-      - coretemp-isa-0000/Core 0/temp2_input
-      - coretemp-isa-0000/Core 1/temp3_input
-      - coretemp-isa-0000/Core 2/temp4_input
-      - coretemp-isa-0000/Core 3/temp5_input
-      - SMF_Z9100_ON-isa-0000/CPU On-board (U2900)/temp1_input
-      - "SMF_Z9100_ON-isa-0000/BCM Switch On-Board #1 (U44)/temp2_input"
-      - SMF_Z9100_ON-isa-0000/Front BCM On-Board (U4)/temp3_input
-      - SMF_Z9100_ON-isa-0000/Front BCM On-Board (U2)/temp4_input
-      - "SMF_Z9100_ON-isa-0000/BCM Switch On-Board #1 (U38)/temp6_input"
-      - SMF_Z9100_ON-isa-0000/Rear (U2900)/temp9_input
-      - SMF_Z9100_ON-isa-0000/PSU1 Temp/temp14_input
-      - SMF_Z9100_ON-isa-0000/PSU2 Temp/temp15_input
-
-    psu_skips: {}
-
-
-
-  Force10-S6000:
+  x86_64-dell_s6000_s1220-r0:
     alarms:
       fan:
       - dni_dps460-i2c-1-58/fan1/fan1_alarm
@@ -483,7 +351,7 @@ sensors_checks:
         - dni_dps460-i2c-1-59
         - ltc4215-i2c-11-42
 
-  Mellanox-SN2700:
+  x86_64-mlnx_msn2700-r0:
     alarms:
       fan:
       - dps460-i2c-10-59/fan1/fan1_alarm
@@ -598,7 +466,7 @@ sensors_checks:
         skip_list:
         - dps460-i2c-10-59
 
-  ACS-MSN2740:
+  x86_64-mlnx_msn2740-r0:
     alarms:
       fan:
       - dps460-i2c-4-58/fan1/fan1_alarm
@@ -727,7 +595,7 @@ sensors_checks:
         skip_list:
         - dps460-i2c-4-59
 
-  ACS-MSN2410:
+  x86_64-mlnx_msn2410-r0:
     alarms:
       fan:
       - dps460-i2c-10-59/fan1/fan1_alarm
@@ -842,7 +710,7 @@ sensors_checks:
         skip_list:
         - dps460-i2c-10-59
 
-  ACS-MSN2100:
+  x86_64-mlnx_msn2100-r0:
     alarms:
       fan: []
       power:
@@ -913,7 +781,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  ACS-MSN2010:
+  x86_64-mlnx_msn2010-r0:
     alarms:
       fan: []
       power:
@@ -965,7 +833,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  ACS-MSN3700:
+  x86_64-mlnx_msn3700-r0:
     alarms:
       fan:
       - dps460-i2c-4-58/PSU-1 Fan 1/fan1_alarm
@@ -1171,203 +1039,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  ACS-MSN3700C:
-    alarms:
-      fan:
-      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_alarm
-      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_fault
-
-      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_alarm
-      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_fault
-
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 1/fan1_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 2/fan2_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 1/fan3_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 2/fan4_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 1/fan5_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 2/fan6_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 1/fan7_fault
-      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 2/fan8_fault
-      power:
-      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_crit_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_max_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_crit_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_max_alarm
-      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in)/in1_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in2_crit_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in2_lcrit_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail (out)/in3_crit_alarm
-      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail (out)/in3_lcrit_alarm
-
-      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_crit_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_max_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_crit_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_max_alarm
-      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in)/in1_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in2_crit_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in2_lcrit_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail (out)/in3_crit_alarm
-      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail (out)/in3_lcrit_alarm
-
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_max_alarm
-      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in)/in1_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in2_crit_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in2_lcrit_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail (out)/in3_crit_alarm
-      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail (out)/in3_lcrit_alarm
-
-      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
-      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
-      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in)/in1_alarm
-      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_crit_alarm
-      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_lcrit_alarm
-
-      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_crit_alarm
-      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_max_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_crit_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_lcrit_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_max_alarm
-      - dps460-i2c-4-58/PSU-1 220V Rail Pwr (in)/power1_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_cap_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_crit_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_max_alarm
-      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_crit_alarm
-      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_lcrit_alarm
-      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_max_alarm
-      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_min_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_crit_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_lcrit_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_max_alarm
-      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_min_alarm
-
-      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_crit_alarm
-      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_max_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_crit_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_lcrit_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_max_alarm
-      - dps460-i2c-4-59/PSU-2 220V Rail Pwr (in)/power1_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_cap_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_crit_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_max_alarm
-      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_crit_alarm
-      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_lcrit_alarm
-      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_max_alarm
-      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_min_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_crit_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_lcrit_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_max_alarm
-      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_min_alarm
-      temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
-      - coretemp-isa-0000/Core 0/temp2_crit_alarm
-      - coretemp-isa-0000/Core 1/temp3_crit_alarm
-
-      - mlxsw-i2c-2-48/front panel 001/temp2_fault
-      - mlxsw-i2c-2-48/front panel 002/temp3_fault
-      - mlxsw-i2c-2-48/front panel 003/temp4_fault
-      - mlxsw-i2c-2-48/front panel 004/temp5_fault
-      - mlxsw-i2c-2-48/front panel 005/temp6_fault
-      - mlxsw-i2c-2-48/front panel 006/temp7_fault
-      - mlxsw-i2c-2-48/front panel 007/temp8_fault
-      - mlxsw-i2c-2-48/front panel 008/temp9_fault
-      - mlxsw-i2c-2-48/front panel 009/temp10_fault
-      - mlxsw-i2c-2-48/front panel 010/temp11_fault
-      - mlxsw-i2c-2-48/front panel 011/temp12_fault
-      - mlxsw-i2c-2-48/front panel 012/temp13_fault
-      - mlxsw-i2c-2-48/front panel 013/temp14_fault
-      - mlxsw-i2c-2-48/front panel 014/temp15_fault
-      - mlxsw-i2c-2-48/front panel 015/temp16_fault
-      - mlxsw-i2c-2-48/front panel 016/temp17_fault
-      - mlxsw-i2c-2-48/front panel 017/temp18_fault
-      - mlxsw-i2c-2-48/front panel 018/temp19_fault
-      - mlxsw-i2c-2-48/front panel 019/temp20_fault
-      - mlxsw-i2c-2-48/front panel 020/temp21_fault
-      - mlxsw-i2c-2-48/front panel 021/temp22_fault
-      - mlxsw-i2c-2-48/front panel 022/temp23_fault
-      - mlxsw-i2c-2-48/front panel 023/temp24_fault
-      - mlxsw-i2c-2-48/front panel 024/temp25_fault
-      - mlxsw-i2c-2-48/front panel 025/temp26_fault
-      - mlxsw-i2c-2-48/front panel 026/temp27_fault
-      - mlxsw-i2c-2-48/front panel 027/temp28_fault
-      - mlxsw-i2c-2-48/front panel 028/temp29_fault
-      - mlxsw-i2c-2-48/front panel 029/temp30_fault
-      - mlxsw-i2c-2-48/front panel 030/temp31_fault
-      - mlxsw-i2c-2-48/front panel 031/temp32_fault
-      - mlxsw-i2c-2-48/front panel 032/temp33_fault
-
-      - tps53679-i2c-5-70/PMIC-1 Temp 1/temp1_crit_alarm
-      - tps53679-i2c-5-70/PMIC-1 Temp 1/temp1_max_alarm
-      - tps53679-i2c-5-70/PMIC-1 Temp 2/temp2_crit_alarm
-      - tps53679-i2c-5-70/PMIC-1 Temp 2/temp2_max_alarm
-
-      - tps53679-i2c-5-71/PMIC-2 Temp 1/temp1_crit_alarm
-      - tps53679-i2c-5-71/PMIC-2 Temp 1/temp1_max_alarm
-      - tps53679-i2c-5-71/PMIC-2 Temp 2/temp2_crit_alarm
-      - tps53679-i2c-5-71/PMIC-2 Temp 2/temp2_max_alarm
-
-      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_crit_alarm
-      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_max_alarm
-      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_crit_alarm
-      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_max_alarm
-
-      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
-      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
-      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
-      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
-
-      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_crit_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_lcrit_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_max_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_min_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_crit_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_lcrit_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_max_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_min_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_crit_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_lcrit_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_max_alarm
-      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_min_alarm
-
-      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_crit_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_lcrit_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_max_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_min_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_crit_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_lcrit_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_max_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_min_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_crit_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_lcrit_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_max_alarm
-      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_min_alarm
-    compares:
-      power: []
-      temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
-      - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
-      - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
-
-      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
-        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
-
-      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
-        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
-
-      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
-        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
-    non_zero:
-      fan: []
-      power: []
-      temp: []
-    psu_skips: {}
-
-  Arista-7050-QX32:
+  x86_64-arista_7050_qx32:
     alarms:
       fan: []
       power:
@@ -1420,7 +1092,7 @@ sensors_checks:
 
     psu_skips: {}
 
-  Arista-7260CX3-D108C8:
+  x86_64-arista_7260cx3_64:
     alarms:
       fan:
       - pmbus-i2c-3-58/fan1/fan1_alarm
@@ -1509,7 +1181,7 @@ sensors_checks:
 
     psu_skips: {}
 
-  INGRASYS-S9100-C32:
+  x86_64-ingrasys_s9100-r0:
     alarms:
       fan:
       - w83795adg-i2c-0-2f/FANTRAY 1-A/fan1_alarm
@@ -1559,7 +1231,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  INGRASYS-S8900-54XC:
+  x86_64-ingrasys_s8900_54xc-r0:
     alarms:
       fan:
       - w83795adg-i2c-0-2f/FANTRAY 1-A/fan1_alarm
@@ -1609,7 +1281,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  INGRASYS-S8900-64XC:
+  x86_64-ingrasys_s8900_64xc-r0:
     alarms:
       fan:
       - w83795adg-i2c-0-2f/FANTRAY 1-A/fan1_alarm
@@ -1667,7 +1339,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  INGRASYS-S8810-32Q:
+  x86_64-ingrasys_s8810_32q-r0:
     alarms:
       fan:
       - w83795adg-i2c-0-2f/FANTRAY 1-A/fan1_alarm
@@ -1720,7 +1392,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  INGRASYS-S9130-32X:
+  x86_64-ingrasys_s9130_32x-r0:
     alarms:
       fan:
       - w83795adg-i2c-8-2f/FANTRAY 1-A/fan1_alarm
@@ -1771,7 +1443,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  Arista-7060CX-32S-C32:
+  x86_64-arista_7060_cx32s:
     alarms:
       fan:
       - pmbus-i2c-5-58/fan1/fan1_alarm
@@ -1840,7 +1512,7 @@ sensors_checks:
 
     psu_skips: {}
 
-  Accton-AS7712-32X:
+  x86_64-accton_as7712_32x-r0:
     alarms:
       fan:
       - as7712_32x_fan-i2c-2-66/fan1/fan1_fault
@@ -1913,7 +1585,7 @@ sensors_checks:
         skip_list:
         - ym2651-i2c-11-5b
 
-  Seastone-DX010:
+  x86_64-cel_seastone-r0:
     alarms:
       fan:
       - dps460-i2c-10-5a/fan1/fan1_alarm
@@ -2092,7 +1764,7 @@ sensors_checks:
       - lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
     psu_skips: {}
 
-  Arista-7170-64C:
+  x86_64-arista_7170_64c:
     alarms:
       fan:
       - dps1900-i2c-6-58/fan1/fan1_alarm
@@ -2172,103 +1844,7 @@ sensors_checks:
 
     psu_skips: {}
 
-  Arista-7260CX3-Q64:
-    alarms:
-      fan:
-      - pmbus-i2c-3-58/fan1/fan1_alarm
-      - pmbus-i2c-4-58/fan1/fan1_alarm
-      - pmbus-i2c-3-58/fan1/fan1_fault
-      - pmbus-i2c-4-58/fan1/fan1_fault
-      - la_cpld-i2c-85-60/fan1/fan1_fault
-      - la_cpld-i2c-85-60/fan2/fan2_fault
-      - la_cpld-i2c-85-60/fan3/fan3_fault
-      - la_cpld-i2c-85-60/fan4/fan4_fault
-      power:
-      - pmbus-i2c-3-58/iin/curr1_max_alarm
-      - pmbus-i2c-3-58/iout1/curr2_max_alarm
-      - pmbus-i2c-3-58/iout1/curr2_crit_alarm
-      - pmbus-i2c-3-58/iout2/curr3_crit_alarm
-      - pmbus-i2c-3-58/vin/in1_alarm
-      - pmbus-i2c-3-58/vout1/in2_lcrit_alarm
-      - pmbus-i2c-3-58/vout1/in2_crit_alarm
-      - pmbus-i2c-4-58/iin/curr1_max_alarm
-      - pmbus-i2c-4-58/iout1/curr2_max_alarm
-      - pmbus-i2c-4-58/iout1/curr2_crit_alarm
-      - pmbus-i2c-4-58/iout2/curr3_crit_alarm
-      - pmbus-i2c-4-58/vin/in1_alarm
-      - pmbus-i2c-4-58/vout1/in2_lcrit_alarm
-      - pmbus-i2c-4-58/vout1/in2_crit_alarm
-      temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
-      - coretemp-isa-0000/Core 0/temp2_crit_alarm
-      - coretemp-isa-0000/Core 1/temp3_crit_alarm
-      - lm73-i2c-88-48/Front panel temp sensor/temp1_min_alarm
-      - lm73-i2c-88-48/Front panel temp sensor/temp1_max_alarm
-      - max6658-i2c-1-4c/Asic temp sensor/temp1_min_alarm
-      - max6658-i2c-1-4c/Asic temp sensor/temp1_max_alarm
-      - max6658-i2c-1-4c/Asic temp sensor/temp1_crit_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 1/temp1_min_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 1/temp1_max_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 1/temp1_crit_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 2/temp2_min_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 2/temp2_max_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 2/temp2_crit_alarm
-      - max6658-i2c-73-4c/Back panel temp sensor 2/temp2_fault
-      - pmbus-i2c-3-58/Power supply 1 exhaust temp sensor/temp3_alarm
-      - pmbus-i2c-3-58/Power supply 1 inlet temp sensor/temp2_alarm
-      - pmbus-i2c-3-58/Power supply 1 hotspot sensor/temp1_alarm
-      - pmbus-i2c-4-58/Power supply 2 exhaust temp sensor/temp3_alarm
-      - pmbus-i2c-4-58/Power supply 2 inlet temp sensor/temp2_alarm
-      - pmbus-i2c-4-58/Power supply 2 hotspot sensor/temp1_alarm
-
-    compares:
-      fan: []
-      power:
-      - - pmbus-i2c-3-58/iin/curr1_input
-        - pmbus-i2c-3-58/iin/curr1_max
-      - - pmbus-i2c-3-58/iout1/curr2_input
-        - pmbus-i2c-3-58/iout1/curr2_max
-      - - pmbus-i2c-4-58/iin/curr1_input
-        - pmbus-i2c-4-58/iin/curr1_max
-      - - pmbus-i2c-4-58/iout1/curr2_input
-        - pmbus-i2c-4-58/iout1/curr2_max
-      temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
-      - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
-      - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
-      - - lm73-i2c-88-48/Front panel temp sensor/temp1_input
-        - lm73-i2c-88-48/Front panel temp sensor/temp1_max
-      - - max6658-i2c-1-4c/Asic temp sensor/temp1_input
-        - max6658-i2c-1-4c/Asic temp sensor/temp1_max
-      - - max6658-i2c-73-4c/Back panel temp sensor 1/temp1_input
-        - max6658-i2c-73-4c/Back panel temp sensor 1/temp1_max
-      - - max6658-i2c-73-4c/Back panel temp sensor 2/temp2_input
-        - max6658-i2c-73-4c/Back panel temp sensor 2/temp2_max
-
-    non_zero:
-      fan:
-      - pmbus-i2c-3-58/fan1/fan1_input
-      - pmbus-i2c-4-58/fan1/fan1_input
-      - la_cpld-i2c-85-60/fan1/fan1_input
-      - la_cpld-i2c-85-60/fan2/fan2_input
-      - la_cpld-i2c-85-60/fan3/fan3_input
-      - la_cpld-i2c-85-60/fan4/fan4_input
-      power:
-      - pmbus-i2c-4-58/pin/power1_input
-      - pmbus-i2c-4-58/pout1/power2_input
-      - pmbus-i2c-4-58/pout2/power3_input
-      - pmbus-i2c-3-58/pin/power1_input
-      - pmbus-i2c-3-58/pout1/power2_input
-      - pmbus-i2c-3-58/pout2/power3_input
-      temp:
-      - pch_haswell-virtual-0/temp1/temp1_input
-
-    psu_skips: {}
-    
-  Celestica-E1031-T48S4:
+  x86_64-cel_e1031-r0:
     alarms:
       fan: []
       power: []
@@ -2293,7 +1869,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-  Arista-7050-QX-32S:
+  x86_64-arista_7050_qx32s:
     alarms:
       fan:
       - pmbus-i2c-5-58/fan1/fan1_alarm

--- a/ansible/roles/sonic-common/tasks/sensors_check.yml
+++ b/ansible/roles/sonic-common/tasks/sensors_check.yml
@@ -2,15 +2,15 @@
   shell: docker ps -a --format '{{'{{'}}.Image{{'}} {{'}}.Names{{'}}'}}' | grep 'platform' | awk '{print $2}'
   register: pmon_ps
 
+- name: Get platform name
+  shell: show platform summary | grep Platform | awk '{print $2}'
+  register: platform
+
 - set_fact: 
     ansible_python_interpreter: "docker exec -i {{ pmon_ps.stdout }} python"
 
-- set_fact:
-    minigraph_hwsku: "Mellanox-SN2700"
-  when: minigraph_hwsku == 'ACS-MSN2700'
-
 - name: Gather sensors
-  sensors_facts: checks={{ sensors_checks[minigraph_hwsku] }}
+  sensors_facts: checks={{ sensors_checks[platform.stdout] }}
   vars:
     ansible_shell_type: docker
 


### PR DESCRIPTION
Summary:
### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

Many platforms have multiple HWSKUs defined. But they share the same set of sensor
definition. It makes sense for the sensor test definition also be the same.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
Ran sensor test on a few platforms that I have access to.
