### PR TITLE
Fix docker shell 2

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -17,7 +17,7 @@
   become: yes
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i swss python
+    container_name: swss
 
 - name: generate config_db.json
   shell: sonic-cfggen -H -j /etc/sonic/vlan.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json

--- a/ansible/roles/sonic-common/tasks/lldp.yml
+++ b/ansible/roles/sonic-common/tasks/lldp.yml
@@ -45,7 +45,7 @@
 
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: Copy lldpctl helper script
   become: true

--- a/ansible/roles/sonic-common/tasks/sensors_check.yml
+++ b/ansible/roles/sonic-common/tasks/sensors_check.yml
@@ -6,16 +6,11 @@
   shell: show platform summary | grep Platform | awk '{print $2}'
   register: platform
 
-- set_fact: 
-    ansible_python_interpreter: "docker exec -i {{ pmon_ps.stdout }} python"
-
 - name: Gather sensors
   sensors_facts: checks={{ sensors_checks[platform.stdout] }}
   vars:
     ansible_shell_type: docker
-
-- set_fact: 
-    ansible_python_interpreter: "/usr/bin/python"
+    container_name: "{{ pmon_ps.stdout }}"
 
 - name: Output of sensors information
   debug: var=vars['sensors']

--- a/ansible/roles/sonic-common/tasks/snmp.yml
+++ b/ansible/roles/sonic-common/tasks/snmp.yml
@@ -110,4 +110,4 @@
 
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i snmp python
+    container_name: snmp

--- a/ansible/roles/sonicv2/tasks/quagga.yml
+++ b/ansible/roles/sonicv2/tasks/quagga.yml
@@ -80,7 +80,7 @@
 
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i bgp python
+    container_name: bgp
 
 - name: Copy vtysh helper script
   become: true

--- a/ansible/roles/sonicv2/tasks/teamd_interface.yml
+++ b/ansible/roles/sonicv2/tasks/teamd_interface.yml
@@ -16,4 +16,4 @@
 
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i teamd python
+    container_name: teamd

--- a/ansible/roles/test/tasks/acltb_ranges_test.yml
+++ b/ansible/roles/test/tasks/acltb_ranges_test.yml
@@ -79,7 +79,7 @@
 
     vars:
       ansible_shell_type: docker
-      ansible_python_interpreter: docker exec -i swss python
+      container_name: swss
 
   always:
     - include_tasks: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml

--- a/ansible/roles/test/tasks/bgp_entry_flap.yml
+++ b/ansible/roles/test/tasks/bgp_entry_flap.yml
@@ -15,11 +15,11 @@
   become: yes
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i sswsyncd python
+    container_name: sswsyncd
 
 - block:
   - name: Assert the particular entry is in nexthopgroup table
-    assert: 
+    assert:
       that: nexthop[addr] in nexthopgroup[item]
     with_items: "{{ nexthopgroup }}"
 
@@ -46,8 +46,8 @@
     become: yes
     vars:
       ansible_shell_type: docker
-      ansible_python_interpreter: docker exec -i sswsyncd python
-  
+      container_name: sswsyncd
+
   - name: Poll for updated tables until peer is not in nexthop groups
     switch_tables: asic="{{asic}}" nexthop=yes nexthopgroup=yes
     become: yes
@@ -58,7 +58,7 @@
     with_items: "{{ nexthopgroup }}"
     vars:
       ansible_shell_type: docker
-      ansible_python_interpreter: docker exec -i sswsyncd python
+      container_name: sswsyncd
 
   - name: Restart BGP session from neighbor
     action: cisco template=bgp_neighbor_noshut.j2
@@ -75,7 +75,7 @@
     become: yes
     vars:
       ansible_shell_type: docker
-      ansible_python_interpreter: docker exec -i sswsyncd python
+      container_name: sswsyncd
 
   - name: Poll for updated tables until peer is in nexthop groups
     switch_tables: asic="{{asic}}" nexthop=yes nexthopgroup=yes
@@ -87,6 +87,6 @@
     with_items: "{{ nexthopgroup }}"
     vars:
       ansible_shell_type: docker
-      ansible_python_interpreter: docker exec -i sswsyncd python
+      container_name: sswsyncd
 
   when: "'T2' in name"

--- a/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
+++ b/ansible/roles/test/tasks/bgp_gr_helper/get_vm_info.yml
@@ -34,7 +34,7 @@
   lldp:
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: Get VM IP address.
   set_fact:

--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -7,7 +7,7 @@
       supervisorctl: state=stopped name={{ item }}
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i lldp python
+        container_name: lldp
       with_items:
         - lldp-syncd
         - lldpd
@@ -40,13 +40,13 @@
       template: src=ptf_nn_agent.conf.dut.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i syncd python
