### PR TITLE
[tests/Mgmt-vrf]:Adding script for management vrf

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -32,6 +32,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=180, wait=1
 
     # pool for executing tasks asynchronously
     pool = ThreadPool()
+    dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
 
     try:
         reboot_command = reboot_commands[reboot_type]
@@ -45,7 +46,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=180, wait=1
     reboot_res = pool.apply_async(execute_reboot)
 
     logger.info('waiting for ssh to drop')
-    res = localhost.wait_for(host=duthost.hostname,
+    res = localhost.wait_for(host=dut_ip,
                              port=SONIC_SSH_PORT,
                              state='absent',
                              search_regex=SONIC_SSH_REGEX,
@@ -62,7 +63,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=180, wait=1
     #       testbed information
 
     logger.info('waiting for ssh to startup')
-    res = localhost.wait_for(host=duthost.hostname,
+    res = localhost.wait_for(host=dut_ip,
                              port=SONIC_SSH_PORT,
                              state='started',
                              search_regex=SONIC_SSH_REGEX,
@@ -79,9 +80,9 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=180, wait=1
 
     if reboot_type == 'warm':
         logger.info('waiting for warmboot-finalizer service to finish')
-        finalizer_state = 'active'
+        finalizer_state = 'activating'
         count = 0
-        while finalizer_state == 'active':
+        while finalizer_state == 'activating':
             try:
                 res = duthost.command('systemctl is-active warmboot-finalizer.service')
             except AnsibleModuleException as err:

--- a/tests/mvrf/config_service_acls.sh
+++ b/tests/mvrf/config_service_acls.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# config_service_acls.sh
+#
+#  Configure service ACLs in such a way that should prevent Ansible
+#  server from connecting to running services. This should cause Ansible
+#  playbook tasks which remotely connect to thses services to fail (timeout),
+#  ensuring service ACLs are implemented correctly and actually dropping
+#  unpermitted traffic.
+#
+
+# Generate an ACL config file which allows only IP address ranges which
+# shouldn't contian the IP address of our Ansible server
+cat << EOF > /tmp/testacl.json
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "SNMP-ACL": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": "IP_UDP",
+                                        "source-ip-address": "1.1.1.1/32"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "config": {
+                        "name": "SNMP-ACL"
+                    }
+                },
+                "ssh-only": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": "IP_TCP",
+                                        "source-ip-address": "1.1.1.1/32"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "config": {
+                        "name": "ssh-only"
+                    }
+                }
+            }
+        }
+    }
+}
+EOF
+
+# Install the new service ACLs
+acl-loader update full /tmp/testacl.json
+
+# Sleep to allow Ansible playbook ample time to attempt to connect and timeout
+sleep 60
+
+# Delete the test ACL config file
+rm -rf /tmp/testacl.json
+
+# IMPORTANT! Delete the ACLs we just added in order to restore connectivity
+acl-loader delete

--- a/tests/mvrf/config_vrf_del.sh
+++ b/tests/mvrf/config_vrf_del.sh
@@ -1,0 +1,2 @@
+sudo config vrf del mgmt
+time.sleep(5)

