### PR TITLE
[PFC] Test if PFC can pause lossless priorities

### DIFF
--- a/ansible/roles/test/files/ptftests/pfc_pause_test.py
+++ b/ansible/roles/test/files/ptftests/pfc_pause_test.py
@@ -63,12 +63,32 @@ class PfcPauseTest(BaseTest):
         """ DSCP for background traffic """
         self.dscp_bg = self.test_params['dscp_bg']
         self.queue_paused = self.test_params['queue_paused']
+        """ if DUT has MAC information """
+        self.dut_has_mac = self.test_params['dut_has_mac']
         
     def runTest(self):
         pass_cnt = 0
         tos = self.dscp<<2
         tos_bg = self.dscp_bg<<2
         
+        """ If DUT needs to learn MAC addresses """
+        if not self.dut_has_mac:            
+            pkt = simple_udp_packet(
+                eth_dst=self.mac_dst,
+                eth_src=self.mac_src,
+                ip_src=self.ip_src,
+                ip_dst=self.ip_dst)
+            
+            send_packet(self, self.port_src, pkt, 5)
+            
+            pkt = simple_udp_packet(
+                eth_dst=self.mac_src,
+                eth_src=self.mac_dst,
+                ip_src=self.ip_dst,
+                ip_dst=self.ip_src)
+            
+            send_packet(self, self.port_dst, pkt, 5)
+                    
         for x in range(self.pkt_count):
             sport = random.randint(0, 65535)
             dport = random.randint(0, 65535)

--- a/ansible/roles/test/files/ptftests/pfc_pause_test.py
+++ b/ansible/roles/test/files/ptftests/pfc_pause_test.py
@@ -14,7 +14,7 @@ import ptf.dataplane as dataplane
 from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
-from ptf.testutils import *
+from ptf.testutils import add_filter, reset_filters, dp_poll, simple_udp_packet, send_packet, test_params_get
 
 def udp_filter(pkt_str):
     try:
@@ -24,7 +24,7 @@ def udp_filter(pkt_str):
     except:
         return False
 
