### PR TITLE
[mlnx][fanout] add 'no-autoneg' when configuring port speed on fanout

### DIFF
--- a/ansible/roles/fanout/templates/mlnx_fanout.j2
+++ b/ansible/roles/fanout/templates/mlnx_fanout.j2
@@ -75,7 +75,7 @@ interface ethernet {{ qsfp_split_4[i] }} module-type qsfp-split-4 force
 {% endfor %}
 
 {% for i in range(1, port_speed|length) %}
-interface ethernet {{ eth_ports[i] }} speed {{ port_speed[i] }} force
+interface ethernet {{ eth_ports[i] }} speed {{ port_speed[i] }} no-autoneg force
 {% endfor %}
 
 {% for i in range(1, eth_ports|length) %}


### PR DESCRIPTION
Otherwise it is observed that it take longer time for link to become up, which affects fast-reboot

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
