### PR TITLE
[tests/telemetry] Verify default config parameters

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -25,27 +25,25 @@ def test_config_db_parameters(duthost):
     """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
-    if gnmi is None or certs is None:
-        pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
-        pytest_assert(certs is not None, "TELEMETRY|certs does not exist in config_db")
-    else:
-        d = get_dict_stdout(gnmi, certs)
-        for key, value in d.items():
-            if str(key) == "client_auth":
-                client_auth_expected = "true"
-                pytest_assert(str(value) == client_auth_expected, "'client_auth' value is not '{}'".format(client_auth_expected))
-            if str(key) == "port":
-                port_expected = "50051"
-                pytest_assert(str(value) == port_expected, "'port' value is not '{}'".format(port_expected))
-            if str(key) == "ca_crt":
-                ca_crt_value_expected = "/etc/sonic/telemetry/dsmsroot.cer"
-                pytest_assert(str(value) == ca_crt_value_expected, "'ca_crt' value is not '{}'".format(ca_crt_value_expected))
-            if str(key) == "server_key":
-                server_key_expected = "/etc/sonic/telemetry/streamingtelemetryserver.key"
-                pytest_assert(str(value) == server_key_expected, "'server_key' value is not '{}'".format(server_key_expected))
-            if str(key) == "server_crt":
-                server_crt_expected = "/etc/sonic/telemetry/streamingtelemetryserver.cer"
-                pytest_assert str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected))
+    pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
+    pytest_assert(certs is not None, "TELEMETRY|certs does not exist in config_db")
+    d = get_dict_stdout(gnmi, certs)
+    for key, value in d.items():
+        if str(key) == "client_auth":
+            client_auth_expected = "true"
+            pytest_assert(str(value) == client_auth_expected, "'client_auth' value is not '{}'".format(client_auth_expected))
+        if str(key) == "port":
+            port_expected = "50051"
+            pytest_assert(str(value) == port_expected, "'port' value is not '{}'".format(port_expected))
+        if str(key) == "ca_crt":
+            ca_crt_value_expected = "/etc/sonic/telemetry/dsmsroot.cer"
+            pytest_assert(str(value) == ca_crt_value_expected, "'ca_crt' value is not '{}'".format(ca_crt_value_expected))
+        if str(key) == "server_key":
+            server_key_expected = "/etc/sonic/telemetry/streamingtelemetryserver.key"
+            pytest_assert(str(value) == server_key_expected, "'server_key' value is not '{}'".format(server_key_expected))
+        if str(key) == "server_crt":
+            server_crt_expected = "/etc/sonic/telemetry/streamingtelemetryserver.cer"
+            pytest_assert(str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected))
 
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -29,15 +29,20 @@ def test_config_db_parameters(duthost):
         d = get_dict_stdout(gnmi, certs)
         for key, value in d.items():
             if str(key) == "client_auth":
-                assert str(value) == "true", 'Client_auth should be set to true!'
+                client_auth_expected = "true"
+                assert str(value) == client_auth_expected, "'client_auth' value is not '{}'".format(client_auth_expected)
             if str(key) == "port":
-                assert str(value) == "50051", "Port should be set to 50051"
+                port_expected = "50051"
+                assert str(value) == port_expected, "'port' value is not '{}'".format(port_expected)
             if str(key) == "ca_crt":
-                assert str(value) == "/etc/sonic/telemetry/dsmsroot.cer", "ca_crt  value should be set to /etc/sonic/telemetry/dsmsroot.cer"
+                ca_crt_value_expected = "/etc/sonic/telemetry/dsmsroot.cer"
+                assert str(value) == ca_crt_value_expected , "'ca_crt' value is not '{}'".format(ca_crt_value_expected)
             if str(key) == "server_key":
-                assert str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.key", "server_key  value should be set to  /etc/sonic/telemetry/streamingtelemetryserver.key"
+                server_key_expected = "/etc/sonic/telemetry/streamingtelemetryserver.key"
+                assert str(value) == server_key_expected , "'server_key' value is not '{}'".format(server_key_expected)
             if str(key) == "server_crt":
-                assert str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.cer", "server_crt is set to /etc/sonic/telemetry/streamingtelemetryserver.cer"
+                server_crt_expected = "/etc/sonic/telemetry/streamingtelemetryserver.cer"
+                assert str(value) == server_crt_expected , "'server_crt' value is not '{}'".format(server_crt_expected)
 
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default
@@ -47,4 +52,5 @@ def test_telemetry_enabledbydefault(duthost):
     status_dict = dict(itertools.izip_longest(*[iter(status_list)] *2, fillvalue=""))
     for k,v in status_dict.items():
         if str(k) == "status":
-            assert str(v) == "enabled", "Telemetry status should be enabled!"
+            status_expected = "enabled";
+            assert str(v) == status_expected, "'Telemetry' status is not '{}'".format(status_expected)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,8 +1,6 @@
 import pytest
 import logging
 
-logger = logging.getLogger(__name__)
-
 # Helper functions
 def get_dict_stdout(gnmi_out, certs_out):
     result = ""
@@ -22,7 +20,6 @@ def get_list_stdout(cmd_out):
 # Test functions
 def test_config_db_parameters(duthost):
     """Verifies required telemetry parameters from config_db.
