### PR TITLE
[recovery] introduce adaptive recover method

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -350,6 +350,24 @@ class SonicHost(AnsibleHostBase):
     def get_asic_type(self):
         return self.facts["asic_type"]
 
+    def shutdown(self, portname):
+        """
+            Shutdown interface (parity function as EosHost)
+
+            Args:
+                portname: the interface to shutdown
+        """
+        return self.command("sudo config interface shutdown {}".format(portname))
+
+    def no_shutdown(self, portname):
+        """
+            Bring up interface (parity function as EosHost)
+
+            Args:
+                portname: the interface to bring up
+        """
+        return self.command("sudo config interface startup {}".format(portname))
+
 
 class EosHost(AnsibleHostBase):
     """

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -350,23 +350,23 @@ class SonicHost(AnsibleHostBase):
     def get_asic_type(self):
         return self.facts["asic_type"]
 
-    def shutdown(self, portname):
+    def shutdown(self, ifname):
         """
-            Shutdown interface (parity function as EosHost)
+            Shutdown interface specified by ifname
 
             Args:
-                portname: the interface to shutdown
+                ifname: the interface to shutdown
         """
-        return self.command("sudo config interface shutdown {}".format(portname))
+        return self.command("sudo config interface shutdown {}".format(ifname))
 
-    def no_shutdown(self, portname):
+    def no_shutdown(self, ifname):
         """
-            Bring up interface (parity function as EosHost)
+            Bring up interface specified by ifname
 
             Args:
-                portname: the interface to bring up
+                ifname: the interface to bring up
         """
-        return self.command("sudo config interface startup {}".format(portname))
+        return self.command("sudo config interface startup {}".format(ifname))
 
 
 class EosHost(AnsibleHostBase):

--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -12,11 +12,12 @@ PRINT_LOGS = {
 
 # Recover related definitions
 RECOVER_METHODS = {
-    "config_reload": {"cmd": "config reload -y", "reboot": False},
-    "load_minigraph": {"cmd": "config load_minigraph -y", "reboot": False},
-    "reboot": {"cmd": "reboot", "reboot": True},
-    "warm_reboot": {"cmd": "warm-reboot", "reboot": True},
-    "fast_reboot": {"cmd": "fast_reboot", "reboot": True}
+    "config_reload": {"cmd": "config reload -y", "reboot": False, "adaptive": False},
+    "load_minigraph": {"cmd": "config load_minigraph -y", "reboot": False, "adaptive": False},
+    "reboot": {"cmd": "reboot", "reboot": True, "adaptive": False},
+    "warm_reboot": {"cmd": "warm-reboot", "reboot": True, "adaptive": False},
+    "fast_reboot": {"cmd": "fast_reboot", "reboot": True, "adaptive": False},
+    "adaptive": {"cmd": None, "reboot": False, "adaptive": True},
 }       # All supported recover methods
 
 SUPPORTED_CHECK_ITEMS = ["services", "interfaces", "dbmemory"]          # Supported checks

--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -12,12 +12,12 @@ PRINT_LOGS = {
 
 # Recover related definitions
 RECOVER_METHODS = {
-    "config_reload": {"cmd": "config reload -y", "reboot": False, "adaptive": False},
-    "load_minigraph": {"cmd": "config load_minigraph -y", "reboot": False, "adaptive": False},
-    "reboot": {"cmd": "reboot", "reboot": True, "adaptive": False},
-    "warm_reboot": {"cmd": "warm-reboot", "reboot": True, "adaptive": False},
-    "fast_reboot": {"cmd": "fast_reboot", "reboot": True, "adaptive": False},
-    "adaptive": {"cmd": None, "reboot": False, "adaptive": True},
+    "config_reload": {"cmd": "config reload -y", "reboot": False, "adaptive": False, 'recover_wait': 60},
+    "load_minigraph": {"cmd": "config load_minigraph -y", "reboot": False, "adaptive": False, 'recover_wait': 60},
+    "reboot": {"cmd": "reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
+    "warm_reboot": {"cmd": "warm-reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
+    "fast_reboot": {"cmd": "fast_reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
+    "adaptive": {"cmd": None, "reboot": False, "adaptive": True, 'recover_wait': 30},
 }       # All supported recover methods
 
 SUPPORTED_CHECK_ITEMS = ["services", "interfaces", "dbmemory"]          # Supported checks

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -56,7 +56,7 @@ def adaptive_recover(dut, localhost, fanouthosts, check_results):
                 __recover_interfaces(dut, fanouthosts, result)
             elif result['check_item'] == 'services':
                 action             = __recover_services(dut, result)
-                # Only allow outstanding_action be overriden when it is
+                # Only allow outstanding_action be overridden when it is
                 # None. In case the outstanding_action has already been
                 # been set to 'reboot'.
                 outstanding_action = action if not outstanding_action

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -56,6 +56,9 @@ def adaptive_recover(dut, localhost, fanouthosts, check_results):
                 __recover_interfaces(dut, fanouthosts, result)
             elif result['check_item'] == 'services':
                 action             = __recover_services(dut, result)
+                # Only allow outstanding_action be overriden when it is
+                # None. In case the outstanding_action has already been
+                # been set to 'reboot'.
                 outstanding_action = action if not outstanding_action
             else:
                 outstanding_action = 'reboot'

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -1,10 +1,9 @@
 
 import logging
-import time
 
 import constants
 
-from common.utilities import wait, wait_until
+from common.utilities import wait
 from common.errors import RunAnsibleModuleFail
 from common.platform.device_utils import fanout_switch_port_lookup
 
@@ -64,7 +63,8 @@ def adaptive_recover(dut, localhost, fanouthosts, check_results, wait_time):
                 # Only allow outstanding_action be overridden when it is
                 # None. In case the outstanding_action has already been
                 # been set to 'reboot'.
-                outstanding_action = action if not outstanding_action
+                if not outstanding_action:
+                    outstanding_action = action
             else:
                 outstanding_action = 'reboot'
 

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -55,7 +55,8 @@ def adaptive_recover(dut, localhost, fanouthosts, check_results):
             if result['check_item'] == 'interfaces':
                 __recover_interfaces(dut, fanouthosts, result)
             elif result['check_item'] == 'services':
-                outstanding_action = __recover_services(dut, result)
+                action             = __recover_services(dut, result)
+                outstanding_action = action if not outstanding_action
             else:
                 outstanding_action = 'reboot'
 


### PR DESCRIPTION
### Description of PR
Summary:
- For interfaces down failure, try to bring up the interfaces.
- For service down failure, reload config to bring them back up.
- For all other failures, reboot to recover.
- Make adaptive the default recover method.
- Restore by reboot if database service is not running. However this change doesn't really take effect because when database is down, failure happens way earlier.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Add adaptive recover method.

#### How did you verify/test it?
Left a fanout switch port disabled and run any test case. Sanity check recovered the system and proceeded with the test case.
Disable a dut port and run any test case. Sanity check recovered the system and proceeded with the test case.
Disabled a service (pmon), sanity check recovered by config reload and proceeded.