### PR TITLE
Fix the yield issue of psu_controller

### DIFF
--- a/tests/common/plugins/psu_controller/__init__.py
+++ b/tests/common/plugins/psu_controller/__init__.py
@@ -32,6 +32,7 @@ def psu_controller(duthost):
         logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create psu_controller" %
                      duthost.hostname)
         yield None
+        return
 
     controller_vars = inv_mgr.get_host(pdu_host).get_vars()
 
@@ -40,6 +41,7 @@ def psu_controller(duthost):
         logging.info("No 'ansible_host' is defined in inventory file for '%s'" % pdu_host)
         logging.info("Unable to create psu_controller for %s" % duthost.hostname)
         yield None
+        return
 
     controller_protocol = controller_vars.get("protocol")
     if not controller_protocol:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Whenever a fixture yield something, pytest will execute right
after yield during teardown. So, if we yield something in a `if`
statement, that code path must have `return`. Otherwise, there
are some issues:
1. For example if pdu_host is None, then `inv_mgr.get_host(pdu_host)`
will be evaluated to None. And `inv_mgr.get_host(pdu_host).get_vars()`
will raise exception.
2. It does not make sense to run any teardown code if we `yield None`.

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add 'return' for 'yield None' in if statement.

#### How did you verify/test it?
Tested on Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