-       This is scoped as module as it need to be run once before first test run.
     """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
@@ -42,7 +39,7 @@ def test_config_db_parameters(duthost):
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default
     """
-    status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=True)['stdout_lines']
+    status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
     status_dict = dict(itertools.izip_longest(*[iter(status_list)] *2, fillvalue=""))
     for k,v in status_dict.items():

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -24,9 +24,11 @@ def test_config_db_parameters(duthost):
     """Verifies required telemetry parameters from config_db.
     """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
-    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
     pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
+
+    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']    
     pytest_assert(certs is not None, "TELEMETRY|certs does not exist in config_db")
+
     d = get_dict_stdout(gnmi, certs)
     for key, value in d.items():
         if str(key) == "client_auth":

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,3 +1,5 @@
+from common.helpers.assertions import pytest_assert
+
 # Helper functions
 def get_dict_stdout(gnmi_out, certs_out):
     """ Extracts dictionary from redis output.
@@ -24,25 +26,26 @@ def test_config_db_parameters(duthost):
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
     if gnmi is None or certs is None:
-        assert False, "Either TELEMETRY|gnmi or TELEMETRY|certs does not exist in config_db"
+        pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
+        pytest_assert(certs is not None, "TELEMETRY|certs does not exist in config_db")
     else:
         d = get_dict_stdout(gnmi, certs)
         for key, value in d.items():
             if str(key) == "client_auth":
                 client_auth_expected = "true"
-                assert str(value) == client_auth_expected, "'client_auth' value is not '{}'".format(client_auth_expected)
+                pytest_assert(str(value) == client_auth_expected, "'client_auth' value is not '{}'".format(client_auth_expected))
             if str(key) == "port":
                 port_expected = "50051"
-                assert str(value) == port_expected, "'port' value is not '{}'".format(port_expected)
+                pytest_assert(str(value) == port_expected, "'port' value is not '{}'".format(port_expected))
             if str(key) == "ca_crt":
                 ca_crt_value_expected = "/etc/sonic/telemetry/dsmsroot.cer"
-                assert str(value) == ca_crt_value_expected, "'ca_crt' value is not '{}'".format(ca_crt_value_expected)
+                pytest_assert(str(value) == ca_crt_value_expected, "'ca_crt' value is not '{}'".format(ca_crt_value_expected))
             if str(key) == "server_key":
                 server_key_expected = "/etc/sonic/telemetry/streamingtelemetryserver.key"
-                assert str(value) == server_key_expected, "'server_key' value is not '{}'".format(server_key_expected)
+                pytest_assert(str(value) == server_key_expected, "'server_key' value is not '{}'".format(server_key_expected))
             if str(key) == "server_crt":
                 server_crt_expected = "/etc/sonic/telemetry/streamingtelemetryserver.cer"
-                assert str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected)
+                pytest_assert str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected))
 
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default
@@ -53,4 +56,4 @@ def test_telemetry_enabledbydefault(duthost):
     for k, v in status_dict.items():
         if str(k) == "status":
             status_expected = "enabled";
-            assert str(v) == status_expected, "'Telemetry' status is not 'enabled'"
+            pytest_assert(str(v) == status_expected, "Telemetry feature is not enabled")

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -11,7 +11,6 @@ def get_dict_stdout(gnmi_out, certs_out):
     return params_dict
 
 def get_list_stdout(cmd_out):
-    result = ""
     out_list = []
     for x in cmd_out:
         result = x.encode('UTF-8')
@@ -29,16 +28,16 @@ def test_config_db_parameters(duthost):
     else:
         d = get_dict_stdout(gnmi, certs)
         for key, value in d.items():
-            if str(key) == "client_auth" and str(value) == "true":
-                assert True, "Client_auth set to true"
-            if str(key) == "port" and str(value) == "50051":
-                assert True, "port is set to 50051"
-            if str(key) == "ca_crt" and str(value) == "/etc/sonic/telemetry/dsmsroot.cer":
-                assert True, "ca_crt is set to {}".format(str(value))
-            if str(key) == "server_key" and str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.key":
-                assert True, "server_key is set to {}".format(str(value))
-            if str(key) == "server_crt" and str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.cer":
-                assert True, "server_crt is set to {}".format(str(value))
+            if str(key) == "client_auth":
+                assert str(value) == "true", 'Client_auth should be set to true!'
+            if str(key) == "port":
+                assert str(value) == "50051", "Port should be set to 50051"
+            if str(key) == "ca_crt":
+                assert str(value) == "/etc/sonic/telemetry/dsmsroot.cer", "ca_crt  value should be set to /etc/sonic/telemetry/dsmsroot.cer"
+            if str(key) == "server_key":
+                assert str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.key", "server_key  value should be set to  /etc/sonic/telemetry/streamingtelemetryserver.key"
+            if str(key) == "server_crt":
+                assert str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.cer", "server_crt is set to /etc/sonic/telemetry/streamingtelemetryserver.cer"
 
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default
@@ -47,5 +46,5 @@ def test_telemetry_enabledbydefault(duthost):
     status_list = get_list_stdout(status)
     status_dict = dict(itertools.izip_longest(*[iter(status_list)] *2, fillvalue=""))
     for k,v in status_dict.items():
-        if str(k) == "status" and str(v) == "enabled":
-            assert True, "Telemetry status is enabled"
+        if str(k) == "status":
+            assert str(v) == "enabled", "Telemetry status should be enabled!"

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,9 +1,13 @@
 # Helper functions
 def get_dict_stdout(gnmi_out, certs_out):
-    result = ""
+    """ Extracts dictionary from redis output.
+    """
     gnmi_list = []
     gnmi_list = get_list_stdout(gnmi_out) + get_list_stdout(certs_out)
-    params_dict= dict(itertools.izip_longest(*[iter(gnmi_list)] *2, fillvalue = ""))
+    # Elements in list alternate between key and value. Separate them and combine into a dict.
+    key_list = gnmi_list[0::2]
+    value_list = gnmi_list[1::2]
+    params_dict = dict(zip(key_list, value_list))
     return params_dict
 
 def get_list_stdout(cmd_out):

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -36,13 +36,13 @@ def test_config_db_parameters(duthost):
                 assert str(value) == port_expected, "'port' value is not '{}'".format(port_expected)
             if str(key) == "ca_crt":
                 ca_crt_value_expected = "/etc/sonic/telemetry/dsmsroot.cer"
-                assert str(value) == ca_crt_value_expected , "'ca_crt' value is not '{}'".format(ca_crt_value_expected)
+                assert str(value) == ca_crt_value_expected, "'ca_crt' value is not '{}'".format(ca_crt_value_expected)
             if str(key) == "server_key":
                 server_key_expected = "/etc/sonic/telemetry/streamingtelemetryserver.key"
-                assert str(value) == server_key_expected , "'server_key' value is not '{}'".format(server_key_expected)
+                assert str(value) == server_key_expected, "'server_key' value is not '{}'".format(server_key_expected)
             if str(key) == "server_crt":
                 server_crt_expected = "/etc/sonic/telemetry/streamingtelemetryserver.cer"
-                assert str(value) == server_crt_expected , "'server_crt' value is not '{}'".format(server_crt_expected)
+                assert str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected)
 
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default
@@ -50,7 +50,7 @@ def test_telemetry_enabledbydefault(duthost):
     status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
     status_dict = dict(itertools.izip_longest(*[iter(status_list)] *2, fillvalue=""))
-    for k,v in status_dict.items():
+    for k, v in status_dict.items():
         if str(k) == "status":
             status_expected = "enabled";
-            assert str(v) == status_expected, "'Telemetry' status is not '{}'".format(status_expected)
+            assert str(v) == status_expected, "'Telemetry' status is not 'enabled'"

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,12 +1,9 @@
-import pytest
-import logging
-
 # Helper functions
 def get_dict_stdout(gnmi_out, certs_out):
     result = ""
     gnmi_list = []
     gnmi_list = get_list_stdout(gnmi_out) + get_list_stdout(certs_out)
-    params_dict= dict(itertools.izip_longest(*[iter(gnmi_list)] *2, fillvalue=""))
+    params_dict= dict(itertools.izip_longest(*[iter(gnmi_list)] *2, fillvalue = ""))
     return params_dict
 
 def get_list_stdout(cmd_out):

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -52,6 +52,7 @@ def test_telemetry_enabledbydefault(duthost):
     """
     status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
