### PR TITLE
[PFC] Add a pytest test for PFC counters

### DIFF
--- a/ansible/library/sonic_pfc_counters.py
+++ b/ansible/library/sonic_pfc_counters.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 import time
-from collections import defaultdict
 
 DOCUMENTATION = '''
 ---
@@ -19,31 +18,36 @@ def parse_pfc_counters(output):
     counters = dict()
 	
     lines = output.splitlines()
-    direction = '' # TX or RX
+    """ Tx or Rx """
+    direction = None    
 
     for line in lines:
         line = line.strip()
         if 'Port Rx' in line:
             direction = rx_direction
             continue
- 
+		
         elif 'Port Tx' in line:
-	        direction = tx_direction
-	        continue
-
+            direction = tx_direction
+            continue
+		
         elif line.startswith('---'):
-	        continue
- 			
+            continue
+					
         words = line.split()
-        # port_name, counter0, counter1, .... counter7
+        """ port_name, counter0, counter1, .... counter7 """
         if len(words) != 9:
-	        continue
- 
+            continue
+		
         port = words[0]
         if port not in counters:
             counters[port] = dict()
+        
+        if direction is not None:
             counters[port][direction] = [x for x in words[1:]]
-		
+        else:
+            module.fail_json(msg = "Direction is unknown")
+
     return counters	
 
 def get_pfc_counters(module):
@@ -51,7 +55,7 @@ def get_pfc_counters(module):
     while True:
         rc, out, err = module.run_command("sudo pfcstat")
         if rc != 0:
-            module.fail_json(msg="Command pfcstat failed rc=%d, out=%s, err=%s" % (rc, out, err))
+            module.fail_json(msg = "Command pfcstat failed rc=%d, out=%s, err=%s" % (rc, out, err))
         
         elif out is None or len(out) == 0:
             time.sleep(1)
@@ -64,7 +68,7 @@ def get_pfc_counters(module):
 def clear_pfc_counters(module):
     rc, out, err = module.run_command("sudo pfcstat -c")
     if rc != 0:
-        module.fail_json(msg="Command pfcstat -c failed rc=%d, out=%s, err=%s" % (rc, out, err))
+        module.fail_json(msg = "Command pfcstat -c failed rc=%d, out=%s, err=%s" % (rc, out, err))
 
 def main():
     module = AnsibleModule(argument_spec = dict(method = dict(required = True)), supports_check_mode = False)	

--- a/ansible/library/sonic_pfc_counters.py
+++ b/ansible/library/sonic_pfc_counters.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+import time
+from collections import defaultdict
+
+DOCUMENTATION = '''
+---
+module: sonic_pfc_counters
+version_added: "1.0"
+author: Wei Bai (webai@microsoft.com)
+short_description: Get/Clear PFC counters for a device  
+'''
+
+from ansible.module_utils.basic import *
+
+tx_direction = "Tx"
+rx_direction = "Rx"
+
+def parse_pfc_counters(output):
+    counters = dict()
+	
+    lines = output.splitlines()
+    direction = '' # TX or RX
+
+    for line in lines:
+	line = line.strip()
+	if 'Port Rx' in line:
+	    direction = rx_direction
+	    continue
+		
+	elif 'Port Tx' in line:
+	    direction = tx_direction
+	    continue
+		
+	if line.startswith('---'):
+	    continue
+					
+	words = line.split()
+	# port_name, counter0, counter1, .... counter7
+	if len(words) != 9:
+	    continue
+		
+	port = words[0]
+	if port not in counters:
+	    counters[port] = dict()
+            counters[port][direction] = [x for x in words[1:]]
+		
+    return counters	
+
+def get_pfc_counters(module):
+    out = None
+    while True:
+        rc, out, err = module.run_command("sudo pfcstat")
+        if rc != 0:
+            module.fail_json(msg="Command pfcstat failed rc=%d, out=%s, err=%s" % (rc, out, err))
+        
+        elif out is None or len(out) == 0:
+            time.sleep(1)
+        
+        else:
+            break
+
+    return out		
+
+def clear_pfc_counters(module):
+    rc, out, err = module.run_command("sudo pfcstat -c")
+    if rc != 0:
+        module.fail_json(msg="Command pfcstat -c failed rc=%d, out=%s, err=%s" % (rc, out, err))
+
+def main():
+    module = AnsibleModule(argument_spec = dict(method = dict(required = True)), supports_check_mode = False)	
+	
+    method = module.params['method']
+    if method == "get":
+        counters = parse_pfc_counters(get_pfc_counters(module))
+        module.exit_json(ansible_facts = counters)
+	
+    elif method == "clear":
+        clear_pfc_counters(module)
+        module.exit_json()
+
+    else:
+        module.fail_json(msg = "Unknown method %s" % (method))		
+
+if __name__ == "__main__":
+    main()

--- a/ansible/library/sonic_pfc_counters.py
+++ b/ansible/library/sonic_pfc_counters.py
@@ -22,27 +22,27 @@ def parse_pfc_counters(output):
     direction = '' # TX or RX
 
     for line in lines:
-	line = line.strip()
-	if 'Port Rx' in line:
-	    direction = rx_direction
-	    continue
-		
-	elif 'Port Tx' in line:
-	    direction = tx_direction
-	    continue
-		
-	elif line.startswith('---'):
-	    continue
-					
-	words = line.split()
-	# port_name, counter0, counter1, .... counter7
-	if len(words) != 9:
-	    continue
-		
-	port = words[0]
-	if port not in counters:
-        counters[port] = dict()
-        counters[port][direction] = [x for x in words[1:]]
+        line = line.strip()
+        if 'Port Rx' in line:
+            direction = rx_direction
+            continue
+ 
+        elif 'Port Tx' in line:
+	        direction = tx_direction
+	        continue
+
+        elif line.startswith('---'):
+	        continue
+ 			
+        words = line.split()
+        # port_name, counter0, counter1, .... counter7
+        if len(words) != 9:
+	        continue
+ 
+        port = words[0]
+        if port not in counters:
+            counters[port] = dict()
+            counters[port][direction] = [x for x in words[1:]]
 		
     return counters	
 

--- a/ansible/library/sonic_pfc_counters.py
+++ b/ansible/library/sonic_pfc_counters.py
@@ -31,7 +31,7 @@ def parse_pfc_counters(output):
 	    direction = tx_direction
 	    continue
 		
-	if line.startswith('---'):
+	elif line.startswith('---'):
 	    continue
 					
 	words = line.split()
@@ -42,7 +42,7 @@ def parse_pfc_counters(output):
 	port = words[0]
 	if port not in counters:
 	    counters[port] = dict()
-            counters[port][direction] = [x for x in words[1:]]
+        counters[port][direction] = [x for x in words[1:]]
 		
     return counters	
 

--- a/ansible/library/sonic_pfc_counters.py
+++ b/ansible/library/sonic_pfc_counters.py
@@ -41,7 +41,7 @@ def parse_pfc_counters(output):
 		
 	port = words[0]
 	if port not in counters:
-	    counters[port] = dict()
+        counters[port] = dict()
         counters[port][direction] = [x for x in words[1:]]
 		
     return counters	

--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -1,0 +1,21 @@
+import pytest
+import os
+
+@pytest.fixture(scope = "module")
+def conn_graph_facts(testbed_devices):
+    """
+    @summary: Fixture for getting testbed topology connectivity information.
+    @param testbed_devices: Devices in the testbed
+    @return: Return the topology connectivity information
+    """
+    dut = testbed_devices["dut"]
+    localhost = testbed_devices["localhost"]
+
+    base_path = os.path.dirname(os.path.realpath(__file__))
+    lab_conn_graph_file = os.path.join(base_path, "../../ansible/files/lab_connection_graph.xml")
+    result = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
+	
+    return result
+
+
+

--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -17,5 +17,20 @@ def conn_graph_facts(testbed_devices):
 	
     return result
 
+@pytest.fixture(scope = "module")
+def leaf_fanouts(conn_graph_facts):
+    """
+    @summary: Fixture for getting the list of leaf fanout switches
+    @param conn_graph_facts: Topology connectivity information
+    @return: Return the list of leaf fanout switches
+    """
+    leaf_fanouts = []
+    conn_facts = conn_graph_facts['device_conn']
+    
+    """ for each interface of DUT """
+    for intf in conn_facts:
+        peer_device = conn_facts[intf]['peerdevice']
+        if peer_device not in leaf_fanouts:
+            leaf_fanouts.append(peer_device)
 
-
+    return leaf_fanouts

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -1,0 +1,7 @@
+def eos_to_linux_intf(eos_intf_name):
+    """
+    @Summary: Map EOS's interface name to Linux's interface name
+    @param eos_intf_name: Interface name in EOS
+    @return: Return the interface name in Linux
+    """
+    return eos_intf_name.replace('Ethernet', 'et').replace('/', '_') 

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -40,9 +40,10 @@ def setup_testbed(ansible_adhoc, testbed, leaf_fanouts):
         file_src = os.path.join(os.path.dirname(__file__), PFC_GEN_FILE_RELATIVE_PATH)
         peerdev_ans.copy(src = file_src, dest = PFC_GEN_FILE_DEST, force = True)
 
-def run_pfc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time):
+def run_test(is_pfc, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time):
     """
-    @Summary: Run the priority-based flow control (PFC) test case
+    @Summary: Run test for Ethernet flow control (FC) or priority-based flow control (PFC)
+    @param is_pfc: If this test is for PFC?
     @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
     mandatory argument for the class constructors.
     @param testbed: Testbed information
@@ -52,79 +53,63 @@ def run_pfc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time):
     """
     setup_testbed(ansible_adhoc, testbed, leaf_fanouts)
     conn_facts = conn_graph_facts['device_conn']
-     
-    """ Generate PFC packets for all the priority queues of all the interfaces """
-    for intf in conn_facts:
+    
+    dut_hostname = testbed['dut']
+    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
+    int_status = dut_ans.show_interface(command = "status")['ansible_facts']['int_status']
+    
+    """ We only test active interfaces """
+    active_intfs = []
+    for intf in int_status:
+        if int_status[intf]['admin_state'] == 'up' and \
+           int_status[intf]['oper_state'] == 'up':
+            active_intfs.append(intf)
+        
+    """ Generate PFC or FC packets for active interfaces """
+    for intf in active_intfs:
+        if intf not in conn_facts:
+            continue
+        
         peer_device = conn_facts[intf]['peerdevice']
         peer_port = conn_facts[intf]['peerport']
         peer_port_name = eos_to_linux_intf(peer_port)
 
         peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
-        for priority in range(PRIO_COUNT):
-            cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
+        if is_pfc:
+            for priority in range(PRIO_COUNT):
+                cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
+                peerdev_ans.command(cmd)
+        else:
+            cmd = "sudo python %s -i %s -g -t %d -n %d" % (PFC_GEN_FILE_DEST, peer_port_name, pause_time, PKT_COUNT)
             peerdev_ans.command(cmd)
-	
+            
     """ SONiC takes some time to update counters in database """
     time.sleep(5)
 
     """ Check results """
-    dut_hostname = testbed['dut']
-    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
     counter_facts = dut_ans.sonic_pfc_counters(method = "get")['ansible_facts']
 
-    for intf in conn_facts:
+    for intf in active_intfs:
         assert intf in counter_facts
         assert 'Rx' in counter_facts[intf]
-        assert counter_facts[intf]['Rx'] == [str(PKT_COUNT)] * PRIO_COUNT
-
-def run_fc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time):
-    """
-    @Summary: Run the flow control (FC) test case
-    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
-    mandatory argument for the class constructors.
-    @param testbed: Testbed information
-    @param conn_graph_facts: Testbed topology connectivity information
-    @param leaf_fanouts: Leaf fanout switches
-    @param pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
-    """
-    setup_testbed(ansible_adhoc, testbed, leaf_fanouts)
-    conn_facts = conn_graph_facts['device_conn']
-
-    """ Generate flow control packets for all the interfaces """
-    for intf in conn_facts:
-        peer_device = conn_facts[intf]['peerdevice']
-        peer_port = conn_facts[intf]['peerport']
-        peer_port_name = eos_to_linux_intf(peer_port)
-
-        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
-        cmd = "sudo python %s -i %s -g -t %d -n %d" % (PFC_GEN_FILE_DEST, peer_port_name, pause_time, PKT_COUNT)
-        peerdev_ans.command(cmd)
-	
-    """ SONiC takes some time to update counters in database """
-    time.sleep(5)
-
-    """ Check resuls. SONiC should not update PFC counters when receiving global pause/unpause frames """
-    dut_hostname = testbed['dut']
-    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
-    counter_facts = dut_ans.sonic_pfc_counters(method = "get")['ansible_facts']
-    
-    for intf in conn_facts:
-        assert intf in counter_facts
-        assert 'Rx' in counter_facts[intf]
-        assert counter_facts[intf]['Rx'] == ['0'] * PRIO_COUNT
+        
+        if is_pfc:
+            assert counter_facts[intf]['Rx'] == [str(PKT_COUNT)] * PRIO_COUNT
+        else:
+            assert counter_facts[intf]['Rx'] == ['0'] * PRIO_COUNT
 
 def test_pfc_pause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run PFC pause frame (pause time quanta > 0) tests """
-    run_pfc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 65535)
-			
+    run_test(True, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 65535)
+	
 def test_pfc_unpause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run PFC unpause frame (pause time quanta = 0) tests """
-    run_pfc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 0)        
+    run_test(True, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 0)        
 
 def test_fc_pause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run FC pause frame (pause time quanta > 0) tests """
-    run_fc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 65535)
+    run_test(False, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 65535)
 
 def test_fc_unpause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run FC pause frame (pause time quanta = 0) tests """ 
-    run_fc(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 0) 	
+    run_test(False, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 0)

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -26,7 +26,7 @@ def setup_testbed(ansible_adhoc, testbed, conn_graph_facts):
     @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
     mandatory argument for the class constructors.
     @param testbed: Testbed information
-    @conn_graph_facts: Testbed topology connectivity information
+    @param conn_graph_facts: Testbed topology connectivity information
     """
     dut_hostname = testbed['dut']
     dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
@@ -90,8 +90,8 @@ def run_fc(ansible_adhoc, testbed, conn_graph_facts, pause_time):
     @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
     mandatory argument for the class constructors.
     @param testbed: Testbed information
-    @conn_graph_facts: Testbed topology connectivity information
-    @pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
+    @param conn_graph_facts: Testbed topology connectivity information
+    @param pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
     """
     setup_testbed(ansible_adhoc, testbed, conn_graph_facts)
     conn_facts = conn_graph_facts['device_conn']

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -40,15 +40,15 @@ def setup_testbed(ansible_adhoc, testbed, leaf_fanouts):
         file_src = os.path.join(os.path.dirname(__file__), PFC_GEN_FILE_RELATIVE_PATH)
         peerdev_ans.copy(src = file_src, dest = PFC_GEN_FILE_DEST, force = True)
 
-def run_test(is_pfc, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time):
+def run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc = True, pause_time = 65535):
     """
     @Summary: Run test for Ethernet flow control (FC) or priority-based flow control (PFC)
-    @param is_pfc: If this test is for PFC?
     @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
     mandatory argument for the class constructors.
     @param testbed: Testbed information
     @param conn_graph_facts: Testbed topology connectivity information
     @param leaf_fanouts: Leaf fanout switches
+    @param is_pfc: If this test is for PFC?
     @param pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
     """
     setup_testbed(ansible_adhoc, testbed, leaf_fanouts)
@@ -93,16 +93,16 @@ def run_test(is_pfc, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pau
 
 def test_pfc_pause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run PFC pause frame (pause time quanta > 0) tests """
-    run_test(True, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 65535)
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts)
 
 def test_pfc_unpause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run PFC unpause frame (pause time quanta = 0) tests """
-    run_test(True, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 0)        
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time = 0)        
 
 def test_fc_pause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run FC pause frame (pause time quanta > 0) tests """
-    run_test(False, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 65535)
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc = False)
 
 def test_fc_unpause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run FC pause frame (pause time quanta = 0) tests """ 
-    run_test(False, ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, 0)
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc = False, pause_time = 0)

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -40,7 +40,7 @@ def setup_testbed(ansible_adhoc, testbed, leaf_fanouts):
         file_src = os.path.join(os.path.dirname(__file__), PFC_GEN_FILE_RELATIVE_PATH)
         peerdev_ans.copy(src = file_src, dest = PFC_GEN_FILE_DEST, force = True)
 
-def run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc = True, pause_time = 65535):
+def run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc=True, pause_time=65535):
     """
     @Summary: Run test for Ethernet flow control (FC) or priority-based flow control (PFC)
     @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
@@ -97,12 +97,12 @@ def test_pfc_pause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
 
 def test_pfc_unpause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run PFC unpause frame (pause time quanta = 0) tests """
-    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time = 0)        
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, pause_time=0)        
 
 def test_fc_pause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run FC pause frame (pause time quanta > 0) tests """
-    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc = False)
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc=False)
 
 def test_fc_unpause(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts):
     """ @Summary: Run FC pause frame (pause time quanta = 0) tests """ 
-    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc = False, pause_time = 0)
+    run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, is_pfc=False, pause_time=0)

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -1,0 +1,144 @@
+from ansible_host import AnsibleHost
+from qos_fixtures import conn_graph_facts
+import os
+import time
+
+"""
+This module implements test cases for PFC counters of SONiC.
+The PFC Rx counter should be increased when the switch receives a priority-based flow control (PFC) pause/unpause frame.
+The PFC Rx counter should NOT be updated when the switch receives a global flow control pause/unpause frame.
+
+In each test case, we send a specific number of pause/unpause frames to a given priority queue of a given port at the
+device under test (DUT). Then we check the SONiC PFC Rx counters. 
+"""
+
+PFC_GEN_FILE_RELATIVE_PATH = r'../../ansible/roles/test/files/helpers/pfc_gen.py'
+""" Expected PFC generator path at the leaf fanout switch """
+PFC_GEN_FILE_DEST = r'~/pfc_gen.py'
+""" Number of generated packets for each test case """
+PKT_COUNT = 10
+""" Number of switch priorities """ 
+PRIO_COUNT = 8
+
+def setup_testbed(ansible_adhoc, testbed, conn_graph_facts):
+    """
+    @Summary: Set up the testbed, including clearing counters, and copying the PFC generator to the leaf fanout switches.
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @conn_graph_facts: Testbed topology connectivity information
+    """
+    dut_hostname = testbed['dut']
+    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
+    """ Clear PFC counters """
+    dut_ans.sonic_pfc_counters(method = "clear")
+
+    conn_facts = conn_graph_facts['device_conn']	
+    """ Get all the leaf fanout switches """
+    leaf_fanouts = []
+    """ For each interface of DUT"""
+    for intf in conn_facts:
+        peer_device = conn_facts[intf]['peerdevice']
+        if peer_device not in leaf_fanouts:
+            leaf_fanouts.append(peer_device)
+	
+    """ Copy the PFC generator to all the leaf fanout switches """
+    for peer_device in leaf_fanouts:
+        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
+        file_src = os.path.join(os.path.dirname(__file__), PFC_GEN_FILE_RELATIVE_PATH)
+        peerdev_ans.copy(src = file_src, dest = PFC_GEN_FILE_DEST, force = True)
+
+def run_pfc(ansible_adhoc, testbed, conn_graph_facts, pause_time):
+    """
+    @Summary: Run the priority-based flow control (PFC) test case
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @param conn_graph_facts: Testbed topology connectivity information
+    @param pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
+    """
+    setup_testbed(ansible_adhoc, testbed, conn_graph_facts)
+    conn_facts = conn_graph_facts['device_conn']
+     
+    """ Generate PFC packets for all the priority queues of all the interfaces """
+    for intf in conn_facts:
+        peer_device = conn_facts[intf]['peerdevice']
+        peer_port = conn_facts[intf]['peerport']
+        peer_port_name = eos_to_linux_intf(peer_port)
+
+        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
+        for priority in range(PRIO_COUNT):
+            cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
+            peerdev_ans.command(cmd)
+	
+    """ SONiC takes some time to update counters in database """
+    time.sleep(5)
+
+    """ Check results """
+    dut_hostname = testbed['dut']
+    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
+    counter_facts = dut_ans.sonic_pfc_counters(method = "get")['ansible_facts']
+
+    for intf in conn_facts:
+        assert intf in counter_facts
+        assert 'Rx' in counter_facts[intf]
+        assert counter_facts[intf]['Rx'] == [str(PKT_COUNT)] * PRIO_COUNT
+
+def run_fc(ansible_adhoc, testbed, conn_graph_facts, pause_time):
+    """
+    @Summary: Run the flow control (FC) test case
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @conn_graph_facts: Testbed topology connectivity information
+    @pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
+    """
+    setup_testbed(ansible_adhoc, testbed, conn_graph_facts)
+    conn_facts = conn_graph_facts['device_conn']
+
+    """ Generate flow control packets for all the interfaces """
+    for intf in conn_facts:
+        peer_device = conn_facts[intf]['peerdevice']
+        peer_port = conn_facts[intf]['peerport']
+        peer_port_name = eos_to_linux_intf(peer_port)
+
+        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
+        cmd = "sudo python %s -i %s -g -t %d -n %d" % (PFC_GEN_FILE_DEST, peer_port_name, pause_time, PKT_COUNT)
+        peerdev_ans.command(cmd)
+	
+    """ SONiC takes some time to update counters in database """
+    time.sleep(5)
+
+    """ Check resuls. SONiC should not update PFC counters when receiving global pause/unpause frames """
+    dut_hostname = testbed['dut']
+    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
+    counter_facts = dut_ans.sonic_pfc_counters(method = "get")['ansible_facts']
+    
+    for intf in conn_facts:
+        assert intf in counter_facts
+        assert 'Rx' in counter_facts[intf]
+        assert counter_facts[intf]['Rx'] == ['0'] * PRIO_COUNT
+
+def eos_to_linux_intf(eos_intf_name):
+    """
+    @Summary: Map EOS's interface name to Linux's interface name
+    @param eos_intf_name: Interface name in EOS
+    @return: Return the interface name in Linux 
+    """
+    return eos_intf_name.replace('Ethernet', 'et').replace('/', '_')
+
+def test_pfc_pause(ansible_adhoc, testbed, conn_graph_facts):
+    """ @Summary: Run PFC pause frame (pause time quanta > 0) tests """
+    run_pfc(ansible_adhoc, testbed, conn_graph_facts, 65535)
+			
+def test_pfc_unpause(ansible_adhoc, testbed, conn_graph_facts):
+    """ @Summary: Run PFC unpause frame (pause time quanta = 0) tests """
+    run_pfc(ansible_adhoc, testbed, conn_graph_facts, 0)        
+
+def test_fc_pause(ansible_adhoc, testbed, conn_graph_facts):
+    """ @Summary: Run FC pause frame (pause time quanta > 0) tests """
+    run_fc(ansible_adhoc, testbed, conn_graph_facts, 65535)
+
+def test_fc_unpause(ansible_adhoc, testbed, conn_graph_facts):
+    """ @Summary: Run FC pause frame (pause time quanta = 0) tests """ 
+    run_fc(ansible_adhoc, testbed, conn_graph_facts, 0) 	


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: A pytest test to validate SONiC PFC counters

### Type of change
- [] Test case(new/improvement)

### Approach
#### How did you do it?
- Added sonic_pfc_counters module in ansible/library/ to get and clear SONiC PFC counters
- Added a new folder test/qos for all QoS related pytest tests
- Added test_pfc_counters.py in test/qos to validate the behavior of PFC counters under PFC pause frames, PFC unpause frames, global pause frames, and global unpause frames. 

#### How did you verify/test it?
Test it in Microsoft internal testbed. 

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
I tested it in a T1 topology but it should support all the topologies.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
