### PR TITLE
configlet support extended to testbed.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -114,6 +114,12 @@
                   dest=/etc/sonic/minigraph.xml
         become: true
 
+      - name: Copy corresponding configlet files if apply_configlet=true
+        copy: src=vars/configlet/{{ topo }}/
+              dest=/etc/sonic/
+        become: true
+        when: apply_configlet is defined and apply_configlet|bool == true
+
       - name: disable automatic minigraph update if we are deploying new minigraph into SONiC
         lineinfile:
             name: /etc/sonic/updategraph.conf
@@ -134,6 +140,11 @@
       - name: execute cli "config bgp startup all" to bring up all bgp sessions for test
         become: true
         shell: config bgp startup all
+
+      - name: execute configlet application script, which applies configlets in strict order.
+        become: true
+        shell: bash -c "/etc/sonic/apply_clet.sh"
+        when: apply_configlet is defined and apply_configlet|bool == true
 
       - name: execute cli "config save -y" to save current minigraph as startup-config
         become: true

--- a/ansible/doc/README.testbed.SimXSetup.md
+++ b/ansible/doc/README.testbed.SimXSetup.md
@@ -136,7 +136,7 @@ host_var_file=host_vars/<HYPERVISOR_HOSTNAME>.yml
 server_1
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
 
 [sonic]
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -38,7 +38,7 @@ EXAMPLES = '''
         testcases:
             acl:
                 filename: acl.yml
-                topologies: [t1, t1-lag, t1-64-lag]
+                topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
                 execvar:
                   ptf_host:
                   testbed_type:
@@ -49,7 +49,7 @@ EXAMPLES = '''
                   ptf_host:
             bgp_fact:
                 filename: bgp_fact.yml
