### PR TITLE
[sonicvm]: destroy VM when it is in paused state

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -154,6 +154,13 @@
   register: vm_list_running
   become: true
 
+- name: Retrieve a list of the paused VMs
+  virt: command=list_vms
+        uri=qemu:///system
+        state=pause
+  register: vm_list_paused
+  become: true
+
 - name: Find current server group
   set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
 

--- a/ansible/roles/vm_set/tasks/stop_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/stop_sonic_vm.yml
@@ -5,7 +5,7 @@
   virt: name={{ dut_name }}
         state=destroyed
         uri=qemu:///system
-  when: dut_name in vm_list_running.list_vms
+  when: dut_name in vm_list_running.list_vms or dut_name in vm_list_paused.list_vms
   become: yes
 
 - name: Undefine vm {{ dut_name }}


### PR DESCRIPTION
You cannot undefine VM when it is in paused state. You need to
destroy the VM first.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
