### PR TITLE
[pytest] Port advanced reboot based test cases (sad path)

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -408,7 +408,11 @@ class AdvancedReboot:
         '''
         logger.info("Running PTF runner on PTF host: {0}".format(self.ptfhost))
 
+        # Non-routing neighbor/dut lag/bgp, vlan port up/down operation is performed before dut reboot process
+        # lack of routing indicates it is preboot operation
         prebootOper = rebootOper if rebootOper is not None and 'routing' not in rebootOper else None
+        # Routing add/remove is performed during dut reboot process
+        # presence of routing in reboot operation indicates it is during reboot operation (inboot)
         inbootOper = rebootOper if rebootOper is not None and 'routing' in rebootOper else None
 
         self.__updateAndRestartArpResponder(rebootOper)

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -408,8 +408,8 @@ class AdvancedReboot:
         '''
         logger.info("Running PTF runner on PTF host: {0}".format(self.ptfhost))
 
-        prebootOper = rebootOper if rebootOper is not None and 'routing' in rebootOper else None
-        inbootOper = rebootOper if rebootOper is not None and 'routing' not in rebootOper else None
+        prebootOper = rebootOper if rebootOper is not None and 'routing' not in rebootOper else None
+        inbootOper = rebootOper if rebootOper is not None and 'routing' in rebootOper else None
 
         self.__updateAndRestartArpResponder(rebootOper)
 

