### PR TITLE
[fanout] Deploy Mellanox fanout using non-root account

### DIFF
--- a/ansible/group_vars/fanout/secrets.yml
+++ b/ansible/group_vars/fanout/secrets.yml
@@ -1,4 +1,6 @@
 ansible_ssh_user: user
 ansible_ssh_pass: password
+fanout_mlnx_user: admin
+fanout_mlnx_password: admin
 fanout_sonic_user: admin
 fanout_sonic_password: password

--- a/ansible/roles/fanout/tasks/fanout_mlnx.yml
+++ b/ansible/roles/fanout/tasks/fanout_mlnx.yml
@@ -1,8 +1,8 @@
 ##############################################################################################
-### playbook to deploy the fanout swtich
+### playbook to deploy the fanout switch
 ### Use this playbook to deploy the VLAN configurations of fanout leaf switch in SONiC testbed
-### This playbook will run based on hardware flatform. Each fanout switch hardware type has its
-### own unique feature and configuration command or format. Unless you use the hardware swtich
+### This playbook will run based on hardware platform. Each fanout switch hardware type has its
+### own unique feature and configuration command or format. Unless you use the hardware switch
 ### specified in this playbook, you would need to come up with your own fanout switch deployment
 ### playbook
 ################################################################################################
@@ -13,19 +13,13 @@
   tags: always
 
 - name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_admin_user }} ansible_ssh_pass={{ fanout_admin_password }} peer_hwsku={{device_info['HwSku']}}
+  set_fact: ansible_ssh_user={{ fanout_mlnx_user }} ansible_ssh_pass={{ fanout_mlnx_password }} peer_hwsku={{device_info['HwSku']}}
   tags: always
 
-- set_fact:
-    fanout_root_user: "user"
-    fanout_root_pass: "password"
-  tags: deploy,pfcwd_config,check_pfcwd_config
-
- ##########################################################
- # deploy tasks to deploy default configuration on fanout #
- ##########################################################
+##########################################################
+# deploy tasks to deploy default configuration on fanout #
+##########################################################
 - block:
-  - debug: msg={{ inventory_hostname }}
   - name: build fanout startup config for fanout mlnx-os-switch
     action: apswitch template=mlnx_fanout.j2
     connection: switch

--- a/ansible/roles/fanout/tasks/mlnx/deploy_pfcwd_fanout.yml
+++ b/ansible/roles/fanout/tasks/mlnx/deploy_pfcwd_fanout.yml
@@ -1,17 +1,15 @@
 ##############################################################################################
-### sub-playbook to deploy the docker images needed for the pfcwd test to fanout swtich
+### sub-playbook to deploy the docker images needed for the pfcwd test to fanout switch
 ### to run separately:
 ### ansible-playbook -i lab fanout.yml -l ${FANOUT} --become --tags pfcwd_config -vvvv
 ### Optionally "-e pfcwd_dockers_url=<www_path>" can be specified to fetch dockers without
 ### building them. This is useful to save time or run task in sonic-mgmt docker.
 ### E.g.
-### ansible-playbook -i lab fanout.yml -l ${FANOUT} -e pfcwd_dockers_url=http://arc-build-server/sonic/ --become --tags pfcwd_config -vvvv
+### ansible-playbook -i lab fanout.yml -l ${FANOUT} -e pfcwd_dockers_url=http://some-http-server/pfcwd-dockers/ --become --tags pfcwd_config -vvvv
 ################################################################################################
 
-- set_fact:
-    fanout_addr: "{{device_info['mgmtip']}}"
-    ansible_ssh_user: "{{fanout_root_user}}"
-    ansible_ssh_pass: "{{fanout_root_pass}}"
+- name: Define variables for deployment of pfcwd dockers on fanout
+  set_fact:
     pfcwd_dockers: "['roles/test/files/mlnx/docker-tests-pfcgen/pfc_storm.tgz']"
     fanout_img_path: "/var/opt/tms/images/"
 
@@ -23,28 +21,19 @@
   delegate_to: localhost
   when: pfcwd_dockers_url is not defined
 
-- name: Copy test match and ignore files to switch
-  copy:
-      src: "{{ item }}"
-      dest: "{{fanout_img_path}}"
+- name: Copy pfcwd docker images to switch
+  include: scp_copy.yml
+  vars:
+    src: "{{ item }}"
+    dest: "{{ fanout_img_path }}"
   with_items: pfcwd_dockers
   when: pfcwd_dockers_url is not defined
 
 - name: Download pre-built pfcwd dockers if path specified
-  get_url: url={{pfcwd_dockers_url}}{{item | basename}} dest={{fanout_img_path}}/{{item | basename}}
+  include: download_copy_pfcwd_fanout.yml
   with_items: pfcwd_dockers
+  delegate_to: localhost
   when: pfcwd_dockers_url is defined
-
-- block:
-    - name: Mount FS to read-write
-      command: mount -o remount, rw /
-
-    - name: Update storage driver for Docker
-      command: 'sed -i s/\"storage-driver\":\ \"vfs\",/\"storage-driver\":\ \"devicemapper\",\\n\ \ \ \ \"storage-opts\":\ [\\n\ \ \ \ \ \ \ \ \"dm.fs=ext4\"\\n\ \ \ \ ],\/g /opt/tms/bin/docker_config.json'
-
-  always:
-    - name: Remount FS back to read-only
-      command: mount -r -o remount /
 
 - name: Load and start dockers
   action: apswitch template=mlnx_deploy_pfcwd_fanout.j2

--- a/ansible/roles/fanout/tasks/mlnx/download_copy_pfcwd_fanout.yml
+++ b/ansible/roles/fanout/tasks/mlnx/download_copy_pfcwd_fanout.yml
@@ -1,0 +1,21 @@
+- block:
+
+    - name: Get timestamp
+      set_fact: timestamp="{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
+
+    - name: Get temporary filename
+      set_fact: filename="/tmp/pfcwd_docker_{{ timestamp }}"
+
+    - name: Download pre-built pfcwd docker image
+      get_url: url={{ pfcwd_dockers_url }}/{{ item | basename }} dest={{ filename }}
+
+    - name: Copy the downloaded pfcwd docker image to switch
+      include: scp_copy.yml
+      vars:
+        src: "{{ filename }}"
+        dest: "{{ fanout_img_path }}"
+
+  always:
+
+    - name: Remove the downloaded pfcwd docker image
+      file: path={{ filename }} state=absent

--- a/ansible/roles/fanout/tasks/mlnx/scp_copy.yml
+++ b/ansible/roles/fanout/tasks/mlnx/scp_copy.yml
@@ -1,0 +1,6 @@
+- name: Use scp to copy local file to remote host
+  command: "{{ scp_cmd }} {{ scp_params }} {{ src }} {{ ansible_ssh_user }}@{{ ansible_host }}:{{ dest }}"
+  vars:
+    scp_cmd: "sshpass -p {{ ansible_ssh_pass }} scp"
+    scp_params: "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+  delegate_to: localhost


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The Mellanox ONYX fanout switch can be deployed using the normal
admin account rather than the root account which is not always
available to users.

This change removed the dependency of using the root account.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Removed the dependency of root account.

#### How did you verify/test it?
Tested on Mellanox ONYX 3.8.2004
Tested scenarios:
1. Deploy Mellanox ONYX fanout.
2. Run the PFCWD test case (Uses pfc_storm docker created during fanout deployment).

#### Any platform specific information?
Only for Mellanox ONYX fanout switch.

#### Supported testbed topology if it's a new test case?
NA
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
