### PR TITLE
Update docker registry RO password

### DIFF
--- a/ansible/vars/docker_registry.yml
+++ b/ansible/vars/docker_registry.yml
@@ -1,4 +1,4 @@
 docker_registry_host: sonicdev-microsoft.azurecr.io:443
 
 docker_registry_username: 1dafc8d7-d19c-4f58-8653-e8d904f30dab
-docker_registry_password: sonic
+docker_registry_password: MicrosoftSonic#1


### PR DESCRIPTION
`New-AzureRmADAppCredential` command now requires `The password must be at least 16 characters long, contain at least 1 special character, and contain at least 1 numeric character`, so we are forced to change password after original credential expires.