### PR TITLE
[devices.py] Refactor method of determining whether a service is fully started

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -136,15 +136,15 @@ class SonicHost(AnsibleHostBase):
         """
         @summary: Check whether a SONiC specific service is fully started.
 
-        The last step in the starting script of all SONiC services is to run "docker wait <service_name>". This command
-        will not exit unless the docker container of the service is stopped. We use this trick to determine whether
-        a SONiC service has completed starting.
+        This function assumes that the final step of all services checked by this function is to spawn a Docker
+        container with the same name as the service. We determine that the service has fully started if the
+        Docker container is running.
 
         @param service: Name of the SONiC service
         """
         try:
-            output = self.command('pgrep -f "docker wait %s"' % service)
-            if output["stdout_lines"]:
+            output = self.command("docker inspect -f '{{.State.Running}}' %s" % service)
+            if output["stdout"].strip() == "true":
                 return True
             else:
                 return False

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -143,7 +143,7 @@ class SonicHost(AnsibleHostBase):
         @param service: Name of the SONiC service
         """
         try:
-            output = self.command("docker inspect -f '{{.State.Running}}' %s" % service)
+            output = self.command("docker inspect -f \{\{.State.Running\}\} %s" % service)
             if output["stdout"].strip() == "true":
                 return True
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

### Summary

Instead of checking for the whether a `docker wait <service_name>` command is running to determine whether a service is fully started, instead we check whether or not the container itself is running using `docker inspect -f '{{.State.Running}}' <service_name>`.

Fixes https://github.com/Azure/sonic-mgmt/issues/1215

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

Instead of checking for the whether a `docker wait <service_name>` command is running to determine whether a service is fully started, instead we check whether or not the container itself is running using `docker inspect -f '{{.State.Running}}' <service_name>`.
