### PR TITLE
[bgp] Enhance BGP speaker test

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -212,8 +212,8 @@ class FibTest(BaseTest):
         @param dest_ip_addr: destination IP to build packet with.
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         '''
-        sport = random.randint(0, 65535)
-        dport = random.randint(0, 65535)
+        sport = random.randint(10000, 65535)
+        dport = random.randint(10000, 65535)
         ip_src = "10.0.0.1"
         ip_dst = dst_ip_addr
         src_mac = self.dataplane.get_mac(0, 0)
@@ -261,8 +261,8 @@ class FibTest(BaseTest):
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         @return Boolean
         '''
-        sport = random.randint(0, 65535)
-        dport = random.randint(0, 65535)
+        sport = random.randint(10000, 65535)
+        dport = random.randint(10000, 65535)
         ip_src = '2000::1'
         ip_dst = dst_ip_addr
         src_mac = self.dataplane.get_mac(0, 0)

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -212,8 +212,8 @@ class FibTest(BaseTest):
         @param dest_ip_addr: destination IP to build packet with.
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         '''
-        sport = random.randint(10000, 65535)
-        dport = random.randint(10000, 65535)
+        sport = random.randint(0, 65535)
+        dport = random.randint(0, 65535)
         ip_src = "10.0.0.1"
         ip_dst = dst_ip_addr
         src_mac = self.dataplane.get_mac(0, 0)
@@ -261,8 +261,8 @@ class FibTest(BaseTest):
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         @return Boolean
         '''
-        sport = random.randint(10000, 65535)
-        dport = random.randint(10000, 65535)
+        sport = random.randint(0, 65535)
+        dport = random.randint(0, 65535)
         ip_src = '2000::1'
         ip_dst = dst_ip_addr
         src_mac = self.dataplane.get_mac(0, 0)

--- a/tests/test_bgp_speaker.py
+++ b/tests/test_bgp_speaker.py
@@ -101,11 +101,13 @@ def common_setup_teardown(duthost, ptfhost):
                        port=str(port_num[i]))
 
     for i in range(0, 3):
+        ret = {}
         for count in range(0, 5):
             time.sleep(15)
             ret = ptfhost.exabgp(name="bgps%d" % i, state="status")
-            if 'RUNNING' is ret['status']:
-                break 
+            if u'RUNNING' == ret['status']:
+                break
+        assert u'RUNNING' == ret['status']
 
     logging.info("########### Done setup for bgp speaker testing ###########")
 

--- a/tests/test_bgp_speaker.py
+++ b/tests/test_bgp_speaker.py
@@ -65,7 +65,7 @@ def common_setup_teardown(duthost, ptfhost):
         duthost.command("ip route flush %s/32" % ip.ip)
         duthost.command("ip route add %s/32 dev %s" % (ip.ip, mg_facts['minigraph_vlan_interfaces'][0]['attachto']))
 
-    port_num = [5000, 6000, 7000]
+    port_num = [7000, 8000, 9000]
 
     lo_addr = mg_facts['minigraph_lo_interfaces'][0]['addr']
     lo_addr_prefixlen = int(mg_facts['minigraph_lo_interfaces'][0]['prefixlen'])
@@ -99,6 +99,13 @@ def common_setup_teardown(duthost, ptfhost):
                        local_asn=bgp_speaker_asn,
                        peer_asn=mg_facts['minigraph_bgp_asn'],
                        port=str(port_num[i]))
+
+    for i in range(0, 3):
+        for count in range(0, 5):
+            time.sleep(15)
+            ret = ptfhost.exabgp(name="bgps%d" % i, state="status")
+            if 'RUNNING' is ret['status']:
+                break 
 
     logging.info("########### Done setup for bgp speaker testing ###########")
 


### PR DESCRIPTION
Made the following change:
1. Changed the exabgp ports such that they do not conflict with announce
   routes used for test bed setup.
2. Added busy wait loop in order to make sure exabgp's have started

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
py.test --inventory veos.vtb --host-pattern all --user admin -vvvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml test_bgp_speaker.py -vvvv
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
