### PR TITLE
Updated MAC tests to use additional MLNX fanout config

### DIFF
--- a/tests/drop_counters/fanout/mellanox/mlnx_update_mac.j2
+++ b/tests/drop_counters/fanout/mellanox/mlnx_update_mac.j2
@@ -1,0 +1,5 @@
+config t
+
+protocol openflow
+openflow add-flows {{ rule_id }} table=0,priority=10,dl_src={{ match_mac }},in_port={{ trunk_port }},actions=set_field:{{ set_mac }}->{{ eth_field }}
+exit

--- a/tests/drop_counters/fanout/mellanox/mlnx_update_smac.j2
+++ b/tests/drop_counters/fanout/mellanox/mlnx_update_smac.j2
@@ -1,5 +1,0 @@
-config t
-
-protocol openflow
-openflow add-flows {{ rule_id }} table=0,priority=10,dl_src={{ match_mac }},in_port={{ trunk_port }},actions=set_field:{{ set_mac }}->eth_src
-exit


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fixed test cases which verify drops with incorrect MAC adresses.
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### How did you do it?
Added functionality which set openflow rules to transmit incorrect packets through Fanout switch.

Updated the following test cases:
test_equal_smac_dmac_drop
test_multicast_smac_drop
test_reserved_dmac_drop

#### How did you verify/test it?
Tested on local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
