### PR TITLE
[pytest/conn_graph_facts] Modify conn_graph_facts to choose appropriate inventory graph

### DIFF
--- a/ansible/group_vars/all/inv_mapping.json
+++ b/ansible/group_vars/all/inv_mapping.json
@@ -1,0 +1,4 @@
+{
+   "lab": "lab_connection_graph.xml",
+   "": "// This is a comment.  specify all internal mappings below this line"
+}

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -2,25 +2,21 @@ import pytest
 import os
 import json
 
-from ansible_host import AnsibleHost
-
 @pytest.fixture(scope="module")
-def conn_graph_facts(testbed_devices, ansible_adhoc):
+def conn_graph_facts(testbed_devices):
+    conn_graph_facts = dict()
     dut = testbed_devices["dut"]
     localhost = testbed_devices["localhost"]
 
     base_path = os.path.dirname(os.path.realpath(__file__))
-    # default lab graph file
-    lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/lab_connection_graph.xml")
     # json file contains mapping from inventory file name to its corresponding graph file
     inv_mapping_file = os.path.join(base_path, "../../../ansible/group_vars/all/inv_mapping.json")
     if os.path.exists(inv_mapping_file):
         with open(inv_mapping_file) as fd:
             inv_map = json.load(fd)
-        ans_host = AnsibleHost(ansible_adhoc, dut.hostname)
-        inv_file = ans_host.host.options['inventory'].split('/')[-1]
-        if inv_file in inv_map:
+        inv_file = dut.host.options['inventory'].split('/')[-1]
+        if inv_map and inv_file in inv_map:
             lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/{}".format(inv_map[inv_file]))
 
-    conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
+            conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
     return conn_graph_facts

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -16,11 +16,11 @@ def conn_graph_facts(testbed_devices, ansible_adhoc):
     inv_mapping_file = os.path.join(base_path, "../../../ansible/group_vars/all/inv_mapping.json")
     if os.path.exists(inv_mapping_file):
         with open(inv_mapping_file) as fd:
-            data = fd.read()
-            inv_map = json.loads(data)
+            inv_map = json.load(fd)
         ans_host = AnsibleHost(ansible_adhoc, dut.hostname)
-        inv_file = inv_map[ans_host.host.options['inventory'].split('/')[-1]]
-        lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/{}".format(inv_file))
+        inv_file = ans_host.host.options['inventory'].split('/')[-1]
+        if inv_file in inv_map:
+            lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/{}".format(inv_map[inv_file]))
 
     conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
     return conn_graph_facts

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -1,12 +1,26 @@
 import pytest
 import os
+import json
+
+from ansible_host import AnsibleHost
 
 @pytest.fixture(scope="module")
-def conn_graph_facts(testbed_devices):
+def conn_graph_facts(testbed_devices, ansible_adhoc):
     dut = testbed_devices["dut"]
     localhost = testbed_devices["localhost"]
 
     base_path = os.path.dirname(os.path.realpath(__file__))
-    conn_graph_file = os.path.join(base_path, "../../../ansible/files/lab_connection_graph.xml")
-    conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=conn_graph_file)['ansible_facts']
+    # default lab graph file
+    lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/lab_connection_graph.xml")
+    # json file contains mapping from inventory file name to its corresponding graph file
+    inv_mapping_file = os.path.join(base_path, "../../../ansible/group_vars/all/inv_mapping.json")
+    if os.path.exists(inv_mapping_file):
+        with open(inv_mapping_file) as fd:
+            data = fd.read()
+            inv_map = json.loads(data)
+        ans_host = AnsibleHost(ansible_adhoc, dut.hostname)
+        inv_file = inv_map[ans_host.host.options['inventory'].split('/')[-1]]
+        lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/{}".format(inv_file))
+
+    conn_graph_facts = localhost.conn_graph_facts(host=dut.hostname, filename=lab_conn_graph_file)['ansible_facts']
     return conn_graph_facts


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Add ability to use a different graph xml other than the default 'lab_connection_graph.xml'

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Created an 'inv_mapping.json' file under group_vars/all which contains the inventory file name to the graph xml mapping
Modify existing conn_graph_facts to choose the graph appropriately.

#### How did you verify/test it?
Specified mappings in the inv_mapping.json and verified that the correct graph is picked
Without the json file, verified that 'lab_connection_graph.xml' is used