### PR TITLE
[test_nbr_health]: add test to check neighbor device health

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -1,0 +1,30 @@
+import pytest
+import logging
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer,
+]
+
+def test_neighbors_health(duthost, testbed_devices, eos):
+    """Check each neighbor device health"""
+
+    fails = []
+    localhost = testbed_devices['localhost']
+    config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
+    for k, v in nei_meta.items():
+        logger.info("Check neighbor {}, mgmt ip {} snmp".format(k, v['mgmt_addr']))
+        res = localhost.snmp_facts(host=v['mgmt_addr'], version='v2c', community=eos['snmp_rocommunity'])
+        try:
+            snmp_data = res['ansible_facts']
+        except:
+            fails.append("neighbor {} has no snmp data".format(k))
+            continue
+        logger.info("Neighbor {}, sysdescr {}".format(k, snmp_data['ansible_sysdescr']))
+
+    # TODO: check link, bgp, etc. on 
+
+    if len(fails) > 0:
+        pytest.fail("\n".join(fails))


### PR DESCRIPTION
it is important to ensure the neighbor device health before
starting the test.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
johnar@1cafe0c9f994:/data/tests$ py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --log-file ~/abc.log test_nbr_health.py | tee ~/abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item

test_nbr_health.py::test_neighbors_health PASSED                         [100%]

=============================== warnings summary ===============================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
