### PR TITLE
[bugfix]: start-vms does not define dut_name

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -205,5 +205,6 @@
       include_tasks: stop_sid.yml
       when: action == 'stop_sid' and hostvars[dut_name]['type'] == 'simx'
   when:
+    - dut_name is defined
     - hostvars[dut_name] is defined
     - hostvars[dut_name].type is defined


### PR DESCRIPTION
start-vms only starts eos vms

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
./testbed-cli.sh -m veos.vtb start-vms server_1 password.txt
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