-                topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-64-lag]
+                topologies: [t0, t0-64, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
             ...
 
     To use it:
@@ -85,6 +85,7 @@ RETURN = '''
                 t1:        [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, pfc_wd]
                 t1-lag:    [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
                 t1-64-lag: [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
+                t1-64-lag-clet: [acl, bgp_fact, bgp_multipath_relax, decap, everflow_testbed, fib, lldp, lag_2, pfc_wd]
             }
 '''
 

--- a/ansible/minigraph/switch-t1-64-lag-clet.xml
+++ b/ansible/minigraph/switch-t1-64-lag-clet.xml
@@ -1,0 +1,2349 @@
+<DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+      <BGPSession>
+        <StartRouter>ARISTA01T0</StartRouter>
+        <StartPeer>10.0.0.33</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.32</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA01T0</StartRouter>
+        <StartPeer>FC00::42</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::41</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA02T0</StartRouter>
+        <StartPeer>10.0.0.35</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.34</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA02T0</StartRouter>
+        <StartPeer>FC00::46</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::45</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA03T0</StartRouter>
+        <StartPeer>10.0.0.37</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.36</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA03T0</StartRouter>
+        <StartPeer>FC00::4A</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::49</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA04T0</StartRouter>
+        <StartPeer>10.0.0.39</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.38</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA04T0</StartRouter>
+        <StartPeer>FC00::4E</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::4D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA05T0</StartRouter>
+        <StartPeer>10.0.0.41</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.40</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA05T0</StartRouter>
+        <StartPeer>FC00::52</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::51</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA06T0</StartRouter>
+        <StartPeer>10.0.0.43</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.42</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA06T0</StartRouter>
+        <StartPeer>FC00::56</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::55</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA07T0</StartRouter>
+        <StartPeer>10.0.0.45</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.44</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA07T0</StartRouter>
+        <StartPeer>FC00::5A</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA08T0</StartRouter>
+        <StartPeer>10.0.0.47</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.46</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA08T0</StartRouter>
+        <StartPeer>FC00::5E</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::5D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA09T0</StartRouter>
+        <StartPeer>10.0.0.49</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.48</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA09T0</StartRouter>
+        <StartPeer>FC00::62</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA10T0</StartRouter>
+        <StartPeer>10.0.0.51</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.50</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA10T0</StartRouter>
+        <StartPeer>FC00::66</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::65</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA11T0</StartRouter>
+        <StartPeer>10.0.0.53</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.52</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA11T0</StartRouter>
+        <StartPeer>FC00::6A</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::69</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA12T0</StartRouter>
+        <StartPeer>10.0.0.55</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.54</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA12T0</StartRouter>
+        <StartPeer>FC00::6E</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::6D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA13T0</StartRouter>
+        <StartPeer>10.0.0.57</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.56</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA13T0</StartRouter>
+        <StartPeer>FC00::72</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::71</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA14T0</StartRouter>
+        <StartPeer>10.0.0.59</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.58</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA14T0</StartRouter>
+        <StartPeer>FC00::76</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::75</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA15T0</StartRouter>
+        <StartPeer>10.0.0.61</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.60</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA15T0</StartRouter>
+        <StartPeer>FC00::7A</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::79</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA16T0</StartRouter>
+        <StartPeer>10.0.0.63</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.62</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA16T0</StartRouter>
+        <StartPeer>FC00::7E</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::7D</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA17T0</StartRouter>
+        <StartPeer>10.0.0.65</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.64</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA17T0</StartRouter>
+        <StartPeer>FC00::82</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::81</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA18T0</StartRouter>
+        <StartPeer>10.0.0.67</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.66</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA18T0</StartRouter>
+        <StartPeer>FC00::86</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::85</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA19T0</StartRouter>
+        <StartPeer>10.0.0.69</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>10.0.0.68</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ARISTA19T0</StartRouter>
+        <StartPeer>FC00::8A</StartPeer>
+        <EndRouter>switch-t1-64-lag-clet</EndRouter>
+        <EndPeer>FC00::89</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>10.0.0.0</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>FC00::1</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>10.0.0.4</StartPeer>
+        <EndRouter>ARISTA03T2</EndRouter>
+        <EndPeer>10.0.0.5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>FC00::5</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::6</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>10.0.0.8</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>10.0.0.9</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>FC00::9</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>FC00::A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>10.0.0.12</StartPeer>
+        <EndRouter>ARISTA07T2</EndRouter>
+        <EndPeer>10.0.0.13</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t1-64-lag-clet</StartRouter>
+        <StartPeer>FC00::D</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>FC00::E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>switch-t1-64-lag-clet</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.33</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.35</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.37</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.39</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.41</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.43</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.45</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.47</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.49</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.51</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.53</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.55</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.65</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.67</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.69</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.5</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.9</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.13</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64001</a:ASN>
+        <a:Hostname>ARISTA01T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64002</a:ASN>
+        <a:Hostname>ARISTA02T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64003</a:ASN>
+        <a:Hostname>ARISTA03T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64004</a:ASN>
+        <a:Hostname>ARISTA04T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64005</a:ASN>
+        <a:Hostname>ARISTA05T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64006</a:ASN>
+        <a:Hostname>ARISTA06T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64007</a:ASN>
+        <a:Hostname>ARISTA07T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64008</a:ASN>
+        <a:Hostname>ARISTA08T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64009</a:ASN>
+        <a:Hostname>ARISTA09T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64010</a:ASN>
+        <a:Hostname>ARISTA10T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64011</a:ASN>
+        <a:Hostname>ARISTA11T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64012</a:ASN>
+        <a:Hostname>ARISTA12T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64013</a:ASN>
+        <a:Hostname>ARISTA13T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64014</a:ASN>
+        <a:Hostname>ARISTA14T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64015</a:ASN>
+        <a:Hostname>ARISTA15T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64016</a:ASN>
+        <a:Hostname>ARISTA16T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64017</a:ASN>
+        <a:Hostname>ARISTA17T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64018</a:ASN>
+        <a:Hostname>ARISTA18T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64019</a:ASN>
+        <a:Hostname>ARISTA19T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA01T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA03T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA05T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA07T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.64.247.225/23</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.64.247.225/23</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:2::32/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:2::32/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>switch-t1-64-lag-clet</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel0</Name>
+          <AttachTo>fortyGigE1/1/1;fortyGigE1/1/2</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel4</Name>
+          <AttachTo>fortyGigE1/1/5;fortyGigE1/1/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel8</Name>
+          <AttachTo>fortyGigE1/2/1;fortyGigE1/2/2</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel12</Name>
+          <AttachTo>fortyGigE1/2/5;fortyGigE1/2/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel34</Name>
+          <AttachTo>fortyGigE1/3/3</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel36</Name>
+          <AttachTo>fortyGigE1/3/5</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel37</Name>
+          <AttachTo>fortyGigE1/3/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel38</Name>
+          <AttachTo>fortyGigE1/3/7</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel39</Name>
+          <AttachTo>fortyGigE1/3/8</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel42</Name>
+          <AttachTo>fortyGigE1/3/11</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel44</Name>
+          <AttachTo>fortyGigE1/3/13</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel45</Name>
+          <AttachTo>fortyGigE1/3/14</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel46</Name>
+          <AttachTo>fortyGigE1/3/15</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel47</Name>
+          <AttachTo>fortyGigE1/3/16</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel50</Name>
+          <AttachTo>fortyGigE1/4/3</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel52</Name>
+          <AttachTo>fortyGigE1/4/5</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel53</Name>
+          <AttachTo>fortyGigE1/4/6</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel54</Name>
+          <AttachTo>fortyGigE1/4/7</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel55</Name>
+          <AttachTo>fortyGigE1/4/8</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel58</Name>
+          <AttachTo>fortyGigE1/4/11</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel60</Name>
+          <AttachTo>fortyGigE1/4/13</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel61</Name>
+          <AttachTo>fortyGigE1/4/14</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel62</Name>
+          <AttachTo>fortyGigE1/4/15</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+        <PortChannel>
+          <ElementType>PortChannelInterface</ElementType>
+          <Name>PortChannel63</Name>
+          <AttachTo>fortyGigE1/4/16</AttachTo>
+           <SubInterface/> 
+         </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces/>
+      <IPInterfaces>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0</AttachTo>
+          <Prefix>10.0.0.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0</AttachTo>
+          <Prefix>FC00::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel4</AttachTo>
+          <Prefix>10.0.0.4/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel4</AttachTo>
+          <Prefix>FC00::5/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel8</AttachTo>
+          <Prefix>10.0.0.8/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel8</AttachTo>
+          <Prefix>FC00::9/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel12</AttachTo>
+          <Prefix>10.0.0.12/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel12</AttachTo>
+          <Prefix>FC00::D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel34</AttachTo>
+          <Prefix>10.0.0.32/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel34</AttachTo>
+          <Prefix>FC00::41/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel36</AttachTo>
+          <Prefix>10.0.0.34/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel36</AttachTo>
+          <Prefix>FC00::45/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel37</AttachTo>
+          <Prefix>10.0.0.36/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel37</AttachTo>
+          <Prefix>FC00::49/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel38</AttachTo>
+          <Prefix>10.0.0.38/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel38</AttachTo>
+          <Prefix>FC00::4D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel39</AttachTo>
+          <Prefix>10.0.0.40/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel39</AttachTo>
+          <Prefix>FC00::51/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel42</AttachTo>
+          <Prefix>10.0.0.42/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel42</AttachTo>
+          <Prefix>FC00::55/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel44</AttachTo>
+          <Prefix>10.0.0.44/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel44</AttachTo>
+          <Prefix>FC00::59/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel45</AttachTo>
+          <Prefix>10.0.0.46/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel45</AttachTo>
+          <Prefix>FC00::5D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel46</AttachTo>
+          <Prefix>10.0.0.48/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel46</AttachTo>
+          <Prefix>FC00::61/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel47</AttachTo>
+          <Prefix>10.0.0.50/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel47</AttachTo>
+          <Prefix>FC00::65/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel50</AttachTo>
+          <Prefix>10.0.0.52/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel50</AttachTo>
+          <Prefix>FC00::69/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel52</AttachTo>
+          <Prefix>10.0.0.54/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel52</AttachTo>
+          <Prefix>FC00::6D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel53</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel53</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel54</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel54</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel55</AttachTo>
+          <Prefix>10.0.0.60/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel55</AttachTo>
+          <Prefix>FC00::79/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel58</AttachTo>
+          <Prefix>10.0.0.62/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel58</AttachTo>
+          <Prefix>FC00::7D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel60</AttachTo>
+          <Prefix>10.0.0.64/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel60</AttachTo>
+          <Prefix>FC00::81/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel61</AttachTo>
+          <Prefix>10.0.0.66/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel61</AttachTo>
+          <Prefix>FC00::85/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel62</AttachTo>
+          <Prefix>10.0.0.68/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel62</AttachTo>
+          <Prefix>FC00::89/126</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces/>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/1/1</EndPort>
+        <StartDevice>ARISTA01T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/1/2</EndPort>
+        <StartDevice>ARISTA01T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/1/5</EndPort>
+        <StartDevice>ARISTA03T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/1/6</EndPort>
+        <StartDevice>ARISTA03T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/2/1</EndPort>
+        <StartDevice>ARISTA05T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/2/2</EndPort>
+        <StartDevice>ARISTA05T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/2/5</EndPort>
+        <StartDevice>ARISTA07T2</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/2/6</EndPort>
+        <StartDevice>ARISTA07T2</StartDevice>
+        <StartPort>Ethernet2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/3</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/3</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/6</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/7</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/8</EndPort>
+        <StartDevice>ARISTA01T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/11</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/11</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/14</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/15</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/3/16</EndPort>
+        <StartDevice>ARISTA02T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/3</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/3</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/6</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/7</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/8</EndPort>
+        <StartDevice>ARISTA03T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/11</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/11</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/14</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/15</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t1-64-lag-clet</EndDevice>
+        <EndPort>fortyGigE1/4/16</EndPort>
+        <StartDevice>ARISTA04T0</StartDevice>
+        <StartPort>Ethernet1</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="LeafRouter">
+        <Hostname>switch-t1-64-lag-clet</Hostname>
+        <HwSku>Force10-S6100</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>10.64.247.225</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA01T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.204</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA01T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.200</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA02T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.205</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA03T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.206</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA03T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.201</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA04T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.207</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA05T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.208</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA05T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.202</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA06T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.209</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA07T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.210</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>"ARISTA07T2"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.203</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA08T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.211</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA09T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.212</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA10T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.213</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA11T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.214</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA12T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.215</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA13T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.216</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA14T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.217</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA15T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.218</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA16T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.219</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA17T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.220</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA18T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.221</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>"ARISTA19T0"</Hostname>
+         <HwSku>Arista-VM</HwSku>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.222</a:IPPrefix>
+         </ManagementAddress>
+       </Device>
+    </Devices>
+  </PngDec>
+  <DeviceInfos>
+    <DeviceInfo>
+      <AutoNegotiation>true</AutoNegotiation>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/1/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/2/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/3/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE1/4/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>Force10-S6100</HwSku> 
+      <ManagementInterfaces/>
+    </DeviceInfo> 
+  </DeviceInfos>
+  <Hostname>switch-t1-64-lag-clet</Hostname>
+  <HwSku>Force10-S6100</HwSku>
+</DeviceMiniGraph>

--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -91,7 +91,7 @@ class DecapPacketTest(BaseTest):
         self.fib = fib.Fib(self.test_params['fib_info'])
         if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag':
             self.src_ports = range(0, 32)
-        if self.test_params['testbed_type'] == 't1-64-lag':
+        if self.test_params['testbed_type'] == 't1-64-lag' or self.test_params['testbed_type'] == 't1-64-lag-clet':
             self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
         if self.test_params['testbed_type'] == 't0':
             self.src_ports = range(1, 25) + range(28, 32)

--- a/ansible/roles/test/files/ptftests/dip_sip.py
+++ b/ansible/roles/test/files/ptftests/dip_sip.py
@@ -5,7 +5,7 @@ Description:
     This test uses UDP packets to validate that HW supports routing of L3 packets with DIP=SIP
 
 Topologies:
-    Supports t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag and t1-64-lag topology
+    Supports t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag t1-64-lag and t1-64-lag-clet topology
 
 Parameters:
     testbed_type    - testbed type
@@ -185,7 +185,7 @@ class DipSipTest(BaseTest):
     #--------------------------------------------------------------------------
 
     def runTest(self):
-        if self.testbed_type in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1', 't1-lag', 't1-64-lag']:
+        if self.testbed_type in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']:
             self.log("Run PORT/LAG-router based test")
 
             test = PortLagRouterBasedTest(self)

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -98,7 +98,7 @@ class FibTest(BaseTest):
         # Provide the list of all UP interfaces with index in sequence order starting from 0
         if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag' or self.test_params['testbed_type'] == 't0-64-32':
             self.src_ports = range(0, 32)
-        if self.test_params['testbed_type'] == 't1-64-lag':
+        if self.test_params['testbed_type'] == 't1-64-lag' or self.test_params['testbed_type'] == 't1-64-lag-clet':
             self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
         if self.test_params['testbed_type'] == 't0':
             self.src_ports = range(1, 25) + range(28, 32)

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -58,7 +58,7 @@ class HashTest(BaseTest):
         # Provide the list of all UP interfaces with index in sequence order starting from 0
         if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag':
             self.src_ports = range(0, 32)
-        if self.test_params['testbed_type'] == 't1-64-lag':
+        if self.test_params['testbed_type'] == 't1-64-lag' or self.test_params['testbed_type'] == 't1-64-lag-clet':
             self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
         if self.test_params['testbed_type'] == 't0':
             self.src_ports = range(1, 25) + range(28, 32)

--- a/ansible/roles/test/files/ptftests/mtu_test.py
+++ b/ansible/roles/test/files/ptftests/mtu_test.py
@@ -128,7 +128,7 @@ class MtuTest(BaseTest):
         dst_port_list = []
         if self.testbed_type == 't1' or self.testbed_type == 't1-lag':
             dst_port_list = [31]
-        elif self.testbed_type == 't1-64-lag':
+        elif self.testbed_type == 't1-64-lag' or self.testbed_type == 't1-64-lag-clet':
             dst_port_list = [58]
 
         (matched_index, received) = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)