--- a/tests/test_mgmtvrf.py
+++ b/tests/test_mgmtvrf.py
@@ -1,0 +1,202 @@
+import pytest
+import sys
+import time
+from common import reboot
+from common.utilities import wait_until
+import re
+from ansible_host import AnsibleModuleException
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module',autouse=True)
+def setup_mvrf(duthost, testbed_devices, testbed, localhost):
+    '''
+    Setup Management vrf configs before the start of testsuite
+    '''
+    logging.info(' Configure mgmt vrf')
+    global var
+    global mvrf 
+    mvrf = True  
+    var = {}
+    var['dut_ip'] = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
+    var['ptf_ip'] = testbed['ptf_ip']
+    var['filename'] = 'README.md'
+    duthost.command('sudo config vrf add  mgmt')
+    logger.info('waiting for ssh to startup')
+    SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
+
+    res = localhost.wait_for(host=var['dut_ip'],
+                             port=22,
+                             state='started',
+                             search_regex=SONIC_SSH_REGEX,
+                             timeout=90)
+    time.sleep(5)
+    verify_show_command(duthost)
+    yield 
+    mvrf = False 
+    logging.info(' Unconfigure  mgmt vrf')
+    duthost.copy(src="mvrf/config_vrf_del.sh",dest="/tmp/config_vrf_del.sh",mode=0755)
+    duthost.shell("nohup /tmp/config_vrf_del.sh < /dev/null > /dev/null 2>&1 &")
+
+    res = localhost.wait_for(host=var['dut_ip'],
+                             port=22,
+                             state='started',
+                             search_regex=SONIC_SSH_REGEX,
+                             timeout=90)
+    time.sleep(10)
+
+    duthost.command('sudo config save -y')
+    verify_show_command(duthost, mvrf=False)
+
+
+def verify_show_command(duthost, mvrf=True):
+
+    show_mgmt_vrf=duthost.shell('show mgmt-vrf')['stdout']
+    mvrf_interfaces = {}
+    logging.debug("show mgmt vrf \n {}".format(show_mgmt_vrf))
+    if mvrf: 
+        mvrf_interfaces['mgmt'] = "\d+:\s+mgmt:\s+<NOARP,MASTER,UP,LOWER_UP> mtu\s+\d+\s+qdisc\s+noqueue\s+state\s+UP"
+        mvrf_interfaces['vrf_table'] = "vrf table 5000"
+        mvrf_interfaces['eth0'] = "\d+:\s+eth0+:\s+<BROADCAST,MULTICAST,UP,LOWER_UP>.*master mgmt\s+state\s+UP "
+        mvrf_interfaces['lo']   = "\d+:\s+lo-m:\s+<BROADCAST,NOARP,UP,LOWER_UP>.*master mgmt"    
+        assert "ManagementVRF : Enabled" in show_mgmt_vrf
+        for intf , pattern in mvrf_interfaces.items():
+            assert re.search(pattern,show_mgmt_vrf) is not None
+    else: 
+         assert "ManagementVRF : Disabled" in show_mgmt_vrf
+
+
+def execute_dut_command(duthost, command, mvrf = True, ignore_errors=False):
+    result = {} 
+    prefix = ""
+    if mvrf: 
+         prefix = "sudo  cgexec -g l3mdev:mgmt "
+    result=duthost.command(prefix+command, module_ignore_errors=ignore_errors)
+    return result
+    
+class TestMvrfInbound():
+
+    def test_ping(self,duthost, localhost):
+       res = duthost.ping()
+
+    def test_snmp_fact(self,testbed_devices):
+       localhost = testbed_devices['localhost']
+       duthost = testbed_devices['dut']
+       snmp_res = localhost.snmp_facts(host=var['dut_ip'],version='v2c',community='public' )  
+       
+class TestMvrfOutbound(): 
+
+    @pytest.fixture  
+    def apt_install_wget(self, duthost):
+        logging.info("apt-get update , apt-get install wget")
+        apt_update_cmd = ' apt-get update -y'
+        apt_install_wget = ' apt-get install wget -y'
+        apt_remove = ' apt-get remove wget -y'
+        execute_dut_command(duthost, apt_update_cmd, mvrf=True)
+        execute_dut_command(duthost, apt_install_wget, mvrf=True)
+        yield 
+        logging.info(" remove wget")
+        duthost.file(path=var['filename'], state='absent')
+        execute_dut_command(duthost, apt_remove, mvrf = True)
+
+    def test_ping(self, testbed, duthost):
+        logging.info("Test OutBound Ping")
+        command = "ping  -c 3 " + var['ptf_ip'] 
+        result = execute_dut_command(duthost, command, mvrf=True)
+            
+    def test_wget(self, duthost, apt_install_wget):
+        logging.info("Test Wget")
+        wget_command=" wget  https://raw.githubusercontent.com/Azure/SONiC/master/README.md"
+        result = execute_dut_command(duthost, wget_command, mvrf=True)
+        file_exists=duthost.stat(path=var['filename'])
+        assert file_exists['stat']['exists'] == True
+
+    def test_curl(self, duthost):
+        logging.info("Test Curl")
+        curl_cmd = 'curl https://raw.githubusercontent.com/Azure/SONiC/master/README.md -o %s -f'%var['filename']
+        result = execute_dut_command(duthost,curl_cmd,mvrf=True)
+        file_exists = duthost.stat(path=var['filename'])
+        assert file_exists['stat']['exists']==True
+        duthost.file(path=var['filename'], state='absent')
+
+
+
+class TestServices():
+
+    def check_ntp_status(self, duthost): 
+       ntpstat_cmd = "ntpstat"
+       ntp_stat = execute_dut_command(duthost,ntpstat_cmd,mvrf=True,ignore_errors=True)
+       if ntp_stat['rc'] != 0 :
+          return False 
+       return True 
+
+    def test_ntp(self, duthost):
+        force_ntp=" ntpd -gq"
+        duthost.service(name='ntp' , state='stopped') 
+        logging.info("Ntp restart in mgmt vrf")
+        execute_dut_command(duthost, force_ntp)
+        duthost.service(name='ntp' , state='restarted')
+        assert wait_until(100, 10, self.check_ntp_status , duthost), "Ntp not started"
+
+    def test_service_acl(self, duthost, localhost):
+        # SSH definitions
+        logging.info("test Service acl")
+        SONIC_SSH_PORT  = 22
+        SONIC_SSH_REGEX = 'OpenSSH_[\\w\\.]+ Debian'
+        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
+        duthost.copy(src="mvrf/config_service_acls.sh",dest="/tmp/config_service_acls.sh",mode=0755) 
+        duthost.shell("nohup /tmp/config_service_acls.sh < /dev/null > /dev/null 2>&1 &")       
+        time.sleep(5)
+        logger.info('waiting for ssh to drop')
+        res = localhost.wait_for(host=dut_ip,
+                         port=SONIC_SSH_PORT,
+                         state='stopped',
+                         search_regex=SONIC_SSH_REGEX,
+                         timeout=90)
+        logger.info("ssh stopped for few seconds , wait for the ssh to come up")
+        res = localhost.wait_for(host=dut_ip,
+                         port=SONIC_SSH_PORT,
+                         state='started',
+                         search_regex=SONIC_SSH_REGEX,
+                         timeout=90)
+        time.sleep(20) 
+        duthost.file(path="/tmp/config_service_acls.sh",state='absent')
+
+
+class TestReboot():
+
+    def basic_check_after_reboot(self, duthost, localhost, testbed_devices, testbed):
+         verify_show_command(duthost)
+         inbound_test = TestMvrfInbound()
+         outbound_test = TestMvrfOutbound()
+         outbound_test.test_ping(testbed,duthost)
+         inbound_test.test_ping(duthost,localhost)
+         inbound_test.test_snmp_fact(testbed_devices)
+
+
+    def test_warmboot(self, localhost, testbed_devices, testbed):
+
+        duthost = testbed_devices["dut"]
+        duthost.command('sudo config save -y')
+        reboot(duthost, localhost, reboot_type='warm')
+        assert wait_until(120, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        self.basic_check_after_reboot(duthost, localhost, testbed_devices, testbed)
+
+
+    def test_reboot(self, localhost, testbed_devices, testbed):
+        duthost = testbed_devices["dut"]
+        duthost.command('sudo config save -y')
+        reboot(duthost, localhost)
+        assert wait_until(300, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        self.basic_check_after_reboot(duthost, localhost, testbed_devices, testbed)
+
+    def test_fastboot(self, localhost, testbed_devices, testbed):
+ 
+        duthost = testbed_devices["dut"]
+        duthost.command('sudo config save -y')
+        reboot(duthost, localhost,reboot_type='fast')
+        assert wait_until(300, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        self.basic_check_after_reboot(duthost, localhost, testbed_devices, testbed)
+


### PR DESCRIPTION


Summary:
Adding script for management vrf

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
#### How did you verify/test it?

	root@15d676a9e0f5:/var/johnar/sonic-mgmt/tests# py.test --inventory=../ansible/lab --host-pattern=sonic-z9264f-03 --module-path ../ansible/library/ --testbed
	=vms-t0-116  --testbed_file=../ansible/testbed.csv test_mgmtvrf.py   --disable_loganalyzer    -log-cli-level=INFO --log-level=INFO -v  --show-capture=stdout
	--duration=0
	==================================================================== test session starts ====================================================================
	platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.0, pluggy-0.12.0 -- /usr/bin/python
	cachedir: .pytest_cache
	ansible: 2.0.0.2
	rootdir: /var/johnar/sonic-mgmt/tests, inifile: pytest.ini
	plugins: ansible-2.0.2
	collected 10 items
	
	test_mgmtvrf.py::TestMvrfInbound::test_ping PASSED                                                                                                    [ 10%]
	test_mgmtvrf.py::TestMvrfInbound::test_snmp_fact PASSED                                                                                               [ 20%]
	test_mgmtvrf.py::TestMvrfOutbound::test_ping PASSED                                                                                                   [ 30%]
	test_mgmtvrf.py::TestMvrfOutbound::test_wget PASSED                                                                                                   [ 40%]
	test_mgmtvrf.py::TestMvrfOutbound::test_curl PASSED                                                                                                   [ 50%]
	test_mgmtvrf.py::TestServices::test_ntp PASSED                                                                                                        [ 60%]
	test_mgmtvrf.py::TestServices::test_service_acl PASSED                                                                                                [ 70%]
	test_mgmtvrf.py::TestReboot::test_warmboot PASSED                                                                                                     [ 80%]
	test_mgmtvrf.py::TestReboot::test_reboot PASSED                                                                                                       [ 90%]
	test_mgmtvrf.py::TestReboot::test_fastboot PASSED                                                                                                     [100%]
	
	================================================================== slowest test durations ===================================================================
	240.93s call     test_mgmtvrf.py::TestReboot::test_reboot
	234.44s call     test_mgmtvrf.py::TestReboot::test_warmboot
	181.07s call     test_mgmtvrf.py::TestReboot::test_fastboot
	84.56s call     test_mgmtvrf.py::TestServices::test_service_acl
	23.81s teardown test_mgmtvrf.py::TestReboot::test_fastboot
	20.88s call     test_mgmtvrf.py::TestServices::test_ntp
	20.72s setup    test_mgmtvrf.py::TestMvrfInbound::test_ping
	7.88s setup    test_mgmtvrf.py::TestMvrfOutbound::test_wget
	4.17s teardown test_mgmtvrf.py::TestMvrfOutbound::test_wget
	3.28s call     test_mgmtvrf.py::TestMvrfInbound::test_snmp_fact
	2.36s call     test_mgmtvrf.py::TestMvrfOutbound::test_ping
	0.81s call     test_mgmtvrf.py::TestMvrfOutbound::test_wget
	0.69s call     test_mgmtvrf.py::TestMvrfOutbound::test_curl
	0.60s teardown test_mgmtvrf.py::TestReboot::test_reboot
	0.59s teardown test_mgmtvrf.py::TestMvrfOutbound::test_ping
	0.58s setup    test_mgmtvrf.py::TestMvrfOutbound::test_ping
	0.57s teardown test_mgmtvrf.py::TestReboot::test_warmboot
	0.56s setup    test_mgmtvrf.py::TestReboot::test_reboot
	0.56s teardown test_mgmtvrf.py::TestMvrfInbound::test_snmp_fact
	0.53s setup    test_mgmtvrf.py::TestReboot::test_fastboot
	0.52s teardown test_mgmtvrf.py::TestMvrfOutbound::test_curl
	0.51s teardown test_mgmtvrf.py::TestServices::test_ntp
	0.51s setup    test_mgmtvrf.py::TestMvrfOutbound::test_curl
	0.51s setup    test_mgmtvrf.py::TestReboot::test_warmboot
	0.51s teardown test_mgmtvrf.py::TestServices::test_service_acl
	0.51s setup    test_mgmtvrf.py::TestServices::test_service_acl
	0.50s setup    test_mgmtvrf.py::TestServices::test_ntp
	0.50s setup    test_mgmtvrf.py::TestMvrfInbound::test_snmp_fact
	0.50s teardown test_mgmtvrf.py::TestMvrfInbound::test_ping
	0.19s call     test_mgmtvrf.py::TestMvrfInbound::test_ping
	================================================================ 10 passed in 834.44 seconds ================================================================
	


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Independent of topology
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
