### PR TITLE
[hash_test] increase BALANCING_TEST_TIMES to 10000

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -31,7 +31,7 @@ class HashTest(BaseTest):
     # Class variables
     #---------------------------------------------------------------------
     DEFAULT_BALANCING_RANGE = 0.25
-    BALANCING_TEST_TIMES = 1000
+    BALANCING_TEST_TIMES = 10000
 
     def __init__(self):
         '''


### PR DESCRIPTION
Signed-off-by: shikenghua <kh_shi@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: If BALANCING_TEST_TIMES is set to 1000, hash_test has high possibility to fail when tested on topology t1/t1-lag for which their ECMP routes have 16 nexthops.
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Run hash test on topology t1 using Edgecore AS7726-32X switch.

BALANCING_TEST_TIMES = 1000:
port: packets received = {0: 67, 1: 63, 2: 60, 3: 64, 4: 60, 5: 54, 6: 65, 7: 61, 8: 66, 9: 85, 10: 56, 11: 62, 12: 76, 13: 41, 14: 59, 15: 61}
The average is 62.5 (1000/16) and the test failed because port 9 (receive 85 packets) and port 13 (receive 41 packets) are outside the 0.25 balancing range.

BALANCING_TEST_TIMES = 10000:
port: packets received = {0: 635, 1: 640, 2: 611, 3: 651, 4: 628, 5: 603, 6: 627, 7: 656, 8: 626, 9: 576, 10: 597, 11: 660, 12: 627, 13: 633, 14: 654, 15: 576}
The average is 625 and the test passed.

P.S.: ECMP test in fib_test also has its BALANCING_TEST_TIMES set to 10000
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
