### PR TITLE
[pytest] Escape quotes in parameters string of ptf_runner

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -1,7 +1,9 @@
+import pipes
+
 def ptf_runner(host, testdir, testname, platform_dir, params={}, \
                platform="remote", qlen=0, relax=True, debug_level="info", log_file=None):
 
-    ptf_test_params = ";".join(["{}=\"{}\"".format(k, v) for k, v in params.items()])
+    ptf_test_params = ";".join(["{}={}".format(k, repr(v)) for k, v in params.items()])
 
     cmd = "ptf --test-dir {} {} --platform-dir {}".format(testdir, testname, platform_dir)
     if qlen:
@@ -9,7 +11,7 @@ def ptf_runner(host, testdir, testname, platform_dir, params={}, \
     if platform:
         cmd += " --platform {}".format(platform)
     if ptf_test_params:
-        cmd += " -t '{}'".format(ptf_test_params)
+        cmd += " -t {}".format(pipes.quote(ptf_test_params))
     if relax:
         cmd += " --relax"
     if debug_level:


### PR DESCRIPTION
### Description of PR
Summary:
Escape quotes in parameters string in ptf_runner, later ptf could construct the object of parameters back.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
1. use `repr` to generate evaluatable string representation when construct ptf_test_parameters
2. use `pipes.qoute` to gen shell-escaped string when consturct ptf shell commands
#### How did you verify/test it?
consider a simple ptf test:
```
class Test(BaseTest):
    def __init__(self):
        BaseTest.__init__(self)
        self.test_params = test_params_get()
    def runTest(self):
        logging.info(self.test_params)
```
```
ptf_runner(ptfhost,
           "ptftests",
           "test.Test",
           platform_dir='ptftests',
           params={'str': "192.168.1.1",
                    'bool': True,
                    'int': 1000,
                    'float': 1.2,
                    'list': [1,2,3,4,[2,3,4],["192.168.1.1","2.2.2.2"]]
                    },
           log_file="/tmp/test.log")
```

Before:
```
{'int': '1000', 'bool': 'True', 'float': '1.2', 'list': '[1, 2, 3, 4, [2, 3, 4], [192.168.1.1, 2.2.2.2]]', 'str': '192.168.1.1'}
```
After:
```
{'int': 1000, 'bool': True, 'float': 1.2, 'list': [1, 2, 3, 4, [2, 3, 4], ['192.168.1.1', '2.2.2.2']], 'str': '192.168.1.1'}
```