### PR TITLE
[Mellanox]Remove checking hw-management-thermal in platform test

### DIFF
--- a/tests/platform/mellanox/check_hw_mgmt_service.py
+++ b/tests/platform/mellanox/check_hw_mgmt_service.py
@@ -28,10 +28,6 @@ def check_hw_management_service(dut):
     assert hw_mgmt_service_state["ActiveState"] == "active", "The hw-management service is not active"
     assert hw_mgmt_service_state["SubState"] == "exited", "The hw-management service is not exited"
 
-    logging.info("Check the thermal control process")
-    tc_pid = dut.command("pgrep -f /usr/bin/hw-management-thermal-control.sh")
-    assert re.match(r"\d+", tc_pid["stdout"]), "The hw-management-thermal-control process is not running"
-
     logging.info("Check thermal control status")
     tc_suspend = dut.command("cat /var/run/hw-management/config/suspend")
     assert tc_suspend["stdout"] == "1", "Thermal control is not suspended"


### PR DESCRIPTION
### Description of PR

Summary:
Remove the checking hw-management-thermal in platform test. With the thermal control feature merged, this script won't run any longer, so we need to remove the related checking.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
