### PR TITLE
Reload config from config_db in cleanup section

### DIFF
--- a/ansible/roles/test/tasks/neighbour-mac-noptf.yml
+++ b/ansible/roles/test/tasks/neighbour-mac-noptf.yml
@@ -11,7 +11,7 @@
     register: pgrep_out
 
   - debug: var=pgrep_out.stdout_lines
-  
+
   - name: Verify that orchagent process is running
     assert: { that: "{{ pgrep_out.stdout_lines | length }} > 0"}
 
@@ -65,7 +65,7 @@
     command: "ip neigh change {{ v4_nei }} lladdr {{ v4_mac2 }} dev {{ v4_intf }}"
 
   - name: pause a second and check
-    pause: seconds=2 
+    pause: seconds=2
 
   - name: gather orchagent pid, make sure orchagent is still running after v4 neighbor change mac
     command: "pgrep orchagent"
@@ -73,7 +73,7 @@
 
   - assert: { that: orchid.stdout != '' }
 
-  - name: check kernel arp table again 
+  - name: check kernel arp table again
     switch_arptable:
 
   - name: make sure neighbor mac address was changed on SONiC
@@ -145,7 +145,7 @@
     - name: reset all changes
       include_tasks: "roles/test/tasks/common_tasks/reload_config.yml"
       vars:
-        config_source: "minigraph"
+        config_source: "config_db"
 
     - name: check port status
       interface_facts: up_ports={{ minigraph_ports }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

After deployed SONiC for testing, we may need to change some
configurations and save that change to config_db for certain
cases or workarounds. If we load configuration from minigraph
again, then we may lose the configuration previously saved. This 
could lead to some issues in certain circumstances.

This is a one line change. Replaced reloading from minigraph to reloading from config_db
in cleanup section of the neighbour_mac_noptf script.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Replace reloading from minigraph to reload from config_db in cleanup section of the neighbour_mac_noptf script.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
