### PR TITLE
[pytest snmp] convert test_snmp_interfaces to use config_facts

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -1,28 +1,26 @@
 from ansible_host import AnsibleHost
 
-def test_snmp_interfaces(ansible_adhoc, testbed, creds):
+def test_snmp_interfaces(ansible_adhoc, duthost, creds):
     """compare the bgp facts between observed states and target state"""
 
-    hostname = testbed['dut']
-    ans_host = AnsibleHost(ansible_adhoc, hostname)
     lhost = AnsibleHost(ansible_adhoc, 'localhost', True)
 
-    hostip = ans_host.host.options['inventory_manager'].get_host(hostname).vars['ansible_host']
+    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
     snmp_facts = lhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
-    mg_facts   = ans_host.minigraph_facts(host=hostname)['ansible_facts']
+    config_facts  = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
     snmp_ifnames = [ v['name'] for k, v in snmp_facts['snmp_interfaces'].items() ]
     print snmp_ifnames
 
     # Verify all physical ports in snmp interface list
-    for k, v in mg_facts['minigraph_ports'].items():
-        assert mg_facts['minigraph_port_name_to_alias_map'][k] in snmp_ifnames
+    for _, alias in config_facts['port_name_to_alias_map'].items():
+        assert alias in snmp_ifnames
 
     # Verify all port channels in snmp interface list
-    for k, v in mg_facts['minigraph_portchannels'].items():
-        assert k in snmp_ifnames
+    for po_name in config_facts.get('PORTCHANNEL', {}):
+        assert po_name in snmp_ifnames
     
     # Verify management port in snmp interface list
-    assert mg_facts['minigraph_mgmt_interface']['alias'] in snmp_ifnames
-    print mg_facts['minigraph_mgmt_interface']
+    for name in config_facts.get('MGMT_INTERFACE', {}):
+        assert name in snmp_ifnames


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Depends on #1313 
Summary:
 - Use `config_facts` instead of `minigraph_facts` in this test, enabling it to run on `l2 preset` config

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
`pytest --module-path=../ansible/library --inventory=../ansible/inventory --testbed_file=testbed.csv --testbed=${SWITCH}-${TOPO} --host-pattern=${SWITCH}-${TOPO} snmp/test_snmp_interfaces.py  --log-file=logfile.log --log-level=INFO `
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