--- a/ansible/roles/test/tasks/bgp_gr_helper.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper.yml
@@ -6,7 +6,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is unsupported."
-  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag']
+  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 - name: Get VM info.
   include: "roles/test/tasks/bgp_gr_helper/get_vm_info.yml"

--- a/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
@@ -16,7 +16,7 @@
       vm_name: "{{ item.value.name }}"
       vm_intf: "{{ item.key }}"
   with_dict: "{{ minigraph_neighbors }}"
-  when: "testbed_type in ['t1', 't1-lag', 't1-64-lag'] and 'T0' in item.value.name and not vm_name"
+  when: "testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet'] and 'T0' in item.value.name and not vm_name"
 
 - name: Get neighbor IPv4 address.
   set_fact:

--- a/ansible/roles/test/tasks/bgp_multipath_relax.yml
+++ b/ansible/roles/test/tasks/bgp_multipath_relax.yml
@@ -9,8 +9,8 @@
 - fail: msg="please provide testbed_type for bgp_multipath_relax test"
   when: testbed_type is not defined 
 
-- fail: mgs="This test only works for leaf routers as DUT in topology, t1, t1-lag, t1-64-lag"
-  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag']
+- fail: mgs="This test only works for leaf routers as DUT in topology, t1, t1-lag, t1-64-lag, t1-64-lag-clet"
+  when: testbed_type not in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/decap.yml
+++ b/ansible/roles/test/tasks/decap.yml
@@ -39,7 +39,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['spine']}}"
-  when: testbed_type in ['t1', 't1-lag', 't1-64-lag']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
@@ -47,7 +47,7 @@
 
 - name: Expand properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"
