### PR TITLE
[pytest/ansible] Support comments in testbed file

### DIFF
--- a/ansible/doc/README.testbed.Cli.md
+++ b/ansible/doc/README.testbed.Cli.md
@@ -12,7 +12,7 @@
 
 ## Add/Remove topo
 ```
-# uniq-name,testbed-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,owner
+# conf-name,testbed-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,owner
 vms1-1-t1,vms1-1,t1,docker-ptf-sai-mlnx,10.0.10.5/23,server_1,VM0100,str-msn2700-11,t1 tests
 vms1-1-t1-lag,vms1-1,t1-lag,docker-ptf-sai-mlnx,10.0.10.5/23,server_1,VM0100,str-msn2700-11,t1-lag tests
 
@@ -32,7 +32,7 @@ Caveat: Have to remember what was the initial topology. Should be fixed in futur
 
 # Renumber topo
 ```
-# uniq-name,testbed-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,owner
+# conf-name,testbed-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,owner
 vms2-2-b,vms2-2,t1,docker-ptf-sai-brcm,10.0.10.7/23,server_1,VM0100,str-d6000-05,brcm test
 vms2-2-m,vms2-2,t1,docker-ptf-sai-mlnx,10.0.10.7/23,server_1,VM0100,str-msn2700-5,mlnx test
 

--- a/ansible/doc/README.testbed.Config.md
+++ b/ansible/doc/README.testbed.Config.md
@@ -44,13 +44,13 @@ vms-t1-lag,vms1-1,t1-lag,docker-ptf-sai-mlnx,10.255.0.178/24,server_1,VM0100,str
 
 ### ```testbed.csv``` consistency rules
 ```
-# uniq-name,testbed-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,owner
+# conf-name,testbed-name,topo,ptf_image_name,ptf_ip,server,vm_base,dut,owner
 vms2-2-b,vms2-2,t1,docker-ptf-sai-brcm,10.0.10.7/23,server_1,VM0100,str-d6000-05,brcm test
 vms2-2-m,vms2-2,t1,docker-ptf-sai-mlnx,10.0.10.7/23,server_1,VM0100,str-msn2700-5,mlnx test
 
 ```
 Must be strictly checked in code reviews
- - uniq-name must be unique
+ - conf-name must be unique
  - All testbed records with the same testbed-name must have the same:
    - ptf_ip
    - server

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -106,18 +106,17 @@ class ParseTestbedTopoinfo():
         self.testbed_topo = {}
 
     def read_testbed_topo(self):
