### PR TITLE
 FDB test case not support some tepology.

### DIFF
--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -1,8 +1,11 @@
 - fail: msg="testbed_type is not defined"
   when: testbed_type is not defined
 
-- fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-52']
+- fail: msg="testcase_name is not defined"
+  when: testcase_name is not defined
+
+- fail: msg="cannot find {{ testcase_name }} in available testcases"
+  when: testcases[testcase_name] is not defined
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}


### PR DESCRIPTION
In /roles/test/vars/testcases.yml , ansible fdb test case support t0, t0-16, t0-52, t0-56, t0-64, t0-64-32 and t0-116 topology 
But in fdb.yml only support 't0', 't0-64', 't0-116' and 't0-52' .
Modifity code that match testcases.yml define.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
