### PR TITLE
[Continuous_reboot]: Sometimes it fails when ready timeout is not lon…

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -9,7 +9,7 @@
 
 - name: set default value for sonic ready timeout
   set_fact:
-    ready_timeout: 180
+    ready_timeout: 200
   when: ready_timeout is not defined
 
 - fail:


### PR DESCRIPTION
### Description of PR
sometimes when running continuous reboot test, it may fail
By changing the ready timeout from 180 seconds to 200 seconds at line 12 in reboot_sonic.yml file as the following then the  issue does not happen

- name: set default value for sonic ready timeout
  set_fact:
    ready_timeout: 200
  when: ready_timeout is not defined 
  
  I am not sure whether it is acceptable to wait 20 seconds more than the original setting in reboot_sonic.yml file

### Type of change

- [] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
Modified the ready timeout = 200 seconds in the file roles/test/tasks/common_tasks/reboot_sonic.yml

#### How did you verify/test it?
tested in local testbed

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A