### PR TITLE
[pytest/common/devices] Remove immediately checking of shut/no_shut

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -373,19 +373,15 @@ class EosHost(AnsibleHostBase):
         out = self.host.eos_config(
             lines=['shutdown'],
             parents='interface %s' % interface_name)
-        if not self.check_intf_link_state(interface_name):
-            logging.info('Shut interface [%s]' % interface_name)
-            return out
-        raise RunAnsibleModuleFail("The interface state is Up but expect Down, detail output: %s" % out[self.hostname])
+        logging.info('Shut interface [%s]' % interface_name)
+        return out
 
     def no_shutdown(self, interface_name):
         out = self.host.eos_config(
             lines=['no shutdown'],
             parents='interface %s' % interface_name)
-        if self.check_intf_link_state(interface_name):
-            logging.info('No shut interface [%s]' % interface_name)
-            return out
-        raise RunAnsibleModuleFail("The interface state is Down but expect Up, detail output: %s" % out[self.hostname])
+        logging.info('No shut interface [%s]' % interface_name)
+        return out
 
     def check_intf_link_state(self, interface_name):
         show_int_result = self.host.eos_command(


### PR DESCRIPTION
Remove immediately checking of shut/no_shut

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
The shutdown and no_shutdown methods in EosHost should only fire the command.
Whether checking the shut result should up to user.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Remove immediately checking of shutdown/no_shutdown method in EosHost.
Keep the check method to allow user to check the interface state by need.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
