### PR TITLE
Enable PfcWd test to be run as individual subtests

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -129,21 +129,40 @@
         minigraph_vlan_interfaces: []
       when: minigraph_vlan_interfaces is undefined
 
+    - name: Set timers
+      set_fact:
+        pfc_wd_detect_time: 400
+        pfc_wd_restore_time: 400
+        pfc_wd_restore_time_large: 3000
+        pfc_wd_poll_time: 400
+
+    - name: Set polling interval {{ pfc_wd_poll_time }}.
+      shell: "pfcwd interval {{ pfc_wd_poll_time }}"
+      become: yes
+
     - block:
+        - name: Clean up config
+          command: pfcwd stop
+          become: yes
+
         - name: Test PFC WD configuration validation.
           vars:
             pfc_wd_template: roles/test/templates/pfc_wd_config.j2
           include_tasks: roles/test/tasks/pfc_wd/config_test/config_test.yml
+          when: subtest is undefined or (subtest is defined and 'pfc_config' in subtest)
 
         - name: Test PFC WD Functional tests.
           include_tasks: roles/test/tasks/pfc_wd/functional_test/functional_test.yml
           with_dict: "{{select_test_ports}}"
+          when: subtest is undefined or (subtest is defined and 'pfc_functional' in subtest)
 
         - name: Test PFC WD Timer accuracy.
           include_tasks: roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
+          when: subtest is undefined or (subtest is defined and 'pfc_timer' in subtest)
 
         - name: Test PFC WD extreme case when all ports have storm
           include_tasks: roles/test/tasks/pfc_wd/functional_test/storm_all_test.yml
+          when: subtest is undefined or (subtest is defined and 'pfc_all_port_storm' in subtest)
 
         - name: Set vlan members
           set_fact:

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
@@ -1,6 +1,28 @@
 # Verify timers
 - set_fact:
     pfc_wd_test_port: "{{test_ports.keys()[0]}}"
+    testname: functional_test
+
+- conn_graph_facts: host={{test_ports[pfc_wd_test_port]['peer_device']}}
+  connection: local
+  become: no
+
+- name: Prepare variables required for PFC test
+  set_fact:
+    pfc_gen_file: pfc_gen.py
+    pfc_queue_index: 4
+    pfc_frames_number: 100000
+    pfc_wd_test_pkt_count: 100
+    pfc_fanout_interface: "{{neighbors[pfc_wd_test_port]['peerport']}}"
+    peer_hwsku: "{{device_info['HwSku']}}"
+    peer_mgmt: "{{device_info['mgmtip']}}"
+    peer_login: "{{switch_login[hwsku_map[device_info['HwSku']]]}}"
+
+- name: set pfc storm templates based on fanout platform sku
+  include_tasks: roles/test/tasks/pfc_wd/functional_test/set_pfc_storm_templates.yml
+
+- name: Deploy pfc packet generater file to fanout switch
+  include_tasks: roles/test/tasks/pfc_wd/functional_test/deploy_pfc_pktgen.yml
 
 - block:
     - name: Apply config with proper timers to {{ pfc_wd_test_port }}.

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/functional_test.yml
@@ -66,21 +66,10 @@
 - name: set pfc storm templates based on fanout platform sku
   include_tasks: roles/test/tasks/pfc_wd/functional_test/set_pfc_storm_templates.yml
 
-- name: Set timers
-  set_fact:
-      pfc_wd_detect_time: 400
-      pfc_wd_restore_time: 400
-      pfc_wd_restore_time_large: 3000
-      pfc_wd_poll_time: 400
-
 - name: Set timers if user has specified
   set_fact:
       pfc_wd_restore_time_large: "{{restore_time}}"
   when: restore_time is defined
-
-- name: Set polling interval {{ pfc_wd_poll_time }}.
-  shell: "pfcwd interval {{ pfc_wd_poll_time }}"
-  become: yes
 
 - name: Set timers 2
   set_fact:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Enable each of the Pfcwd test (config, functional, timer, all storm) to be run as a subtest.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Added a subtest knob to run each testcase individually and supporting changes for the variables needed in each subtest

#### How did you verify/test it?
Ran each subtest on T0 topology and they passed
Ran the entire test without the subtest knob to ensure backward compatibility