### PR TITLE
[platform]Add teardown for reboot

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -159,7 +159,7 @@ class SonicHost(AnsibleHostBase):
         for service in self.CRITICAL_SERVICES:
             result[service] = self.is_service_fully_started(service)
 
-        logging.debug("Status of critical services: %s" % str(result))
+        logging.info("Status of critical services: %s" % str(result))
         return all(result.values())
 
 

--- a/tests/platform/check_transceiver_status.py
+++ b/tests/platform/check_transceiver_status.py
@@ -45,7 +45,7 @@ def all_transceivers_detected(dut, interfaces):
     db_output = dut.command("redis-cli --raw -n 6 keys TRANSCEIVER_INFO\*")["stdout_lines"]
     not_detected_interfaces = [intf for intf in interfaces if "TRANSCEIVER_INFO|%s" % intf not in db_output]
     if len(not_detected_interfaces) > 0:
-        logging.debug("Interfaces not detected: %s" % str(not_detected_interfaces))
+        logging.info("Interfaces not detected: %s" % str(not_detected_interfaces))
         return False
     return True
 

--- a/tests/platform/mellanox/check_sysfs.py
+++ b/tests/platform/mellanox/check_sysfs.py
@@ -129,14 +129,14 @@ def check_sysfs(dut):
             psu_status_output = dut.command("cat %s" % psu_status_file)
             psu_status = int(psu_status_output["stdout"])
             if not psu_status:
-                logging.info("PSU %d doesn't exist, skipped".format(psu_id))
+                logging.info("PSU %d doesn't exist, skipped" % psu_id)
                 continue
 
             psu_pwr_status_file = "/var/run/hw-management/thermal/psu{}_pwr_status".format(psu_id)
             psu_pwr_status_output = dut.command("cat %s" % psu_pwr_status_file)
             psu_pwr_status = int(psu_pwr_status_output["stdout"])
             if not psu_pwr_status:
-                logging.info("PSU %d isn't poweron, skipped".format(psu_id))
+                logging.info("PSU %d isn't poweron, skipped" % psu_id)
                 continue
 
             psu_temp_file = "/var/run/hw-management/thermal/psu{}_temp".format(psu_id)

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -66,13 +66,12 @@ reboot_ctrl_dict = {
 }
 
 
-ansible_dut = None
-ansible_interfaces = None
-
-def teardown_module():
+@pytest.fixture(scope="module", autouse=True)
+def teardown_module(duthost, conn_graph_facts):
     logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
-    check_critical_services(ansible_dut)
-    check_further_interfaces_and_services(ansible_dut, ansible_interfaces)
+    interfaces = conn_graph_facts["device_conn"]
+    check_critical_services(duthost)
+    check_further_interfaces_and_services(duthost, interfaces)
 
 
 def check_reboot_cause(dut, reboot_cause_expected):
@@ -99,11 +98,6 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
     @param reboot_helper: The helper function used only by power off reboot
     @param reboot_kwargs: The argument used by reboot_helper
     """
-    global ansible_dut
-    global ansible_interfaces
-    ansible_dut = dut
-    ansible_interfaces = interfaces
-
     logging.info("Run %s reboot on DUT" % reboot_type)
 
     assert reboot_type in reboot_ctrl_dict.keys(), "Unknown reboot type %s" % reboot_type

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -68,6 +68,8 @@ reboot_ctrl_dict = {
 
 @pytest.fixture(scope="module", autouse=True)
 def teardown_module(duthost, conn_graph_facts):
+    yield
+
     logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     interfaces = conn_graph_facts["device_conn"]
     check_critical_services(duthost)

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -66,9 +66,6 @@ reboot_ctrl_dict = {
 }
 
 
-sku_supporting_reboot_cause_test = ['ACS-MSN2410', 'ACS-MSN2700', "LS-SN2700", 'Mellanox-SN2700', 'Mellanox-SN2700-D48C8', 'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800', 'Mellanox-SN3800-D112C8']
-sku_supporting_fast_reboot = ['ACS-MSN2410', 'ACS-MSN2700', "LS-SN2700", 'Mellanox-SN2700', 'Mellanox-SN2700-D48C8', 'ACS-MSN2100', 'ACS-MSN2010', 'ACS-MSN2740']
-
 ansible_dut = None
 ansible_interfaces = None
 
@@ -258,7 +255,7 @@ def _power_off_reboot_helper(kwargs):
         psu_ctrl.turn_on_psu(psu["psu_id"])
 
 
-def _test_power_off_reboot(testbed_devices, conn_graph_facts, psu_controller, power_off_delay):
+def test_power_off_reboot(testbed_devices, conn_graph_facts, psu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param testbed_devices: Fixture initialize devices in testbed

--- a/tests/platform/test_reboot.py
+++ b/tests/platform/test_reboot.py
@@ -156,7 +156,7 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
         logging.info("Further checking skipped for %s test which intends to verify reboot-cause only".format(reboot_type))
         return
 
-    check_further_interfaces_and_services(dut)
+    check_further_interfaces_and_services(dut, interfaces)
 
 
 def check_further_interfaces_and_services(dut, interfaces):
@@ -258,7 +258,7 @@ def _power_off_reboot_helper(kwargs):
         psu_ctrl.turn_on_psu(psu["psu_id"])
 
 
-def test_power_off_reboot(testbed_devices, conn_graph_facts, psu_controller, power_off_delay):
+def _test_power_off_reboot(testbed_devices, conn_graph_facts, psu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param testbed_devices: Fixture initialize devices in testbed


### PR DESCRIPTION
### Description of PR
Summary:
In some kinds of reboot-test the main purpose is to check the reboot cause. Therefore these tests return success without waiting for other conditions to be true.
However, this fails the sanity check because other conditions aren't satisfied.
To avoid that, we introduce the teardown module to make sure all the necessary checks passed ahead of exiting.
The level of logs that report the status of services or interfaces has also been promoted from debug to info. This kind of logs won’t be too much but contain import information, so it’s reasonable to promote the log level. By doing so it’s able to provide clear information to the user especially when the test fails.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
See above.

#### How did you verify/test it?
Run platform test.
[test-teardown-reboot.txt](https://github.com/Azure/sonic-mgmt/files/4214043/test-teardown-reboot.txt)
[test_cold_rebo.1-intf-down.txt](https://github.com/Azure/sonic-mgmt/files/4239345/test_cold_rebo.1-intf-down.txt)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
