### PR TITLE
[test_sfp.py]Ignore the error logs for known issue in SFP reset & LPM test

### DIFF
--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -62,11 +62,12 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     """
     ans_host = testbed_devices["dut"]
 
-    loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='sfp_cfg')
-    loganalyzer.load_common_config()
+    if ans_host.facts["asic_type"] in ["mellanox"]:
+        loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='sfp_cfg')
+        loganalyzer.load_common_config()
 
-    loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
-    marker = loganalyzer.init()
+        loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
+        marker = loganalyzer.init()
 
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -123,7 +124,8 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
 
-    loganalyzer.analyze(marker)
+    if ans_host.facts["asic_type"] in ["mellanox"]:
+        loganalyzer.analyze(marker)
 
 
 def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
@@ -137,11 +139,12 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     """
     ans_host = testbed_devices["dut"]
 
-    loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='sfp_lpm')
-    loganalyzer.load_common_config()
+    if ans_host.facts["asic_type"] in ["mellanox"]:
+        loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='sfp_lpm')
+        loganalyzer.load_common_config()
 
-    loganalyzer.ignore_regex.append("Eeprom query failed")
-    marker = loganalyzer.init()
+        loganalyzer.ignore_regex.append("Eeprom query failed")
+        marker = loganalyzer.init()
 
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
@@ -196,4 +199,5 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
 
-    loganalyzer.analyze(marker)
+    if ans_host.facts["asic_type"] in ["mellanox"]:
+        loganalyzer.analyze(marker)

--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -13,7 +13,11 @@ import copy
 import pytest
 
 from platform_fixtures import conn_graph_facts
+from loganalyzer import LogAnalyzer
 
+pytestmark = [
+    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+]
 
 def parse_output(output_lines):
     """
@@ -56,8 +60,13 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     * show interface transceiver eeprom
     * sfputil reset <interface name>
     """
-
     ans_host = testbed_devices["dut"]
+
+    loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='sfp_cfg')
+    loganalyzer.load_common_config()
+
+    loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
+    marker = loganalyzer.init()
 
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -114,6 +123,8 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
 
+    loganalyzer.analyze(marker)
+
 
 def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     """
@@ -125,6 +136,12 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     * sfputil lpmode on
     """
     ans_host = testbed_devices["dut"]
+
+    loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='sfp_lpm')
+    loganalyzer.load_common_config()
+
+    loganalyzer.ignore_regex.append("Eeprom query failed")
+    marker = loganalyzer.init()
 
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
@@ -178,3 +195,5 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     intf_facts = ans_host.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
+
+    loganalyzer.analyze(marker)


### PR DESCRIPTION
### Description of PR
Ignore the error logs of "Eeprom query failed" in reset sfp & lpm test.
It is introduced temporarily as a workaround for the known issue [[test_sfp.py]Ignore the error logs for known issue in SFP reset & LPM test #1205](https://github.com/Azure/sonic-buildimage/issues/3774) and will be removed after the issue is resolved.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Fix the issue that error logs "Eeprom query failed" found during test_sfp running by ignoring the log.
During the test, the sfp modules can be reset or set to lpm mode, which causes the sfp module inaccessible temporary. When the xcvrd receives the "plugin" event it tries to access the module but it takes seconds for the sfp module to be accessible, which causes that log.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
