### PR TITLE
Add the APC PSU support for SNMP PSU controller

### DIFF
--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -9,40 +9,73 @@ from controller_base import PsuControllerBase
 from controller_base import run_local_cmd
 
 
-def get_psu_controller_type(psu_controller_host):
+try:
+    from pysnmp.proto import rfc1902
+    from pysnmp.entity.rfc3413.oneliner import cmdgen
+    from pyasn1.type import univ
+    has_pysnmp = True
+except:
+    has_pysnmp = False
+
+class snmpPsuController(PsuControllerBase):
     """
-    @summary: Use SNMP to get the type of PSU controller host
-    @param psu_controller_host: IP address of PSU controller host
-    @return: Returns type string of the specified PSU controller host
+    PSU Controller class for SNMP conrolled PSUs - 'Sentry Switched CDU' and 'APC Web/SNMP Management Card'
+
+    This class implements the interface defined in PsuControllerBase class for SNMP conrtolled PDU type 
+    'Sentry Switched CDU' and 'APC Web/SNMP Management Card'
     """
-    result = None
-    cmd = "snmpget -v 1 -c public -Ofenqv %s .1.3.6.1.2.1.1.1.0" % psu_controller_host
-    try:
-        stdout = run_local_cmd(cmd)
 
-        lines = stdout.splitlines()
-        if len(lines) > 0:
-            result = lines[0].strip()
-            result = result.replace('"', '')
-    except Exception as e:
-        logging.debug("Failed to get psu controller type, exception: " + repr(e))
+    def get_psu_controller_type(self):
+        """
+        @summary: Use SNMP to get the type of PSU controller host
+        @param psu_controller_host: IP address of PSU controller host
+        @return: Returns type string of the specified PSU controller host
+        """
+        psu = None
+        cmd = "snmpget -v 1 -c public -Ofenqv %s .1.3.6.1.2.1.1.1.0" % self.controller
+        try:
+            stdout = run_local_cmd(cmd)
+            lines = stdout.splitlines()
+            if len(lines) > 0:
+                psu = lines[0].strip().replace('"','')
+                print(psu)
+                if 'Sentry Switched CDU' in psu:
+                    self.psuType = "SENTRY"
+                    print(self.psuType)
+                if 'APC Web/SNMP Management Card' in psu:
+                    self.psuType = "APC"
+                    print(self.psuType)
+        except Exception as e:
+            logging.debug("Failed to get psu controller type, exception: " + repr(e))
 
-    return result
 
+    def psuCntrlOid(self):
+        """
+        Define Oids based on the PSU Type
+        """
+        # MIB OIDs for 'APC Web/SNMP Management PSU'
+        APC_PORT_NAME_BASE_OID = ".1.3.6.1.4.1.318.1.1.4.4.2.1.4"
+        APC_PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
+        APC_PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"
+        # MIB OID for 'Sentry Switched CDU'
+        SENTRY_PORT_NAME_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.3.1"
+        SENTRY_PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.5.1"
+        SENTRY_PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.11.1"
+        self.STATUS_ON = "1"
+        self.STATUS_OFF = "0"
+        self.CONTROL_ON = "1"
+        self.CONTROL_OFF = "2"
+        if self.psuType == "APC":
+            self.PORT_NAME_BASE_OID      = APC_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID    = APC_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID   = APC_PORT_CONTROL_BASE_OID
+        elif self.psuType == "SENTRY":
+            self.PORT_NAME_BASE_OID      = SENTRY_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID    = SENTRY_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID   = SENTRY_PORT_CONTROL_BASE_OID
+        else:
+            pass
 
-class SentrySwitchedCDU(PsuControllerBase):
-    """
-    PSU Controller class for 'Sentry Switched CDU'
-
-    This class implements the interface defined in PsuControllerBase class for PDU type 'Sentry Switched CDU'
-    """
-    PORT_NAME_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.3.1"
-    PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.5.1"
-    PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.11.1"
-    STATUS_ON = "1"
-    STATUS_OFF = "0"
-    CONTROL_ON = "1"
-    CONTROL_OFF = "2"
 
     def _get_pdu_ports(self):
         """
@@ -69,148 +102,10 @@ class SentrySwitchedCDU(PsuControllerBase):
         self.hostname = hostname
         self.controller = controller
         self.pdu_ports = []
+        self.psuType = None
+        self.get_psu_controller_type()
         self._get_pdu_ports()
-        logging.info("Initialized " + self.__class__.__name__)
-
-    def turn_on_psu(self, psu_id):
-        """
-        @summary: Use SNMP to turn on power to PSU of DUT specified by psu_id
-
-        DUT hostname must be configured in PDU port name/description. But it is hard to specify which PDU port is
-        connected to the first PSU of DUT and which port is connected to the second PSU.
-
-        Because of this, currently we just find out which PDU ports are connected to PSUs of which DUT. We cannot
-        find out the exact mapping between PDU ports and PSUs of DUT.
-
-        To overcome this limitation, the trick is to convert the specified psu_id to integer, then calculate the mode
-        upon the number of PSUs on DUT. The calculated mode is used as an index to get PDU ports ID stored in
-        self.pdu_ports. But still, we cannot gurante that psu_id 0 is first PSU of DUT, and so on.
-
-        @param psu_id: ID of the PSU on SONiC DUT
-        @return: Return true if successfully execute the command for turning on power. Otherwise return False.
-        """
-        try:
-            idx = int(psu_id) % len(self.pdu_ports)
-            port_oid = self.PORT_CONTROL_BASE_OID + self.pdu_ports[idx]
-            cmd = "snmpset -v1 -C q -c private %s %s i %s" % (self.controller, port_oid, self.CONTROL_ON)
-            run_local_cmd(cmd)
-            logging.info("Turned on PSU %s" % str(psu_id))
-            return True
-        except Exception as e:
-            logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), repr(e)))
-            return False
-
-    def turn_off_psu(self, psu_id):
-        """
-        @summary: Use SNMP to turn off power to PSU of DUT specified by psu_id
-
-        DUT hostname must be configured in PDU port name/description. But it is hard to specify which PDU port is
-        connected to the first PSU of DUT and which port is connected to the second PSU.
-
-        Because of this, currently we just find out which PDU ports are connected to PSUs of which DUT. We cannot
-        find out the exact mapping between PDU ports and PSUs of DUT.
-
-        To overcome this limitation, the trick is to convert the specified psu_id to integer, then calculate the mode
-        upon the number of PSUs on DUT. The calculated mode is used as an index to get PDU ports ID stored in
-        self.pdu_ports. But still, we cannot gurante that psu_id 0 is first PSU of DUT, and so on.
-
-        @param psu_id: ID of the PSU on SONiC DUT
-        @return: Return true if successfully execute the command for turning off power. Otherwise return False.
-        """
-        try:
-            idx = int(psu_id) % len(self.pdu_ports)
-            port_oid = self.PORT_CONTROL_BASE_OID + self.pdu_ports[idx]
-            cmd = "snmpset -v1 -C q -c private %s %s i %s" % (self.controller, port_oid, self.CONTROL_OFF)
-            run_local_cmd(cmd)
-            logging.info("Turned off PSU %s" % str(psu_id))
-            return True
-        except Exception as e:
-            logging.debug("Failed to turn off PSU %s, exception: %s" % (str(psu_id), repr(e)))
-            return False
-
-    def get_psu_status(self, psu_id=None):
-        """
-        @summary: Use SNMP to get status of PDU ports supplying power to PSUs of DUT
-
-        DUT hostname must be configured in PDU port name/description. But it is hard to specify which PDU port is
-        connected to the first PSU of DUT and which port is connected to the second PSU.
-
-        Because of this, currently we just find out which PDU ports are connected to PSUs of which DUT. We cannot
-        find out the exact mapping between PDU ports and PSUs of DUT.
-
-        To overcome this limitation, the trick is to convert the specified psu_id to integer, then calculate the mode
-        upon the number of PSUs on DUT. The calculated mode is used as an index to get PDU ports ID stored in
-        self.pdu_ports. But still, we cannot gurante that psu_id 0 is first PSU of DUT, and so on.
-
-        @param psu_id: Optional. If specified, only return status of PDU port connected to specified PSU of DUT. If
-                       omitted, return status of all PDU ports connected to PSUs of DUT.
-        @return: Return status of PDU ports connected to PSUs of DUT in a list of dictionary. Example result:
-                     [{"psu_id": 0, "psu_on": True}, {"psu_id": 1, "psu_on": True}]
-                 The psu_id in returned result is integer starts from 0.
-        """
-        results = []
-        try:
-            cmd = "snmpwalk -v 1 -c public -Ofenq %s %s " % (self.controller, self.PORT_STATUS_BASE_OID)
-            stdout = run_local_cmd(cmd)
-            for line in stdout.splitlines():
-                for idx, port in enumerate(self.pdu_ports):
-                    port_oid = self.PORT_STATUS_BASE_OID + port
-                    fields = line.strip().split()
-                    if len(fields) == 2 and fields[0] == port_oid:
-                        status = {"psu_id": idx, "psu_on": True if fields[1] == self.STATUS_ON else False}
-                        results.append(status)
-            if psu_id is not None:
-                idx = int(psu_id) % len(self.pdu_ports)
-                results = results[idx:idx+1]
-            logging.info("Got PSU status: %s" % str(results))
-        except Exception as e:
-            logging.debug("Failed to get psu status, exception: " + repr(e))
-        return results
-
-    def close(self):
-        pass
-
-
-class APCSnmpPSU(PsuControllerBase):
-    """
-    PSU Controller class for 'APC Web/SNMP Management PSU'
-
-    This class implements the interface defined in PsuControllerBase class for PDU type 'APC Web/SNMP Management PSU'
-    """
-    PORT_NAME_BASE_OID = ".1.3.6.1.4.1.318.1.1.4.4.2.1.4"
-    PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
-    PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"
-    STATUS_ON = "1"
-    STATUS_OFF = "0"
-    CONTROL_ON = "1"
-    CONTROL_OFF = "2"
-
-    def _get_pdu_ports(self):
-        """
-        @summary: Helper method for getting PDU ports connected to PSUs of DUT
-
-        The PDU ports connected to DUT must have hostname of DUT configured in port name/description.
-        This method depends on this configuration to find out the PDU ports connected to PSUs of specific DUT.
-        """
-        try:
-            cmd = "snmpwalk -v 1 -c public -Ofenq %s %s " % (self.controller, self.PORT_NAME_BASE_OID)
-            stdout = run_local_cmd(cmd)
-            for line in stdout.splitlines():
-                if self.hostname in line:  # PDU port name/description should have DUT hostname
-                    fields = line.split()
-                    if len(fields) == 2:
-                        # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
-                        self.pdu_ports.append(fields[0].replace(self.PORT_NAME_BASE_OID, ''))
-        except Exception as e:
-            logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + repr(e))
-
-    def __init__(self, hostname, controller):
-        logging.info("Initializing " + self.__class__.__name__)
-        PsuControllerBase.__init__(self)
-        self.hostname = hostname
-        self.controller = controller
-        self.pdu_ports = []
-        self._get_pdu_ports()
+        self.psuCntrlOid()
         logging.info("Initialized " + self.__class__.__name__)
 
     def turn_on_psu(self, psu_id):
@@ -317,17 +212,4 @@ def get_psu_controller(controller_ip, dut_hostname):
     @summary: Factory function to create the actual PSU controller object.
     @return: The actual PSU controller object. Returns None if something went wrong.
     """
-
-    psu_controller_type = get_psu_controller_type(controller_ip)
-    if not psu_controller_type:
-        return None
-
-    if "Sentry Switched CDU" in psu_controller_type:
-        logging.info("Initializing Sentry PSU controller")
-        return SentrySwitchedCDU(dut_hostname, controller_ip)
-
-    if "APC Web/SNMP Management Card" in psu_controller_type:
-        loggin.info("Initializing APC PSU controller")
-        return APCSnmpPSU(dut_hostname, controller_ip)
-
-    return None
+    return snmpPsuController(dut_hostname, controller_ip)

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -51,16 +51,13 @@ class snmpPsuController(PsuControllerBase):
                 current_val = val.prettyPrint()
                 if current_oid == SYSDESCR:
                     psu = current_val
-                print(psu)
         if psu == None:
             self.psuType = None
             return
         if 'Sentry Switched CDU' in psu:
             self.psuType = "SENTRY"
-            print(self.psuType)
         if 'APC Web/SNMP Management Card' in psu:
             self.psuType = "APC"
-            print(self.psuType)
         return
 
     def psuCntrlOid(self):
@@ -162,7 +159,7 @@ class snmpPsuController(PsuControllerBase):
             cmdgen.CommandGenerator().setCmd(
                 cmdgen.CommunityData('private'),
                 cmdgen.UdpTransportTarget((self.controller, 161)),
-                (port_oid, self.CONTROL_ON),
+                (port_oid, rfc1902.Integer(self.CONTROL_ON)),
             )
             if errorIndication or errorStatus != 0:
                 logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), str(errorStatus)))
@@ -195,7 +192,7 @@ class snmpPsuController(PsuControllerBase):
             cmdgen.CommandGenerator().setCmd(
                 cmdgen.CommunityData('private'),
                 cmdgen.UdpTransportTarget((self.controller, 161)),
-                (port_oid, self.CONTROL_OFF),
+                (port_oid, rfc1902.Integer(self.CONTROL_OFF)),
             )
             if errorIndication or errorStatus != 0:
                 logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), str(errorStatus)))

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -8,13 +8,13 @@ import logging
 from controller_base import PsuControllerBase
 from controller_base import run_local_cmd
 
-
 try:
     from pysnmp.proto import rfc1902
     from pysnmp.entity.rfc3413.oneliner import cmdgen
     from pyasn1.type import univ
 except:
     logging.error("Missing required pysnmp module (check docs)")
+
 class snmpPsuController(PsuControllerBase):
     """
     PSU Controller class for SNMP conrolled PSUs - 'Sentry Switched CDU' and 'APC Web/SNMP Management Card'
@@ -142,7 +142,7 @@ class snmpPsuController(PsuControllerBase):
         @param psu_id: ID of the PSU on SONiC DUT
         @return: Return true if successfully execute the command for turning on power. Otherwise return False.
         """
-        port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[psu_id]
+        port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[rfc1902.Integer(psu_id)]
         errorIndication, errorStatus, _, _ = \
         cmdgen.CommandGenerator().setCmd(
             cmdgen.CommunityData('private'),
@@ -171,7 +171,7 @@ class snmpPsuController(PsuControllerBase):
         @param psu_id: ID of the PSU on SONiC DUT
         @return: Return true if successfully execute the command for turning off power. Otherwise return False.
         """
-        port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[psu_id]
+        port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[rfc1902.Integer(psu_id)]
         errorIndication, errorStatus, _, _ = \
         cmdgen.CommandGenerator().setCmd(
             cmdgen.CommunityData('private'),

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -41,7 +41,7 @@ class snmpPsuController(PsuControllerBase):
             current_val = val.prettyPrint()
             if current_oid == SYSDESCR:
                 psu = current_val
-        if psu == None:
+        if psu is None:
             self.psuType = None
             return
         if 'Sentry Switched CDU' in psu:

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -171,6 +171,147 @@ class SentrySwitchedCDU(PsuControllerBase):
         pass
 
 
+class APCSnmpPSU(PsuControllerBase):
+    """
+    PSU Controller class for 'APC Web/SNMP Management PSU'
+
+    This class implements the interface defined in PsuControllerBase class for PDU type 'APC Web/SNMP Management PSU'
+    """
+    PORT_NAME_BASE_OID = ".1.3.6.1.4.1.318.1.1.4.4.2.1.4"
+    PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
+    PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"
+    STATUS_ON = "1"
+    STATUS_OFF = "0"
+    CONTROL_ON = "1"
+    CONTROL_OFF = "2"
+
+    def _get_pdu_ports(self):
+        """
+        @summary: Helper method for getting PDU ports connected to PSUs of DUT
+
+        The PDU ports connected to DUT must have hostname of DUT configured in port name/description.
+        This method depends on this configuration to find out the PDU ports connected to PSUs of specific DUT.
+        """
+        try:
+            cmd = "snmpwalk -v 1 -c public -Ofenq %s %s " % (self.controller, self.PORT_NAME_BASE_OID)
+            stdout = run_local_cmd(cmd)
+            for line in stdout.splitlines():
+                if self.hostname in line:  # PDU port name/description should have DUT hostname
+                    fields = line.split()
+                    if len(fields) == 2:
+                        # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
+                        self.pdu_ports.append(fields[0].replace(self.PORT_NAME_BASE_OID, ''))
+        except Exception as e:
+            logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + repr(e))
+
+    def __init__(self, hostname, controller):
+        logging.info("Initializing " + self.__class__.__name__)
+        PsuControllerBase.__init__(self)
+        self.hostname = hostname
+        self.controller = controller
+        self.pdu_ports = []
+        self._get_pdu_ports()
+        logging.info("Initialized " + self.__class__.__name__)
+
+    def turn_on_psu(self, psu_id):
+        """
+        @summary: Use SNMP to turn on power to PSU of DUT specified by psu_id
+
+        DUT hostname must be configured in PDU port name/description. But it is hard to specify which PDU port is
+        connected to the first PSU of DUT and which port is connected to the second PSU.
+
+        Because of this, currently we just find out which PDU ports are connected to PSUs of which DUT. We cannot
+        find out the exact mapping between PDU ports and PSUs of DUT.
+
+        To overcome this limitation, the trick is to convert the specified psu_id to integer, then calculate the mode
+        upon the number of PSUs on DUT. The calculated mode is used as an index to get PDU ports ID stored in
+        self.pdu_ports. But still, we cannot gurante that psu_id 0 is first PSU of DUT, and so on.
+
+        @param psu_id: ID of the PSU on SONiC DUT
+        @return: Return true if successfully execute the command for turning on power. Otherwise return False.
+        """
+        try:
+            idx = int(psu_id) % len(self.pdu_ports)
+            port_oid = self.PORT_CONTROL_BASE_OID + self.pdu_ports[idx]
+            cmd = "snmpset -v1 -C q -c private %s %s i %s" % (self.controller, port_oid, self.CONTROL_ON)
+            run_local_cmd(cmd)
+            logging.info("Turned on PSU %s" % str(psu_id))
+            return True
+        except Exception as e:
+            logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), repr(e)))
+            return False
+
+    def turn_off_psu(self, psu_id):
+        """
+        @summary: Use SNMP to turn off power to PSU of DUT specified by psu_id
+
+        DUT hostname must be configured in PDU port name/description. But it is hard to specify which PDU port is
+        connected to the first PSU of DUT and which port is connected to the second PSU.
+
+        Because of this, currently we just find out which PDU ports are connected to PSUs of which DUT. We cannot
+        find out the exact mapping between PDU ports and PSUs of DUT.
+
+        To overcome this limitation, the trick is to convert the specified psu_id to integer, then calculate the mode
+        upon the number of PSUs on DUT. The calculated mode is used as an index to get PDU ports ID stored in
+        self.pdu_ports. But still, we cannot gurante that psu_id 0 is first PSU of DUT, and so on.
+
+        @param psu_id: ID of the PSU on SONiC DUT
+        @return: Return true if successfully execute the command for turning off power. Otherwise return False.
+        """
+        try:
+            idx = int(psu_id) % len(self.pdu_ports)
+            port_oid = self.PORT_CONTROL_BASE_OID + self.pdu_ports[idx]
+            cmd = "snmpset -v1 -C q -c private %s %s i %s" % (self.controller, port_oid, self.CONTROL_OFF)
+            run_local_cmd(cmd)
+            logging.info("Turned off PSU %s" % str(psu_id))
+            return True
+        except Exception as e:
+            logging.debug("Failed to turn off PSU %s, exception: %s" % (str(psu_id), repr(e)))
+            return False
+
+    def get_psu_status(self, psu_id=None):
+        """
+        @summary: Use SNMP to get status of PDU ports supplying power to PSUs of DUT
+
+        DUT hostname must be configured in PDU port name/description. But it is hard to specify which PDU port is
+        connected to the first PSU of DUT and which port is connected to the second PSU.
+
+        Because of this, currently we just find out which PDU ports are connected to PSUs of which DUT. We cannot
+        find out the exact mapping between PDU ports and PSUs of DUT.
+
+        To overcome this limitation, the trick is to convert the specified psu_id to integer, then calculate the mode
+        upon the number of PSUs on DUT. The calculated mode is used as an index to get PDU ports ID stored in
+        self.pdu_ports. But still, we cannot gurante that psu_id 0 is first PSU of DUT, and so on.
+
+        @param psu_id: Optional. If specified, only return status of PDU port connected to specified PSU of DUT. If
+                       omitted, return status of all PDU ports connected to PSUs of DUT.
+        @return: Return status of PDU ports connected to PSUs of DUT in a list of dictionary. Example result:
+                     [{"psu_id": 0, "psu_on": True}, {"psu_id": 1, "psu_on": True}]
+                 The psu_id in returned result is integer starts from 0.
+        """
+        results = []
+        try:
+            cmd = "snmpwalk -v 1 -c public -Ofenq %s %s " % (self.controller, self.PORT_STATUS_BASE_OID)
+            stdout = run_local_cmd(cmd)
+            for line in stdout.splitlines():
+                for idx, port in enumerate(self.pdu_ports):
+                    port_oid = self.PORT_STATUS_BASE_OID + port
+                    fields = line.strip().split()
+                    if len(fields) == 2 and fields[0] == port_oid:
+                        status = {"psu_id": idx, "psu_on": True if fields[1] == self.STATUS_ON else False}
+                        results.append(status)
+            if psu_id is not None:
+                idx = int(psu_id) % len(self.pdu_ports)
+                results = results[idx:idx+1]
+            logging.info("Got PSU status: %s" % str(results))
+        except Exception as e:
+            logging.debug("Failed to get psu status, exception: " + repr(e))
+        return results
+
+    def close(self):
+        pass
+
+
 def get_psu_controller(controller_ip, dut_hostname):
     """
     @summary: Factory function to create the actual PSU controller object.
@@ -182,7 +323,11 @@ def get_psu_controller(controller_ip, dut_hostname):
         return None
 
     if "Sentry Switched CDU" in psu_controller_type:
-        logging.info("Initializing PSU controller")
+        logging.info("Initializing Sentry PSU controller")
         return SentrySwitchedCDU(dut_hostname, controller_ip)
+
+    if "APC Web/SNMP Management Card" in psu_controller_type:
+        loggin.info("Initializing APC PSU controller")
+        return APCSnmpPSU(dut_hostname, controller_ip)
 
     return None

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -31,45 +31,65 @@ class snmpPsuController(PsuControllerBase):
         @param psu_controller_host: IP address of PSU controller host
         @return: Returns type string of the specified PSU controller host
         """
+        pSYSDESCR = ".1.3.6.1.2.1.1.1.0"
+        SYSDESCR = "1.3.6.1.2.1.1.1.0"
         psu = None
-        cmd = "snmpget -v 1 -c public -Ofenqv %s .1.3.6.1.2.1.1.1.0" % self.controller
-        try:
-            stdout = run_local_cmd(cmd)
-            lines = stdout.splitlines()
-            if len(lines) > 0:
-                psu = lines[0].strip().replace('"','')
+        if not has_pysnmp:
+            logging.info("Missing required pysnmp module (check docs)")
+        else:
+            cmdGen = cmdgen.CommandGenerator()
+            snmp_auth = cmdgen.CommunityData('public')
+            errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
+                snmp_auth,
+                cmdgen.UdpTransportTarget((self.controller, 161), timeout=5.0),
+                cmdgen.MibVariable(pSYSDESCR,),
+                )
+            if errorIndication:
+                logging.info("Failed to get psu controller type, exception: " + str(errorIndication))
+            for oid, val in varBinds:
+                current_oid = oid.prettyPrint()
+                current_val = val.prettyPrint()
+                if current_oid == SYSDESCR:
+                    psu = current_val
                 print(psu)
-                if 'Sentry Switched CDU' in psu:
-                    self.psuType = "SENTRY"
-                    print(self.psuType)
-                if 'APC Web/SNMP Management Card' in psu:
-                    self.psuType = "APC"
-                    print(self.psuType)
-        except Exception as e:
-            logging.debug("Failed to get psu controller type, exception: " + repr(e))
-
+        if psu == None:
+            self.psuType = None
+            return
+        if 'Sentry Switched CDU' in psu:
+            self.psuType = "SENTRY"
+            print(self.psuType)
+        if 'APC Web/SNMP Management Card' in psu:
+            self.psuType = "APC"
+            print(self.psuType)
+        return
 
     def psuCntrlOid(self):
         """
         Define Oids based on the PSU Type
         """
         # MIB OIDs for 'APC Web/SNMP Management PSU'
-        APC_PORT_NAME_BASE_OID = ".1.3.6.1.4.1.318.1.1.4.4.2.1.4"
-        APC_PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
-        APC_PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"
+        APC_PORT_NAME_BASE_OID = "1.3.6.1.4.1.318.1.1.4.4.2.1.4"
+        APC_PORT_STATUS_BASE_OID = "1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
+        APC_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"
         # MIB OID for 'Sentry Switched CDU'
-        SENTRY_PORT_NAME_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.3.1"
-        SENTRY_PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.5.1"
-        SENTRY_PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.1718.3.2.3.1.11.1"
+        SENTRY_PORT_NAME_BASE_OID = "1.3.6.1.4.1.1718.3.2.3.1.3.1"
+        SENTRY_PORT_STATUS_BASE_OID = "1.3.6.1.4.1.1718.3.2.3.1.5.1"
+        SENTRY_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.1718.3.2.3.1.11.1"
         self.STATUS_ON = "1"
         self.STATUS_OFF = "0"
         self.CONTROL_ON = "1"
         self.CONTROL_OFF = "2"
         if self.psuType == "APC":
+            self.pPORT_NAME_BASE_OID     = '.'+APC_PORT_NAME_BASE_OID
+            self.pPORT_STATUS_BASE_OID   = '.'+APC_PORT_STATUS_BASE_OID
+            self.pPORT_CONTROL_BASE_OID  = '.'+APC_PORT_CONTROL_BASE_OID
             self.PORT_NAME_BASE_OID      = APC_PORT_NAME_BASE_OID
             self.PORT_STATUS_BASE_OID    = APC_PORT_STATUS_BASE_OID
             self.PORT_CONTROL_BASE_OID   = APC_PORT_CONTROL_BASE_OID
         elif self.psuType == "SENTRY":
+            self.pPORT_NAME_BASE_OID     = '.'+SENTRY_PORT_NAME_BASE_OID
+            self.pPORT_STATUS_BASE_OID   = '.'+SENTRY_PORT_STATUS_BASE_OID
+            self.pPORT_CONTROL_BASE_OID  = '.'+SENTRY_PORT_CONTROL_BASE_OID
             self.PORT_NAME_BASE_OID      = SENTRY_PORT_NAME_BASE_OID
             self.PORT_STATUS_BASE_OID    = SENTRY_PORT_STATUS_BASE_OID
             self.PORT_CONTROL_BASE_OID   = SENTRY_PORT_CONTROL_BASE_OID
@@ -84,17 +104,25 @@ class snmpPsuController(PsuControllerBase):
         The PDU ports connected to DUT must have hostname of DUT configured in port name/description.
         This method depends on this configuration to find out the PDU ports connected to PSUs of specific DUT.
         """
-        try:
-            cmd = "snmpwalk -v 1 -c public -Ofenq %s %s " % (self.controller, self.PORT_NAME_BASE_OID)
-            stdout = run_local_cmd(cmd)
-            for line in stdout.splitlines():
-                if self.hostname in line:  # PDU port name/description should have DUT hostname
-                    fields = line.split()
-                    if len(fields) == 2:
+        if not has_pysnmp:
+            logging.info("Missing required pysnmp module (check docs)")
+        else:
+            cmdGen = cmdgen.CommandGenerator()
+            snmp_auth = cmdgen.CommunityData('public')
+            errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
+                snmp_auth,
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                cmdgen.MibVariable(self.pPORT_NAME_BASE_OID,),
+                )
+            if errorIndication:
+                logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
+            for varBinds in varTable:
+                for oid, val in varBinds:
+                    current_oid = oid.prettyPrint()
+                    current_val = val.prettyPrint()
+                    if self.hostname.lower()  in current_val.lower():
                         # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
-                        self.pdu_ports.append(fields[0].replace(self.PORT_NAME_BASE_OID, ''))
-        except Exception as e:
-            logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + repr(e))
+                        self.pdu_ports.append(current_oid.replace(self.PORT_NAME_BASE_OID, ''))
 
     def __init__(self, hostname, controller):
         logging.info("Initializing " + self.__class__.__name__)
@@ -104,8 +132,8 @@ class snmpPsuController(PsuControllerBase):
         self.pdu_ports = []
         self.psuType = None
         self.get_psu_controller_type()
-        self._get_pdu_ports()
         self.psuCntrlOid()
+        self._get_pdu_ports()
         logging.info("Initialized " + self.__class__.__name__)
 
     def turn_on_psu(self, psu_id):
@@ -125,16 +153,21 @@ class snmpPsuController(PsuControllerBase):
         @param psu_id: ID of the PSU on SONiC DUT
         @return: Return true if successfully execute the command for turning on power. Otherwise return False.
         """
-        try:
-            idx = int(psu_id) % len(self.pdu_ports)
-            port_oid = self.PORT_CONTROL_BASE_OID + self.pdu_ports[idx]
-            cmd = "snmpset -v1 -C q -c private %s %s i %s" % (self.controller, port_oid, self.CONTROL_ON)
-            run_local_cmd(cmd)
-            logging.info("Turned on PSU %s" % str(psu_id))
+        idx = int(psu_id) % len(self.pdu_ports)
+        port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[idx]
+        if not has_pysnmp:
+            logging.info("Missing required pysnmp module (check docs)")
+        else:
+            errorIndication, errorStatus, _, _ = \
+            cmdgen.CommandGenerator().setCmd(
+                cmdgen.CommunityData('private'),
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                (port_oid, self.CONTROL_ON),
+            )
+            if errorIndication or errorStatus != 0:
+                logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), str(errorStatus)))
+                return False
             return True
-        except Exception as e:
-            logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), repr(e)))
-            return False
 
     def turn_off_psu(self, psu_id):
         """
@@ -153,16 +186,21 @@ class snmpPsuController(PsuControllerBase):
         @param psu_id: ID of the PSU on SONiC DUT
         @return: Return true if successfully execute the command for turning off power. Otherwise return False.
         """
-        try:
-            idx = int(psu_id) % len(self.pdu_ports)
-            port_oid = self.PORT_CONTROL_BASE_OID + self.pdu_ports[idx]
-            cmd = "snmpset -v1 -C q -c private %s %s i %s" % (self.controller, port_oid, self.CONTROL_OFF)
-            run_local_cmd(cmd)
-            logging.info("Turned off PSU %s" % str(psu_id))
+        idx = int(psu_id) % len(self.pdu_ports)
+        port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[idx]
+        if not has_pysnmp:
+            logging.info("Missing required pysnmp module (check docs)")
+        else:
+            errorIndication, errorStatus, _, _ = \
+            cmdgen.CommandGenerator().setCmd(
+                cmdgen.CommunityData('private'),
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                (port_oid, self.CONTROL_OFF),
+            )
+            if errorIndication or errorStatus != 0:
+                logging.debug("Failed to turn on PSU %s, exception: %s" % (str(psu_id), str(errorStatus)))
+                return False
             return True
-        except Exception as e:
-            logging.debug("Failed to turn off PSU %s, exception: %s" % (str(psu_id), repr(e)))
-            return False
 
     def get_psu_status(self, psu_id=None):
         """
