### PR TITLE
[sensors] Added support of Montara and Maverics platforms

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2189,6 +2189,92 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
+  x86_64-accton_wedge100bf_65x-r0:
+    alarms:
+      fan: []
+      power: []
+      temp: []
+
+    compares:
+      fan: []
+      power: []
+      temp:
+      - - tmp75-i2c-3-48/Outlet Middle Temp/temp1_input
+        - tmp75-i2c-3-48/Outlet Middle Temp/temp1_max
+      - - tmp75-i2c-3-49/Inlet Middle Temp/temp1_input
+        - tmp75-i2c-3-49/Inlet Middle Temp/temp1_max
+      - - tmp75-i2c-3-4a/Inlet Left Temp/temp1_input
+        - tmp75-i2c-3-4a/Inlet Left Temp/temp1_max
+      - - tmp75-i2c-3-4b/Switch Temp/temp1_input
+        - tmp75-i2c-3-4b/Switch Temp/temp1_max
+      - - tmp75-i2c-3-4c/Inlet Right Temp/temp1_input
+        - tmp75-i2c-3-4c/Inlet Right Temp/temp1_max
+      - - tmp75-i2c-8-48/Outlet Right Temp/temp1_input
+        - tmp75-i2c-8-48/Outlet Right Temp/temp1_max
+      - - tmp75-i2c-8-49/Outlet Left Temp/temp1_input
+        - tmp75-i2c-8-49/Outlet Left Temp/temp1_max
+
+    non_zero:
+      fan:
+      - fancpld-i2c-8-33/Fan 1 front/fan1_input
+      - fancpld-i2c-8-33/Fan 1 rear/fan2_input
+      - fancpld-i2c-8-33/Fan 2 front/fan3_input
+      - fancpld-i2c-8-33/Fan 2 rear/fan4_input
+      - fancpld-i2c-8-33/Fan 3 front/fan5_input
+      - fancpld-i2c-8-33/Fan 3 rear/fan6_input
+      - fancpld-i2c-8-33/Fan 4 front/fan7_input
+      - fancpld-i2c-8-33/Fan 4 rear/fan8_input
+      - fancpld-i2c-8-33/Fan 5 front/fan9_input
+      - fancpld-i2c-8-33/Fan 5 rear/fan10_input
+
+      power: []
+      temp: []
+
+    psu_skips: {}
+
+  x86_64-accton_wedge100bf_32x-r0:
+    alarms:
+      fan: []
+      power: []
+      temp: []
+
+    compares:
+      fan: []
+      power: []
+      temp:
+      - - tmp75-i2c-3-48/Outlet Middle Temp/temp1_input
+        - tmp75-i2c-3-48/Outlet Middle Temp/temp1_max
+      - - tmp75-i2c-3-49/Inlet Middle Temp/temp1_input
+        - tmp75-i2c-3-49/Inlet Middle Temp/temp1_max
+      - - tmp75-i2c-3-4a/Inlet Left Temp/temp1_input
+        - tmp75-i2c-3-4a/Inlet Left Temp/temp1_max
+      - - tmp75-i2c-3-4b/Switch Temp/temp1_input
+        - tmp75-i2c-3-4b/Switch Temp/temp1_max
+      - - tmp75-i2c-3-4c/Inlet Right Temp/temp1_input
+        - tmp75-i2c-3-4c/Inlet Right Temp/temp1_max
+      - - tmp75-i2c-8-48/Outlet Right Temp/temp1_input
+        - tmp75-i2c-8-48/Outlet Right Temp/temp1_max
+      - - tmp75-i2c-8-49/Outlet Left Temp/temp1_input
+        - tmp75-i2c-8-49/Outlet Left Temp/temp1_max
+
+    non_zero:
+      fan:
+      - fancpld-i2c-8-33/Fan 1 front/fan1_input
+      - fancpld-i2c-8-33/Fan 1 rear/fan2_input
+      - fancpld-i2c-8-33/Fan 2 front/fan3_input
+      - fancpld-i2c-8-33/Fan 2 rear/fan4_input
+      - fancpld-i2c-8-33/Fan 3 front/fan5_input
+      - fancpld-i2c-8-33/Fan 3 rear/fan6_input
+      - fancpld-i2c-8-33/Fan 4 front/fan7_input
+      - fancpld-i2c-8-33/Fan 4 rear/fan8_input
+      - fancpld-i2c-8-33/Fan 5 front/fan9_input
+      - fancpld-i2c-8-33/Fan 5 rear/fan10_input
+
+      power: []
+      temp: []
+
+    psu_skips: {}
+
   x86_64-arista_7060_cx32s:
     alarms:
       fan:


### PR DESCRIPTION


Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR
Added support  of Montara and Maverics platforms to sku-sensors-data.yml which makes sensors CT passing for those platforms

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ *] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
