### PR TITLE
Frr template

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -117,6 +117,11 @@
     delegate_to: localhost
     when: local_minigraph is defined and local_minigraph|bool == true
 
+  - name: create frr.conf file in ansible minigraph folder
+    template: src=templates/frr.j2
+              dest=minigraph/frr.conf
+    connection: local
+
   - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig

--- a/ansible/templates/frr.j2
+++ b/ansible/templates/frr.j2
@@ -15,6 +15,11 @@ router bgp {{ vm_topo_config['dut_asn'] }}
   bgp log-neighbor-changes
   no bgp default ipv4-unicast
   bgp bestpath as-path multipath-relax
+{% if 'tor' in vm_topo_config['dut_type'] | lower %}
+  neighbor DYNAMIC-V4 peer-group
+  neighbor DYNAMIC-V4 remote-as 65432
+  neighbor DYNAMIC-V4 timers 3 9
+{% endif %}
   neighbor NEIGHBOR-V4 peer-group
   neighbor NEIGHBOR-V4 timers 3 9
   neighbor NEIGHBOR-V6 peer-group
@@ -37,18 +42,28 @@ router bgp {{ vm_topo_config['dut_asn'] }}
   neighbor {{ vm_topo_config['vm'][vm]['peer_ipv6'] }} description {{ vm }}
 {% endif %}
 {% endfor %}
+  !
+{% if 'tor' in vm_topo_config['dut_type'] | lower %}
+  bgp listen limit 20
+  bgp listen range 192.168.0.0/24 peer-group DYNAMIC-V4
+  bgp listen range 10.255.0.0/25 peer-group DYNAMIC-V4
+{% endif %}
 !
 address-family ipv4 unicast
 {% for index in range(vms_number) %}
 {% set vm=vms[index] %}
 {% if vm_topo_config['vm'][vm]['peer_ipv4'] %}
   network {{ vm_topo_config['vm'][vm]['peer_ipv4'] }}/31
-  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv4'] }} activate
 {% endif %}
 {% endfor %}
+  !
+{% if 'tor' in vm_topo_config['dut_type'] | lower %}
+  neighbor DYNAMIC-V4 activate
+{% endif %}
   neighbor NEIGHBOR-V4 activate
   neighbor NEIGHBOR-V4 route-map NEIGHBOR-V4-IN in
   neighbor NEIGHBOR-V4 route-map NEIGHBOR-V4-OUT out
+  !
   maximum-paths 64
   maximum-paths ibgp 64
 exit-address-family
@@ -58,12 +73,13 @@ address-family ipv6 unicast
 {% set vm=vms[index] %}
 {% if vm_topo_config['vm'][vm]['peer_ipv6'] %}
   network {{ vm_topo_config['vm'][vm]['peer_ipv6'] }}/126
-  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv6'] }} activate
 {% endif %}
 {% endfor %}
+  !
   neighbor NEIGHBOR-V6 activate
   neighbor NEIGHBOR-V6 route-map NEIGHBOR-V6-IN in
   neighbor NEIGHBOR-V6 route-map NEIGHBOR-V6-OUT out
+  !
   maximum-paths 64
   maximum-paths ibgp 64
 exit-address-family

