### PR TITLE
Improvement vxlan test

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -309,7 +309,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
-        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.2)
+        nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.5)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
@@ -341,7 +341,7 @@ class Vxlan(BaseTest):
 
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.2)
+        nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.5)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
@@ -378,7 +378,7 @@ class Vxlan(BaseTest):
                  )
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.2)
+        nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.5)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -48,7 +48,7 @@
       with_items: "{{ minigraph_vlans }}"
 
     - set_fact:
-          send_packet_count: 1
+          send_packet_count: 10
       when: send_packet_count is not defined
 
     - include_tasks: ptf_runner.yml

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -58,7 +58,7 @@
         ptf_test_params:
         - vxlan_enabled=False
         - config_file='/tmp/vxlan_decap.json'
-        - count=10
+        - count=1
 
     - name: Configure vxlan decap tunnel
       shell: sonic-cfggen -j /tmp/vxlan_db.tunnel.json --write-to-db
@@ -78,7 +78,7 @@
         ptf_test_params:
         - vxlan_enabled=True
         - config_file='/tmp/vxlan_decap.json'
-        - count=10
+        - count=1
 
     - name: Remove vxlan tunnel maps configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map{{ item }}"
@@ -98,7 +98,7 @@
         ptf_test_params:
         - vxlan_enabled=False
         - config_file='/tmp/vxlan_decap.json'
-        - count=10
+        - count=1
 
 - block:
     - name: Remove vxlan tunnel maps configuration

--- a/ansible/roles/test/tasks/vxlan-decap.yml
+++ b/ansible/roles/test/tasks/vxlan-decap.yml
@@ -47,6 +47,10 @@
       template: src=vxlan_db.maps.json.j2 dest=/tmp/vxlan_db.maps.{{ item }}.json
       with_items: "{{ minigraph_vlans }}"
 
+    - set_fact:
+          send_packet_count: 1
+      when: send_packet_count is not defined
+
     - include_tasks: ptf_runner.yml
       vars:
         ptf_test_name: Vxlan decap test - No vxlan configuration
@@ -58,7 +62,7 @@
         ptf_test_params:
         - vxlan_enabled=False
         - config_file='/tmp/vxlan_decap.json'
-        - count=1
+        - count={{ send_packet_count }}
 
     - name: Configure vxlan decap tunnel
       shell: sonic-cfggen -j /tmp/vxlan_db.tunnel.json --write-to-db
@@ -78,7 +82,7 @@
         ptf_test_params:
         - vxlan_enabled=True
         - config_file='/tmp/vxlan_decap.json'
-        - count=1
+        - count={{ send_packet_count }}
 
     - name: Remove vxlan tunnel maps configuration
       shell: docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map{{ item }}"
@@ -98,7 +102,7 @@
         ptf_test_params:
         - vxlan_enabled=False
         - config_file='/tmp/vxlan_decap.json'
-        - count=1
+        - count={{ send_packet_count }}
 
 - block:
     - name: Remove vxlan tunnel maps configuration


### PR DESCRIPTION
### Description of PR

Summary:
I run vxlan test and it's not stable.  It may fails sometimes.
The fail case is on RegularVLANtoLAG, while not receiving the packet.

"Error: RegularVLANtoLAG test failed:"
"  sent = 10 rcvd = 0 | src_port=1 dst_ports=[28] | src_mac=ec:0d:9a:cd:94:01 dst_mac=80:a2:35:d2:4c:b5 src_ip=192.168.0.2 dst_ip=10.0.0.57 | pc_info_rel=0 acc_port_rel=0

I modify ptf python test and tried to re-verify receive the packet when vxlan receive fail, and the result is pass.
I think we need only 1 packet to check if vxlan work or not. and it also can reduce the test time.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### How did you do it?
1.Increase wating time from 0.2 to 0.5.
2.Modify send_packet count from 10 to 1.
#### How did you verify/test it?
run vlxan test case on boadcom
#### Any platform specific information?
no
