### PR TITLE
[tests/common/devices] Add FanoutHost

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -327,3 +327,37 @@ class EosHost(AnsibleHostBase):
                   'ansible_password': passwd, \
                   'ansible_become_method': 'enable' }
         self.host.options['variable_manager'].extra_vars.update(evars)
+
+    def shutdown(self, interface_name):
+        out = self.host.eos_config(
+            lines=['shutdown'],
+            parents='interface %s' % interface_name)
+        logging.info('Shut interface [%s]' % interface_name)
+        return out
+
+    def no_shutdown(self, interface_name):
+        out = self.host.eos_config(
+            lines=['no shutdown'],
+            parents='interface %s' % interface_name)
+        logging.info('No shut interface [%s]' % interface_name)
+        return out
+
+class FanoutHost():
+    """
+    @summary: Class for Fanout switch
+
+    For running ansible module on the Fanout switch
+    """
+
+    def __init__(self, ansible_adhoc, os, hostname, user, passwd):
+        if os == 'sonic':
+            self.host = SonicHost(ansible_adhoc, hostname)
+        else:
+            # Use eos host if the os type is unknown
+            self.host = EosHost(ansible_adhoc, hostname, user, passwd)
+    
+    def shutdown(self, interface_name):
+        self.host.shutdown(interface_name)
+    
+    def no_shutdown(self, interface_name):
+        self.host.no_shutdown(interface_name)

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -360,8 +360,11 @@ class FanoutHost():
             self.os = 'eos'
             self.host = EosHost(ansible_adhoc, hostname, user, passwd)
 
-    def get_fanout_type(self):
+    def get_fanout_os(self):
         return self.os
+
+    def get_fanout_type(self):
+        return self.type
     
     def shutdown(self, interface_name):
         self.host.shutdown(interface_name)

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -349,15 +349,28 @@ class FanoutHost():
     For running ansible module on the Fanout switch
     """
 
-    def __init__(self, ansible_adhoc, os, hostname, user, passwd):
+    def __init__(self, ansible_adhoc, os, hostname, device_type, user, passwd):
+        self.hostname = hostname
+        self.type = device_type
         if os == 'sonic':
+            self.os = os
             self.host = SonicHost(ansible_adhoc, hostname)
         else:
             # Use eos host if the os type is unknown
+            self.os = 'eos'
             self.host = EosHost(ansible_adhoc, hostname, user, passwd)
+
+    def get_fanout_type(self):
+        return self.os
     
     def shutdown(self, interface_name):
         self.host.shutdown(interface_name)
     
     def no_shutdown(self, interface_name):
         self.host.no_shutdown(interface_name)
+
+    def __str__(self):
+        return "{ os: '%s', hostname: '%s', device_type: '%s' }" % (self.os, self.hostname, self.type)
+    
+    def __repr__(self):
+        return self.__str__()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,13 +190,31 @@ def ptfhost(testbed_devices):
 @pytest.fixture(scope="module")
 def nbrhosts(ansible_adhoc, testbed, creds):
     """
-    Shortcut fixture for getting PTF host
+    Shortcut fixture for getting VM host
     """
 
     vm_base = int(testbed['vm_base'][2:])
     devices = {}
     for k, v in testbed['topo']['properties']['topology']['VMs'].items():
         devices[k] = EosHost(ansible_adhoc, "VM%04d" % (vm_base + v['vm_offset']), creds['eos_login'], creds['eos_password'])
+    return devices
+
+@pytest.fixture(scope="module")
+def fanouthosts(ansible_adhoc, creds):
+    """
+    Shortcut fixture for getting Fanout host
+    """
+    devices = {}
+
+    # TODO: Create a new module for get lab_graph
+    lab_graph = Parse_Lab_Graph(filename)
+    for device in lab_graph.devices:
+        if device['Type'] == 'FanoutLeaf' or device['Type'] == 'FanoutRoot':
+            # TODO: Get OS by device hwsku: https://github.com/Azure/sonic-mgmt/blob/11904a9cc64bfcd68910cbaa3843516ee3e7feae/ansible/testbed-new.yaml
+            os = 'eos'
+            fanout_host = FanoutHost(ansible_adhoc, device['Hostname'], os, creds['fanout_admin_user'], creds['fanout_admin_password']])
+            devices[device['Hostname']] = fanout_host
+            devices[device['mgmtip']] = fanouthosts
     return devices
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
- Add FanoutHost which aggregate different fanout switch host
- Add fanouthosts fixture shortcut to get fanouthost easily

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
1. Extract all fanout switches from localhost's conn_graph_facts
1. Binding ansible host to FanoutHost by fanout os type
1. Index fanout hosts by both mgmt ip and hostname
1. Implement shutdown/no_shutdown for EosHost

#### How did you verify/test it?
Below is an sample after you import fixture ```fanouthosts``` (The dict value is an instance of FanoutHost):
```
{
  u'str-7260-10': {
    os: 'eos',
    hostname: 'str-7260-10',
    device_type: 'FanoutLeaf'
  },
  u'10.251.0.13': {
    os: 'eos',
    hostname: 'str-7260-10',
    device_type: 'FanoutLeaf'
  },
  u'10.251.0.234': {
    os: 'eos',
    hostname: 'str-7260-11',
    device_type: 'FanoutRoot'
  },
  u'str-7260-11': {
    os: 'eos',
    hostname: 'str-7260-11',
    device_type: 'FanoutRoot'
  }
}
```
Here is the fanouthosts usage:
```python
def test(fanouthosts):
    fanout_host = fanouthosts['10.251.0.234']
    # Or you can use fanouthosts['str-7260-11']
    
    # Then you can operate with the fanout host
    fanout_host.shutdown('Eth1')
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
There are two design for fanout host abstraction:
The first is:
![image](https://user-images.githubusercontent.com/6898708/78332970-98bbcc80-75bb-11ea-9c20-5912601ff630.png)
Create an abstract FanoutHost and inherit by detail host type. Let the abstraction provide a default behaviors for it interfaces, such as raise 'NotSupport' exception when sub-class not implement 'shutdown' method.
But the disadvantage is that we need to create new class for each fanout sku.

The second is:
![image](https://user-images.githubusercontent.com/6898708/78333269-17b10500-75bc-11ea-99c8-253cef1028a1.png)
This method trying to reuse existing EOSHost and SONiCHost, the concept is "Favor object composition over class inheritance".
Since Fanout usually act as a transparent role in our testbed, there are no so much operations on it in usual. Expose limited interfaces will help us reduce confusing on the usage of fanout switch.
The root FanoutHost class will compose an ansible host(reuse exists hosts) based on os type and implement the interface internally(we can handle exception here if the ansible host not implement expected interfaces).
In this PR, I choose the second way.