### PR TITLE
[advanced-reboot] Fix testing hang when doing BGP shutdown on Arista VM

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -373,7 +373,13 @@ class Arista(object):
         state = ['shut', 'no shut']
         self.do_cmd('configure')
         self.do_cmd('router bgp %s' % asn)
-        self.do_cmd('%s' % state[is_up])
+        if is_up == True:
+            self.do_cmd('%s' % state[is_up])
+        else:
+            # shutdown BGP will pop confirm message, the message is 
+            # "You are attempting to shutdown BGP. Are you sure you want to shutdown? [confirm]"
+            self.do_cmd('%s' % state[is_up], prompt = '[confirm]')
+            self.do_cmd('y')
         self.do_cmd('exit')
         self.do_cmd('exit')
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -64,6 +64,9 @@ class Arista(object):
         self.do_cmd('enable')
         self.do_cmd('terminal length 0')
 
+        version_output = self.do_cmd('show version')
+        self.veos_version = self.parse_version(version_output)
+
         return self.shell
 
     def get_arista_prompt(self, first_prompt):
@@ -373,13 +376,16 @@ class Arista(object):
         state = ['shut', 'no shut']
         self.do_cmd('configure')
         self.do_cmd('router bgp %s' % asn)
-        if is_up == True:
+        if self.veos_version < 4.20:
             self.do_cmd('%s' % state[is_up])
         else:
-            # shutdown BGP will pop confirm message, the message is 
-            # "You are attempting to shutdown BGP. Are you sure you want to shutdown? [confirm]"
-            self.do_cmd('%s' % state[is_up], prompt = '[confirm]')
-            self.do_cmd('y')
+            if is_up == True:
+                self.do_cmd('%s' % state[is_up])
+            else:
+                # shutdown BGP will pop confirm message, the message is 
+                # "You are attempting to shutdown BGP. Are you sure you want to shutdown? [confirm]"
+                self.do_cmd('%s' % state[is_up], prompt = '[confirm]')
+                self.do_cmd('y')
         self.do_cmd('exit')
         self.do_cmd('exit')
 
@@ -531,3 +537,10 @@ class Arista(object):
 
         # Note: the first item is a placeholder
         return 0, change_count
+
+    def parse_version(self, output):
+        version = 0
+        for line in output.split('\n'):
+            if ('Software image version: ' in line):
+                version = float(re.search('([1-9]{1}\d*)(\.\d{0,2})', line).group())
+        return version


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Fix warm-reboot-sad-bgp testing hang after vEOS upgraded to 4.20.15M.
It pops a confirm message when doing BGP shutdown.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Add checking the confirm message prompt when doing BGP shutdown on Arista VM

#### How did you verify/test it?
Run warm-reboot-sad-bgp testing, it doesn't hang and the testing result is passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
