### PR TITLE
[config_facts] Add config facts module

### DIFF
--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import json
-import ipaddr as ipaddress
 from collections import defaultdict
 from natsort import natsorted
 
@@ -25,177 +24,46 @@ options:
 '''
 
 PERSISTENT_CONFIG_PATH = "/etc/sonic/config_db.json"
+TABLE_NAME_SEPARATOR = '|'
 
-def parse_meta_servers(config):
-    dhcp_servers = []
-    ntp_servers = []
-
-    if "DHCP_SERVER" in config:
-        dhcp_servers = config["DHCP_SERVER"].keys()
-
-    if "NTP_SERVER" in config:
-        dhcp_servers = config["NTP_SERVER"].keys()
-
-    return dhcp_servers, ntp_servers
-
-def parse_meta(config):
-
-    localhost_config = config['DEVICE_METADATA']['localhost']
-
-    hostname = localhost_config.get('hostname', None)
-    hwsku = localhost_config.get('hwsku', None)
-    deployment_id = localhost_config.get('deployment_id', None)
-    bgp_asn = localhost_config.get('bgp_asn', None)
-    mac = localhost_config.get('mac', None)
-    platform = localhost_config.get('platform', None)
-
-    return hostname, hwsku, deployment_id, bgp_asn, mac, platform
-
-def parse_bgp(config):
-
-    bgp_sessions = []
-    bgp_peers_with_range = []
-
-    try:
-        for addr in config["BGP_NEIGHBOR"]:
-            bgp_sessions.append({
-                'name': config["BGP_NEIGHBOR"][addr]['name'],
-                'addr': addr,
-                'peer_addr': config["BGP_NEIGHBOR"][addr]['local_addr'],
-                'asn' : int(config["BGP_NEIGHBOR"][addr]['asn'])
-            })
-
-        for peer_range in config["BGP_PEER_RANGE"].values():
-            bgp_peers_with_range.append({
-                'name': peer_range['name'],
-                'ip_range' : peer_range['ip_range']
-            })
-    except KeyError:
-        pass
-
-    return bgp_sessions, bgp_peers_with_range
-
-
-def parse_interfaces(config):
-    router_intfs = []
-    vlan_intfs = []
-    pc_intfs = []
-    lo_intfs = []
-    mgmt_intfs = {}
-
-    if "INTERFACE" in config:
-        for entry in config["INTERFACE"].keys():
-            if '|' not in entry: 
-                continue
-            interface_name, subnet = entry.split('|')
-            subnet = ipaddress.IPNetwork(subnet)
-            router_intfs.append({
-                'name' : interface_name,
-                'attachto' : interface_name,
-                'subnet' : str(subnet),
-                'addr' : str(subnet.ip),
-                'prefixlen' : subnet.prefixlen,
-                'mask' : str(subnet.netmask)
-            })
-    if "VLAN_INTERFACE" in config:
-        for entry in config["VLAN_INTERFACE"].keys():
-            if '|' not in entry: 
-                continue
-            vlan_name, subnet = entry.split('|')
-            subnet = ipaddress.IPNetwork(subnet)
-            vlan_intfs.append({
-                'name' : vlan_name,
-                'attachto' : vlan_name,
-                'subnet' : str(subnet),
-                'addr' : str(subnet.ip),
-                'prefixlen' : subnet.prefixlen,
-                'mask' : str(subnet.netmask)
-            })
-    if "PORTCHANNEL_INTERFACE" in config:
-        for entry in config["PORTCHANNEL_INTERFACE"].keys():
-            if '|' not in entry: 
-                continue
-            pc_name, subnet = entry.split('|')
-            subnet = ipaddress.IPNetwork(subnet)
-            pc_intfs.append({
-                'name' : pc_name,
-                'attachto' : pc_name,
-                'subnet' : str(subnet),
-                'addr' : str(subnet.ip),
-                'prefixlen' : subnet.prefixlen,
-                'mask' : str(subnet.netmask)
-            })
-
-    if "MGMT_INTERFACE" in config:
-        for entry, v in config["MGMT_INTERFACE"].iteritems():
-            if '|' not in entry: 
-                continue
-            interface_name, subnet = entry.split('|')
-            # Looking for IPv4 mgmt interface here
+def format_config(json_data):
+    """Format config data. 
+    Returns:
+        Config data in a dictionary form of TABLE, KEY, [ ENTRY ], FV
+    Example:
+    {
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet2": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet4": {
+            "tagging_mode": "untagged"
+        }
+    }
+    Is converted into 
+     'VLAN_MEMBER': {'Vlan1000': {'Ethernet10': {'tagging_mode': 'untagged'},
+                                  'Ethernet12': {'tagging_mode': 'untagged'}
+                    }
+    """
+    res = {}
+    for table, item in json_data.items():
+        data = {}
+        for key, entry in item.items():
             try:
-                subnet = ipaddress.IPNetwork(subnet, version=4)
+                (key_l1, key_l2)= key.split(TABLE_NAME_SEPARATOR, 1)
+                data.setdefault(key_l1, {})[key_l2] = entry
             except ValueError:
-                continue
-            mgmt_intfs = {
-                'name' : interface_name,
-                'alias' : interface_name,
-                'subnet' : str(subnet),
-                'addr' : str(subnet.ip),
-                'prefixlen' : subnet.prefixlen,
-                'mask' : str(subnet.netmask),
-                'gwaddr' : v['gwaddr']
-            }
+                # This is a single level key
+                data.setdefault(key, entry)
 
-    if "LOOPBACK_INTERFACE" in config:
-        for entry, v in config["LOOPBACK_INTERFACE"].iteritems():
-            if '|' not in entry: 
-                continue
-            interface_name, subnet = entry.split('|')
-            subnet = ipaddress.IPNetwork(subnet)
-            lo_intfs.append({
-                'name' : interface_name,
-                'subnet' : str(subnet),
-                'addr' : str(subnet.ip),
-                'prefixlen' : subnet.prefixlen,
-                'mask' : str(subnet.netmask),
-            })
+        res.setdefault(table, data)
 
-    return router_intfs, vlan_intfs, pc_intfs, lo_intfs, mgmt_intfs
+    return res
 
 
-def parse_ports(config):
-    ports = {}
-    portchannels = {}
-    vlans = {}
+def create_maps(config):
+    """ Create a map of SONiC port name to physical port index """
 
-    if "PORT" in config:
-        for k, v in config["PORT"].items():
-            ports[k] = {
-                'alias' : v['alias'],
-                'speed' : v['speed'],
-                'admin_status' : v.get('admin_status', 'down'),
-                'name' : k
-            }
-    if "VLAN" in config:
-        for k, v in config["VLAN"].items():
-            vlans[k] = {
-                'vlanid' : v['vlanid'],
-                'name' : k,
-                'members' : [ entry.split('|')[-1] for entry in config["VLAN_MEMBER"] if k in entry ]
-            }
-    if "PORTCHANNEL" in config:
-        for k, v in config["PORTCHANNEL"].items():
-            portchannels[k] = {
-                'admin_status' : v.get('admin_status', 'down'),
-                'name' : k,
-                'members' : v['members']
-            }
-
-    return ports, vlans, portchannels
-
-def create_alias_maps(config):
-    # Create a map of SONiC port name to physical port index
-    # Start by creating a list of all port names
     port_name_list = config["PORT"].keys()
     port_name_list_sorted = natsorted(port_name_list)
 
@@ -208,72 +76,32 @@ def create_alias_maps(config):
     # Create inverse mapping between port name and alias
     port_alias_to_name_map = {v: k for k, v in port_name_to_alias_map.iteritems()}
 
-    return port_name_to_alias_map, port_alias_to_name_map, port_index_map
-
-
-def parse_acl(config):
-    return config.get('ACL_TABLE', {})
-
-
-def parse_devices(config):
-
-    devices = config.get('DEVICE_NEIGHBOR', {})
-    neighbors = config.get('DEVICE_NEIGHBOR_METADATA', {})
-    return devices, neighbors
+    return {
+    'port_name_to_alias_map' : port_name_to_alias_map,
+    'port_alias_to_name_map' : port_alias_to_name_map,
+    'port_index_map' : port_index_map
+    }
 
 
 def get_running_config(module):
 
     rt, out, err = module.run_command("sonic-cfggen -d --print-data")
     if rt != 0:
-        module.fail_json(msg="failed to dump running config!")
+        module.fail_json(msg="Failed to dump running config! {}".format(err))
     json_info = json.loads(out)
     return json_info
 
 
-def parse_config(config):
+def get_facts(config):
+    """ Create the facts dict """
 
-    # Generate results
     Tree = lambda: defaultdict(Tree)
 
     results = Tree()
-    hostname, hwsku, deployment_id, bgp_asn, mac, platform = parse_meta(config)
-    results['config_hwsku'] = hwsku
-    results['deployment_id'] = deployment_id
-    results['config_hostname'] = hostname
-    results['inventory_hostname'] = hostname
-    results['config_bgp_asn'] = bgp_asn
 
-    bgp_sessions, bgp_peers_with_range = parse_bgp(config)
-    results['config_bgp'] = bgp_sessions
-    results['config_bgp_peers_with_range'] = bgp_peers_with_range
+    results.update(format_config(config))
 
-    router_intfs, vlan_intfs, pc_intfs, lo_intfs, mgmt_intfs = parse_interfaces(config)
-    results['config_interfaces'] = sorted(router_intfs, key=lambda x: x['name'])
-    results['config_vlan_interfaces'] = sorted(vlan_intfs, key=lambda x: x['name'])
-    results['config_portchannel_interfaces'] = sorted(pc_intfs, key=lambda x: x['name'])
-    results['config_mgmt_interface'] = mgmt_intfs
-    results['config_lo_interfaces'] = lo_intfs
-
-    ports, vlans, portchannels = parse_ports(config)
-    results['config_ports'] = ports
-    results['config_vlans'] = vlans
-    results['config_portchannels'] = portchannels
-
-    results['config_acls'] = parse_acl(config)
-
-    port_name_to_alias_map, port_alias_to_name_map, port_index_map = create_alias_maps(config)
-    results['config_port_indices'] = port_index_map
-    results['config_port_name_to_alias_map'] = port_name_to_alias_map
-    results['config_port_alias_to_name_map'] = port_alias_to_name_map
-
-    devices, neighbors = parse_devices(config)
-    results['config_neighbors'] = neighbors
-    results['config_devices'] = devices
-
-    dhcp_servers, ntp_servers = parse_meta_servers(config) 
-    results['dhcp_servers'] = dhcp_servers
-    results['ntp_servers'] = ntp_servers
+    results.update(create_maps(config))
 
     return results
 
@@ -295,14 +123,13 @@ def main():
                 config = json.load(f)
         elif m_args["source"] == "running":    
             config = get_running_config(module)
-
-        results = parse_config(config)
+        results = get_facts(config)
         module.exit_json(ansible_facts=results)
     except Exception as e:
         module.fail_json(msg=e.message)
 
 
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
 
 if __name__ == "__main__":
     main()

--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+import json
+import ipaddr as ipaddress
+from collections import defaultdict
+from natsort import natsorted
+
+DOCUMENTATION = '''
+---
+module: config_facts
+version_added: "1.0"
+author: Mykola Faryma (mykolaf@mellanox.com)
+short_description: Retrive configuration facts for a device.
+description:
+    - Retrieve configuration facts for a device, the facts will be
+      inserted to the ansible_facts key.
+    - The data can be pulled from redis (running config) or /etc/sonic/config_db.json (persistent config)
+options:
+    host:
+        description:
+            - Set to target switch (normally {{inventory_hostname}})
+        required: true
+    source:
+        description:
+            - Set to "running" for running config, or "persistent" for persistent config from /etc/sonic/config_db.json
+'''
+
+PERSISTENT_CONFIG_PATH = "/etc/sonic/config_db.json"
+
+def parse_meta_servers(config):
+    dhcp_servers = []
+    ntp_servers = []
+
+    if "DHCP_SERVER" in config:
+        dhcp_servers = config["DHCP_SERVER"].keys()
+
+    if "NTP_SERVER" in config:
+        dhcp_servers = config["NTP_SERVER"].keys()
+
+    return dhcp_servers, ntp_servers
+
+def parse_meta(config):
+
+    localhost_config = config['DEVICE_METADATA']['localhost']
+
+    hostname = localhost_config.get('hostname', None)
+    hwsku = localhost_config.get('hwsku', None)
+    deployment_id = localhost_config.get('deployment_id', None)
+    bgp_asn = localhost_config.get('bgp_asn', None)
+    mac = localhost_config.get('mac', None)
+    platform = localhost_config.get('platform', None)
+
+    return hostname, hwsku, deployment_id, bgp_asn, mac, platform
+
+def parse_bgp(config):
+
+    bgp_sessions = []
+    bgp_peers_with_range = []
+
+    try:
+        for addr in config["BGP_NEIGHBOR"]:
+            bgp_sessions.append({
+                'name': config["BGP_NEIGHBOR"][addr]['name'],
+                'addr': addr,
+                'peer_addr': config["BGP_NEIGHBOR"][addr]['local_addr'],
+                'asn' : int(config["BGP_NEIGHBOR"][addr]['asn'])
+            })
+
+        for peer_range in config["BGP_PEER_RANGE"].values():
+            bgp_peers_with_range.append({
+                'name': peer_range['name'],
+                'ip_range' : peer_range['ip_range']
+            })
+    except KeyError:
+        pass
+
+    return bgp_sessions, bgp_peers_with_range
+
+
+def parse_interfaces(config):
+    router_intfs = []
+    vlan_intfs = []
+    pc_intfs = []
+    lo_intfs = []
+    mgmt_intfs = {}
+
+    if "INTERFACE" in config:
+        for entry in config["INTERFACE"].keys():
+            if '|' not in entry: 
+                continue
+            interface_name, subnet = entry.split('|')
+            subnet = ipaddress.IPNetwork(subnet)
+            router_intfs.append({
+                'name' : interface_name,
+                'attachto' : interface_name,
+                'subnet' : str(subnet),
+                'addr' : str(subnet.ip),
+                'prefixlen' : subnet.prefixlen,
+                'mask' : str(subnet.netmask)
+            })
+    if "VLAN_INTERFACE" in config:
+        for entry in config["VLAN_INTERFACE"].keys():
+            if '|' not in entry: 
+                continue
+            vlan_name, subnet = entry.split('|')
+            subnet = ipaddress.IPNetwork(subnet)
+            vlan_intfs.append({
+                'name' : vlan_name,
+                'attachto' : vlan_name,
+                'subnet' : str(subnet),
+                'addr' : str(subnet.ip),
+                'prefixlen' : subnet.prefixlen,
+                'mask' : str(subnet.netmask)
+            })
+    if "PORTCHANNEL_INTERFACE" in config:
+        for entry in config["PORTCHANNEL_INTERFACE"].keys():
+            if '|' not in entry: 
+                continue
+            pc_name, subnet = entry.split('|')
+            subnet = ipaddress.IPNetwork(subnet)
+            pc_intfs.append({
+                'name' : pc_name,
+                'attachto' : pc_name,
+                'subnet' : str(subnet),
+                'addr' : str(subnet.ip),
+                'prefixlen' : subnet.prefixlen,
+                'mask' : str(subnet.netmask)
+            })
+
+    if "MGMT_INTERFACE" in config:
+        for entry, v in config["MGMT_INTERFACE"].iteritems():
+            if '|' not in entry: 
+                continue
+            interface_name, subnet = entry.split('|')
+            # Looking for IPv4 mgmt interface here
+            try:
+                subnet = ipaddress.IPNetwork(subnet, version=4)
+            except ValueError:
+                continue
+            mgmt_intfs = {
+                'name' : interface_name,
+                'alias' : interface_name,
+                'subnet' : str(subnet),
+                'addr' : str(subnet.ip),
+                'prefixlen' : subnet.prefixlen,
+                'mask' : str(subnet.netmask),
+                'gwaddr' : v['gwaddr']
+            }
+
+    if "LOOPBACK_INTERFACE" in config:
+        for entry, v in config["LOOPBACK_INTERFACE"].iteritems():
+            if '|' not in entry: 
+                continue
+            interface_name, subnet = entry.split('|')
+            subnet = ipaddress.IPNetwork(subnet)
+            lo_intfs.append({
+                'name' : interface_name,
+                'subnet' : str(subnet),
+                'addr' : str(subnet.ip),
+                'prefixlen' : subnet.prefixlen,
+                'mask' : str(subnet.netmask),
+            })
+
+    return router_intfs, vlan_intfs, pc_intfs, lo_intfs, mgmt_intfs
+
+
+def parse_ports(config):
+    ports = {}
+    portchannels = {}
+    vlans = {}
+
+    if "PORT" in config:
+        for k, v in config["PORT"].items():
+            ports[k] = {
+                'alias' : v['alias'],
+                'speed' : v['speed'],
+                'admin_status' : v.get('admin_status', 'down'),
+                'name' : k
+            }
+    if "VLAN" in config:
+        for k, v in config["VLAN"].items():
+            vlans[k] = {
+                'vlanid' : v['vlanid'],
+                'name' : k,
+                'members' : [ entry.split('|')[-1] for entry in config["VLAN_MEMBER"] if k in entry ]
+            }
+    if "PORTCHANNEL" in config:
+        for k, v in config["PORTCHANNEL"].items():
+            portchannels[k] = {
+                'admin_status' : v.get('admin_status', 'down'),
+                'name' : k,
+                'members' : v['members']
+            }
+
+    return ports, vlans, portchannels
+
+def create_alias_maps(config):
+    # Create a map of SONiC port name to physical port index
+    # Start by creating a list of all port names
+    port_name_list = config["PORT"].keys()
+    port_name_list_sorted = natsorted(port_name_list)
+
+    port_index_map = {}
+    for idx, val in enumerate(port_name_list_sorted):
+        port_index_map[val] = idx
+
+    port_name_to_alias_map = { name : v['alias'] for name, v in config["PORT"].iteritems()}
+
+    # Create inverse mapping between port name and alias
+    port_alias_to_name_map = {v: k for k, v in port_name_to_alias_map.iteritems()}
+
+    return port_name_to_alias_map, port_alias_to_name_map, port_index_map
+
+
+def parse_acl(config):
+    return config.get('ACL_TABLE', {})
+
+
+def parse_devices(config):
+
+    devices = config.get('DEVICE_NEIGHBOR', {})
+    neighbors = config.get('DEVICE_NEIGHBOR_METADATA', {})
+    return devices, neighbors
+
+
+def get_running_config(module):
+
+    rt, out, err = module.run_command("sonic-cfggen -d --print-data")
+    if rt != 0:
+        module.fail_json(msg="failed to dump running config!")
+    json_info = json.loads(out)
+    return json_info
+
+
+def parse_config(config):
+
+    # Generate results
+    Tree = lambda: defaultdict(Tree)
+
+    results = Tree()
+    hostname, hwsku, deployment_id, bgp_asn, mac, platform = parse_meta(config)
+    results['config_hwsku'] = hwsku
+    results['deployment_id'] = deployment_id
+    results['config_hostname'] = hostname
+    results['inventory_hostname'] = hostname
+    results['config_bgp_asn'] = bgp_asn
+
+    bgp_sessions, bgp_peers_with_range = parse_bgp(config)
+    results['config_bgp'] = bgp_sessions
+    results['config_bgp_peers_with_range'] = bgp_peers_with_range
+
+    router_intfs, vlan_intfs, pc_intfs, lo_intfs, mgmt_intfs = parse_interfaces(config)
+    results['config_interfaces'] = sorted(router_intfs, key=lambda x: x['name'])
+    results['config_vlan_interfaces'] = sorted(vlan_intfs, key=lambda x: x['name'])
+    results['config_portchannel_interfaces'] = sorted(pc_intfs, key=lambda x: x['name'])
+    results['config_mgmt_interface'] = mgmt_intfs
+    results['config_lo_interfaces'] = lo_intfs
+
+    ports, vlans, portchannels = parse_ports(config)
+    results['config_ports'] = ports
+    results['config_vlans'] = vlans
+    results['config_portchannels'] = portchannels
+
+    results['config_acls'] = parse_acl(config)
+
+    port_name_to_alias_map, port_alias_to_name_map, port_index_map = create_alias_maps(config)
+    results['config_port_indices'] = port_index_map
+    results['config_port_name_to_alias_map'] = port_name_to_alias_map
+    results['config_port_alias_to_name_map'] = port_alias_to_name_map
+
+    devices, neighbors = parse_devices(config)
+    results['config_neighbors'] = neighbors
+    results['config_devices'] = devices
+
+    dhcp_servers, ntp_servers = parse_meta_servers(config) 
+    results['dhcp_servers'] = dhcp_servers
+    results['ntp_servers'] = ntp_servers
+
+    return results
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True),
+            source=dict(required=True, choices=["running", "persistent"]),
+            filename=dict(),
+        ),
+        supports_check_mode=True
+    )
+
+    m_args = module.params
+    try:
+        config = {}
+        if m_args["source"] == "persistent":
+            with open(PERSISTENT_CONFIG_PATH, "r") as f:
+                config = json.load(f)
+        elif m_args["source"] == "running":    
+            config = get_running_config(module)
+
+        results = parse_config(config)
+        module.exit_json(ansible_facts=results)
+    except Exception as e:
+        module.fail_json(msg=e.message)
+
+
+from ansible.module_utils.basic import *
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Change-Id: I5a8b71fdef1f581d02bc8e25a3f58fc5e2767b2c
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
New config facts module. Can get facts from `persistent` config (config_db.json) and `running` config (dump from redis).

Motivation: for BSL testing the DUT is configured using `sonic-cfggen -H -k ${HWSKU} --preset l2 > /etc/sonic/config_db.json` and this way the config is not based on minigraph. Need to have facts based on config db. 
As per SONiC documentation minigraph is deprecated for more than 2 years, nevertheless most tests are based on minigraph facts. Consider using this module instead. 

Example facts:

```
{
"PORTCHANNEL":{
"PortChannel0001":{
"admin_status":"up",
"mtu":"9100",
"members":[
"Ethernet64"
],
"min_links":"1"
},
"PortChannel0003":{
"admin_status":"up",
"mtu":"9100",
"members":[
"Ethernet68"
],
"min_links":"1"
},
"PortChannel0002":{
"admin_status":"up",
"mtu":"9100",
"members":[
"Ethernet66"
],
"min_links":"1"
},
"PortChannel0004":{
"admin_status":"up",
"mtu":"9100",
"members":[
"Ethernet70"
],
"min_links":"1"
}
},
"PORTCHANNEL_INTERFACE":{
"PortChannel0001":{
"10.0.0.56/31":{
},
"FC00::71/126":{
}
},
"PortChannel0003":{
"10.0.0.60/31":{
},
"FC00::79/126":{
}
},
"PortChannel0002":{
"FC00::75/126":{
},
"10.0.0.58/31":{
}
},
"PortChannel0004":{
"FC00::7D/126":{
},
"10.0.0.62/31":{
}
}
}
}

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach

A parameter source can be passed to the module to specify the source of facts data:

- running (read from redis)
- persistent (read from /etc/sonic/config_db.json)

For redis data the facts module can take output of 
`sonic-cfggen -d --print-data`
 as input. (Contents of redis formated as json)

Example (in pytest):

`    config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']`
#### How did you do it?


#### How did you verify/test it?
Written tests using the module, converted tests to use it instead of the minigraph_facts. (tests coming in separate PRs).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
