### PR TITLE
Refactore PTF containers definition

### DIFF
--- a/ansible/doc/README.new.testbed.Configuration.md
+++ b/ansible/doc/README.new.testbed.Configuration.md
@@ -45,7 +45,7 @@ The device_groups section generates the lab file which is the inventory file nec
 ### devices section
 **USAGE**: files/sonic_lab_devices, group_vars/fanout/secrets, group_vars/lab/secrets, lab
 
-The devices section is a dictionary that contains all devices and hosts. This section does not contain information on PTF containers. For more information on PTF containers, see the testbed.csv file. 
+The devices section is a dictionary that contains all devices, hosts and PTF containers.
 
 For each device that you add, add the following:
 
@@ -111,21 +111,22 @@ Define:
 
 This is where the topology configuration file for the testbed will collect information from when running TestbedProcessing.py. 
 
-| #conf-name | group-name | topo | ptf_image_name | ptf_ip | server | vm_base | dut | comment |
-| ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| [ptf32 conf-name] | [ptf32 group-name] | [ptf32] | [docker-ptf] | [ip address] | [server group] | [vm_base] | [dut] | [comment] |
-| [t0 conf-name] | [t0 group-name] | [t0] | [docker-ptf] | [ip address] | [server group] | [vm_base] | [dut] | [comment] |
+| #conf-name | group-name | topo | ptf_image_name | ptf_ip | ptf | server | vm_base | dut | comment |
+| ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| [ptf32 conf-name] | [ptf32 group-name] | [ptf32] | [docker-ptf] | [ip address] | [PTF Container] | [server group] | [vm_base] | [dut] | [comment] |
+| [t0 conf-name] | [t0 group-name] | [t0] | [docker-ptf] | [ip address] | [PTF Container] | [server group] | [vm_base] | [dut] | [comment] |
 
 
 For each topology you use in your testbed environment, define the following:
 - conf-name - to address row in table
 - group-name - used in interface names, up to 8 characters. The variable can be anything but should be identifiable. 
 - topo - name of topology 
-- ptf_image_name - defines PTF image. In this guide, the docker-ptf was an image already on the local registry. However, there is a docker-ptf from the sonic-mgmt github that a user can pull from
+- ptf_image_name - Could be missed if specified ptf field. Defines PTF image. In this guide, the docker-ptf was an image already on the local registry. However, there is a docker-ptf from the sonic-mgmt github that a user can pull from
     > git clone --recursive https://github.com/Azure/sonic-buildimage.git <br/>
     > make configure PLATFORM=generic <br/>
     > make target/docker-ptf.gz
-- ptf_ip - ip address for mgmt interface of PTF container. Choose an IP address that is available
+- ptf_ip - ip address for mgmt interface of PTF container. Choose an IP address that is available. Could be missed if specified ptf field
+- ptf - name of device with type PTF. See Device section
 - server - server where the testbed resides. Choose a veos_group to use that contains both the lab server and virtual machines
 - vm_base - enter in the lowest ID value for the VMs you will be using to run the test cases. The lowest VM ID value can be found under the veos section of the testbed configuration file. IF empty, no VMs are used
 - dut - enter in the target DUT that is used in the testbed environment

--- a/ansible/roles/test/tasks/sonic.yml
+++ b/ansible/roles/test/tasks/sonic.yml
@@ -67,7 +67,7 @@
     - name: set testbed_type
       set_fact:
         testbed_type: "{{ testbed_facts['topo'] }}"
-        ptf_host: "{{ testbed_facts['ptf_ip'] }}"
+        ptf_host: "{{ testbed_facts['ptf'] }}"
         topo: "topo_{{ testbed_facts['topo'] }}.yml"
 
     - name: set vm

--- a/ansible/testbed-new.yaml
+++ b/ansible/testbed-new.yaml
@@ -75,7 +75,7 @@ device_groups:
     ptf:
         host: [ptf_ptf1, ptf_vms1-1]                             # source: sonic-mgmt/ansible/lab
 
-# devices is a dictionary that contains all devices and hosts but not ptfs (ptfs found under testbed)
+# devices is a dictionary that contains all devices, hosts and ptfs. 
 # devices is used to export sonic_lab_devices, fanout/secrets, lab/secrets, lab
 # there are no cross references
 devices:
@@ -209,6 +209,23 @@ devices:
             sonicadmin_user: 
             sonicadmin_password: 
             sonicadmin_initial_password: 
+
+    ptf_ptf1:
+        device_type: PTF
+        ptf_image_name: docker-ptf
+        mgmt_subnet_mask_length: "24"
+        ansible:
+            ansible_host: use_own_value
+            ansible_ssh_user: use_own_value
+            ansible_ssh_pass: use_own_value
+    ptf_vms1-1:
+        device_type: PTF
+        ptf_image_name: docker-ptf
+        mgmt_subnet_mask_length: "24"
+        ansible:
+            ansible_host: use_own_value
+            ansible_ssh_user: use_own_value
+            ansible_ssh_pass: use_own_value
 
 # host_vars is a dictionary that contains all host_var values
 # host_vars is used to export the host_vars files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,9 @@ def testbed_devices(ansible_adhoc, testbed):
         "localhost": Localhost(ansible_adhoc),
         "dut": SonicHost(ansible_adhoc, testbed["dut"], gather_facts=True)}
 
-    if "ptf" in testbed:
+    if "ptf" in testbed and testbed.get("ptf", None) and testbed["ptf"] != "ptf-unknown":
+        # when ptf column is present in testbed file
+        # and value for this testbed is not empty or ptf-unknown
         devices["ptf"] = PTFHost(ansible_adhoc, testbed["ptf"])
     else:
         # when no ptf defined in testbed.csv


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
To be able to delegate tasks to PTF container from ansible and from py.test exactly, this container should be present in Ansible inventory. See related issue and this [comment](https://github.com/Azure/sonic-mgmt/blob/master/ansible/roles/test/tasks/ptf_runner.yml#L4)
These changes unify the PTF container's definition in `testbed-new.yml`. The generated files will be the same as before just with PTF hosts in the inventory file and ptf column in testbed.csv.

Summary:
Fixes # (https://github.com/Azure/sonic-mgmt/issues/1293)
Extends #(https://github.com/Azure/sonic-mgmt/pull/1337)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
Add PTF containers to the inventory and testbed.csv files
Avoid ptf_host extra var definition for testcases in start cmd.
#### How did you do it?
- Add logic in TestbedProcessing.py to parse devices with type PTF for the inventory file and correct the logic which generates testbed.csv.
- Update Documentation

#### How did you verify/test it?
Described my laboratory in testbed-new.yml generate configs and run a few ansible and py.test TC.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
