### PR TITLE
 Adding scripts to test sflow

### DIFF
--- a/ansible/roles/test/files/ptftests/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/sflow_test.py
@@ -1,0 +1,265 @@
+#ptf --test-dir ptftests sflow_test --platform-dir ptftests --platform remote -t "enabled_sflow_interfaces=[u'Ethernet116', u'Ethernet124', u'Ethernet112', u'Ethernet120'];active_collectors=[];dst_port=3;testbed_type='t0';router_mac=u'52:54:00:f7:0c:d0';sflow_ports_file='/tmp/sflow_ports.json';agent_id=u'10.250.0.101'" --relax --debug info --log-file /tmp/TestSflowCollector.test_two_collectors.log --socket-recv-size 16384
+#/usr/bin/python /usr/bin/ptf --test-dir ptftests sflow_test --platform-dir ptftests --platform remote -t "enabled_sflow_interfaces=[u'Ethernet116', u'Ethernet124', u'Ethernet112', u'Ethernet120'];active_collectors=['collector1'];dst_port=3;testbed_type='t0';router_mac='52:54:00:f7:0c:d0';sflow_ports_file='/tmp/sflow_ports.json';agent_id=u'10.250.0.101'" --relax --debug info --log-file /tmp/TestSflow.log --socket-recv-size 16384
+
+import ptf
+import ptf.packet as scapy
+import ptf.dataplane as dataplane
+import json
+from ptf import config
+from ptf.base_tests import BaseTest
+import ptf.dataplane as dataplane
+from ptf.testutils import *
+from ptf.mask import Mask
+import ipaddress
+from json import loads
+import threading
+import time
+import select
+from collections import Counter
+import logging 
+import ast 
+
+class SflowTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = test_params_get()
+    #--------------------------------------------------------------------------
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.router_mac = self.test_params['router_mac']
+        self.dst_port = self.test_params['dst_port']
+
+        if 'enabled_sflow_interfaces' in self.test_params:
+            self.enabled_intf = self.test_params['enabled_sflow_interfaces']
+        self.agent_id = self.test_params['agent_id']
+        self.active_col = self.test_params['active_collectors']
+        self.sflow_interfaces = []
+        self.sflow_ports_file = self.test_params['sflow_ports_file']
+        if 'polling_int' in self.test_params:
+            self.poll_tests = True
+            self.polling_int =  self.test_params['polling_int']
+        else: 
+            self.poll_tests = False
+        with open(self.sflow_ports_file) as fp:
+            self.interfaces = json.load(fp)
+            for port,index in self.interfaces.items():
+                self.sflow_interfaces.append(index["ptf_indices"])
+        logging.info("Sflow interfaces under Test : %s" %self.interfaces)
+        self.collectors=['collector0','collector1']
+        for param,value  in self.test_params.items():
+            logging.info("%s : %s" %(param,value) )
+    def tearDown(self):
+        self.cmd(["supervisorctl", "stop", "arp_responder"])
+        self.cmd(["killall" , "sflowtool"])
+    #--------------------------------------------------------------------------
+    def generate_ArpResponderConfig(self):
+        config = {}
+        vlan_ip_prefixes = ['192.168.0.2','192.168.0.3','192.168.0.4']
+        config['eth%d' %self.dst_port] = ['192.168.0.4']
+        with open('/tmp/sflow_arpresponder.conf', 'w') as fp:
+             json.dump(config, fp)
+        self.cmd(["supervisorctl", "restart", "arp_responder"])
+
+    #--------------------------------------------------------------------------
+
+    def cmd(self, cmds):
+        process = subprocess.Popen(cmds,
+                                   shell=False,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+        return_code = process.returncode
+
+        return stdout, stderr, return_code
+
+    #--------------------------------------------------------------------------
+
+    def read_data(self, collector, sflow_port=['6343']):
+        """
+        Starts sflowtool with the corresponding port and saves the data to file for processing
+        """
+        outfile='/tmp/%s'%collector
+        with open(outfile , 'w') as f:
+          process = subprocess.Popen(
+                  ['/usr/local/bin/sflowtool','-j','-p'] + sflow_port ,
+                  stdout=f,
+                  stderr=subprocess.STDOUT,
+                  shell = False
+                  )
+   
+          flow_count = 0
+          counter_count = 0
+          port_sample ={}
+          port_sample[collector]={}
+          port_sample[collector]['FlowSample'] = {}
+          port_sample[collector]['CounterSample'] = {}
+          logging.info("Collector %s starts collecting ......"%collector)
+          while not  self.stop_collector :
+              continue
+        process.terminate()
+        f.close()
+        with open(outfile , 'r') as sflow_data:
+             for line in sflow_data:
+                j = json.dumps(ast.literal_eval(line))
+                datagram = json.loads(j)
+                agent= datagram["agent"]
+                samples = datagram["samples"]
+                for sample in samples:
+                    sampleType = sample["sampleType"]
+                    if sampleType == "FLOWSAMPLE":
+                        flow_count+=1
+                        port_sample[collector]['FlowSample'][flow_count] = sample
+                    elif sampleType == "COUNTERSSAMPLE":
+                        counter_count+=1
+                        port_sample[collector]['CounterSample'][counter_count] = sample
+                        port_sample[collector]['CounterSample'][counter_count]['agent_id'] = agent
+        sflow_data.close()
+        port_sample[collector]['counter_count'] = counter_count
+        port_sample[collector]['flow_count'] = flow_count
+        port_sample[collector]['total_count'] = counter_count + flow_count
+        logging.info( "%s Sampled Packets : Total flow samples -> %s Total counter samples -> %s" %(collector,flow_count,counter_count))
+        return(port_sample)
+    #--------------------------------------------------------------------------
+
+    def collector_0(self):
+        collector='collector0'
+        self.collector0_samples=self.read_data('collector0')
+    #--------------------------------------------------------------------------
+
+
+    def collector_1(self):
+        collector = 'collector1'
+        self.collector1_samples=count=self.read_data('collector1',['6344'])
+
+    #--------------------------------------------------------------------------
+
+    def packet_analyzer(self, port_sample, collector, poll_test):
+        logging.info("Analysing collector  %s"%collector)
+        data= {} 
+        data['total_samples'] = 0
+        data['total_flow_count'] = port_sample[collector]['flow_count']
+        data['total_counter_count'] = port_sample[collector]['counter_count']
+        data['total_samples'] =  port_sample[collector]['flow_count'] + port_sample[collector]['counter_count'] 
+        logging.info(data)
+        if data['total_flow_count']: 
+            data['flow_port_count'] = Counter(k['inputPort']  for k  in port_sample[collector]['FlowSample'].values())
+
+        if collector not in self.active_col:
+           logging.info("....%s : Sample Packets are not expected , received %s flow packets  and %s counter packets"%(collector,data['total_flow_count'],data['total_counter_count']))
+           self.assertTrue(data['total_samples'] == 0 ,
+                    "Packets are not expected from %s , but received %s flow packets  and %s counter packets" %(collector,data['total_flow_count'],data['total_counter_count']))
+        else:
+            if poll_test:
+                if self.polling_int == 0:
+                    logging.info("....Polling is disabled , Number of counter samples collected %s"%data['total_counter_count'])
+                    self.assertTrue(data['total_counter_count'] == 0,
+                        "Received %s counter packets when polling is disabled in %s"%(data['total_counter_count'],collector))
+                else: 
+                    logging.info("..Analyzing polling test counter packets")
+                    self.assertTrue(data['total_samples'] != 0 ,
+                        "....Packets are not received in active collector  ,%s"%collector)
+                    self.analyze_counter_sample(data,collector,self.polling_int,port_sample)
+            else:
+                logging.info("Analyzing flow samples in collector %s"%collector)
+                self.assertTrue(data['total_samples'] != 0 ,
+                    "....Packets are not received in active collector  ,%s"%collector)
+                self.analyze_flow_sample(data,collector)
+        return data
+
+    #--------------------------------------------------------------------------
+
+    def analyze_counter_sample(self, data, collector, polling_int, port_sample):
+        counter_sample = {}
+        for intf in self.interfaces.keys():
+             counter_sample[intf] = 0
+        self.assertTrue(data['total_counter_count'] >0, "No counter packets are received in collector %s"%collector)
+        for i in range(1,data['total_counter_count']+1):
+            rcvd_agent_id = port_sample[collector]['CounterSample'][i]['agent_id']
+            self.assertTrue(rcvd_agent_id == self.agent_id , "Agent id in Sampled packet is not expected . Expected :  %s , received : %s"%(self.agent_id,rcvd_agent_id))
+            elements = port_sample[collector]['CounterSample'][i]['elements']
+            for element  in elements:
+                try:
+                    if 'ifName' in element  and element['ifName'] in  self.interfaces.keys():
+                        intf =   element['ifName']
+                        counter_sample[intf] +=1
+                except KeyError:
+                    pass
+        logging.info("....%s : Counter samples collected for Individual  ports  = %s" %(collector,counter_sample))
+        for port in counter_sample:
+            # checking  for max  2 samples instead of 1 considering  initial time delay before tests as the counter sampling is random and non-deterministic over period of polling time
+            self.assertTrue(1 <= counter_sample[port] <= 2," %s counter sample packets are collected  in %s seconds of  polling interval in port %s instead of 1 or 2  "%(counter_sample[port],self.polling_int,port))
+                
+    #---------------------------------------------------------------------------
+
+    def analyze_flow_sample(self, data, collector): 
+        logging.info("packets collected from interfaces ifindex : %s" %data['flow_port_count'])
+        logging.info("Expected number of packets from each port : %s to %s"%(50*0.6,50*1.4))
+        for port in self.interfaces:
+            ifindex = self.interfaces[port]['ifindex'] 
+            logging.info("....%s : Flow packets collected from port %s = %s"%(collector,port,data['flow_port_count'][ifindex]))
+            if port in self.enabled_intf :
+                # Checking samples with tolerance of 40 % as the sampling is random and  not deterministic.Over many samples it should converge to a mean of 1:N
+                # Number of packets sent = 50 * sampling rate of interface 
+                self.assertTrue(50*0.6 <= data['flow_port_count'][ifindex] <= 50*1.4 ,
+                        "Expected Number of samples are not collected  collected from Interface %s  in collector %s , Received %s" %(port,collector,data['flow_port_count'][ifindex]))
+            else:
+                self.assertTrue(data['flow_port_count'][ifindex] == 0 ,
+                               "Packets are collected from Non Sflow interface %s in collector %s"%(port,collector)) 
+
+    #---------------------------------------------------------------------------
+
+    def sendTraffic(self):
+        self.src_ip_list = ['192.158.8.1','192.168.16.1', '192.168.24.1','192.168.32.1']
+        ip_dst_addr = '192.168.0.4'
+        src_mac = self.dataplane.get_mac(0, 0)
+        pktlen=100
+        #send 50*sampling_rate packets in each interface for better  analysis
+        for j in range(0,50,1):
+            index = 0
+            for intf in self.interfaces:
+                ip_src_addr = str(self.src_ip_list[index])
+                src_port = self.interfaces[intf]['ptf_indices']
+                dst_port = self.dst_port
+                tcp_pkt = simple_tcp_packet(pktlen=pktlen,
+                            eth_dst=self.router_mac,
+                            eth_src=src_mac,
+                            ip_src=ip_src_addr,
+                            ip_dst=ip_dst_addr,
+                            ip_ttl=64)
+                no_of_packets=self.interfaces[intf]['sample_rate']
+                send(self,src_port,tcp_pkt,count=no_of_packets)
+                index+=1
+            pktlen += 10 # send traffic with different packet sizes
+
+    #--------------------------------------------------------------------------
+
+    def runTest(self):
+        self.generate_ArpResponderConfig()
+        time.sleep(1)
+        self.stop_collector=False
+        thr1 = threading.Thread(target=self.collector_0)
+        thr2 = threading.Thread(target=self.collector_1)
+        thr1.start()
+        time.sleep(2)
+        thr2.start()
+        #wait for the collectors to initialise
+        time.sleep(5)
+        pktlen=100
+        if self.poll_tests:
+           if self.polling_int==0:
+              time.sleep(20)
+           else:
+               #wait for polling time for collector to collect packets 
+               logging.info("Waiting for % seconds of polling interval"%self.polling_int)
+               time.sleep(self.polling_int)
+        else: 
+           self.sendTraffic()
+           time.sleep(5)
+        self.stop_collector = True
+        thr1.join()
+        thr2.join()
+        logging.debug(self.collector0_samples)
+        logging.debug(self.collector1_samples)
+        self.packet_analyzer(self.collector0_samples,'collector0',self.poll_tests)
+        self.packet_analyzer(self.collector1_samples,'collector1',self.poll_tests)
+ 

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -1,0 +1,451 @@
+import pytest
+import logging
+import time
+import json
+import re
+from ptf_runner import ptf_runner
+from common import reboot
+from common  import config_reload
+from common.utilities import wait_until
+from netaddr import *
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope='module',autouse=True)
+def setup(duthost, ptfhost):
+    global var
+    var = {}
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    var['host_facts']  = duthost.setup()['ansible_facts']
+    vlan_dict = mg_facts['minigraph_vlans']
+    var['test_ports'] = []
+    var['ptf_test_indices'] = []
+    var['sflow_ports'] = {}
+
+    for i in range(0,3,1):
+        var['test_ports'].append(vlan_dict['Vlan1000']['members'][i])
+        var['ptf_test_indices'].append(mg_facts['minigraph_port_indices'][vlan_dict['Vlan1000']['members'][i]])
+
+    collector_ips = ['20.1.1.2' ,'30.1.1.2']
+    var['dut_intf_ips'] = ['20.1.1.1','30.1.1.1']
+    var['mgmt_ip'] = mg_facts['minigraph_mgmt_interface']['addr']
+    var['lo_ip'] =  mg_facts['minigraph_lo_interfaces'][0]['addr']
+ 
+    config_dut_ports(duthost,var['test_ports'][0:2],vlan=1000)
+ 
+    for port_channel, interfaces in mg_facts['minigraph_portchannels'].items():
+        port = interfaces['members'][0]
+        var['sflow_ports'][port] = {}
+        var['sflow_ports'][port]['ifindex'] = get_ifindex(duthost,port)
+        var['sflow_ports'][port]['ptf_indices'] = mg_facts['minigraph_port_indices'][interfaces['members'][0]]
+        var['sflow_ports'][port]['sample_rate'] = 512
+    var['portmap'] = json.dumps(var['sflow_ports'])
+
+    udp_port = 6343
+    for i in range(0,2,1):
+        var['collector%s'%i] = {}
+        var['collector%s'%i]['name'] = 'collector%s'%i
+        var['collector%s'%i]['ip_addr'] = collector_ips[i]
+        var['collector%s'%i]['port'] = udp_port
+        udp_port += 1
+    collector_ports = var['ptf_test_indices'][0:2]
+    setup_ptf(ptfhost,collector_ports)
+
+    # -------- Testing ----------
+    yield
+    # -------- Teardown ----------
+    config_reload(duthost, config_source='minigraph', wait=120)
+    
+ # ----------------------------------------------------------------------------------
+def setup_ptf(ptfhost, collector_ports):
+    root_dir   = "/root"
+    extra_vars = {'arp_responder_args' : '--conf /tmp/sflow_arpresponder.conf'}
+    ptfhost.host.options['variable_manager'].extra_vars = extra_vars
+    ptfhost.template(src="../ansible/roles/test/templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
+    ptfhost.copy(src="ptftests", dest=root_dir)
+    ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py", dest="/opt")
+    ptfhost.shell('supervisorctl reread')
+    ptfhost.shell('supervisorctl update')
+    for i in range(len(collector_ports)): 
+        ptfhost.shell('ifconfig eth%s %s/24' %(collector_ports[i],var['collector%s'%i]['ip_addr'])) 
+    ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
+
+# ----------------------------------------------------------------------------------
+
+def config_dut_ports(duthost, ports, vlan):
+   # https://github.com/Azure/sonic-buildimage/issues/2665 
+   # Introducing config vlan member add and remove for the test port due to above mentioned PR. 
+   # Even though port is deleted from vlan , the port shows its master as Bridge upon assigning ip address. 
+   # Hence config reload is done as workaround. ##FIXME
+    for i in range(len(ports)):
+        duthost.command('config vlan member add %s %s' %(vlan,ports[i]))
+        duthost.command('config vlan member del %s %s' %(vlan,ports[i]))
+        duthost.command('config interface ip add %s %s/24' %(ports[i],var['dut_intf_ips'][i]))
+    duthost.command('config save -y')
+    config_reload(duthost, config_source='config_db', wait=120)
+    time.sleep(5)
+
+# ----------------------------------------------------------------------------------
+
+def get_ifindex(duthost, port):
+     ifindex = duthost.shell('cat /sys/class/net/%s/ifindex' %port)['stdout']
+     return ifindex 
+# ----------------------------------------------------------------------------------
+
+def config_sflow(duthost, sflow_status='enable'):
+    duthost.shell('config sflow %s'%sflow_status)
+    time.sleep(2)
+
+# ----------------------------------------------------------------------------------
+
+def config_sflow_interfaces(duthost, intf, **kwargs):
+ 
+    if 'status' in kwargs:
+        duthost.shell('config sflow interface %s %s'%(kwargs['status'],intf))
+    if 'sample_rate' in kwargs: 
+        duthost.shell('config sflow interface sample-rate %s %s' %(intf,kwargs['sample_rate']))
+
+# ----------------------------------------------------------------------------------
+
+def config_sflow_collector(duthost, collector, config):
+     collector = var[collector]
+     if config == 'add': 
+          duthost.shell('config sflow collector add %s %s --port %s ' %(collector['name'],collector['ip_addr'],collector['port']))
+     elif config == 'del':
+          duthost.shell('config sflow collector  del %s' %collector['name'])
+# ----------------------------------------------------------------------------------
+
+
+
+def verify_show_sflow(duthost, status, **kwargs):
+    show_sflow = duthost.shell('show sflow')['stdout']
+    assert re.search("sFlow Admin State:\s+%s"%status,show_sflow), "Sflow Admin State is not %s"%status
+    if 'polling_int' in kwargs:
+        assert re.search("sFlow Polling Interval:\s+%s"%kwargs['polling_int'],show_sflow) , "Sflow Polling Interval is not %s"%kwargs['polling_int']
+    if 'agent_id' in kwargs:
+        assert re.search("sFlow AgentID:\s+%s"%kwargs['agent_id'],show_sflow), "Sflow Agent Id is not %s" %kwargs['agent_id']
+    if 'collector' in kwargs:
+        collector = kwargs['collector']
+        if len(collector) is None: 
+            assert re.search("0 Collectors configured",show_sflow)," Expected 0 collectors , but collectors are present"
+        else: 
+            assert re.search("%s Collectors configured:"%len(collector),show_sflow) ,"Number of Sflow collectors should be %s"%len(collector)
+            for col  in collector: 
+                assert re.search("Name:\s+%s\s+IP addr:\s%s\s+UDP port:\s%s"%(var[col]['name'],var[col]['ip_addr'],var[col]['port']),show_sflow) , "col %s is not properly Configured" %col
+    
+# ----------------------------------------------------------------------------------
+
+def verify_sflow_interfaces(duthost, intf, status, sampling_rate):
+    show_sflow_intf = duthost.shell('show sflow interface')['stdout']
+    assert re.search("%s\s+\|\s+%s\s+\|\s+%s"%(intf,status,sampling_rate),show_sflow_intf),"Interface %s is not properly configured"%intf
+
+# ----------------------------------------------------------------------------------
+
+@pytest.fixture
+def partial_ptf_runner(request, ptfhost, testbed):
+    def _partial_ptf_runner(**kwargs):
+        params = {'testbed_type': testbed['topo']['name'],
+                  'router_mac': var['host_facts']['ansible_Ethernet0']['macaddress'],
+                  'dst_port' : var['ptf_test_indices'][2],
+                  'agent_id' : var['mgmt_ip'],
+                  'sflow_ports_file' : "/tmp/sflow_ports.json"}
+        params.update(kwargs)
+        ptf_runner(host=ptfhost,
+                   testdir="ptftests",
+                   platform_dir="ptftests",
+                   testname="sflow_test",
+                   params=params,
+                   socket_recv_size=16384,
+                   log_file="/tmp/{}.{}.log".format(request.cls.__name__, request.function.__name__))
+
+    return _partial_ptf_runner
+
+# ----------------------------------------------------------------------------------
+@pytest.fixture(scope='class')
+def sflowbase_config(duthost, testbed):
+    config_sflow(duthost,'enable')
+    config_sflow_collector(duthost,'collector0','add')
+    config_sflow_collector(duthost,'collector1','add')
+    duthost.shell("config sflow polling-interval 20")
+    for port in var['sflow_ports']:
+        config_sflow_interfaces(duthost,port,status='enable',sample_rate='512')
+    time.sleep(2)
+    verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
+    for intf in var['sflow_ports']:
+        verify_sflow_interfaces(duthost,intf,'up',512)
+
+
+
+# ----------------------------------------------------------------------------------
+
+class TestSflowCollector():
+    """
+    Test Sflow with 2 collectors , adding or removibg collector and verify collector samples 
+    """
+
+    def test_sflow_config(self, duthost, partial_ptf_runner):
+        # Enable sflow globally and enable sflow on 4 test interfaces 
+        # add single collector , send traffic and check samples are received in collector 
+        config_sflow(duthost,'enable')
+        config_sflow_collector(duthost,'collector0','add')
+        duthost.command("config sflow interface disable all")
+        for port in var['sflow_ports']:
+            config_sflow_interfaces(duthost,port,status='enable',sample_rate='512')
+        verify_show_sflow(duthost,status='up',collector=['collector0'])
+        for intf in var['sflow_ports']:
+            verify_sflow_interfaces(duthost,intf,'up',512)
+        time.sleep(5) 
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0']" )
+
+
+    def test_collector_del_add(self, duthost, partial_ptf_runner):
+        # Delete a collector and check samples are not received in collectors
+        config_sflow_collector(duthost,'collector0','del')
+        time.sleep(2)
+        verify_show_sflow(duthost,status='up',collector=[])
+        time.sleep(5)
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="[]" )
+        #re-add collector
+        config_sflow_collector(duthost,'collector0','add')
+        verify_show_sflow(duthost,status='up',collector=['collector0'])
+        time.sleep(2)
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0']" )
+
+    
+    def test_two_collectors(self, sflowbase_config, duthost, partial_ptf_runner):
+        #add 2 collectors with 2 different udp ports and check samples are received in both collectors 
+        verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
+        time.sleep(2)
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0','collector1']" )
+
+        # Remove second collector anc check samples are received in only 1st collector 
+        config_sflow_collector(duthost,'collector1','del')
+        verify_show_sflow(duthost,status='up',collector=['collector0'])
+        time.sleep(5)
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0']" )
+
+        #Re-add second collector and check if samples are received in both collectors again 
+        config_sflow_collector(duthost,'collector1','add')
+        verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
+        time.sleep(5)        
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0','collector1']" )
+
+        # Add third collector and check only 2 collectors can be configured 
+        out = duthost.command("config sflow collector add collector2 192.168.0.5 ",module_ignore_errors=True)
+        assert "Only 2 collectors can be configured, please delete one" in out['stdout']
+            
+        #remove first collector and check DUT sends samples to collector 2 woth non default port number (6344)  
+        config_sflow_collector(duthost,'collector0','del')
+        verify_show_sflow(duthost,status='up',collector=['collector1'])
+        time.sleep(10)
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector1']" )
+
+
+
+# ------------------------------------------------------------------------------
+
+class TestSflowPolling():
+    """
+    Test Sflow polling with different polling interval and check whether the test interface sends one counter sample for every polling interval 
+    Disable polling and check the dut doesn't send counter samples .
+    """
+
+    def testPolling(self, sflowbase_config, duthost, partial_ptf_runner):
+        duthost.shell("config sflow polling-interval 20")        
+        verify_show_sflow(duthost,status='up',polling_int=20)
+        partial_ptf_runner(
+              polling_int=20,
+              active_collectors="['collector0','collector1']" )
+
+    def testDisablePolling(self, sflowbase_config, duthost, partial_ptf_runner):
+        duthost.shell("config sflow polling-interval 0")
+
+        verify_show_sflow(duthost,status='up',polling_int=0)
+        partial_ptf_runner(
+              polling_int=0,
+              active_collectors="['collector0','collector1']" )
+
+    def testDifferntPollingInt(self, sflowbase_config, duthost, partial_ptf_runner):
+        duthost.shell("config sflow polling-interval 60")
+
+        verify_show_sflow(duthost,status='up',polling_int=60)
+        partial_ptf_runner(
+              polling_int=60,
+              active_collectors="['collector0','collector1']" )
+
+# ------------------------------------------------------------------------------
+
+class TestSflowInterface():
+    """
+    Enable / Disable Sflow interfaces and check the samples are received only from  the intended interface
+    Test interfaceswith different sampling rates
+    """
+
+    def testIntfRemoval(self, sflowbase_config, duthost, partial_ptf_runner):
+        sflow_int = sorted(var['sflow_ports'].keys())
+        config_sflow_interfaces(duthost,sflow_int[0],status='disable')
+        config_sflow_interfaces(duthost,sflow_int[1],status='disable')
+
+        verify_sflow_interfaces(duthost,sflow_int[0],'down',512)
+        verify_sflow_interfaces(duthost,sflow_int[1],'down',512)
+        verify_sflow_interfaces(duthost,sflow_int[2],'up',512)
+        verify_sflow_interfaces(duthost,sflow_int[3],'up',512)
+        enabled_intf = sflow_int[2:4]
+        partial_ptf_runner(
+              enabled_sflow_interfaces=enabled_intf,
+              active_collectors="['collector0','collector1']" )
+
+    def testIntfSamplingRate(self, sflowbase_config, duthost, ptfhost, partial_ptf_runner):
+       
+        #re-add ports with different sampling rate
+        sflow_int = sorted(var['sflow_ports'].keys())
+        test_intf = sflow_int[0]
+        test_intf1 =  sflow_int[1]
+        config_sflow_interfaces(duthost,test_intf,status='enable',sample_rate=256)
+        config_sflow_interfaces(duthost,test_intf1,status='enable',sample_rate=1024)
+
+        var['sflow_ports'][test_intf]['sample_rate'] = 256
+        var['sflow_ports'][test_intf1]['sample_rate'] = 1024
+        var['portmap'] = json.dumps(var['sflow_ports'])
+        for intf in sflow_int :
+            verify_sflow_interfaces(duthost,intf,'up',var['sflow_ports'][intf]['sample_rate'])
+        ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
+        time.sleep(2)
+        partial_ptf_runner(
+              enabled_sflow_interfaces=sflow_int,
+              active_collectors="['collector0','collector1']" )
+  
+    def testIntfChangeSamplingRate(self, sflowbase_config, duthost, partial_ptf_runner, ptfhost):
+
+        sflow_int = sorted(var['sflow_ports'].keys())
+        test_intf = sflow_int[0]
+        test_intf1 =  sflow_int[1]
+        # revert the sampling rate to 512 on both ports 
+        config_sflow_interfaces(duthost,test_intf,sample_rate=512)
+        config_sflow_interfaces(duthost,test_intf1,sample_rate=512)
+        var['sflow_ports'][test_intf]['sample_rate'] = 512
+        var['sflow_ports'][test_intf1]['sample_rate'] = 512
+        var['portmap'] = json.dumps(var['sflow_ports'])
+        for intf in sflow_int :
+            verify_sflow_interfaces(duthost,intf,'up',var['sflow_ports'][intf]['sample_rate'])
+        ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
+        partial_ptf_runner(
+              enabled_sflow_interfaces=sflow_int,
+              active_collectors="['collector0','collector1']" )
+
+# ------------------------------------------------------------------------------
+
+class TestAgentId():
+    """
+    Add loopback0 ip as the agent id and check the samples are received with intended agent-id. 
+    Remove agent-ip and check whether samples are received with previously cofigured agent ip.
+    Add eth0 ip as the agent ip and check the samples are received with intended agent-id. 
+    """
+
+    def testNonDefaultAgent(self, sflowbase_config, duthost, partial_ptf_runner):
+        agent_ip = var['lo_ip']
+        duthost.shell(" config sflow agent-id del")
+        duthost.shell(" config sflow agent-id  add Loopback0")
+        verify_show_sflow(duthost,status='up',agent_id='Loopback0')
+        partial_ptf_runner(
+              polling_int=20,
+              agent_id=agent_ip,
+              active_collectors="['collector0','collector1']" )
+
+
+    def testDelAgent(self, sflowbase_config, duthost, partial_ptf_runner):
+        duthost.shell(" config sflow agent-id del")
+        verify_show_sflow(duthost,status='up',agent_id='default')
+        time.sleep(5)
+        #Verify  whether the samples are received with previously configured agent ip 
+        partial_ptf_runner(
+              polling_int=20,
+              agent_id=var['lo_ip'],
+              active_collectors="['collector0','collector1']" )
+
+    def testAddAgent(self, sflowbase_config, duthost, partial_ptf_runner):
+        agent_ip = var['mgmt_ip']
+        duthost.shell(" config sflow agent-id  add  eth0")
+        verify_show_sflow(duthost,status='up',agent_id='eth0')
+        partial_ptf_runner(
+              polling_int=20,
+              agent_id=agent_ip,
+              active_collectors="['collector0','collector1']" )
+
+# ------------------------------------------------------------------------------
+
+class TestReboot():
+
+    def testRebootSflowEnable(self, sflowbase_config, duthost, testbed_devices, localhost, partial_ptf_runner, ptfhost):
+        duthost = testbed_devices["dut"]
+        duthost.command("config sflow polling-interval 80")
+        verify_show_sflow(duthost,status='up',polling_int=80)
+        duthost.command('sudo config save -y')
+        reboot(duthost, localhost)
+        assert wait_until(300, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        verify_show_sflow(duthost,status='up',collector=['collector0','collector1'],polling_int=80)
+        for intf in var['sflow_ports']:
+            var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost,intf)
+            verify_sflow_interfaces(duthost,intf,'up',512)
+        var['portmap'] = json.dumps(var['sflow_ports'])
+        ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0','collector1']" )
+        # Test Polling
+        partial_ptf_runner(
+              polling_int=80,
+              active_collectors="['collector0','collector1']" )
+
+
+    def testRebootSflowDisable(self, sflowbase_config, duthost, testbed_devices, localhost, partial_ptf_runner, ptfhost):
+        config_sflow(duthost,sflow_status='disable')
+        verify_show_sflow(duthost,status='down')
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="[]" )
+        duthost.command('sudo config save -y')
+        reboot(duthost, localhost)
+        assert wait_until(300, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        verify_show_sflow(duthost,status='down')
+        for intf in var['sflow_ports']:
+            var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost,intf)
+        var['portmap'] = json.dumps(var['sflow_ports'])
+        ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="[]" )
+
+
+    def testFastreboot(self, sflowbase_config, duthost, testbed_devices, localhost, partial_ptf_runner, ptfhost):
+
+        config_sflow(duthost,sflow_status='enable')
+        verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
+        duthost.command('sudo config save -y')
+        reboot(duthost, localhost,reboot_type='fast')
+        assert wait_until(300, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
+        for intf in var['sflow_ports']:
+            var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost,intf)
+            verify_sflow_interfaces(duthost,intf,'up',512)
+        var['portmap'] = json.dumps(var['sflow_ports'])
+        ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
+        partial_ptf_runner(
+              enabled_sflow_interfaces=var['sflow_ports'].keys(),
+              active_collectors="['collector0','collector1']" )
+
+


