### PR TITLE
use delegate_to to wait for eos VM to reboot

### DIFF
--- a/ansible/roles/eos/handlers/main.yml
+++ b/ansible/roles/eos/handlers/main.yml
@@ -10,20 +10,20 @@
 
 - name: Wait for VM to shutdown
   wait_for:
-    host: "{{ ansible_ssh_host }}"
+    host: "{{ ansible_host }}"
     port: 22
     state: stopped
     delay: 10
     timeout: 300
-  connection: local
+  delegate_to: "{{ VM_host[0] }}"
   listen: "Update VM state"
 
 - name: Wait for VM to startup
   wait_for:
-    host: "{{ ansible_ssh_host }}"
+    host: "{{ ansible_host }}"
     port: 22
     state: started
     delay: 10
     timeout: 1200
-  connection: local
+  delegate_to: "{{ VM_host[0] }}"
   listen: "Update VM state"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
In some cases, the controller cannot reach eos VM directly.
We need to delegate_to to vm host name to test reachability
of port 22 on VM.

Also need to change from ansible_ssh_host to ansible_host
as ansible_ssh_host is changed the the delegated_to host.
ansible_host will remain to be the eos VM ip.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
