### PR TITLE
[pfcwd] Assign a random port when no ports are selected

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -107,6 +107,14 @@
   with_dict: "{{test_ports}}"
   when: (item.value.test_port_id | int % 15) == (seed | int % 15)
 
+- set_fact:
+    random_port: "{{ test_ports.keys()[0] }}"
+  when: select_test_ports is not defined
+
+- set_fact:
+    select_test_ports: "{{ select_test_ports | default({}) | combine({random_port : test_ports[random_port]}) | to_json }}"
+  when: select_test_ports is not defined
+
 - debug: msg="{{select_test_ports}}"
 
 - name: Run default test if user has not specified warm reboot test


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
'select_test_ports' ends up being undefined in some cases when none of the test ports satisfy the condition (test_port_id % 15 == seed % 15) where seed is ansible_date_time['day']
 
With this change, a random port is selected and assigned to 'select_test_ports' if the above check fails to populate any ports
	
### Type of change
	
- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)
	
#### How did you verify/test it?
Verified that failures are no longer seen with this change on the device with the particular seed value where it was failing earlier. Verified that this change is skipped when the ports are already populated 