-  when: testbed_type in ['t1', 't1-lag', 't1-64-lag']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 # Gather minigraph facts
 - name: Gathering minigraph facts about the device

--- a/ansible/roles/test/tasks/dip_sip.yml
+++ b/ansible/roles/test/tasks/dip_sip.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{ test_type }} is invalid"
-  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1', 't1-lag', 't1-64-lag']
+  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 - include_vars: "vars/topo_{{ testbed_type }}.yml"
 
@@ -126,4 +126,4 @@
   vars:
     dst_lag: "default('')"
     src_lag: "default('')"
-  when: testbed_type in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1-lag', 't1-64-lag']
+  when: testbed_type in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't1-lag', 't1-64-lag', 't1-64-lag-clet']

--- a/ansible/roles/test/tasks/everflow_testbed/get_general_port_info.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/get_general_port_info.yml
@@ -35,5 +35,5 @@
 
 - name: Get the list of ports to be combined to Everflow ACL tables
   set_fact:
-    everflow_table_ports: "{{ (testbed_type in ['t1-lag', 't1-64-lag']) | ternary(portchannel_ports + tor_ports, spine_ports + tor_ports) }}"
+    everflow_table_ports: "{{ (testbed_type in ['t1-lag', 't1-64-lag', 't1-64-lag-clet']) | ternary(portchannel_ports + tor_ports, spine_ports + tor_ports) }}"
 

