### PR TITLE
[COPP] Fix COPP test

### DIFF
--- a/ansible/roles/test/tasks/copp.yml
+++ b/ansible/roles/test/tasks/copp.yml
@@ -4,6 +4,7 @@
   with_items:
     - "lldp"
     - "syncd"
+    - "swss"
 
 - block:
     - fail: msg="Please set ptf_host variable"
@@ -53,6 +54,14 @@
       copy: src=roles/test/files/ptftests dest=/root
       delegate_to: "{{ ptf_host }}"
 
+    - name: copy copp configuration file
+      copy: src=roles/test/tasks/copp/ip2me_600.json dest=/root
+      delegate_to: "{{ ansible_host }}_swss"
+
+    - name: update copp configuration
+      shell: "swssconfig /root/ip2me_600.json"
+      delegate_to: "{{ ansible_host }}_swss"
+
     - include_tasks: ptf_runner.yml
       vars:
         ptf_test_name: COPP test - {{ item }}
@@ -77,6 +86,14 @@
         - IP2METest
 
   always:
+    - name: copy copp configuration file
+      copy: src=roles/test/tasks/copp/ip2me_6000.json dest=/root
+      delegate_to: "{{ ansible_host }}_swss"
+
+    - name: restore copp configuration
+      shell: "swssconfig /root/ip2me_6000.json"
+      delegate_to: "{{ ansible_host }}_swss"
+
     - name: Remove existing ip from ptf host
       script: roles/test/files/helpers/remove_ip.sh
       delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/test/tasks/copp/ip2me_600.json
+++ b/ansible/roles/test/tasks/copp/ip2me_600.json
@@ -1,0 +1,9 @@
+[
+    {
+         "COPP_TABLE:trap.group.ip2me": {
+             "cir":"600",
+             "cbs":"600"
+         },
+         "OP": "SET"
+     }
+ ]

--- a/ansible/roles/test/tasks/copp/ip2me_6000.json
+++ b/ansible/roles/test/tasks/copp/ip2me_6000.json
@@ -1,0 +1,9 @@
+[
+    {
+         "COPP_TABLE:trap.group.ip2me": {
+             "cir":"6000",
+             "cbs":"6000"
+         },
+         "OP": "SET"
+     }
+ ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Due to https://github.com/Azure/sonic-swss/pull/1000 CT COPP fails on SNMP packets check assertion.

Summary:
Fix COPP test
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
The first approach was to change the number of packets sent for a specific test case, but ptf was not able to produce the needed packet rate. 
The second approach is to temporary change configuration for a test run and restores after.

#### How did you do it?
Temporary change configuration for ip2me group for a test run and restores after.

#### How did you verify/test it?
Run COPP CT

#### Any platform specific information?
The platform should have implemented  `sai_set_policer_attribute` for cir/cbs attribute.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
