### PR TITLE
[fast-reboot]: Fix IP range overlapping

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -61,7 +61,7 @@
         - ports_file=\"/tmp/ports.json\"
         - dut_mac='{{ dut_mac }}'
         - dut_vlan_ip='192.168.0.1'
-        - default_ip_range='192.168.0.0/16'
+        - default_ip_range='192.168.100.0/18'
         - vlan_ip_range='{{ vlan_ip_range }}'
         - lo_v6_prefix='{{ lo_v6_prefix }}'
         - arista_vms=\"['{{ vm_hosts | list | join("','") }}']\"


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:

Fast-Reboot test uses random generator to pick up an arbitrary IP address from the `default_ip_range` subnet:
https://github.com/Azure/sonic-mgmt/blob/201811/ansible/roles/test/files/ptftests/advanced-reboot.py#L504
Sometimes it may overlap with the DUT VLAN IP subnet which will result in packet drops:
```
root@6aad39fed86f:~# ./run.sh
WARNING: No route found for IPv6 destination :: (no default route?)
advanced-reboot.ReloadTest ... 2020-04-29 16:04:44 : Converted addresses VMs: ['10.9.78.183', '10.9.78.182', '10.9.78.181', '10.9.78.180']
2020-04-29 16:04:44 : Test params:
2020-04-29 16:04:44 : DUT ssh: admin@sonic
2020-04-29 16:04:44 : DUT reboot limit in seconds: 0:00:30
2020-04-29 16:04:44 : DUT mac address: 7c:fe:90:f5:36:40
2020-04-29 16:04:44 : From server src addr: 192.168.1.214
2020-04-29 16:04:44 : From server src port: 15
2020-04-29 16:04:44 : From server dst addr: 192.168.7.69
2020-04-29 16:04:44 : From server dst ports: [28, 30, 29, 31]
2020-04-29 16:04:44 : From upper layer number of packets: 500
2020-04-29 16:04:44 : VMs: ['10.9.78.183','10.9.78.182','10.9.78.181','10.9.78.180']
2020-04-29 16:04:44 : Disabling arp_responder
```

DUT IP config:
```
root@sonic:/home/admin# show ip interfaces
Interface        IPv4 address/mask    Admin/Oper
---------------  -------------------  ------------
PortChannel0001  10.0.0.56/31         up/down
PortChannel0002  10.0.0.58/31         up/down
PortChannel0003  10.0.0.60/31         up/down
PortChannel0004  10.0.0.62/31         up/down
Vlan1000         192.168.0.1/21       up/down
docker0          240.127.1.1/24       up/down
eth0             10.9.74.46/24        up/up
lo               127.0.0.1/8          up/up
                 10.1.0.32/32
```

VLAN IP:
```
Address:   192.168.0.1           11000000.10101000.00000 000.00000001
Netmask:   255.255.248.0 = 21    11111111.11111111.11111 000.00000000
Wildcard:  0.0.7.255             00000000.00000000.00000 111.11111111
=>
Network:   192.168.0.0/21        11000000.10101000.00000 000.00000000 (Class C)
Broadcast: 192.168.7.255         11000000.10101000.00000 111.11111111
HostMin:   192.168.0.1           11000000.10101000.00000 000.00000001
HostMax:   192.168.7.254         11000000.10101000.00000 111.11111110
Hosts/Net: 2046                  (Private Internet)
```

FAST-REBOOT VLAN IP range (old):
```
Address:   192.168.0.0           11000000.10101000 .00000000.00000000
Netmask:   255.255.0.0 = 16      11111111.11111111 .00000000.00000000
Wildcard:  0.0.255.255           00000000.00000000 .11111111.11111111
=>
Network:   192.168.0.0/16        11000000.10101000 .00000000.00000000 (Class C)
Broadcast: 192.168.255.255       11000000.10101000 .11111111.11111111
HostMin:   192.168.0.1           11000000.10101000 .00000000.00000001
HostMax:   192.168.255.254       11000000.10101000 .11111111.11111110
Hosts/Net: 65534                 (Private Internet)
```

FAST-REBOOT VLAN IP range (new):
```
Address:   192.168.100.0         11000000.10101000.01 100100.00000000
Netmask:   255.255.192.0 = 18    11111111.11111111.11 000000.00000000
Wildcard:  0.0.63.255            00000000.00000000.00 111111.11111111
=>
Network:   192.168.64.0/18       11000000.10101000.01 000000.00000000 (Class C)
Broadcast: 192.168.127.255       11000000.10101000.01 111111.11111111
HostMin:   192.168.64.1          11000000.10101000.01 000000.00000001
HostMax:   192.168.127.254       11000000.10101000.01 111111.11111110
Hosts/Net: 16382                 (Private Internet)
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
* Fixed `default_ip_range` subnet

#### How did you verify/test it?
1. Run fast-reboot test

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
* N/A