### PR TITLE
[recover] improve adaptive recover methods

### DIFF
--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -12,8 +12,8 @@ PRINT_LOGS = {
 
 # Recover related definitions
 RECOVER_METHODS = {
-    "config_reload": {"cmd": "config reload -y", "reboot": False, "adaptive": False, 'recover_wait': 60},
-    "load_minigraph": {"cmd": "config load_minigraph -y", "reboot": False, "adaptive": False, 'recover_wait': 60},
+    "config_reload": {"cmd": "bash -c 'config reload -y &>/dev/null'", "reboot": False, "adaptive": False, 'recover_wait': 60},
+    "load_minigraph": {"cmd": "bash -c 'config load_minigraph -y &>/dev/null'", "reboot": False, "adaptive": False, 'recover_wait': 60},
     "reboot": {"cmd": "reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
     "warm_reboot": {"cmd": "warm-reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},
     "fast_reboot": {"cmd": "fast_reboot", "reboot": True, "adaptive": False, 'recover_wait': 120},


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

- When process is missing, reload_config.
- When port channle or vlan link is down, reload_config.
- redirect output of config reload and load minigraph to /dev/null.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run all pytest cases, currently some test case will leave the system in a bad state that would require config reload to recover. Making sure that the test would continue.

This is a step towards better recovery. However, specific scenarios like config_db.json got contaminated is not addressed by this change.