### PR TITLE
[201811] Make tests/ptftests a proper symlink

### DIFF
--- a/tests/ptftests
+++ b/tests/ptftests
@@ -1,1 +1,1 @@
-../ansible/roles/test/files/ptftests
+../ansible/roles/test/files/ptftests/


### PR DESCRIPTION
The previous file was somehow committed as a text file, not an actual symlink.