### PR TITLE
[tests/conftest] Construct FanoutHost by it os type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,9 +215,9 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
         if fanout_host in fanout_hosts.keys():
             fanout  = fanout_hosts[fanout_host]
         else:
-            # FIXME: assuming all fanout hosts are EOS for now. Needs to figure out the os type and
-            #        create fanout switch with the right type.
-            fanout  = FanoutHost(ansible_adhoc, 'eos', fanout_host, 'FanoutLeaf', creds['fanout_admin_user'], creds['fanout_admin_password'])
+            host_vars = ansible_adhoc().options['inventory_manager'].get_host(fanout_host).vars
+            os_type = 'eos' if 'os' not in host_vars else host_vars['os']
+            fanout  = FanoutHost(ansible_adhoc, os_type, fanout_host, 'FanoutLeaf', creds['fanout_admin_user'], creds['fanout_admin_password'])
             fanout_hosts[fanout_host] = fanout
         fanout.add_port_map(dut_port, fanout_port)
 


### PR DESCRIPTION
Read os var from ansible inventory manager

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
The fanout switch might EOS or SONiC or other OS, we need to create the fanout host instance by its OS type to operate on it properly.
If no OS specified in inventory file, we will just use EOS as its OS type by default.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
- Read os var from ansible inventory manager

#### How did you verify/test it?
**Inventory file**
```ini
[fanout]
str-7260-10       ansible_host=10.251.0.13
str-7260-11       ansible_host=10.251.0.234
str-msn2700-02    ansible_host=10.251.0.235 os=sonic
```
**Test 1:**
```python
    host_vars = ansible_adhoc().options['inventory_manager'].get_host('str-7260-10').vars
    os_type = 'eos' if 'os' not in host_vars else host_vars['os']
    logging.info("host_vars: %s, os_type: %s" % (host_vars, os_type))
```
```
{
  'inventory_file': u'/data/sonic-mgmt/tests/veos.vtb',
  'inventory_dir': u'/data/sonic-mgmt/tests',
  u'ansible_host': u'10.251.0.13'
},
os_type: eos
```
**Test 2:**
```python
    host_vars = ansible_adhoc().options['inventory_manager'].get_host('str-msn2700-02').vars
    os_type = 'eos' if 'os' not in host_vars else host_vars['os']
    logging.info("host_vars: %s, os_type: %s" % (host_vars, os_type))
```
```
{
  'inventory_file': u'/data/sonic-mgmt/tests/veos.vtb',
  u'os': u'sonic',
  'inventory_dir': u'/data/sonic-mgmt/tests',
  u'ansible_host': u'10.251.0.235'
},
os_type: sonic
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
