### PR TITLE
[SNMP_CPU] Use background to execute shell and add to consider CPU core number

### DIFF
--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -18,6 +18,8 @@ def test_snmp_cpu(ansible_adhoc, testbed, creds):
     ans_host = AnsibleHost(ansible_adhoc, hostname)
     lhost = AnsibleHost(ansible_adhoc, 'localhost', True)
     hostip = ans_host.host.options['inventory_manager'].get_host(hostname).vars['ansible_host']
+    host_facts = ans_host.setup()['ansible_facts']
+    host_vcpus = int(host_facts['ansible_processor_vcpus'])
 
     # Gather facts with SNMP version 2
     snmp_facts = lhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"], is_dell=True)['ansible_facts']
@@ -25,8 +27,9 @@ def test_snmp_cpu(ansible_adhoc, testbed, creds):
     assert int(snmp_facts['ansible_ChStackUnitCpuUtil5sec'])
 
     try:
-        ans_host.shell("cpu_load() { yes > /dev/null & }; cpu_load && cpu_load && cpu_load && cpu_load")
-    
+        for i in range(host_vcpus):
+            ans_host.shell("nohup yes > /dev/null 2>&1 & sleep 1")
+
         # Wait for load to reflect in SNMP
         time.sleep(20)
 


### PR DESCRIPTION
### Description of PR
1. The shell command which would be like to run in the background should use this format

        `nohup xxxxxx > /dev/null 2>&1 & sleep 1`
    Currently, it is no error because the pipelining is set to Ture in the ansible.cfg here. 

2. Different targets have different numbers of CPU cores. If there are N CPU
    cores, the yes utility should be triggered N times because one yes only rasing one core.
    In current testing code, it didn't consider the numbers of CPU cores

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [v] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

