### PR TITLE
[exabgp] Fix start/restart verification condition

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -142,10 +142,10 @@ def start_exabgp(module, name):
 
     for count in range(0, 60):
         time.sleep(1)
-        ret = get_exabgp_status(module, name)
-        if u'RUNNING' == ret['status']:
+        status = get_exabgp_status(module, name)
+        if u'RUNNING' == status:
             break
-    assert u'RUNNING' == ret['status']
+    assert u'RUNNING' == status
 
 def restart_exabgp(module, name):
     refresh_supervisord(module)
@@ -154,9 +154,9 @@ def restart_exabgp(module, name):
     for count in range(0, 60):
         time.sleep(1)
         ret = get_exabgp_status(module, name)
-        if u'RUNNING' == ret['status']:
+        if u'RUNNING' == status:
             break
-    assert u'RUNNING' == ret['status']
+    assert u'RUNNING' == status
 
 def stop_exabgp(module, name):
     exec_command(module, cmd="supervisorctl stop exabgp-%s" % name, ignore_error=True)


### PR DESCRIPTION
Fix the issue when checking the return from status API. Previously
the check was done outside the module and the return was in a form of
hash map. With relocation of the condition to the exabgp module,
the return type is string and is not a hash map.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
py.test --inventory veos.vtb --host-pattern all --user admin -vvvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml test_announce_routes.py -vvvv

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