--- a/tests/platform/test_advanced_reboot.py
+++ b/tests/platform/test_advanced_reboot.py
@@ -15,3 +15,152 @@ def test_warm_reboot(request, get_advanced_reboot):
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     advancedReboot.runRebootTestcase()
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_sad(request, get_advanced_reboot):
+    '''
+    Warm reboot with sad path
+
+    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    For non lag member cases, this parameter will be skipped
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    prebootList = [
+        'neigh_bgp_down',
+        'dut_bgp_down',
+        'dut_lag_down',
+        'neigh_lag_down',
+        'dut_lag_member_down:1:1',
+        'neigh_lag_member_down:1:1',
+        'vlan_port_down',
+    ]
+
+    advancedReboot.runRebootTestcase(
+        prebootList=prebootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_multi_sad(request, get_advanced_reboot):
+    '''
+    Warm reboot with multi sad path
+
+    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    For non lag member cases, this parameter will be skipped
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    lagMemberCnt = advancedReboot.getlagMemberCnt()
+    prebootList = [
+        'neigh_bgp_down:2',
+        'dut_bgp_down:3',
+        'dut_lag_down:2',
+        'neigh_lag_down:3',
+        'dut_lag_member_down:3:1',
+        'neigh_lag_member_down:2:1',
+        'vlan_port_down:4',
+    ] + ([
+        'dut_lag_member_down:2:{0}'.format(lagMemberCnt),
+        'neigh_lag_member_down:3:{0}'.format(lagMemberCnt),
+    ] if advancedReboot.getTestbedType() in ['t0-64', 't0-116', 't0-64-32'] else [])
+
+    advancedReboot.runRebootTestcase(
+        prebootList=prebootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
+    '''
+    Warm reboot with multi sad path (during boot)
+
+    inboot list format: 'inboot_oper:route_cnt'
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    inbootList = [
+        'routing_del:50',
+        'routing_add:50',
+    ]
+
+    advancedReboot.runRebootTestcase(
+        inbootList=inbootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
+    '''
+    Warm reboot with sad (bgp)
+
+    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    For non lag member cases, this parameter will be skipped
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    prebootList = [
+        'neigh_bgp_down:2',
+        'dut_bgp_down:3',
+    ]
+
+    advancedReboot.runRebootTestcase(
+        prebootList=prebootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
+    '''
+    Warm reboot with sad path (lag member)
+
+    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    For non lag member cases, this parameter will be skipped
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    lagMemberCnt = advancedReboot.getlagMemberCnt()
+    prebootList = [
+        'dut_lag_member_down:3:1',
+        'neigh_lag_member_down:2:1',
+    ] + ([
+        'dut_lag_member_down:2:{0}'.format(lagMemberCnt),
+        'neigh_lag_member_down:3:{0}'.format(lagMemberCnt),
+    ] if advancedReboot.getTestbedType() in ['t0-64', 't0-116', 't0-64-32'] else [])
+
+    advancedReboot.runRebootTestcase(
+        prebootList=prebootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_sad_lag(request, get_advanced_reboot):
+    '''
+    Warm reboot with sad path (lag)
+
+    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    For non lag member cases, this parameter will be skipped
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    prebootList = [
+        'dut_lag_down:2',
+        'neigh_lag_down:3',
+    ]
+
+    advancedReboot.runRebootTestcase(
+        prebootList=prebootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )
+
+@pytest.mark.usefixtures('get_advanced_reboot')
+def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot):
+    '''
+    Warm reboot with sad path (vlan port)
+
+    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    For non lag member cases, this parameter will be skipped
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    prebootList = [
+        'vlan_port_down:4',
+    ]
+
+    advancedReboot.runRebootTestcase(
+        prebootList=prebootList,
+        prebootFiles='peer_dev_info,neigh_port_info'
+    )

--- a/tests/platform/test_advanced_reboot.py
+++ b/tests/platform/test_advanced_reboot.py
@@ -4,6 +4,9 @@ import pytest
 def test_fast_reboot(request, get_advanced_reboot):
     '''
     Fast reboot test case is run using advacned reboot test fixture
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot')
     advancedReboot.runRebootTestcase()
@@ -12,6 +15,9 @@ def test_fast_reboot(request, get_advanced_reboot):
 def test_warm_reboot(request, get_advanced_reboot):
     '''
     Warm reboot test case is run using advacned reboot test fixture
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     advancedReboot.runRebootTestcase()
@@ -21,18 +27,21 @@ def test_warm_reboot_sad(request, get_advanced_reboot):
     '''
     Warm reboot with sad path
 
-    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    prebootList format is 'preboot oper type:number of VMS down:number of lag members down'.
     For non lag member cases, this parameter will be skipped
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     prebootList = [
-        'neigh_bgp_down',
-        'dut_bgp_down',
-        'dut_lag_down',
-        'neigh_lag_down',
-        'dut_lag_member_down:1:1',
-        'neigh_lag_member_down:1:1',
-        'vlan_port_down',
+        'neigh_bgp_down',               # Shutdown single BGP session on remote device (VM) before reboot DUT
+        'dut_bgp_down',                 # Shutdown single BGP session on DUT brefore rebooting it
+        'dut_lag_down',                 # Shutdown single LAG session on DUT brefore rebooting it
+        'neigh_lag_down',               # Shutdown single LAG session on remote device (VM) before reboot DUT
+        'dut_lag_member_down:1:1',      # Shutdown 1 LAG member corresponding to 1 remote device (VM) on DUT
+        'neigh_lag_member_down:1:1',    # Shutdown 1 LAG member on 1 remote device (VM)
+        'vlan_port_down',               # Shutdown 1 vlan port (interface) on DUT
     ]
 
     advancedReboot.runRebootTestcase(
@@ -45,22 +54,30 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot):
     '''
     Warm reboot with multi sad path
 
-    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    prebootList format is 'preboot oper type:number of VMS down:number of lag members down'.
     For non lag member cases, this parameter will be skipped
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     lagMemberCnt = advancedReboot.getlagMemberCnt()
     prebootList = [
-        'neigh_bgp_down:2',
-        'dut_bgp_down:3',
-        'dut_lag_down:2',
-        'neigh_lag_down:3',
-        'dut_lag_member_down:3:1',
-        'neigh_lag_member_down:2:1',
+        'neigh_bgp_down:2',             # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
+        'dut_bgp_down:3',               # Shutdown 3 BGP sessions on DUT brefore rebooting it
+        'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it
+        'neigh_lag_down:3',             # Shutdown 1 LAG session on 3 remote devices (VMs) before reboot DUT
+        'dut_lag_member_down:3:1',      # Shutdown 1 LAG member of 3 LAG sessions corresponding to 3 remote devices (VM)
+                                        # on DUT
+        'neigh_lag_member_down:2:1',    # Shutdown 1 LAG member of 2 LAG sessions on 2 remote devices (VM) (1 each)
         'vlan_port_down:4',
     ] + ([
         'dut_lag_member_down:2:{0}'.format(lagMemberCnt),
+                                        # Shutdown <lag count> LAG member(s) of 2 LAG sessions corresponding to 2 remote
+                                        # devices (VM) on DUT
         'neigh_lag_member_down:3:{0}'.format(lagMemberCnt),
+                                        # Shutdown <lag count> LAG member(s) of 3 LAG sessions on 3 remote devices (VM)
+                                        # (1 each)
     ] if advancedReboot.getTestbedType() in ['t0-64', 't0-116', 't0-64-32'] else [])
 
     advancedReboot.runRebootTestcase(
@@ -74,11 +91,14 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
     Warm reboot with multi sad path (during boot)
 
     inboot list format: 'inboot_oper:route_cnt'
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     inbootList = [
-        'routing_del:50',
-        'routing_add:50',
+        'routing_del:50',               # Delete 50 routes IPv4/IPv6 each (100 total) from each BGP session
+        'routing_add:50',               # Add 50 routes IPv4/IPv6 each (100 total) from each BGP session
     ]
 
     advancedReboot.runRebootTestcase(
@@ -91,13 +111,16 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
     '''
     Warm reboot with sad (bgp)
 
-    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    prebootList format is 'preboot oper type:number of VMS down:number of lag members down'.
     For non lag member cases, this parameter will be skipped
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     prebootList = [
-        'neigh_bgp_down:2',
-        'dut_bgp_down:3',
+        'neigh_bgp_down:2',             # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
+        'dut_bgp_down:3',               # Shutdown 3 BGP sessions on DUT brefore rebooting it
     ]
 
     advancedReboot.runRebootTestcase(
@@ -110,17 +133,25 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
     '''
     Warm reboot with sad path (lag member)
 
-    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    prebootList format is 'preboot oper type:number of VMS down:number of lag members down'.
     For non lag member cases, this parameter will be skipped
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     lagMemberCnt = advancedReboot.getlagMemberCnt()
     prebootList = [
-        'dut_lag_member_down:3:1',
-        'neigh_lag_member_down:2:1',
+        'dut_lag_member_down:3:1',      # Shutdown 1 LAG member of 3 LAG sessions corresponding to 3 remote devices (VM)
+                                        # on DUT
+        'neigh_lag_member_down:2:1',    # Shutdown 1 LAG member of 2 LAG sessions on 2 remote devices (VM) (1 each)
     ] + ([
         'dut_lag_member_down:2:{0}'.format(lagMemberCnt),
+                                        # Shutdown <lag count> LAG member(s) of 2 LAG sessions corresponding to 2 remote
+                                        # devices (VM) on DUT
         'neigh_lag_member_down:3:{0}'.format(lagMemberCnt),
+                                        # Shutdown <lag count> LAG member(s) of 3 LAG sessions on 3 remote devices (VM)
+                                        # (1 each)
     ] if advancedReboot.getTestbedType() in ['t0-64', 't0-116', 't0-64-32'] else [])
 
     advancedReboot.runRebootTestcase(
@@ -133,13 +164,16 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot):
     '''
     Warm reboot with sad path (lag)
 
-    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    prebootList format is 'preboot oper type:number of VMS down:number of lag members down'.
     For non lag member cases, this parameter will be skipped
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     prebootList = [
-        'dut_lag_down:2',
-        'neigh_lag_down:3',
+        'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it
+        'neigh_lag_down:3',             # Shutdown 1 LAG session on 3 remote devices (VMs) before reboot DUT
     ]
 
     advancedReboot.runRebootTestcase(
@@ -152,12 +186,15 @@ def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot):
     '''
     Warm reboot with sad path (vlan port)
 
-    preboot_list format is 'preboot oper type:number of VMS down:number of lag members down'.
+    prebootList format is 'preboot oper type:number of VMS down:number of lag members down'.
     For non lag member cases, this parameter will be skipped
+
+    @param request: Spytest commandline argument
+    @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     prebootList = [
-        'vlan_port_down:4',
+        'vlan_port_down:4',              # Shutdown 4 vlan ports (interfaces) on DUT
     ]
 
     advancedReboot.runRebootTestcase(


### PR DESCRIPTION
### Description of PR
This patch ports remaining sad path advanced reboot test cases
to pytest infra.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
