### PR TITLE
[portstat] Fix portstat output handling

### DIFF
--- a/ansible/roles/test/tasks/portstat/portstat_clear.yml
+++ b/ansible/roles/test/tasks/portstat/portstat_clear.yml
@@ -18,7 +18,7 @@
   - name: Pull out RX and TX OK counters
     set_fact:
       before_rx_ok: "{{ portstat_eth0.split()[2].replace(',','') }}"
-      before_tx_ok: "{{ portstat_eth0.split()[9].replace(',','') }}"
+      before_tx_ok: "{{ portstat_eth0.split()[8].replace(',','') }}"
 
   # This is the test command
   - name: Testing '{{ command }}'
@@ -41,7 +41,7 @@
   - name: Pull out RX and TX OK counters
     set_fact:
       after_rx_ok: "{{ portstat_eth0.split()[2].replace(',','') }}"
-      after_tx_ok: "{{ portstat_eth0.split()[9].replace(',','') }}"
+      after_tx_ok: "{{ portstat_eth0.split()[8].replace(',','') }}"
 
   - name: Assert that the cleared rx counter is less than the current counter
     assert:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
According to [portstat#L33](https://github.com/Azure/sonic-utilities/blob/0ada5cf3d4e0460a839e26b11aabcb0178d4565b/scripts/portstat#L33)
the column with the TX_OK is 8 when counting from 0

Summary:
Fixed portstat output handling.

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
run portstat test on the latest sonic image
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
