### PR TITLE
[mlnx][fanout] disable cli paging

### DIFF
--- a/ansible/roles/fanout/templates/mlnx_fanout.j2
+++ b/ansible/roles/fanout/templates/mlnx_fanout.j2
@@ -54,6 +54,10 @@
 
 {% macro fanout_deploy() %}
 conf t
+
+{# Disable CLI paging #}
+no cli default paging enable
+
 no lldp
 no spanning-tree
 ip routing


### PR DESCRIPTION
If the output of some command runs through a pager, pexpect will
hang on expecting the prompt.

This is observed in case on Onyx OS 'show docker ps' when there are
several dockers running, so the output is passed through the pager.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
