### PR TITLE
[pytest] Fix get_asic_type method and logging

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -348,7 +348,7 @@ class SonicHost(AnsibleHostBase):
         return ret
 
     def get_asic_type(self):
-        return dut.facts["asic_type"]
+        return self.facts["asic_type"]
 
 
 class EosHost(AnsibleHostBase):

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -323,7 +323,7 @@ class SonicHost(AnsibleHostBase):
             return self.get_now_time() - datetime.strptime(start_time["ExecMainStartTimestamp"],
                                                            "%a %Y-%m-%d %H:%M:%S UTC")
         except Exception as e:
-            self.logger.error("Exception raised while getting networking restart time: %s" % repr(e))
+            logging.error("Exception raised while getting networking restart time: %s" % repr(e))
             return None
 
     def get_image_info(self):


### PR DESCRIPTION
### Description of PR

The get_asic_type method dereferences dut which is not a member of the the class.
the dut is an instance of SonicHost class and so should reference self. Also, logging was 
dereferenced as an instance inside SonicHost object and it is not.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
