### PR TITLE
Warm reboot is not enabled on Mellanox ACS-MSN2410 on 201811 yet

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -104,7 +104,7 @@ SWITCH_MODELS = {
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
-            "warm_reboot": True
+            "warm_reboot": False
         },
         "fans": {
             "number": 4,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

On 201811 branch, the Mellanox ACS-MSN2410 switch does not
have warm reboot enabled yet.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
