### PR TITLE
[vnet_crm]: Update test to run BITMAP VNET case only for Mellanox

### DIFF
--- a/ansible/roles/test/tasks/crm.yml
+++ b/ansible/roles/test/tasks/crm.yml
@@ -59,8 +59,10 @@
      when: testbed_type == "t0"
 
    - name: Run test case "CRM VNET resources"
-     include_tasks: roles/test/tasks/crm/crm_test_vnet_bitmap.yml
-     when: testbed_type == "t0"
+     include: roles/test/tasks/crm/crm_test_vnet_bitmap.yml
+     when:
+       - testbed_type == "t0"
+       - sonic_asic_type == "mellanox"
 
 
   always:


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Updated CRM test to run BITMAP VNET test case only for Mellanox platforms since BITMAP implementation is vendor specific.

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Updated CRM test to run BITMAP VNET test case only for Mellanox platforms since BITMAP implementation is vendor specific.
#### How did you verify/test it?
Ran ansible test
#### Any platform specific information?
BITMAP implementation of VNET feature is Mellanox specific so "crm bitmap vnet" test case should be executed only on Mellanox platforms.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
N/A
