### PR TITLE
[advanced reboot] Add Paramiko module for device connection

### DIFF
--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -8,9 +8,9 @@ DEFAULT_CMD_EXECUTION_TIMEOUT_SEC = 10
 
 class DeviceConnection:
     '''
-    DeviceConnection uses Pramiko module to connect to devices
+    DeviceConnection uses Paramiko module to connect to devices
 
-    Pramiko module uses fallback mechanism where it would first try to use
+    Paramiko module uses fallback mechanism where it would first try to use
     ssh key and that fails, it will attempt username/password combination
     '''
     def __init__(self, hostname, username, password=None):

--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -1,0 +1,66 @@
+import paramiko
+import logging
+from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CMD_EXECUTION_TIMEOUT_SEC = 10
+
+class DeviceConnection:
+    '''
+    DeviceConnection uses Pramiko module to connect to devices
+
+    Pramiko module uses fallback mechanism where it would first try to use
+    ssh key and that fails, it will attempt username/password combination
+    '''
+    def __init__(self, hostname, username, password=None):
+        '''
+        Class constructor
+
+        @param hostname: hostname of device to connect to
+        @param username: username for device connection
+        @param password: password for device connection
+        '''
+        self.hostname = hostname
+        self.username = username
+        self.password = password
+
+    def execCommand(self, cmd, timeout=DEFAULT_CMD_EXECUTION_TIMEOUT_SEC):
+        '''
+        Executes command on remote device
+
+        @param cmd: command to be run on remote device
+        @param timeout: timeout for command run session
+        @return: stdout, stderr, value
+            stdout is a list of lines of the remote stdout gathered during command execution
+            stderr is a list of lines of the remote stderr gathered during command execution
+            value: 0 if command execution raised no exception
+                   nonzero if exception is raised
+        '''
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        if isinstance(cmd, list):
+            cmd = ' '.join(cmd)
+
+        stdOut = stdErr = []
+        retValue = 1
+        try:
+            client.connect(self.hostname, username=self.username, password=self.password, allow_agent=False)
+            si, so, se = client.exec_command(cmd, timeout=timeout)
+            stdOut = so.readlines()
+            stdErr = se.readlines()
+            retValue = 0
+        except SSHException as sshException:
+            logger.error('SSH Command failed with message: %s' % sshException)
+            pass
+        except AuthenticationException as authenticationException:
+            logger.error('SSH Authentiaction failure with message: %s' % authenticationException)
+            pass
+        except BadHostKeyException as badHostKeyException:
+            logger.error('SSH Authentiaction failure with message: %s' % badHostKeyException)
+            pass
+        finally:
+            client.close()
+
+        return stdOut, stdErr, retValue

--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -53,13 +53,10 @@ class DeviceConnection:
             retValue = 0
         except SSHException as sshException:
             logger.error('SSH Command failed with message: %s' % sshException)
-            pass
         except AuthenticationException as authenticationException:
             logger.error('SSH Authentiaction failure with message: %s' % authenticationException)
-            pass
         except BadHostKeyException as badHostKeyException:
             logger.error('SSH Authentiaction failure with message: %s' % badHostKeyException)
-            pass
         finally:
             client.close()
 

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -1,7 +1,6 @@
 import datetime
 import ipaddress
 import re
-import subprocess
 import time
 
 from arista import Arista

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -335,15 +335,15 @@ class SadOper(SadPath):
     def build_neigh_rt_map(self, neigh_rt_info):
         # construct neigh to route cnt map
         self.neigh_rt_map = dict()
-        for line in neigh_rt_info.strip().split('\n'):
-            key, value = line.split(' ')
+        for line in neigh_rt_info:
+            key, value = line.strip().split(' ')
             self.neigh_rt_map.update({key:value})
 
     def verify_route_cnt(self, rt_incr, is_up=True, v4=True):
         neigh_rt_info, ret = self.get_bgp_route_cnt(is_up=is_up, v4=v4)
         if not ret:
-            for line in neigh_rt_info.strip().split('\n'):
-                neigh_ip, rt_cnt = line.split(' ')
+            for line in neigh_rt_info:
+                neigh_ip, rt_cnt = line.strip().split(' ')
                 exp_cnt = int(self.neigh_rt_map[neigh_ip]) + rt_incr
                 if int(rt_cnt) != exp_cnt:
                     self.fails['dut'].add('%s: Route cnt incorrect for neighbor %s Expected: %d Obtained: %d' % (self.msg_prefix[is_up], neigh_ip, exp_cnt, int(rt_cnt)))

