### PR TITLE
[multi-vlan] Retain dictionary params

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -83,10 +83,7 @@
     when: ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower")
 
   - name: find all vlan configurations for T0 topology
-    vlan_config: 
-      vm_topo_config: "{{ vm_topo_config }}"
-      port_alias: "{{ port_alias }}"
-      vlan_config: "{{ vlan_config | default(None) }}"
+    vlan_config: vm_topo_config={{ vm_topo_config }} port_alias={{ port_alias }} vlan_config={{ vlan_config | default(None) }}
     delegate_to: localhost
     when: ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower")
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -83,7 +83,10 @@
     when: ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower")
 
   - name: find all vlan configurations for T0 topology
-    vlan_config: vm_topo_config={{ vm_topo_config }} port_alias={{ port_alias }} vlan_config={{ vlan_config | default(None) }}
+    vlan_config:
+      vm_topo_config: "{{ vm_topo_config }}"
+      port_alias: "{{ port_alias }}"
+      vlan_config: "{{ vlan_config | default(None) }}"
     delegate_to: localhost
     when: ("'host_interfaces' in vm_topo_config") and ("'tor' in vm_topo_config['dut_type'] | lower")
 

--- a/ansible/library/vlan_config.py
+++ b/ansible/library/vlan_config.py
@@ -30,8 +30,8 @@ EXAMPLES = '''
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            vm_topo_config=dict(required=True),
-            port_alias=dict(required=True),
+            vm_topo_config=dict(required=True, type="dict"),
+            port_alias=dict(required=True, type="list"),
             vlan_config=dict(required=False, type='str', default=None),
         ),
         supports_check_mode=True


### PR DESCRIPTION
Fixing a but where when dictionary item is in between double quotes, Ansible framework converts it into dictionary. This is causing building failure due to indexing string with keyword.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
