### PR TITLE
[sonic_ks]: wait for swss instead of bgp service before IP config

### DIFF
--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -108,7 +108,7 @@ class SerialSession(object):
 
 def session(new_params):
     seq = [
-        ('while true; do if [ $(systemctl is-active bgp) == "active" ]; then break; fi; echo $(systemctl is-active bgp); sleep 1; done', [r'#'], 60),
+        ('while true; do if [ $(systemctl is-active swss) == "active" ]; then break; fi; echo $(systemctl is-active swss); sleep 1; done', [r'#'], 180),
         ('pkill dhclient', [r'#']),
         ('hostname %s' % str(new_params['hostname']), [r'#']),
         ('sed -i s:sonic:%s: /etc/hosts' % str(new_params['hostname']), [r'#']),


### PR DESCRIPTION
The kickstart script configured the eth0 IP address. The configuration
should be after sonic interface-config service. interface-config.service
is before swss. There is no dependency between bgp and interface-config.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
