### PR TITLE
[drop counters] Improve support for combined L2/L3 drop counters

### DIFF
--- a/tests/drop_counters/combined_drop_counters.yml
+++ b/tests/drop_counters/combined_drop_counters.yml
@@ -20,6 +20,10 @@
 #   - "x86_64-mlnx"
 #   - "x86_64-dell.*"
 l2_l3:
+    - "x86_64-dell.*"
+    - "x86_64-arista.*"
 
 acl_l2:
     - "x86_64-mlnx"
+    - "x86_64-dell.*"
+    - "x86_64-arista.*"

--- a/tests/drop_counters/test_drop_counters.py
+++ b/tests/drop_counters/test_drop_counters.py
@@ -423,41 +423,35 @@ def verify_drop_counters(duthost, dut_iface, get_cnt_cli_cmd, column_key):
         pytest.fail(fail_msg)
 
 
-def get_receiving_iface(ports_info, tx_dut_ports):
-    """
-    Returns which interface on the DUT to check for drops.
-
-    This method ensures that the correct L2 interface is checked for devices that
-    have combined L2/L3 drop counters.
-    """
-    if COMBINED_L2L3_DROP_COUNTER:
-        return ports_info["dut_iface"]
-
-    return tx_dut_ports[ports_info["dut_iface"]]
-
-
-def base_verification(discard_group, pkt, ptfadapter, duthost, ptf_tx_port_id, dut_iface, l2_col_key=RX_DRP, l3_col_key=RX_ERR):
+def base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_dut_ports=None,
+                      l2_col_key=RX_DRP, l3_col_key=RX_ERR):
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL'
     """
-    send_packets(pkt, duthost, ptfadapter, ptf_tx_port_id)
+    send_packets(pkt, duthost, ptfadapter, ports_info["ptf_tx_port_id"])
     if discard_group == "L2":
-        verify_drop_counters(duthost, dut_iface, GET_L2_COUNTERS, l2_col_key)
+        verify_drop_counters(duthost, ports_info["dut_iface"], GET_L2_COUNTERS, l2_col_key)
         ensure_no_l3_drops(duthost)
     elif discard_group == "L3":
         if COMBINED_L2L3_DROP_COUNTER:
-            verify_drop_counters(duthost, dut_iface, GET_L2_COUNTERS, l2_col_key)
+            verify_drop_counters(duthost, ports_info["dut_iface"], GET_L2_COUNTERS, l2_col_key)
             ensure_no_l3_drops(duthost)
         else:
-            verify_drop_counters(duthost, dut_iface, GET_L3_COUNTERS, l3_col_key)
+            if not tx_dut_ports:
+                pytest.fail("No L3 interface specified")
+
+            verify_drop_counters(duthost, tx_dut_ports[ports_info["dut_iface"]], GET_L3_COUNTERS, l3_col_key)
             ensure_no_l2_drops(duthost)
     elif discard_group == "ACL":
+        if not tx_dut_ports:
+            pytest.fail("No L3 interface specified")
+
         time.sleep(ACL_COUNTERS_UPDATE_INTERVAL)
         acl_drops = duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]["DATAACL"]["rules"]["RULE_1"]["packets_count"]
         if acl_drops != PKT_NUMBER:
             fail_msg = "ACL drop counter was not incremented on iface {}. DUT ACL counter == {}; Sent pkts == {}".format(
-                dut_iface, acl_drops, PKT_NUMBER
+                tx_dut_ports[ports_info["dut_iface"]], acl_drops, PKT_NUMBER
             )
             pytest.fail(fail_msg)
         if not COMBINED_ACL_DROP_COUNTER:
@@ -467,18 +461,18 @@ def base_verification(discard_group, pkt, ptfadapter, duthost, ptf_tx_port_id, d
         pytest.fail("Incorrect 'discard_group' specified. Supported values: 'L2' or 'L3'")
 
 
-def do_test(discard_group, pkt, ptfadapter, duthost, ptf_tx_port_id, dut_iface, sniff_ports, l2_col_key=RX_DRP, l3_col_key=RX_ERR):
+def do_test(discard_group, pkt, ptfadapter, duthost, ports_info, sniff_ports, tx_dut_ports=None,
+            l2_col_key=RX_DRP, l3_col_key=RX_ERR):
     """
     Execute test - send packet, check that expected discard counters were incremented and packet was dropped
     @param discard_group: Supported 'discard_group' values: 'L2', 'L3', 'ACL'
     @param pkt: PTF composed packet, sent by test case
     @param ptfadapter: fixture
     @param duthost: fixture
