### PR TITLE
fix fdb test on sonic kvm image

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -152,8 +152,6 @@ def test_fdb(ansible_adhoc, testbed, ptfadapter):
         if "dynamic" in l.lower():
             total_mac_count += 1
 
+    print res
     # Verify that the number of dummy MAC entries is expected
     assert dummy_mac_count == DUMMY_MAC_COUNT * vlan_member_count
-    # Verify that total number of MAC entries is expected
-    assert total_mac_count == DUMMY_MAC_COUNT * vlan_member_count + vlan_member_count
-

--- a/tests/ptf_fixtures.py
+++ b/tests/ptf_fixtures.py
@@ -49,11 +49,11 @@ def ptfadapter(ptfhost, testbed):
     ifaces_map = {int(ifname.replace(ETH_PFX, '')): ifname for ifname in ifaces}
 
     # generate supervisor configuration for ptf_nn_agent
-    ptfhost.host.options['variable_manager'].extra_vars = {
+    ptfhost.host.options['variable_manager'].extra_vars.update({
         'device_num': DEFAULT_DEVICE_NUM,
         'ptf_nn_port': DEFAULT_PTF_NN_PORT,
         'ifaces_map': ifaces_map,
-    }
+    })
     ptfhost.template(src='ptfadapter/templates/ptf_nn_agent.conf.ptf.j2',
                      dest='/etc/supervisor/conf.d/ptf_nn_agent.conf')
 


### PR DESCRIPTION
Do not check total mac as there could be more macs from neighbors
Result unstable tests

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Do not check total mac as there could be more macs from neighbors
Result unstable tests

#### How did you verify/test it?

```
johnar@2cd47dfe744e:/data/sonic-mgmt/tests$ py.test --inventory veos.vtb --host-pattern all --user admin --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv fdb/test_fdb.py   | tee abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.6, py-1.8.0, pluggy-0.13.0
ansible: 2.8.7
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item

fdb/test_fdb.py .                                                        [100%]

========================== 1 passed in 230.50 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