@@ -185,22 +223,31 @@ class snmpPsuController(PsuControllerBase):
                  The psu_id in returned result is integer starts from 0.
         """
         results = []
-        try:
-            cmd = "snmpwalk -v 1 -c public -Ofenq %s %s " % (self.controller, self.PORT_STATUS_BASE_OID)
-            stdout = run_local_cmd(cmd)
-            for line in stdout.splitlines():
-                for idx, port in enumerate(self.pdu_ports):
-                    port_oid = self.PORT_STATUS_BASE_OID + port
-                    fields = line.strip().split()
-                    if len(fields) == 2 and fields[0] == port_oid:
-                        status = {"psu_id": idx, "psu_on": True if fields[1] == self.STATUS_ON else False}
-                        results.append(status)
-            if psu_id is not None:
-                idx = int(psu_id) % len(self.pdu_ports)
-                results = results[idx:idx+1]
-            logging.info("Got PSU status: %s" % str(results))
-        except Exception as e:
-            logging.debug("Failed to get psu status, exception: " + repr(e))
+        if not has_pysnmp:
+            logging.info("Missing required pysnmp module (check docs)")
+        else:
+            cmdGen = cmdgen.CommandGenerator()
+            snmp_auth = cmdgen.CommunityData('public')
+            errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
+                snmp_auth,
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                cmdgen.MibVariable(self.pPORT_STATUS_BASE_OID,),
+                )
+            if errorIndication:
+                logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
+            for varBinds in varTable:
+                for oid, val in varBinds:
+                    current_oid = oid.prettyPrint()
+                    current_val = val.prettyPrint()
+                    for idx, port in enumerate(self.pdu_ports):
+                        port_oid = self.PORT_STATUS_BASE_OID + port
+                        if current_oid == port_oid:
+                            status = {"psu_id": idx, "psu_on": True if current_val == self.STATUS_ON else False}
+                            results.append(status)
+        if psu_id is not None:
+            idx = int(psu_id) % len(self.pdu_ports)
+            results = results[idx:idx+1]
+        logging.info("Got PSU status: %s" % str(results))
         return results
 
     def close(self):

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -6,14 +6,9 @@ The classes must implement the PsuControllerBase interface defined in controller
 import logging
 
 from controller_base import PsuControllerBase
-from controller_base import run_local_cmd
 
-try:
-    from pysnmp.proto import rfc1902
-    from pysnmp.entity.rfc3413.oneliner import cmdgen
-    from pyasn1.type import univ
-except:
-    logging.error("Missing required pysnmp module (check docs)")
+from pysnmp.proto import rfc1902
+from pysnmp.entity.rfc3413.oneliner import cmdgen
 
 class snmpPsuController(PsuControllerBase):
     """


### PR DESCRIPTION
Add the SNMP PSU controller for APC PSU device
### Description of PR
APC PSU SNMP control support

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Add APC SNMP MIB for PDU control
+    PORT_NAME_BASE_OID = ".1.3.6.1.4.1.318.1.1.4.4.2.1.4"
+    PORT_STATUS_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
+    PORT_CONTROL_BASE_OID = ".1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"

#### How did you verify/test it?
{username}@{sonic-mgmt-docker}:/var/sonic-mgmt-int/tests/common/plugins/psu_controller$ python
Python 2.7.12 (default, Oct  8 2019, 14:14:10) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
> from snmp_psu_controllers import * 
> psucntl = get_psu_controller('<controller_ip>',"<device_name>")
> psucntl.get_psu_status()
[{'psu_id': 0, 'psu_on': True}]
> psucntl.turn_off_psu('0')
True
> psucntl.get_psu_status() 
[{'psu_id': 0, 'psu_on': False}]
> psucntl.turn_on_psu('0')  
True
> psucntl.get_psu_status()
[{'psu_id': 0, 'psu_on': True}]
> print psucntl.psuType
APC


#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
Any
### Documentation 
https://www.apc.com/us/en/faqs/FA156048/
