### PR TITLE
[pfc_wd] Wait for PFC storm end marker

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/timer_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/timer_test.yml
@@ -35,6 +35,10 @@
   shell: "date -d {{storm_detect.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
   register: storm_detect_millis
 
+- name: Wait for PFC storm end marker to appear in logs
+  pause:
+    seconds: 1
+
 - name: Find PFC storm end marker
   shell: grep "[P]FC_STORM_END" /var/log/syslog
   register: storm_end


### PR DESCRIPTION
### Description of PR
Fix for PFC WD timer test.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach
#### How did you do it?
Depending on platform the PFC storm end marker may not appear in logs in time so, added 1 sec sleep before searching for PFC_STORM_END marker in the syslog

#### How did you verify/test it?
Verified by running PFC WD test on BFN platform


