### PR TITLE
[pfc_wd] Add 150 ms delta for pfc_wd detect and restore wait time

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
@@ -57,6 +57,7 @@
     - set_fact:
         detect_time_list: "{{detect_time_list | sort}}"
         restore_time_list: "{{restore_time_list | sort}}"
+        pfc_wd_wait_delta: 100
 
     - debug:
         var: "{{item}}"
@@ -67,7 +68,7 @@
     - name: Verify that real detection time is not greater than configured
       fail:
         msg: Real detection time is greater than configured
-      when: "{{(detect_time_list[9]) > pfc_wd_detect_time + pfc_wd_poll_time}}"
+      when: "{{(detect_time_list[9]) > pfc_wd_detect_time + pfc_wd_poll_time + pfc_wd_wait_delta}}"
 
     - name: Verify that real detection time is not less than configured
       fail:
@@ -82,7 +83,7 @@
     - name: Verify that real restoration time is less than configured
       fail:
           msg: Real restoration time is greater than configured
-      when: "{{(restore_time_list[9]) > pfc_wd_restore_time + pfc_wd_poll_time}}"
+      when: "{{(restore_time_list[9]) > pfc_wd_restore_time + pfc_wd_poll_time + pfc_wd_wait_delta}}"
 
   always:
     - name: Clean up config

--- a/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml
@@ -57,10 +57,10 @@
     - set_fact:
         detect_time_list: "{{detect_time_list | sort}}"
         restore_time_list: "{{restore_time_list | sort}}"
-        pfc_wd_wait_delta: 100
+        pfc_wd_wait_delta: 150
 
     - debug:
-        var: "{{item}}"
+        msg: "{{item}}"
       with_items:
         - "{{ detect_time_list }}"
         - "{{ restore_time_list }}"


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR
The timer accuracy test as it's written right now shows very random results. This is because it expects that PFC detection/restoration time is equal to pfc_wd_detect_time + pfc_wd_poll_time. In fact the worst case looks as follows:

wait time == pfc_wd_detect_time + pfc_wd_poll_time + delta1(time while "storm"/"restore" flag gets stored to REDIS) + delta2 (time while these flags are read from REDIS by orchdaemon) + delta3 (time when PFC WD storm detect/restore log appears in syslog). I don't know what the exact sum of this delta but on BFN paltform I see that it's usually in the range from 10-85ms for detect time and up to 150 ms for restore time.

So I added 150ms delta to wait time which should solve this. 

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach
#### How did you do it?

Added 100 ms delta to PFC WD wait time in timer accuracy check.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
