### PR TITLE
Fix test_techsupport.py so it could run with T1 topology

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -136,9 +136,16 @@ def neighbor_ip(duthost, testbed):
     # ptf-32 topo is not supported in mirroring
     if testbed['topo']['name'] == 'ptf32':
         pytest.skip('Unsupported Topology')
-
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
-    dst_ip = mg_facts["minigraph_portchannel_interfaces"][0]['peer_addr']
+    dst_ip = None
+    if mg_facts["minigraph_portchannel_interfaces"]:
+        dst_ip = mg_facts["minigraph_portchannel_interfaces"][0]['peer_addr']
+    else:
+        dst_ip = [(item['peer_addr']) for item in mg_facts["minigraph_interfaces"] if 'peer_addr' in item][0]
+
+    if dst_ip is None:
+        pytest.skip("No neighbor ip available. Skipping test.")
+
     yield str(dst_ip)
 
 
@@ -173,7 +180,6 @@ def mirroring(duthost, neighbor_ip, mirror_setup, gre_version):
     :param mirror_setup: mirror_setup fixture
     :param mirror_config: mirror_config fixture
     """
-
     logger.info("Adding mirror_session to DUT")
     acl_rule_file = os.path.join(mirror_setup['dut_tmp_dir'], ACL_RULE_PERSISTENT_FILE)
     extra_vars = {
@@ -257,8 +263,8 @@ def test_techsupport(request, config, duthost, testbed):
 
     for i in range(loop_range):
         logger.debug("Running show techsupport ... ")
-        wait_until(300, 20, execute_command, duthost, since)
-        tar_file = [i for i in pytest.tar_stdout.split('\n') if i != ''][-1]
+        wait_until(300, 20, execute_command, duthost, str(since))
+        tar_file = [j for j in pytest.tar_stdout.split('\n') if j != ''][-1]
         stdout = duthost.command("rm -rf {}".format(tar_file))
         logger.debug("Sleeping for {} seconds".format(loop_delay))
         time.sleep(loop_delay)

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -141,7 +141,9 @@ def neighbor_ip(duthost, testbed):
     if mg_facts["minigraph_portchannel_interfaces"]:
         dst_ip = mg_facts["minigraph_portchannel_interfaces"][0]['peer_addr']
     else:
-        dst_ip = [(item['peer_addr']) for item in mg_facts["minigraph_interfaces"] if 'peer_addr' in item][0]
+        peer_addr_list = [(item['peer_addr']) for item in mg_facts["minigraph_interfaces"] if 'peer_addr' in item]
+        if peer_addr_list:
+            dst_ip = peer_addr_list[0]
 
     if dst_ip is None:
         pytest.skip("No neighbor ip available. Skipping test.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fix test_techsupport.py so Mirroring part could run with T1 topology.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
N/A
#### How did you verify/test it?
```ini
py.test --inventory ../ansible/inventory --host-pattern <host> --module-path ../ansible/library/ --testbed <host>-t1 --testbed_file ../ansible/testbed.csv --show-capture=no --capture=no --log-cli-level debug -ra -vvvvv show_techsupport/test_techsupport.py --loop_num=1 --loop_delay=1 --logs_since=1 -k test_techsupport[mirroring]
```
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
