### PR TITLE
[ecn_wred] Add ecn_wred config for no template config project

### DIFF
--- a/ansible/roles/test/tasks/ecn.json
+++ b/ansible/roles/test/tasks/ecn.json
@@ -1,0 +1,14 @@
+{
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS": {
+            "red_max_threshold": "518720", 
+            "yellow_max_threshold": "32760", 
+            "green_min_threshold": "4095", 
+            "red_min_threshold": "4095", 
+            "yellow_min_threshold": "4095", 
+            "green_max_threshold": "32760", 
+            "wred_yellow_enable": "true", 
+            "wred_green_enable": "true"
+        }
+    }
+}

--- a/ansible/roles/test/tasks/ecn_wred.yml
+++ b/ansible/roles/test/tasks/ecn_wred.yml
@@ -17,8 +17,25 @@
   register: wred_value
   failed_when: wred_value.rc != 0
 
+- name: Copy JSON config to switch.
+  copy: src=roles/test/tasks/ecn.json dest=/tmp
+  when: wred_value.stdout == ""
+
+- name: Add config
+  shell: config load /tmp/ecn.json -y
+  become: yes
+  when: wred_value.stdout == ""
+
+- name: Make sure config updated
+  pause: seconds=2
+
+- set_fact:
+    red_min_threshold=4095
+  when: wred_value.stdout == ""
+
 - set_fact:
     red_min_threshold={{ wred_value.stdout }}
+  when: wred_value.stdout != ""
 
 - include_tasks: add_container_to_inventory.yml
   vars:


### PR DESCRIPTION
Add ecn_wred config for no template config project

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Add ecn_wred config for those projects who don't have template config.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
If the DUT doesn't have WRED setting which should be applied from template config, we add a default WRED setting to continue this ansible test.
#### How did you verify/test it?
By executing ecn_wred ansible test.
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA