### PR TITLE
[pytest/ACL] fix acl cannot run on t1-64-lag

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -81,7 +81,9 @@ def setup(duthost, testbed):
     port_channels = mg_facts['minigraph_portchannels']
 
     # get the list of port to be combined to ACL tables
-    acl_table_ports += tor_ports
+    if testbed['topo']['name'] in ('t1', 't1-lag'):
+        acl_table_ports += tor_ports
+    
     if testbed['topo']['name'] in ('t1-lag', 't1-64-lag', 't1-64-lag-clet'):
         acl_table_ports += port_channels
     else:

--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -64,5 +64,5 @@ def ptfadapter(ptfhost, testbed):
     ptfhost.command('supervisorctl reread')
     ptfhost.command('supervisorctl update')
 
-    with PtfTestAdapter(testbed['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, len(ifaces_map)) as adapter:
+    with PtfTestAdapter(testbed['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys()) as adapter:
         yield adapter

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -12,17 +12,17 @@ class PtfTestAdapter(BaseTest):
     DEFAULT_PTF_TIMEOUT = 2
     DEFAULT_PTF_NEG_TIMEOUT = 0.1
 
-    def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_ports_num):
+    def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set):
         """ initialize PtfTestAdapter
         :param ptf_ip: PTF host IP
         :param ptf_nn_port: PTF nanomessage agent port
         :param device_num: device number
-        :param ptf_ports_num: PTF ports count
+        :param ptf_port_set: PTF ports
         :return:
         """
         self.runTest = lambda : None # set a no op runTest attribute to satisfy BaseTest interface
         super(PtfTestAdapter, self).__init__()
-        self._init_ptf_dataplane(ptf_ip, ptf_nn_port, device_num, ptf_ports_num)
+        self._init_ptf_dataplane(ptf_ip, ptf_nn_port, device_num, ptf_port_set)
 
     def __enter__(self):
         """ enter in 'with' block """
@@ -34,20 +34,20 @@ class PtfTestAdapter(BaseTest):
 
         self.kill()
 
-    def _init_ptf_dataplane(self, ptf_ip, ptf_nn_port, device_num, ptf_ports_num, ptf_config=None):
+    def _init_ptf_dataplane(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptf_config=None):
         """
         initialize ptf framework and establish connection to ptf_nn_agent
         running on PTF host
         :param ptf_ip: PTF host IP
         :param ptf_nn_port: PTF nanomessage agent port
         :param device_num: device number
-        :param ptf_ports_num: PTF ports count
+        :param ptf_port_set: PTF ports
         :return:
         """
         self.ptf_ip = ptf_ip
         self.ptf_nn_port = ptf_nn_port
         self.device_num = device_num
-        self.ptf_ports_num = ptf_ports_num
+        self.ptf_port_set = ptf_port_set
 
         ptfutils.default_timeout = self.DEFAULT_PTF_TIMEOUT
         ptfutils.default_negative_timeout = self.DEFAULT_PTF_NEG_TIMEOUT
@@ -55,7 +55,7 @@ class PtfTestAdapter(BaseTest):
         ptf.config.update({
             'platform': 'nn',
             'device_sockets': [
-                (device_num, range(ptf_ports_num), 'tcp://{}:{}'.format(ptf_ip, ptf_nn_port))
+                (device_num, ptf_port_set, 'tcp://{}:{}'.format(ptf_ip, ptf_nn_port))
             ],
             'qlen': self.DEFAULT_PTF_QUEUE_LEN,
             'relax': True,
@@ -87,4 +87,4 @@ class PtfTestAdapter(BaseTest):
         :param ptf_config: PTF configuration dictionary
         """
         self.kill()
-        self._init_ptf_dataplane(self.ptf_ip, self.ptf_nn_port, self.device_num, self.ptf_ports_num, ptf_config)
+        self._init_ptf_dataplane(self.ptf_ip, self.ptf_nn_port, self.device_num, self.ptf_port_set, ptf_config)


### PR DESCRIPTION
### Fix ACL failed on t1-64-lag
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: ACL cannot bound normal ports which belong to port-channel on t1-64-lag and dataplane cannot send packet by PTF container

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
1. remove bound normal ports on t1-64-lag from test case, because normal ports only available on t1 or t1-lag.
2. create interfaces of dataplane according interfaces of PTF container.
#### How did you verify/test it?
run test on t1-64-lag show pass
#### Any platform specific information?
no
#### Supported testbed topology if it's a new test case?
t1-64-lag
### Documentation 

