### PR TITLE
[bgp_facts]: fix num_npus param bug

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -51,18 +51,17 @@ class BgpModule(object):
         self.instances =[]
         self.module = AnsibleModule(
             argument_spec=dict(
-                num_npus=dict(),
+                num_npus=dict(type='int', default=1),
             ),
             supports_check_mode=True)
 
         m_args = self.module.params
-        
-        if 'num_npus' in m_args and m_args['num_npus'] is not '1':
-            npus = int(m_args['num_npus'])
+        npus = m_args['num_npus']
+        if npus > 1:
             for npu in range(0, npus):
                 self.instances.append("bgp{}".format(npu))
         else:
-             self.instances.append("bgp")
+            self.instances.append("bgp")
                     
         self.out = None
         self.facts = {}
@@ -81,7 +80,7 @@ class BgpModule(object):
             self.get_statistics()
         self.module.exit_json(ansible_facts=self.facts)
 
-    def collect_data(self, command_str,instance):
+    def collect_data(self, command_str, instance):
         """
             Collect bgp information by reading output of 'vtysh' command line tool
         """


### PR DESCRIPTION
if test does not pass num_npus param, the default value is None

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
johnar@1cafe0c9f994:/data/tests$ py.test -vvv --inventory veos.vtb --host-pattern all --user admin --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --show-capture stdout test_bgp_speaker.py | tee ~/abc.txt               ============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 2 items 

test_bgp_speaker.py::test_bgp_speaker_bgp_sessions PASSED                [ 50%]
test_bgp_speaker.py::test_bgp_speaker_announce_routes[True-False-1514] PASSED [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