--- a/ansible/roles/test/tasks/everflow_testbed/run_test.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/run_test.yml
@@ -6,7 +6,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag']
+  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't1-64-lag-clet']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/mtu.yml
+++ b/ansible/roles/test/tasks/mtu.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag']
+  when: testbed_type not in ['t1-lag', 't1', 't1-64-lag', 't1-64-lag-clet']
 
 - set_fact: mtu=9114   #using the default mtu,The value includes the 14 bytes Layer 2 Ethernet header
   when: mtu is not defined

--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -14,7 +14,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['spine']}}"
-  when: testbed_type in ['t1', 't1-lag', 't1-64-lag']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
@@ -22,7 +22,7 @@
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"
-  when: testbed_type in ['t1', 't1-lag', 't1-64-lag']
+  when: testbed_type in ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet']
 
 - name: Gathering minigraph facts about the device
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -13,7 +13,7 @@
 ::/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{% elif testbed_type == 't1-64-lag' %}
+{% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
 0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
 ::/0 [0 1] [4 5] [16 17] [20 21]
 {% elif testbed_type == 't0-116' %}
@@ -39,7 +39,7 @@
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{% elif testbed_type == 't1-64-lag' %}
+{% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 [0 1] [4 5] [16 17] [20 21]
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
 {% elif testbed_type == 't0' or testbed_type == 't0-52' or testbed_type == 't0-64' or testbed_type == 't0-64-32' %}

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -1,28 +1,28 @@
 testcases:
     acl:
       filename: acltb.yml
-      topologies: [t1, t1-lag, t1-64-lag]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
 
     arp:
       filename: arpall.yml
-      topologies: [ptf32, ptf64, t1, t1-lag, t1-64-lag]
+      topologies: [ptf32, ptf64, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
 
     bgp_fact:
       filename: bgp_fact.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
 
     bgp_gr_helper:
       filename: bgp_gr_helper.yml
-      topologies: [t1, t1-lag, t1-64-lag]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
 
     bgp_multipath_relax:
       filename: bgp_multipath_relax.yml
-      topologies: [t1, t1-lag, t1-64-lag]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
@@ -36,12 +36,12 @@ testcases:
 
     config:
         filename: config.yml
-        topologies: [t1-lag, t1-64-lag, t0, t0-64, t0-116]
+        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t0, t0-64, t0-116]
 
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
 
     copp:
       filename: copp.yml
@@ -51,7 +51,7 @@ testcases:
 
     decap:
       filename: decap.yml
-      topologies: [t1, t1-lag, t1-64-lag, t0, t0-52, t0-56, t0-64, t0-116]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t0, t0-52, t0-56, t0-64, t0-116]
       required_vars:
           ptf_host:
           testbed_type:
@@ -69,7 +69,7 @@ testcases:
 
     everflow_testbed:
       filename: everflow_testbed.yml
-      topologies: [t1, t1-lag, t1-64-lag]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
@@ -115,14 +115,14 @@ testcases:
 
     fib:
       filename: simple-fib.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
 
     hash:
       filename: hash.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
@@ -130,7 +130,7 @@ testcases:
     warm-reboot-fib:
       filename: warm-reboot-fib.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
@@ -159,32 +159,32 @@ testcases:
 
     lag_2:
       filename: lag_2.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1-lag, t1-64-lag]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
 
     lldp:
       filename: lldp.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-64-32, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
 
     link_flap:
       filename: link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     continuous_link_flap:
       filename: continuous_link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
 
     mem_check:
       filename: mem_check.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     mtu:
       filename: mtu.yml
-      topologies: [t1, t1-lag, t1-64-lag]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:
@@ -197,16 +197,16 @@ testcases:
 
     neighbour_mac_noptf:
       filename: neighbour-mac-noptf.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     ntp:
       filename: ntp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     pfc_wd:
       filename: pfc_wd.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     portstat:
       filename: portstat.yml
@@ -215,7 +215,7 @@ testcases:
     port_toggle:
       filename: port_toggle.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     qos:
       filename: qos.yml
@@ -227,40 +227,40 @@ testcases:
 
     reboot:
       filename: reboot.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     restart_swss:
       filename: run_config_cleanup.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     restart_swss_service:
       filename: restart_swss.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     restart_syncd:
       filename: restart_syncd.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     sensors:
       filename: sensors_check.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     service_acl:
       filename: service_acl.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     snmp:
       filename: snmp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     syslog:
       filename: syslog.yml
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet, ptf32, ptf64]
 
     vlan:
       filename: vlantb.yml
@@ -275,7 +275,7 @@ testcases:
 
     dip_sip:
       filename: dip_sip.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, t1-64-lag-clet]
       required_vars:
           ptf_host:
           testbed_type:

--- a/ansible/testbed-new.yaml
+++ b/ansible/testbed-new.yaml
@@ -227,7 +227,7 @@ veos_groups:
     servers:
         children: [server_1, server_2]                      # source: sonic-mgmt/veos
         vars: 
