### PR TITLE
[qos] Fix script to accomodate the per-port buffer settings

### DIFF
--- a/ansible/roles/test/tasks/qos_get_ports.yml
+++ b/ansible/roles/test/tasks/qos_get_ports.yml
@@ -157,7 +157,7 @@
 - include_tasks: roles/test/tasks/qos_get_max_buff_size.yml
   vars:
     target_table: 'BUFFER_PG'
-    target_port_name: "***{{dut_switch_ports[src_port_id|int]}}***"
+    target_port_name: "{{dut_switch_ports[src_port_id|int]}}"
     target_pg: '0'
     target_buffer_profile_type: 'ingress lossy'
 
@@ -179,7 +179,7 @@
 - include_tasks: roles/test/tasks/qos_get_max_buff_size.yml
   vars:
     target_table: 'BUFFER_QUEUE'
-    target_port_name: "***{{dut_switch_ports[src_port_id|int]}}***"
+    target_port_name: "{{dut_switch_ports[src_port_id|int]}}"
     target_pg: '3-4'
     target_buffer_profile_type: 'egress lossless'
 
@@ -196,7 +196,7 @@
 - include_tasks: roles/test/tasks/qos_get_max_buff_size.yml
   vars:
     target_table: 'BUFFER_QUEUE'
-    target_port_name: "***{{dut_switch_ports[src_port_id|int]}}***"
+    target_port_name: "{{dut_switch_ports[src_port_id|int]}}"
     target_pg: '0-2'
     target_buffer_profile_type: 'egress lossy'
 

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -70,9 +70,6 @@
     - name: copy portmap
       copy: src={{ptf_portmap}} dest=/root
       delegate_to: "{{ptf_host}}"
-      when: minigraph_hwsku is defined and
-            (minigraph_hwsku in mellanox_hwskus or minigraph_hwsku in
-            ['Arista-7050-QX-32S', 'Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64'])
 
     - name: Init PTF base test parameters
       set_fact:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
* Buffer settings are now applied per port. Change the script to not match on multiple ports. 
* PTF portmap file is needed for all sku's to get the correct ptf port to interface mapping. Copy it to the ptf irrespective of sku type

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach

#### How did you verify/test it?
Ran QOS test on one of the hwsku's and it passed
