### PR TITLE
[pytest/fib]: use setup routes based on the topology name

### DIFF
--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -3,7 +3,9 @@ import time
 import math
 import requests
 import pytest
+import logging
 import ipaddr as ipaddress
+logger = logging.getLogger(__name__)
 
 def announce_routes(ptfip, port, family, podset_number, tor_number, tor_subnet_number,
                     spine_asn, leaf_asn_start, tor_asn_start,
@@ -85,8 +87,8 @@ def announce_routes(ptfip, port, family, podset_number, tor_number, tor_subnet_n
     print r
     assert r.status_code == 200
 
-@pytest.fixture(scope='module')
 def fib_t0(ptfhost, testbed):
+    logger.info("use fib_t0 to setup routes for topo {}".format(testbed['topo']['name']))
 
     podset_number = 200
     tor_number = 16
@@ -143,8 +145,8 @@ def fib_t0(ptfhost, testbed):
                         spine_asn, leaf_asn_start, tor_asn_start,
                         local_ip, local_ipv6)
 
-@pytest.fixture(scope='module')
 def fib_t1_lag(ptfhost, testbed):
+    logger.info("use fib_t1_lag to setup routes for topo {}".format(testbed['topo']['name']))
 
     podset_number = 200
     tor_number = 16
@@ -207,3 +209,13 @@ def fib_t1_lag(ptfhost, testbed):
             announce_routes(ptfip, port, "v4", podset_number, tor_number, tor_subnet_number,
                             None, leaf_asn_start, tor_asn_start,
                             local_ip, local_ipv6, router_type="tor")
+
+@pytest.fixture(scope='module')
+def fib(ptfhost, testbed):
+    logger.info("setup fib to topo {}".format(testbed['topo']['name']))
+    if testbed['topo']['name'] == "t0":
+        fib_t0(ptfhost, testbed)
+    elif testbed['topo']['name'] == "t1-lag":
+        fib_t1_lag(ptfhost, testbed)
+    else:
+        logger.error("unknonw topology {}".format(testbed['topo']['name']))

--- a/tests/test_announce_routes.py
+++ b/tests/test_announce_routes.py
@@ -1,7 +1,7 @@
 import pytest
 
-def test_announce_routes(fib_t0):
-    """Simple test case that utilize fib_t0 to announce route in order to a newly setup test bed receive
+def test_announce_routes(fib):
+    """Simple test case that utilize fib to announce route in order to a newly setup test bed receive
        BGP routes from remote devices
     """
-    assert(True)
+    assert True


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

run test_announce_routes.py for both t0 and t1-lag topology and check the routes.

```
johnar@1cafe0c9f994:/data/tests$ py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --showlocals --log-file ~/abc.log test_announce_routes.py | tee ~/abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item

test_announce_routes.py::test_announce_routes PASSED                     [100%]

=============================== warnings summary ===============================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
