### PR TITLE
[telemetry certs] deploy certs for telemetry in deploy-mg

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -41,47 +41,72 @@
           state: directory
       become: true
 
+    - name: Init telemetry keys
+      set_fact:
+          server_key: ""
+          server_csr: ""
+          dsmsroot_key: ""
+          dsmsroot_csr: ""
+
+    - name: read server key
+      set_fact:
+          server_key: "{{ telemetry_certs['server_key'] }}"
+      when: telemetry_certs['server_key'] is defined
+
+    - name: read server csr
+      set_fact:
+          server_csr: "{{ telemetry_certs['server_csr'] }}"
+      when: telemetry_certs['server_csr'] is defined
+
+    - name: read dsmsroot key
+      set_fact:
+          dsmsroot_key: "{{ telemetry_certs['dsmsroot_key'] }}"
+      when: telemetry_certs['dsmsroot_key'] is defined
+
+    - name: read dsmsroot csr
+      set_fact:
+          dsmsroot_csr: "{{ telemetry_certs['dsmsroot_csr'] }}"
+      when: telemetry_certs['dsmsroot_csr'] is defined
+
     - name: Create telemetry server private key
       openssl_privatekey:
-          path: /etc/sonic/telemetry/streamingtelemetryserver.key
+          path: "{{ server_key }}"
           size: 2048
       become: true 
 
     - name: create telemetry server csr
       openssl_csr:
-          path: /etc/sonic/telemetry/streamingtelemetryserver.csr
-          privatekey_path: /etc/sonic/telemetry/streamingtelemetryserver.key
+          path: "{{ server_csr }}"
+          privatekey_path: "{{ server_key }}"
       become: true
     
     - name: Generate a Self Signed OpenSSL telemetry server certificate
       openssl_certificate:
           path: /etc/sonic/telemetry/streamingtelemetryserver.cer
-          privatekey_path: /etc/sonic/telemetry/streamingtelemetryserver.key
-          csr_path: /etc/sonic/telemetry/streamingtelemetryserver.csr
-          subject:
-              commonName: ndastreamingservertest.osdinfra.net
+          privatekey_path: "{{ server_key }}"
+          csr_path: "{{ server_csr }}"
           provider: selfsigned
       become: true
 
     - name: Create telemetry dsmsroot private key
       openssl_privatekey:
-          path: /etc/sonic/telemetry/dsmsroot.key
+          path: "{{ dsmsroot_key }}"
           size: 2048
       become: true
    
     - name: create telemetry dsmsroot csr
       openssl_csr:
-          path: /etc/sonic/telemetry/dsmsroot.csr
-          privatekey_path: /etc/sonic/telemetry/dsmsroot.key
+          path: "{{ dsmsroot_csr }}"
+          privatekey_path: "{{ dsmsroot_key }}"
       become: true
     
     - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
       openssl_certificate:
           path: /etc/sonic/telemetry/dsmsroot.cer
-          privatekey_path: /etc/sonic/telemetry/dsmsroot.key
-          csr_path: /etc/sonic/telemetry/dsmsroot.csr
+          privatekey_path: "{{ dsmsroot_key }}"
+          csr_path: "{{ dsmsroot_csr }}"
           subject:
-              commonName: ndastreamingservertest.osdinfra.net
+              commonName: ndastreamingclienttest.osdinfra.net
           provider: selfsigned
       become: true
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -35,6 +35,56 @@
   tasks:
 
   - block:
+    - name: Creates telemetry directory
+      file:
+          path: /etc/sonic/telemetry
+          state: directory
+      become: true
+
+    - name: Create telemetry server private key
+      openssl_privatekey:
+          path: /etc/sonic/telemetry/streamingtelemetryserver.key
+          size: 2048
+      become: true 
+
+    - name: create telemetry server csr
+      openssl_csr:
+          path: /etc/sonic/telemetry/streamingtelemetryserver.csr
+          privatekey_path: /etc/sonic/telemetry/streamingtelemetryserver.key
+      become: true
+    
+    - name: Generate a Self Signed OpenSSL telemetry server certificate
+      openssl_certificate:
+          path: /etc/sonic/telemetry/streamingtelemetryserver.cer
+          privatekey_path: /etc/sonic/telemetry/streamingtelemetryserver.key
+          csr_path: /etc/sonic/telemetry/streamingtelemetryserver.csr
+          subject:
+              commonName: ndastreamingservertest.osdinfra.net
+          provider: selfsigned
+      become: true
+
+    - name: Create telemetry dsmsroot private key
+      openssl_privatekey:
+          path: /etc/sonic/telemetry/dsmsroot.key
+          size: 2048
+      become: true
+   
+    - name: create telemetry dsmsroot csr
+      openssl_csr:
+          path: /etc/sonic/telemetry/dsmsroot.csr
+          privatekey_path: /etc/sonic/telemetry/dsmsroot.key
+      become: true
+    
+    - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
+      openssl_certificate:
+          path: /etc/sonic/telemetry/dsmsroot.cer
+          privatekey_path: /etc/sonic/telemetry/dsmsroot.key
+          csr_path: /etc/sonic/telemetry/dsmsroot.csr
+          subject:
+              commonName: ndastreamingservertest.osdinfra.net
+          provider: selfsigned
+      become: true
+
     - name: set default testbed file
       set_fact:
         testbed_file: testbed.csv

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -45,8 +45,11 @@
       set_fact:
           server_key: ""
           server_csr: ""
