### PR TITLE
Improvements for syslog test

### DIFF
--- a/ansible/roles/test/tasks/syslog.yml
+++ b/ansible/roles/test/tasks/syslog.yml
@@ -22,13 +22,19 @@
   delegate_to: localhost
   register: local_facts
 
+- name: Get external host facts
+  setup:
+  delegate_to: "{{ testbed_server }}"
+  register: external_facts
+
 #- debug: var=local_facts.ansible_facts.ansible_eth0.ipv4.address
 
 
 # Set variables for the test
 - name: Set variables for the test
   set_fact:
-    local_srcip: "{{ local_facts.ansible_facts.ansible_eth0.ipv4.address }}"
+    local_srcip: "{{ external_facts.ansible_facts.ansible_br1.ipv4.address }}"
+    docker_mgmt_srcip: "{{ local_facts.ansible_facts.ansible_eth0.ipv4.address }}"
     original_syslog_servers: "{{ syslog_servers }}"
     syslog_port: "{{ 65535 | random(start=65000) }}"
     test_message: "Basic Test Message"
@@ -45,6 +51,28 @@
 - name: Restart Syslog Daemon
   become: true
   service: name=rsyslog state=restarted
+
+# Add iptables rules for rsyslog test
+- name: Add DOCKER chain input rule
+  delegate_to: "{{ testbed_server }}"
+  become: true
+  iptables:
+    chain: DOCKER
+    protocol: udp
+    destination: "{{ docker_mgmt_srcip }}"
+    destination_port: "{{ syslog_port }}"
+    jump: ACCEPT
+
+- name: Add DOCKER chain DNAT rule
+  delegate_to: "{{ testbed_server }}"
+  become: true
+  iptables:
+    table: nat
+    chain: DOCKER
+    protocol: udp
+    destination_port: "{{ syslog_port }}"
+    jump: DNAT
+    to_destination: "{{ docker_mgmt_srcip }}:{{ syslog_port }}"
 
 # Start local ryslog Server
 
@@ -88,11 +116,12 @@
 - name: Start Syslog Daemon
   delegate_to: localhost
   become: true
-  service: name=rsyslog state=started
+  shell: service rsyslog restart
+  ignore_errors: true
 
 - name: Wait a little bit for service to start
   wait_for:
-    timeout: 2
+    timeout: 30
 
 # SSH to device and generate a syslog
 - name: Send test syslog
@@ -109,6 +138,34 @@
 - name: Restart Syslog Daemon
   become: true
   service: name=rsyslog state=restarted
+
+- name: Wait a little bit for service to start
+  wait_for:
+    timeout: 30
+
+# Remove iptables rules for rsyslog test
+- name: remove DOCKER chain input rule
+  delegate_to: "{{ testbed_server }}"
+  become: true
+  iptables:
+    chain: DOCKER
+    state: absent
+    protocol: udp
+    destination: "{{ docker_mgmt_srcip }}"
+    destination_port: "{{ syslog_port }}"
+    jump: ACCEPT
+
+- name: remove DOCKER chain DNAT rule
+  delegate_to: "{{ testbed_server }}"
+  become: true
+  iptables:
+    table: nat
+    chain: DOCKER
+    state: absent
+    protocol: udp
+    destination_port: "{{ syslog_port }}"
+    jump: DNAT
+    to_destination: "{{ docker_mgmt_srcip }}:{{ syslog_port }}"
 
 # Check Messages
 - name: Check syslog messages for the test message


### PR DESCRIPTION
Signed-off-by: Mykhailo Onipko <monipko@barefootnetworks.com>

### Description of PR
Faced with problem when during automated regression run DUT's syslog cannot send data to the isolated (NAT mode networking enabled) docker-sonic-mgmt container without restarting one with host mode networking.
Considering all above have added steps to the test's tasks with add/remove host's Iptables rules to the Docker's chain. 
Also have increased timeout duration after syslog restart and added same timeout before test message check.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach

#### How did you do it?

#### How did you verify/test it?

Run syslog test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
