### PR TITLE
Add condition check to skip FDB unsupported topo.

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -165,6 +165,9 @@ def test_fdb(ansible_adhoc, testbed, ptfadapter, duthost, ptfhost, pkt_type):
     1. verify fdb forwarding.
     2. verify show mac command on DUT for learned mac.
     """
+    
+    if testbed['topo']['type'] in ['t1', 'ptf']:
+        pytest.skip('unsupported testbed type')
 
     host_facts  = duthost.setup()['ansible_facts']
     conf_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']


### PR DESCRIPTION
only support t0 topology, other topologies need to be filtered

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Perform FDB test in unsupported topology will failed.
Add condition check to skip FDB test unsupported topology.
FDB test only support t0 topology, other topologies need to be filtered,

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

Add condition check to skip unsupported topo.

#### How did you verify/test it?

Perform pytest to confirm FDB test IS skipped in unsupported topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