--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -51,7 +51,8 @@
         ptf_qlen: 1000
         ptf_test_params:
         - verbose=False
-        - dut_username=\"{{ ansible_ssh_user }}\"
+        - dut_username=\"{{ sonicadmin_user }}\"
+        - dut_password=\"{{ sonicadmin_password }}\"
         - dut_hostname=\"{{ ansible_host }}\"
         - reboot_limit_in_seconds={{ reboot_limit }}
         - reboot_type=\"{{ reboot_type }}\"

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -115,9 +115,14 @@ class AdvancedReboot:
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
         self.rebootData['dut_mac'] = hostFacts['ansible_Ethernet0']['macaddress']
-        self.rebootData['dut_username'] = hostFacts['ansible_env']['SUDO_USER']
         self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
         self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
+
+        invetory = self.duthost.host.options['inventory'].split('/')[-1]
+        secrets = self.duthost.host.options['variable_manager']._hostvars[self.duthost.hostname]['secret_group_vars']
+        self.rebootData['dut_username'] = secrets[invetory]['sonicadmin_user']
+        self.rebootData['dut_password'] = secrets[invetory]['sonicadmin_password']
+
         self.rebootData['default_ip_range'] = str(
             ipaddress.ip_interface(self.mgFacts['minigraph_vlan_interfaces'][0]['addr'] + '/16').network
         )
@@ -223,13 +228,24 @@ class AdvancedReboot:
             self.ptfhost.shell('ssh-keygen -f /root/.ssh/known_hosts -R ' + dutIp)
 
         logger.info('Generate public key for ptf host')
-        self.ptfhost.shell('ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""')
-        result = self.ptfhost.shell('cat /root/.ssh/id_rsa.pub')
+        self.ptfhost.file(path='/root/.ssh/', mode='u+rwx,g-rwx,o-rwx', state='directory')
+        result = self.ptfhost.openssh_keypair(
+            path='/root/.ssh/id_rsa',
+            size=2048,
+            force=True,
+            type='rsa',
+            mode='u=rw,g=,o='
+        )
+        # There is an error with id_rsa.pub access permissions documented in:
+        # https://github.com/ansible/ansible/issues/61411
+        # @TODO: remove the following line when upgrading to Ansible 2.9x
+        self.ptfhost.file(path='/root/.ssh/id_rsa.pub', mode='u=rw,g=,o=')
+
         cmd = '''
             mkdir -p /home/{0}/.ssh && 
             echo "{1}" >> /home/{0}/.ssh/authorized_keys && 
             chown -R {0}:{0} /home/{0}/.ssh/
-        '''.format(dutUsername, result['stdout'])
+        '''.format(dutUsername, result['public_key'])
         self.duthost.shell(cmd)
 
     def __handleMellanoxDut(self):
@@ -423,6 +439,7 @@ class AdvancedReboot:
             platform="remote",
             params={
                 "dut_username" : self.rebootData['dut_username'],
+                "dut_password" : self.rebootData['dut_password'],
                 "dut_hostname" : self.rebootData['dut_hostname'],
                 "reboot_limit_in_seconds" : self.rebootLimit,
                 "reboot_type" :self.rebootType,
@@ -452,15 +469,17 @@ class AdvancedReboot:
         '''
         Resotre previous image and reboot DUT
         '''
-        logger.info('Restore current image')
-        self.duthost.shell('sonic_installer set_default {0}'.format(self.currentImage))
-
-        rebootDut(
-            self.duthost,
-            self.localhost,
-            reboot_type=self.rebootType.replace('-reboot', ''),
-            wait = 180 + self.readyTimeout
-        )
+        currentImage = self.duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+        if currentImage != self.currentImage:
+            logger.info('Restore current image')
+            self.duthost.shell('sonic_installer set_default {0}'.format(self.currentImage))
+    
+            rebootDut(
+                self.duthost,
+                self.localhost,
+                reboot_type=self.rebootType.replace('-reboot', ''),
+                wait = self.readyTimeout
+            )
 
     def tearDown(self):
         '''


### PR DESCRIPTION
### Description of PR
Parmiko module provides fallback mechanism to using username/password
This is required if we are rebooting into new image using advanced
reboot test fixture.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
