### PR TITLE
[pytest]: add get_ip_route_info in SonicHost

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -1,6 +1,4 @@
 import ipaddress
-import re
-import pytest
 import logging
 from common.helpers.assertions import pytest_assert
 

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -7,34 +7,9 @@ from common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 def test_default_route_set_src(duthost):
-    """check if ipv4 and ipv6 default src address match Loopback0 address
+    """
+    check if ipv4 and ipv6 default src address match Loopback0 address
 
-admin@vlab-01:~$ ip route list match 0.0.0.0
-default proto bgp src 10.1.0.32 metric 20
-        nexthop via 10.0.0.57 dev PortChannel0001 weight 1
-        nexthop via 10.0.0.59 dev PortChannel0002 weight 1
-        nexthop via 10.0.0.61 dev PortChannel0003 weight 1
-        nexthop via 10.0.0.63 dev PortChannel0004 weight 1
-
-admin@vlab-01:~$ ip -6 route list match ::
-default proto bgp src fc00:1::32 metric 20
-        nexthop via fc00::72 dev PortChannel0001 weight 1
-        nexthop via fc00::76 dev PortChannel0002 weight 1
-        nexthop via fc00::7a dev PortChannel0003 weight 1
-        nexthop via fc00::7e dev PortChannel0004 weight 1 pref medium
-
-============ 4.9 kernel ===============
-admin@vlab-01:~$ ip route list match 0.0.0.0
-default proto 186 src 10.1.0.32 metric 20
-        nexthop via 10.0.0.57  dev PortChannel0001 weight 1
-        nexthop via 10.0.0.59  dev PortChannel0002 weight 1
-        nexthop via 10.0.0.61  dev PortChannel0003 weight 1
-        nexthop via 10.0.0.63  dev PortChannel0004 weight 1
-admin@vlab-01:~$ ip -6 route list match ::
-default via fc00::72 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
-default via fc00::76 dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
-default via fc00::7a dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
-default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
     """
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -55,53 +30,24 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
     pytest_assert(lo_ipv4, "cannot find ipv4 Loopback0 address")
     pytest_assert(lo_ipv6, "cannot find ipv6 Loopback0 address")
 
-    rt = duthost.command("ip route list match 0.0.0.0")['stdout_lines']
-    m = re.match(r"^default proto (bgp|186) src (\S+)", rt[0])
-    if m:
-        pytest_assert(ipaddress.ip_address(m.group(2)) == lo_ipv4.ip, \
-            "default route set src to wrong IP {} != {}".format(m.group(1), lo_ipv4.ip))
-    else:
-        pytest.fail("default route do not have set src. {}".format(rt))
+    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(u"0.0.0.0"))
+    pytest_assert(rtinfo['set_src'], "default route do not have set src. {}".format(rtinfo))
+    pytest_assert(rtinfo['set_src'] == lo_ipv4.ip, \
+            "default route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv4.ip))
 
-    rt = duthost.command("ip -6 route list match ::")['stdout_lines']
-    m = re.match(r"^default proto bgp src (\S+)", rt[0])
-    m1 = re.match(r"default via (\S+) dev (\S+) proto 186 src (\S+)", rt[0])
-    if m:
-        pytest_assert(ipaddress.ip_address(m.group(1)) == lo_ipv6.ip, \
-            "default route set src to wrong IP {} != {}".format(m.group(1), lo_ipv6.ip))
-    elif m1:
-        pytest_assert(ipaddress.ip_address(m1.group(3)) == lo_ipv6.ip, \
-            "default route set src to wrong IP {} != {}".format(m1.group(3), lo_ipv6.ip))
-    else:
-        pytest.fail("default route do not have set src. {}".format(rt))
+    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(u"::"))
+    pytest_assert(rtinfo['set_src'], "default v6 route do not have set src. {}".format(rtinfo))
+    pytest_assert(rtinfo['set_src'] == lo_ipv6.ip, \
+            "default v6 route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv6.ip))
 
 def test_default_ipv6_route_next_hop_global_address(duthost):
-    """check if ipv6 default route nexthop address uses global address
-
-admin@vlab-01:~$ ip -6 route list match ::
-default proto bgp src fc00:1::32 metric 20
-        nexthop via fc00::72 dev PortChannel0001 weight 1
-        nexthop via fc00::76 dev PortChannel0002 weight 1
-        nexthop via fc00::7a dev PortChannel0003 weight 1
-        nexthop via fc00::7e dev PortChannel0004 weight 1 pref medium
-
-============ 4.9 kernel ===============
-admin@vlab-01:~$ ip -6 route list match ::
-default via fc00::72 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
-default via fc00::76 dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
-default via fc00::7a dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
-default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
+    """
+    check if ipv6 default route nexthop address uses global address
 
     """
 
-    rt = duthost.command("ip -6 route list match ::")['stdout_lines']
-    logger.info("default ipv6 route {}".format(rt))
-    found_nexthop_via = False
-    for l in rt:
-        m = re.search(r"(default|nexthop) via (\S+)", l)
-        if m:
-            found_nexthop_via = True
-            pytest_assert(not ipaddress.ip_address(m.group(2)).is_link_local, \
-                "use link local address {} for nexthop".format(m.group(2)))
-
-    pytest_assert(found_nexthop_via, "cannot find ipv6 nexthop for default route {}".format(rt))
+    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(u"::"))
+    pytest_assert(rtinfo['nexthops'] > 0, "cannot find ipv6 nexthop for default route")
+    for nh in rtinfo['nexthops']:
+        pytest_assert(not nh[0].is_link_local, \
+                "use link local address {} for nexthop".format(nh[0]))


### PR DESCRIPTION
get_ip_route_info returns ip route info in the kernel
for a given destination ip

refactor test_default_route to use the new method

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
add get_ip_route_info in SonicHost

#### How did you verify/test it?
```
johnar@1cafe0c9f994:/data/tests$ py.test $PYTEST_COMMON_OPTS --log-file ~/abc.log route/test_default_route.py  | tee ~/abc.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... collected 2 items

route/test_default_route.py::test_default_route_set_src PASSED           [ 50%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address PASSED [100%]

=============================== warnings summary ===============================
```
#### Any platform specific information?
platform independent

#### Supported testbed topology if it's a new test case?
topology independent

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
