### PR TITLE
[wr_arp] Added ssl support in ferret.py for wr_arp test case

### DIFF
--- a/ansible/roles/test/files/helpers/ferret.py
+++ b/ansible/roles/test/files/helpers/ferret.py
@@ -11,6 +11,7 @@ import BaseHTTPServer
 import time
 import socket
 import ctypes
+import ssl
 import struct
 import binascii
 import itertools
@@ -89,10 +90,15 @@ class Ferret(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 class RestAPI(object):
-    PORT = 85
+    PORT = 448
 
     def __init__(self, obj, db, src_ip):
         self.httpd = SocketServer.TCPServer(("", self.PORT), obj)
+        self.context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        self.context.verify_mode = ssl.CERT_NONE
+        self.context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        self.context.load_cert_chain(certfile="/opt/test.pem", keyfile="/opt/test.key")
+        self.httpd.socket=self.context.wrap_socket(self.httpd.socket, server_side=True)
         self.db = db
         obj.db = db
         obj.src_ip = src_ip

--- a/ansible/roles/test/tasks/wr_arp.yml
+++ b/ansible/roles/test/tasks/wr_arp.yml
@@ -77,11 +77,6 @@
   become: yes
   when: "'PortChannel' in route_output.stdout"
 
-- name: Update supervisor configuration
-  include_tasks: "roles/test/tasks/common_tasks/update_supervisor.yml"
-  vars:
-    supervisor_host: "{{ ptf_host }}"
-
 - name: Copy tests to the PTF container
   copy: src=roles/test/files/ptftests dest=/root
   delegate_to: "{{ ptf_host }}"
@@ -99,6 +94,17 @@
 - name: Render DUT parameters to json file for the test
   template: src=vxlan_decap.json.j2 dest=/tmp/vxlan_decap.json
   delegate_to: "{{ ptf_host }}"
+
+- name: Generate pem and key files for ssl
+  command: openssl req -new -x509 -keyout test.key -out test.pem -days 365 -nodes -subj "/C=10/ST=Test/L=Test/O=Test/OU=Test/CN=test.com"
+  args:
+    chdir: /opt
+    delegate_to: "{{ ptf_host }}"
+
+- name: Update supervisor configuration
+  include_tasks: "roles/test/tasks/common_tasks/update_supervisor.yml"
+  vars:
+    supervisor_host: "{{ ptf_host }}"
 
 - name: Dump debug info. DUT ip
   debug: var=ansible_eth0.ipv4.address

--- a/ansible/roles/test/tasks/wr_arp.yml
+++ b/ansible/roles/test/tasks/wr_arp.yml
@@ -99,7 +99,7 @@
   command: openssl req -new -x509 -keyout test.key -out test.pem -days 365 -nodes -subj "/C=10/ST=Test/L=Test/O=Test/OU=Test/CN=test.com"
   args:
     chdir: /opt
-    delegate_to: "{{ ptf_host }}"
+  delegate_to: "{{ ptf_host }}"
 
 - name: Update supervisor configuration
   include_tasks: "roles/test/tasks/common_tasks/update_supervisor.yml"


### PR DESCRIPTION
Added certificate generation for ssl to wr_arp.yml

Signed-off-by: SavchukRomanLv <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
After merging https://github.com/Azure/sonic-utilities/pull/792, was removed ability to access endpoint using http protocol.
wr_apr test using farret, that can work only with HTTP protocol

### Type of change

- [] Bug fix
- [+] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### How did you do it?

- added ssl support to ferret.py, using python ssl library
- added certificate and key generation into wr_arp.yml

#### How did you verify/test it?
Run wr_arp test case on t0 topology, after changes test passed 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
