### PR TITLE
[linkstate] Fix "eos_root_password is undefined" issue

### DIFF
--- a/ansible/linkstate/down.yml
+++ b/ansible/linkstate/down.yml
@@ -44,6 +44,7 @@
 - hosts: eos
   gather_facts: no
   tasks:
+    - include_vars: ../group_vars/all/creds.yml
     - name: Set ansible login user name and password
       set_fact: ansible_user="root" ansible_password={{ eos_root_password }}
     - name: Check list of processes

--- a/ansible/linkstate/up.yml
+++ b/ansible/linkstate/up.yml
@@ -3,6 +3,7 @@
 - hosts: eos
   gather_facts: no
   tasks:
+    - include_vars: ../group_vars/all/creds.yml
     - name: Set ansible login user name and password
       set_fact: ansible_user="root" ansible_password={{ eos_root_password }}
     - name: Check list of processes


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/Azure/sonic-mgmt/issues/1316

Variable ```eos_root_password``` is undefined for ```linkstate``` playbooks and because of that it fails to start and stop ```linkstate``` scripts which are needed for fast and warm reboot.

It happens due to some restrictions in Ansible v2.4 and higher which are mentioned in the comment to this issue https://github.com/Azure/sonic-mgmt/issues/1316.

Link to the Ansible documentation with the problem description:
https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.4.html?highlight=vars_files#initial-playbook-relative-group-vars-and-host-vars

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
As suggested in Ansible documentation added ```include_vars``` module to ```linkstate``` playbooks in order to include file with required ```veos``` credentials.
#### How did you verify/test it?
Ran ```linkstate``` playbooks and verified they passed and there no errors:
```
# ansible-playbook -i linkstate/testbed_inv.py -e target_host=<host> linkstate/up.yml
# ansible-playbook -i linkstate/testbed_inv.py -e target_host=<host> linkstate/down.yml
```
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
N/A
