### PR TITLE
Filter irregular lines when parsing the testbed CSV file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,9 @@ class TestbedInfo(object):
                 tb_prop = {}
                 name = ''
                 for key in line:
+                    if line[key] is None:
+                        break
+                    
                     if ('uniq-name' in key or 'conf-name' in key) and '#' in line[key]:
                         continue
                     elif 'uniq-name' in key or 'conf-name' in key:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ class TestbedInfo(object):
                         continue
                     elif 'uniq-name' in key or 'conf-name' in key:
                         name = line[key]
-                    elif 'ptf_ip' in key and line[key]:
+                    elif 'ptf_ip' in key:
                         ptfaddress = ipaddress.IPNetwork(line[key])
                         tb_prop['ptf_ip'] = str(ptfaddress.ip)
                         tb_prop['ptf_netmask'] = str(ptfaddress.netmask)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Signed-off-by: Wei Bai baiwei0427@gmail.com

Summary: Filter irregular lines when parsing the testbed CSV file
Fixes # (issue)

### Type of change

- [*] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Modify the function that is used to parse testbed CSV file
Filter the line if any field is missing (e.g., a comment line like <code># ptfs</code>)

#### How did you verify/test it?
Print parsed testbed info as follows:
<pre>
 for key in line:
     if line[key] is None:
         break
     print line
</pre>

 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
It seems that current conftest.py cannot handle comment lines in testbed CSV files correctly. For example, it parses the comment line <code># ptfs</code> as follows:
<code>{'testbed-name': None, 'ptf_ip': None, '# uniq-name': '# ptfs', 'vm_base': None, 'server': None, 'topo': None, 'dut': None, 'ptf': None, 'owner': None, 'ptf_image_name': None}</code>