### PR DESCRIPTION

### Description of PR

Summary:
Adding scripts to test sflow 

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
- The test will run on the t0 testbed. The script  is validated in sonic-vs image with vms-kvm-t0 topology loaded. 
-  1 port from each port channel is used for sending traffic. Sflow is enabled on these 4 ports 
-  2 ports  from Vlan1000 are removed and assigned with ip address  and used  to reach sflow collector in ptf docker .
- Traffic is sent from ptf docker with different packet sizes to the port channel interfaces  which are enabled with sflow .
- Collection is implemented using the sflowtool. Counter sampling output and flow sampling output are directed to a text file. The test script parses the text file and validates the data according to the polling/sampling rate configured and the interfaces enabled.
- For this test to run sflowtool to be installed in ptf docker https://github.com/Azure/sonic-buildimage/pull/4045 

Test plan Document :  https://github.com/Azure/SONiC/pull/554

#### How did you verify/test it?

- The test will run on the t0 testbed. The script  is validated in sonic-vs image with vms-kvm-t0 topology loaded. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Runs in t0 topology. 

Script run : 

```
root@e9a663910a81:/var/johnar/sonic-mgmt/tests# py.test --inventory=../ansible/lab --host-pattern=vlab-01  --module-path ../ansible/library/ --testbed=vms-kvm-t0  --testbed_file=vtestbed.csv    test_sflow.py  -vvv  --disable_loganalyzer -rab     --duration=0 --show-capture=stdout
================================================================================================================================================= test session starts =================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.6, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.0.0.2
rootdir: /var/johnar/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.0.2
collected 15 items

test_sflow.py::TestSflowCollector::test_sflow_config PASSED                                     [  6%]
test_sflow.py::TestSflowCollector::test_collector_del_add PASSED                                [ 13%]
test_sflow.py::TestSflowCollector::test_two_collectors PASSED                                   [ 20%]
test_sflow.py::TestSflowPolling::testPolling PASSED                                             [ 26%]
test_sflow.py::TestSflowPolling::testDisablePolling PASSED                                      [ 33%]
test_sflow.py::TestSflowPolling::testDifferntPollingInt PASSED                                  [ 40%]
test_sflow.py::TestSflowInterface::testIntfRemoval PASSED                                       [ 46%]
test_sflow.py::TestSflowInterface::testIntfSamplingRate PASSED                                  [ 53%]
test_sflow.py::TestSflowInterface::testIntfChangeSamplingRate PASSED                            [ 60%]
test_sflow.py::TestAgentId::testNonDefaultAgent PASSED                                          [ 66%]
test_sflow.py::TestAgentId::testDelAgent PASSED                                                 [ 73%]
test_sflow.py::TestAgentId::testAddAgent PASSED                                                 [ 80%]
test_sflow.py::TestReboot::testRebootSflowEnable PASSED                                         [ 86%]
test_sflow.py::TestReboot::testRebootSflowDisable PASSED                                        [ 93%]
test_sflow.py::TestReboot::testFastreboot PASSED                                                [100%]

============================================== slowest test durations ==============================================
513.19s call     test_sflow.py::TestSflowCollector::test_two_collectors
419.81s call     test_sflow.py::TestReboot::testRebootSflowEnable
389.54s call     test_sflow.py::TestReboot::testRebootSflowDisable
356.24s call     test_sflow.py::TestReboot::testFastreboot
297.33s call     test_sflow.py::TestSflowCollector::test_collector_del_add
164.32s call     test_sflow.py::TestSflowCollector::test_sflow_config
133.97s call     test_sflow.py::TestSflowInterface::testIntfSamplingRate
132.87s call     test_sflow.py::TestSflowInterface::testIntfChangeSamplingRate
132.08s call     test_sflow.py::TestSflowInterface::testIntfRemoval
73.84s call     test_sflow.py::TestSflowPolling::testDifferntPollingInt
39.27s call     test_sflow.py::TestAgentId::testDelAgent
35.03s call     test_sflow.py::TestAgentId::testNonDefaultAgent
34.16s call     test_sflow.py::TestSflowPolling::testPolling
34.04s call     test_sflow.py::TestAgentId::testAddAgent
33.81s call     test_sflow.py::TestSflowPolling::testDisablePolling
22.66s setup    test_sflow.py::TestSflowInterface::testIntfRemoval
22.15s setup    test_sflow.py::TestSflowCollector::test_sflow_config
21.86s setup    test_sflow.py::TestReboot::testRebootSflowEnable
21.71s setup    test_sflow.py::TestSflowPolling::testPolling
20.90s setup    test_sflow.py::TestAgentId::testNonDefaultAgent
20.82s setup    test_sflow.py::TestSflowCollector::test_two_collectors
5.98s teardown test_sflow.py::TestReboot::testFastreboot
1.43s teardown test_sflow.py::TestReboot::testRebootSflowDisable
1.36s teardown test_sflow.py::TestSflowCollector::test_sflow_config
1.32s teardown test_sflow.py::TestReboot::testRebootSflowEnable
1.26s teardown test_sflow.py::TestSflowInterface::testIntfChangeSamplingRate
1.25s teardown test_sflow.py::TestSflowInterface::testIntfRemoval
1.24s teardown test_sflow.py::TestSflowCollector::test_collector_del_add
1.16s teardown test_sflow.py::TestSflowInterface::testIntfSamplingRate
1.15s setup    test_sflow.py::TestReboot::testFastreboot
1.08s setup    test_sflow.py::TestReboot::testRebootSflowDisable
1.02s teardown test_sflow.py::TestSflowCollector::test_two_collectors
1.01s teardown test_sflow.py::TestAgentId::testAddAgent
0.99s teardown test_sflow.py::TestSflowPolling::testPolling
0.99s setup    test_sflow.py::TestAgentId::testDelAgent
0.99s teardown test_sflow.py::TestAgentId::testDelAgent
0.96s teardown test_sflow.py::TestAgentId::testNonDefaultAgent
0.93s setup    test_sflow.py::TestSflowInterface::testIntfChangeSamplingRate
0.93s setup    test_sflow.py::TestSflowPolling::testDisablePolling
0.92s setup    test_sflow.py::TestSflowPolling::testDifferntPollingInt
0.92s teardown test_sflow.py::TestSflowPolling::testDisablePolling
0.90s teardown test_sflow.py::TestSflowPolling::testDifferntPollingInt
0.88s setup    test_sflow.py::TestSflowCollector::test_collector_del_add
0.81s setup    test_sflow.py::TestSflowInterface::testIntfSamplingRate
0.80s setup    test_sflow.py::TestAgentId::testAddAgent
============================================== 15 passed in 2950.05 seconds ===========================================
root@e9a663910a81:/var/johnar/sonic-mgmt/tests#
```
Known issue: 
https://github.com/Azure/sonic-buildimage/issues/3991 will be seen until    https://github.com/Azure/sonic-linux-kernel/pull/120 is merged in buildimage 