### PR TITLE
[advanced reboot] Verify post-boot operation before dut revert

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -902,8 +902,6 @@ class ReloadTest(BaseTest):
             # revert to pretest state
             if self.sad_oper and self.sad_handle:
                 self.sad_revert()
-                if self.test_params['inboot_oper']:
-                    self.check_postboot_sad_status()
                 self.log(" ")
 
             # Generating report


### PR DESCRIPTION
### Description of PR
Current logic verifies that operation done during boot operation after
reboot. However operation is reverted, the verification logic
reports error as it expects the operation to persist after reboot. The
verification logic is not required as it was done earlier

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
