### PR TITLE
Configure and enable core uploader

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -144,6 +144,41 @@
         become: true
         when: stat_result.stat.exists is defined and stat_result.stat.exists
 
+      - name: read account key
+        set_fact:
+            core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] | default('') }}"
+
+      - name: read https proxy
+        set_fact:
+            core_proxy: "{{ corefile_uploader['env']['https_proxy'] | default('') }}"
+
+      - name: Put secret in core_analyzer.rc.json
+        lineinfile:
+            name: /etc/sonic/core_analyzer.rc.json
+            regexp: '^.*account_key'
+            line: '        "account_key": "{{ core_key }}",'
+        become: true
+        when: core_key != ""
+
+      - name: Put https-proxy in core_analyzer.rc.json
+        lineinfile:
+            name: /etc/sonic/core_analyzer.rc.json
+            regexp: '^.*https_proxy'
+            line: '        "https_proxy": "{{ core_proxy }}"'
+        become: true
+        when: core_proxy != ""
+
+      - name: enable core uploader service
+        become: true
+        command: systemctl enable core_uploader.service
+        when: core_key != ""
+
+      - name: start core uploader service
+        become: true
+        command: systemctl start core_uploader.service
+        when: core_key != ""
+
+
       - name: Replace snmp community string
         lineinfile:
             name: /etc/sonic/snmp.yml

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -144,13 +144,14 @@
         become: true
         when: stat_result.stat.exists is defined and stat_result.stat.exists
 
+      - name: Init account key
+        set_fact:
+            core_key: ""
+
       - name: read account key
         set_fact:
-            core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] | default('') }}"
-
-      - name: read https proxy
-        set_fact:
-            core_proxy: "{{ corefile_uploader['env']['https_proxy'] | default('') }}"
+            core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] }}"
+        when: corefile_uploader['azure_sonic_core_storage']['account_key'] is defined
 
       - name: Put secret in core_analyzer.rc.json
         lineinfile:
@@ -164,9 +165,9 @@
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
             regexp: '^.*https_proxy'
-            line: '        "https_proxy": "{{ core_proxy }}"'
+            line: '        "https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
         become: true
-        when: core_proxy != ""
+        when: corefile_uploader['env']['https_proxy'] is defined
 
       - name: enable core uploader service
         become: true
@@ -177,7 +178,6 @@
         become: true
         command: systemctl start core_uploader.service
         when: core_key != ""
-
 
       - name: Replace snmp community string
         lineinfile:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -156,16 +156,18 @@
       - name: Put secret in core_analyzer.rc.json
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
-            regexp: '^.*account_key'
-            line: '        "account_key": "{{ core_key }}",'
+            regexp: '(^.*)account_key'
+            line: '\1account_key": "{{ core_key }}",'
+            backrefs: yes
         become: true
         when: core_key != ""
 
       - name: Put https-proxy in core_analyzer.rc.json
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
-            regexp: '^.*https_proxy'
-            line: '        "https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
+            regexp: '(^.*)https_proxy'
+            line: '\1https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
+            backrefs: yes
         become: true
         when: corefile_uploader['env']['https_proxy'] is defined
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -144,14 +144,20 @@
         become: true
         when: stat_result.stat.exists is defined and stat_result.stat.exists
 
-      - name: Init account key
+      - name: Init account key and proxy
         set_fact:
             core_key: ""
+            core_proxy: ""
 
       - name: read account key
         set_fact:
             core_key: "{{ corefile_uploader['azure_sonic_core_storage']['account_key'] }}"
         when: corefile_uploader['azure_sonic_core_storage']['account_key'] is defined
+
+      - name: read https proxy
+        set_fact:
+            core_proxy: "{{ corefile_uploader['env']['https_proxy'] }}"
+        when: corefile_uploader['env']['https_proxy'] is defined
 
       - name: Put secret in core_analyzer.rc.json
         lineinfile:
@@ -166,10 +172,10 @@
         lineinfile:
             name: /etc/sonic/core_analyzer.rc.json
             regexp: '(^.*)https_proxy'
-            line: '\1https_proxy": "{{ corefile_uploader['env']['https_proxy'] }}"'
+            line: '\1https_proxy": "{{ core_proxy }}"'
             backrefs: yes
         become: true
-        when: corefile_uploader['env']['https_proxy'] is defined
+        when: core_proxy != ""
 
       - name: enable core uploader service
         become: true

--- a/ansible/group_vars/all/corefile_uploader.yml
+++ b/ansible/group_vars/all/corefile_uploader.yml
@@ -3,6 +3,5 @@
 #corefile_uploader:
 #        azure_sonic_core_storage:
 #                account_key: "Your Secret"
-#
 #        env:
 #                https_proxy: "http://10.10.10.10:8000"

--- a/ansible/group_vars/all/corefile_uploader.yml
+++ b/ansible/group_vars/all/corefile_uploader.yml
@@ -1,0 +1,8 @@
+# Configure core file storage secret key and https-proxy as required
+#
+#corefile_uploader:
+#        azure_sonic_core_storage:
+#                account_key: "Your Secret"
+#
+#        env:
+#                https_proxy: "http://10.10.10.10:8000"


### PR DESCRIPTION
If secret key for core file uploader is available, configure it, enable & start the service.
Also program https-proxy if available for the core file uploader service.

Tested in private internal branch.