### PR TITLE
[ansible/MCLAG]: add t0-mclag and t0-mclag-16 typologies support

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -57,8 +57,15 @@
       when: "testbed_facts['vm_base'] != ''"
     when: testbed_name is defined
 
-  - topo_facts: topo={{ topo }}
+  - name: Gathering topology execpt t0-mclag
+    topo_facts: topo={{ topo }}
     connection: local
+    when: topo not in ["t0-mclag", "t0-mclag-16"]
+
+  - name: Gathering t0-mclag information
+    topo_facts: topo="{{ topo }}_dut{{dut_no}}"
+    connection: local
+    when: topo in ["t0-mclag", "t0-mclag-16"] and dut_no is defined
 
   - set_fact:
       VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -234,11 +234,13 @@ def main():
         argument_spec=dict(
             host=dict(required=False),
             filename=dict(required=False),
+            helper_device=dict(required=False),
         ),
         supports_check_mode=True
     )
     m_args = module.params
     hostname = m_args['host']
+    helper_device = m_args['helper_device']
     try:
         if m_args['filename']:
             filename = m_args['filename']
@@ -256,6 +258,17 @@ def main():
             results['device_vlan_range'] = lab_graph.get_host_vlan(hostname)['VlanRange']
             results['device_vlan_list'] = lab_graph.get_host_vlan(hostname)['VlanList']
         results['device_port_vlans'] = lab_graph.get_host_port_vlans(hostname)
+
+        if helper_device:
+            helper_dev = lab_graph.get_host_device_info(helper_device)
+            if helper_dev is None:
+                module.fail_json(msg="cannot find helper device info for "+helper_device)
+        results['helper_device_info'] =  lab_graph.get_host_device_info(helper_device) if helper_device else {}
+        results['helper_device_conn'] = lab_graph.get_host_connections(helper_device) if helper_device else {}
+        results['helper_device_vlan_range'] = lab_graph.get_host_vlan(helper_device)['VlanRange'] if helper_device else []
+        results['helper_device_vlan_list'] = lab_graph.get_host_vlan(helper_device)['VlanList'] if helper_device else []
+        results['helper_device_port_vlans'] = lab_graph.get_host_port_vlans(helper_device) if helper_device else {}
+
         module.exit_json(ansible_facts=results)
     except (IOError, OSError):
         module.fail_json(msg="Can not find lab graph file "+LAB_CONNECTION_GRAPH_FILE)

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -46,6 +46,7 @@ class ParseTestbedTopoinfo():
             vm_topo_config['dut_asn'] = dut_asn
             vm_topo_config['dut_type'] = topo_definition['configuration_properties']['common']['dut_type']
             vmconfig = dict()
+            vm_topo_config['link_vm_interfaces'] = []
             for vm in topo_definition['topology']['VMs']:
                 vmconfig[vm] = dict()
                 vmconfig[vm]['intfs'] = []
@@ -67,6 +68,7 @@ class ParseTestbedTopoinfo():
                         vmconfig[vm]['bgp_ipv4'] = ip.upper()
                     if ip[0:5].upper() in vmconfig[vm]['peer_ipv6'].upper():
                         vmconfig[vm]['bgp_ipv6'] = ip.upper()
+                vm_topo_config['link_vm_interfaces'] += topo_definition['topology']['VMs'][vm]['vlans']
             vm_topo_config['vm'] = vmconfig
 
         if 'host_interfaces' in topo_definition['topology']:
@@ -78,6 +80,11 @@ class ParseTestbedTopoinfo():
             vm_topo_config['disabled_host_interfaces'] = topo_definition['topology']['disabled_host_interfaces']
         else:
             vm_topo_config['disabled_host_interfaces'] = []
+
+        if 'devices_interconnect_interfaces' in topo_definition['topology']:
+            vm_topo_config['devices_interconnect_interfaces'] = topo_definition['topology']['devices_interconnect_interfaces']
+        else:
+            vm_topo_config['devices_interconnect_interfaces'] = []
 
         self.vm_topo_config = vm_topo_config
         return vm_topo_config

