### PR TITLE
Enhance packet validation for lag member ports on VLAN ansible test.

### DIFF
--- a/ansible/roles/test/files/ptftests/vlan_test.py
+++ b/ansible/roles/test/files/ptftests/vlan_test.py
@@ -40,7 +40,7 @@ class VlanTest(BaseTest):
 
         for vlan_port in self.vlan_ports_list:
             vlan_port["pvid"] = int(vlan_port["pvid"])
-            vlan_port["port_index"] = int(vlan_port["port_index"])
+            vlan_port["is_lag"] = eval(vlan_port["is_lag"])
 
         self.dataplane = ptf.dataplane_instance
         self.test_params = test_params_get()
@@ -49,11 +49,13 @@ class VlanTest(BaseTest):
         for vlan_port in self.vlan_ports_list:
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
                 if int(permit_vlanid) != vlan_port["pvid"]:
-                    self.shell(["ip", "link", "add", "link", "eth%d"%vlan_port["port_index"], 
-                                "name", "eth%d.%s"%(vlan_port["port_index"], permit_vlanid), 
-                                "type", "vlan", "id", str(permit_vlanid)])
-                    self.shell(["ip", "link", "set", 
-                                "eth%d.%s"%(vlan_port["port_index"], permit_vlanid), "up"])
+                    port_list = vlan_port["port_indices"] if vlan_port["is_lag"] else [vlan_port["port_index"]]
+                    for port in port_list:
+                        self.shell(["ip", "link", "add", "link", "eth%d"%port,
+                                    "name", "eth%d.%s"%(port, permit_vlanid),
+                                    "type", "vlan", "id", str(permit_vlanid)])
+                        self.shell(["ip", "link", "set",
+                                    "eth%d.%s"%(port, permit_vlanid), "up"])
 
         self.setUpArpResponder()
         self.log("Start arp_responder")
@@ -68,11 +70,13 @@ class VlanTest(BaseTest):
         d = defaultdict(list)
         for vlan_port in vlan_ports_list:
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
-                if int(permit_vlanid) == vlan_port["pvid"]:
-                    iface = "eth%d" % vlan_port["port_index"]
-                else:
-                    iface = "eth%d.%s" % (vlan_port["port_index"], permit_vlanid)
-                d[iface].append(vlan_port["permit_vlanid"][str(permit_vlanid)]["peer_ip"])
+                port_list = vlan_port["port_indices"] if vlan_port["is_lag"] else [vlan_port["port_index"]]
+                for port in port_list:
+                    if int(permit_vlanid) == vlan_port["pvid"]:
+                        iface = "eth%d" % port
+                    else:
+                        iface = "eth%d.%s" % (port, permit_vlanid)
+                    d[iface].append(vlan_port["permit_vlanid"][str(permit_vlanid)]["peer_ip"])
         with open('/tmp/from_t1.json', 'w') as file:
             json.dump(d, file)
 
@@ -87,13 +91,14 @@ class VlanTest(BaseTest):
         for vlan_port in self.vlan_ports_list:
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
                 if int(permit_vlanid) != vlan_port["pvid"]:
-                    self.shell(["ip", "link", "delete", "eth%d.%d"%(vlan_port["port_index"], int(permit_vlanid))])
-
+                    port_list = vlan_port["port_indices"] if vlan_port["is_lag"] else [vlan_port["port_index"]]
+                    for port in port_list:
+                        self.shell(["ip", "link", "delete", "eth%d.%s"%(port, permit_vlanid)])
         pass
 
     #--------------------------------------------------------------------------
