### PR TITLE
To skip LLDP pytest on ptf32 and ptf64 topology.

### DIFF
--- a/tests/test_lldp.py
+++ b/tests/test_lldp.py
@@ -1,5 +1,12 @@
 from ansible_host import AnsibleHost
 import logging
+import pytest
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['name'] in ('ptf32','ptf64'):
+        pytest.skip('Unsupported topology')
+
 logger = logging.getLogger(__name__)
 
 def test_lldp(localhost, ansible_adhoc, testbed):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The ptf32 and ptf64 topology don't use VMs which run LLDP.
DUT will not get any LLDP neighbor and test case will fail due to LLDP neighbor checking.
According to testcases.yml, lldp don't support on ptf32 and ptf64 topology.
To check topology and then skip LLDP pytest on ptf32 and ptf64 topology.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
To skip LLDP pytest on ptf32 and ptf64 topology.
#### How did you verify/test it?
> 
     sonic@81f2fbf4efaf:~/sonic-mgmt/tests$ py.test --inventory=lab --host-pattern=2-9_ptf32  --module-path ../ansible/library/ --testbed=2-9_ptf32 --testbed_file=testbed.csv test_lldp.py --log-level=INFO -vvvv --show-capture=stdout --duration=0
     =============================================================================================== test session starts ===============================================================================================
     platform linux2 -- Python 2.7.12, pytest-4.6.7, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
     cachedir: .pytest_cache
     ansible: 2.8.7
     rootdir: /var/sonic/sonic-mgmt/tests, inifile: pytest.ini
     plugins: ansible-2.2.2, pyfakefs-3.7.1, csv-2.0.2
     collected 2 items   

     test_lldp.py::test_lldp SKIPPED                                                                                                                                                                             [ 50%]
     test_lldp.py::test_lldp_neighbor SKIPPED                                                                                                                                                                    [100%]     

     ============================================================================================= slowest test durations ==============================================================================================
     1.58s setup    test_lldp.py::test_lldp
     0.00s setup    test_lldp.py::test_lldp_neighbor
     0.00s teardown test_lldp.py::test_lldp_neighbor
     0.00s teardown test_lldp.py::test_lldp
     ============================================================================================ 2 skipped in 1.60 seconds ============================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
