### PR TITLE
[Mellanox]Relax the cpu_temp checking

### DIFF
--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -97,9 +97,12 @@ def check_sysfs(dut):
         cpu_pack_crit_temp_file_output = dut.command("cat %s" % cpu_pack_crit_temp_file)
         cpu_pack_crit_temp = float(cpu_pack_crit_temp_file_output["stdout"])/1000
 
+        if cpu_pack_temp >= cpu_pack_max_temp:
+            logging.warning("cpu pack temperature ({}) is higher than alarm threshold ({}) ".format(cpu_pack_temp, cpu_pack_max_temp))
+
         assert cpu_pack_max_temp <= cpu_pack_crit_temp, "Bad CPU pack max temp or critical temp, %s, %s " \
                                                         % (str(cpu_pack_max_temp), str(cpu_pack_crit_temp))
-        assert cpu_pack_temp < cpu_pack_max_temp, "CPU pack overheated, temp: %s" % (str(cpu_pack_temp))
+        assert cpu_pack_temp < cpu_pack_crit_temp, "CPU pack overheated, temp: %s" % (str(cpu_pack_temp))
 
     cpu_core_count = SWITCH_MODELS[dut_hwsku]["cpu_cores"]["number"]
     for core_id in range(0, cpu_core_count):
@@ -115,9 +118,12 @@ def check_sysfs(dut):
         cpu_core_crit_temp_file_output = dut.command("cat %s" % cpu_core_crit_temp_file)
         cpu_core_crit_temp = float(cpu_core_crit_temp_file_output["stdout"])/1000
 
+        if cpu_core_temp >= cpu_core_max_temp:
+            logging.warning("cpu core {} temperature ({}) is higher than alarm threshold ({})".format(core_id, cpu_pack_temp, cpu_pack_max_temp))
+
         assert cpu_core_max_temp <= cpu_core_crit_temp, "Bad CPU core%d max temp or critical temp, %s, %s " \
                                                         % (core_id, str(cpu_core_max_temp), str(cpu_core_crit_temp))
-        assert cpu_core_temp < cpu_core_max_temp, "CPU core%d overheated, temp: %s" % (core_id, str(cpu_core_temp))
+        assert cpu_core_temp < cpu_core_crit_temp, "CPU core%d overheated, temp: %s" % (core_id, str(cpu_core_temp))
 
     psu_count = SWITCH_MODELS[dut_hwsku]["psus"]["number"]
     for psu_id in range(1, psu_count + 1):


### PR DESCRIPTION
### Description of PR
Relax the cpu_temp checking by checking it against critical threshold

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Relax the cpu_temp checking by checking it against critical threshold for now.
Add log if cpu_temp is greater than alarm threshold.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
