### PR TITLE
[advanced-reboot] Refactored BGP state checking 

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -124,12 +124,10 @@ class Arista(object):
             bgp_neig_output = self.do_cmd('show ip bgp neighbors')
             info['bgp_neig'] = self.parse_bgp_neighbor(bgp_neig_output)
 
-            bgp_route_v4_output = self.do_cmd('show ip route bgp | json')
-            v4_routing_ok = self.parse_bgp_route(bgp_route_v4_output, self.v4_routes)
+            v4_routing_ok, bgp_route_v4_output = self.check_bgp_route(self.v4_routes)
             info['bgp_route_v4'] = v4_routing_ok
 
-            bgp_route_v6_output = self.do_cmd("show ipv6 route bgp | json")
-            v6_routing_ok = self.parse_bgp_route(bgp_route_v6_output, self.v6_routes)
+            v6_routing_ok, bgp_route_v6_output = self.check_bgp_route(self.v6_routes, ipv6=True)
             info["bgp_route_v6"] = v6_routing_ok
 
             portchannel_output = self.do_cmd("show interfaces po1 | json")
@@ -349,6 +347,18 @@ class Arista(object):
                 prefixes.add(prefix)
 
         return set(expects) == prefixes
+
+    def check_bgp_route(self, expects, ipv6=False):
+        cmd = 'show ip route {} | json'
+        if ipv6:
+            cmd = 'show ipv6 route {} | json'
+
+        ok = True
+        for prefix in set(expects):
+            output = self.do_cmd(cmd.format(prefix))
+            ok &= self.parse_bgp_route(output, [prefix])
+
+        return ok, output
 
     def get_bgp_info(self):
         # Retreive BGP info (peer addr, AS) for the dut and neighbor


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
After changes in routing configuration for topology arista module takes to much time to check BGP state, so refactored logic to check the best route match instead of checking all BGP routes.
Fixes # (#1655)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
- refactored BGP state check to dump the best match instead of parsing all BGP routes
- refactored advanced reboot test to avoid queue growing
#### How did you verify/test it?
Pass fast-reboot test
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
