### PR TITLE
[Platform]Ignore error message in test_turn_on_off_psu_and_check_psustatus

### DIFF
--- a/tests/platform/test_platform_info.py
+++ b/tests/platform/test_platform_info.py
@@ -189,11 +189,18 @@ def check_all_psu_on(dut, psu_test_results):
     return len(power_off_psu_list) == 0
 
 
+@pytest.mark.disable_loganalyzer
 def test_turn_on_off_psu_and_check_psustatus(testbed_devices, psu_controller):
     """
     @summary: Turn off/on PSU and check PSU status using 'show platform psustatus'
     """
     ans_host = testbed_devices["dut"]
+
+    loganalyzer = LogAnalyzer(ansible_host=ans_host, marker_prefix='turn_on_off_psu_and_check_psustatus')
+    loganalyzer.load_common_config()
+
+    loganalyzer.ignore_regex.append("Error getting sensor data: dps460.*Kernel interface error")
+    marker = loganalyzer.init()
 
     psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
 
@@ -251,6 +258,8 @@ def test_turn_on_off_psu_and_check_psustatus(testbed_devices, psu_controller):
 
     for psu in psu_test_results:
         assert psu_test_results[psu], "Test psu status of PSU %s failed" % psu
+
+    loganalyzer.analyze(marker)
 
 
 def parse_platform_summary(raw_input_lines):


### PR DESCRIPTION
Summary:
Ignore error message in test_turn_on_off_psu_and_check_psustatus
The logic of the test is:
1. to turn off and then on some of the PSU
2. to check the status of PSU and check whether the info aligns with the status of PSU.
However, there is a background daemon sensord which is running and fetching sensors periodically. With PSU turned off, its sensors are inaccessible, causing those errors.
We're going to ignore the log for now and check whether it's possible and necessary to find a solution for sensord to ignore the shutdown PSU during polling sensors.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
