### PR TITLE
[ansible] Fix symlink to ferret.conf.j2

### DIFF
--- a/ansible/roles/test/templates/ferret.conf.j2
+++ b/ansible/roles/test/templates/ferret.conf.j2
@@ -1,1 +1,1 @@
-../../../../tests/templates/ferret.conf.j2
+../../../../tests/arp/files/ferret.conf.j2


### PR DESCRIPTION
### Description of PR
Template file was move to arp/files/ferret.conf.j2 and symlink update was missed

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
It was missed out in previous PR

#### How did you verify/test it?
ansible-playbook test_sonic.yml -i str --limit str-s6100-acs-2 --vault-password-file=../.vault-file -e testbed_name=vms7-t0-s6100 -e testcase_name=wr_arp -vvvv

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
