### PR TITLE
[dhcp_relay] Add link state change tests

### DIFF
--- a/ansible/roles/test/tasks/dhcp_relay.yml
+++ b/ansible/roles/test/tasks/dhcp_relay.yml
@@ -51,3 +51,102 @@
       - relay_iface_mac=\"{{ relay_iface_mac }}\"
       - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
     ptf_extra_options: "--relax"
+
+- name: Bring all uplink interfaces down
+  shell: ifconfig {{ item.key }} down
+  with_dict: minigraph_portchannels
+  become: true
+
+- name: Pause to ensure uplinks are down
+  pause:
+    seconds: 10
+
+- name: Bring all uplink interfaces up
+  shell: ifconfig {{ item.key }} up
+  with_dict: minigraph_portchannels
+  become: true
+
+- name: Pause to ensure uplinks are up
+  pause:
+    seconds: 10
+
+# Run the DHCP relay PTF test
+- include_tasks: ptf_runner.yml
+  vars:
+    ptf_test_name: DHCP Relay Test
+    ptf_test_dir: ptftests
+    ptf_test_path: dhcp_relay_test.DHCPTest
+    ptf_platform: remote
+    ptf_platform_dir: ptftests
+    ptf_test_params:
+      - hostname=\"{{ inventory_hostname }}\"
+      - client_port_index=\"{{ client_port_index }}\"
+      - client_iface_alias=\"{{ client_iface_alias }}\"
+      - leaf_port_indices=\"{{ leaf_port_indices }}\"
+      - num_dhcp_servers=\"{{ dhcp_servers | length }}\"
+      - server_ip=\"{{ dhcp_servers[0] }}\"
+      - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
+      - relay_iface_mac=\"{{ relay_iface_mac }}\"
+      - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+    ptf_extra_options: "--relax"
+
+- name: Stop DHCP relay service
+  become: true
+  service:
+    name: dhcp_relay
+    state: stopped
+
+- name: Bring all uplink interfaces down
+  shell: ifconfig {{ item.key }} down
+  with_dict: minigraph_portchannels
+  become: true
+
+- name: Pause to ensure uplinks are down
+  pause:
+    seconds: 10
+
+- name: Start DHCP relay service with uplinks down
+  become: true
+  service:
+    name: dhcp_relay
+    state: restarted
+
+- name: Give the DHCP relay container time to start up
+  pause:
+    seconds: 30
+
+- name: Bring all uplink interfaces up
+  shell: ifconfig {{ item.key }} up
+  with_dict: minigraph_portchannels
+  become: true
+
+- name: Pause to ensure uplinks are up
+  pause:
+    seconds: 10
+
+# Run the DHCP relay PTF test
+- include_tasks: ptf_runner.yml
+  vars:
+    ptf_test_name: DHCP Relay Test
+    ptf_test_dir: ptftests
+    ptf_test_path: dhcp_relay_test.DHCPTest
+    ptf_platform: remote
+    ptf_platform_dir: ptftests
+    ptf_test_params:
+      - hostname=\"{{ inventory_hostname }}\"
+      - client_port_index=\"{{ client_port_index }}\"
+      - client_iface_alias=\"{{ client_iface_alias }}\"
+      - leaf_port_indices=\"{{ leaf_port_indices }}\"
+      - num_dhcp_servers=\"{{ dhcp_servers | length }}\"
+      - server_ip=\"{{ dhcp_servers[0] }}\"
+      - relay_iface_ip=\"{{ minigraph_vlan_interfaces[0]['addr'] }}\"
+      - relay_iface_mac=\"{{ relay_iface_mac }}\"
+      - relay_iface_netmask=\"{{ minigraph_vlan_interfaces[0]['mask'] }}\"
+    ptf_extra_options: "--relax"
+
+- name: Restart DHCP relay service to ensure it is in a healthy state
+  become: true
+  service:
+    name: dhcp_relay
+    state: restarted
+  tags: always


### PR DESCRIPTION
### Summary:

Enhance DHCP relay test to ensure relay agent is robust enough to handle link state changes and starting up when configured links are down. This test validates the bug fix in https://github.com/Azure/sonic-buildimage/pull/3851 and should help prevent regressions.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

After the standard DHCP relay test, run two more tests, as follows:
1.	With the relay healthy, flap the uplinks and test again
2.	Stop relay, shut down links, start relay, bring up links, test again

#### How did you verify/test it?
Tested on a DUT with and without the patch mentioned above. Without the patch, the test fails; with the patch, the test succeeds.
