### PR TITLE
'show techsupport' Test Plan

### DIFF
--- a/tests/show_techsupport/README.md
+++ b/tests/show_techsupport/README.md
@@ -1,0 +1,85 @@
+# show techsupport Test Plan
+
+### Table of contents:
+- [Overview](#overview)
+
+  * [Scope](#scope)
+
+  * [Testbed](#testbed)
+
+- [Setup Configurations](#setup-configurations)
+
+- [Test Cases](#test-cases)
+
+- [Execution Example](#execution-example)
+
+
+## Overview
+The purpose is to test execution of “show techsupport” command in a loop. 
+
+Verify that log analyzer, memory and CPU are valid. 
+
+
+### Scope
+The test is targeting a running SONiC system, with basic setup configuration. 
+
+Additional configurations available: **ACL** , **Mirroring**
+
+
+### Testbed
+The test will run on testbeds with all possible topologies. 
+
+
+## Setup configurations
+
+In order to setup additional configurations, the user will insert the wanted configuration name via command line.
+The test will configure and clean all additional configurations after test ends. 
+
+A configuration fixture will call the suitable fixture in order to setup the configurations.
+
+
+Using a parametrized fixture, for each supported configuration named in test execution, the fixture will generate the configuration on the DUT. 
+
+- For additional configurations support, add a fixture to setup the configurations, and execute the test with the suitable configuration name. 
+
+
+
+## Test Cases
+
+### Test - execute show techsupport in a loop
+
+#### Test Objectives
+
+- Configure required configuration
+- Execute "show techsupport" command in a loop 
+- Clean additional configurations 
+
+ Verify CPU, memory and log analyzer are valid. 
+
+
+## Execution Example
+
+
+from sonic-mgmt, docker container, tests folder:
+
+```
+$  py.test --inventory ../ansible/inventory --host-pattern <host> --module-path ../ansible/library/
+--testbed <host>-<topology> --testbed_file ../ansible/testbed.csv --show-capture=no --capture=no
+ --log-cli-level debug -ra -vvvvv techsupport/test_techsupport.py 
+ --loop_num=5 --loop_delay=8 --logs_since=3 --mirror_stage=ingress
+ -k test_techsupport[acl]
+ ```
+ 
+
+
+_user parameters:_ 
+
+
+**loop_num**  - number of times the "show techsupport" command should run.
+
+**loop_delay** - number of seconds to wait between command executions.
+
+**logs_since** - number of minutes to pass to 'show techsupport' command.
+If nothing specified, a random number of minutes will be raffled between 1 and 60. 
+
+**mirror_stage** - ingress/egress. If not mentioned, default is ingress. 

--- a/tests/show_techsupport/README.md
+++ b/tests/show_techsupport/README.md
@@ -27,15 +27,16 @@ Additional configurations available: **ACL** , **Mirroring**
 
 
 ### Testbed
-The test will run on testbeds with all possible topologies. 
+With ACL configurations - The test will run on testbeds with all possible topologies.
 
+With Mirroring configurations  The test will run on testbed with all topologies except ptf32.
 
 ## Setup configurations
 
 In order to setup additional configurations, the user will insert the wanted configuration name via command line.
 The test will configure and clean all additional configurations after test ends. 
 
-A configuration fixture will call the suitable fixture in order to setup the configurations.
+A configuration fixture will call the suitable fixtures in order to setup the configurations.
 
 
 Using a parametrized fixture, for each supported configuration named in test execution, the fixture will generate the configuration on the DUT. 
@@ -66,7 +67,7 @@ from sonic-mgmt, docker container, tests folder:
 $  py.test --inventory ../ansible/inventory --host-pattern <host> --module-path ../ansible/library/
 --testbed <host>-<topology> --testbed_file ../ansible/testbed.csv --show-capture=no --capture=no
  --log-cli-level debug -ra -vvvvv techsupport/test_techsupport.py 
- --loop_num=5 --loop_delay=8 --logs_since=3 --mirror_stage=ingress
+ --loop_num=5 --loop_delay=8 --logs_since=3
  -k test_techsupport[acl]
  ```
  
@@ -82,6 +83,5 @@ _user parameters:_
 **logs_since** - number of minutes to pass to 'show techsupport' command.
 If nothing specified, a random number of minutes will be raffled between 1 and 60. 
 
-**mirror_stage** - ingress/egress. If not mentioned, default is ingress.
 
 

--- a/tests/show_techsupport/README.md
+++ b/tests/show_techsupport/README.md
@@ -82,4 +82,6 @@ _user parameters:_
 **logs_since** - number of minutes to pass to 'show techsupport' command.
 If nothing specified, a random number of minutes will be raffled between 1 and 60. 
 
-**mirror_stage** - ingress/egress. If not mentioned, default is ingress. 
+**mirror_stage** - ingress/egress. If not mentioned, default is ingress.
+
+


### PR DESCRIPTION
README file for 'show techsupport' command test
The purpose is to check memory, CPU and loganalyzer are valid after 'show techsupport' execution in a loop. 
Number of loops, delay between loops and number of minutes the command will take data from (since='x minute ago'), are configurable by test execution command. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR 
Created README file for new 'show techsupport' pytest
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [v] Test case(new/improvement)
run 'show techsupport' in a loop
verify CPU, memory and loganalyzer are valid. 

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
The test is topology-agnostic. 
Additional configurations can be setup according to users needs. 
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

