### PR TITLE
Fix in 'nbrhosts' pytest fixture

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -25,15 +25,17 @@ class AnsibleHostBase(object):
     on the host.
     """
 
-    def __init__(self, ansible_adhoc, hostname, connection=None):
+    def __init__(self, ansible_adhoc, hostname, connection=None, inventory=None):
         if hostname == 'localhost':
             self.host = ansible_adhoc(inventory='localhost', connection='local', host_pattern=hostname)[hostname]
         else:
+            if not inventory:
+                inventory = ansible_adhoc().options["inventory"]
             if connection is None:
-                self.host = ansible_adhoc(become=True)[hostname]
+                self.host = ansible_adhoc(become=True, inventory=inventory)[hostname]
             else:
                 logging.debug("connection {} for {}".format(connection, hostname))
-                self.host = ansible_adhoc(become=True, connection=connection)[hostname]
+                self.host = ansible_adhoc(become=True, connection=connection, inventory=inventory)[hostname]
         self.hostname = hostname
 
     def __getattr__(self, item):
@@ -376,8 +378,8 @@ class EosHost(AnsibleHostBase):
     For running ansible module on the Eos switch
     """
 
-    def __init__(self, ansible_adhoc, hostname, user, passwd, gather_facts=False):
-        AnsibleHostBase.__init__(self, ansible_adhoc, hostname, connection="network_cli")
+    def __init__(self, ansible_adhoc, hostname, user, passwd, gather_facts=False, inventory=None):
+        AnsibleHostBase.__init__(self, ansible_adhoc, hostname, connection="network_cli", inventory=inventory)
         evars = { 'ansible_connection':'network_cli', \
                   'ansible_network_os':'eos', \
                   'ansible_user': user, \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ pytest_plugins = ('common.plugins.ptfadapter',
                   'common.plugins.loganalyzer',
                   'common.plugins.psu_controller',
                   'common.plugins.sanity_check')
-VEOS_INVENTORY = "../ansible/veos"
+VEOS_INVENTORY = os.path.normpath(os.path.join(os.path.split(__file__)[0], "../ansible/veos"))
 
 class TestbedInfo(object):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ pytest_plugins = ('common.plugins.ptfadapter',
                   'common.plugins.loganalyzer',
                   'common.plugins.psu_controller',
                   'common.plugins.sanity_check')
-
+VEOS_INVENTORY = "../ansible/veos"
 
 class TestbedInfo(object):
     """
@@ -197,7 +197,8 @@ def nbrhosts(ansible_adhoc, testbed, creds):
     vm_base = int(testbed['vm_base'][2:])
     devices = {}
     for k, v in testbed['topo']['properties']['topology']['VMs'].items():
-        devices[k] = EosHost(ansible_adhoc, "VM%04d" % (vm_base + v['vm_offset']), creds['eos_login'], creds['eos_password'])
+        devices[k] = EosHost(ansible_adhoc, "VM%04d" % (vm_base + v['vm_offset']), creds['eos_login'], creds['eos_password'],
+            inventory=VEOS_INVENTORY)
     return devices
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fix "nbrhosts" fixture to use inventory file with defined VMs
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
During run tests which uses "nbrhosts" fixture it was observed the following error:

```
    @pytest.fixture(scope="module")
    def nbrhosts(ansible_adhoc, testbed, creds):
        """
        Shortcut fixture for getting VM host
        """

        vm_base = int(testbed['vm_base'][2:])
        devices = {}
        for k, v in testbed['topo']['properties']['topology']['VMs'].items():
>           devices[k] = EosHost(ansible_adhoc, "VM%04d" % (vm_base + v['vm_offset']), creds['eos_login'], creds['eos_password'])

conftest.py:200:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
common/devices.py:362: in __init__
    AnsibleHostBase.__init__(self, ansible_adhoc, hostname, connection="network_cli")
common/devices.py:36: in __init__
    self.host = ansible_adhoc(become=True, connection=connection)[hostname]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pytest_ansible.host_manager.v28.HostManagerV28 object at 0x7fd207ec8410>, item = 'VM0604'

    def __getitem__(self, item):
        """Return a ModuleDispatcher instance described the provided `item`."""
        # Handle slicing
        if isinstance(item, slice):
            new_item = "all["
            if item.start is not None:
                new_item += str(item.start)
            new_item += '-'
            if item.stop is not None:
                new_item += str(item.stop)
            item = new_item + ']'

        if item in self.__dict__:
            return self.__dict__[item]
        else:
            if not self.has_matching_inventory(item):
>               raise KeyError(item)
E               KeyError: 'VM0604'

```

Description:
For now main inventory file which is used for test cases run is located in "ansible/inventory" file.
But also for now Virtual Machine hosts are defined in separate "ansible/veos" inventory file.
So to have possibility in test cases to simultaneously use devices like DUT/Fanouts and VMs there should be possibility to specify which inventory file to use for specific device type.

Base item what is used for create interface to the devices is pytest-ansible fixture "ansible_adhoc".
It uses inventory file which is specified by "--inventory" option.
For now as main inventory what is passed for test case run is "ansible/inventory", so it was added global variable which points to another inventory with defined VMs.

Later this can be enhanced by combining inventory files or by adding pytest option for passing specific inventory files.

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
