### PR TITLE
[ansible ssh] disable host key check for ssh

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -186,7 +186,7 @@ become_method='sudo'
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use 
 # paramiko on older platforms rather than removing it
-ssh_args = -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null
+ssh_args = -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 
 
 # The path to use for the ControlPath sockets. This defaults to


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

Disable ssh host key check at global level. Looks like we already
tried to disable it from ansible.cfg with ansible options but that
somehow didn't work.

Adding it to the global ssh option list.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test against a DUT. Install a new image. Run test again.

Upon image change, without the change, test would fail claiming DUT is unreachable. With the change test proceeds.