### PR TITLE
[pytest/ntp] Use local time when testbed is behind proxy

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -10,8 +10,11 @@ pytestmark = [
 ]
 
 @pytest.fixture(scope="module")
-def setup_ntp(ptfhost, duthost):
+def setup_ntp(ptfhost, duthost, creds):
     """setup ntp client and server"""
+    if creds.get('proxy_env'):
+        # If testbed is behaind proxy then force ntpd inside ptf use local time
+        ptfhost.lineinfile(path="/etc/ntp.conf", line="server 127.127.1.0 prefer")
 
     # enable ntp server
     ptfhost.service(name="ntp", state="started")
@@ -31,7 +34,6 @@ def setup_ntp(ptfhost, duthost):
 
     # stop ntp server
     ptfhost.service(name="ntp", state="stopped")
-
     # reset ntp client configuration
     duthost.command("sudo config ntp del %s" % ptfip)
     for ntp_server in ntp_servers:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
When testbed is behind a proxy then NTP inside the ptf container cant synchronize with public NTP servers and test hung on `ntpd -gq` command

Summary: Use the local time instead of public NTP servers in the ptf container when the testbed is behind a proxy.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Change NTP config inside ptf container to prefer a local time when proxy configured 
#### How did you verify/test it?

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
