### PR TITLE
[advanced-reboot] The destination IP address of the packet chosen by the ansible script match static route of vlan100 sometimes, which will result in the error.

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -41,6 +41,18 @@
       vars:
         supervisor_host: "{{ ptf_host }}"
 
+    - include_vars: "vars/topo_{{testbed_type}}.yml"
+
+    - name: Expand properties into props
+      set_fact: props="{{configuration_properties['common']}}"
+      when: testbed_type in ['t0', 't0-56', 't0-64', 't0-116', 't0-64-32']
+
+    # Generate route file
+    - name: Generate route-port map information
+      template: src=roles/test/templates/fib.j2
+            dest=/root/fib_info.txt
+      delegate_to: "{{ptf_host}}"
+
     - include_tasks: ptf_runner.yml
       vars:
         ptf_test_name: Advanced-reboot test
@@ -58,9 +70,9 @@
         - portchannel_ports_file=\"/tmp/portchannel_interfaces.json\"
         - vlan_ports_file=\"/tmp/vlan_interfaces.json\"
         - ports_file=\"/tmp/ports.json\"
+        - fib_info=\"/root/fib_info.txt\"
         - dut_mac='{{ dut_mac }}'
         - dut_vlan_ip='192.168.0.1'
-        - default_ip_range='192.168.0.0/16'
         - vlan_ip_range='{{ vlan_ip_range }}'
         - lo_v6_prefix='{{ lo_v6_prefix }}'
         - arista_vms=\"['{{ vm_hosts | list | join("','") }}']\"

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -6,7 +6,7 @@
 ::/0 {% for ifname, v in minigraph_neighbors.iteritems() %}
 {% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
-{% elif testbed_type == 't0' or testbed_type == 't0-52'or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-64-32' %}
+{% elif testbed_type == 't0'or testbed_type == 't0-16' or testbed_type == 't0-52' or testbed_type == 't0-56' or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-64-32' or testbed_type == 't0-116' %}
 0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
@@ -16,9 +16,6 @@
 {% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
 0.0.0.0/0 [0 1] [4 5] [16 17] [20 21]
 ::/0 [0 1] [4 5] [16 17] [20 21]
-{% elif testbed_type == 't0-116' %}
-0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
-::/0 [24 25] [26 27] [28 29] [30 31]
 {% endif %}
 {#routes to uplink#}
 {#Limit the number of podsets and subnets to be covered to limit script execution time#}
@@ -42,7 +39,7 @@
 {% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
 192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 [0 1] [4 5] [16 17] [20 21]
 20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 [0 1] [4 5] [16 17] [20 21]
-{% elif testbed_type == 't0' or testbed_type == 't0-52' or testbed_type == 't0-64' or testbed_type == 't0-64-32' %}
+{% elif testbed_type == 't0' or testbed_type == 't0-16' or testbed_type == 't0-52' or testbed_type == 't0-56' or testbed_type == 't0-64' or testbed_type == 't0-64-32' or testbed_type == 't0-116' %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}
@@ -60,21 +57,6 @@
 {{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{% endif %}
-{% elif testbed_type == 't0-116' %}
-{% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
-                  (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
-                  (subnet * props.tor_subnet_size) ) %}
-{% set octet2 = (168 + ((suffix // (256 ** 2)))) %}
-{% set octet1 = (192 + (octet2 // 256)) %}
-{% set octet2 = (octet2 % 256) %}
-{% set octet3 = ((suffix // 256) % 256) %}
-{% set octet4 = (suffix % 256) %}
-{% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
-{# Skip 192.168.0.0 as it is in Vlan1000 subnet  #}
-{% if octet2 != 168 and octet3 != 0 and octet4 != 0 %}
-{{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} [24 25] [26 27] [28 29] [30 31]
-{{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 [24 25] [26 27] [28 29] [30 31]
 {% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
One of dataplane traffic is sent from VLAN interfaces to portchannel ports. The destination IP address of the packet is chosen randomly from valid choices. The found that destination IP address traffic chosen by the ansible script match static route of vlan100 sometimes, which will result in the error.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Modify the algorithm to choose the destination IP from the given route entries in the fib database.
The generate dst_ip flow is shown below.
1.Traverse through all of the route entries in the fib and keep the route entries with the desired next hop in a list
2.Emits an error when the list created in the Step 1 is empty.
3.Choose a route entry randomly from the list created in the Step 1.
4.Choose a ip based on the route entry chosen in the Step 3.
#### How did you verify/test it?
Ran the warm-reboot, fast-reboot,warm-reboot-sad-vlan-port and warm-reboot-sad-lag-member test on t0/t0-64 topology and it passed. Check the destination IP address of the from server to T1 traffic in test logs not match static route of vlan1000.

Ran the others warm-reboot-sad-xxx and test item on t0/t0-64 topology. Check the destination IP address of the from server to T1 traffic in test logs not match static route of vlan1000.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
