### PR TITLE
convert ansible decap test to pytest

### DIFF
--- a/tests/decap/decap_conf.j2
+++ b/tests/decap/decap_conf.j2
@@ -1,0 +1,28 @@
+[
+{% if outer_ipv4 | bool %}
+        {
+                "TUNNEL_DECAP_TABLE:IPINIP_V4_TUNNEL" : {
+                        "tunnel_type":"IPINIP",
+                        "dst_ip":"{{ lo_ip }}",
+                        "dscp_mode":"{{ dscp_mode }}",
+                        "ecn_mode":"{{ ecn_mode }}",
+                        "ttl_mode":"{{ ttl_mode }}"
+                },
+                "OP": "{{ op }}"
+        }
+{% endif %}
+{% if outer_ipv6 | bool and outer_ipv4 | bool %} ,
+{% endif %}
+{% if outer_ipv6 | bool %}
+        {
+                "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+                        "tunnel_type":"IPINIP",
+                        "dst_ip":"{{ lo_ipv6 }}",
+                        "dscp_mode":"{{ dscp_mode }}",
+                        "ecn_mode":"{{ ecn_mode }}",
+                        "ttl_mode":"{{ ttl_mode }}"
+                },
+                "OP": "{{ op }}"
+        }
+{% endif %}
+]

--- a/tests/test_decap.py
+++ b/tests/test_decap.py
@@ -1,0 +1,116 @@
+import pytest
+from netaddr import *
+import time
+import logging
+import requests
+from ptf_runner import ptf_runner
+from ansible_host import AnsibleHost
+from datetime import datetime
+
+
+
+
+def decap_entry_cfg_swss(duthost, decap_setup, outer_ipv4, outer_ipv6, op):
+    testbed_type, lo_ipv6, lo_ipv4,dscp_mode, ecn_mode,ttl_mode = decap_setup
+    dst_ip = lo_ipv4 if outer_ipv4 is True else lo_ipv6
+    extra_vars = {
+        'outer_ipv4': outer_ipv4,
+        'outer_ipv6': outer_ipv6,
+        'lo_ip': lo_ipv4,
+        'lo_ipv6': lo_ipv6,
+        "dscp_mode": dscp_mode,
+        "ecn_mode": ecn_mode,
+        "ttl_mode": ttl_mode,
+        "op": op
+    }
+
+    duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
+    duthost.template(src="decap/decap_conf.j2", dest="/tmp/decap_conf.json")
+    duthost.shell('docker cp /tmp/decap_conf.json swss:/decap_conf.json')
+    duthost.shell('docker exec swss sh -c "swssconfig /decap_conf.json"')
+
+def decap_config_ptfhost(ptf_vars,ptfhost):
+    ptfhost.host.options['variable_manager'].extra_vars.update(ptf_vars)
+    logging.info("extra_vars: %s" % str(ptfhost.host.options['variable_manager'].extra_vars))
+    ptfhost.template(src="fib/fib.j2", dest="/root/fib_info.txt")
+    ptfhost.copy(src="ptftests", dest="/root")
+
+
+@pytest.fixture(scope="module")
+def decap_setup(ansible_adhoc, testbed,duthost,ptfhost):
+    hostname = testbed['dut']
+    testbed_type = testbed['topo']['name']
+
+    props= testbed['topo']['properties']['configuration_properties']['spine']
+    props_tor = testbed['topo']['properties']['configuration_properties']['tor']
+
+    ans_host = AnsibleHost(ansible_adhoc, hostname)
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    ptf_vars = {'testbed_type': testbed_type,
+                  'props': props,
+                  'props_tor': props_tor,
+                  'minigraph_portchannels': mg_facts['minigraph_portchannels'],
+                  'minigraph_vlans': mg_facts['minigraph_vlans'],
+                  'minigraph_port_indices': mg_facts['minigraph_port_indices'],
+                  'minigraph_neighbors': mg_facts['minigraph_neighbors']
+    }
+
+    
+    for intf in mg_facts['minigraph_lo_interfaces']:
+        addr = intf['addr'].decode("utf-8")
+        if ":" in addr:
+            lo_ipv6 = addr
+        else:
+            lo_ipv4 = addr
+
+    dscp_mode =None
+    ecn_mode = None
+    asic_type= duthost.facts['asic_type']
+    
+    if asic_type.lower() == 'broadcom' or asic_type.lower() == 'marvell':
+        dscp_mode = 'pipe'
+        ecn_mode = 'copy_from_outer'
+    elif asic_type.lower() == 'mellanox':
+        dscp_mode = 'uniform'
+        ecn_mode = 'standard'
+    ttl_mode = 'pipe'
+
+    decap_config_ptfhost(ptf_vars, ptfhost)
+
+    yield testbed_type, lo_ipv6, lo_ipv4,dscp_mode, ecn_mode,ttl_mode
+
+
+@pytest.mark.parametrize("outer_ipv4, outer_ipv6", [pytest.param(True, False),pytest.param(False,True)])
+def test_decap(decap_setup,duthost, ptfhost,outer_ipv4, outer_ipv6):
+
+    testbed_type, lo_ipv6, lo_ipv4,dscp_mode, ecn_mode,ttl_mode = decap_setup
+
+    decap_entry_cfg_swss(duthost, decap_setup, outer_ipv4, outer_ipv6, "SET")
+    router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+
+    log_file = "/tmp/decap.{}".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
+    logging.info("PTF log file: %s" % log_file)
+
+    logging.info("run ptf test")
+
+    ptf_runner(ptfhost,
+               "ptftests",
+               "IP_decap_test.DecapPacketTest",
+               platform_dir="ptftests",
+               params={"testbed_type": testbed_type,
+                       "router_mac": router_mac,
+                       "fib_info": "/root/fib_info.txt",
+                       "dscp_mode": dscp_mode,
+                       "ttl_mode": ttl_mode,
+                       "lo_ip": lo_ipv4,
+                       "lo_ipv6": lo_ipv6,
+                       "outer_ipv4": outer_ipv4,
+                        "outer_ipv6": outer_ipv6,
+                        "inner_ipv4": True,
+                        "inner_ipv6": True,
+                },
+                log_file=log_file,
+                socket_recv_size=16384)
+
+    decap_entry_cfg_swss(duthost, decap_setup, outer_ipv4, outer_ipv6,"SET")
+


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshminarasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:convert ansible decap test to pytest
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
arlakshm@3176a03c5c39:/var/repos/public/my_repo/sonic-mgmt/tests$ ANSIBLE_KEEP_REMOTE_FILES=1  py.test  --inventory /var/repos/files/veos.vtb  --host-pattern all --user admin -vvv --testbed vms12-t1-lag-1 --testbed_file /var/repos/files/vtestbed.csv --disable_loganalyzer --junitxml=test_decap.xml --show-capture stdout test_decap.py
================================================================================================================= test session starts ==================================================================================================================platform linux2 -- Python 2.7.12, pytest-4.6.6, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/repos/public/my_repo/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 2 items                                                                                                                                                                                                                                       
test_decap.py::test_decap[True-False] PASSED                                                                                                                                                                                                     [ 50%] 
test_decap.py::test_decap[False-True] PASSED                                                                                                                                                                                                     [100%] 
------------------------------------------------------------------------------------ generated xml file: /var/repos/public/my_repo/sonic-mgmt/tests/test_decap.xml -------------------------------------------------------------------------------------
============================================================================================================== 2 passed in 337.94 seconds ==============================================================================================================
arlakshm@3176a03c5c39:/var/repos/public/my_repo/sonic-mgmt/tests$
#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
Supported on t1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
