### PR TITLE
[pytest]: add tacacs test to test rw user

### DIFF
--- a/ansible/group_vars/lab/lab.yml
+++ b/ansible/group_vars/lab/lab.yml
@@ -21,6 +21,12 @@ radius_servers: []
 
 tacacs_servers: ['10.0.0.9', '10.0.0.8']
 
+tacacs_passkey: testing123
+tacacs_rw_user: test_rwuser
+tacacs_rw_user_passwd: '123456'
+tacacs_ro_user: test_rouser
+tacacs_ro_user_passwd: '123456'
+
 # tacacs grous
 tacacs_group: 'testlab'
 

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -89,6 +89,7 @@ def sanity_check(testbed_devices, request):
 
     if skip_sanity:
         logger.info("Skip sanity check according to configuration of test script.")
+        yield
         return
 
     if not check_items:

--- a/tests/tacacs/tac_plus.conf.j2
+++ b/tests/tacacs/tac_plus.conf.j2
@@ -1,0 +1,34 @@
+# Created by Henry-Nicolas Tourneur(henry.nicolas@tourneur.be)
+# See man(5) tac_plus.conf for more details
+
+# Define where to log accounting data, this is the default.
+
+accounting file = /var/log/tac_plus.acct
+
+# This is the key that clients have to use to access Tacacs+
+
+key = {{ tacacs_passkey }}
+
+group = netadmin {
+	default service = permit
+	service = exec {
+		priv-lvl = 15
+	}
+}
+
+user = {{ tacacs_rw_user }} {
+	login = des {{ tacacs_rw_user_passwd }}
+	member = netadmin
+}
+
+group = netuser {
+	default service = permit
+	service = exec {
+		priv-lvl = 1
+	}
+}
+
+user = {{ tacacs_ro_user }} {
+	login = des {{ tacacs_ro_user_passwd }}
+	member = netuser
+}

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -1,0 +1,56 @@
+import pytest
+import crypt
+from ansible_host import AnsibleHost
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer
+]
+
+def test_rw_user(ptfhost, duthost, creds):
+    """test tacacs rw user
+    """
+
+    # disable tacacs server
+    ptfhost.shell("service tacacs_plus stop")
+
+    # configure tacacs client
+    duthost.shell("sudo config tacacs passkey %s" % creds['tacacs_passkey'])
+   
+    # get default tacacs servers
+    config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    for tacacs_server in config_facts.get('TACPLUS_SERVER', {}):
+        duthost.shell("sudo config tacacs delete %s" % tacacs_server)
+
+    ptfip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
+    duthost.shell("sudo config tacacs add %s" % ptfip)
+    duthost.shell("sudo config tacacs authtype login")
+
+    # enable tacacs+
+    duthost.shell("sudo config aaa authentication login tacacs+")
+
+    # configure tacacs server
+    extra_vars = {'tacacs_passkey': creds['tacacs_passkey'],
+                  'tacacs_rw_user': creds['tacacs_rw_user'],
+                  'tacacs_rw_user_passwd': crypt.crypt(creds['tacacs_rw_user_passwd'], 'abc'),
+                  'tacacs_ro_user': creds['tacacs_ro_user'],
+                  'tacacs_ro_user_passwd': crypt.crypt(creds['tacacs_ro_user_passwd'], 'abc')}
+
+    ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
+    ptfhost.template(src="tacacs/tac_plus.conf.j2", dest="/etc/tacacs+/tac_plus.conf")
+
+    # start tacacs server
+    ptfhost.shell("service tacacs_plus start")
+
+    try:
+        duthost.host.options['variable_manager'].extra_vars.update(
+            {'ansible_user':creds['tacacs_rw_user'], 'ansible_password':creds['tacacs_rw_user_passwd']})
+
+        res = duthost.shell("cat /etc/passwd")
+
+        for l in res['stdout_lines']:
+            fds = l.split(':')
+            if fds[0] == "testadmin":
+                assert fds[4] == "remote_user_su"
+    finally:
+        ptfhost.shell("service tacacs_plus stop")


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
johnar@e1ea830bda60:/data/sonic-mgmt/tests$ py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --log-level=debug --log-file=aaa tacacs/test_rw_user.py  | tee abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.6, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item

tacacs/test_rw_user.py::test_rw_user PASSED                              [100%]

========================== 1 passed in 10.89 seconds ===========================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
