### PR TITLE
Fix error while running add-topo 

### DIFF
--- a/ansible/group_vars/vm_host/creds.yml
+++ b/ansible/group_vars/vm_host/creds.yml
@@ -1,5 +1,4 @@
 ---
 ansible_user: use_own_value
 ansible_password: use_own_value
-ansible_sudo_pass: use_own_value
-
+ansible_become_password: use_own_value


### PR DESCRIPTION
### Description of PR
add topo is giving error as part of VEOS task
TASK [eos : Get VM front panel interface number]
with error FAILED! => {"msg": "Incorrect sudo password"}

In file group_vars/vm_host/creds.yml 
instead of using ansible_sudo_password make it ansible_become_password
based on below thread: https://github.com/ansible/ansible/issues/62042


Summary:
Fixes # (issue)

### Type of change

Bug Fix

### Approach
#### How did you do it?
updating veos inventory file 

#### How did you verify/test it?
./testbed-cli.sh add-topo vms17-t1 password.txt