### PR TITLE
[tests/config]: Add protection to test_config.py for adapt different topo structure

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,9 @@ def test_config(ansible_adhoc, testbed):
     bgp_facts = ans_host.bgp_facts()['ansible_facts']
 
     # Initialize portchannel
+    if len(mg_facts['minigraph_portchannels'].keys()) == 0:
+        pytest.skip("Skip test due to there is no portchannel exists in current topology.")
+
     portchannel = mg_facts['minigraph_portchannels'].keys()[0]
     tmp_portchannel = "PortChannel999"
     # Initialize portchannel_ip and portchannel_members
@@ -31,6 +34,9 @@ def test_config(ansible_adhoc, testbed):
     logging.info("portchannel_members=%s" % portchannel_members)
  
     try:
+        if len(portchannel_members) == 0:
+            pytest.skip("Skip test due to there is no portchannel member exists in current topology.")
+
         # Step 1: Remove portchannel members from portchannel
         for member in portchannel_members:
             ans_host.shell("config portchannel member del %s %s" % (portchannel, member))


### PR DESCRIPTION
- [tests/config]: Add protection to test_config.py for adapt different topo structure

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
The test will simply been skipped if there are no portchannel or portchannel has no member

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Check portchannel and portchannel member before execute test

#### How did you verify/test it?
Run test locally and it pass/skip

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