+          server_cer: ""
           dsmsroot_key: ""
           dsmsroot_csr: ""
+          dsmsroot_cer: ""
+          dir_path: ""
 
     - name: read server key
       set_fact:
@@ -57,6 +60,11 @@
       set_fact:
           server_csr: "{{ telemetry_certs['server_csr'] }}"
       when: telemetry_certs['server_csr'] is defined
+ 
+    - name: read server cer
+      set_fact:
+          server_cer: "{{ telemetry_certs['server_cer'] }}"
+      when: telemetry_certs['server_cer'] is defined
 
     - name: read dsmsroot key
       set_fact:
@@ -68,6 +76,16 @@
           dsmsroot_csr: "{{ telemetry_certs['dsmsroot_csr'] }}"
       when: telemetry_certs['dsmsroot_csr'] is defined
 
+    - name: read dsmsroot cer
+      set_fact:
+          dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"
+      when: telemetry_certs['dsmsroot_cer'] is defined
+
+    - name: read directory path
+      set_fact:
+          dir_path: "{{ telemetry_certs['dir_path'] }}"
+      when: telemetry_certs['dir_path'] is defined
+
     - name: Create telemetry server private key
       openssl_privatekey:
           path: "{{ server_key }}"
@@ -76,13 +94,13 @@
 
     - name: create telemetry server csr
       openssl_csr:
-          path: "{{ server_csr }}"
+          path: "{{ telemetry_certs['server_csr'] }}"
           privatekey_path: "{{ server_key }}"
       become: true
     
     - name: Generate a Self Signed OpenSSL telemetry server certificate
       openssl_certificate:
-          path: /etc/sonic/telemetry/streamingtelemetryserver.cer
+          path: "{{ server_cer }}"
           privatekey_path: "{{ server_key }}"
           csr_path: "{{ server_csr }}"
           provider: selfsigned
@@ -102,7 +120,7 @@
     
     - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
       openssl_certificate:
-          path: /etc/sonic/telemetry/dsmsroot.cer
+          path: "{{ dsmsroot_cer }}"
           privatekey_path: "{{ dsmsroot_key }}"
           csr_path: "{{ dsmsroot_csr }}"
           subject:
@@ -130,7 +148,34 @@
       set_fact:
         vm_base: "{{ testbed_facts['vm_base'] }}"
       when: "testbed_facts['vm_base'] != ''"
-    when: testbed_name is defined
+      when: testbed_name is defined
+
+    - name: Set ptf_host
+      set_fact:
+        ptf_host: "{{ testbed_facts['ptf_ip'] }}"
+
+    - fail: msg="Please set ptf_host first"
+      when: ptf_host is not defined
+
+    - name: create dir on ptfhost
+      file:
+          path: "{{ dir_path }}"
+          state: directory
+      become: true
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Copy certs on ptfhost
+      synchronize:
+          src: "{{ dir_path }}"
+          dest: "{{ dir_path }}"
+      become: true
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Rename dsmsroot.cer to client cer
+      command: mv "{{ dsmsroot_cer }}" "{{ client_cer }}"
+
+    - name: Rename dsmsroot.key to client key
+      command: mv "{{ dsmsroot_key }}" "{{ client_key }}"
 
   - topo_facts: topo={{ topo }}
     delegate_to: localhost

--- a/ansible/group_vars/all/telemetry_certs.yml
+++ b/ansible/group_vars/all/telemetry_certs.yml
@@ -1,0 +1,7 @@
+# Configure telemetry server and dsmsroot key,cer
+
+telemetry_certs:
+    server_key: "/etc/sonic/telemetry/streamingtelemetryserver.key"
+    server_csr: "/etc/sonic/telemetry/streamingtelemetryserver.csr"
+    dsmsroot_key: "/etc/sonic/telemetry/dsmsroot.key"
+    dsmsroot_csr: "/etc/sonic/telemetry/dsmsroot.csr"

--- a/ansible/group_vars/all/telemetry_certs.yml
+++ b/ansible/group_vars/all/telemetry_certs.yml
@@ -3,5 +3,10 @@
 telemetry_certs:
     server_key: "/etc/sonic/telemetry/streamingtelemetryserver.key"
     server_csr: "/etc/sonic/telemetry/streamingtelemetryserver.csr"
+    server_cer: "/etc/sonic/telemetry/streamingtelemetryserver.cer"
     dsmsroot_key: "/etc/sonic/telemetry/dsmsroot.key"
     dsmsroot_csr: "/etc/sonic/telemetry/dsmsroot.csr"
+    dsmsroot_cer: "/etc/sonic/telemetry/dsmsroot.cer"
+    client_key: "/etc/sonic/telemetry/streamingtelemetryclient.key"
+    client_cer: "/etc/sonic/telemetry/streamingtelemetryclient.cer"
+    dir_path: "/etc/sonic/telemetry"


### PR DESCRIPTION
### Description of PR
Adding server and dsmsroot certs to start telemetry in auth mode

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
using deploy-mg on virtual test bed 
![image](https://user-images.githubusercontent.com/49077256/80289438-47eb4f80-86f3-11ea-9d3d-1f82dc0c9580.png)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
