### PR TITLE
[pytest] Add condition check to skip tests in unsupported topo.

### DIFF
--- a/tests/test_bgp_fact.py
+++ b/tests/test_bgp_fact.py
@@ -1,4 +1,10 @@
+import pytest
 from ansible_host import AnsibleHost
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['type'] == 'ptf':
+        pytest.skip('Unsupported topology')
 
 def test_bgp_facts(ansible_adhoc, testbed,duthost):
     """compare the bgp facts between observed states and target state"""

--- a/tests/test_bgp_speaker.py
+++ b/tests/test_bgp_speaker.py
@@ -5,6 +5,10 @@ import logging
 import requests
 from ptf_runner import ptf_runner
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['type'] in ['t1', 'ptf']:
+        pytest.skip('Unsupported topology')
 
 def generate_ips(num, prefix, exclude_ips):
     """

--- a/tests/test_dhcp_relay.py
+++ b/tests/test_dhcp_relay.py
@@ -3,6 +3,10 @@ import time
 
 from ptf_runner import ptf_runner
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['type'] in ['t1', 'ptf']:
+        pytest.skip('Unsupported topology')
 
 @pytest.fixture(scope="module", autouse=True)
 def copy_ptftests_directory(ptfhost):

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -31,6 +31,11 @@ from common.utilities import wait_until
     So, we prefer a fixture rather than xunit-style setup/teardown functions.
 """
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['name'] != 't0':
+        pytest.skip('Unsupported topology')
+
 # global variables
 g_vars = {}
 

--- a/tests/test_vrf_attr.py
+++ b/tests/test_vrf_attr.py
@@ -10,6 +10,10 @@ from test_vrf import (
 )
 from ptf_runner import ptf_runner                     
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_topo(testbed):
+    if testbed['topo']['name'] != 't0':
+        pytest.skip('Unsupported topology')
 
 # tests
 class TestVrfAttrSrcMac():


### PR DESCRIPTION
Signed-off-by: Emma Lin <emma_lin@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Perform some tests in unsupported topology will failed.
Add condition check to skip tests in unsupported topology.

bgp_speaker: skip tests in t1 & ptf
bgp_fact:    skip tests in ptf
dhcp_relay:  skip tests in t1 & ptf
vrf:         only support t0 topology, other topologies need to be filtered

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Add condition check to skip tests in unsupported topo.

#### How did you verify/test it?
Perform pytest to confirm bgp_speaker/bgp_fact/dhcp_relay/vrf tests are skipped in unsupported topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
