### PR TITLE
[201811][wr_arp] change wr_arp.yml according to the ansible version

### DIFF
--- a/ansible/roles/test/tasks/wr_arp.yml
+++ b/ansible/roles/test/tasks/wr_arp.yml
@@ -102,7 +102,7 @@
   delegate_to: "{{ ptf_host }}"
 
 - name: Update supervisor configuration
-  include_tasks: "roles/test/tasks/common_tasks/update_supervisor.yml"
+  include: "roles/test/tasks/common_tasks/update_supervisor.yml"
   vars:
     supervisor_host: "{{ ptf_host }}"
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Lower version ansible doesn't support include_tasks.

#### How did you verify/test it?
Run wr_arp test. This change only solves the syntax error. Doesn't solve the python version dependency issue. (this test requires python 2.7.13 or later).

