### PR TITLE
Add conditional check to skip snmp lldp pytest case when topo is ptf32 or ptf64.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,11 +67,11 @@ class TestbedInfo(object):
                 self.testbed_topo[line['conf-name']] = line
 
     def get_testbed_type(self, topo_name):
-        testbed_type = ['t0', 't1', 'ptf']
-        for val in testbed_type:
-            if topo_name.find(val) != -1:
-                return val
-        raise Exception("Unsupported testbed type - {}".format(topo_name))
+        pattern = re.compile(r'^(t0|t1|ptf)')
+        match = pattern.match(topo_name)
+        if match == None:
+            raise Exception("Unsupported testbed type - {}".format(topo_name))
+        return match.group()
 
 def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,11 +60,18 @@ class TestbedInfo(object):
                 del line['topo']
                 line['topo'] = defaultdict()
                 line['topo']['name'] = topo
+                line['topo']['type'] = self.get_testbed_type(line['topo']['name'])
                 with open("../ansible/vars/topo_{}.yml".format(topo), 'r') as fh:
                     line['topo']['properties'] = yaml.safe_load(fh)
 
                 self.testbed_topo[line['conf-name']] = line
 
+    def get_testbed_type(self, topo_name):
+        testbed_type = ['t0', 't1', 'ptf']
+        for val in testbed_type:
+            if topo_name.find(val) != -1:
+                return val
+        raise Exception("Unsupported testbed type - {}".format(topo_name))
 
 def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,6 +1,11 @@
 import pytest
 from ansible_host import AnsibleHost
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['name'] in ('ptf32','ptf64'):
+        pytest.skip('Unsupported topology')
+
 @pytest.mark.bsl
 def test_snmp_lldp(ansible_adhoc, testbed, creds):
     """

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -3,7 +3,7 @@ from ansible_host import AnsibleHost
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_topo(testbed):
-    if testbed['topo']['name'] in ('ptf32','ptf64'):
+    if testbed['topo']['type'] == 'ptf':
         pytest.skip('Unsupported topology')
 
 @pytest.mark.bsl


### PR DESCRIPTION
### Description of PR

Summary: 
Add conditional check to skip snmp lldp pytest case when topo is ptf32 or ptf64.

When topo is ptf32 or ptf64, snmp lldp pytest will failed. Because there are no lldp data respond from sonic device. The topologies for lldp does not include ptf32 and ptf64 on testcase.yml. Thus the ptf32 and ptf64 topo shall be skipped.

### Type of change

- [v] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add conditional check to skip snmp lldp pytest case when topo is ptf32 or ptf64
#### How did you verify/test it?
Perform pytest to confirm snmp lldp is skipped when topo is ptf32 or ptf64.

```
sonic@2501de585901:~/sonic-mgmt/tests$ py.test --inventory=lab --host-pattern=2-9_ptf32  --module-path ../ansible/library/ --testbed=2-9_ptf32  --testbed_file =testbed.csv snmp/test_snmp_lldp.py -log-cli-level=INFO --log-level=DEBUG -v  --show-capture=stdout --duration=0
==================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.7, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/sonic/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item                                                                                                                                             

snmp/test_snmp_lldp.py::test_snmp_interfaces SKIPPED                                                                                                   [100%]

=================================================================== slowest test durations ===================================================================
1.66s setup    snmp/test_snmp_lldp.py::test_snmp_interfaces

(0.00 durations hidden.  Use -vv to show these durations.)
================================================================= 1 skipped in 1.67 seconds ==================================================================
```

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
N/A