### PR TITLE
[ceos]: increase the inotify limits on ceos image

### DIFF
--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -9,3 +9,6 @@ sonic_default_passwords:
  - "YourPaSsWoRd"
  - "password"
 sonic_password: "password"
+
+ceos_image_orig: ceosimage:4.23.2F
+ceos_image: ceosimage:4.23.2F-1

--- a/ansible/group_vars/eos/eos.yml
+++ b/ansible/group_vars/eos/eos.yml
@@ -3,5 +3,4 @@ snmp_rocommunity: strcommunity
 snmp_location: str
 bgp_gr_timer: 700
 
-ceos_image: ceosimage:4.23.2F
 ceos_image_mount_dir: /data/ceos

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -6,5 +6,24 @@
     fp_mtu:       "{{ fp_mtu_size }}"
     max_fp_num:   "{{ max_fp_num }}"
 
+- name: create directory for build ceos image
+  become: yes
+  file:
+    path: "/tmp/ceosimage"
+    state: directory
+
+- name: copy the ceos image template
+  become: yes
+  template: src=ceos_dockerfile.j2 dest=/tmp/ceosimage/Dockerfile mode=0644
+
+- name: Build the ceos image with increase inotify limit
+  become: yes
+  docker_image:
+    name: "{{ ceos_image }}"
+    build:
+      path: "/tmp/ceosimage"
+      pull: no
+    source: build
+
 - include_tasks: add_ceos.yml
   with_items: "{{ VM_targets }}"

--- a/ansible/roles/vm_set/templates/ceos_dockerfile.j2
+++ b/ansible/roles/vm_set/templates/ceos_dockerfile.j2
@@ -1,0 +1,3 @@
+FROM {{ ceos_image_orig }}
+
+RUN sed -e "/^fs.inotify.max_user_watches/s/[0-9]\+/1024000/" -e "/^fs.inotify.max_user_instances/s/[0-9]\+/8192/" /etc/sysctl.d/99-eos.conf > /etc/sysctl.d/99-eos.conf.bak; mv /etc/sysctl.d/99-eos.conf.bak /etc/sysctl.d/99-eos.conf


### PR DESCRIPTION
increase the sysctl

fs.inotify.max_user_watches=512000
fs.inotify.max_user_instances=1256

to

fs.inotify.max_user_watches=1024000
fs.inotify.max_user_instances=8192

to support more ceos container in one host

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
