### PR TITLE
[add-topo]: wait till docker interface deleted in the system

### DIFF
--- a/ansible/doc/README.testbed.VsSetup.md
+++ b/ansible/doc/README.testbed.VsSetup.md
@@ -22,27 +22,6 @@ $ sudo ifconfig br1 up
    - ```Aboot-veos-serial-8.0.0.iso```
    - ```vEOS-lab-4.20.15M.vmdk```
 
-## Setup docker registry for *PTF* docker
-
-PTF docker is used to send and receive packets to test data plane. 
-
-- Build PTF docker
-```
-$ git clone --recursive https://github.com/Azure/sonic-buildimage.git
-$ make configure PLATFORM=generic
-$ make target/docker-ptf.gz
-```
-
-- Download pre-built *docker-ptf* image from [here](https://sonic-jenkins.westus2.cloudapp.azure.com/job/broadcom/job/buildimage-brcm-all/lastSuccessfulBuild/artifact/target/docker-ptf-brcm.gz)
-```
-$ wget https://sonic-jenkins.westus2.cloudapp.azure.com/job/broadcom/job/buildimage-brcm-all/lastSuccessfulBuild/artifact/target/docker-ptf-brcm.gz
-```
-
-- Load *docker-ptf* image
-```
-$ docker load -i docker-ptf-brcm.gz
-```
-
 ## Build or download *sonic-mgmt* docker image
 
 ansible playbook in *sonic-mgmt* repo requires to setup ansible and various dependencies.

--- a/ansible/vtestbed.csv
+++ b/ansible/vtestbed.csv
@@ -1,3 +1,3 @@
 # conf-name,group-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,comment
-vms-kvm-t0,vms6-1,t0,docker-ptf-brcm,10.250.0.102/24,server_1,VM0100,vlab-01,Tests virtual switch vm
-vms-kvm-t0-64,vms6-1,t0-64,docker-ptf-brcm,10.250.0.102/24,server_1,VM0100,vlab-02,Tests virtual switch vm
+vms-kvm-t0,vms6-1,t0,docker-ptf,10.250.0.102/24,server_1,VM0100,vlab-01,Tests virtual switch vm
+vms-kvm-t0-64,vms6-1,t0-64,docker-ptf,10.250.0.102/24,server_1,VM0100,vlab-02,Tests virtual switch vm

--- a/tests/vtestbed.csv
+++ b/tests/vtestbed.csv
@@ -1,3 +1,3 @@
 # conf-name,group-name,topo,ptf_image_name,ptf,ptf_ip,server,vm_base,dut,comment
-vms-kvm-t0,vms6-1,t0,docker-ptf-brcm,ptf-01,10.250.0.102/24,server_1,VM0100,vlab-01,Tests virtual switch vm
-vms-kvm-t0-64,vms6-1,t0-64,docker-ptf-brcm,ptf-01,10.250.0.102/24,server_1,VM0100,vlab-02,Tests virtual switch vm
+vms-kvm-t0,vms6-1,t0,docker-ptf,ptf-01,10.250.0.102/24,server_1,VM0100,vlab-01,Tests virtual switch vm
+vms-kvm-t0-64,vms6-1,t0-64,docker-ptf,ptf-01,10.250.0.102/24,server_1,VM0100,vlab-02,Tests virtual switch vm


### PR DESCRIPTION
ptf docker is restarted during add topo and wait till docker
interfaces deleted in the system

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