-    @param ptf_tx_port_id: TX PTF port ID
     @param dut_iface: DUT interface name expected to receive packets from PTF
     @param sniff_ports: DUT ports to check that packets were not egressed from
     """
-    base_verification(discard_group, pkt, ptfadapter, duthost, ptf_tx_port_id, dut_iface, l2_col_key, l3_col_key)
+    base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_dut_ports, l2_col_key, l3_col_key)
 
     # Verify packets were not egresed the DUT
     exp_pkt = expected_packet_mask(pkt)
@@ -506,7 +500,7 @@ def test_equal_smac_dmac_drop(ptfadapter, duthost, setup, fanouthost, pkt_fields
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    do_test("L2", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], ports_info["dut_iface"], setup["neighbor_sniff_ports"])
+    do_test("L2", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"])
 
 
 def test_multicast_smac_drop(ptfadapter, duthost, setup, fanouthost, pkt_fields, ports_info):
@@ -532,7 +526,7 @@ def test_multicast_smac_drop(ptfadapter, duthost, setup, fanouthost, pkt_fields,
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    do_test("L2", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], ports_info["dut_iface"], setup["neighbor_sniff_ports"])
+    do_test("L2", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"])
 
 
 def test_reserved_dmac_drop(ptfadapter, duthost, setup, fanouthost, pkt_fields, ports_info):
@@ -561,7 +555,7 @@ def test_reserved_dmac_drop(ptfadapter, duthost, setup, fanouthost, pkt_fields, 
             tcp_sport=pkt_fields["tcp_sport"],
             tcp_dport=pkt_fields["tcp_dport"])
 
-        do_test("L2", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], ports_info["dut_iface"], setup["neighbor_sniff_ports"])
+        do_test("L2", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"])
 
 
 def test_not_expected_vlan_tag_drop(ptfadapter, duthost, setup, pkt_fields, ports_info):
@@ -592,7 +586,7 @@ def test_not_expected_vlan_tag_drop(ptfadapter, duthost, setup, pkt_fields, port
         vlan_vid=vlan_id,
         )
 
-    do_test("L2", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], ports_info["dut_iface"], setup["neighbor_sniff_ports"])
+    do_test("L2", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"])
 
 
 def test_dst_ip_is_loopback_addr(ptfadapter, duthost, setup, pkt_fields, tx_dut_ports, ports_info):
@@ -611,8 +605,7 @@ def test_dst_ip_is_loopback_addr(ptfadapter, duthost, setup, pkt_fields, tx_dut_
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface, setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_src_ip_is_loopback_addr(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -631,8 +624,7 @@ def test_src_ip_is_loopback_addr(ptfadapter, duthost, setup, tx_dut_ports, pkt_f
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface, setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_dst_ip_absent(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -649,8 +641,7 @@ def test_dst_ip_absent(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, por
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface, setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("ip_addr", ["ipv4", "ipv6"])
@@ -685,9 +676,7 @@ def test_src_ip_is_multicast_addr(ptfadapter, duthost, setup, tx_dut_ports, pkt_
 
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"], ip_src)
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_src_ip_is_class_e(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -708,9 +697,7 @@ def test_src_ip_is_class_e(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields,
             tcp_sport=pkt_fields["tcp_sport"],
             tcp_dport=pkt_fields["tcp_dport"])
 
-        recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-        do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-                setup["neighbor_sniff_ports"])
+        do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("addr_type, addr_direction", [("ipv4", "src"), ("ipv6", "src"), ("ipv4", "dst"),
@@ -756,9 +743,7 @@ def test_ip_is_zero_addr(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, a
 
     logger.info(pkt_params)
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["dut_to_ptf_port_map"].values())
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["dut_to_ptf_port_map"].values(), tx_dut_ports)
 
 
 @pytest.mark.parametrize("addr_direction", ["src", "dst"])
@@ -786,9 +771,7 @@ def test_ip_link_local(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, add
     pkt = testutils.simple_tcp_packet(**pkt_params)
 
     logger.info(pkt_params)
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
@@ -822,9 +805,7 @@ def test_loopback_filter(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, p
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_ip_pkt_with_exceeded_mtu(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, mtu_config, ports_info):
@@ -851,8 +832,7 @@ def test_ip_pkt_with_exceeded_mtu(ptfadapter, duthost, setup, tx_dut_ports, pkt_
         tcp_dport=pkt_fields["tcp_dport"]
         )
 
-    do_test("L2", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], ports_info["dut_iface"], setup["neighbor_sniff_ports"],
-            l2_col_key=RX_ERR)
+    do_test("L2", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], l2_col_key=RX_ERR)
 
 
 def test_ip_pkt_with_expired_ttl(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -871,9 +851,7 @@ def test_ip_pkt_with_expired_ttl(ptfadapter, duthost, setup, tx_dut_ports, pkt_f
         tcp_dport=pkt_fields["tcp_dport"],
         ip_ttl=0)
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("igmp_version,msg_type", [("v1", "membership_query"), ("v3", "membership_query"), ("v1", "membership_report"),
@@ -934,9 +912,7 @@ def test_non_routable_igmp_pkts(ptfadapter, duthost, setup, tx_dut_ports, pkt_fi
     del pkt[testutils.scapy.scapy.all.Raw]
     pkt = pkt / igmp_types[igmp_version][msg_type]
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["dut_to_ptf_port_map"].values())
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["dut_to_ptf_port_map"].values(), tx_dut_ports)
 
 
 def test_absent_ip_header(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -959,9 +935,7 @@ def test_absent_ip_header(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, 
     pkt.type = 0x800
     pkt = pkt/tcp
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("pkt_field, value", [("version", 1), ("chksum", 10), ("ihl", 1)])
@@ -981,9 +955,7 @@ def test_broken_ip_header(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, 
         )
     setattr(pkt[testutils.scapy.scapy.all.IP], pkt_field, value)
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("eth_dst", ["01:00:5e:00:01:02", "ff:ff:ff:ff:ff:ff"])
@@ -1005,9 +977,7 @@ def test_unicast_ip_incorrect_eth_dst(ptfadapter, duthost, setup, tx_dut_ports, 
         tcp_dport=pkt_fields["tcp_dport"]
         )
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_acl_drop(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, acl_setup, ports_info):
@@ -1029,7 +999,7 @@ def test_acl_drop(ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, acl_setu
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"]
         )
-    base_verification("ACL", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], tx_dut_ports[ports_info["dut_iface"]])
+    base_verification("ACL", pkt, ptfadapter, duthost, ports_info, tx_dut_ports)
 
     # Verify packets were not egresed the DUT
     exp_pkt = expected_packet_mask(pkt)
@@ -1053,6 +1023,4 @@ def test_egress_drop_on_down_link(ptfadapter, duthost, setup, tx_dut_ports, pkt_
         tcp_dport=pkt_fields["tcp_dport"]
         )
 
-    recv_iface = get_receiving_iface(ports_info, tx_dut_ports)
-    do_test("L3", pkt, ptfadapter, duthost, ports_info["ptf_tx_port_id"], recv_iface,
-            setup["neighbor_sniff_ports"])
+    do_test("L3", pkt, ptfadapter, duthost, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)


### PR DESCRIPTION
- Get the correct interface for combined L2/L3 counters
- Add Arista and Dell SKUs to the combined counter list

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Improves support for the interface drop counters tests for SKUs that have combined L2/L3 drop counters.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
I added a check for the `COMBINED_L2L3_DROP_COUNTER` flag before passing in the receiving interface on the DUT.

Before the tests would try to check for interfaces like "PortChannel0001" or "Vlan100" in the output of `portstat -j` when checking the combined counters. Instead, we need to check the underlying physical interface, which is present in `portstat`.

#### How did you verify/test it?
Ran the L3 test cases against HWSKUs with combined drop counters. I also ran the ACL tests to make sure there wasn't a similar problem there, and those are working as expected as well.

#### Any platform specific information?
I added the platforms that I tested to the combined counters list.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
