### PR TITLE
[fdb] For SimX virtual testbed set dummy_mac_number to 1

### DIFF
--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -33,6 +33,12 @@
       dummy_mac_number: "10"
       vlan_member_count: 0
 
+  - name: Set dummy mac number for SimX virtual testbed
+    set_fact:
+      dummy_mac_number: "1"
+    when:
+      - hostvars[ansible_hostname]['type'] == 'simx'
+
   - name: "Start PTF runner"
     include: ptf_runner.yml
     vars:


### PR DESCRIPTION
SimX simulator performance is not enough to handle 264 new MAC
addresses. By setting dummy_mac_number to 1 we test 48 MACs
which make FDB test stable on SimX.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md



Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->


# Depends on https://github.com/Azure/sonic-mgmt/pull/1157
