### PR TITLE
Added conditional check in snmp physical table test case to run only for SFP/SPF+ ports

### DIFF
--- a/ansible/roles/test/tasks/snmp/phys_table.yml
+++ b/ansible/roles/test/tasks/snmp/phys_table.yml
@@ -3,6 +3,10 @@
   snmp_facts: host={{ ansible_host }} version=v2c community={{ snmp_rocommunity }}
   delegate_to: localhost
 
+- name: Get Transceiver info
+  shell: redis-cli -n 6 keys *TRANSCEIVER_INFO* |cut -d "|" -f 2
+  register: trans_output
+
 - set_fact:
     chassis_id: "1"
     sensor_partial_oids: {
@@ -29,26 +33,30 @@
 - debug:
     msg: "{{ snmp_physical_entities.keys()  }}"
 
+- name: Check SFP/SFP+ ports are connected in DUT
+  fail: msg="No SFP ports are connected in DUT"
+  when: "{{ trans_output.stdout_lines|length == 0}}"
+
 # OID index is defined as ifindex*1000, for EthernetN the ifindex is N+1, so OID index for EthernetN will be (N + 1)*1000
 - name: Check all transceivers present in Entity MIB
   fail:
-    msg: '{{ (((item.value.name.split("Ethernet")[-1] | int + 1) * 1000) | string) }}'
-  when: '{{ (((item.value.name.split("Ethernet")[-1] | int + 1) * 1000) | string) not in snmp_physical_entities.keys() }}'
-  with_dict: "{{ minigraph_ports }}"
+    msg: '{{ (((item.split("Ethernet")[-1] | int + 1) * 1000) | string) }}'
+  when: '{{ (((item.split("Ethernet")[-1] | int + 1) * 1000) | string) not in snmp_physical_entities.keys() }}'
+  with_items: "{{ trans_output.stdout_lines }}"
 
 - name: Check all transceiver DOM sensors present in Entity MIB
   fail:
-  when: '{{ ((((item[0].name.split("Ethernet")[-1] | int + 1) * 1000) + item[1]) | string) not in snmp_physical_entities.keys() }}'
+  when: '{{ ((((item[0].split("Ethernet")[-1] | int + 1) * 1000) + item[1]) | string) not in snmp_physical_entities.keys() }}'
   with_nested:
-      - "{{ minigraph_ports.values() }}"
+      - "{{ trans_output.stdout_lines }}"
       - "{{ sensor_partial_oids.values() }}"
 
 - debug: var=snmp_sensors
 
 - name: Check all transceiver DOM sensors present in Entity Sensor MIB
   fail:
-  when: '{{ ((((item[0].name.split("Ethernet")[-1] | int + 1) * 1000) + item[1]) | string) not in snmp_sensors.keys() }}'
+  when: '{{ ((((item[0].split("Ethernet")[-1] | int + 1) * 1000) + item[1]) | string) not in snmp_sensors.keys() }}'
   with_nested:
-      - "{{ minigraph_ports.values() }}"
+      - "{{ trans_output.stdout_lines }}"
       - "{{ sensor_partial_oids.values() }}"
 


### PR DESCRIPTION
### Description of PR
Devices Like M0 will not have all interface as SFP/SFP+ interface. For the 1G Ports this snmp physical table test case is failing.

Summary:
Fixes # (issue)
Added conditional check in snmp physical table test case to run only for SFP/SPF+ ports

### Type of change
- [] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
Modified the file roles/test/tasks/phys_table.yml file and added a conditional check for SFP/SFP+ ports

#### How did you verify/test it?
Tested in local testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A