### PR TITLE
[version list] add method to get sonic version list

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -312,6 +312,28 @@ class SonicHost(AnsibleHostBase):
             self.logger.error("Exception raised while getting networking restart time: %s" % repr(e))
             return None
 
+    def get_image_info(self):
+        """
+        @summary: get list of images installed on the dut.
+                  return a dictionary of "current, next, installed_list"
+        """
+        output = self.command("sonic_installer list")["stdout"]
+        lines  = output.split('\n')
+        ret    = {}
+        list   = []
+        for line in lines:
+            words = line.strip().split(' ')
+            if len(words) == 2:
+                if words[0] == 'Current:':
+                    ret['current'] = words[1]
+                elif words[0] == 'Next:':
+                    ret['next'] = words[1]
+            elif len(words) == 1 and words[0].startswith('SONiC-OS'):
+                list.append(words[0])
+
+        ret['installed_list'] = list
+        return ret
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -317,8 +317,7 @@ class SonicHost(AnsibleHostBase):
         @summary: get list of images installed on the dut.
                   return a dictionary of "current, next, installed_list"
         """
-        output = self.command("sonic_installer list")["stdout"]
-        lines  = output.splitlines()
+        lines = self.command("sonic_installer list")["stdout_lines"]
         ret    = {}
         images = []
         for line in lines:

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -318,9 +318,9 @@ class SonicHost(AnsibleHostBase):
                   return a dictionary of "current, next, installed_list"
         """
         output = self.command("sonic_installer list")["stdout"]
-        lines  = output.split('\n')
+        lines  = output.splitlines()
         ret    = {}
-        list   = []
+        images = []
         for line in lines:
             words = line.strip().split(' ')
             if len(words) == 2:
@@ -329,9 +329,9 @@ class SonicHost(AnsibleHostBase):
                 elif words[0] == 'Next:':
                     ret['next'] = words[1]
             elif len(words) == 1 and words[0].startswith('SONiC-OS'):
-                list.append(words[0])
+                images.append(words[0])
 
-        ret['installed_list'] = list
+        ret['installed_list'] = images
         return ret
 
 class EosHost(AnsibleHostBase):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

add method to get sonic version list
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Return information would look like following:
{'current': u'SONiC-OS-20181130.74', 'installed_list': [u'SONiC-OS-20181130.51', u'SONiC-OS-wb-20200214.02', u'SONiC-OS-wb-20200214.01', u'SONiC-OS-20191130.26', u'SONiC-OS-20181130.74'], 'next': u'SONiC-OS-20181130.74'}