### PR TITLE
[platform]Tolerance the case that services are not active immediately after docker start

### DIFF
--- a/tests/platform/check_critical_services.py
+++ b/tests/platform/check_critical_services.py
@@ -21,7 +21,7 @@ def _all_critical_services_fully_started(dut):
             logging.info("ActiveState of %s is %s, expected: active" % (service, status["ActiveState"]))
             return False
         if status["SubState"] != "running":
-            logging.info("SubState of %s is %s, expected: active" % (service, status["SubState"]))
+            logging.info("SubState of %s is %s, expected: running" % (service, status["SubState"]))
             return False
 
     return True

--- a/tests/platform/check_critical_services.py
+++ b/tests/platform/check_critical_services.py
@@ -11,7 +11,7 @@ from common.utilities import wait_until
 
 def _all_critical_services_fully_started(dut):
     logging.info("Check critical service status")
-    if not dut.critical_services_fully_started:
+    if not dut.critical_services_fully_started():
         logging.info("dut.critical_services_fully_started is False")
         return False
 

--- a/tests/platform/check_critical_services.py
+++ b/tests/platform/check_critical_services.py
@@ -9,6 +9,23 @@ import logging
 from common.utilities import wait_until
 
 
+def _all_critical_services_fully_started(dut):
+    logging.info("Check critical service status")
+    if not dut.critical_services_fully_started:
+        logging.info("dut.critical_services_fully_started is False")
+        return False
+
+    for service in dut.CRITICAL_SERVICES:
+        status = dut.get_service_props(service)
+        if status["ActiveState"] != "active":
+            logging.info("ActiveState of %s is %s, expected: active" % (service, status["ActiveState"]))
+            return False
+        if status["SubState"] != "running":
+            logging.info("SubState of %s is %s, expected: active" % (service, status["SubState"]))
+            return False
+
+    return True
+
 def check_critical_services(dut):
     """
     @summary: Use systemctl to check whether all the critical services have expected status. ActiveState of all
@@ -16,12 +33,5 @@ def check_critical_services(dut):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
     logging.info("Wait until all critical services are fully started")
-    assert wait_until(300, 20, dut.critical_services_fully_started), "Not all critical services are fully started"
+    assert wait_until(300, 20, _all_critical_services_fully_started, dut), "Not all critical services are fully started"
 
-    logging.info("Check critical service status")
-    for service in dut.CRITICAL_SERVICES:
-        status = dut.get_service_props(service)
-        assert status["ActiveState"] == "active", \
-            "ActiveState of %s is %s, expected: active" % (service, status["ActiveState"])
-        assert status["SubState"] == "running", \
-            "SubState of %s is %s, expected: active" % (service, status["SubState"])


### PR DESCRIPTION
### Description of PR

Summary:
Fixes the following issue in the platform test
```
FAILED platform/test_reboot.py::test_fast_reboot - AssertionError: ActiveState of pmon is activating, expected: active
FAILED platform/test_reboot.py::test_warm_reboot - AssertionError: ActiveState of pmon is activating, expected: active
FAILED platform/test_reboot.py::test_power_off_reboot[5] - AssertionError: ActiveState of pmon is activating, expected: active
FAILED platform/test_reboot.py::test_watchdog_reboot - AssertionError: ActiveState of pmon is activating, expected: active
```
The critical services are up if the following 2 conditions are both satisfied:

1. Check whether the docker is running by using `docker inspect -f {{.State.Running}} <service-name>`
2. Check whether the service state is active by using `systemctl status pmon.service`

Originally the logic of checking whether all services are started is:

    wait for condition 1 for 300 seconds or assert
    if not condition 2 assert

However, it is possible that the service state isn't active immediately after the docker is running because it can take seconds for the daemons to start.
In this sense, we improved the checking logic to:

    wait for condition 1 and condition 2 for 300 seconds or assert

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Execute platform/test_reboot.py
[test-result.txt](https://github.com/Azure/sonic-mgmt/files/4224076/test-result.txt)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