+        CSV_FIELDS = ('conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'server', 'vm_base', 'dut', 'comment')
         with open(self.testbed_filename) as f:
-            topo = csv.DictReader(f)
+            topo = csv.DictReader(f, fieldnames=CSV_FIELDS)
             for line in topo:
+                if '#' in line['conf-name']:
+                    ### skip comment line
+                    continue
                 tb_prop = {}
-                name = ''
+                name = line['conf-name']
                 for key in line:
-                    if ('uniq-name' in key or 'conf-name' in key) and '#' in line[key]:
-                        ### skip comment line
-                        continue
-                    elif 'uniq-name' in key or 'conf-name' in key:
-                        name = line[key]
-                    elif 'ptf_ip' in key and line[key]:
+                    if 'ptf_ip' in key and line[key]:
                         ptfaddress = ipaddress.IPNetwork(line[key])
                         tb_prop['ptf_ip'] = str(ptfaddress.ip)
                         tb_prop['ptf_netmask'] = str(ptfaddress.netmask)

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -100,7 +100,7 @@ class ParseTestbedTopoinfo():
     Parse the CSV file used to describe whole testbed info
     Please refer to the example of the CSV file format
     CSV file first line is title
-    The topology name in title is using uniq-name | conf-name
+    The topology name in title is using conf-name
     '''
     def __init__(self, testbed_file):
         self.testbed_filename = testbed_file

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -117,7 +117,7 @@ class ParseTestbedTopoinfo():
                 assert header[field].replace('#', '').strip() == field
 
             for line in topo:
-                if '#' in line['conf-name']:
+                if line['conf-name'].lstrip().startswith('#'):
                     ### skip comment line
                     continue
                 if line['ptf_ip']:

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -6,6 +6,7 @@ import csv
 from operator import itemgetter
 from itertools import groupby
 import yaml
+from collections import defaultdict
 
 DOCUMENTATION = '''
 module: test_facts.py
@@ -103,7 +104,7 @@ class ParseTestbedTopoinfo():
     '''
     def __init__(self, testbed_file):
         self.testbed_filename = testbed_file
-        self.testbed_topo = {}
+        self.testbed_topo = defaultdict()
 
     def read_testbed_topo(self):
         CSV_FIELDS = ('conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'server', 'vm_base', 'dut', 'comment')
@@ -113,17 +114,12 @@ class ParseTestbedTopoinfo():
                 if '#' in line['conf-name']:
                     ### skip comment line
                     continue
-                tb_prop = {}
-                name = line['conf-name']
-                for key in line:
-                    if 'ptf_ip' in key and line[key]:
-                        ptfaddress = ipaddress.IPNetwork(line[key])
-                        tb_prop['ptf_ip'] = str(ptfaddress.ip)
-                        tb_prop['ptf_netmask'] = str(ptfaddress.netmask)
-                    else:
-                        tb_prop[key] = line[key]
-                if name:
-                    self.testbed_topo[name] = tb_prop
+                if line['ptf_ip']:
+                    ptfaddress = ipaddress.IPNetwork(line['ptf_ip'])
+                    line['ptf_ip'] = str(ptfaddress.ip)
+                    line['ptf_netmask'] = str(ptfaddress.netmask)
+
+                self.testbed_topo[line['conf-name']] = line
         return
 
     def get_testbed_info(self, testbed_name):

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -110,6 +110,12 @@ class ParseTestbedTopoinfo():
         CSV_FIELDS = ('conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'server', 'vm_base', 'dut', 'comment')
         with open(self.testbed_filename) as f:
             topo = csv.DictReader(f, fieldnames=CSV_FIELDS)
+
+            # Validate all field are in the same order and are present
+            header = next(topo)
+            for field in CSV_FIELDS:
+                assert header[field].replace('#', '').strip() == field
+
             for line in topo:
                 if '#' in line['conf-name']:
                     ### skip comment line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,12 @@ class TestbedInfo(object):
 
         with open(self.testbed_filename) as f:
             topo = csv.DictReader(f, fieldnames=CSV_FIELDS)
+
+            # Validate all field are in the same order and are present
+            header = next(topo)
+            for field in CSV_FIELDS:
+                assert header[field].replace('#', '').strip() == field
+
             for line in topo:
                 if '#' in line['conf-name']:
                     ### skip comment line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ class TestbedInfo(object):
                 assert header[field].replace('#', '').strip() == field
 
             for line in topo:
-                if '#' in line['conf-name']:
+                if line['conf-name'].lstrip().startswith('#'):
                     ### skip comment line
                     continue
                 if line['ptf_ip']:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,18 +35,18 @@ class TestbedInfo(object):
     def __init__(self, testbed_file):
         self.testbed_filename = testbed_file
         self.testbed_topo = {}
+        CSV_FIELDS = ('conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'server', 'vm_base', 'dut', 'comment')
 
         with open(self.testbed_filename) as f:
-            topo = csv.DictReader(f)
+            topo = csv.DictReader(f, fieldnames=CSV_FIELDS)
             for line in topo:
+                if '#' in line['conf-name']:
+                    ### skip comment line
+                    continue
                 tb_prop = {}
-                name = ''
+                name = line['conf-name']
                 for key in line:
-                    if ('uniq-name' in key or 'conf-name' in key) and '#' in line[key]:
-                        continue
-                    elif 'uniq-name' in key or 'conf-name' in key:
-                        name = line[key]
-                    elif 'ptf_ip' in key and line[key]:
+                    if 'ptf_ip' in key and line[key]:
                         ptfaddress = ipaddress.IPNetwork(line[key])
                         tb_prop['ptf_ip'] = str(ptfaddress.ip)
                         tb_prop['ptf_netmask'] = str(ptfaddress.netmask)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ class TestbedInfo(object):
     Parse the CSV file used to describe whole testbed info
     Please refer to the example of the CSV file format
     CSV file first line is title
-    The topology name in title is using uniq-name | conf-name
+    The topology name in title is using conf-name
     """
 
     def __init__(self, testbed_file):


### PR DESCRIPTION
When there are comments lines, the Python DictReader will return
the comment as the first field while remaining fields will be
None. This causes testbed parsing fails. This fixd detects if
the first field is a comment and skips this line.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added support to detect comments

#### How did you verify/test it?
Tested on vsimage

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