-            topologies: ['t1', 't1-lag', 't1-64-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
+            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
     server_1:
         children: [vm_host_1, vms_1]                        # source: sonic-mgmt/veos
         vars:

--- a/ansible/vars/configlet/t1-64-lag-clet/apply_clet.sh
+++ b/ansible/vars/configlet/t1-64-lag-clet/apply_clet.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+# Sleep to let all BGP sessions go up & running before adding a T0
+sleep 1m
+/usr/bin/configlet -j /etc/sonic/clet-to_clear.json -d
+/usr/bin/configlet -j /etc/sonic/clet-add_20T0.json -u

--- a/ansible/vars/configlet/t1-64-lag-clet/clet-add_20T0.json
+++ b/ansible/vars/configlet/t1-64-lag-clet/clet-add_20T0.json
@@ -1,0 +1,221 @@
+[
+    {
+        "PORT": {
+            "Ethernet63": {
+                "description": "ARISTA20T0:Ethernet1",
+                "mtu": "9100",
+                "admin_status": "down"
+            }
+        }
+    },
+    {
+        "PORTCHANNEL": {
+            "PortChannel0024": {
+                "admin_status": "up",
+                "min_links": "1",
+                "mtu": "9100"
+            } 
+        }
+    },
+    {
+        "PORTCHANNEL_MEMBER": {
+            "PortChannel0024|Ethernet63": {}
+        }
+    },
+    {
+        "PORTCHANNEL_INTERFACE": {
+            "PortChannel0024|10.0.0.70/31": {},
+            "PortChannel0024|FC00::8D/126": {}
+        }
+    },
+    {
+        "ACL_TABLE": {
+            "EVERFLOW": {
+                "type": "MIRROR",
+                "policy_desc": "EVERFLOW",
+                "ports": [
+                    "PortChannel0001",
+                    "PortChannel0002",
+                    "PortChannel0003",
+                    "PortChannel0004",
+                    "PortChannel0005",
+                    "PortChannel0006",
+                    "PortChannel0007",
+                    "PortChannel0008",
+                    "PortChannel0009",
+                    "PortChannel0010",
+                    "PortChannel0011",
+                    "PortChannel0012",
+                    "PortChannel0013",
+                    "PortChannel0014",
+                    "PortChannel0015",
+                    "PortChannel0016",
+                    "PortChannel0017",
+                    "PortChannel0018",
+                    "PortChannel0019",
+                    "PortChannel0020",
+                    "PortChannel0021",
+                    "PortChannel0022",
+                    "PortChannel0023",
+                    "PortChannel0024"
+                ]
+            },
+            "EVERFLOWV6": {
+                "type": "MIRRORV6",
+                "policy_desc": "EVERFLOWV6",
+                "ports": [
+                    "PortChannel0001",
+                    "PortChannel0002",
+                    "PortChannel0003",
+                    "PortChannel0004",
+                    "PortChannel0005",
+                    "PortChannel0006",
+                    "PortChannel0007",
+                    "PortChannel0008",
+                    "PortChannel0009",
+                    "PortChannel0010",
+                    "PortChannel0011",
+                    "PortChannel0012",
+                    "PortChannel0013",
+                    "PortChannel0014",
+                    "PortChannel0015",
+                    "PortChannel0016",
+                    "PortChannel0017",
+                    "PortChannel0018",
+                    "PortChannel0019",
+                    "PortChannel0020",
+                    "PortChannel0021",
+                    "PortChannel0022",
+                    "PortChannel0023",
+                    "PortChannel0024"
+                ]
+            }
+        }
+    },
+    {
+        "DEVICE_NEIGHBOR": {
+            "Ethernet63": {
+                "name": "ARISTA20T0",
+                "port": "Ethernet1"
+            }   
+        }   
+    },
+    {
+        "DEVICE_NEIGHBOR_METADATA": {
+            "ARISTA20T0": {
+                "lo_addr": "None",
+                "mgmt_addr": "10.64.247.223",
+                "hwsku": "Arista-VM", 
+                "type": "ToRRouter",
+                "deployment_id": "2"
+            }   
+        }
+    },
+    {
+        "CABLE_LENGTH": {
+            "AZURE": {
+                "Ethernet63": "300m"
+            }
+        }
+    },
+    {
+        "QUEUE": {
+            "Ethernet63|0": {
+                "scheduler": "[SCHEDULER|scheduler.0]"
+            },
+            "Ethernet63|1": {
+                "scheduler": "[SCHEDULER|scheduler.0]"
+            },
+            "Ethernet63|2": {
+                "scheduler": "[SCHEDULER|scheduler.0]"
+            },
+            "Ethernet63|3": {
+                "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
+                "scheduler": "[SCHEDULER|scheduler.1]"
+            },
+            "Ethernet63|4": {
+                "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
+                "scheduler": "[SCHEDULER|scheduler.1]"
+            },
+            "Ethernet63|5": {
+                "scheduler": "[SCHEDULER|scheduler.0]"
+            },
+            "Ethernet63|6": {
+                "scheduler": "[SCHEDULER|scheduler.0]"
+            }
+        }
+    },
+    {
+        "BUFFER_PG": {
+            "Ethernet63|0": {
+                "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+            }
+        }
+    },
+    {
+        "BUFFER_QUEUE": {
+            "Ethernet63|0-2": {
+                "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+            },  
+            "Ethernet63|3-4": {
+                "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+            },  
+            "Ethernet63|5-6": {
+                "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+            }  
+
+        }
+    },
+    {
+        "PORT_QOS_MAP": {
+            "Ethernet63": {
+                "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+                "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]",
+                "pfc_enable": "3,4",
+                "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+                "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]"
+            }
+        }
+    },
+    {
+        "PFC_WD": {
+            "Ethernet63": {
+                "action": "drop",
+                "detection_time": "400",
+                "restoration_time": "400"
+            }
+        }
+    },
+    {
+        "BGP_NEIGHBOR": {
+            "10.0.0.71": {
+                "rrclient": "0",
+                "name": "ARISTA20T0",
+                "local_addr": "10.0.0.70",
+                "nhopself": "0",
+                "admin_status": "up",
+                "holdtime": "10",
+                "asn": "64020",
+                "keepalive": "3"
+            },
+            "fc00::8e": {
+                "rrclient": "0",
+                "name": "ARISTA20T0",
+                "local_addr": "fc00::8d",
+                "nhopself": "0",
+                "admin_status": "up",
+                "holdtime": "10",
+                "asn": "64020",
+                "keepalive": "3"
+            }
+        }
+    },
+    {
+        "PORT": {
+            "Ethernet63": {
+                "admin_status": "up"
+            }
+        }
+    }
+]
+

--- a/ansible/vars/configlet/t1-64-lag-clet/clet-to_clear.json
+++ b/ansible/vars/configlet/t1-64-lag-clet/clet-to_clear.json
@@ -1,0 +1,9 @@
+[
+    {
+        "ACL_TABLE": {
+            "EVERFLOW": {},
+            "EVERFLOWV6": {}
+        }
+    }
+]
+

--- a/ansible/vars/topo_t1-64-lag-clet.yml
+++ b/ansible/vars/topo_t1-64-lag-clet.yml
@@ -1,0 +1,683 @@
+topology:
+  VMs:
+    ARISTA01T2:
+      vlans:
+        - 0
+        - 1
+      vm_offset: 0
+    ARISTA03T2:
+      vlans:
+        - 4 
+        - 5
+      vm_offset: 1
+    ARISTA05T2:
+      vlans:
+        - 16
+        - 17
+      vm_offset: 2
+    ARISTA07T2:
+      vlans:
+        - 20
+        - 21
+      vm_offset: 3
+    ARISTA01T0:
+      vlans:
+        - 34
+      vm_offset: 4
+    ARISTA02T0:
+      vlans:
+        - 36
+      vm_offset: 5
+    ARISTA03T0:
+      vlans:
+        - 37
+      vm_offset: 6
+    ARISTA04T0:
+      vlans:
+        - 38
+      vm_offset: 7
+    ARISTA05T0:
+      vlans:
+        - 39
+      vm_offset: 8
+    ARISTA06T0:
+      vlans:
+        - 42
+      vm_offset: 9
+    ARISTA07T0:
+      vlans:
+        - 44
+      vm_offset: 10
+    ARISTA08T0:
+      vlans:
+        - 45
+      vm_offset: 11
+    ARISTA09T0:
+      vlans:
+        - 46
+      vm_offset: 12
+    ARISTA10T0:
+      vlans:
+        - 47
+      vm_offset: 13
+    ARISTA11T0:
+      vlans:
+        - 50
+      vm_offset: 14
+    ARISTA12T0:
+      vlans:
+        - 52
+      vm_offset: 15
+    ARISTA13T0:
+      vlans:
+        - 53
+      vm_offset: 16
+    ARISTA14T0:
+      vlans:
+        - 54
+      vm_offset: 17
+    ARISTA15T0:
+      vlans:
+        - 55
+      vm_offset: 18
+    ARISTA16T0:
+      vlans:
+        - 58
+      vm_offset: 19
+    ARISTA17T0:
+      vlans:
+        - 60
+      vm_offset: 20
+    ARISTA18T0:
+      vlans:
+        - 61
+      vm_offset: 21
+    ARISTA19T0:
+      vlans:
+        - 62
+      vm_offset: 22
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: LeafRouter
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+  spine:
+    swrole: spine
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    leaf_asn_start: 62001
+    tor_asn_start: 65501
+    failure_rate: 0
+  tor:
+    swrole: tor
+    tor_subnet_number: 5
+
+configuration:
+  ARISTA01T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.0
+        - FC00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+
+  ARISTA03T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.4
+        - FC00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::6/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::6/64
+
+  ARISTA05T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.8
+        - FC00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::a/64
+
+  ARISTA07T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.12
+        - FC00::D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::e/126
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::e/64
+
+  ARISTA01T0:
+    properties:
+    - common
+    - tor
+    tornum: 1
+    bgp:
+      asn: 64001
+      peers:
+        65100:
+        - 10.0.0.32
+        - FC00::41
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::22/64
+
+  ARISTA02T0:
+    properties:
+    - common
+    - tor
+    tornum: 2
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+        - 10.0.0.34
+        - FC00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::25/64
+
+  ARISTA03T0:
+    properties:
+    - common
+    - tor
+    tornum: 3
+    bgp:
+      asn: 64003
+      peers:
+        65100:
+        - 10.0.0.36
+        - FC00::49
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::26/64
+    vips:
+      ipv4: 
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
+
+  ARISTA04T0:
+    properties:
+    - common
+    - tor
+    tornum: 4
+    bgp:
+      asn: 64004
+      peers:
+        65100:
+        - 10.0.0.38
+        - FC00::4D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::29/64
+
+  ARISTA05T0:
+    properties:
+    - common
+    - tor
+    tornum: 5
+    bgp:
+      asn: 64005
+      peers:
+        65100:
+        - 10.0.0.40
+        - FC00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::2a/64
+    vips:
+      ipv4: 
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
+
+  ARISTA06T0:
+    properties:
+    - common
+    - tor
+    tornum: 6
+    bgp:
+      asn: 64006
+      peers:
+        65100:
+        - 10.0.0.42
+        - FC00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::2d/64
+
+  ARISTA07T0:
+    properties:
+    - common
+    - tor
+    tornum: 7
+    bgp:
+      asn: 64007
+      peers:
+        65100:
+        - 10.0.0.44
+        - FC00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::2e/64
+
+  ARISTA08T0:
+    properties:
+    - common
+    - tor
+    tornum: 8
+    bgp:
+      asn: 64008
+      peers:
+        65100:
+        - 10.0.0.46
+        - FC00::5D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::31/64
+
+  ARISTA09T0:
+    properties:
+    - common
+    - tor
+    tornum: 9
+    bgp:
+      asn: 64009
+      peers:
+        65100:
+        - 10.0.0.48
+        - FC00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::32/64
+
+  ARISTA10T0:
+    properties:
+    - common
+    - tor
+    tornum: 10
+    bgp:
+      asn: 64010
+      peers:
+        65100:
+        - 10.0.0.50
+        - FC00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::35/64
+
+  ARISTA11T0:
+    properties:
+    - common
+    - tor
+    tornum: 11
+    bgp:
+      asn: 64011
+      peers:
+        65100:
+        - 10.0.0.52
+        - FC00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::36/64
+
+  ARISTA12T0:
+    properties:
+    - common
+    - tor
+    tornum: 12
+    bgp:
+      asn: 64012
+      peers:
+        65100:
+        - 10.0.0.54
+        - FC00::6D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::39/64
+
+  ARISTA13T0:
+    properties:
+    - common
+    - tor
+    tornum: 13
+    bgp:
+      asn: 64013
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA14T0:
+    properties:
+    - common
+    - tor
+    tornum: 14
+    bgp:
+      asn: 64014
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA15T0:
+    properties:
+    - common
+    - tor
+    tornum: 15
+    bgp:
+      asn: 64015
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA16T0:
+    properties:
+    - common
+    - tor
+    tornum: 16
+    bgp:
+      asn: 64016
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
+
+  ARISTA17T0:
+    properties:
+    - common
+    - tor
+    tornum: 17
+    bgp:
+      asn: 64017
+      peers:
+        65100:
+        - 10.0.0.64
+        - FC00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+    bp_interface:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::43/64
+
+  ARISTA18T0:
+    properties:
+    - common
+    - tor
+    tornum: 18
+    bgp:
+      asn: 64018
+      peers:
+        65100:
+        - 10.0.0.66
+        - FC00::85
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.34/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.67/31
+        ipv6: fc00::86/126
+    bp_interface:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::45/64
+
+  ARISTA19T0:
+    properties:
+    - common
+    - tor
+    tornum: 19
+    bgp:
+      asn: 64019
+      peers:
+        65100:
+        - 10.0.0.68
+        - FC00::89
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.35/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.69/31
+        ipv6: fc00::8a/126
+    bp_interface:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::47/64

--- a/ansible/veos
+++ b/ansible/veos
@@ -108,4 +108,4 @@ server_1
 server_2
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']

--- a/ansible/veos.vtb
+++ b/ansible/veos.vtb
@@ -26,7 +26,7 @@ host_var_file=host_vars/STR-ACS-VSERV-01.yml
 server_1
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
 
 [sonic]
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -61,7 +61,7 @@ def setup(duthost, testbed):
     port_channels = []
     acl_table_ports = []
 
-    if testbed['topo'] not in ('t1', 't1-lag', 't1-64-lag'):
+    if testbed['topo'] not in ('t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet'):
         pytest.skip('Unsupported topology')
 
     # gather ansible facts
@@ -82,7 +82,7 @@ def setup(duthost, testbed):
 
     # get the list of port to be combined to ACL tables
     acl_table_ports += tor_ports
-    if testbed['topo'] in ('t1-lag', 't1-64-lag'):
+    if testbed['topo'] in ('t1-lag', 't1-64-lag', 't1-64-lag-clet'):
         acl_table_ports += port_channels
     else:
         acl_table_ports += spine_ports

--- a/tests/veos.vtb
+++ b/tests/veos.vtb
@@ -26,7 +26,7 @@ host_var_file=host_vars/STR-ACS-VSERV-01.yml
 server_1
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
 
 [sonic]
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000 ansible_password=password ansible_user=admin


### PR DESCRIPTION
Introduced a new topo: t1-64-lag-clet.
Has a topo (topo_t1-64-lag-clet.yml) which is same as topo_t1-64-lag.yml deprived of ARISTA20T0.
The ansible/config_sonic_basedon_testbed.yml upon loading config & starting BGP
adds ARISTA20T0, by invoking ansible/vars/configlet/t1-64-lag-clet/apply_clet.sh.
The running daemons should adopt this new T0 transparently, w/o requiring any
daemon/service restart.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
