### PR TITLE
Fix interface name key error for test_interfaces.py.

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -43,7 +43,10 @@ def verify_ip_address(host_facts, intfs):
         if intf.has_key('attachto'):
             ans_ifname = "ansible_%s" % intf['attachto']
         else:
-            ans_ifname = "ansible_%s" % intf['name']
+            if  intf['name'] == 'Loopback0':
+                ans_ifname = "ansible_lo"
+            else:
+                ans_ifname = "ansible_%s" % intf['name']
 
         ip = IPAddress(intf['addr'])
         if ip.version == 4:


### PR DESCRIPTION
Summary:
Fixes # (issue)
Pytest run test_interface.py test, it has key error fail.
I add an judgement that intf name is Loopback0, then ans_ifname is ansible_lo.

host_facts = {'ansible_Bridge': {'active': True, 'device': u'Bridge', 'features': {'busy_poll': u'off [fixed]', 'fcoe_mtu': u'off [...ve_offload': u'on', 'generic_segmentation_offload': u'off [requested on]', ...}, 'hw_timestamp_filters': [], ...}, ...}
intfs = [{'addr': u'10.1.0.32', 'mask': u'255.255.255.255', 'name': u'Loopback0', 'prefixlen': 32}, {'addr': u'fc00:1::32', 'mask': u'128', 'name': u'Loopback0', 'prefixlen': 128}]

    def verify_ip_address(host_facts, intfs):
        for intf in intfs:
            if intf.has_key('attachto'):
                ans_ifname = "ansible_%s" % intf['attachto']
            else:
                ans_ifname = "ansible_%s" % intf['name']
    
            ip = IPAddress(intf['addr'])
            if ip.version == 4:
                addrs = []
>               addrs.append(host_facts[ans_ifname]['ipv4'])
E               KeyError: u'ansible_Loopback0'

test_interfaces.py:56: KeyError
### Type of change

- [v] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Fix interface name key error for test_interfaces.py.
#### How did you verify/test it?
I run pytest on broadcom platform.
 =========== 1 passed in 14.73 seconds  ===========
4_t0 test_interfaces.py  --show-capture=stdout --duration=0 -v  lab --testbed=1-4
============test session starts  ===========
platform linux2 -- Python 2.7.12, pytest-4.6.7, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/sonic/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item

test_interfaces.py::test_interfaces PASSED                               [100%]

============ slowest test durations ===========

#### Any platform specific information?
no
#### Supported testbed topology if it's a new test case?
no