-def capture_matched_packets(test, exp_packet, port, device_number = 0,timeout = 1):
+def capture_matched_packets(test, exp_packet, port, device_number=0, timeout=1):
     """
     Receive all packets on the port and return all the received packets.
     As soon as the packets stop arriving, the function waits for the timeout value and returns the received packets. Therefore, this function requires a positive timeout value.
@@ -34,7 +34,7 @@ def capture_matched_packets(test, exp_packet, port, device_number = 0,timeout = 
     
     pkts = list()
     while True:
-        result = dp_poll(test, device_number = device_number, port_number = port, timeout = timeout)
+        result = dp_poll(test, device_number=device_number, port_number=port, timeout=timeout)
         if isinstance(result, test.dataplane.PollSuccess):
             if ptf.dataplane.match_exp_pkt(exp_packet, result.packet):
                 pkts.append(result.packet)
@@ -74,32 +74,32 @@ class PfcPauseTest(BaseTest):
             dport = random.randint(0, 65535)
         
             pkt = simple_udp_packet(
-                        eth_dst = self.mac_dst,
-                        eth_src = self.mac_src,
-                        ip_src = self.ip_src,
-                        ip_dst = self.ip_dst,
-                        ip_tos = tos,
-                        udp_sport = sport,
-                        udp_dport = dport,
-                        ip_ttl = 64)
+                        eth_dst=self.mac_dst,
+                        eth_src=self.mac_src,
+                        ip_src=self.ip_src,
+                        ip_dst=self.ip_dst,
+                        ip_tos=tos,
+                        udp_sport=sport,
+                        udp_dport=dport,
+                        ip_ttl=64)
             
             pkt_bg = simple_udp_packet(
-                        eth_dst = self.mac_dst,
-                        eth_src = self.mac_src,
-                        ip_src = self.ip_src,
-                        ip_dst = self.ip_dst,
-                        ip_tos = tos_bg,
-                        udp_sport = sport,
-                        udp_dport = dport,
-                        ip_ttl = 64)
+                        eth_dst=self.mac_dst,
+                        eth_src=self.mac_src,
+                        ip_src=self.ip_src,
+                        ip_dst=self.ip_dst,
+                        ip_tos=tos_bg,
+                        udp_sport=sport,
+                        udp_dport=dport,
+                        ip_ttl=64)
                           
             exp_pkt = simple_udp_packet(
-                        ip_src = self.ip_src,
-                        ip_dst = self.ip_dst,
-                        ip_tos = tos_bg,
-                        udp_sport = sport,
-                        udp_dport = dport,
-                        ip_ttl = 63)
+                        ip_src=self.ip_src,
+                        ip_dst=self.ip_dst,
+                        ip_tos=tos_bg,
+                        udp_sport=sport,
+                        udp_dport=dport,
+                        ip_ttl=63)
             
             masked_exp_pkt = Mask(exp_pkt)
             masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")

--- a/ansible/roles/test/files/ptftests/pfc_pause_test.py
+++ b/ansible/roles/test/files/ptftests/pfc_pause_test.py
@@ -1,0 +1,129 @@
+import ipaddress
+import logging
+import random
+import socket
+import sys
+import struct
+import ipaddress
+import re
+
+import ptf
+import ptf.packet as scapy
+import ptf.dataplane as dataplane
+
+from ptf import config
+from ptf.base_tests import BaseTest
+from ptf.mask import Mask
+from ptf.testutils import *
+
+def udp_filter(pkt_str):
+    try:
+        pkt = scapy.Ether(pkt_str)
+        return scapy.UDP in pkt
+
+    except:
+        return False
+
+def capture_matched_packets(test, exp_packet, port, device_number = 0,timeout = 1):
+    """
+    Receive all packets on the port and return all the received packets.
+    As soon as the packets stop arriving, the function waits for the timeout value and returns the received packets. Therefore, this function requires a positive timeout value.
+    """
+    if timeout <= 0:
+        raise Exception("%s() requires positive timeout value." % sys._getframe().f_code.co_name)
+    
+    pkts = list()
+    while True:
+        result = dp_poll(test, device_number = device_number, port_number = port, timeout = timeout)
+        if isinstance(result, test.dataplane.PollSuccess):
+            if ptf.dataplane.match_exp_pkt(exp_packet, result.packet):
+                pkts.append(result.packet)
+        else:
+            break
+    
+    return pkts 
+        
+class PfcPauseTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = test_params_get()
+
+    def setUp(self):
+        add_filter(udp_filter)
+        self.dataplane = ptf.dataplane_instance
+        self.mac_src = self.test_params['mac_src']
+        self.mac_dst = self.test_params['mac_dst']
+        self.pkt_count = int(self.test_params['pkt_count'])
+        self.pkt_intvl = float(self.test_params['pkt_intvl']) 
+        self.port_src = int(self.test_params['port_src'])
+        self.port_dst = self.test_params['port_dst']
+        self.ip_src = self.test_params['ip_src']
+        self.ip_dst = self.test_params['ip_dst']
+        self.dscp = self.test_params['dscp']
+        """ DSCP for background traffic """
+        self.dscp_bg = self.test_params['dscp_bg']
+        self.queue_paused = self.test_params['queue_paused']
+        
+    def runTest(self):
+        pass_cnt = 0
+        tos = self.dscp<<2
+        tos_bg = self.dscp_bg<<2
+        
+        for x in range(self.pkt_count):
+            sport = random.randint(0, 65535)
+            dport = random.randint(0, 65535)
+        
+            pkt = simple_udp_packet(
+                        eth_dst = self.mac_dst,
+                        eth_src = self.mac_src,
+                        ip_src = self.ip_src,
+                        ip_dst = self.ip_dst,
+                        ip_tos = tos,
+                        udp_sport = sport,
+                        udp_dport = dport,
+                        ip_ttl = 64)
+            
+            pkt_bg = simple_udp_packet(
+                        eth_dst = self.mac_dst,
+                        eth_src = self.mac_src,
+                        ip_src = self.ip_src,
+                        ip_dst = self.ip_dst,
+                        ip_tos = tos_bg,
+                        udp_sport = sport,
+                        udp_dport = dport,
+                        ip_ttl = 64)
+                          
+            exp_pkt = simple_udp_packet(
+                        ip_src = self.ip_src,
+                        ip_dst = self.ip_dst,
+                        ip_tos = tos_bg,
+                        udp_sport = sport,
+                        udp_dport = dport,
+                        ip_ttl = 63)
+            
+            masked_exp_pkt = Mask(exp_pkt)
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "tos")
+            
+            send_packet(self, self.port_src, pkt, 1)
+            send_packet(self, self.port_src, pkt_bg, 1)
+            
+            pkts = capture_matched_packets(self, masked_exp_pkt, self.port_dst)
+            
+            time.sleep(self.pkt_intvl)
+            
+            """ If the queue is paused, we should only receive the background packet """
+            if self.queue_paused:
+                pass_cnt += int(len(pkts) == 1 and scapy.Ether(pkts[0])[scapy.IP].tos == tos_bg)
+
+            else:
+                pass_cnt += int(len(pkts) == 2)
+            
+        print "Passes: %d / %d" % (pass_cnt, self.pkt_count)
+    
+    def tearDown(self):   
+        reset_filters()
+        BaseTest.tearDown(self)

--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -44,7 +44,7 @@ def conn_graph_facts(testbed_devices):
     localhost = testbed_devices["localhost"]
 
     base_path = os.path.dirname(os.path.realpath(__file__))
-    lab_conn_graph_file = os.path.join(base_path, "../../ansible/files/starlab_connection_graph.xml")
+    lab_conn_graph_file = os.path.join(base_path, "../../ansible/files/lab_connection_graph.xml")
     result = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
 	
     return result

--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -1,5 +1,37 @@
 import pytest
 import os
+from ansible_host import AnsibleHost
+
+@pytest.fixture(scope = "module")
+def lossless_prio_dscp_map(testbed_devices):
+    dut = testbed_devices["dut"]
+    config_facts = dut.config_facts(host=dut.hostname, source="persistent")['ansible_facts']
+    
+    if "PORT_QOS_MAP" not in config_facts.keys():
+        return None 
+    
+    port_qos_map = config_facts["PORT_QOS_MAP"]
+    lossless_priorities = list()
+    intf = port_qos_map.keys()[0]
+    if 'pfc_enable' not in port_qos_map[intf]:
+        return None 
+        
+    lossless_priorities = [int(x) for x in port_qos_map[intf]['pfc_enable'].split(',')]
+    dscp_to_tc_map = config_facts["DSCP_TO_TC_MAP"]
+    
+    result = dict()
+    for prio in lossless_priorities:
+        result[prio] = list()
+
+    profile = dscp_to_tc_map.keys()[0]
+         
+    for dscp in dscp_to_tc_map[profile]:
+        tc = dscp_to_tc_map[profile][dscp]
+        
+        if int(tc) in lossless_priorities:
+            result[int(tc)].append(int(dscp))
+    
+    return result 
 
 @pytest.fixture(scope = "module")
 def conn_graph_facts(testbed_devices):
@@ -12,7 +44,7 @@ def conn_graph_facts(testbed_devices):
     localhost = testbed_devices["localhost"]
 
     base_path = os.path.dirname(os.path.realpath(__file__))
-    lab_conn_graph_file = os.path.join(base_path, "../../ansible/files/lab_connection_graph.xml")
+    lab_conn_graph_file = os.path.join(base_path, "../../ansible/files/starlab_connection_graph.xml")
     result = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
 	
     return result

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -1,7 +1,15 @@
 from ansible_host import AnsibleHost
 from netaddr import IPAddress, IPNetwork
+from qos_fixtures import lossless_prio_dscp_map, conn_graph_facts, leaf_fanouts
 import json
 import re
+import ipaddress
+
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+def natural_keys(text):
+    return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 def ansible_stdout_to_str(ansible_stdout):
     """