--- a/ansible/roles/eos/templates/t0-mclag-16-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-16-leaf.j2
@@ -1,0 +1,186 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management1
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+route-map DEFAULT_ROUTES permit
+!
+{# #}
+{# NOTE: Using large enough values (e.g., podset_number = 200, #}
+{# us to overflow the 192.168.0.0/16 private address space here. #}
+{# This should be fine for internal use, but may pose an issue if used otherwise #}
+{# #}
+{% for podset in range(0, props.podset_number) %}
+{% for tor in range(0, props.tor_number) %}
+{% for subnet in range(0, props.tor_subnet_number) %}
+{# Skip tor 0 podset 0 #}
+{% if podset != 0 or tor != 0 %}
+{% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (subnet * props.tor_subnet_size) ) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
+{% set octet3 = ((suffix // 256) % 256) %}
+{% set octet4 = (suffix % 256) %}
+{% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
+ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
+ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+!
+{% for podset in range(0, props.podset_number) %}
+{% for tor in range(0, props.tor_number) %}
+{# Skip tor 0 podset 0 #}
+{% if podset != 0 or tor != 0 %}
+{% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (tor * props.max_tor_subnet_number * props.tor_subnet_size) ) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
+{% set octet3 = ((suffix // 256) % 256) %}
+{% set octet4 = (suffix % 256) %}
+{% set prefixlen_v4 = (32 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
+{% set prefixlen_v6 = (64 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
+ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
+ seq 10 permit {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
+exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+!
+interface Management 1
+ description TO LAB MGMT SWITCH
+ vrf forwarding MGMT
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ no switchport
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% for podset in range(0, props.podset_number) %}
+{% if range(0, 1000)|random() >= props.failure_rate %}
+{% for tor in range(0, props.tor_number) %}
+{% set leafasn = props.leaf_asn_start + podset %}
+{% set torasn = props.tor_asn_start + tor %}
+route-map PREPENDAS permit {{ 2 * (podset * props.tor_number + tor + 1) }}
+  match ip address prefix-list test_ipv4_{{ podset }}_{{ tor }}
+{% if podset == 0 %}
+  set as-path prepend {{ torasn }}
+{% else %}
+  set as-path prepend {{ props.spine_asn }} {{ leafasn }} {{ torasn }}
+{% endif %}
+!
+route-map PREPENDAS permit {{ 2 * (podset * props.tor_number + tor + 1) + 1 }}
+  match ipv6 address prefix-list test_ipv6_{{ podset }}_{{ tor }}
+{% if podset == 0 %}
+  set as-path prepend {{ torasn }}
+{% else %}
+  set as-path prepend {{ props.spine_asn }} {{ leafasn }} {{ torasn }}
+{% endif %}
+!
+{% endfor %}
+{% endif %}
+{% endfor %}
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} default-originate route-map DEFAULT_ROUTES
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+ redistribute static route-map PREPENDAS
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end
+s

--- a/ansible/roles/eos/templates/t0-mclag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-leaf.j2
@@ -1,0 +1,186 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+no schedule tech-support
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management1
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+route-map DEFAULT_ROUTES permit
+!
+{# #}
+{# NOTE: Using large enough values (e.g., podset_number = 200, #}
+{# us to overflow the 192.168.0.0/16 private address space here. #}
+{# This should be fine for internal use, but may pose an issue if used otherwise #}
+{# #}
+{% for podset in range(0, props.podset_number) %}
+{% for tor in range(0, props.tor_number) %}
+{% for subnet in range(0, props.tor_subnet_number) %}
+{# Skip tor 0 podset 0 #}
+{% if podset != 0 or tor != 0 %}
+{% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (subnet * props.tor_subnet_size) ) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
+{% set octet3 = ((suffix // 256) % 256) %}
+{% set octet4 = (suffix % 256) %}
+{% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
+ip route {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {{ props.nhipv4 }}
+ipv6 route {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {{ props.nhipv6 }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+!
+{% for podset in range(0, props.podset_number) %}
+{% for tor in range(0, props.tor_number) %}
+{# Skip tor 0 podset 0 #}
+{% if podset != 0 or tor != 0 %}
+{% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
+                  (tor * props.max_tor_subnet_number * props.tor_subnet_size) ) %}
+{% set octet2 = (168 + (suffix // (256 ** 2))) %}
+{% set octet1 = (192 + (octet2 // 256)) %}
+{% set octet2 = (octet2 % 256) %}
+{% set octet3 = ((suffix // 256) % 256) %}
+{% set octet4 = (suffix % 256) %}
+{% set prefixlen_v4 = (32 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
+{% set prefixlen_v6 = (64 - (((props.max_tor_subnet_number * props.tor_subnet_size) | log(2)) | int) ) %}
+ip prefix-list test_ipv4_{{ podset}}_{{ tor }} seq 10 permit {{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} ge {{ prefixlen_v4 }}
+ipv6 prefix-list test_ipv6_{{ podset}}_{{ tor }}
+ seq 10 permit {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/{{ prefixlen_v6 }} ge {{ prefixlen_v6 }}
+exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+!
+interface Management 1
+ description TO LAB MGMT SWITCH
+ vrf forwarding MGMT
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ no switchport
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% for podset in range(0, props.podset_number) %}
+{% if range(0, 1000)|random() >= props.failure_rate %}
+{% for tor in range(0, props.tor_number) %}
+{% set leafasn = props.leaf_asn_start + podset %}
+{% set torasn = props.tor_asn_start + tor %}
+route-map PREPENDAS permit {{ 2 * (podset * props.tor_number + tor + 1) }}
+  match ip address prefix-list test_ipv4_{{ podset }}_{{ tor }}
+{% if podset == 0 %}
+  set as-path prepend {{ torasn }}
+{% else %}
+  set as-path prepend {{ props.spine_asn }} {{ leafasn }} {{ torasn }}
+{% endif %}
+!
+route-map PREPENDAS permit {{ 2 * (podset * props.tor_number + tor + 1) + 1 }}
+  match ipv6 address prefix-list test_ipv6_{{ podset }}_{{ tor }}
+{% if podset == 0 %}
+  set as-path prepend {{ torasn }}
+{% else %}
+  set as-path prepend {{ props.spine_asn }} {{ leafasn }} {{ torasn }}
+{% endif %}
+!
+{% endfor %}
+{% endif %}
+{% endfor %}
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} default-originate route-map DEFAULT_ROUTES
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+ redistribute static route-map PREPENDAS
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end
+s

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -92,6 +92,7 @@ EXCEPTION_DEBUG_FNAME = '/tmp/vmtopology.exception.txt'
 OVS_FP_BRIDGE_REGEX = 'br-%s-\d+'
 OVS_FP_BRIDGE_TEMPLATE = 'br-%s-%d'
 OVS_FP_TAP_TEMPLATE = '%s-t%d'
+OVS_INTERCONNECTION_BRIDGE_TEMPLATE = 'br-%s-ic-%s'
 OVS_BRIDGE_BACK_TEMPLATE = 'br-%s-back'
 INJECTED_INTERFACES_TEMPLATE = 'inje-%s-%d'
 PTF_NAME_TEMPLATE = 'ptf_%s'
@@ -134,6 +135,11 @@ class VMTopology(object):
             self.host_interfaces = topo['host_interfaces']
         else:
             self.host_interfaces = []
+
+        if 'devices_interconnect_interfaces' in topo:
+            self.devices_interconnect_interfaces = topo['devices_interconnect_interfaces']
+        else:
+            self.devices_interconnect_interfaces = []
 
         self.dut_fp_ports = dut_fp_ports
 
@@ -331,6 +337,52 @@ class VMTopology(object):
 
         return
 
+    def bind_devices_interconnect(self):
+        self.update()
+
+        for link_index, vlans in self.devices_interconnect_interfaces.items():
+            interconnection_bridge = OVS_INTERCONNECTION_BRIDGE_TEMPLATE % (self.vm_set_name, link_index)
+            self.create_bridge(interconnection_bridge, self.fp_mtu)
+            vlan1_iface = self.dut_fp_ports[vlans[0]]
+            vlan2_iface = self.dut_fp_ports[vlans[1]]
+            self.bind_devices_interconnect_ports(interconnection_bridge, vlan1_iface, vlan2_iface)
+
+        return
+
+    def unbind_devices_interconnect(self):
+        self.update()
+
+        for link_index, vlans in self.devices_interconnect_interfaces.items():
+            interconnection_bridge = OVS_INTERCONNECTION_BRIDGE_TEMPLATE % (self.vm_set_name, link_index)
+            vlan1_iface = self.dut_fp_ports[vlans[0]]
+            vlan2_iface = self.dut_fp_ports[vlans[1]]
+            self.unbind_ovs_port(interconnection_bridge, vlan1_iface)
+            self.unbind_ovs_port(interconnection_bridge, vlan2_iface)
+            self.destroy_bridge(interconnection_bridge)
+
+        return
+
+    def bind_devices_interconnect_ports(self, br_name, vlan1_iface, vlan2_iface):
+        ports = VMTopology.get_ovs_br_ports(br_name)
+
+        if vlan1_iface not in ports:
+            VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, vlan1_iface))
+
+        if vlan2_iface not in ports:
+            VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, vlan2_iface))
+
+        bindings = VMTopology.get_ovs_port_bindings(br_name)
+        vlan1_iface_id = bindings[vlan1_iface]
+        vlan2_iface_id = bindings[vlan2_iface]
+
+        # clear old bindings
+        VMTopology.cmd('ovs-ofctl del-flows %s' % br_name)
+
+        VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vlan1_iface_id, vlan2_iface_id))
+        VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, vlan2_iface_id, vlan1_iface_id))
+
+        return
+
     def bind_fp_ports(self, disconnect_vm=False):
         for attr in self.VMs.itervalues():
             for vlan_num, vlan in enumerate(attr['vlans']):
@@ -440,20 +492,24 @@ class VMTopology(object):
 
     def unbind_ovs_ports(self, br_name, vm_port):
         """unbind all ports except the vm port from an ovs bridge"""
-        ports = VMTopology.get_ovs_br_ports(br_name)
+        self.update()
+        if br_name in self.host_ifaces:
+            ports = VMTopology.get_ovs_br_ports(br_name)
 
-        for port in ports:
-            if port != vm_port:
-                VMTopology.cmd('ovs-vsctl del-port %s %s' % (br_name, port))
+            for port in ports:
+                if port != vm_port:
+                    VMTopology.cmd('ovs-vsctl del-port %s %s' % (br_name, port))
 
         return
 
     def unbind_ovs_port(self, br_name, port):
         """unbind a port from an ovs bridge"""
-        ports = VMTopology.get_ovs_br_ports(br_name)
+        self.update()
+        if br_name in self.host_ifaces:
+            ports = VMTopology.get_ovs_br_ports(br_name)
 
-        if port in ports:
-            VMTopology.cmd('ovs-vsctl del-port %s %s' % (br_name, port))
+            if port in ports:
+                VMTopology.cmd('ovs-vsctl del-port %s %s' % (br_name, port))
 
         return
 
@@ -629,6 +685,26 @@ def check_topo(topo):
 
     return hostif_exists, vms_exists
 
+def check_devices_interconnect(topo):
+    devices_interconnect_exists = False
+    all_vlans = set()
+
+    if 'devices_interconnect_interfaces' in topo:
+        links = topo['devices_interconnect_interfaces']
+
+        for key, vlans in links.items():
+            for vlan in vlans:
+                if not isinstance(vlan, int) or vlan < 0:
+                    raise Exception("topo['devices_interconnect_interfaces'][%s] should be a list of integers" % key)
+                if vlan in all_vlans:
+                    raise Exception("topo['devices_interconnect_interfaces'][%s] double use of vlan: %d" % (key, vlan))
+                else:
+                    all_vlans.add(vlan)
+
+        devices_interconnect_exists = True
+
+    return devices_interconnect_exists
+
 def check_params(module, params, mode):
     for param in params:
         if param not in module.params:
@@ -686,6 +762,7 @@ def main():
                 raise Exception("vm_set_name can't be longer than %d characters: %s (%d)" % (VM_SET_NAME_MAX_LEN, vm_set_name, len(vm_set_name)))
 
             hostif_exists, vms_exists = check_topo(topo)
+            devices_interconnect_exists = check_devices_interconnect(topo)
 
             if vms_exists:
                 check_params(module, ['vm_base'], cmd)
@@ -710,6 +787,9 @@ def main():
 
             if hostif_exists:
                 net.inject_host_ports()
+
+            if devices_interconnect_exists:
+                net.bind_devices_interconnect()
         elif cmd == 'unbind':
             check_params(module, ['vm_set_name',
                                   'topo',
@@ -723,6 +803,7 @@ def main():
                 raise Exception("vm_set_name can't be longer than %d characters: %s (%d)" % (VM_SET_NAME_MAX_LEN, vm_set_name, len(vm_set_name)))
 
             hostif_exists, vms_exists = check_topo(topo)
+            devices_interconnect_exists = check_devices_interconnect(topo)
 
             if vms_exists:
                 check_params(module, ['vm_base'], cmd)
@@ -740,6 +821,9 @@ def main():
 
             if hostif_exists:
                 net.deject_host_ports()
+
+            if devices_interconnect_exists:
+                net.unbind_devices_interconnect()
         elif cmd == 'renumber':
             check_params(module, ['vm_set_name',
                                   'topo',
@@ -756,6 +840,7 @@ def main():
                 raise Exception("vm_set_name can't be longer than %d characters: %s (%d)" % (VM_SET_NAME_MAX_LEN, vm_set_name, len(vm_set_name)))
 
             hostif_exists, vms_exists = check_topo(topo)
+            devices_interconnect_exists = check_devices_interconnect(topo)
 
             if vms_exists:
                 check_params(module, ['vm_base'], cmd)
@@ -777,6 +862,9 @@ def main():
                 net.bind_fp_ports()
             if hostif_exists:
                 net.inject_host_ports()
+
+            if devices_interconnect_exists:
+                net.bind_devices_interconnect()
         elif cmd == 'connect-vms' or cmd == 'disconnect-vms':
             check_params(module, ['vm_set_name',
                                   'topo',

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -41,7 +41,7 @@
 - name: Setup vlan port for vlan tunnel
   vlan_port:
     external_port: "{{ external_port }}"
-    vlan_ids: "{{ device_vlan_list }}"
+    vlan_ids: "{{ device_vlan_list + helper_device_vlan_list }}"
     cmd: "create"
   become: yes
   when: external_port is defined

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -16,7 +16,7 @@
 - name: Remove vlan port for vlan tunnel
   vlan_port:
     external_port: "{{ external_port }}"
-    vlan_ids: "{{ device_vlan_list }}"
+    vlan_ids: "{{ device_vlan_list + helper_device_vlan_list }}"
     cmd: "remove"
   become: yes
   when: external_port is defined

--- a/ansible/roles/vm_set/tasks/set_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/set_dut_port.yml
@@ -1,7 +1,7 @@
 - name: Set front panel port for vlan tunnel
   vlan_port:
     external_port: "{{ external_port }}"
-    vlan_ids: "{{ device_vlan_list }}"
+    vlan_ids: "{{ device_vlan_list + helper_device_vlan_list }}"
     cmd: "list"
   become: yes
   when: external_port is defined

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -85,6 +85,7 @@ function read_file
  server=${line_arr[5]}
  vm_base=${line_arr[6]}
  dut=${line_arr[7]}
+ helper_device=${line_arr[9]}
 }
 
 function start_vms
@@ -119,9 +120,9 @@ function add_topo
 
   read_file ${topology}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$testbed_name" -e ptf_imagename="$ptf_imagename" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$testbed_name" -e ptf_imagename="$ptf_imagename" -e helper_device="$helper_device" $@
 
-  ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$dut" $@
+  ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$dut" -e helper_device="$helper_device" $@
 
   # Delete the obsoleted arp entry for the PTF IP
   ip neighbor flush $ptf_ip
@@ -139,7 +140,7 @@ function remove_topo
 
   read_file ${topology}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$testbed_name" -e ptf_imagename="$ptf_imagename" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$testbed_name" -e ptf_imagename="$ptf_imagename" -e helper_device="$helper_device" $@
 
   echo Done
 }
@@ -154,9 +155,9 @@ function renumber_topo
 
   read_file ${topology}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$testbed_name" -e ptf_imagename="$ptf_imagename" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e dut_name="$dut" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$testbed_name" -e ptf_imagename="$ptf_imagename" -e helper_device="$helper_device" $@
 
-  ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$dut" $@
+  ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$dut" -e helper_device="$helper_device" $@
 
   echo Done
 }

--- a/ansible/testbed.csv
+++ b/ansible/testbed.csv
@@ -1,4 +1,4 @@
-# conf-name,group-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,comment
+# conf-name,group-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,comment,helper_device
 ptf1-m,ptf1,ptf32,docker-ptf-sai-mlnx,10.255.0.188/24,server_1,,str-msn2700-01,Test ptf Mellanox
 ptf2-b,ptf2,ptf64,docker-ptf-sai-brcm,10.255.0.189/24,server_1,,lab-s6100-01,Test ptf Broadcom
 vms-sn2700-t1,vms1-1,t1,docker-ptf-sai-mlnx,10.255.0.178/24,server_1,VM0100,str-msn2700-01,Tests Mellanox SN2700 vms
@@ -9,3 +9,7 @@ vms-a7260-t0,vms3-1,t0-116,docker-ptf-sai-brcm,10.255.0.180/24,server_1,VM0100,l
 vms-s6100-t0,vms4-1,t0-64,docker-ptf-sai-brcm,10.255.0.181/24,server_1,VM0100,lab-s6100-01,Tests Dell S6100 vms
 vms-s6100-t1,vms4-1,t1-64,docker-ptf-sai-brcm,10.255.0.182/24,server_1,VM0100,lab-s6100-01,Tests Dell S6100 vms
 vms-s6100-t1-lag,vms5-1,t1-64-lag,docker-ptf-sai-brcm,10.255.0.183/24,server_1,VM0100,lab-s6100-01,Tests Dell S6100 vms
+vms-t0-mclag,vms6-1,t0-mclag,docker-ptf-team,10.255.0.198/24,server_1,VM0100,sonic-dut-01,Tests vms,sonic-dut-02
+vms-t0-mclag-dut2,vms6-1,t0-mclag,docker-ptf-team,10.255.0.198/24,server_1,VM0100,sonic-dut-02,Tests vms
+vms-t0-mclag-16,vms6-1,t0-mclag-16,docker-ptf-team,10.255.0.198/24,server_1,VM0100,sonic-dut-01,Tests vms,sonic-dut-02
+vms-t0-mclag-16-dut2,vms6-1,t0-mclag-16,docker-ptf-team,10.255.0.198/24,server_1,VM0100,sonic-dut-02,Tests vms

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -68,7 +68,9 @@
     include_vars: "vars/topo_{{ topo }}.yml"
 
   - name: Read dut minigraph
-    conn_graph_facts: host={{ dut_name }}
+    conn_graph_facts: 
+      host={{ dut_name }}
+      helper_device={{ helper_device }}
     connection: local
 
   roles:

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -51,7 +51,9 @@
     include_vars: "vars/topo_{{ topo }}.yml"
 
   - name: Read dut minigraph
-    conn_graph_facts: host={{ dut_name }}
+    conn_graph_facts: 
+      host={{ dut_name }}
+      helper_device={{ helper_device }}
     connection: local
 
   roles:

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -50,7 +50,9 @@
     include_vars: "vars/topo_{{ topo }}.yml"
 
   - name: Read dut minigraph
-    conn_graph_facts: host={{ dut_name }}
+    conn_graph_facts: 
+      host={{ dut_name }}
+      helper_device={{ helper_device }}
     connection: local
 
   roles:

--- a/ansible/vars/topo_t0-mclag-16.yml
+++ b/ansible/vars/topo_t0-mclag-16.yml
@@ -1,0 +1,172 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+  devices_interconnect_interfaces:
+    1:
+      - 10
+      - 26
+    2:
+      - 11
+      - 27
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 12
+        - 28
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 13
+        - 29
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 14
+        - 30
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 15
+        - 31
+      vm_offset: 3
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 64
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65100
+    failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+        65101:
+        - 10.0.0.120
+        - FC00::F1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Ethernet2:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+        65101:
+        - 10.0.0.122
+        - FC00::F5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Ethernet2:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::f6/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+        65101:
+        - 10.0.0.124
+        - FC00::F9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Ethernet2:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+        65101:
+        - 10.0.0.126
+        - FC00::FD
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Ethernet2:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::fe/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64

--- a/ansible/vars/topo_t0-mclag-16_dut1.yml
+++ b/ansible/vars/topo_t0-mclag-16_dut1.yml
@@ -1,0 +1,132 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+  devices_interconnect_interfaces:
+    1:
+      - 10
+    2:
+      - 11
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 12
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 13
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 14
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 15
+      vm_offset: 3
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 64
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65100
+    failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64

--- a/ansible/vars/topo_t0-mclag-16_dut2.yml
+++ b/ansible/vars/topo_t0-mclag-16_dut2.yml
@@ -1,0 +1,132 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+  devices_interconnect_interfaces:
+    1:
+      - 10
+    2:
+      - 11
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 12
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 13
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 14
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 15
+      vm_offset: 3
+
+configuration_properties:
+  common:
+    dut_asn: 65101
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 64
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65100
+    failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.120
+        - FC00::F1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet2:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.122
+        - FC00::F5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet2:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::f6/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.124
+        - FC00::F9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet2:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.126
+        - FC00::FD
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet2:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::fe/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64

--- a/ansible/vars/topo_t0-mclag.yml
+++ b/ansible/vars/topo_t0-mclag.yml
@@ -1,0 +1,205 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+    - 32
+    - 33
+    - 34
+    - 35
+    - 36
+    - 37
+    - 38
+    - 39
+    - 40
+    - 41
+    - 42
+    - 43
+    - 44
+    - 45
+    - 46
+    - 47
+    - 48
+    - 49
+    - 50
+    - 51
+    - 52
+    - 53
+    - 54
+    - 55
+    - 56
+    - 57
+  devices_interconnect_interfaces:
+    1:
+      - 26
+      - 58
+    2:
+      - 27
+      - 59
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 28
+        - 60
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 29
+        - 61
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 30
+        - 62
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 31
+        - 63
+      vm_offset: 3
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 64
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65100
+    failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+        65101:
+        - 10.0.0.120
+        - FC00::F1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Ethernet2:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+        65101:
+        - 10.0.0.122
+        - FC00::F5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Ethernet2:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::f6/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+        65101:
+        - 10.0.0.124
+        - FC00::F9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Ethernet2:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+        65101:
+        - 10.0.0.126
+        - FC00::FD
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Ethernet2:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::fe/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
+

--- a/ansible/vars/topo_t0-mclag_dut1.yml
+++ b/ansible/vars/topo_t0-mclag_dut1.yml
@@ -1,0 +1,149 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+  devices_interconnect_interfaces:
+    1:
+      - 26
+    2:
+      - 27
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 28
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 29
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 30
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 31
+      vm_offset: 3
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 64
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65100
+    failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
+

--- a/ansible/vars/topo_t0-mclag_dut2.yml
+++ b/ansible/vars/topo_t0-mclag_dut2.yml
@@ -1,0 +1,149 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+  devices_interconnect_interfaces:
+    1:
+      - 26
+    2:
+      - 27
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 28
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 29
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 30
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 31
+      vm_offset: 3
+
+configuration_properties:
+  common:
+    dut_asn: 65101
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 64
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65100
+    failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.120
+        - FC00::F1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet2:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.122
+        - FC00::F5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet2:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::f6/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.124
+        - FC00::F9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet2:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65101:
+        - 10.0.0.126
+        - FC00::FD
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet2:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::fe/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
+

--- a/ansible/veos
+++ b/ansible/veos
@@ -108,4 +108,4 @@ server_1
 server_2
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116', 't0-mclag', 't0-mclag-16']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Submit deploy topology t0-mclag and t0-mclag-16 according to mclag test plan [Azure/SONiC/pull/422](https://github.com/Azure/SONiC/pull/422).

It works together with below PRs:

• MCLAG feature for SONIC [Azure/sonic-buildimage/pull/2514](https://github.com/Azure/sonic-buildimage/pull/2514)

• [tests/mclag] Submit mclag testcases according to mclag test plan [Azure/sonic-mgmt/pull/1239](https://github.com/Azure/sonic-mgmt/pull/1239)

### Type of change

- [] Bug fix
- [√] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach

#### How did you do it?

1. Add t0-mclag-16 or t0-mclag topologies.

```jason
root@sonic-mgmt:/var/root/sonic-mgmt-mclag/ansible# ./testbed-cli.sh add-topo vms-t0-mclag-16 password.txt
Deploying topology 'vms-t0-mclag-16'
reading
Found topology vms-t0-mclag-16

PLAY [servers:&vm_host] *************************************************************************************************************************

TASK [Check for a single host] ******************************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.164)       0:00:00.164 ******* 
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ play_hosts|length }} != 1

skipping: [STR-ACS-SERV-03]

TASK [Check that variable vm_set_name is defined] ***********************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.033)       0:00:00.198 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Check that variable dut_name is defined] **************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.030)       0:00:00.229 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Check that variable VM_base is defined] ***************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.033)       0:00:00.262 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Check that variable ptf_ip is defined] ****************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.036)       0:00:00.299 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Check that variable topo is defined] ******************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.040)       0:00:00.340 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Check if it is a known topology] **********************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.036)       0:00:00.376 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Check that variable ptf_imagename is defined] *********************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.033)       0:00:00.409 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Load topo variables] **********************************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.035)       0:00:00.445 ******* 
ok: [STR-ACS-SERV-03]

TASK [Read dut minigraph] ***********************************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.058)       0:00:00.503 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host distribution] ***********************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.350)       0:00:00.853 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host distribution version] ***************************************************************************************************
Monday 02 December 2019  06:38:50 +0000 (0:00:00.274)       0:00:01.127 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host kernel version] *********************************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.160)       0:00:01.287 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Check if kernel upgrade needed] **************************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.170)       0:00:01.458 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : debug] ***************************************************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.041)       0:00:01.499 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Upgrade kernel package] **********************************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.039)       0:00:01.539 ******* 
skipping: [STR-ACS-SERV-03] => (item=[]) 

TASK [vm_set : Prompt for rebooting] ************************************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.046)       0:00:01.586 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Ensure root in docker,sudo group] ************************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.039)       0:00:01.625 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Install br_netfilter kernel module] **********************************************************************************************
Monday 02 December 2019  06:38:51 +0000 (0:00:00.455)       0:00:02.080 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Set sysctl bridge parameters for testbed] ****************************************************************************************
Monday 02 December 2019  06:38:52 +0000 (0:00:00.285)       0:00:02.366 ******* 
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-arptables)
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-ip6tables)
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-iptables)

TASK [vm_set : Set sysctl RCVBUF max parameter for testbed] *************************************************************************************
Monday 02 December 2019  06:38:52 +0000 (0:00:00.529)       0:00:02.896 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Set sysctl RCVBUF default parameter for testbed] *********************************************************************************
Monday 02 December 2019  06:38:52 +0000 (0:00:00.163)       0:00:03.059 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Setup external front port] *******************************************************************************************************
Monday 02 December 2019  06:38:53 +0000 (0:00:00.149)       0:00:03.208 ******* 
included: /var/root/sonic-mgmt-mclag/ansible/roles/vm_set/tasks/external_port.yml for STR-ACS-SERV-03

TASK [vm_set : setup external interface as trunk port] ******************************************************************************************
Monday 02 December 2019  06:38:53 +0000 (0:00:00.056)       0:00:03.265 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : bring up external port] **********************************************************************************************************
Monday 02 December 2019  06:38:53 +0000 (0:00:00.664)       0:00:03.929 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Setup internal management network] ***********************************************************************************************
Monday 02 December 2019  06:38:53 +0000 (0:00:00.041)       0:00:03.971 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : getent] **************************************************************************************************************************
Monday 02 December 2019  06:38:53 +0000 (0:00:00.038)       0:00:04.009 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : set_fact] ************************************************************************************************************************
Monday 02 December 2019  06:38:54 +0000 (0:00:00.304)       0:00:04.313 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : debug] ***************************************************************************************************************************
Monday 02 December 2019  06:38:54 +0000 (0:00:00.039)       0:00:04.353 ******* 
ok: [STR-ACS-SERV-03] => {
    "msg": "/root"
}

TASK [vm_set : Ensure veos-vm exists] ***********************************************************************************************************
Monday 02 December 2019  06:38:54 +0000 (0:00:00.047)       0:00:04.400 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Install cleanup script] **********************************************************************************************************
Monday 02 December 2019  06:38:54 +0000 (0:00:00.162)       0:00:04.563 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Copy vm_resumer.py to the veos-vm] ***********************************************************************************************
Monday 02 December 2019  06:38:54 +0000 (0:00:00.333)       0:00:04.896 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Retrieve a list of the defined VMs] **********************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.442)       0:00:05.338 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Retrieve a list of the running VMs] **********************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.341)       0:00:05.680 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Find current server group] *******************************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.182)       0:00:05.862 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Extract VM names from the inventory] *********************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.048)       0:00:05.911 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Stop VMs] ************************************************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.049)       0:00:05.960 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start VMs] ***********************************************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.048)       0:00:06.008 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Add topology] ********************************************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.035)       0:00:06.044 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Remove topology] *****************************************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.045)       0:00:06.090 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Renumber topology] ***************************************************************************************************************
Monday 02 December 2019  06:38:55 +0000 (0:00:00.037)       0:00:06.127 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Connect VMs] *********************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.038)       0:00:06.165 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Disconnect VMs] ******************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.044)       0:00:06.210 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start SONiC VM] ******************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.035)       0:00:06.245 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Stop SONiC VM] *******************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.036)       0:00:06.282 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start SID] ***********************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.041)       0:00:06.324 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Stop SID] ************************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.039)       0:00:06.363 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : get host distribution] ***********************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.039)       0:00:06.402 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host distribution version] ***************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.202)       0:00:06.605 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host kernel version] *********************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.167)       0:00:06.773 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Check if kernel upgrade needed] **************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.166)       0:00:06.939 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : debug] ***************************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.048)       0:00:06.988 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Upgrade kernel package] **********************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.035)       0:00:07.023 ******* 
skipping: [STR-ACS-SERV-03] => (item=[]) 

TASK [vm_set : Prompt for rebooting] ************************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.058)       0:00:07.082 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Ensure root in docker,sudo group] ************************************************************************************************
Monday 02 December 2019  06:38:56 +0000 (0:00:00.041)       0:00:07.124 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Install br_netfilter kernel module] **********************************************************************************************
Monday 02 December 2019  06:38:57 +0000 (0:00:00.183)       0:00:07.307 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Set sysctl bridge parameters for testbed] ****************************************************************************************
Monday 02 December 2019  06:38:57 +0000 (0:00:00.162)       0:00:07.470 ******* 
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-arptables)
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-ip6tables)
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-iptables)

TASK [vm_set : Set sysctl RCVBUF max parameter for testbed] *************************************************************************************
Monday 02 December 2019  06:38:57 +0000 (0:00:00.431)       0:00:07.902 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Set sysctl RCVBUF default parameter for testbed] *********************************************************************************
Monday 02 December 2019  06:38:57 +0000 (0:00:00.178)       0:00:08.081 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Setup external front port] *******************************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.167)       0:00:08.248 ******* 
included: /var/root/sonic-mgmt-mclag/ansible/roles/vm_set/tasks/external_port.yml for STR-ACS-SERV-03

TASK [vm_set : setup external interface as trunk port] ******************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.066)       0:00:08.315 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : bring up external port] **********************************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.347)       0:00:08.662 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Setup internal management network] ***********************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.087)       0:00:08.749 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : getent] **************************************************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.042)       0:00:08.792 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : set_fact] ************************************************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.171)       0:00:08.964 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : debug] ***************************************************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.044)       0:00:09.008 ******* 
ok: [STR-ACS-SERV-03] => {
    "msg": "/root"
}

TASK [vm_set : Ensure veos-vm exists] ***********************************************************************************************************
Monday 02 December 2019  06:38:58 +0000 (0:00:00.045)       0:00:09.053 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Install cleanup script] **********************************************************************************************************
Monday 02 December 2019  06:38:59 +0000 (0:00:00.159)       0:00:09.213 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Copy vm_resumer.py to the veos-vm] ***********************************************************************************************
Monday 02 December 2019  06:38:59 +0000 (0:00:00.389)       0:00:09.602 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Retrieve a list of the defined VMs] **********************************************************************************************
Monday 02 December 2019  06:38:59 +0000 (0:00:00.455)       0:00:10.058 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Retrieve a list of the running VMs] **********************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.186)       0:00:10.245 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Find current server group] *******************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.184)       0:00:10.429 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Extract VM names from the inventory] *********************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.038)       0:00:10.468 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Stop VMs] ************************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.039)       0:00:10.507 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start VMs] ***********************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.042)       0:00:10.550 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Add topology] ********************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.041)       0:00:10.592 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Remove topology] *****************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.047)       0:00:10.640 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Renumber topology] ***************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.041)       0:00:10.681 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Connect VMs] *********************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.039)       0:00:10.720 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Disconnect VMs] ******************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.039)       0:00:10.760 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start SONiC VM] ******************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.042)       0:00:10.803 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Stop SONiC VM] *******************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.046)       0:00:10.849 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start SID] ***********************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.041)       0:00:10.891 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Stop SID] ************************************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.035)       0:00:10.926 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : get host distribution] ***********************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.037)       0:00:10.964 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host distribution version] ***************************************************************************************************
Monday 02 December 2019  06:39:00 +0000 (0:00:00.162)       0:00:11.126 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : get host kernel version] *********************************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.164)       0:00:11.290 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Check if kernel upgrade needed] **************************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.158)       0:00:11.449 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : debug] ***************************************************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.049)       0:00:11.499 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Upgrade kernel package] **********************************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.042)       0:00:11.541 ******* 
skipping: [STR-ACS-SERV-03] => (item=[]) 

TASK [vm_set : Prompt for rebooting] ************************************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.061)       0:00:11.602 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Ensure root in docker,sudo group] ************************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.040)       0:00:11.643 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Install br_netfilter kernel module] **********************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.187)       0:00:11.831 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Set sysctl bridge parameters for testbed] ****************************************************************************************
Monday 02 December 2019  06:39:01 +0000 (0:00:00.150)       0:00:11.981 ******* 
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-arptables)
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-ip6tables)
ok: [STR-ACS-SERV-03] => (item=net.bridge.bridge-nf-call-iptables)

TASK [vm_set : Set sysctl RCVBUF max parameter for testbed] *************************************************************************************
Monday 02 December 2019  06:39:02 +0000 (0:00:00.420)       0:00:12.402 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Set sysctl RCVBUF default parameter for testbed] *********************************************************************************
Monday 02 December 2019  06:39:02 +0000 (0:00:00.157)       0:00:12.559 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Setup external front port] *******************************************************************************************************
Monday 02 December 2019  06:39:02 +0000 (0:00:00.157)       0:00:12.717 ******* 
included: /var/root/sonic-mgmt-mclag/ansible/roles/vm_set/tasks/external_port.yml for STR-ACS-SERV-03

TASK [vm_set : setup external interface as trunk port] ******************************************************************************************
Monday 02 December 2019  06:39:02 +0000 (0:00:00.067)       0:00:12.784 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : bring up external port] **********************************************************************************************************
Monday 02 December 2019  06:39:02 +0000 (0:00:00.346)       0:00:13.131 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Setup internal management network] ***********************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.040)       0:00:13.172 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : getent] **************************************************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.039)       0:00:13.211 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : set_fact] ************************************************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.168)       0:00:13.380 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : debug] ***************************************************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.043)       0:00:13.424 ******* 
ok: [STR-ACS-SERV-03] => {
    "msg": "/root"
}

TASK [vm_set : Ensure veos-vm exists] ***********************************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.042)       0:00:13.466 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Install cleanup script] **********************************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.181)       0:00:13.648 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Copy vm_resumer.py to the veos-vm] ***********************************************************************************************
Monday 02 December 2019  06:39:03 +0000 (0:00:00.383)       0:00:14.031 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Retrieve a list of the defined VMs] **********************************************************************************************
Monday 02 December 2019  06:39:04 +0000 (0:00:00.459)       0:00:14.490 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Retrieve a list of the running VMs] **********************************************************************************************
Monday 02 December 2019  06:39:05 +0000 (0:00:01.200)       0:00:15.691 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Find current server group] *******************************************************************************************************
Monday 02 December 2019  06:39:05 +0000 (0:00:00.201)       0:00:15.892 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Extract VM names from the inventory] *********************************************************************************************
Monday 02 December 2019  06:39:05 +0000 (0:00:00.041)       0:00:15.933 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Stop VMs] ************************************************************************************************************************
Monday 02 December 2019  06:39:05 +0000 (0:00:00.047)       0:00:15.980 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start VMs] ***********************************************************************************************************************
Monday 02 December 2019  06:39:05 +0000 (0:00:00.039)       0:00:16.020 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Add topology] ********************************************************************************************************************
Monday 02 December 2019  06:39:05 +0000 (0:00:00.047)       0:00:16.067 ******* 
included: /var/root/sonic-mgmt-mclag/ansible/roles/vm_set/tasks/add_topo.yml for STR-ACS-SERV-03

TASK [vm_set : Set default value for ptf_imagetag] **********************************************************************************************
Monday 02 December 2019  06:39:06 +0000 (0:00:00.085)       0:00:16.153 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Login into docker registry] ******************************************************************************************************
Monday 02 December 2019  06:39:06 +0000 (0:00:00.049)       0:00:16.202 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Create ptf container ptf_vms3-1] *************************************************************************************************
Monday 02 December 2019  06:39:06 +0000 (0:00:00.530)       0:00:16.733 ******* 
changed: [STR-ACS-SERV-03]

TASK [vm_set : Enable ipv6 for docker container ptf_vms3-1] *************************************************************************************
Monday 02 December 2019  06:39:07 +0000 (0:00:01.384)       0:00:18.117 ******* 
changed: [STR-ACS-SERV-03]

TASK [vm_set : Set front panel/mgmt port for dut] ***********************************************************************************************
Monday 02 December 2019  06:39:08 +0000 (0:00:00.300)       0:00:18.417 ******* 
included: /var/root/sonic-mgmt-mclag/ansible/roles/vm_set/tasks/set_dut_port.yml for STR-ACS-SERV-03

TASK [vm_set : Set front panel port for vlan tunnel] ********************************************************************************************
Monday 02 December 2019  06:39:08 +0000 (0:00:00.059)       0:00:18.477 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Setup mgmt port for physical dut] ************************************************************************************************
Monday 02 December 2019  06:39:08 +0000 (0:00:00.397)       0:00:18.875 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Get front panel and mgmt port for kvm vm] ****************************************************************************************
Monday 02 December 2019  06:39:08 +0000 (0:00:00.044)       0:00:18.919 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Get front panel and mgmt port for SID] *******************************************************************************************
Monday 02 December 2019  06:39:08 +0000 (0:00:00.040)       0:00:18.959 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Setup vlan port for vlan tunnel] *************************************************************************************************
Monday 02 December 2019  06:39:08 +0000 (0:00:00.040)       0:00:18.999 ******* 
ok: [STR-ACS-SERV-03]

TASK [vm_set : Bind topology t0-mclag-16 to VMs. base vm = VM0300] ******************************************************************************
Monday 02 December 2019  06:39:09 +0000 (0:00:00.390)       0:00:19.389 ******* 
changed: [STR-ACS-SERV-03]

TASK [vm_set : Send arp ping packet to gw for flusing the ARP table] ****************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:06.809)       0:00:26.199 ******* 
changed: [STR-ACS-SERV-03]

TASK [vm_set : Remove topology] *****************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.572)       0:00:26.772 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Renumber topology] ***************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.038)       0:00:26.811 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Connect VMs] *********************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.042)       0:00:26.853 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Disconnect VMs] ******************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.040)       0:00:26.894 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start SONiC VM] ******************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.045)       0:00:26.939 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Stop SONiC VM] *******************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.037)       0:00:26.977 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Start SID] ***********************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.040)       0:00:27.017 ******* 
skipping: [STR-ACS-SERV-03]

TASK [vm_set : Stop SID] ************************************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.044)       0:00:27.061 ******* 
skipping: [STR-ACS-SERV-03]

PLAY [servers:&eos] *****************************************************************************************************************************

TASK [Check that variable topo is defined] ******************************************************************************************************
Monday 02 December 2019  06:39:16 +0000 (0:00:00.046)       0:00:27.107 ******* 
skipping: [VM0300]
skipping: [VM0301]
skipping: [VM0302]
skipping: [VM0303]

TASK [Check if it is a known topology] **********************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.057)       0:00:27.165 ******* 
skipping: [VM0300]
skipping: [VM0301]
skipping: [VM0302]
skipping: [VM0303]

TASK [Check that variable VM_base is defined] ***************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.062)       0:00:27.227 ******* 
skipping: [VM0300]
skipping: [VM0301]
skipping: [VM0302]
skipping: [VM0303]

TASK [Load topo variables] **********************************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.067)       0:00:27.295 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [Find current server group] ****************************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.092)       0:00:27.387 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [Extract VM names from the inventory] ******************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.067)       0:00:27.455 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [Generate vm list of target VMs] ***********************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.066)       0:00:27.522 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Set ansible login user name and password] *******************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.067)       0:00:27.590 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Load topo variables] ****************************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.067)       0:00:27.657 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Include server vars] ****************************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.100)       0:00:27.758 ******* 
ok: [VM0301]
ok: [VM0300]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Find current server group] **********************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.128)       0:00:27.886 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Extract VM names from the inventory] ************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.064)       0:00:27.950 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Get VM host name] *******************************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.063)       0:00:28.014 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Generate hostname for target VM] ****************************************************************************************************
Monday 02 December 2019  06:39:17 +0000 (0:00:00.064)       0:00:28.079 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : fail] *******************************************************************************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.065)       0:00:28.145 ******* 
skipping: [VM0300]
skipping: [VM0301]
skipping: [VM0302]
skipping: [VM0303]

TASK [eos : Get VM front panel interface number] ************************************************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.083)       0:00:28.228 ******* 
changed: [VM0300 -> 10.251.0.244]
changed: [VM0301 -> 10.251.0.244]
changed: [VM0302 -> 10.251.0.244]
changed: [VM0303 -> 10.251.0.244]

TASK [eos : Set EOS backplane port name] ********************************************************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.281)       0:00:28.509 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Set properties list to default value, when properties are not defined] **************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.064)       0:00:28.574 ******* 
skipping: [VM0300]
skipping: [VM0301]
skipping: [VM0302]
skipping: [VM0303]

TASK [eos : Set properties list to values, when they're defined] ********************************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.065)       0:00:28.639 ******* 
ok: [VM0301]
ok: [VM0300]
ok: [VM0302]
ok: [VM0303]

TASK [eos : Expand ARISTA01T1 properties into props] ********************************************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.069)       0:00:28.708 ******* 
ok: [VM0300] => (item=common)
ok: [VM0301] => (item=common)
ok: [VM0302] => (item=common)
ok: [VM0303] => (item=common)

TASK [eos : copy rc.eos] ************************************************************************************************************************
Monday 02 December 2019  06:39:18 +0000 (0:00:00.081)       0:00:28.790 ******* 
ok: [VM0302]
ok: [VM0300]
ok: [VM0303]
ok: [VM0301]

TASK [eos : copy boot-config] *******************************************************************************************************************
Monday 02 December 2019  06:39:20 +0000 (0:00:01.619)       0:00:30.410 ******* 
ok: [VM0300]
ok: [VM0301]
ok: [VM0302]
ok: [VM0303]

TASK [eos : update startup-config] **************************************************************************************************************
Monday 02 December 2019  06:39:20 +0000 (0:00:00.480)       0:00:30.891 ******* 
ok: [VM0300]
ok: [VM0302]
ok: [VM0301]
ok: [VM0303]

PLAY RECAP **************************************************************************************************************************************
STR-ACS-SERV-03            : ok=73   changed=4    unreachable=0    failed=0    skipped=60   rescued=0    ignored=0   
VM0300                     : ok=18   changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
VM0301                     : ok=18   changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
VM0302                     : ok=18   changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
VM0303                     : ok=18   changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   

Monday 02 December 2019  06:39:21 +0000 (0:00:00.956)       0:00:31.847 ******* 
=============================================================================== 
vm_set : Bind topology t0-mclag-16 to VMs. base vm = VM0300 ------------------------------------------------------------------------------ 6.81s
eos : copy rc.eos ------------------------------------------------------------------------------------------------------------------------ 1.62s
vm_set : Create ptf container ptf_vms3-1 ------------------------------------------------------------------------------------------------- 1.38s
vm_set : Retrieve a list of the defined VMs ---------------------------------------------------------------------------------------------- 1.20s
eos : update startup-config -------------------------------------------------------------------------------------------------------------- 0.96s
vm_set : setup external interface as trunk port ------------------------------------------------------------------------------------------ 0.66s
vm_set : Send arp ping packet to gw for flusing the ARP table ---------------------------------------------------------------------------- 0.57s
vm_set : Login into docker registry ------------------------------------------------------------------------------------------------------ 0.53s
vm_set : Set sysctl bridge parameters for testbed ---------------------------------------------------------------------------------------- 0.53s
eos : copy boot-config ------------------------------------------------------------------------------------------------------------------- 0.48s
vm_set : Copy vm_resumer.py to the veos-vm ----------------------------------------------------------------------------------------------- 0.46s
vm_set : Copy vm_resumer.py to the veos-vm ----------------------------------------------------------------------------------------------- 0.46s
vm_set : Ensure root in docker,sudo group ------------------------------------------------------------------------------------------------ 0.46s
vm_set : Copy vm_resumer.py to the veos-vm ----------------------------------------------------------------------------------------------- 0.44s
vm_set : Set sysctl bridge parameters for testbed ---------------------------------------------------------------------------------------- 0.43s
vm_set : Set sysctl bridge parameters for testbed ---------------------------------------------------------------------------------------- 0.42s
vm_set : Set front panel port for vlan tunnel -------------------------------------------------------------------------------------------- 0.40s
vm_set : Setup vlan port for vlan tunnel ------------------------------------------------------------------------------------------------- 0.39s
vm_set : Install cleanup script ---------------------------------------------------------------------------------------------------------- 0.39s
vm_set : Install cleanup script ---------------------------------------------------------------------------------------------------------- 0.38s

PLAY [servers:&vm_host] *************************************************************************************************************************

TASK [fail] *************************************************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.137)       0:00:00.137 ******* 
skipping: [STR-ACS-SERV-03]

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.037)       0:00:00.174 ******* 
ok: [STR-ACS-SERV-03]

TASK [debug] ************************************************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.043)       0:00:00.217 ******* 
ok: [STR-ACS-SERV-03] => {
    "msg": "Connect str-acs-serv-03:ens192 to sonic-dut-01"
}

TASK [get the username running the deploy] ******************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.041)       0:00:00.259 ******* 
ok: [STR-ACS-SERV-03]

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.307)       0:00:00.567 ******* 
ok: [STR-ACS-SERV-03]

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.041)       0:00:00.609 ******* 
ok: [STR-ACS-SERV-03]

TASK [include_tasks] ****************************************************************************************************************************
Monday 02 December 2019  06:39:23 +0000 (0:00:00.040)       0:00:00.650 ******* 
included: /var/root/sonic-mgmt-mclag/ansible/roles/fanout/tasks/rootfanout_connect.yml for STR-ACS-SERV-03

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.069)       0:00:00.719 ******* 
ok: [STR-ACS-SERV-03]

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.045)       0:00:00.764 ******* 
skipping: [STR-ACS-SERV-03]

TASK [Gathering connection facts about the DUT or leaffanout device] ****************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.038)       0:00:00.803 ******* 
ok: [STR-ACS-SERV-03]

TASK [Gathering connection facts about the lab] *************************************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.395)       0:00:01.199 ******* 
ok: [STR-ACS-SERV-03]

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.289)       0:00:01.488 ******* 
ok: [STR-ACS-SERV-03]

TASK [Find the root fanout switch] **************************************************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.059)       0:00:01.548 ******* 
skipping: [STR-ACS-SERV-03] => (item=str-acs-serv-03) 
skipping: [STR-ACS-SERV-03] => (item=ptf_vms3-1) 
skipping: [STR-ACS-SERV-03] => (item=str-7260-10) 
skipping: [STR-ACS-SERV-03] => (item=sonic-dut-01) 
skipping: [STR-ACS-SERV-03] => (item=sonic-dut-02) 
skipping: [STR-ACS-SERV-03] => (item=ptf_ptf3) 
ok: [STR-ACS-SERV-03] => (item=str-7260-11)

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:39:24 +0000 (0:00:00.117)       0:00:01.665 ******* 
ok: [STR-ACS-SERV-03]

PLAY RECAP **************************************************************************************************************************************
STR-ACS-SERV-03            : ok=12   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   

Monday 02 December 2019  06:39:25 +0000 (0:00:00.035)       0:00:01.700 ******* 
=============================================================================== 
Gathering connection facts about the DUT or leaffanout device ---------------------------------------------------------------------------- 0.40s
get the username running the deploy ------------------------------------------------------------------------------------------------------ 0.31s
Gathering connection facts about the lab ------------------------------------------------------------------------------------------------- 0.29s
Find the root fanout switch -------------------------------------------------------------------------------------------------------------- 0.12s
include_tasks ---------------------------------------------------------------------------------------------------------------------------- 0.07s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.06s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.05s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.04s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.04s
debug ------------------------------------------------------------------------------------------------------------------------------------ 0.04s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.04s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.04s
fail ------------------------------------------------------------------------------------------------------------------------------------- 0.04s
set_fact --------------------------------------------------------------------------------------------------------------------------------- 0.04s
Done
```

2. The default configuration is deployed separately on each device, using the additional parameter dut_no.

ansible-playbook -i lab config_sonic_basedon_testbed.yml -l sonic-dut-01 -e vm_base="VM0300" -e topo=t0-mclag-16 -e deploy=True -e save=True -e save=True -e testbed_name=vms-t0-mclag-16 -e dut_no=1

ansible-playbook -i lab config_sonic_basedon_testbed.yml -l sonic-dut-02 -e vm_base="VM0300" -e topo=t0-mclag-16 -e deploy=True -e save=True -e testbed_name=vms-t0-mclag-16-dut2 -e dut_no=2

```jason
root@sonic-mgmt:/var/root/sonic-mgmt-mclag/ansible#ansible-playbook -i lab config_sonic_basedon_testbed.yml -l sonic-dut-01 -e vm_base="VM0300" -e topo=t0-mclag-16 -e deploy=True -e save=True -e save=True -e testbed_name=vms-t0-mclag-16 -e dut_no=1

PLAY [sonic] ************************************************************************************************************************************

TASK [set default testbed file] *****************************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.557)       0:00:00.557 ******* 
ok: [sonic-dut-01]

TASK [Gathering testbed information] ************************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.033)       0:00:00.590 ******* 
ok: [sonic-dut-01]

TASK [fail] *************************************************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.511)       0:00:01.101 ******* 
skipping: [sonic-dut-01]

TASK [set testbed_type] *************************************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.033)       0:00:01.134 ******* 
ok: [sonic-dut-01]

TASK [set vm] ***********************************************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.040)       0:00:01.175 ******* 
ok: [sonic-dut-01]

TASK [Gathering topology execpt t0-mclag] *******************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.042)       0:00:01.218 ******* 
skipping: [sonic-dut-01]

TASK [Gathering t0-mclag information] ***********************************************************************************************************
Monday 02 December 2019  06:44:36 +0000 (0:00:00.033)       0:00:01.252 ******* 
ok: [sonic-dut-01]

TASK [set_fact] *********************************************************************************************************************************
Monday 02 December 2019  06:44:37 +0000 (0:00:00.396)       0:00:01.648 ******* 
ok: [sonic-dut-01]

TASK [gather testbed VM informations] ***********************************************************************************************************
Monday 02 December 2019  06:44:37 +0000 (0:00:00.038)       0:00:01.686 ******* 
ok: [sonic-dut-01]

TASK [find interface name mapping and individual interface speed if defined] ********************************************************************
Monday 02 December 2019  06:44:37 +0000 (0:00:00.431)       0:00:02.118 ******* 
ok: [sonic-dut-01]

TASK [find all enabled host_interfaces] *********************************************************************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:01.508)       0:00:03.626 ******* 
ok: [sonic-dut-01]

TASK [find all vlan interface names for T0 topology] ********************************************************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:00.044)       0:00:03.671 ******* 
ok: [sonic-dut-01] => (item=0)
ok: [sonic-dut-01] => (item=1)
ok: [sonic-dut-01] => (item=2)
ok: [sonic-dut-01] => (item=3)
ok: [sonic-dut-01] => (item=4)
ok: [sonic-dut-01] => (item=5)
ok: [sonic-dut-01] => (item=6)
ok: [sonic-dut-01] => (item=7)
ok: [sonic-dut-01] => (item=8)
ok: [sonic-dut-01] => (item=9)

TASK [find all interface indexes mapping connecting to VM] **************************************************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:00.149)       0:00:03.821 ******* 
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::7D', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.63', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.62', u'interface_indexes': [15], u'peer_ipv6': u'FC00::7E', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA04T1'})
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::79', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.61', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.60', u'interface_indexes': [14], u'peer_ipv6': u'FC00::7A', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA03T1'})
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::75', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.59', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.58', u'interface_indexes': [13], u'peer_ipv6': u'FC00::76', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA02T1'})
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::71', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.57', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.56', u'interface_indexes': [12], u'peer_ipv6': u'FC00::72', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA01T1'})

TASK [find all interface indexes connecting to VM] **********************************************************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:00.097)       0:00:03.918 ******* 
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::7D', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.63', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.62', u'interface_indexes': [15], u'peer_ipv6': u'FC00::7E', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA04T1'})
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::79', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.61', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.60', u'interface_indexes': [14], u'peer_ipv6': u'FC00::7A', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA03T1'})
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::75', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.59', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.58', u'interface_indexes': [13], u'peer_ipv6': u'FC00::76', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA02T1'})
ok: [sonic-dut-01] => (item={'value': {u'bgp_ipv6': u'FC00::71', u'intfs': [u'Ethernet1'], u'ipv4mask': u'31', u'peer_ipv4': u'10.0.0.57', u'ipv6mask': u'126', u'ip_intf': u'Ethernet1', u'bgp_ipv4': u'10.0.0.56', u'interface_indexes': [12], u'peer_ipv6': u'FC00::72', u'bgp_asn': 64600, u'properties': [u'common']}, 'key': u'ARISTA01T1'})

TASK [find all interface names] *****************************************************************************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:00.087)       0:00:04.006 ******* 
ok: [sonic-dut-01] => (item={'value': [15], 'key': u'ARISTA04T1'})
ok: [sonic-dut-01] => (item={'value': [14], 'key': u'ARISTA03T1'})
ok: [sonic-dut-01] => (item={'value': [13], 'key': u'ARISTA02T1'})
ok: [sonic-dut-01] => (item={'value': [12], 'key': u'ARISTA01T1'})

TASK [create minigraph file in ansible minigraph folder] ****************************************************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:00.092)       0:00:04.099 ******* 
skipping: [sonic-dut-01]

TASK [saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)] ********************************************************
Monday 02 December 2019  06:44:39 +0000 (0:00:00.047)       0:00:04.146 ******* 
changed: [sonic-dut-01]

TASK [create new minigraph file for SONiC device] ***********************************************************************************************
Monday 02 December 2019  06:44:40 +0000 (0:00:00.386)       0:00:04.532 ******* 
changed: [sonic-dut-01]

TASK [Copy corresponding configlet files if apply_configlet=true] *******************************************************************************
Monday 02 December 2019  06:44:41 +0000 (0:00:00.920)       0:00:05.453 ******* 
skipping: [sonic-dut-01]

TASK [disable automatic minigraph update if we are deploying new minigraph into SONiC] **********************************************************
Monday 02 December 2019  06:44:41 +0000 (0:00:00.048)       0:00:05.501 ******* 
ok: [sonic-dut-01]

TASK [restart automatic minigraph update service] ***********************************************************************************************
Monday 02 December 2019  06:44:41 +0000 (0:00:00.457)       0:00:05.959 ******* 
changed: [sonic-dut-01]

TASK [execute cli "config load_minigraph -y" to apply new minigraph] ****************************************************************************
Monday 02 December 2019  06:44:57 +0000 (0:00:16.133)       0:00:22.093 ******* 
changed: [sonic-dut-01]

TASK [execute cli "config bgp startup all" to bring up all bgp sessions for test] ***************************************************************
Monday 02 December 2019  06:46:19 +0000 (0:01:21.485)       0:01:43.579 ******* 
changed: [sonic-dut-01]

TASK [execute configlet application script, which applies configlets in strict order.] **********************************************************
Monday 02 December 2019  06:46:19 +0000 (0:00:00.377)       0:01:43.957 ******* 
skipping: [sonic-dut-01]

TASK [execute cli "config save -y" to save current minigraph as startup-config] *****************************************************************
Monday 02 December 2019  06:46:19 +0000 (0:00:00.044)       0:01:44.001 ******* 
changed: [sonic-dut-01]

PLAY RECAP **************************************************************************************************************************************
sonic-dut-01               : ok=20   changed=6    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   

Monday 02 December 2019  06:46:20 +0000 (0:00:00.693)       0:01:44.695 ******* 
=============================================================================== 
execute cli "config load_minigraph -y" to apply new minigraph --------------------------------------------------------------------------- 81.49s
restart automatic minigraph update service ---------------------------------------------------------------------------------------------- 16.13s
find interface name mapping and individual interface speed if defined -------------------------------------------------------------------- 1.51s
create new minigraph file for SONiC device ----------------------------------------------------------------------------------------------- 0.92s
execute cli "config save -y" to save current minigraph as startup-config ----------------------------------------------------------------- 0.69s
Gathering testbed information ------------------------------------------------------------------------------------------------------------ 0.51s
disable automatic minigraph update if we are deploying new minigraph into SONiC ---------------------------------------------------------- 0.46s
gather testbed VM informations ----------------------------------------------------------------------------------------------------------- 0.43s
Gathering t0-mclag information ----------------------------------------------------------------------------------------------------------- 0.40s
saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist) -------------------------------------------------------- 0.39s
execute cli "config bgp startup all" to bring up all bgp sessions for test --------------------------------------------------------------- 0.38s
find all vlan interface names for T0 topology -------------------------------------------------------------------------------------------- 0.15s
find all interface indexes mapping connecting to VM -------------------------------------------------------------------------------------- 0.10s
find all interface names ----------------------------------------------------------------------------------------------------------------- 0.09s
find all interface indexes connecting to VM ---------------------------------------------------------------------------------------------- 0.09s
Copy corresponding configlet files if apply_configlet=true ------------------------------------------------------------------------------- 0.05s
create minigraph file in ansible minigraph folder ---------------------------------------------------------------------------------------- 0.05s
find all enabled host_interfaces --------------------------------------------------------------------------------------------------------- 0.04s
execute configlet application script, which applies configlets in strict order. ---------------------------------------------------------- 0.04s
set vm ----------------------------------------------------------------------------------------------------------------------------------- 0.04s
root@sonic-mgmt:/var/root/sonic-mgmt-mclag/ansible#
```

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

t0-mclag and t0-mclag-16

### Documentation

https://github.com/shine4chen/SONiC/blob/mclag-test-case/doc/mclag_hld/MCLAG-ansible-test-plan.md

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
