### PR TITLE
[everflow]: Make Policer test more robust

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
@@ -3,6 +3,12 @@
 - set_fact:
     policer_name: TEST_POLICER
     policer_session_name: TEST_POLICER_SESSION
+    policer_meter_type: "packets"
+    policer_mode: "sr_tcm"
+    policer_cir: "100"
+    policer_cbs: "100"
+    policer_red_packet_action: "drop"
+    policer_tolerance: "10"
     dscp_table_name: EVERFLOW_DSCP
 
 - set_fact:
@@ -20,7 +26,12 @@
 - block:
   - name: Create a policer
     shell: |
-      redis-cli -n 4 hmset "POLICER|{{policer_name}}" "meter_type" "packets" "mode" "sr_tcm" "cir" "100" "cbs" "100" "red_packet_action" "drop"
+      redis-cli -n 4 hmset "POLICER|{{ policer_name }}" \
+      "meter_type" "{{ policer_meter_type }}" \
+      "mode" "{{ policer_mode }}" \
+      "cir" "{{ policer_cir }}" \
+      "cbs" "{{ policer_cbs }}" \
+      "red_packet_action" "{{ policer_red_packet_action }}"
     become: yes
 
   - name: Create a policer enforced mirror session
@@ -56,6 +67,10 @@
         - dst_ports='{{",".join((spine_ptf_ports))}}'
         - dst_mirror_ports='{{dst_port_1_ptf_id}}'
         - mirror_stage='{{ mirror_stage }}'
+        - meter_type='{{ policer_meter_type }}'
+        - cir='{{ policer_cir }}'
+        - cbs='{{ policer_cbs }}'
+        - tolerance='{{ policer_tolerance }}'
       ptf_extra_options: "--relax --debug info"
 
   always:

--- a/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/testcase_5.yml
@@ -67,11 +67,15 @@
         - dst_ports='{{",".join((spine_ptf_ports))}}'
         - dst_mirror_ports='{{dst_port_1_ptf_id}}'
         - mirror_stage='{{ mirror_stage }}'
+        - session_src_ip='{{ session_src_ip }}'
+        - session_dst_ip='{{ session_dst_ip }}'
+        - session_ttl='{{ session_ttl }}'
+        - session_dscp='{{ session_dscp }}'
         - meter_type='{{ policer_meter_type }}'
         - cir='{{ policer_cir }}'
         - cbs='{{ policer_cbs }}'
         - tolerance='{{ policer_tolerance }}'
-      ptf_extra_options: "--relax --debug info"
+      ptf_extra_options: "--relax --debug info --log-file /tmp/everflow_policer_test.EverflowPolicerTest.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}.log"
 
   always:
     - name: Remove the rule with DSCP value and mask


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fixed everflow Policer test: logic was made more robust

### Type of change

- [x] Bug fix
- [x] Test case(new/improvement)
- [ ] Testbed and Framework(new/improvement)

### Approach
#### How did you do it?
* Changed packet generator logic: send all packets at full rate
* Added CBS bucket refill calculation
* Default tolerance is 10%

#### How did you verify/test it?
1. Deploy t1-lag
2. Run test
```bash
root@93d22705bd72:~# ./run.sh
everflow_policer_test.EverflowPolicerTest ...
Recieved 500 original packets
Received 100 mirrored packets after rate limiting
ok

----------------------------------------------------------------------
Ran 1 test in 3.423s

OK
```
3. The test will print nice user friendly assert in case of failure
```bash
root@93d22705bd72:~# ./run.sh
everflow_policer_test.EverflowPolicerTest ...
Recieved 500 original packets
Received 88 mirrored packets after rate limiting
FAIL

======================================================================
FAIL: everflow_policer_test.EverflowPolicerTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "acstests/everflow_policer_test.py", line 212, in runTest
    assert count >= self.min_range and count <= self.max_range, assert_str
AssertionError: min(90) <= count(88) <= max(110)

----------------------------------------------------------------------
Ran 1 test in 2.911s

FAILED (failures=1)
No handlers could be found for logger "dataplane"

******************************************
ATTENTION: SOME TESTS DID NOT PASS!!!

The following tests failed:
EverflowPolicerTest

******************************************
```

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
* N/A
