### PR TITLE
Add cli argument for skipping pytest sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/README.md
+++ b/tests/common/plugins/sanity_check/README.md
@@ -61,6 +61,13 @@ With this design, we can extend the sanity check items in the future. By default
 ## Log collecting
 If sanity check is to be performed, the script will also run some commands on the DUT to collect some basic information for debugging. Please refer to sonic-mgmt/tests/common/plugins/sanity_check/constants::PRINT_LOGS for the list of logs that will be collected.
 
+## Pytest cmd option `--skip_sanity`
+
+Besides specifying keywoard argument `skip_sanity=True` for `pytest.mark.sanity_check`, we can skip sanity check for test scripts. However, modifying test script is still required. With the pytest command line option `--skip_sanity`, we can skip sanity check on the fly for test scripts. For example:
+```
+$ pytest -i inventory --host-pattern switch1-t0 --module-path ../ansible/library/ --testbed switch1-t0 --testbed-file testbed.csv --log-cli-level info test_something.py --skip_sanity
+```
+
 ## Pytest cmd option `--allow_recover`
 
 The sanity check plugin also supports pytest command line option `--allow_recover`. When this command option presents, sanity check will always try to recover the test bed in case sanity check failed in the first round. The command option has higher priority than the keyword argument value of `allow_recover` for `pytest.mark.sanity_check`. For example:

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 def pytest_addoption(parser):
     """Describe plugin specified options"""
+    parser.addoption("--skip_sanity", action="store_true", default=False,
+                     help="Skip sanity check")
     parser.addoption("--allow_recover", action="store_true", default=False,
                      help="Allow recovery attempt in sanity check in case of failure")
 
@@ -81,14 +83,16 @@ def sanity_check(testbed_devices, request):
                                           constants.SUPPORTED_CHECK_ITEMS)
         post_check = customized_sanity_check.kwargs.get("post_check", False)
 
+    if request.config.option.skip_sanity:
+        skip_sanity = True
     if request.config.option.allow_recover:
-        allow_recover=True
+        allow_recover = True
 
-    logger.info("Sanity check settings: check_items=%s, allow_recover=%s, recover_method=%s, post_check=%s" % \
-        (check_items, allow_recover, recover_method, post_check))
+    logger.info("Sanity check settings: skip_sanity=%s, check_items=%s, allow_recover=%s, recover_method=%s, post_check=%s" % \
+        (skip_sanity, check_items, allow_recover, recover_method, post_check))
 
     if skip_sanity:
-        logger.info("Skip sanity check according to configuration of test script.")
+        logger.info("Skip sanity check according to command line argument or configuration of test script.")
         yield
         return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This change is an enhancement to the pytest sanity check. Previously, to skip
sanity check, we have to add pytest marker with "skip_sanity=True" in test
script. It is not convenient enough.

With this change, we can append argument "--skip_sanity" to the pytest cli
to skip pytest sanity check for test scripts.

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Add pytest command option "--skip_sanity" for skipping sanity check on the fly.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
