### PR TITLE
[platform/test_sfp]Operate SFP only once for split ports when resetting or setting LPM

### DIFF
--- a/tests/platform/files/getportmap.py
+++ b/tests/platform/files/getportmap.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import sonic_platform_base.sonic_sfp.sfputilhelper
+import json
+from sonic_daemon_base.daemon_base import DaemonBase
+db = DaemonBase()
+port_config_path = db.get_path_to_port_config_file()
+platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
+platform_sfputil.read_porttab_mappings(port_config_path)
+print json.dumps(platform_sfputil.logical_to_physical)
+

--- a/tests/platform/files/getportmap.py
+++ b/tests/platform/files/getportmap.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python
+# This script runs on the DUT and is intended to retrieve the portmapping from logical interfaces to physical ones
+# The way the port mapping retrieved is exactly the same as what xcvrd does
+
 import sonic_platform_base.sonic_sfp.sfputilhelper
 import json
 from sonic_daemon_base.daemon_base import DaemonBase
+
+# load and parse the port configuration file on DUT
 db = DaemonBase()
 port_config_path = db.get_path_to_port_config_file()
 platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
 platform_sfputil.read_porttab_mappings(port_config_path)
+
+# print the mapping to stdout in json format
 print json.dumps(platform_sfputil.logical_to_physical)
 
+# json will be loaded by sonic-mgmt

--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -9,6 +9,7 @@ import re
 import os
 import time
 import copy
+import json
 
 import pytest
 
@@ -44,6 +45,25 @@ def parse_eeprom(output_lines):
     return res
 
 
