### PR TITLE
Fix Ansible compatibility issues in warm-reboot sad scripts

### DIFF
--- a/ansible/roles/test/tasks/warm-reboot-sad-bgp.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-bgp.yml
@@ -15,7 +15,7 @@
   when: (vnet is not defined) or (vnet_pkts is not defined)
 
 - name: Warm-reboot test
-  include_tasks: advanced-reboot.yml
+  include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
       preboot_list: "{{ pre_list }}"

--- a/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
@@ -21,7 +21,7 @@
   when: (vnet is not defined) or (vnet_pkts is not defined)
 
 - name: Warm-reboot test
-  include_tasks: advanced-reboot.yml
+  include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
       preboot_list: "{{ pre_list }}"

--- a/ansible/roles/test/tasks/warm-reboot-sad-lag.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-lag.yml
@@ -15,7 +15,7 @@
   when: (vnet is not defined) or (vnet_pkts is not defined)
 
 - name: Warm-reboot test
-  include_tasks: advanced-reboot.yml
+  include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
       preboot_list: "{{ pre_list }}"

--- a/ansible/roles/test/tasks/warm-reboot-sad-vlan-port.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-vlan-port.yml
@@ -15,7 +15,7 @@
   when: (vnet is not defined) or (vnet_pkts is not defined)
 
 - name: Warm-reboot test
-  include_tasks: advanced-reboot.yml
+  include: advanced-reboot.yml
   vars:
       reboot_type: warm-reboot
       preboot_list: "{{ pre_list }}"


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

Fix test run start failure caused due to changes made for Ansible upgrade

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you verify/test it?
Ran warm-reboot-sad-bgp test with the change and was able to get the test run started successfully
