### PR TITLE
Fix for snmp_facts.py file is fetching wrong attribute for snmp interface

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -432,7 +432,7 @@ def main():
             if v.ifMtu in current_oid:
                 ifIndex = int(current_oid.rsplit('.', 1)[-1])
                 results['snmp_interfaces'][ifIndex]['mtu'] = current_val
-            if v.ifMtu in current_oid:
+            if v.ifSpeed in current_oid:
                 ifIndex = int(current_oid.rsplit('.', 1)[-1])
                 results['snmp_interfaces'][ifIndex]['speed'] = current_val
             if v.ifPhysAddress in current_oid:


### PR DESCRIPTION
### Description of PR
Fix for snmp_facts.py file is fetching wrong attributes for snmp interface
snmp_facts.py was retrieving mtu info in place of ifSpeed attribute

### Type of change
- [] Bug fix

### Approach
#### How did you do it?
Modified the library/snmp_facts.py file

#### How did you verify/test it?
Tested it on local testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A