+        container_name: syncd
 
     - name: Restart ptf_nn_agent inside dut
       supervisorctl: state=restarted name=ptf_nn_agent
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i syncd python
+        container_name: syncd
 
     - name: copy the test to ptf container
       copy: src=roles/test/files/ptftests dest=/root
@@ -98,20 +98,20 @@
       template: src=ptf_nn_agent.conf.dut.j2 dest=/etc/supervisor/conf.d/ptf_nn_agent.conf
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i syncd python
+        container_name: syncd
 
     - name: Restart ptf_nn_agent inside dut
       supervisorctl: state=restarted name=ptf_nn_agent
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i syncd python
+        container_name: syncd
 
     - name: Restore LLDP Daemon
       become: yes
       supervisorctl: state=started name={{ item }}
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i lldp python
+        container_name: lldp
       with_items:
         - lldpd
         - lldp-syncd

--- a/ansible/roles/test/tasks/dip_sip.yml
+++ b/ansible/roles/test/tasks/dip_sip.yml
@@ -24,7 +24,7 @@
   lldp:
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: "Copy tests to PTF"
   copy: src=roles/test/files/ptftests dest=/root

--- a/ansible/roles/test/tasks/ecn_wred.yml
+++ b/ansible/roles/test/tasks/ecn_wred.yml
@@ -27,7 +27,7 @@
          - "{{ test_files_dir }}/*"
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i database python
+    container_name: database
 
 - block:
     # Test case #3(MA): Check configuration applied

--- a/ansible/roles/test/tasks/interface_up_down.yml
+++ b/ansible/roles/test/tasks/interface_up_down.yml
@@ -10,13 +10,13 @@
            enabled=yes
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: Gather information from lldp
   lldp:
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: If underlay exists, use underlay to replace it.
   set_fact:
@@ -49,7 +49,7 @@
   lldp:
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: rearrange lldp received data structure for interface up down test
   interface_up_down_data_struct_facts: data="{{ lldp }}"

--- a/ansible/roles/test/tasks/lag_2.yml
+++ b/ansible/roles/test/tasks/lag_2.yml
@@ -27,7 +27,7 @@
   lldp:
   vars:
     ansible_shell_type: docker
-    ansible_python_interpreter: docker exec -i lldp python
+    container_name: lldp
 
 - name: gathering minigraph of the device configuration
   minigraph_facts: host={{ inventory_hostname }}

--- a/ansible/roles/test/tasks/lagall.yml
+++ b/ansible/roles/test/tasks/lagall.yml
@@ -46,7 +46,7 @@
   lldp:
   vars:
       ansible_shell_type: docker
-      ansible_python_interpreter: docker exec -i lldp python
+      container_name: lldp
 
 - debug:
     msg: "{{ dut_lag_members }}"

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -23,7 +23,7 @@
       supervisorctl: state=stopped name={{item}}
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i lldp python
+        container_name: lldp
       with_items:
         - lldpd
         - lldp-syncd
@@ -37,7 +37,7 @@
         - Restart Quagga Daemon
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i bgp python
+        container_name: bgp
 
     - meta: flush_handlers
 
@@ -49,7 +49,7 @@
           shell: python /root/packets_aging.py disable
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i syncd python
+        container_name: syncd
       when: minigraph_hwsku is defined and minigraph_hwsku in mellanox_hwskus
 
     - name: copy ptf tests
@@ -566,7 +566,7 @@
       supervisorctl: state=started name={{item}}
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i lldp python
+        container_name: lldp
       with_items:
         - lldpd
         - lldp-syncd
@@ -580,7 +580,7 @@
         - Restart Quagga Daemon
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i bgp python
+        container_name: bgp python
 
     - name: Restore original watermark polling status
       shell: counterpoll watermark {{watermark_status.stdout}}
@@ -596,7 +596,7 @@
       shell: python /root/packets_aging.py enable
       vars:
         ansible_shell_type: docker
-        ansible_python_interpreter: docker exec -i syncd python
+        container_name: syncd
       when: minigraph_hwsku is defined and minigraph_hwsku in mellanox_hwskus
 
     - meta: flush_handlers


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
In this PR #1253 I have tested docker plugin by running dip_sib and lag2 (lldp task run in lldp container) test cases and everything was fine.
But after regression, I have noticed that some tests failed due to this plugin with error:
```KeyError: 'Requested entry (plugin_type: shell plugin: docker setting: ansible_python_interpreter ) was not defined in configuration.'``` on copy task.


Here is the fix for the error described above.

Summary:
Fixed docker shell plugin part 2
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Defined mandatory `container_name` option for this plugin
Change `remove` and `build_module_command` to use it as a container name source and replace:
```
vars:
    ansible_shell_type: docker
    ansible_python_interpreter: docker exec -i swss python
```
to
```
vars:
    ansible_shell_type: docker
    container_name: swss
```
#### How did you verify/test it?
run ecn_wred, coop and dip_sib test_cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