+    # Elements in list alternate between key and value. Separate them and combine into a dict.
     status_key_list = status_list[0::2]
     status_value_list = status_list[1::2]
     status_dict = dict(zip(status_key_list, status_value_list))

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -52,7 +52,9 @@ def test_telemetry_enabledbydefault(duthost):
     """
     status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
-    status_dict = dict(itertools.izip_longest(*[iter(status_list)] *2, fillvalue=""))
+    status_key_list = status_list[0::2]
+    status_value_list = status_list[1::2]
+    status_dict = dict(zip(status_key_list, status_value_list))
     for k, v in status_dict.items():
         if str(k) == "status":
             status_expected = "enabled";

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -24,18 +24,21 @@ def test_config_db_parameters(duthost):
     """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
-    d = get_dict_stdout(gnmi, certs)
-    for key, value in d.items():
-        if str(key) == "client_auth" and str(value) == "true":
-            assert True, "Client_auth set to true"
-        if str(key) == "port" and str(value) == "50051":
-            assert True, "port is set to 50051"
-        if str(key) == "ca_crt" and str(value) == "/etc/sonic/telemetry/dsmsroot.cer":
-            assert True, "ca_crt is set to {}".format(str(value))
-        if str(key) == "server_key" and str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.key":
-            assert True, "server_key is set to {}".format(str(value))
-        if str(key) == "server_crt" and str(value) == "/etc/sonic/telemetry/streamingtelemetry.cer":
-            assert True, "server_crt is set to {}".format(str(value))
+    if gnmi is None or certs is None:
+        assert False, "Either TELEMETRY|gnmi or TELEMETRY|certs does not exist in config_db"
+    else:
+        d = get_dict_stdout(gnmi, certs)
+        for key, value in d.items():
+            if str(key) == "client_auth" and str(value) == "true":
+                assert True, "Client_auth set to true"
+            if str(key) == "port" and str(value) == "50051":
+                assert True, "port is set to 50051"
+            if str(key) == "ca_crt" and str(value) == "/etc/sonic/telemetry/dsmsroot.cer":
+                assert True, "ca_crt is set to {}".format(str(value))
+            if str(key) == "server_key" and str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.key":
+                assert True, "server_key is set to {}".format(str(value))
+            if str(key) == "server_crt" and str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.cer":
+                assert True, "server_crt is set to {}".format(str(value))
 
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -4,23 +4,30 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Helper functions
-def get_telemetry_keyvalues(gnmi_out, certs_out):
-    gnmi_values = gnmi_out.split('\n')
-    cert_values = certs_out.split('\n')
+def get_dict_stdout(gnmi_out, certs_out):
+    result = ""
     gnmi_list = []
