### PR TITLE
[pytest]: add EosHost for neighbor devices

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def testbed(request):
 
 
 @pytest.fixture(scope="module")
-def testbed_devices(ansible_adhoc, testbed, creds):
+def testbed_devices(ansible_adhoc, testbed):
     """
     @summary: Fixture for creating dut, localhost and other necessary objects for testing. These objects provide
         interfaces for interacting with the devices used in testing.
@@ -124,16 +124,6 @@ def testbed_devices(ansible_adhoc, testbed, creds):
         ptf_host = dut.host.options["inventory_manager"].get_host(dut.hostname).get_vars()["ptf_host"]
         devices["ptf"] = PTFHost(ansible_adhoc, ptf_host)
 
-    # In the future, we can implement more classes for interacting with other testbed devices in the lib.devices
-    # module. Then, in this fixture, we can initialize more instance of the classes and store the objects in the
-    # devices dict here. For example, we could have
-    #       from common.devices import FanoutHost
-    #       devices["fanout"] = FanoutHost(ansible_adhoc, testbed["dut"])
-
-    vm_base = int(testbed['vm_base'][2:])
-    devices['neighbor'] = {}
-    for k, v in testbed['topo']['properties']['topology']['VMs'].items():
-        devices['neighbor'][k] = EosHost(ansible_adhoc, "VM%04d" % (vm_base + v['vm_offset']), creds['eos_login'], creds['eos_password'])
     return devices
 
 def disable_ssh_timout(dut):
@@ -190,6 +180,17 @@ def ptfhost(testbed_devices):
 
     return testbed_devices["ptf"]
 
+@pytest.fixture(scope="module")
+def nbrhosts(ansible_adhoc, testbed, creds):
+    """
+    Shortcut fixture for getting PTF host
+    """
+
+    vm_base = int(testbed['vm_base'][2:])
+    devices = {}
+    for k, v in testbed['topo']['properties']['topology']['VMs'].items():
+        devices[k] = EosHost(ansible_adhoc, "VM%04d" % (vm_base + v['vm_offset']), creds['eos_login'], creds['eos_password'])
+    return devices
 
 @pytest.fixture(scope='session')
 def eos():

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import logging
 logger = logging.getLogger(__name__)
@@ -7,6 +8,39 @@ pytestmark = [
     pytest.mark.disable_loganalyzer,
 ]
 
+def check_snmp(hostname, mgmt_addr, localhost, community):
+    logger.info("Check neighbor {}, mgmt ip {} snmp".format(hostname, mgmt_addr))
+    res = localhost.snmp_facts(host=mgmt_addr, version='v2c', is_eos=True, community=community)
+    try:
+        snmp_data = res['ansible_facts']
+    except:
+        return "neighbor {} has no snmp data".format(hostname)
+    logger.info("Neighbor {}, sysdescr {}".format(hostname, snmp_data['ansible_sysdescr']))
+
+def check_eos_facts(hostname, mgmt_addr, host):
+    logger.info("Check neighbor {} eos facts".format(hostname))
+    res = host.eos_facts()
+    logger.info("facts: {}".format(json.dumps(res, indent=4)))
+    try:
+        eos_facts = res['ansible_facts']
+    except:
+        return "neighbor {} has no eos_facts".format(hostname)
+
+    try:
+        mgmt_ip = eos_facts['ansible_net_interfaces']['Management0']['ipv4']['address']
+    except:
+        return "neighbor {} managment address not assigned".format(hostname)
+
+    if mgmt_ip != mgmt_addr:
+        return "neighbor {} management address {} not correct".format(hostname, mgmt_ip)
+
+def check_bgp_facts(hostname, host):
+    logger.info("Check neighbor {} bgp facts".format(hostname))
+    res = host.eos_command(commands=['show ip bgp sum'])
+    logger.info("bgp: {}".format(res))
+    if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
+        return "neighbor {} bgp not configured correctly".format(hostname)
+
 def test_neighbors_health(duthost, testbed_devices, eos):
     """Check each neighbor device health"""
 
@@ -15,16 +49,19 @@ def test_neighbors_health(duthost, testbed_devices, eos):
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
     for k, v in nei_meta.items():
-        logger.info("Check neighbor {}, mgmt ip {} snmp".format(k, v['mgmt_addr']))
-        res = localhost.snmp_facts(host=v['mgmt_addr'], version='v2c', is_eos=True, community=eos['snmp_rocommunity'])
-        try:
-            snmp_data = res['ansible_facts']
-        except:
-            fails.append("neighbor {} has no snmp data".format(k))
-            continue
-        logger.info("Neighbor {}, sysdescr {}".format(k, snmp_data['ansible_sysdescr']))
+        failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'])
+        if failmsg:
+            fails.append(failmsg)
 
-    # TODO: check link, bgp, etc. on 
+        eoshost = testbed_devices['neighbor'][k]
+        failmsg = check_eos_facts(k, v['mgmt_addr'], eoshost)
+        if failmsg:
+            fails.append(failmsg)
 
+        failmsg = check_bgp_facts(k, eoshost)
+        if failmsg:
+            fails.append(failmsg)
+
+    # TODO: check link, bgp, etc. on
     if len(fails) > 0:
         pytest.fail("\n".join(fails))

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -41,7 +41,7 @@ def check_bgp_facts(hostname, host):
     if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
         return "neighbor {} bgp not configured correctly".format(hostname)
 
-def test_neighbors_health(duthost, testbed_devices, eos):
+def test_neighbors_health(duthost, testbed_devices, nbrhosts, eos):
     """Check each neighbor device health"""
 
     fails = []
@@ -53,7 +53,7 @@ def test_neighbors_health(duthost, testbed_devices, eos):
         if failmsg:
             fails.append(failmsg)
 
-        eoshost = testbed_devices['neighbor'][k]
+        eoshost = nbrhosts[k]
         failmsg = check_eos_facts(k, v['mgmt_addr'], eoshost)
         if failmsg:
             fails.append(failmsg)

--- a/tests/veos.vtb
+++ b/tests/veos.vtb
@@ -9,7 +9,34 @@ VM0100 ansible_host=10.250.0.51
 VM0101 ansible_host=10.250.0.52
 VM0102 ansible_host=10.250.0.53
 VM0103 ansible_host=10.250.0.54
-
+VM0104 ansible_host=10.250.0.55
+VM0105 ansible_host=10.250.0.56
+VM0106 ansible_host=10.250.0.57
+VM0107 ansible_host=10.250.0.58
+VM0108 ansible_host=10.250.0.59
+VM0109 ansible_host=10.250.0.60
+VM0110 ansible_host=10.250.0.61
+VM0111 ansible_host=10.250.0.62
+VM0112 ansible_host=10.250.0.63
+VM0113 ansible_host=10.250.0.64
+VM0114 ansible_host=10.250.0.65
+VM0115 ansible_host=10.250.0.66
+VM0116 ansible_host=10.250.0.67
+VM0117 ansible_host=10.250.0.68
+VM0118 ansible_host=10.250.0.69
+VM0119 ansible_host=10.250.0.70
+VM0120 ansible_host=10.250.0.71
+VM0121 ansible_host=10.250.0.72
+VM0122 ansible_host=10.250.0.73
+VM0123 ansible_host=10.250.0.74
+VM0124 ansible_host=10.250.0.75
+VM0125 ansible_host=10.250.0.76
+VM0126 ansible_host=10.250.0.77
+VM0127 ansible_host=10.250.0.78
+VM0128 ansible_host=10.250.0.79
+VM0129 ansible_host=10.250.0.80
+VM0130 ansible_host=10.250.0.81
+VM0131 ansible_host=10.250.0.82
 
 [eos:children]
 vms_1


### PR DESCRIPTION
also use eos_facts to check eos neighbor device health

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
johnar@1cafe0c9f994:/data/tests$ py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --log-file ~/abc.log --log-level debug test_nbr_health.py | tee ~/abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item

test_nbr_health.py::test_neighbors_health PASSED                         [100%]

=============================== warnings summary ===============================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
