### PR TITLE
Refactor the bgp_speaker test script

### DIFF
--- a/tests/test_bgp_speaker.py
+++ b/tests/test_bgp_speaker.py
@@ -161,7 +161,6 @@ def test_bgp_speaker_announce_routes(common_setup_teardown, duthost, ptfhost, ip
     bgp_facts = duthost.bgp_facts()['ansible_facts']
     for ip in speaker_ips:
         assert bgp_facts['bgp_neighbors'][str(ip.ip)]['accepted prefixes'] == 1
-    assert bgp_facts['bgp_neighbors'][str(vlan_ips[0].ip)]['accepted prefixes'] == 1
 
     logging.info("Generate route-port map information")
     extra_vars = {'announce_prefix': '10.10.10.0/26',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #1234
Change:
* Replace AnsibleHost with new duthost and ptfhost fixtures to be consistent
  with other platform pytest scripts. We can gradually deprecate the AnsibleHost
  class. With the new fixtures we can run the script with old testbed.csv file
  which does not have the "ptf" column.
* Refactor the script to use setup teardown pattern
* Break the testing into two sub-cases
* Add workaround for known issue https://github.com/Azure/SONiC/issues/387
  Otherwise the ptf test will fail.
* Add more logging
* Improve cleanup

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Tested on Mellanox platform

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