+def get_port_map(testbed_devices):
+    """
+    @summary: Get the port mapping info from the DUT
+    @return: a dictionary containing the port map
+    """
+    # copy the helper to DUT
+    ans_host = testbed_devices["dut"]
+    src_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'files/getportmap.py')
+    dest_path = os.path.join('/usr/share/sonic/device', ans_host.facts['platform'], 'plugins/getportmap.py')
+    ans_host.copy(src=src_path, dest=dest_path)
+
+    # execute command on the DUT to get portmap
+    get_portmap_cmd = 'docker exec pmon python /usr/share/sonic/platform/plugins/getportmap.py'
+    portmap_json_string = ans_host.command(get_portmap_cmd)["stdout"]
+
+    # parse the json
+    return json.loads(portmap_json_string)
+
+
 def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     """
     @summary: Check SFP status and configure SFP
@@ -64,6 +84,9 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
     cmd_sfp_reset = "sudo sfputil reset"
     cmd_xcvr_presence = "show interface transceiver presence"
     cmd_xcvr_eeprom = "show interface transceiver eeprom"
+
+    portmap = get_port_map(testbed_devices)
+    logging.info("Got portmap {}".format(portmap))
 
     logging.info("Check output of '%s'" % cmd_sfp_presence)
     sfp_presence = ans_host.command(cmd_sfp_presence)
@@ -94,7 +117,14 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
     logging.info("Test '%s <interface name>'" % cmd_sfp_reset)
+    reseted_physical_ports = set()
     for intf in conn_graph_facts["device_conn"]:
+        phy_intf = portmap[intf][0]
+        if phy_intf in reseted_physical_ports:
+            logging.info("skip reset {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+            continue
+        reseted_physical_ports.add(phy_intf)
+        logging.info("resetting {} physical interface {}".format(intf, phy_intf))
         reset_result = ans_host.command("%s %s" % (cmd_sfp_reset, intf))
         assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
         time.sleep(5)
@@ -130,6 +160,9 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
     cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
     cmd_sfp_set_lpmode = "sudo sfputil lpmode"
 
+    portmap = get_port_map(testbed_devices)
+    logging.info("Got portmap {}".format(portmap))
+
     logging.info("Check output of '%s'" % cmd_sfp_show_lpmode)
     lpmode_show = ans_host.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
@@ -139,7 +172,14 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
+    changed_physical_ports = set()
     for intf in conn_graph_facts["device_conn"]:
+        phy_intf = portmap[intf][0]
+        if phy_intf in changed_physical_ports:
+            logging.info("skip set {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+            continue
+        changed_physical_ports.add(phy_intf)
+        logging.info("setting {} physical interface {}".format(intf, phy_intf))
         new_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
         lpmode_set_result = ans_host.command("%s %s %s" % (cmd_sfp_set_lpmode, new_lpmode, intf))
         assert lpmode_set_result["rc"] == 0, "'%s %s %s' failed" % (cmd_sfp_set_lpmode, new_lpmode, intf)
@@ -153,7 +193,14 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
+    changed_physical_ports = set()
     for intf in conn_graph_facts["device_conn"]:
+        phy_intf = portmap[intf][0]
+        if phy_intf in changed_physical_ports:
+            logging.info("skip restore {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+            continue
+        changed_physical_ports.add(phy_intf)
+        logging.info("restoring {} physical interface {}".format(intf, phy_intf))
         new_lpmode = original_lpmode[intf].lower()
         lpmode_set_result = ans_host.command("%s %s %s" % (cmd_sfp_set_lpmode, new_lpmode, intf))
         assert lpmode_set_result["rc"] == 0, "'%s %s %s' failed" % (cmd_sfp_set_lpmode, new_lpmode, intf)

--- a/tests/platform/test_sfp.py
+++ b/tests/platform/test_sfp.py
@@ -139,13 +139,13 @@ def test_check_sfp_status_and_configure_sfp(testbed_devices, conn_graph_facts):
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
     logging.info("Test '%s <interface name>'" % cmd_sfp_reset)
-    reseted_physical_ports = set()
+    tested_physical_ports = set()
     for intf in conn_graph_facts["device_conn"]:
         phy_intf = portmap[intf][0]
-        if phy_intf in reseted_physical_ports:
-            logging.info("skip reset {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+        if phy_intf in tested_physical_ports:
+            logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
             continue
-        reseted_physical_ports.add(phy_intf)
+        tested_physical_ports.add(phy_intf)
         logging.info("resetting {} physical interface {}".format(intf, phy_intf))
         reset_result = ans_host.command("%s %s" % (cmd_sfp_reset, intf))
         assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
@@ -194,13 +194,13 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
-    changed_physical_ports = set()
+    tested_physical_ports = set()
     for intf in conn_graph_facts["device_conn"]:
         phy_intf = portmap[intf][0]
-        if phy_intf in changed_physical_ports:
-            logging.info("skip set {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+        if phy_intf in tested_physical_ports:
+            logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
             continue
-        changed_physical_ports.add(phy_intf)
+        tested_physical_ports.add(phy_intf)
         logging.info("setting {} physical interface {}".format(intf, phy_intf))
         new_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
         lpmode_set_result = ans_host.command("%s %s %s" % (cmd_sfp_set_lpmode, new_lpmode, intf))
@@ -215,13 +215,13 @@ def test_check_sfp_low_power_mode(testbed_devices, conn_graph_facts):
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
-    changed_physical_ports = set()
+    tested_physical_ports = set()
     for intf in conn_graph_facts["device_conn"]:
         phy_intf = portmap[intf][0]
-        if phy_intf in changed_physical_ports:
-            logging.info("skip restore {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+        if phy_intf in tested_physical_ports:
+            logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
             continue
-        changed_physical_ports.add(phy_intf)
+        tested_physical_ports.add(phy_intf)
         logging.info("restoring {} physical interface {}".format(intf, phy_intf))
         new_lpmode = original_lpmode[intf].lower()
         lpmode_set_result = ans_host.command("%s %s %s" % (cmd_sfp_set_lpmode, new_lpmode, intf))


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)
For split ports, only operate them once when testing reset and low power mode.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
1. introduce a snippet of script which retrieves port mapping from DUT
2. get_port_map:
  - for the first time being called, it copies the script to the DUT, executes it on DUT and then parses the result to construct the port mapping. It also saves the map for future use
  - for the following time being called, it just returns the saved map.
3. when reset/set LPM for SFP modules, it uses the following logic to avoid repeating operating the physical SFP modules offering split ports:
```
    operated_phy_set = {}
    for each logical port
        phyport = port_mapping[logical]
        if phyport in operated_phy_set,
            skip
        else
            operate the SFP
            add phyport to operated_phy_set
```
#### How did you verify/test it?
run test_sfp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
[2100.split.extracted.2.txt](https://github.com/Azure/sonic-mgmt/files/4079942/2100.split.extracted.2.txt)
[2700.split.extract.txt](https://github.com/Azure/sonic-mgmt/files/4079943/2700.split.extract.txt)
[3800.split.extract.txt](https://github.com/Azure/sonic-mgmt/files/4079944/3800.split.extract.txt)
[2010.split.extract.txt](https://github.com/Azure/sonic-mgmt/files/4079945/2010.split.extract.txt)
[2100.split.extract.txt](https://github.com/Azure/sonic-mgmt/files/4079946/2100.split.extract.txt)
