### PR TITLE
[pytest] add BSL marks

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -157,6 +157,7 @@ def fdb_cleanup(ansible_adhoc, testbed):
         duthost.command('sonic-clear fdb all')
 
 
+@pytest.mark.bsl
 @pytest.mark.usefixtures('fdb_cleanup')
 @pytest.mark.parametrize("pkt_type", PKT_TYPES)
 def test_fdb(ansible_adhoc, testbed, ptfadapter, duthost, ptfhost, pkt_type):

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -2,6 +2,7 @@ import pytest
 import time
 from ansible_host import AnsibleHost
 
+@pytest.mark.bsl
 def test_snmp_cpu(ansible_adhoc, testbed, creds):
     """
     Test SNMP CPU Utilization

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -1,5 +1,7 @@
+import pytest
 from ansible_host import AnsibleHost
 
+@pytest.mark.bsl
 def test_snmp_interfaces(ansible_adhoc, duthost, creds):
     """compare the bgp facts between observed states and target state"""
 

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,5 +1,7 @@
+import pytest
 from ansible_host import AnsibleHost
 
+@pytest.mark.bsl
 def test_snmp_lldp(ansible_adhoc, testbed, creds):
     """
     Test checks for ieee802_1ab MIBs:

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -3,6 +3,7 @@ from ansible_host import AnsibleHost
 
 PSU_STATUS_OK = 2
 
+@pytest.mark.bsl
 def test_snmp_numpsu(testbed_devices, creds, duthost):
 
     ans_host = testbed_devices['dut']
@@ -17,6 +18,7 @@ def test_snmp_numpsu(testbed_devices, creds, duthost):
     assert numpsus == len(snmp_facts['snmp_psu'])
 
 
+@pytest.mark.bsl
 def test_snmp_psu_status(testbed_devices, creds):
 
     ans_host = testbed_devices['dut']


### PR DESCRIPTION
Change-Id: I75fe8f5bdad947d9b3665be4895dd9363c3296ab
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Add BSL marks to the relevant tests (vlan is already marked). 
You will be able to run all the BSL tests with
`pytest -m bsl ...`

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
