### PR TITLE
[bgp] Fix exabgp port used in bgp speaker test

### DIFF
--- a/tests/test_bgp_speaker.py
+++ b/tests/test_bgp_speaker.py
@@ -65,7 +65,7 @@ def common_setup_teardown(duthost, ptfhost):
         duthost.command("ip route flush %s/32" % ip.ip)
         duthost.command("ip route add %s/32 dev %s" % (ip.ip, mg_facts['minigraph_vlan_interfaces'][0]['attachto']))
 
-    port_num = [5000, 6000, 7000]
+    port_num = [7000, 8000, 9000]
 
     lo_addr = mg_facts['minigraph_lo_interfaces'][0]['addr']
     lo_addr_prefixlen = int(mg_facts['minigraph_lo_interfaces'][0]['prefixlen'])


### PR DESCRIPTION
Ports used in bgp speaker test for exabgp do conflict with announce
route exabgp used for testbed setup and so the bgp speaker test
is faling. With this fix, bgp speaker test is passing.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
py.test --inventory veos.vtb --host-pattern all --user admin -vvvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml test_bgp_speaker.py -vvvv
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
