### PR TITLE
Add support of specifying multiple inventory files

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -13,9 +13,21 @@ def conn_graph_facts(duthost, testbed_devices):
     if os.path.exists(inv_mapping_file):
         with open(inv_mapping_file) as fd:
             inv_map = json.load(fd)
-        inv_file = duthost.host.options['inventory'].split('/')[-1]
-        if inv_map and inv_file in inv_map:
-            lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/{}".format(inv_map[inv_file]))
+        inv_opt = duthost.host.options['inventory']
+        inv_files = []
+        if isinstance(inv_opt, str):
+            inv_files = (duthost.host.options['inventory'])  # Make it iterable for later use
+        elif isinstance(inv_opt, list) or isinstance(inv_opt, tuple):
+            inv_files = duthost.host.options['inventory']
 
-            conn_graph_facts = localhost.conn_graph_facts(host=duthost.hostname, filename=lab_conn_graph_file)['ansible_facts']
+        for inv_file in inv_files:
+            inv_file = os.path.basename(inv_file)
+
+            # Loop through the list of inventory files supplied in --inventory argument.
+            # For the first inventory file that has a mapping in inv_mapping.json, return
+            # its conn_graph_facts.
+            if inv_map and inv_file in inv_map:
+                lab_conn_graph_file = os.path.join(base_path, "../../../ansible/files/{}".format(inv_map[inv_file]))
+                conn_graph_facts = localhost.conn_graph_facts(host=duthost.hostname, filename=lab_conn_graph_file)['ansible_facts']
+                return conn_graph_facts
     return conn_graph_facts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,28 @@ def pytest_addoption(parser):
                     help="number of minutes for show techsupport command")
 
 
+@pytest.fixture(scope="session", autouse=True)
+def enhance_inventory(request):
+    """
+    This fixture is to enhance the capability of parsing the value of pytest cli argument '--inventory'.
+    The pytest-ansible plugin always assumes that the value of cli argument '--inventory' is a single
+    inventory file. With this enhancement, we can pass in multiple inventory files using the cli argument
+    '--inventory'. The multiple inventory files can be separated by comma ','.
+
+    For example:
+        pytest --inventory "inventory1, inventory2" <other arguments>
+        pytest --inventory inventory1,inventory2 <other arguments>
+
+    This fixture is automatically applied, you don't need to declare it in your test script.
+    """
+    inv_opt = request.config.getoption("ansible_inventory")
+    inv_files = [inv_file.strip() for inv_file in inv_opt.split(",")]
+    try:
+        setattr(request.config.option, "ansible_inventory", inv_files)
+    except AttributeError:
+        logger.error("Failed to set enhanced 'ansible_inventory' to request.config.option")
+
+
 @pytest.fixture(scope="session")
 def testbed(request):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The pytest-ansible plugin always assumes that the value
of cli argument '--inventory' is a single inventory file.
With this enhancement, we can pass in multiple inventory
files using the cli argument '--inventory'. The multiple
inventory files can be separated by comma ','.

For example:
        pytest --inventory "inventory1, inventory2" <other arguments>
        pytest --inventory inventory1,inventory2 <other arguments>

This PR is an alternative approach to fix the issue addressed by PR https://github.com/Azure/sonic-mgmt/pull/1594

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Added an auto used fixture to enhance the capability of interpreting the value of pytest cli argument '--inventory'.

#### How did you verify/test it?
Run test scripts that depends on multiple inventory files by specifying multiple inventory files from command line:
```
py.test --inventory "../ansible/veos, ../ansible/inventory" --host-pattern all --testbed example_testbed_t0 --testbed_file ../ansible/testbed.csv --show-capture no --log-cli-level debug test_nbr_health.py
```

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
