### PR TITLE
Enable core uploader service

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -144,6 +144,41 @@
         become: true
         when: stat_result.stat.exists is defined and stat_result.stat.exists
 
+      - name: read account key
+        set_fact:
+            core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] | default('') }}"
+
+      - name: read https proxy
+        set_fact:
+            core_proxy: "{{ corefile_uploader['env']['https_proxy'] | default('') }}"
+
+      - name: Put secret in core_analyzer.rc.json
+        lineinfile:
+            name: /etc/sonic/core_analyzer.rc.json
+            regexp: '^.*account_key'
+            line: '        "account_key": "{{ core_key }}",'
+        become: true
+        when: core_key != ""
+
+      - name: Put https-proxy in core_analyzer.rc.json
+        lineinfile:
+            name: /etc/sonic/core_analyzer.rc.json
+            regexp: '^.*https_proxy'
+            line: '        "https_proxy": "{{ core_proxy }}"'
+        become: true
+        when: core_proxy != ""
+
+      - name: enable core uploader service
+        become: true
+        command: systemctl enable core_uploader.service
+        when: core_key != ""
+
+      - name: start core uploader service
+        become: true
+        command: systemctl start core_uploader.service
+        when: core_key != ""
+
+
       - name: Replace snmp community string
         lineinfile:
             name: /etc/sonic/snmp.yml

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -144,13 +144,14 @@
         become: true
         when: stat_result.stat.exists is defined and stat_result.stat.exists
 
+      - name: Init account key
+        set_fact:
+            core_key: ""
+
       - name: read account key
         set_fact:
-            core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] | default('') }}"
-
-      - name: read https proxy
-        set_fact:
-            core_proxy: "{{ corefile_uploader['env']['https_proxy'] | default('') }}"
+            core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] }}"
+        when: corefile_uploader['azure_sonic_core_storage']['account_key'] is defined
 
       - name: Put secret in core_analyzer.rc.json
         lineinfile:
@@ -164,9 +165,9 @@
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
             regexp: '^.*https_proxy'
-            line: '        "https_proxy": "{{ core_proxy }}"'
+            line: '        "https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
         become: true
-        when: core_proxy != ""
+        when: corefile_uploader['env']['https_proxy'] is defined
 
       - name: enable core uploader service
         become: true
@@ -177,7 +178,6 @@
         become: true
         command: systemctl start core_uploader.service
         when: core_key != ""
-
 
       - name: Replace snmp community string
         lineinfile:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -156,16 +156,18 @@
       - name: Put secret in core_analyzer.rc.json
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
-            regexp: '^.*account_key'
-            line: '        "account_key": "{{ core_key }}",'
+            regexp: '(^.*)account_key'
+            line: '\1account_key": "{{ core_key }}",'
+            backrefs: yes
         become: true
         when: core_key != ""
 
       - name: Put https-proxy in core_analyzer.rc.json
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
-            regexp: '^.*https_proxy'
-            line: '        "https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
+            regexp: '(^.*)https_proxy'
+            line: '\1https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
+            backrefs: yes
         become: true
         when: corefile_uploader['env']['https_proxy'] is defined
 


### PR DESCRIPTION
If core-storage secret key is available, add to /etc/sonic/core_analyzer.rc.json and enable & start core_uploader service

If https_proxy is provided, update /etc/sonic/core_analyzer.rc.json.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
