### PR TITLE
[pytest]: add tacacs ro user test

### DIFF
--- a/tests/common/plugins/tacacs.py
+++ b/tests/common/plugins/tacacs.py
@@ -1,0 +1,51 @@
+import pytest
+import crypt
+from ansible_host import AnsibleHost
+
+@pytest.fixture(scope="module")
+def setup_tacacs(ptfhost, duthost, creds):
+    """setup tacacs client and server"""
+
+    # disable tacacs server
+    ptfhost.shell("service tacacs_plus stop")
+
+    # configure tacacs client
+    duthost.shell("sudo config tacacs passkey %s" % creds['tacacs_passkey'])
+   
+    # get default tacacs servers
+    config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    for tacacs_server in config_facts.get('TACPLUS_SERVER', {}):
+        duthost.shell("sudo config tacacs delete %s" % tacacs_server)
+
+    ptfip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
+    duthost.shell("sudo config tacacs add %s" % ptfip)
+    duthost.shell("sudo config tacacs authtype login")
+
+    # enable tacacs+
+    duthost.shell("sudo config aaa authentication login tacacs+")
+
+    # configure tacacs server
+    extra_vars = {'tacacs_passkey': creds['tacacs_passkey'],
+                  'tacacs_rw_user': creds['tacacs_rw_user'],
+                  'tacacs_rw_user_passwd': crypt.crypt(creds['tacacs_rw_user_passwd'], 'abc'),
+                  'tacacs_ro_user': creds['tacacs_ro_user'],
+                  'tacacs_ro_user_passwd': crypt.crypt(creds['tacacs_ro_user_passwd'], 'abc')}
+
+    ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
+    ptfhost.template(src="tacacs/tac_plus.conf.j2", dest="/etc/tacacs+/tac_plus.conf")
+
+    # start tacacs server
+    ptfhost.shell("service tacacs_plus start")
+
+    yield
+
+    # stop tacacs server
+    ptfhost.shell("service tacacs_plus stop")
+
+    # reset tacacs client configuration
+    duthost.shell("sudo config tacacs delete %s" % ptfip)
+    duthost.shell("sudo config tacacs default passkey")
+    duthost.shell("sudo config aaa authentication login default")
+    duthost.shell("sudo config aaa authentication failthrough default")
+
+

--- a/tests/common/plugins/tacacs.py
+++ b/tests/common/plugins/tacacs.py
@@ -1,6 +1,5 @@
 import pytest
 import crypt
-from ansible_host import AnsibleHost
 
 @pytest.fixture(scope="module")
 def setup_tacacs(ptfhost, duthost, creds):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ pytest_plugins = ('common.plugins.ptfadapter',
                   'common.plugins.ansible_fixtures',
                   'common.plugins.dut_monitor',
                   'common.plugins.fib',
+                  'common.plugins.tacacs',
                   'common.plugins.loganalyzer',
                   'common.plugins.psu_controller',
                   'common.plugins.sanity_check')

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer,
+]
+
+def test_ro_user(testbed_devices, duthost, creds, setup_tacacs):
+
+    localhost = localhost = testbed_devices['localhost']
+    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    res = localhost.shell("sshpass -p {} ssh "\
+                          "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
+                          "{}@{} cat /etc/passwd".format(
+            creds['tacacs_ro_user_passwd'], creds['tacacs_ro_user'], dutip))
+
+    for l in res['stdout_lines']:
+        fds = l.split(':')
+        if fds[0] == "test":
+            assert fds[4] == "remote_user"

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -1,56 +1,21 @@
 import pytest
 import crypt
-from ansible_host import AnsibleHost
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer
 ]
 
-def test_rw_user(ptfhost, duthost, creds):
+def test_rw_user(duthost, creds, setup_tacacs):
     """test tacacs rw user
     """
 
-    # disable tacacs server
-    ptfhost.shell("service tacacs_plus stop")
+    duthost.host.options['variable_manager'].extra_vars.update(
+        {'ansible_user':creds['tacacs_rw_user'], 'ansible_password':creds['tacacs_rw_user_passwd']})
 
-    # configure tacacs client
-    duthost.shell("sudo config tacacs passkey %s" % creds['tacacs_passkey'])
-   
-    # get default tacacs servers
-    config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    for tacacs_server in config_facts.get('TACPLUS_SERVER', {}):
-        duthost.shell("sudo config tacacs delete %s" % tacacs_server)
-
-    ptfip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
-    duthost.shell("sudo config tacacs add %s" % ptfip)
-    duthost.shell("sudo config tacacs authtype login")
-
-    # enable tacacs+
-    duthost.shell("sudo config aaa authentication login tacacs+")
-
-    # configure tacacs server
-    extra_vars = {'tacacs_passkey': creds['tacacs_passkey'],
-                  'tacacs_rw_user': creds['tacacs_rw_user'],
-                  'tacacs_rw_user_passwd': crypt.crypt(creds['tacacs_rw_user_passwd'], 'abc'),
-                  'tacacs_ro_user': creds['tacacs_ro_user'],
-                  'tacacs_ro_user_passwd': crypt.crypt(creds['tacacs_ro_user_passwd'], 'abc')}
-
-    ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
-    ptfhost.template(src="tacacs/tac_plus.conf.j2", dest="/etc/tacacs+/tac_plus.conf")
-
-    # start tacacs server
-    ptfhost.shell("service tacacs_plus start")
-
-    try:
-        duthost.host.options['variable_manager'].extra_vars.update(
-            {'ansible_user':creds['tacacs_rw_user'], 'ansible_password':creds['tacacs_rw_user_passwd']})
-
-        res = duthost.shell("cat /etc/passwd")
-
-        for l in res['stdout_lines']:
-            fds = l.split(':')
-            if fds[0] == "testadmin":
-                assert fds[4] == "remote_user_su"
-    finally:
-        ptfhost.shell("service tacacs_plus stop")
+    res = duthost.shell("cat /etc/passwd")
+    
+    for l in res['stdout_lines']:
+        fds = l.split(':')
+        if fds[0] == "testadmin":
+            assert fds[4] == "remote_user_su"


### PR DESCRIPTION
- put tacacs configuration int tacacs fixture
- fix loganalyzer disable logic

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
johnar@e1ea830bda60:/data/sonic-mgmt/tests$ py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --log-level=debug --log-file=aaa tacacs/test_*.py | tee abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.6, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 2 items

tacacs/test_ro_user.py::test_ro_user PASSED                              [ 50%]
tacacs/test_rw_user.py::test_rw_user PASSED                              [100%]

=============================== warnings summary ===============================
tacacs/test_ro_user.py::test_ro_user
  /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py:70: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 2 passed, 1 warnings in 33.81 seconds =====================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
