### PR TITLE
[VRF] Modify some errors for test_bgp_with_loopback in test_vrf.py

### DIFF
--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -822,7 +822,7 @@ class TestVrfLoopbackIntf():
             ns = g_vars['vlan_peer_vrf2ns_map'][vrf]
             ptfhost.shell("ip netns exec {} ip address add {} dev e{}mv1".format(ns, ptf_speaker_ip, vlan_peer_port))
 
-        res = duthost.shell("sonic-cfggen -m -d -y /etc/sonic/deployment_id_asn_map.yml -v \"deployment_id_asn_map[DEVICE_METADATA['localhost']['deployment_id']]\"")
+        res = duthost.shell("sonic-cfggen -m -d -y /etc/sonic/constants.yml -v \"constants.deployment_id_asn_map[DEVICE_METADATA['localhost']['deployment_id']]\"")
         bgp_speaker_asn = res['stdout']
 
         exabgp_dir = "/root/exabgp"
@@ -876,7 +876,7 @@ class TestVrfLoopbackIntf():
             ptfhost.shell("ip netns exec {} ip address del {} dev e{}mv1".format(ns, ptf_speaker_ip, vlan_peer_port))
 
         # FIXME workround to overcome the bgp socket issue
-        duthost.shell("vtysh -c 'config terminal' -c 'no router bgp 65444'")
+        #duthost.shell("vtysh -c 'config terminal' -c 'no router bgp 65444'")
 
     @pytest.mark.usefixtures('setup_bgp_with_loopback')
     def test_bgp_with_loopback(self, duthost, cfg_facts):


### PR DESCRIPTION
### Description of PR
1. Access the asn parameter from /etc/sonic/constants.yml instead of /etc/sonic/deployment_id_asn_map.yml.
2. Don't remove bgp associated with default VRF when there are bgp associated with non default VRF. This is FRR's restriction(https://github.com/FRRouting/frr/commit/dd5868c2cce8b87b50667c3e0e43b2d15127eb5c).

### Type of change

- [v] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### How did you verify/test it?
Run test_bgp_with_loopback again.
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.7, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/sonic/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item

test_vrf_bgp.py::TestVrfLoopbackIntf::test_bgp_with_loopback PASSED      [100%]

=============================== warnings summary ===============================
test_vrf_bgp.py::TestVrfLoopbackIntf::test_bgp_with_loopback
  /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py:70: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1 passed, 1 warnings in 211.35 seconds ====================
```