@@ -22,13 +30,23 @@ def eos_to_linux_intf(eos_intf_name):
     """
     return eos_intf_name.replace('Ethernet', 'et').replace('/', '_')
 
+def get_phy_intfs(host_ans):
+    """
+    @Summary: Get the physical interfaces (e.g., EthernetX) of a DUT
+    @param host_ans: Ansible host instance of this DUT
+    @return: Return the list of active interfaces
+    """
+    intf_facts = host_ans.interface_facts()['ansible_facts']['ansible_interface_facts'] 
+    phy_intfs = [k for k in intf_facts.keys() if k.startswith('Ethernet')]
+    return phy_intfs 
+
 def get_active_intfs(host_ans):
     """
     @Summary: Get the active interfaces of a DUT
     @param host_ans: Ansible host instance of this DUT
     @return: Return the list of active interfaces
     """
-    int_status = host_ans.show_interface(command = "status")['ansible_facts']['int_status']
+    int_status = host_ans.show_interface(command="status")['ansible_facts']['int_status']
     active_intfs = []
     
     for intf in int_status:
@@ -148,5 +166,96 @@ def config_intf_ip_mac(host_ans, intf, ip_addr, netmask, mac_addr):
     host_ans.shell('ifconfig %s hw ether %s' % (intf, mac_addr))
     host_ans.shell('ifconfig %s up' % intf)
     host_ans.shell('ifconfig %s %s netmask %s' % (intf, ip_addr, netmask))
+
+def get_active_vlan_members(host_ans, hostname):
+    """
+    @Summary: Get all the active physical interfaces enslaved to a Vlan
+    @param host_ans: Ansible host instance of the device
+    @param hostname: host name of the device
+    @return: Return the list of active physical interfaces
+    """
+    mg_facts = host_ans.minigraph_facts(host=hostname)['ansible_facts']
+    mg_vlans = mg_facts['minigraph_vlans']
     
+    if len(mg_vlans) != 1:
+        print 'There should be only one Vlan at the DUT'
+        return None
     
+    """ Get all the Vlan memebrs """
+    vlan_intf = mg_vlans.keys()[0]
+    vlan_members = mg_vlans[vlan_intf]['members']
+    
+    """ Filter inactive Vlan members """
+    active_intfs = get_active_intfs(host_ans)
+    vlan_members = [x for x in vlan_members if x in active_intfs]
+    
+    return vlan_members 
+
+def get_vlan_subnet(host_ans, hostname):
+    """
+    @Summary: Get Vlan subnet of a T0 device
+    @param host_ans: Ansible host instance of the device
+    @param hostname: host name of the device
+    @return: Return Vlan subnet, e.g., "192.168.1.1/24"
+    """
+    mg_facts = host_ans.minigraph_facts(host=hostname)['ansible_facts']
+    mg_vlans = mg_facts['minigraph_vlans']
+    
+    if len(mg_vlans) != 1:
+        print 'There should be only one Vlan at the DUT'
+        return None
+    
+    mg_vlan_intfs = mg_facts['minigraph_vlan_interfaces']        
+    vlan_subnet = ansible_stdout_to_str(mg_vlan_intfs[0]['subnet'])
+    return vlan_subnet
+    
+def config_testbed_t0(ansible_adhoc, testbed):
+    """
+    @Summary: Configure a T0 testbed
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @return: Return four values: DUT interfaces, PTF interfaces, PTF IP addresses, and PTF MAC addresses, 
+    """ 
+    dut_hostname = testbed['dut']
+    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
+    
+    """ Get all the active physical interfaces enslaved to the Vlan """
+    """ These interfaces are actually server-faced interfaces at T0 """
+    vlan_members = get_active_vlan_members(dut_ans, dut_hostname)
+    
+    """ Get Vlan subnet """
+    vlan_subnet = get_vlan_subnet(dut_ans, dut_hostname)
+    
+    """ Prefix length to network mask """
+    vlan_subnet_mask = ipaddress.ip_network(unicode(vlan_subnet, "utf-8")).netmask
+    
+    """ Generate IP addresses for servers in the Vlan """
+    vlan_ip_addrs = get_addrs_in_subnet(vlan_subnet, len(vlan_members))
+    
+    """ Generate MAC addresses 00:00:00:00:00:XX for servers in the Vlan """
+    vlan_mac_addrs = [5 * '00:' + format(k, '02x') for k in random.sample(range(1, 256), len(vlan_members))]
+    
+    """ Find correspoinding interfaces on PTF """
+    phy_intfs = get_phy_intfs(dut_ans)
+    phy_intfs.sort(key=natural_keys)
+    vlan_members.sort(key=natural_keys)
+    vlan_members_index = [phy_intfs.index(intf) for intf in vlan_members]
+    ptf_intfs = ['eth' + str(i) for i in vlan_members_index]
+   
+    """ Remove existing IP addresses from PTF host """ 
+    ptf_hostname = testbed['ptf']
+    ptf_ans = AnsibleHost(ansible_adhoc, ptf_hostname)
+    ptf_ans.script('scripts/remove_ip.sh')
+
+    """ Clear MAC table in DUT (host memory and ASIC) """
+    dut_ans.shell('sonic-clear fdb all </dev/null >/dev/null 2>&1 &')
+    dut_ans.shell('sudo ip -s -s neigh flush all </dev/null >/dev/null 2>&1 &')
+        
+    """ Configure IP and MAC addresses on PTF """
+    for i in range(len(ptf_intfs)):
+        config_intf_ip_mac(ptf_ans, ptf_intfs[i], vlan_ip_addrs[i], vlan_subnet_mask, vlan_mac_addrs[i])
+    
+    return vlan_members, ptf_intfs, vlan_ip_addrs, vlan_mac_addrs
+
+        

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -1,7 +1,139 @@
+from ansible_host import AnsibleHost
+from netaddr import IPAddress, IPNetwork
+import json
+import re
+
+def ansible_stdout_to_str(ansible_stdout):
+    """
+    @Summary: The stdout of Ansible host is essentially a list of unicode characters. This function converts it to a string.
+    @param ansible_stdout: stdout of Ansible 
+    @return: Return a string  
+    """
+    result = ""
+    for x in ansible_stdout:
+        result += x.encode('UTF8')
+    return result
+
 def eos_to_linux_intf(eos_intf_name):
     """
     @Summary: Map EOS's interface name to Linux's interface name
     @param eos_intf_name: Interface name in EOS
     @return: Return the interface name in Linux
     """
-    return eos_intf_name.replace('Ethernet', 'et').replace('/', '_') 
+    return eos_intf_name.replace('Ethernet', 'et').replace('/', '_')
+
+def get_active_intfs(dut_ans):
+    """
+    @Summary: Get the active interfaces of a DUT
+    @param dut_ans: Ansible host instance of this DUT
+    @return: Return the list of active interfaces
+    """
+    int_status = dut_ans.show_interface(command = "status")['ansible_facts']['int_status']
+    active_intfs = []
+    
+    for intf in int_status:
+        if int_status[intf]['admin_state'] == 'up' and \
+           int_status[intf]['oper_state'] == 'up':
+            active_intfs.append(intf)
+
+    return active_intfs
+
+def get_addrs_in_subnet(subnet, n):
+    """ 
+    @Summary: Get N IP addresses in a subnet
+    @param subnet: IPv4 subnet, e.g., '192.168.1.1/24'
+    @param n: # of IP addresses to get 
+    @return: Retuen n IPv4 addresses in this subnet in a list
+    """
+    ip_addr = subnet.split('/')[0]
+    ip_addrs = [str(x) for x in list(IPNetwork(subnet))]
+    ip_addrs.remove(ip_addr)
+    
+    """ Try to avoid network and broadcast addresses """
+    if len(ip_addrs) >= n + 2:
+        del ip_addrs[0]
+        del ip_addrs[-1]
+    
+    return ip_addrs[:n]
+
+def get_neigh_ip(ip_addr, netmask):
+    """
+    @Summary: Given an IP address and a netmask, get another IP in this subnet. 
+    @param ip_addr: IPv4 address string (e.g., "192.168.1.1")
+    @param netmask: network mask string (e.g., "255.255.255.254")
+    @return: Return another IP address in this subnet
+    """
+    prefix_len = IPAddress(netmask).netmask_bits()
+    ip_addrs = get_addrs_in_subnet(ip_addr + '/' + str(prefix_len), 1)
+    
+    if len(ip_addrs) != 0:
+        return ip_addrs[0]
+    
+    else:
+        return None  
+
+def gen_arp_responder_config(intfs, ip_addrs, mac_addrs, config_file):
+    """
+    @Summary: Generate a configuration file for ARP responder
+    @param intfs: list of interfaces
+    @param ip_addrs: list of IP addresses
+    @param mac_addrs: list of MAC addresses
+    @param config_file: configuration file path 
+    return: Return true if the config file is successfully generated
+    """
+    if len(intfs) != len(ip_addrs) or len(intfs) != len(mac_addrs):
+        return False 
+    
+    config = dict()
+    for i in range(len(intfs)):
+        config[intfs[i]] = dict()
+        """ The config file accepts MAC addresses like 00112233445566 without any : """
+        config[intfs[i]][ip_addrs[i]] = mac_addrs[i].replace(':', '')
+    
+    with open(config_file, 'w') as fp:
+        json.dump(config, fp)
+            
+    return True 
+
+def check_mac_table(dut_ans, mac_addrs):
+    """
+    @Summary: Check if the DUT's MAC table (FIB) has all the MAC address information
+    @param dut_ans: Ansible host instance of this DUT
+    @param mac_addrs: list of MAC addresses to check 
+    return: Return true if the DUT's MAC table has all the MAC addresses 
+    """
+    if mac_addrs is None:
+        return False 
+    
+    stdout = ansible_stdout_to_str(dut_ans.command('show mac')['stdout'])
+    
+    for mac in mac_addrs:
+        if mac.upper() not in stdout.upper():
+            return False 
+        
+    return True
+
+def get_mac(dut_ans, ip_addr):
+    """
+    @Summary: Get the MAC address of a given IP address in a DUT
+    @param dut_ans: Ansible host instance of this DUT
+    @param ip_addr: IP address
+    return: Return the MAC address or None if we cannot find it
+    """
+    cmd = 'sudo arp -a -n %s' % (ip_addr)
+    stdout = ansible_stdout_to_str(dut_ans.command(cmd)['stdout']).strip()
+    
+    if len(stdout) == 0 or 'incomplete' in stdout:
+        return None 
+         
+    pattern = re.compile(ur'(?:[0-9a-fA-F]:?){12}')
+    results = re.findall(pattern, stdout)
+    
+    if len(results) == 0:
+        return None 
+    
+    else:
+        return results[0]
+    
+    
+    

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -18,7 +18,7 @@ PTF_FILE_RELATIVE_PATH = '../../ansible/roles/test/files/ptftests/pfc_pause_test
 PTF_FILE_DEST = '~/pfc_pause_test.py'
 PTF_PKT_COUNT = 50
 PTF_PKT_INTVL_SEC = 0.1
-PTF_PASS_RATIO_THRESH = 0.75
+PTF_PASS_RATIO_THRESH = 0.6
 
 """ Maximum number of interfaces to test on a DUT """
 MAX_TEST_INTFS_COUNT = 4
@@ -121,7 +121,7 @@ def run_test_t0(ansible_adhoc,
         dut_intf_paused = dut_intfs[dst_index]
         
         """ Clear MAC table in DUT """
-        dut_ans.shell('sonic-clear fdb all </dev/null >/dev/null 2>&1 &')
+        dut_ans.shell('sonic-clear fdb all')
         time.sleep(2)
                                                                  
         if send_pause:            
@@ -277,7 +277,6 @@ def test_pfc_pause_lossless(ansible_adhoc,
                     print "errors occured:\n{}".format("\n".join(errors))
                     assert 0 
 
-#@pytest.mark.skip(reason="")
 def test_no_pfc(ansible_adhoc,
                 testbed, 
                 conn_graph_facts, 

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -1,0 +1,300 @@
+
+from ansible_host import AnsibleHost
+from qos_fixtures import *
+from qos_helpers import ansible_stdout_to_str, eos_to_linux_intf, get_active_intfs, get_addrs_in_subnet, get_neigh_ip,check_mac_table, get_mac
+
+import pytest
+import os
+import time
+import re
+import struct
+import random
+import ipaddress
+
+PFC_GEN_FILE = 'pfc_gen.py'
+PFC_GEN_FILE_RELATIVE_PATH = '../../ansible/roles/test/files/helpers/pfc_gen.py'
+PFC_GEN_FILE_DEST = '~/pfc_gen.py'
+PFC_PKT_COUNT = 1000000000
+
+PTF_FILE_RELATIVE_PATH = '../../ansible/roles/test/files/ptftests/pfc_pause_test.py'
+PTF_FILE_DEST = '~/pfc_pause_test.py'
+PTF_PKT_COUNT = 50
+PTF_PKT_INTVL_SEC = 0.1
+PTF_PASS_RATIO_THRESH = 0.75
+         
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+def natural_keys(text):
+    return [atoi(c) for c in re.split(r'(\d+)', text)]
+
+def setup_testbed(ansible_adhoc, testbed, leaf_fanouts):
+    """
+    @Summary: Set up the testbed, including (1) copying the PFC generator to the leaf fanout switches,
+    and (2) copying the PTF script to the PTF container.
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @param leaf_fanouts: Leaf fanout switches
+    """
+    
+    """ Copy the PFC generator to leaf fanout switches """
+    for peer_device in leaf_fanouts:
+        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
+        cmd = "sudo kill -9 $(pgrep -f %s) </dev/null >/dev/null 2>&1 &" % (PFC_GEN_FILE)
+        peerdev_ans.shell(cmd)
+        file_src = os.path.join(os.path.dirname(__file__), PFC_GEN_FILE_RELATIVE_PATH)
+        peerdev_ans.copy(src=file_src, dest=PFC_GEN_FILE_DEST, force=True)
+                  
+    """ Remove existing python scripts on PTF """
+    ptf_hostname = testbed['ptf']
+    ptf_ans = AnsibleHost(ansible_adhoc, ptf_hostname)
+    result = ptf_ans.find(paths=['~/'], patterns="*.py")['files']
+    files = [ansible_stdout_to_str(x['path']) for x in result]
+    
+    for file in files:
+        ptf_ans.file(path=file, mode="absent")
+
+    """ Copy the PFC test script to the PTF container """  
+    file_src = os.path.join(os.path.dirname(__file__), PTF_FILE_RELATIVE_PATH)
+    ptf_ans.copy(src=file_src, dest=PTF_FILE_DEST, force=True)
+
+def run_test_t0(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, prio, dscp, dscp_bg, queue_paused, is_pfc=True, pause_time=65535, max_test_count=128):
+    """ 
+    @Summary: Run a series of tests on a T0 topology.
+    For the T0 topology, we only test Vlan (server-faced) interfaces.    
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @param conn_graph_facts: Testbed topology
+    @param leaf_fanouts: Leaf fanout switches
+    @param prio: priority of PFC frame
+    @param dscp: DSCP value of test data packets
+    @param dscp_bg: DSCP value of background data packets
+    @param queue_paused: if the queue is expected to be paused
+    @param is_pfc: If this test is for PFC?
+    @param pause_time: pause time quanta of PFC frames. It is 65535 (maximum pause time quanta) by default.
+    @param max_test_count: maximum count of tests to run. By default, it is a very large value to cover all the interfaces.  
+    return: Return # of iterations and # of passed iterations for each tested interface.   
+    """
+    dut_hostname = testbed['dut']
+    dut_ans = AnsibleHost(ansible_adhoc, dut_hostname)
+    mg_facts = dut_ans.minigraph_facts(host=dut_hostname)['ansible_facts']
+    mg_vlans = mg_facts['minigraph_vlans']
+
+    if len(mg_vlans) != 1:
+        print 'There should be only one Vlan at the DUT'
+        return None
+    
+    """ Get all the Vlan memebrs """
+    vlan_intf = mg_vlans.keys()[0]
+    vlan_members = mg_vlans[vlan_intf]['members']
+    
+    """ Filter inactive Vlan members """
+    active_intfs = get_active_intfs(dut_ans)
+    vlan_members = [x for x in vlan_members if x in active_intfs]
+
+    mg_vlan_intfs = mg_facts['minigraph_vlan_interfaces']        
+    vlan_subnet = ansible_stdout_to_str(mg_vlan_intfs[0]['subnet'])
+    vlan_subnet_mask = ipaddress.ip_network(unicode(vlan_subnet, "utf-8")).netmask
+         
+    """ Generate IP addresses for servers in the Vlan """
+    vlan_ip_addrs = get_addrs_in_subnet(vlan_subnet, len(vlan_members))
+    """ Generate MAC addresses 00:00:00:00:00:XX for servers in the Vlan """
+    vlan_mac_addrs = [5 * '00:' + format(k, '02x') for k in random.sample(range(1, 256), len(vlan_members))]
+    
+    """ Find correspoinding interfaces on PTF """
+    intf_facts = dut_ans.interface_facts()['ansible_facts']['ansible_interface_facts'] 
+    phy_intfs = [k for k in intf_facts.keys() if k.startswith('Ethernet')]
+    phy_intfs.sort(key = natural_keys)
+    vlan_members.sort(key = natural_keys)
+    vlan_members_index = [phy_intfs.index(intf) for intf in vlan_members]
+    ptf_intfs = ['eth' + str(i) for i in vlan_members_index]
+    
+    ptf_hostname = testbed['ptf']
+    ptf_ans = AnsibleHost(ansible_adhoc, ptf_hostname)
+    
+    """ Remove existing IP addresses from PTF host """ 
+    ptf_ans.script('scripts/remove_ip.sh')
+    
+    """ Stop PFC storm at the leaf fanout switches """
+    for peer_device in leaf_fanouts:
+        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
+        cmd = "sudo kill -9 $(pgrep -f %s) </dev/null >/dev/null 2>&1 &" % (PFC_GEN_FILE) 
+        peerdev_ans.shell(cmd) 
+        
+    """ Clear DUT's PFC counters """
+    dut_ans.sonic_pfc_counters(method = "clear")
+    
+    """ Disable DUT's PFC wd """
+    dut_ans.shell('sudo pfcwd stop')
+
+    time.sleep(1)
+    results = dict()
+
+    for i in range(min(max_test_count, len(ptf_intfs))):
+        src_index = i
+        dst_index = (i + 1) % len(ptf_intfs)
+        
+        src_intf = ptf_intfs[src_index]
+        dst_intf = ptf_intfs[dst_index]
+        
+        src_ip = vlan_ip_addrs[src_index]
+        dst_ip = vlan_ip_addrs[dst_index]
+        
+        src_mac = vlan_mac_addrs[src_index]
+        dst_mac = vlan_mac_addrs[dst_index]
+       
+        """ DUT interface to pause """
+        dut_intf_paused = vlan_members[dst_index]
+
+        """ Configure IP and MAC on Tx and Rx interfaces of PTF """
+        ptf_ans.shell('ifconfig %s down' % src_intf)
+        ptf_ans.shell('ifconfig %s hw ether %s'% (src_intf, src_mac))
+        ptf_ans.shell('ifconfig %s up' % src_intf)
+        ptf_ans.shell('ifconfig %s %s netmask %s' % (src_intf, src_ip, vlan_subnet_mask))
+        
+        ptf_ans.shell('ifconfig %s down' % dst_intf)
+        ptf_ans.shell('ifconfig %s hw ether %s'% (dst_intf, dst_mac))
+        ptf_ans.shell('ifconfig %s up' % dst_intf)
+        ptf_ans.shell('ifconfig %s %s netmask %s' % (dst_intf, dst_ip, vlan_subnet_mask))
+                
+        """ Clear MAC table in DUT (host memory and ASIC) """
+        dut_ans.shell('sonic-clear fdb all </dev/null >/dev/null 2>&1 &')
+        dut_ans.shell('sudo ip -s -s neigh flush all </dev/null >/dev/null 2>&1 &')
+        time.sleep(2)
+        
+        """ Populate the MAC table """
+        dut_ans.shell('ping -c 2 %s </dev/null >/dev/null 2>&1 &' % (src_ip))
+        dut_ans.shell('ping -c 2 %s </dev/null >/dev/null 2>&1 &' % (dst_ip))
+        time.sleep(2)
+        
+        """ Ensure the MAC table is correct """
+        if not check_mac_table(dut_ans, [src_mac, dst_mac]):
+            print 'MAC table of DUT is incorrect'
+            continue 
+                
+        peer_device = conn_graph_facts['device_conn'][dut_intf_paused]['peerdevice']
+        peer_port = conn_graph_facts['device_conn'][dut_intf_paused]['peerport']
+        peer_port_name = eos_to_linux_intf(peer_port)
+        peerdev_ans = AnsibleHost(ansible_adhoc, peer_device)
+        
+        cmd = "nohup sudo python %s -i %s -g -t %d -n %d </dev/null >/dev/null 2>&1 &" % (PFC_GEN_FILE_DEST, peer_port_name, pause_time, PFC_PKT_COUNT)
+        
+        if is_pfc:
+            cmd = "nohup sudo python %s -i %s -p %d -t %d -n %d </dev/null >/dev/null 2>&1 &" % (PFC_GEN_FILE_DEST, peer_port_name, 2 ** prio, pause_time, PFC_PKT_COUNT)
+                
+        """ Start PFC / FC storm """
+        peerdev_ans.shell(cmd)
+       
+        """ Wait for PFC pause frame generation """
+        time.sleep(2)
+        
+        """ Run PTF test """
+        intf_info = '--interface %d@%s --interface %d@%s' % (src_index, src_intf, dst_index, dst_intf)
+        test_params = 'mac_src=\'%s\';mac_dst=\'%s\';ip_src=\'%s\';ip_dst=\'%s\';dscp=%d;dscp_bg=%d;pkt_count=%d;pkt_intvl=%f;port_src=%d;port_dst=%d;queue_paused=%s' % (src_mac, dst_mac, src_ip, dst_ip, dscp, dscp_bg, PTF_PKT_COUNT, PTF_PKT_INTVL_SEC, src_index, dst_index, queue_paused)
+        cmd = 'ptf --test-dir ~/ %s --test-params="%s"' % (intf_info, test_params)
+        print cmd 
+        stdout = ansible_stdout_to_str(ptf_ans.shell(cmd)['stdout'])
+        words = stdout.split()
+        
+        """ 
+        Expected format: "Passes: a / b" 
+        where a is # of passed iterations and b is total # of iterations
+        """
+        if len(words) != 4:
+            print 'Unknown PTF test result format'
+            results[dut_intf_paused] = [0, 0]
+
+        else:
+            results[dut_intf_paused] = [int(words[1]), int(words[3])] 
+        time.sleep(1)
+
+        """ Stop PFC / FC storm """
+        cmd = "sudo kill -9 $(pgrep -f %s) </dev/null >/dev/null 2>&1 &" % (PFC_GEN_FILE)
+        peerdev_ans.shell(cmd)
+        time.sleep(1)
+                
+    return results
+
+
+def run_test(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, prio, dscp, dscp_bg, queue_paused, is_pfc=True, pause_time=65535, max_test_count=128):
+    """ 
+    @Summary: Run a series of tests on a T0 topology.
+    For the T0 topology, we only test Vlan (server-faced) interfaces. 
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
+    mandatory argument for the class constructors.
+    @param testbed: Testbed information
+    @param conn_graph_facts: Testbed topology
+    @param leaf_fanouts: Leaf fanout switches
+    @param prio: priority of PFC frame
+    @param dscp: DSCP value of test data packets
+    @param dscp_bg: DSCP value of background data packets
+    @param queue_paused: if the queue is expected to be paused
+    @param is_pfc: If this test is for PFC?
+    @param pause_time: pause time quanta of PFC frames. It is 65535 (maximum pause time quanta) by default.
+    @param max_test_count: maximum count of tests to run. By default, it is a very large value to cover all the interfaces.
+    return: Return # of iterations and # of passed iterations for each test case. 
+    """
+    
+    print testbed 
+    if testbed['topo']['name'].startswith('t0'):
+        return run_test_t0(ansible_adhoc=ansible_adhoc,       
+                           testbed=testbed, 
+                           conn_graph_facts=conn_graph_facts, leaf_fanouts=leaf_fanouts, 
+                           prio=prio, 
+                           dscp=dscp, 
+                           dscp_bg=dscp_bg, 
+                           queue_paused=queue_paused, 
+                           is_pfc=is_pfc, 
+                           pause_time=pause_time, 
+                           max_test_count=max_test_count)
+            
+    else:
+        return None 
+
+def test_pfc_pause_lossless(ansible_adhoc, testbed, conn_graph_facts, leaf_fanouts, lossless_prio_dscp_map):
+    """ @Summary: Test if PFC pause frames can pause a lossless priority without affecting the other priorities """    
+    setup_testbed(ansible_adhoc, testbed, leaf_fanouts)
+
+    errors = []
+    
+    for prio in lossless_prio_dscp_map:
+        """ DSCP of the other priorities """
+        other_dscps = [x for x in range(64) if x not in lossless_prio_dscp_map[prio]]
+        
+        for dscp in lossless_prio_dscp_map[prio]:
+            dscp_bg = random.choice(other_dscps)
+            results = run_test(ansible_adhoc=ansible_adhoc, 
+                               testbed=testbed,
+                               conn_graph_facts=conn_graph_facts,
+                               leaf_fanouts=leaf_fanouts, 
+                               prio=prio,
+                               dscp=dscp,
+                               dscp_bg=dscp_bg,
+                               queue_paused=True,
+                               is_pfc=True,
+                               pause_time=65535,
+                               max_test_count=4)
+
+            """ results should not be none """
+            if results is None:
+                assert 0 
+            
+            errors = dict()
+            for intf in results:
+                if len(results[intf]) != 2:
+                    continue
+                
+                pass_count = results[intf][0]
+                total_count = results[intf][1]
+
+                if total_count == 0:
+                    continue
+            
+                if pass_count < total_count * PTF_PASS_RATIO_THRESH:
+                    errors[intf] = results[intf]
+
+            if len(errors) > 0:
+                print "errors occured:\n{}".format("\n".join(errors))
+                assert 0 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Signed-off-by: Wei Bai baiwei0427@gmail.com

Summary: Two pytest tests:
- Test if PFC can pause lossless priorities without affecting the other priorities
- Test if lossless and lossy priorities can forward packets in the absence of PFC pause frames


### Type of change
- [] Test case(new/improvement)

### Approach
#### How did you do it?
1. Set up the testbed, including (1) copy the PFC packet generator toe the leaf fanout switches, and (2) copying the PTF script to the PTF container.

2. Given a tested interface _i_ on the DUT, we generate PFC pause frames at the leaf fanout to _block_ the lossless priority _p_ of this interface.

3. The PTF script transmits two packets which should leave DUT from the interface _i_. One packet is mapped to priority _p_. The other packet is mapped to any other priority.

4. The PTF script should only receive the packet that is not mapped to priority _p_. 

#### How did you verify/test it?
I ran this test case in our testbed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
Currently, the test case only supports T0 topology. I will add more topologies in the future. 

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
