### PR TITLE
Updating arp responder.py to capture and use vlan from packet

### DIFF
--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -168,7 +168,8 @@ def main():
             iface, vlan = iface.split('@')
             vlan_tag = format(int(vlan), 'x')
             vlan_tag = vlan_tag.zfill(4)
-        ip_sets[str(iface)] = {}
+        if str(iface) not in ip_sets:
+            ip_sets[str(iface)] = {}
         if args.extended:
             for ip, mac in ip_dict.items():
                 ip_sets[str(iface)][str(ip)] = binascii.unhexlify(str(mac))

--- a/ansible/roles/test/files/helpers/arp_responder.py
+++ b/ansible/roles/test/files/helpers/arp_responder.py
@@ -7,7 +7,12 @@ import argparse
 import os.path
 from fcntl import ioctl
 from pprint import pprint
-
+import logging
+logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
+import ptf.packet as scapy
+import scapy.all as scapy2
+scapy2.conf.use_pcap=True
+import scapy.arch.pcapdnet
 
 def hexdump(data):
     print " ".join("%02x" % ord(d) for d in data)
@@ -39,18 +44,20 @@ class Interface(object):
             self.socket.close()
 
     def bind(self):
-        self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(self.ETH_P_ALL))
-        self.socket.bind((self.iface, 0))
-        self.socket.settimeout(self.RCV_TIMEOUT)
+        self.socket = scapy2.conf.L2listen(iface=self.iface)
 
     def handler(self):
-        return self.socket.fileno()
+        return self.socket
 
     def recv(self):
-        return self.socket.recv(self.RCV_SIZE)
+        sniffed = self.socket.recv()
+        pkt = sniffed[0]
+        str_pkt = str(pkt).encode("HEX")
+        binpkt = binascii.unhexlify(str_pkt)
+        return binpkt
 
     def send(self, data):
-        self.socket.send(data)
+        scapy2.sendp(data, iface=self.iface)
 
     def mac(self):
         return self.mac_address
@@ -75,7 +82,7 @@ class Poller(object):
 
 
 class ARPResponder(object):
-    ARP_PKT_LEN = 60
+    ARP_PKT_LEN = 64
     ARP_OP_REQUEST = 1
     def __init__(self, ip_sets):
         self.arp_chunk = binascii.unhexlify('08060001080006040002') # defines a part of the packet for ARP Reply
@@ -90,7 +97,7 @@ class ARPResponder(object):
         if len(data) > self.ARP_PKT_LEN:
             return
 
-        remote_mac, remote_ip, request_ip, op_type = self.extract_arp_info(data)
+        remote_mac, remote_ip, request_ip, op_type, vlan_id = self.extract_arp_info(data)
 
         # Don't send ARP response if the ARP op code is not request
         if op_type != self.ARP_OP_REQUEST:
@@ -99,12 +106,6 @@ class ARPResponder(object):
         request_ip_str = socket.inet_ntoa(request_ip)
         if request_ip_str not in self.ip_sets[interface.name()]:
             return
-
-        if 'vlan' in self.ip_sets[interface.name()]:
-            vlan_id = self.ip_sets[interface.name()]['vlan']
-        else:
-            vlan_id = None
-
         arp_reply = self.generate_arp_reply(self.ip_sets[interface.name()][request_ip_str], remote_mac, request_ip, remote_ip, vlan_id)
         interface.send(arp_reply)
 
@@ -112,7 +113,25 @@ class ARPResponder(object):
         
     def extract_arp_info(self, data):
         # remote_mac, remote_ip, request_ip, op_type
-        return data[6:12], data[28:32], data[38:42], (ord(data[20]) * 256 + ord(data[21]))
+        rem_ip_start = 28
+        req_ip_start = 38
+        op_type_start = 20
+        eth_offset = 0
+        vlan_id = None
+        ether_type = str(data[12:14]).encode("HEX")
+        if (ether_type == '8100'):
+            vlan = str(data[14:16]).encode("HEX")
+            if (vlan != '0000'):
+                eth_offset = 4
+                vlan_id = data[14:16]
+        rem_ip_start = rem_ip_start + eth_offset
+        req_ip_start = req_ip_start + eth_offset
+        op_type_start = op_type_start + eth_offset
+        rem_ip_end = rem_ip_start + 4
+        req_ip_end = req_ip_start + 4
+        op_type_end = op_type_start + 1
+
+        return data[6:12], data[rem_ip_start:rem_ip_end], data[req_ip_start:req_ip_end], (ord(data[op_type_start]) * 256 + ord(data[op_type_end])), vlan_id
 
     def generate_arp_reply(self, local_mac, remote_mac, local_ip, remote_ip, vlan_id):
         eth_hdr = remote_mac + local_mac


### PR DESCRIPTION
Fixes based on UT

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Updated arp responder.py to use libpcap socket as low level l2caplisten socket so that arp_responder gets vlan tag from the packet.
The vlan tag is then used in the arp response. 
With this change an interface can have multiple vlans. Earlier there was one vlan per interface which is picked from /tmp/from_t1.json

PLEASE DO NOT MERGE THIS UNTIL https://github.com/Azure/sonic-buildimage/pull/3731 is merged

Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Updated docker-ptf to include python-libpcap. 
After setting conf.use_pcap = True
print the value of conf.L2listen
and the value is
<L2pcapListenSocket: read packets at layer 2 using libpcap>

Without the configuration the value printed would be
<L2ListenSocket: read packets at layer 2 using Linux PF_PACKET sockets>

Use scapy send and recv instead of traditional socket send and recv API calls.

#### How did you verify/test it?
After this change verify by running existing test cases. All the test cases that uses arp_responder.py passed.
Additional ran the script separately to ensure vlan tag is received in a packet during arp request.
Below is the sample received packet
ffffffffffff4c7625f446808100000a080600010800060400014c7625f446800101010100000000000001010103

The packet was sent on vlan 10 and "8100 000a" confirms vlan 10 is present in packet received.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