-    def build_icmp_packet(self, vlan_id, 
-                          src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff", 
+    def build_icmp_packet(self, vlan_id,
+                          src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
                           src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
         pkt = simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
                                  eth_dst=dst_mac,
@@ -106,6 +111,35 @@ class VlanTest(BaseTest):
                                  ip_ttl=ttl)
         return pkt
 
+    #--------------------------------------------------------------------------
+    def verify_packets_any_ports(self, test, pkt, ports=[], device_number=0):
+        """
+        Check that a packet is received on _any_ of the specified ports belonging to
+        the given device (default device_number is 0).
+        """
+        received = False
+        failures = []
+        for device, port in ptf_ports():
+            if device != device_number:
+                continue
+            if port in ports:
+                logging.debug("Checking for pkt on device %d, port %d", device_number, port)
+                result = dp_poll(test, device_number=device, port_number=port, exp_pkt=pkt)
+                if isinstance(result, test.dataplane.PollSuccess):
+                    received = True
+                else:
+                    failures.append((port, result))
+
+        verify_no_other_packets(test)
+
+        if not received:
+            def format_failure(port, failure):
+                return "On port %d:\n%s" % (port, failure.format())
+            for f in failures:
+                self.log("\nf: " + str(f))
+            failure_report = "\n".join([format_failure(f[0], f[1]) for f in failures])
+            test.fail("Did not receive expected packet on any of ports %r for device %d.\n%s"
+                        % (ports, device_number, failure_report))
 
     #--------------------------------------------------------------------------
     def verify_icmp_packets(self, vlan_port, vlan_id):
@@ -117,22 +151,41 @@ class VlanTest(BaseTest):
         tagged_pkt = self.build_icmp_packet(vlan_id)
 
         for port in self.vlan_ports_list:
-            if vlan_port["port_index"] == port["port_index"]:
+            vlan_port_list = vlan_port["port_indices"] if vlan_port["is_lag"] else vlan_port["port_index"]
+            port_list = port["port_indices"] if port["is_lag"] else port["port_index"]
+            if vlan_port_list == port_list:
                 # Skip src port
                 continue
-            if port["pvid"] == vlan_id:
-                untagged_dst_ports.append(port["port_index"])
-                untagged_pkts.append(untagged_pkt)
-            elif vlan_id in map(int, port["permit_vlanid"].keys()):
-                tagged_dst_ports.append(port["port_index"])
-                tagged_pkts.append(tagged_pkt)
+            if port["is_lag"]:
+                if port["pvid"] == vlan_id:
+                    self.log("Verify untagged packets from ports " + str(port_list))
+                    self.verify_packets_any_ports(self, untagged_pkt, port_list)
+                else:
+                    self.log("Verify tagged packets from ports " + str(port_list))
+                    self.verify_packets_any_ports(self, tagged_pkt, port_list)
+            else:
+                if port["pvid"] == vlan_id:
+                    untagged_dst_ports.append(port_list)
+                    untagged_pkts.append(untagged_pkt)
+                elif vlan_id in map(int, port["permit_vlanid"].keys()):
+                    tagged_dst_ports.append(port_list)
+                    tagged_pkts.append(tagged_pkt)
         self.log("Verify untagged packets from ports " + str(untagged_dst_ports) + " tagged packets from ports " + str(tagged_dst_ports))
         verify_each_packet_on_each_port(self, untagged_pkts+tagged_pkts, untagged_dst_ports+tagged_dst_ports)
 
     #--------------------------------------------------------------------------
-    def verify_icmp_packets_from_specified_port(self, port_id, vlan_id, src_mac, dst_mac, src_ip, dst_ip, ttl):
+    def verify_icmp_packets_from_specified_lag(self, port_indices, vlan_id, src_mac, src_ip, dst_ip, ttl):
+        self.log("Verify packet from port " + str(port_indices))
+        exp_pkt = []
+        for port in port_indices:
+            pkt = self.build_icmp_packet(vlan_id, src_mac, self.dataplane.get_mac(0, port), src_ip, dst_ip, ttl)
+            exp_pkt.append(pkt)
+        verify_any_packet_any_port(self, exp_pkt, port_indices)
+
+    #--------------------------------------------------------------------------
+    def verify_icmp_packets_from_specified_port(self, port_id, vlan_id, src_mac, src_ip, dst_ip, ttl):
         self.log("Verify packet from port " + str(port_id))
-        pkt = self.build_icmp_packet(vlan_id, src_mac, dst_mac, src_ip, dst_ip, ttl)
+        pkt = self.build_icmp_packet(vlan_id, src_mac, self.dataplane.get_mac(0, port_id), src_ip, dst_ip, ttl)
         verify_packet(self, pkt, port_id)
 
     #--------------------------------------------------------------------------
@@ -141,29 +194,31 @@ class VlanTest(BaseTest):
         vlan_intf_list = self.vlan_intf_list
 
 
-        # Test case #1 
+        # Test case #1
         self.log("Test case #1 starting ...")
-        # Send untagged packets from each port. 
-        # Verify packets egress without tag from ports whose PVID same with ingress port 
+        # Send untagged packets from each port.
+        # Verify packets egress without tag from ports whose PVID same with ingress port
         # Verify packets egress with tag from ports who include VLAN ID but PVID different from ingress port.
         for vlan_port in vlan_ports_list:
             pkt = self.build_icmp_packet(0)
-            self.log("Send untagged packet from {} ...".format(str(vlan_port["port_index"])))
+            src_port = vlan_port["port_indices"][0] if vlan_port["is_lag"] else vlan_port["port_index"]
+            self.log("Send untagged packet from {} ...".format(str(src_port)))
             self.log(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
-            send(self, vlan_port["port_index"], pkt)
+            send(self, src_port, pkt)
             self.verify_icmp_packets(vlan_port, vlan_port["pvid"])
 
         # Test case #2
         self.log("Test case #2 starting ...")
-        # Send tagged packets from each port. 
-        # Verify packets egress without tag from ports whose PVID same with ingress port 
+        # Send tagged packets from each port.
+        # Verify packets egress without tag from ports whose PVID same with ingress port
         # Verify packets egress with tag from ports who include VLAN ID but PVID different from ingress port.
         for vlan_port in vlan_ports_list:
             for permit_vlanid in map(int, vlan_port["permit_vlanid"].keys()):
                 pkt = self.build_icmp_packet(permit_vlanid)
-                self.log("Send tagged({}) packet from {} ...".format(permit_vlanid, str(vlan_port["port_index"])))
+                src_port = vlan_port["port_indices"][0] if vlan_port["is_lag"] else vlan_port["port_index"]
+                self.log("Send tagged({}) packet from {} ...".format(permit_vlanid, str(src_port)))
                 self.log(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
-                send(self, vlan_port["port_index"], pkt)
+                send(self, src_port, pkt)
                 self.verify_icmp_packets(vlan_port, permit_vlanid)
 
         # Test case #3
@@ -175,9 +230,13 @@ class VlanTest(BaseTest):
         masked_invalid_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
 
         for vlan_port in vlan_ports_list:
-            src_port = vlan_port["port_index"]
-            dst_ports = [port["port_index"] for port in vlan_ports_list 
-                                 if port != vlan_port ]
+            src_port = vlan_port["port_indices"][0] if vlan_port["is_lag"] else vlan_port["port_index"]
+            dst_ports = []
+            for port in vlan_ports_list:
+                if port == vlan_port:
+                    continue
+                port_list = port["port_indices"] if port["is_lag"] else [port["port_index"]]
+                dst_ports.extend(port_list)
             self.log("Send invalid tagged packet " + " from " + str(src_port) + "...")
             self.log(invalid_tagged_pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
             send(self, src_port, invalid_tagged_pkt)
@@ -185,21 +244,27 @@ class VlanTest(BaseTest):
             verify_no_packet_any(self, masked_invalid_tagged_pkt, dst_ports)
 
         # Test case #4
-        # Send packets over VLAN interfaces. 
+        # Send packets over VLAN interfaces.
         # Verify packets can be receive on the egress port.
         self.log("Test case #4 starting ...")
 
         target_list = []
         for vlan_port in vlan_ports_list:
             for vlan_id in vlan_port["permit_vlanid"].keys():
-                item = {"vlan_id": int(vlan_id), "port_index": vlan_port["port_index"], 
-                        "peer_ip": vlan_port["permit_vlanid"][vlan_id]["peer_ip"], 
+                item = {"vlan_id": int(vlan_id),
+                        "peer_ip": vlan_port["permit_vlanid"][vlan_id]["peer_ip"],
                         "remote_ip": vlan_port["permit_vlanid"][vlan_id]["remote_ip"],
-                        "pvid": vlan_port["pvid"]}
+                        "pvid": vlan_port["pvid"], "is_lag": vlan_port["is_lag"]}
+
+                if vlan_port["is_lag"]:
+                    item["port_indices"] = vlan_port["port_indices"]
+                else:
+                    item["port_index"] = vlan_port["port_index"]
+
                 target_list.append(item)
 
         for vlan_port in vlan_ports_list:
-            src_port = vlan_port["port_index"]
+            src_port = vlan_port["port_indices"][0] if vlan_port["is_lag"] else vlan_port["port_index"]
             src_mac = self.dataplane.get_mac(0, src_port)
             dst_mac = self.router_mac
             for vlan_id in map(int, vlan_port["permit_vlanid"].keys()):
@@ -214,10 +279,15 @@ class VlanTest(BaseTest):
                     send(self, src_port, pkt)
                     self.log("Send {} packet from {} ...".format("untagged" if vlan_id == 0 else "tagged(%d)"%vlan_id, src_port))
                     self.log(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
-                    self.verify_icmp_packets_from_specified_port(target["port_index"], 
-                                                                 target["vlan_id"] if target["vlan_id"] != target["pvid"] else 0,
-                                                                 dst_mac, self.dataplane.get_mac(0, target["port_index"]),
-                                                                 src_ip, target["peer_ip"], 63)
+                    if target["is_lag"]:
+                        self.verify_icmp_packets_from_specified_lag(target["port_indices"],
+                                                                    target["vlan_id"] if target["vlan_id"] != target["pvid"] else 0,
+                                                                    dst_mac, src_ip, target["peer_ip"], 63)
+                    else:
+                        self.verify_icmp_packets_from_specified_port(target["port_index"],
+                                                                     target["vlan_id"] if target["vlan_id"] != target["pvid"] else 0,
+                                                                     dst_mac, src_ip, target["peer_ip"], 63)
+
                 # Test for for indirectly-connected routing
                 src_ip = vlan_port["permit_vlanid"][str(vlan_id)]["remote_ip"]
                 for target in target_list:
@@ -229,17 +299,21 @@ class VlanTest(BaseTest):
                     self.log("Send {} packet from {} ...".format("untagged" if vlan_id == 0 else "tagged(%d)"%vlan_id, src_port))
                     self.log(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
                     send(self, src_port, pkt)
-                    self.verify_icmp_packets_from_specified_port(target["port_index"], 
-                                                                 target["vlan_id"] if target["vlan_id"] != target["pvid"] else 0,
-                                                                 dst_mac, self.dataplane.get_mac(0, target["port_index"]),
-                                                                 src_ip, target["remote_ip"], 63)
+                    if target["is_lag"]:
+                        self.verify_icmp_packets_from_specified_lag(target["port_indices"],
+                                                                    target["vlan_id"] if target["vlan_id"] != target["pvid"] else 0,
+                                                                    dst_mac, src_ip, target["remote_ip"], 63)
+                    else:
+                        self.verify_icmp_packets_from_specified_port(target["port_index"],
+                                                                     target["vlan_id"] if target["vlan_id"] != target["pvid"] else 0,
+                                                                     dst_mac, src_ip, target["remote_ip"], 63)
 
         # Test case #5
-        # Send ICMP packets to VLAN interfaces. 
+        # Send ICMP packets to VLAN interfaces.
         # Verify ICMP reply packets can be received from ingress port.
         self.log("Test case #5 starting ...")
         for vlan_port in vlan_ports_list:
-            src_port = vlan_port["port_index"]
+            src_port = vlan_port["port_indices"][0] if vlan_port["is_lag"] else vlan_port["port_index"]
             src_mac = self.dataplane.get_mac(0, src_port)
             dst_mac = self.router_mac
             for vlan_id in map(int, vlan_port["permit_vlanid"].keys()):
@@ -265,7 +339,7 @@ class VlanTest(BaseTest):
 
                     masked_exp_pkt = Mask(exp_pkt)
                     masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
-
-                    verify_packets(self, masked_exp_pkt, list(str(src_port)))
-                    self.log("Verify packet from port " + str(src_port))
+                    port_list = vlan_port["port_indices"] if vlan_port["is_lag"] else [vlan_port["port_index"]]
+                    verify_packets(self, masked_exp_pkt, list(str(port_list)))
+                    self.log("Verify packet from port " + str(port_list))
     #--------------------------------------------------------------------------

--- a/ansible/roles/test/templates/vlan_info.j2
+++ b/ansible/roles/test/templates/vlan_info.j2
@@ -1,22 +1,34 @@
---- 
+---
 
 {% set vlan_id_list = [ 100, 200 ] %}
-vlan_ports_list: 
+vlan_ports_list:
 {% for portchannel in minigraph_portchannels.keys()[:2] %}
 {% set members = minigraph_portchannels[portchannel].members %}
+{% set member_port_index_list = [] %}
   - dev: {{ portchannel }}
-    port_index: {{ minigraph_port_indices[members[0]] }}
+{% for member in members %}
+{% set tmp = member_port_index_list.append(minigraph_port_indices[member]) %}
+{% endfor %}
+    port_indices: {{ member_port_index_list }}
+    is_lag: 'True'
     pvid: '{{ vlan_id_list[loop.index0%2] }}'
-    permit_vlanid: 
+    permit_vlanid:
 {% for vlan in vlan_id_list %}
       '{{ vlan }}':
         peer_ip: '192.168.{{ vlan }}.{{ 2 + minigraph_port_indices.keys().index(members[0]) }}'
         remote_ip: '{{vlan}}.1.1.{{ 2 + minigraph_port_indices.keys().index(members[0]) }}'
 {% endfor %}
 {% endfor %}
-{% for port in minigraph_ports.keys()[:2] %}
+{% set normal_ports = minigraph_ports.keys() %}
+{% for portchannel in minigraph_portchannels.keys() %}
+{% for port in minigraph_portchannels[portchannel].members %}
+{% set tmp = normal_ports.remove(port) %}
+{% endfor %}
+{% endfor %}
+{% for port in normal_ports[:2] %}
   - dev: {{ port }}
-    port_index: '{{ minigraph_port_indices[port]}}'
+    port_index: {{ minigraph_port_indices[port]}}
+    is_lag: 'False'
     pvid: '{{ vlan_id_list[loop.index0%2] }}'
     permit_vlanid:
 {% for vlan in vlan_id_list %}


### PR DESCRIPTION
Signed-off-by: Emma Lin <emma_lin@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Enhance packet validation for lag member ports on VLAN ansible test.

Summary:
Fixes #1288 
It expects to receive ICMP reply packet from fixed port of lag (1st member port) on VLAN ansible test script. It shall not specify fixed port to verify, because the ICMP reply packet may come from any port of lag.

Enhance packet validation for lag member ports:
- vlan_info.j2
  1. Add new field 'is_lag' to identify interface type.
  2. Lag interface: replace 'port_index' with 'port_indices' to take all lag member ports
  3. Normal port interface: only take the port which is not lag member 

- vlan_test.py
  1. If the verify interface is lag, verify packets on all lag member ports. When one of lag member ports receives expected packet, the test shall be passed.
  2. On test case #4, it tests ICMP routing, the DA of ICMP reply packet may equal to one of lag port interfaces on ptf server (because dut may send ARP packet from one of lag member port). So the test shall be passed when following conditions are matched:
      - the ICMP reply packet is come from one of lag member port interface
      - the DA of ICMP reply packet is equal to one of lag member port's MAC

### Type of change
- [x]  Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Run ansible vlan test with t0-116 topology and check the test result. No matter ICMP reply packet is come from which lag member port, the test result is passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
