### PR TITLE
[pytest/creds]: load groups vars into creds for the dut

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,12 +85,12 @@ def pytest_addoption(parser):
     ############################
     # test_techsupport options #
     ############################
-    
+
     parser.addoption("--loop_num", action="store", default=10, type=int,
                     help="Change default loop range for show techsupport command")
     parser.addoption("--loop_delay", action="store", default=10, type=int,
                     help="Change default loops delay")
-    parser.addoption("--logs_since", action="store", type=int, 
+    parser.addoption("--logs_since", action="store", type=int,
                     help="number of minutes for show techsupport command")
 
 
@@ -234,8 +234,11 @@ def eos():
 @pytest.fixture(scope="module")
 def creds(duthost):
     """ read credential information according to the dut inventory """
-    inv   = duthost.host.options['inventory'].split('/')[-1]
-    files = glob.glob("../ansible/group_vars/{}/*.yml".format(inv))
+    groups = duthost.host.options['inventory_manager'].get_host(duthost.hostname).get_vars()['group_names']
+    logger.info("dut {} belongs to groups {}".format(duthost.hostname, groups))
+    files = []
+    for group in groups:
+        files += glob.glob("../ansible/group_vars/{}/*.yml".format(group))
     files += glob.glob("../ansible/group_vars/all/*.yml")
     creds = {}
     for f in files:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,10 +236,9 @@ def creds(duthost):
     """ read credential information according to the dut inventory """
     groups = duthost.host.options['inventory_manager'].get_host(duthost.hostname).get_vars()['group_names']
     logger.info("dut {} belongs to groups {}".format(duthost.hostname, groups))
-    files = []
+    files = glob.glob("../ansible/group_vars/all/*.yml")
     for group in groups:
         files += glob.glob("../ansible/group_vars/{}/*.yml".format(group))
-    files += glob.glob("../ansible/group_vars/all/*.yml")
     creds = {}
     for f in files:
         with open(f) as stream:

--- a/tests/veos.vtb
+++ b/tests/veos.vtb
@@ -55,6 +55,11 @@ server_1
 [servers:vars]
 topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
 
+[lab]
+vlab-01
+vlab-02
+vlab-03
+
 [sonic]
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000 ansible_password=password ansible_user=admin
 vlab-02 ansible_host=10.250.0.102 type=kvm hwsku=Force10-S6100 ansible_password=password


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
johnar@1cafe0c9f994:/data/tests$ py.test $PYTEST_COMMON_OPTS --log-file ~/abc.log tacacs/test_ro_user.py | tee ~/abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 1 item

tacacs/test_ro_user.py::test_ro_user PASSED                              [100%]

=============================== warnings summary ===============================
```

```
INFO     conftest:conftest.py:238 dut vlab-01 belongs to groups [u'lab', u'sonic']
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
