### PR TITLE
[libaray/graph] Export full network graph information in another module

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -209,7 +209,7 @@ class Parse_Lab_Graph():
         if hostname in self.devices:
             return  self.devices[hostname]
         else:
-            return self.devices
+            return None
 
     def get_host_port_vlans(self, hostname):
         """
@@ -218,7 +218,7 @@ class Parse_Lab_Graph():
         if hostname in self.vlanport:
             return self.vlanport[hostname]
         else:
-            return self.vlanport
+            return None
 
     def get_host_connections(self, hostname):
         """
@@ -227,12 +227,12 @@ class Parse_Lab_Graph():
         if hostname in self.links:
             return self.links[hostname]
         else:
-            return self.links
+            return None
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            host=dict(required=False),
+            host=dict(required=True),
             filename=dict(required=False),
         ),
         supports_check_mode=True

--- a/ansible/library/network_graph_facts.py
+++ b/ansible/library/network_graph_facts.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import yaml
+import os
+import traceback
+from collections import defaultdict
+from conn_graph_facts import Parse_Lab_Graph
+
+DOCUMENTATION='''
+module: network_graph_facts.py
+version_added:  2.0
+short_description: Retrive lab switches' information physical connections
+Description:
+    Retrive lab switches' information and physical connections
+    add to Ansible facts
+options:
+    filename: The lab network graph file
+    requred: False
+
+Ansible_facts:
+    devices: The devices information
+    links: The physical connections of devices
+
+'''
+
+EXAMPLES='''
+    - name: network_graph_facts
+
+    return:
+          "devices": {
+              "str-7260-10": {
+                  "ManagementIp": "10.251.0.13/23",
+                  "HwSku": "Arista-7260QX-64",
+                  "Type": "FanoutLeaf'
+              },
+              "str-msn2700-01": {
+                  "HwSku": "Mellanox-2700",
+                  "Type": "DevSonic'
+              }
+          }
+          "links": {
+              "str-7260-10": [
+                  {
+                      "StartPort": "Ethernet0",
+                      "EndPort": "Ethernet33",
+                      "StartDevice": "str-7260-10",
+                      "EndDevice": "str-msn2700-01"
+                      "VlanID": "233"
+                  },
+                  {...}
+              ]
+          }
+'''
+
+LAB_CONNECTION_GRAPH_FILE = 'lab_connection_graph.xml'
+LAB_GRAPHFILE_PATH = 'files/'
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            filename=dict(required=False),
+        ),
+        supports_check_mode=True
+    )
+    m_args = module.params
+    try:
+        if m_args['filename']:
+            filename = m_args['filename']
+        else:
+            filename = LAB_GRAPHFILE_PATH + LAB_CONNECTION_GRAPH_FILE
+        lab_graph = Parse_Lab_Graph(filename)
+        lab_graph.parse_graph()
+
+        results = {}
+        results['devices'] = lab_graph.devices
+        results['links']   = lab_graph.links
+        module.exit_json(ansible_facts=results)
+    except (IOError, OSError):
+        module.fail_json(msg="Can not find lab graph file "+LAB_CONNECTION_GRAPH_FILE)
+    except Exception as e:
+        module.fail_json(msg=traceback.format_exc())
+
+from ansible.module_utils.basic import *
+if __name__== "__main__":
+    main()


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
The Parse_Lab_Graph class have some get_* methods which will returns full list if the given hostname not found. But the conn_graph_facts expect a None result.

- Fix issue where the method of Parse_Lab_Graph returns full list instead of None when host name not found
- Add network_graph_facts to export full graph information with hostname index

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
- Fix issue where the method of Parse_Lab_Graph returns full list instead of None when host name not found
- Add network_graph_facts to export full graph information with hostname index

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