--- a/ansible/templates/frr.j2
+++ b/ansible/templates/frr.j2
@@ -1,0 +1,82 @@
+frr defaults traditional
+no log monitor
+!
+password zebra
+enable password zebra
+!
+log syslog informational
+!
+log facility local4
+!
+{% set vms=vm_topo_config['vm'].keys() | sort %}
+{% set vms_number = vms | length %}
+router bgp {{ vm_topo_config['dut_asn'] }}
+  bgp router-id 10.1.0.32
+  bgp log-neighbor-changes
+  no bgp default ipv4-unicast
+  bgp bestpath as-path multipath-relax
+  neighbor NEIGHBOR-V4 peer-group
+  neighbor NEIGHBOR-V4 timers 3 9
+  neighbor NEIGHBOR-V6 peer-group
+  neighbor NEIGHBOR-V6 timers 3 9
+{% for index in range(vms_number) %}
+{% set vm=vms[index] %}
+{% if vm_topo_config['vm'][vm]['peer_ipv4'] %}
+  !
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv4'] }} remote-as {{ vm_topo_config['vm'][vms[index]]['bgp_asn'] }}
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv4'] }} peer-group NEIGHBOR-V4
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv4'] }} description {{ vm }}
+{% endif %}
+{% endfor %}
+{% for index in range(vms_number) %}
+{% set vm=vms[index] %}
+{% if vm_topo_config['vm'][vm]['peer_ipv6'] %}
+  !
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv6'] }} remote-as {{ vm_topo_config['vm'][vms[index]]['bgp_asn'] }}
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv6'] }} peer-group NEIGHBOR-V6
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv6'] }} description {{ vm }}
+{% endif %}
+{% endfor %}
+!
+address-family ipv4 unicast
+{% for index in range(vms_number) %}
+{% set vm=vms[index] %}
+{% if vm_topo_config['vm'][vm]['peer_ipv4'] %}
+  network {{ vm_topo_config['vm'][vm]['peer_ipv4'] }}/31
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv4'] }} activate
+{% endif %}
+{% endfor %}
+  neighbor NEIGHBOR-V4 activate
+  neighbor NEIGHBOR-V4 route-map NEIGHBOR-V4-IN in
+  neighbor NEIGHBOR-V4 route-map NEIGHBOR-V4-OUT out
+  maximum-paths 64
+  maximum-paths ibgp 64
+exit-address-family
+!
+address-family ipv6 unicast
+{% for index in range(vms_number) %}
+{% set vm=vms[index] %}
+{% if vm_topo_config['vm'][vm]['peer_ipv6'] %}
+  network {{ vm_topo_config['vm'][vm]['peer_ipv6'] }}/126
+  neighbor {{ vm_topo_config['vm'][vm]['peer_ipv6'] }} activate
+{% endif %}
+{% endfor %}
+  neighbor NEIGHBOR-V6 activate
+  neighbor NEIGHBOR-V6 route-map NEIGHBOR-V6-IN in
+  neighbor NEIGHBOR-V6 route-map NEIGHBOR-V6-OUT out
+  maximum-paths 64
+  maximum-paths ibgp 64
+exit-address-family
+!
+route-map NEIGHBOR-V4-IN permit 10
+!
+route-map NEIGHBOR-V4-OUT permit 30
+!
+route-map NEIGHBOR-V6-IN permit 10
+set ipv6 next-hop prefer-global
+!
+route-map NEIGHBOR-V6-OUT permit 30
+set ipv6 next-hop prefer-global
+!
+line vty
+!


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Created a FRR config template.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [- ] Test case(new/improvement)

### Approach
#### How did you do it?
Wrote a jinja template, which generates FRR config for switch.

#### How did you verify/test it?
```
---Ansible output:
TASK [create frr.conf file in ansible minigraph folder] *** Friday 27 July 2018 00:21:24 +0000 (0:00:00.488) 0:00:06.544 **
changed: [falco-test-dut02]

TASK [disable automatic minigraph update if we are deploying new minigraph into SONiC] Friday 27 July 2018 00:21:25 +0000 (0:00:00.395) 0:00:06.940 **
ok: [falco-test-dut02]

TASK [execute cli "config load_minigraph -y" to apply new minigraph] ** Friday 27 July 2018 00:21:25 +0000 (0:00:00.244) 0:00:07.185 **
changed: [falco-test-dut02]

TASK [execute cli "config bgp startup all" to bring up all bgp sessions for test] Friday 27 July 2018 00:22:40 +0000 (0:01:14.775) 0:01:21.960 **
changed: [falco-test-dut02]

TASK [execute cli "config save -y" to save current minigraph as startup-config]
Friday 27 July 2018  00:22:41 +0000 (0:00:01.468)       0:01:23.428 *****
changed: [falco-test-dut02]

TASK [remove fec config from config_db.json] *****
Friday 27 July 2018  00:22:43 +0000 (0:00:01.570)       0:01:24.999 *****
changed: [falco-test-dut02]

TASK [modify port speed config in config_db.json] **** Friday 27 July 2018 00:22:43 +0000 (0:00:00.339) 0:01:25.338 ***
changed: [falco-test-dut02]

TASK [execute cli "config reload -y" to apply modified config_db.json] * Friday 27 July 2018 00:22:43 +0000 (0:00:00.359) 0:01:25.698 ***
changed: [falco-test-dut02]

PLAY RECAP ***********
falco-test-dut02           : ok=25   changed=10   unreachable=0    failed=0

Friday 27 July 2018 00:23:46 +0000 (0:01:02.679) 0:02:28.377 *****

TASK: execute cli "config load_minigraph -y" to apply new minigraph ---- 74.77s
TASK: execute cli "config reload -y" to apply modified config_db.json -- 62.68s
TASK: execute cli "config save -y" to save current minigraph as startup-config --- 1.57s
TASK: execute cli "config bgp startup all" to bring up all bgp sessions for test --- 1.47s
TASK: find all interface indexes mapping connecting to VM --------------- 1.13s

-----------BGP Neighborship---------
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
