### PR TITLE
[vs test] Adding Announce Route test

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+import re
+
 DOCUMENTATION = '''
 module:  exabgp
 version_added:  "1.0"
@@ -125,6 +127,11 @@ def exec_command(module, cmd, ignore_error=False, msg="executing command"):
                          (msg, rc, out, err))
     return out
 
+def get_exabgp_status(module, name):
+    output = exec_command(module, cmd="supervisorctl status exabgp-%s" % name)
+    m = re.search('^([\w|-]*)\s+(\w*).*$', output.decode("utf-8"))
+    return m.group(2)
+
 def refresh_supervisord(module):
     exec_command(module, cmd="supervisorctl reread", ignore_error=True)
     exec_command(module, cmd="supervisorctl update", ignore_error=True)
@@ -193,7 +200,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, type='str'),
-            state=dict(required=True, choices=['started', 'restarted', 'stopped', 'present', 'absent'], type='str'),
+            state=dict(required=True, choices=['started', 'restarted', 'stopped', 'present', 'absent', 'status'], type='str'),
             router_id=dict(required=False, type='str'),
             local_ip=dict(required=False, type='str'),
             peer_ip=dict(required=False, type='str'),
@@ -214,6 +221,7 @@ def main():
 
     setup_exabgp_processor()
 
+    result = {}
     try:
         if state == 'started':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port)
@@ -234,11 +242,14 @@ def main():
             remove_exabgp_supervisord_conf(name)
             remove_exabgp_conf(name)
             refresh_supervisord(module)
+        elif state == 'status':
+            status = get_exabgp_status(module, name)
+            result = {'status' : status}
     except:
         err = str(sys.exc_info())
         module.fail_json(msg="Error: %s" % err)
 
-    module.exit_json()
+    module.exit_json(**result)
 
 if __name__ == '__main__':
     main()

--- a/tests/fib.py
+++ b/tests/fib.py
@@ -10,13 +10,13 @@ def announce_routes(ptfip, port, family, podset_number, tor_number, tor_subnet_n
                     nexthop, nexthop_v6,
                     tor_subnet_size = 128, max_tor_subnet_number = 16):
     messages = []
-    
+
     # default route
     if family in ["v4", "both"]:
         messages.append("announce route 0.0.0.0/0 next-hop {} as-path [ {} ]".format(nexthop, spine_asn))
     if family in ["v6", "both"]:
         messages.append("announce route ::/0 next-hop {} as-path [ {} ]".format(nexthop_v6, spine_asn))
-    
+
     # NOTE: Using large enough values (e.g., podset_number = 200,
     # us to overflow the 192.168.0.0/16 private address space here.
     # This should be fine for internal use, but may pose an issue if used otherwise
@@ -35,17 +35,17 @@ def announce_routes(ptfip, port, family, podset_number, tor_number, tor_subnet_n
                 octet3 = ((suffix / 256) % 256)
                 octet4 = (suffix % 256)
                 prefixlen_v4 = (32 - int(math.log(tor_subnet_size, 2)))
-    
+
                 prefix = "{}.{}.{}.{}/{}".format(octet1, octet2, octet3, octet4, prefixlen_v4)
                 prefix_v6 = "20%02X:%02X%02X:0:%02X::/64" % (octet1, octet2, octet3, octet4) 
-    
+
                 leaf_asn = leaf_asn_start + podset
                 tor_asn  = tor_asn_start + tor
                 if podset == 0:
                     aspath = "{}".format(tor_asn)
                 else:
                     aspath = "{} {} {}".format(spine_asn, leaf_asn, tor_asn)
-               
+
                 if family in ["v4", "both"]:
                     messages.append("announce route {} next-hop {} as-path [ {} ]".format(prefix, nexthop, aspath))
                 if family in ["v6", "both"]:
@@ -56,7 +56,7 @@ def announce_routes(ptfip, port, family, podset_number, tor_number, tor_subnet_n
     r = requests.post(url, data=data)
     print r
     assert r.status_code == 200
-   
+
 @pytest.fixture(scope='module')
 def fib_t0(ptfhost, testbed):
 
@@ -82,7 +82,7 @@ def fib_t0(ptfhost, testbed):
         asn = int(v['bgp']['asn'])
         port = 5000 + vm_offset
         ptfhost.exabgp(name=k,
-                       state="restarted", \
+                       state="started", \
                        router_id = str(local_ip), \
                        local_ip  = str(local_ip), \
                        peer_ip   = str(peer_ip.ip), \
@@ -90,23 +90,47 @@ def fib_t0(ptfhost, testbed):
                        peer_asn  = asn, \
                        port = port)
 
-        announce_routes(ptfip, port, "v4", podset_number, tor_number, tor_subnet_number,
-                        spine_asn, leaf_asn_start, tor_asn_start,
-                        local_ip, local_ipv6)
-
     for k, v in testbed['topo']['properties']['configuration'].items():
         vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
         peer_ip = ipaddress.IPNetwork(v['bp_interface']['ipv6'])
         asn = int(v['bgp']['asn'])
         port = 6000 + vm_offset
         ptfhost.exabgp(name="%s-v6" % k,
-                       state="restarted", \
+                       state="started", \
                        router_id = str(local_ip), \
                        local_ip  = str(local_ipv6), \
                        peer_ip   = str(peer_ip.ip), \
                        local_asn = asn, \
                        peer_asn  = asn, \
                        port = port)
+
+    for k, v in testbed['topo']['properties']['configuration'].items():
+        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+        port = 5000 + vm_offset
+
+        count = 0
+        while count < 5:
+            count += 1
+            time.sleep(15)
+            ret = ptfhost.exabgp(name=k, state="status")
+            if 'RUNNING' is ret['status']:
+                break 
+
+        announce_routes(ptfip, port, "v4", podset_number, tor_number, tor_subnet_number,
+                        spine_asn, leaf_asn_start, tor_asn_start,
+                        local_ip, local_ipv6)
+
+    for k, v in testbed['topo']['properties']['configuration'].items():
+        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+        port = 6000 + vm_offset
+
+        count = 0
+        while count < 5:
+            count += 1
+            time.sleep(15)
+            ret = ptfhost.exabgp(name="%s-v6" % k, state="status")
+            if 'RUNNING' is ret['status']:
+                break 
 
         announce_routes(ptfip, port, "v6", podset_number, tor_number, tor_subnet_number,
                         spine_asn, leaf_asn_start, tor_asn_start,

--- a/tests/test_announce_routes.py
+++ b/tests/test_announce_routes.py
@@ -1,0 +1,7 @@
+import pytest
+
+def test_announce_routes(fib_t0):
+    """Simple test case that utilize fib_t0 to announce route in order to a newly setup test bed receive
+       BGP routes from remote devices
+    """
+    assert(True)


### PR DESCRIPTION
This test case would help setting up new vs test bed by announcing
routes using exabgp

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Enhance exabgp to check the status of exabgp process

#### How did you verify/test it?
py.test --inventory veos.vtb --host-pattern all --user admin -vvvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml test_announce_routes.py -vvvv

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
