### PR TITLE
Change snmp community string before minigraph deploy

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -120,6 +120,13 @@
         become: true
         when: apply_configlet is defined and apply_configlet|bool == true
 
+      - name: Replace snmp community string
+        lineinfile:
+            name: /etc/sonic/snmp.yml
+            regexp: '^snmp_rocommunity:'
+            line: 'snmp_rocommunity: {{ snmp_rocommunity }}'
+        become: true
+
       - name: disable automatic minigraph update if we are deploying new minigraph into SONiC
         lineinfile:
             name: /etc/sonic/updategraph.conf


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

Summary:
Change snmp community string

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

Verified by running the minigraph deploy script on a DUT