-    gnmi_list = gnmi_values + cert_values
+    gnmi_list = get_list_stdout(gnmi_out) + get_list_stdout(certs_out)
     params_dict= dict(itertools.izip_longest(*[iter(gnmi_list)] *2, fillvalue=""))
     return params_dict
+
+def get_list_stdout(cmd_out):
+    result = ""
+    out_list = []
+    for x in cmd_out:
+        result = x.encode('UTF-8')
+        out_list.append(result)
+    return out_list
 
 # Test functions
 def test_config_db_parameters(duthost):
     """Verifies required telemetry parameters from config_db.
+       This is scoped as module as it need to be run once before first test run.
     """
-    gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=True)['stdout']
-    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=True)['stdout']
-    d = get_telemetry_keyvalues(gnmi, certs)
+    gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
+    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
+    d = get_dict_stdout(gnmi, certs)
     for key, value in d.items():
-        logger.info(' testing {}={}'.format(key,value))
         if str(key) == "client_auth" and str(value) == "true":
             assert True, "Client_auth set to true"
         if str(key) == "port" and str(value) == "50051":
@@ -35,10 +42,9 @@ def test_config_db_parameters(duthost):
 def test_telemetry_enabledbydefault(duthost):
     """Verify telemetry should be enabled by default
     """
