### PR TITLE
Correct privilege for sysctl

### DIFF
--- a/ansible/swap_syncd.yml
+++ b/ansible/swap_syncd.yml
@@ -44,6 +44,7 @@
       ignore_errors: yes
 
     - name: Set sysctl RCVBUF parameter for tests
+      become: true
       sysctl:
         name: "net.core.rmem_max"
         value: 509430500


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Test was failing because it was unable to change rmem_max parameter

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Bump up the privilege

#### How did you verify/test it?
Ran the test with the change and it passed
