### PR TITLE
Extended FDB test with ARP scenario

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -12,6 +12,7 @@ DEFAULT_FDB_ETHERNET_TYPE = 0x1234
 DUMMY_MAC_PREFIX = "02:11:22:33"
 DUMMY_MAC_COUNT = 10
 FDB_POPULATE_SLEEP_TIMEOUT = 2
+PKT_TYPES = ["ethernet", "arp_request", "arp_reply"]
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,51 @@ def send_eth(ptfadapter, source_port, source_mac, dest_mac):
         eth_type=DEFAULT_FDB_ETHERNET_TYPE
     )
     logger.debug('send packet source port id {} smac: {} dmac: {}'.format(source_port, source_mac, dest_mac))
+    testutils.send(ptfadapter, source_port, pkt)
+
+
+def send_arp_request(ptfadapter, source_port, source_mac, dest_mac):
+    """
+    send arp request packet
+    :param ptfadapter: PTF adapter object
+    :param source_port: source port
+    :param source_mac: source MAC
+    :param dest_mac: destination MAC
+    :return:
+    """
+    pkt = testutils.simple_arp_packet(pktlen=60,
+                eth_dst='ff:ff:ff:ff:ff:ff',
+                eth_src=source_mac,
+                vlan_vid=0,
+                vlan_pcp=0,
+                arp_op=1,
+                ip_snd='10.10.1.3',
+                ip_tgt='10.10.1.2',
+                hw_snd=source_mac,
+                hw_tgt='ff:ff:ff:ff:ff:ff',
+                )
+    logger.debug('send ARP request packet source port id {} smac: {} dmac: {}'.format(source_port, source_mac, dest_mac))
+    testutils.send(ptfadapter, source_port, pkt)
+
+
+def send_arp_reply(ptfadapter, source_port, source_mac, dest_mac):
+    """
+    send arp reply packet
+    :param ptfadapter: PTF adapter object
+    :param source_port: source port
+    :param source_mac: source MAC
+    :param dest_mac: destination MAC
+    :return:
+    """
+    pkt = testutils.simple_arp_packet(eth_dst=dest_mac,
+                eth_src=source_mac,
+                arp_op=2,
+                ip_snd='10.10.1.2',
+                ip_tgt='10.10.1.3',
+                hw_tgt=dest_mac,
+                hw_snd=source_mac,
+                )
+    logger.debug('send ARP reply packet source port id {} smac: {} dmac: {}'.format(source_port, source_mac, dest_mac))
     testutils.send(ptfadapter, source_port, pkt)
 
 
@@ -55,7 +101,7 @@ def send_recv_eth(ptfadapter, source_port, source_mac, dest_port, dest_mac):
     testutils.verify_packet_any_port(ptfadapter, pkt, [dest_port])
 
 
-def setup_fdb(ptfadapter, vlan_table, router_mac):
+def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type):
     """
     :param ptfadapter: PTF adapter object
     :param vlan_table: VLAN table map: VLAN subnet -> list of VLAN members
@@ -63,6 +109,8 @@ def setup_fdb(ptfadapter, vlan_table, router_mac):
     """
 
     fdb = {}
+
+    assert pkt_type in PKT_TYPES
 
     for vlan in vlan_table:
         for member in vlan_table[vlan]:
@@ -79,7 +127,14 @@ def setup_fdb(ptfadapter, vlan_table, router_mac):
                           for i in range(DUMMY_MAC_COUNT)]
 
             for dummy_mac in dummy_macs:
-                send_eth(ptfadapter, member, dummy_mac, router_mac)
+                if pkt_type == "ethernet":
+                    send_eth(ptfadapter, member, dummy_mac, router_mac)
+                elif pkt_type == "arp_request":
+                    send_arp_request(ptfadapter, member, dummy_mac, router_mac)
+                elif pkt_type == "arp_reply":
+                    send_arp_reply(ptfadapter, member, dummy_mac, router_mac)
+                else:
+                    pytest.fail("Unknown option '{}'".format(pkt_type))
 
             # put in set learned dummy MACs
             fdb[member].update(dummy_macs)
@@ -102,7 +157,8 @@ def fdb_cleanup(ansible_adhoc, testbed):
 
 
 @pytest.mark.usefixtures('fdb_cleanup')
-def test_fdb(ansible_adhoc, testbed, ptfadapter):
+@pytest.mark.parametrize("pkt_type", PKT_TYPES)
+def test_fdb(ansible_adhoc, testbed, ptfadapter, pkt_type, testbed_devices):
     """
     1. verify fdb forwarding in T0 topology.
     2. verify show mac command on DUT for learned mac.
@@ -111,8 +167,8 @@ def test_fdb(ansible_adhoc, testbed, ptfadapter):
     if testbed['topo'] not in ['t0', 't0-64', 't0-116']:
         pytest.skip('unsupported testbed type')
 
-    duthost = AnsibleHost(ansible_adhoc, testbed['dut'])
-    ptfhost = AnsibleHost(ansible_adhoc, testbed['ptf'])
+    duthost = testbed_devices["dut"]
+    ptfhost = testbed_devices["ptf"]
 
     host_facts  = duthost.setup()['ansible_facts']
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
@@ -133,8 +189,7 @@ def test_fdb(ansible_adhoc, testbed, ptfadapter):
         for ifname in mg_facts['minigraph_vlans'][vlan['attachto']]['members']:
             vlan_table[vlan['subnet']].append(mg_facts['minigraph_port_indices'][ifname])
 
-    fdb = setup_fdb(ptfadapter, vlan_table, router_mac)
-
+    fdb = setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type)
     for vlan in vlan_table:
         for src, dst in itertools.combinations(vlan_table[vlan], 2):
             for src_mac, dst_mac in itertools.product(fdb[src], fdb[dst]):


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Added new test cases to verify that FDB is filling in after ARP request or ARP reply received by DUT
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Extended existed pytest FDB test case by adding new packet types to send: ARP request and ARP reply. This scenarios are running as separate test cases.

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
