### PR TITLE
[ansible/testbed-cli] Fix issue where the deploy-mg always apply default veos file

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -61,12 +61,17 @@
   - topo_facts: topo={{ topo }}
     delegate_to: localhost
 
+  - name: set default vm file path
+    set_fact:
+      vm_file: veos
+    when: vm_file is not defined
+
   - set_fact:
       VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
       remote_dut: "{{ ansible_ssh_host }}"
 
   - name: gather testbed VM informations
-    testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }} vmfile={{ vm_file }}
+    testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }} vm_file={{ vm_file }}
     delegate_to: localhost
     when: "VM_topo | bool"
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -20,6 +20,7 @@
 # -e topo=t0                 - the name of topology to generate minigraph file
 # -e testbed_name=vms1-1     - the testbed name specified in testbed.csv file
 #                              (if you give 'testbed_name' option, will use info from testbed and ignore topo and vm_base options)
+# -e vm_file=veos            - the virtual machine file name
 # -e deploy=True             - if deploy the newly generated minigraph to the targent DUT, default is false if not defined
 # -e save=True               - if save the newly generated minigraph to the targent DUT as starup-config, default is false if not defined
 #
@@ -65,7 +66,7 @@
       remote_dut: "{{ ansible_ssh_host }}"
 
   - name: gather testbed VM informations
-    testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }}
+    testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }} vmfile={{ vm_file }}
     delegate_to: localhost
     when: "VM_topo | bool"
 

--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -19,6 +19,7 @@ Description:
  options:
     base_vm:  base vm name defined in testbed.csv for the deployed topology; required: True
     topo:     topology name defined in testbed.csv for the deployed topology; required: True
+    vm_file:  the virtual machine file path ; default: 'veos'
 
 Ansible_facts:
     'neighbor_eosvm_mgmt':  all VM hosts management IPs 
@@ -28,7 +29,7 @@ Ansible_facts:
 
 EXAMPLES = '''
     - name: gather vm information
-      testbed_vm_info: base_vm='VM0100' topo='t1'
+      testbed_vm_info: base_vm='VM0100' topo='t1' vm_file='veos'
 '''
 
 ### Here are the assumption/expectation of files to gather VM informations, if the file location or name changes, please modify it here 
@@ -63,15 +64,8 @@ class TestbedVMFacts():
 
     def gather_veos_vms(self):
         vms = {}
-        try:
-            f = open(self.vmfile)
-            lines = f.readlines()
-        except IOError:
-            # fall back to default vm file if given file is not exist
-            with open(VM_INV_FILE) as default_f:
-                lines = default_f.readlines()
-        finally:
-            f.close()
+        with open(self.vmfile) as default_f:
+            lines = default_f.readlines()
 
         for line in lines:
             if 'VM' in line and 'ansible_host' in line:
@@ -84,7 +78,7 @@ def main():
         argument_spec=dict(
             base_vm=dict(required=True, type='str'),
             topo=dict(required=True, type='str'),
-            vm_file=dict(required=True, type='str')
+            vm_file=dict(default=VM_INV_FILE, type='str')
         ),
         supports_check_mode=True
     )

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -231,7 +231,7 @@ function deploy_minigraph
 
   read_file $topology
 
-  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e deploy=true -e save=true $@
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file $vmfile -e deploy=true -e save=true $@
 
   echo Done
 }

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -213,7 +213,7 @@ function generate_minigraph
 
   read_file $topology
 
-  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e local_minigraph=true $@
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e local_minigraph=true $@
 
   echo Done
 }
@@ -231,7 +231,7 @@ function deploy_minigraph
 
   read_file $topology
 
-  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file $vmfile -e deploy=true -e save=true $@
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e deploy=true -e save=true $@
 
   echo Done
 }
@@ -249,7 +249,7 @@ function test_minigraph
 
   read_file $topology
 
-  ansible-playbook -i "$inventory" --diff --connection=local --check config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e local_minigraph=true $@
+  ansible-playbook -i "$inventory" --diff --connection=local --check config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$dut" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e local_minigraph=true $@
 
   echo Done
 }


### PR DESCRIPTION
- Update ansible playbook command in testbed-cli.sh deploy_minigraph
- Import vm_file to config_sonic_basedon_testbed.yml for init testbed_vm_info module
- Import vm_file to testbed_vm_info.py to allow use custom vm file to generate minigraph

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Import vm_file to testbed_vm_info.py to let it use customize vm_file instead of default 'veos' under ansible folder

#### How did you verify/test it?
Use following command to deploy minigraph
```bash
$ ./testbed-cli.sh -t vtestbed.csv -m veos.vtb deploy-mg vms-kvm-t0 lab password.txt
```
Check minigraph on DUT, the management address of leaf routers are correct now
```xml
...
    <Devices>
      <Device i:type="ToRRouter">
        <Hostname>vlab-01</Hostname>
        <HwSku>Force10-S6000</HwSku>
        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.250.0.101</a:IPPrefix>
        </ManagementAddress>
      </Device>
      <Device i:type="LeafRouter">
         <Hostname>ARISTA04T1</Hostname>
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.250.0.54</a:IPPrefix>
         </ManagementAddress>
         <HwSku>Arista-VM</HwSku>
      </Device>
      <Device i:type="LeafRouter">
         <Hostname>ARISTA03T1</Hostname>
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.250.0.53</a:IPPrefix>
         </ManagementAddress>
         <HwSku>Arista-VM</HwSku>
      </Device>
      <Device i:type="LeafRouter">
         <Hostname>ARISTA02T1</Hostname>
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.250.0.52</a:IPPrefix>
         </ManagementAddress>
         <HwSku>Arista-VM</HwSku>
      </Device>
      <Device i:type="LeafRouter">
         <Hostname>ARISTA01T1</Hostname>
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.250.0.51</a:IPPrefix>
         </ManagementAddress>
         <HwSku>Arista-VM</HwSku>
      </Device>
    </Devices>
...
```
Try login vEOS and succeed
```bash
jika@0d00fe79825e:/data/sonic-mgmt/ansible$ ssh admin@10.250.0.51
Password: 
Last login: Wed Mar 11 11:29:45 2020 from 10.250.0.1
ARISTA01T1>
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
