### PR TITLE
[loganalyzer] Fail flag support in context manager and callback execution

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -52,6 +52,9 @@ class LogAnalyzer:
         self.ansible_host.command(cmd)
 
     def __call__(self, **kwargs):
+        """
+        Pass additional arguments when the instance is called
+        """
         self.fail = kwargs.get("fail", True)
         return self
 

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -36,6 +36,7 @@ class LogAnalyzer:
         self.expect_regex = []
         self.ignore_regex = []
         self._markers = []
+        self.fail = True
 
     def _add_end_marker(self, marker):
         """
@@ -50,6 +51,10 @@ class LogAnalyzer:
         logging.debug("Adding end marker '{}'".format(marker))
         self.ansible_host.command(cmd)
 
+    def __call__(self, **kwargs):
+        self.fail = kwargs.get("fail", True)
+        return self
+
     def __enter__(self):
         """
         Store start markers which are used in analyze phase.
@@ -60,7 +65,7 @@ class LogAnalyzer:
         """
         Analyze syslog messages.
         """
-        self.analyze(self._markers.pop())
+        self.analyze(self._markers.pop(), fail=self.fail)
 
     def _verify_log(self, result):
         """
@@ -108,13 +113,14 @@ class LogAnalyzer:
         @return: Callback execution result
         """
         marker = self.init()
+        fail = kwargs.pop("fail", True)
         try:
             call_result = callback(*args, **kwargs)
         except Exception as err:
             logging.error("Error during callback execution:\n{}".format(err))
-            logging.debug("Log analysis result\n".format(self.analyze(marker)))
+            logging.debug("Log analysis result\n".format(self.analyze(marker, fail=fail)))
             raise err
-        self.analyze(marker)
+        self.analyze(marker, fail=fail)
 
         return call_result
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Loganalyzer class currently lacks the ability to pass in the 'fail' flag setting when used as a context manager or using the 'run_cmd' for callback execution. This PR adds that fix.

### Type of change
- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Tested all forms of invocation and they all work as expected
  1) with loganalyzer:
  2) with loganalyzer(fail=False):
  3) loganalyer.analyze(marker, fail=False)
  4) loganalyzer.run_cmd(exec_func, func_args, fail=False)
  5) loganalyzer.run_cmd(exec_func, func_args)
