### PR TITLE
[plugin/connect/switch] Fix the stuck issue of connecting fanout

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -67,21 +67,22 @@ class Connection(ConnectionBase):
             (user, login_passwd) = self.login['user'][attempt]
             if user != last_user:
                 cmd = self._ssh_command + ['-l', user, self.host]
-                self._display.vvv("SSH: EXEC {0}".format(' '.join(cmd)),
-                              host=self.host)
                 last_user = user
                 for conn_attempt in range(max_retries):
                     if client:
                         client.close()
+                    self._display.vvv("SSH: EXEC {0}".format(' '.join(cmd)), host=self.host)
                     client = pexpect.spawn(' '.join(cmd), env={'TERM': 'dumb'}, timeout=self.timeout)
-                    i = client.expect(['[Pp]assword:', pexpect.EOF])
+                    i = client.expect(['[Pp]assword:', pexpect.EOF, pexpect.TIMEOUT])
                     if i == 0:
                         break
                     else:
-                        if conn_attempt == (max_retries - 1):
-                            raise AnsibleError("Establish connection to server failed after tried %d times." % (conn_attempt + 1))
-                        self._display.vvv("Server closed the connection, retry in %d seconds" % self.connection_retry_interval, host=self.host)
-                        time.sleep(self.connection_retry_interval)
+                        self._display.vvv("Establish connection to server failed", host=self.host)
+                        if conn_attempt < max_retries - 1:   # To avoid unnecessary sleep if max retry reached
+                            self._display.vvv("Retry in %d seconds" % self.connection_retry_interval, host=self.host)
+                            time.sleep(self.connection_retry_interval)
+                else:
+                    raise AnsibleError("Establish connection to server failed after tried %d times." % max_retries)
 
             self._display.vvv("Try password %s..." % login_passwd[0:4], host=self.host)
             client.sendline(login_passwd)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The "switch" connection plugin is used for run
commands on fanout switches. But if fanout switch
is down, the plugin will retry forever.

```
05:18:38 TASK [test : set_fact] *********************************************************
05:18:38 task path: /builds2/jenkins2/workspace/SONiC_Deploy/ansible/roles/test/tasks/resume_fanout_ports.yml:15
05:18:38 Sunday 27 October 2019  21:18:38 +0000 (0:00:00.416)       0:04:02.686 ******** 
05:18:38 ok: [arc-switch1038-t1-lag] => {"ansible_facts": {"peer_host": "10.210.25.42", "peer_hwsku": "MLNX-OS"}, "changed": false, "invocation": {"module_args": {"peer_host": "10.210.25.42", "peer_hwsku": "MLNX-OS"}, "module_name": "set_fact"}}
05:18:38 
05:18:38 TASK [test : set_fact] *********************************************************
05:18:38 task path: /builds2/jenkins2/workspace/SONiC_Deploy/ansible/roles/test/tasks/resume_fanout_ports.yml:19
05:18:38 Sunday 27 October 2019  21:18:38 +0000 (0:00:00.139)       0:04:02.825 ******** 
05:18:39 ok: [arc-switch1038-t1-lag] => {"ansible_facts": {"intfs_to_exclude": "Ethernet32"}, "changed": false, "invocation": {"module_args": {"intfs_to_exclude": "Ethernet32"}, "module_name": "set_fact"}}
05:18:39 
05:18:39 TASK [test : bring up neighbor interface ethernet 1/9 on 10.210.25.42] *********
05:18:39 task path: /builds2/jenkins2/workspace/SONiC_Deploy/ansible/roles/test/tasks/resume_fanout_ports.yml:22
05:18:39 Sunday 27 October 2019  21:18:39 +0000 (0:00:00.146)       0:04:02.972 ******** 
05:18:39 ActionModule run
05:18:39 cisco
05:18:39 {'enable': [], 'user': [(u'admin', u'admin')]}
05:18:39 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
05:18:42 <10.210.25.42> Server closed the connection, retry in 60 seconds
05:19:42 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
05:19:45 <10.210.25.42> Server closed the connection, retry in 60 seconds
05:20:45 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
05:20:48 <10.210.25.42> Server closed the connection, retry in 60 seconds
05:21:48 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
05:21:52 <10.210.25.42> Server closed the connection, retry in 60 seconds
05:22:52 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
05:22:55 <10.210.25.42> Server closed the connection, retry in 60 seconds
05:23:55 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
05:23:58 <10.210.25.42> Server closed the connection, retry in 60 seconds
05:24:58 <10.210.25.42> SSH: EXEC ssh -tt -q -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no -o PubkeyAuthentication=no -o ConnectTimeout=300 -l admin 10.210.25.42
```

The fix is to limit the number of retries if SSH
connection to fanout cannot be established.

The fix is required for 201811 branch too.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
The fix is to limit the number of retries if SSH
connection to fanout cannot be established.

#### How did you verify/test it?
* Fanout switch up, running commands on fanout was OK.
* Fanout switch down, retried connection 3 times and then aborted. AnsibleError exception raised. 

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
