### PR TITLE
[dhcp-relay] Make mac addresses of ptf interfaces unique

### DIFF
--- a/tests/test_dhcp_relay.py
+++ b/tests/test_dhcp_relay.py
@@ -15,6 +15,15 @@ def copy_ptftests_directory(ptfhost):
     """
     ptfhost.copy(src="ptftests", dest="/root")
 
+@pytest.fixture(scope="module", autouse=True)
+def update_ptf_interface_mac_addresses(ptfhost, autouse=True):
+    """ Fixture which copies the change_mac.sh script to the PTF host. This fixture
+        is scoped to the module, as it only needs to be performed once before
+        the first test is run. The fixture also changes mac addresses of ptf containers
+    """
+    ptfhost.copy(src="scripts/change_mac.sh", dest="/tmp")
+
+    ptfhost.shell("/tmp/change_mac.sh")
 
 @pytest.fixture(scope="module")
 def dut_dhcp_relay_data(duthost, ptfhost, testbed):

--- a/tests/test_dhcp_relay.py
+++ b/tests/test_dhcp_relay.py
@@ -16,10 +16,11 @@ def copy_ptftests_directory(ptfhost):
     ptfhost.copy(src="ptftests", dest="/root")
 
 @pytest.fixture(scope="module", autouse=True)
-def update_ptf_interface_mac_addresses(ptfhost, autouse=True):
+def ptf_configure_unique_interface_mac_addresses(ptfhost, autouse=True):
     """ Fixture which copies the change_mac.sh script to the PTF host. This fixture
         is scoped to the module, as it only needs to be performed once before
         the first test is run. The fixture also changes mac addresses of ptf containers
+        to have unique mac addresses.
     """
     ptfhost.copy(src="scripts/change_mac.sh", dest="/tmp")
 

--- a/tests/test_dhcp_relay.py
+++ b/tests/test_dhcp_relay.py
@@ -17,10 +17,12 @@ def copy_ptftests_directory(ptfhost):
 
 @pytest.fixture(scope="module", autouse=True)
 def ptf_configure_unique_interface_mac_addresses(ptfhost, autouse=True):
-    """ Fixture which copies the change_mac.sh script to the PTF host. This fixture
-        is scoped to the module, as it only needs to be performed once before
-        the first test is run. The fixture also changes mac addresses of ptf containers
-        to have unique mac addresses.
+    """ Fixture which copies the change_mac.sh script to the PTF host and executes
+        it there, changing the MAC addresses of the PTF host's interfaces such that
+        each interface has a unique MAC address.
+
+        This fixture is scoped to the module, as it only needs to be performed once
+        before the first test is run.
     """
     ptfhost.copy(src="scripts/change_mac.sh", dest="/tmp")
 

--- a/tests/test_dhcp_relay.py
+++ b/tests/test_dhcp_relay.py
@@ -26,7 +26,7 @@ def ptf_configure_unique_interface_mac_addresses(ptfhost, autouse=True):
     """
     ptfhost.copy(src="scripts/change_mac.sh", dest="/tmp")
 
-    ptfhost.shell("/tmp/change_mac.sh")
+    ptfhost.shell("/bin/bash /tmp/change_mac.sh")
 
 @pytest.fixture(scope="module")
 def dut_dhcp_relay_data(duthost, ptfhost, testbed):


### PR DESCRIPTION
DHCP relay agent uses the mac address to find where the DHCP packet
came from. When having more than one lan, the test fails as all
ptf interfaces use the same mac address. DHCP packet received on
ptf host are not counted as option 82 is not matching expected packets.

signed-of-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
