### PR TITLE
[SNMP] When uptime is less than the boot time of snmp, to pause the task until snmp service is up.

### DIFF
--- a/ansible/roles/test/tasks/snmp.yml
+++ b/ansible/roles/test/tasks/snmp.yml
@@ -1,3 +1,8 @@
+# When uptime is less than the boot time of snmp, to pause the task until snmp service is up.
+- name: Wait for snmp service start
+  pause: seconds={{210 - ansible_uptime_seconds}}
+  when: ansible_uptime_seconds < 210
+
 # Gather facts with SNMP version 2
 - name: Gathering basic snmp facts about the device
   snmp_facts: host={{ ansible_host }} version=v2c community={{ snmp_rocommunity }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,11 +67,11 @@ class TestbedInfo(object):
                 self.testbed_topo[line['conf-name']] = line
 
     def get_testbed_type(self, topo_name):
-        testbed_type = ['t0', 't1', 'ptf']
-        for val in testbed_type:
-            if topo_name.find(val) != -1:
-                return val
-        raise Exception("Unsupported testbed type - {}".format(topo_name))
+        pattern = re.compile(r'^(t0|t1|ptf)')
+        match = pattern.match(topo_name)
+        if match == None:
+            raise Exception("Unsupported testbed type - {}".format(topo_name))
+        return match.group()
 
 def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,11 +60,18 @@ class TestbedInfo(object):
                 del line['topo']
                 line['topo'] = defaultdict()
                 line['topo']['name'] = topo
+                line['topo']['type'] = self.get_testbed_type(line['topo']['name'])
                 with open("../ansible/vars/topo_{}.yml".format(topo), 'r') as fh:
                     line['topo']['properties'] = yaml.safe_load(fh)
 
                 self.testbed_topo[line['conf-name']] = line
 
+    def get_testbed_type(self, topo_name):
+        testbed_type = ['t0', 't1', 'ptf']
+        for val in testbed_type:
+            if topo_name.find(val) != -1:
+                return val
+        raise Exception("Unsupported testbed type - {}".format(topo_name))
 
 def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,6 +1,11 @@
 import pytest
 from ansible_host import AnsibleHost
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['name'] in ('ptf32','ptf64'):
+        pytest.skip('Unsupported topology')
+
 @pytest.mark.bsl
 def test_snmp_lldp(ansible_adhoc, testbed, creds):
     """

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -3,7 +3,7 @@ from ansible_host import AnsibleHost
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_topo(testbed):
-    if testbed['topo']['name'] in ('ptf32','ptf64'):
+    if testbed['topo']['type'] == 'ptf':
         pytest.skip('Unsupported topology')
 
 @pytest.mark.bsl


### PR DESCRIPTION
### Description of PR

Summary:
When uptime is less than the boot time of snmp, to pause the task until snmp service is up.

The default boot time of snmp service is 3m30s in /etc/systemd/system/snmp.timer. Perform snmp ansible test before snmp service up , it will cause test failed. Because it cannot get the response from snmp.

### Type of change

- [v] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Check if ansible_uptime_seconds is larger than 3m30s firstly or not. If uptime is larger than 3m30s, perform the test immediately. If uptime is less than 3m30s, shall perform the test after have a (3m30s - ansible_uptime_seconds) delay.

#### How did you verify/test it?
Perform snmp ansible test when uptime is less than 3m30s, check if have a (3m30s - ansible_uptime_seconds) delay.

#### Any platform specific information?
#### Supported testbed topology if it's a new test case?
### Documentation 