### PR TITLE
do not restart updategraph service if cfg not changed

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -126,12 +126,14 @@
             regexp: '^enabled='
             line: 'enabled=false'
         become: true
+        register: updategraph_conf
 
       - name: restart automatic minigraph update service
         become: true
         service:
           name: updategraph
           state: restarted
+        when: updategraph_conf.changed
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true


### PR DESCRIPTION
This is avoid restarting all services as restarting
updategraph service will restart all services depend on it

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
