### PR TITLE
The continuous-link-flap test would fail when the inactive ports are more than 5.

### DIFF
--- a/ansible/roles/test/tasks/continuous_link_flap.yml
+++ b/ansible/roles/test/tasks/continuous_link_flap.yml
@@ -54,13 +54,14 @@
       delegate_to: localhost
       tags: always
 
-    - debug: msg="{{ device_conn }}"
+    - name: Get up interface facts
+      set_fact: up_ports="{{minigraph_ports | list}}"
 
     - name: include continuous_link_flap_helper.yml
       include_tasks: continuous_link_flap/continuous_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ up_ports }}"
 
     - debug: msg="Second Iteration flap all interfaces one by one on DUT"
 
@@ -73,7 +74,7 @@
       include_tasks: continuous_link_flap/continuous_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ up_ports }}"
 
     - debug: msg="Third Iteration flap all interfaces one by one on DUT"
 
@@ -86,7 +87,7 @@
       include_tasks: continuous_link_flap/continuous_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ up_ports }}"
 
     - debug: msg="First Iteration flap all interfaces one by one on Peer Device"
 


### PR DESCRIPTION
The ansible fail message: "Ipv6 routes are not equal after link flap"
It gets more ipv6 routes after the test. The extra routes are from the originally inactive interfaces.
It does link-flap test for all interfaces, and will enable all interfaces finally.

- What I did
  Modify "continuous link-flap test" to enable/disable on the active interfaces in this topology.

- How I did it

- How to verify it
  Run ansible test to verify it.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
