### PR TITLE
[pfc_storm_icos.j2]: jinja2 template to start PFC storm on ICOS.

### DIFF
--- a/ansible/roles/test/templates/pfc_storm_icos.j2
+++ b/ansible/roles/test/templates/pfc_storm_icos.j2
@@ -1,0 +1,5 @@
+bash
+cd /mnt/flash
+sudo python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{"fpti1_"~pfc_fanout_interface|replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
+exit
+exit

--- a/ansible/roles/test/templates/pfc_storm_stop_icos.j2
+++ b/ansible/roles/test/templates/pfc_storm_stop_icos.j2
@@ -1,0 +1,5 @@
+bash
+cd /mnt/flash
+sudo pkill -f {{pfc_gen_file}}
+exit
+exit


### PR DESCRIPTION
[pfc_storm_stop_icos.j2]: jinja2 template to stop PFC storm on ICOS.

Note: Jinja2 considers physical to logical mapping of interfaces as per ICOS user manual.
fpti1_0_1 0/1
fpti1_0_2 0/2
fpti1_0_3 0/3

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PFC STORM when ICOS is used as FanOut.

### Type of change
Enhancement for new Platform(FO)

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ -] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
```
Created a dummy playbook to test:

108   - name: set vars PC
109     set_fact:
110         pfc_gen_file: "pfc_gen.py"
111         pfc_queue_index: 16
112         pfc_frames_number: 100000
113         pfc_fanout_interface: "0/1"
114         ansible_eth0_ipv4_addr: "10.0.0.1"
115 
116   - name: create pfc.conf file in ansible minigraph folder
117     template: src=roles/test/templates/pfc_storm_icos.j2
118               dest=minigraph/pfc.conf
119     connection: local

Output:
  1 bash
  2 cd /mnt/flash
  3 sudo python pfc_gen.py -p 65536 -t 65535 -n 100000 -i fpti1_0_1 -r 10.0.0.1 &
  4 exit
  5 exit

This will run pfc_gen.py on ICOS.
```
#### Any platform specific information?
ICOS as FO.

#### Supported testbed topology if it's a new test case?
Same as PFC strom.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
