### PR TITLE
[fdb]: Increase expected packet wait timeout: 1 sec -> 5 sec

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -12,6 +12,7 @@ DEFAULT_FDB_ETHERNET_TYPE = 0x1234
 DUMMY_MAC_PREFIX = "02:11:22:33"
 DUMMY_MAC_COUNT = 10
 FDB_POPULATE_SLEEP_TIMEOUT = 2
+FDB_WAIT_EXPECTED_PACKET_TIMEOUT = 5
 PKT_TYPES = ["ethernet", "arp_request", "arp_reply"]
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ def send_recv_eth(ptfadapter, source_port, source_mac, dest_port, dest_mac):
     logger.debug('send packet src port {} smac: {} dmac: {} verifying on dst port {}'.format(
         source_port, source_mac, dest_mac, dest_port))
     testutils.send(ptfadapter, source_port, pkt)
-    testutils.verify_packet_any_port(ptfadapter, pkt, [dest_port])
+    testutils.verify_packet_any_port(ptfadapter, pkt, [dest_port], timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
 
 
 def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type):


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
It seems that the new test framework (ptfadapter + ptf _nn_agnet) introduces some delays in a packet transfer flow which results in expected packets are missed even they actually reached the destination.

The purpose of this fix is to increase the wait timeout  
to allow all the MAC frames to be analysed by PTF framework.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
* Increased expected packet wait timeout: 1 sec -> 5 sec

#### How did you verify/test it?
1. Run FDB test

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
* N/A
