### PR TITLE
[test behavior] disable allow_recover by default

### DIFF
--- a/ansible/roles/test/tasks/test_sonic_by_testname.yml
+++ b/ansible/roles/test/tasks/test_sonic_by_testname.yml
@@ -7,7 +7,7 @@
       - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 
 - set_fact:
-    allow_recover: true
+    allow_recover: false
   when: allow_recover is not defined
 
 - name: do basic sanity check before each test


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

Allow_recover knob controls the behavior of test infrastructure. When set to true, it allows a test to recover DUT in bad state before starting test.

With SONiC stability increases, we should by default disable recovery, and surface more issues. If a test failed in the middle, it should be the test itself to exit with a healthy DUT.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