-    status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=True)['stdout']
-    status_value = status.split('\n')
-    if str(status_value[0]) == "status" and str(status_value[1]) == "enabled":
-        assert True, "Telemetry status is enabled"
-   
-     
-
+    status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=True)['stdout_lines']
+    status_list = get_list_stdout(status)
+    status_dict = dict(itertools.izip_longest(*[iter(status_list)] *2, fillvalue=""))
+    for k,v in status_dict.items():
+        if str(k) == "status" and str(v) == "enabled":
+            assert True, "Telemetry status is enabled"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -13,10 +13,8 @@ def get_telemetry_keyvalues(gnmi_out, certs_out):
     return params_dict
 
 # Test functions
-
 def test_config_db_parameters(duthost):
     """Verifies required telemetry parameters from config_db.
-       This is scoped as module as it need to be run once before first test run.
     """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=True)['stdout']
     certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=True)['stdout']

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,46 @@
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Helper functions
+def get_telemetry_keyvalues(gnmi_out, certs_out):
+    gnmi_values = gnmi_out.split('\n')
+    cert_values = certs_out.split('\n')
+    gnmi_list = []
+    gnmi_list = gnmi_values + cert_values
+    params_dict= dict(itertools.izip_longest(*[iter(gnmi_list)] *2, fillvalue=""))
+    return params_dict
+
+# Test functions
+
+def test_config_db_parameters(duthost):
+    """Verifies required telemetry parameters from config_db.
+       This is scoped as module as it need to be run once before first test run.
+    """
+    gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=True)['stdout']
+    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=True)['stdout']
+    d = get_telemetry_keyvalues(gnmi, certs)
+    for key, value in d.items():
+        logger.info(' testing {}={}'.format(key,value))
+        if str(key) == "client_auth" and str(value) == "true":
+            assert True, "Client_auth set to true"
+        if str(key) == "port" and str(value) == "50051":
+            assert True, "port is set to 50051"
+        if str(key) == "ca_crt" and str(value) == "/etc/sonic/telemetry/dsmsroot.cer":
+            assert True, "ca_crt is set to {}".format(str(value))
+        if str(key) == "server_key" and str(value) == "/etc/sonic/telemetry/streamingtelemetryserver.key":
+            assert True, "server_key is set to {}".format(str(value))
+        if str(key) == "server_crt" and str(value) == "/etc/sonic/telemetry/streamingtelemetry.cer":
+            assert True, "server_crt is set to {}".format(str(value))
+
+def test_telemetry_enabledbydefault(duthost):
+    """Verify telemetry should be enabled by default
+    """
+    status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=True)['stdout']
+    status_value = status.split('\n')
+    if str(status_value[0]) == "status" and str(status_value[1]) == "enabled":
+        assert True, "Telemetry status is enabled"
+   
+     
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Verify default parameters for telemetry docker . Following is the list of parameters to be present in config_db. These are added via minigraph

results['TELEMETRY'] = { 
  'gnmi':   {
    'client_auth': 'true',
    'port':   '50051',
    'log_level':   '2'
   },
  'certs':   { 
 'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer',
  'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key',
  'ca_crt':   '/etc/sonic/telemetry/dsmsroot.cer'
   }}

results['FEATURES']={
'status': 'enabled'
}

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ *] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Using sonic virtual test bed 
![image](https://user-images.githubusercontent.com/49077256/78303710-187d6480-74f2-11ea-8f9c-52f6ef588ee1.png)

#### Any platform specific information?
Applicable for 201911 image
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
