### PR TITLE
Flush ptf rx buffer before ptf send packet.

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -307,6 +307,7 @@ class Vxlan(BaseTest):
         exp_packet = Mask(exp_packet)
         exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
 
+        self.dataplane.flush()
         for i in xrange(self.nr):
             testutils.send_packet(self, acc_port, packet)
         nr_rcvd = testutils.count_matched_packets_all_ports(self, exp_packet, pc_ports, timeout=0.5)
@@ -339,6 +340,7 @@ class Vxlan(BaseTest):
                          ip_ttl = 63,
                        )
 
+        self.dataplane.flush()
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
         nr_rcvd = testutils.count_matched_packets(self, exp_packet, acc_port, timeout=0.5)
@@ -376,6 +378,8 @@ class Vxlan(BaseTest):
                        vxlan_vni=test['vni'],
                        inner_frame=inpacket
                  )
+
+        self.dataplane.flush()
         for i in xrange(self.nr):
             testutils.send_packet(self, net_port, packet)
         nr_rcvd = testutils.count_matched_packets(self, inpacket, acc_port, timeout=0.5)


### PR DESCRIPTION
### Description of PR
I tried to dump packet on testbed server, it only spend 0.000029 seconds.
vxlan sometimes fails with t0-64 or t0-56 topology.
I modify ptf code to check how many packets ptf received in 500ms in both failed and passed case.
In the passed test case, the ptf received less than 100 packets
In the failed test case, the ptf received about 1800 packets before receiving expected packets
It has queued too many unnecessary packets in rx buffer.

Summary:
Flush ptf rx buffer before ptf sending packet to reduce rx buffer queuing many unnecessary packets.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [+ ] Test case(new/improvement)

### Approach
#### How did you do it?
Flush ptf rx buffer before ptf send packet
#### How did you verify/test it?
run vlxan test case on boadcom

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
