### PR TITLE
Deprecate fixture testbed_devices

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -257,7 +257,7 @@ class BaseAclTest(object):
         dut.command('config acl update full {}'.format(remove_rules_dut_path))
 
     @pytest.fixture(scope='class', autouse=True)
-    def acl_rules(self, duthost, testbed_devices, setup, acl_table):
+    def acl_rules(self, duthost, localhost, setup, acl_table):
         """
         setup/teardown ACL rules based on test class requirements
         :param duthost: DUT host object
@@ -266,7 +266,6 @@ class BaseAclTest(object):
         :param acl_table: table creating fixture
         :return:
         """
-        localhost = testbed_devices['localhost']
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='acl_rules')
         loganalyzer.load_common_config()
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -25,12 +25,13 @@ class AdvancedReboot:
     inboot/preboot list. The class transfers number of configuration files to the dut/ptf in preparation for reboot test.
     Test cases can trigger test start utilizing runRebootTestcase API.
     '''
-    def __init__(self, request, duthost, testbed_devices, testbed, **kwargs):
+    def __init__(self, request, duthost, ptfhost, localhost, testbed, **kwargs):
         '''
         Class contructor.
         @param request: pytest request object
         @param duthost: AnsibleHost instance of DUT
-        @param testbed_devices: fixture provides information about testbed devices
+        @param ptfhost: PTFHost for interacting with PTF through ansible
+        @param localhost: Localhost for interacting with localhost through ansible
         @param testbed: fixture provides information about testbed
         @param kwargs: extra parameters including reboot type
         '''
@@ -40,8 +41,8 @@ class AdvancedReboot:
 
         self.request = request
         self.duthost = duthost
-        self.ptfhost = testbed_devices['ptf']
-        self.localhost = testbed_devices['localhost']
+        self.ptfhost = ptfhost
+        self.localhost = localhost
         self.testbed = testbed
         self.__dict__.update(kwargs)
         self.__extractTestParam()
@@ -454,7 +455,7 @@ class AdvancedReboot:
         if currentImage != self.currentImage:
             logger.info('Restore current image')
             self.duthost.shell('sonic_installer set_default {0}'.format(self.currentImage))
-    
+
             rebootDut(
                 self.duthost,
                 self.localhost,
@@ -480,12 +481,13 @@ class AdvancedReboot:
             self.__restorePrevImage()
 
 @pytest.fixture
-def get_advanced_reboot(request, duthost, testbed_devices, testbed):
+def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed):
     '''
     Pytest test fixture that provides access to AdvancedReboot test fixture
         @param request: pytest request object
         @param duthost: AnsibleHost instance of DUT
-        @param testbed_devices: fixture provides information about testbed devices
+        @param ptfhost: PTFHost for interacting with PTF through ansible
+        @param localhost: Localhost for interacting with localhost through ansible
         @param testbed: fixture provides information about testbed
     '''
     instances = []
@@ -495,7 +497,7 @@ def get_advanced_reboot(request, duthost, testbed_devices, testbed):
         API that returns instances of AdvancedReboot class
         '''
         assert len(instances) == 0, "Only one instance of reboot data is allowed"
-        advancedReboot = AdvancedReboot(request, duthost, testbed_devices, testbed, **kwargs)
+        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, **kwargs)
         instances.append(advancedReboot)
         return advancedReboot
 

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -3,9 +3,8 @@ import os
 import json
 
 @pytest.fixture(scope="module")
-def conn_graph_facts(duthost, testbed_devices):
+def conn_graph_facts(duthost, localhost):
     conn_graph_facts = dict()
-    localhost = testbed_devices["localhost"]
 
     base_path = os.path.dirname(os.path.realpath(__file__))
     # json file contains mapping from inventory file name to its corresponding graph file

--- a/tests/common/plugins/sanity_check/README.md
+++ b/tests/common/plugins/sanity_check/README.md
@@ -20,7 +20,7 @@ pytest_plugins = [
 sonic-mgmt/tests/common/plugins/sanity_check:
 ```
 @pytest.fixture(scope="module", autouse=True)
-def sanity_check(testbed_devices, request):
+def sanity_check(localhost, duthost, request, fanouthosts):
     ...
 ```
 

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -49,10 +49,8 @@ def _update_check_items(old_items, new_items, supported_items):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def sanity_check(testbed_devices, duthost, request, fanouthosts):
+def sanity_check(localhost, duthost, request, fanouthosts):
     logger.info("Start pre-test sanity check")
-
-    localhost = testbed_devices["localhost"]
 
     skip_sanity = False
     allow_recover = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,33 +134,6 @@ def testbed(request):
     return tbinfo.testbed_topo[tbname]
 
 
-@pytest.fixture(scope="module")
-def testbed_devices(ansible_adhoc, testbed, duthost):
-    """
-    @summary: Fixture for creating dut, localhost and other necessary objects for testing. These objects provide
-        interfaces for interacting with the devices used in testing.
-    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
-        mandatory argument for the class constructors.
-    @param testbed: Fixture for parsing testbed configuration file.
-    @return: Return the created device objects in a dictionary
-    """
-
-    devices = {
-        "localhost": Localhost(ansible_adhoc),
-        "duts" : [SonicHost(ansible_adhoc, x, gather_facts=True) for x in testbed["duts"]],
-    }
-
-    if "ptf" in testbed:
-        devices["ptf"] = PTFHost(ansible_adhoc, testbed["ptf"])
-    else:
-        # when no ptf defined in testbed.csv
-        # try to parse it from inventory
-        ptf_host = duthost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()["ptf_host"]
-        devices["ptf"] = PTFHost(ansible_adhoc, ptf_host)
-
-    return devices
-
-
 def disable_ssh_timout(dut):
     '''
     @summary disable ssh session on target dut
@@ -218,7 +191,7 @@ def localhost(ansible_adhoc):
 
 
 @pytest.fixture(scope="module")
-def ptfhost(ansible_adhoc, testbed):
+def ptfhost(ansible_adhoc, testbed, duthost):
     if "ptf" in testbed:
         return PTFHost(ansible_adhoc, testbed["ptf"])
     else:

--- a/tests/drop_counters/fanout/mellanox/mellanox_fanout.py
+++ b/tests/drop_counters/fanout/mellanox/mellanox_fanout.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from ..fanout_base import BaseFanoutHandler
 
@@ -13,11 +14,11 @@ DEL_RULE_TEMPLATE = os.path.join(os.path.dirname(__file__), "mlnx_del_of_rule.j2
 
 
 class FanoutHandler(BaseFanoutHandler):
-    def __init__(self, duthost, testbed_devices):
+    def __init__(self, duthost, localhost):
         self.initialized = False
         self.rule_id = MAX_OPENFLOW_RULE_ID
         # Ansible localhost fixture which calls ansible playbook on the local host
-        self.ansible_localhost = testbed_devices["localhost"]
+        self.ansible_localhost = localhost
 
         dut_facts = self.ansible_localhost.conn_graph_facts(host=duthost.hostname, filename=LAB_CONNECTION_GRAPH)["ansible_facts"]
         self.fanout_host = dut_facts["device_conn"]["Ethernet0"]["peerdevice"]

--- a/tests/drop_counters/test_drop_counters.py
+++ b/tests/drop_counters/test_drop_counters.py
@@ -269,7 +269,7 @@ def rif_port_down(duthost, setup, loganalyzer):
 
 
 @pytest.fixture
-def fanouthost(request, duthost, testbed_devices):
+def fanouthost(request, duthost, localhost):
     """
     Fixture that allows to update Fanout configuration if there is a need to send incorrect packets.
     Added possibility to create vendor specific logic to handle fanout configuration.
@@ -285,7 +285,7 @@ def fanouthost(request, duthost, testbed_devices):
             # Import fanout configuration handler based on vendor name
             if "mellanox" in file_name:
                 module = importlib.import_module("fanout.{0}.{0}_fanout".format(file_name.strip(".py")))
-                fanout = module.FanoutHandler(duthost, testbed_devices)
+                fanout = module.FanoutHandler(duthost, localhost)
                 break
 
     yield fanout

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function', autouse=True)
-def prepare_ptf(testbed_devices):
-    ptfhost = testbed_devices["ptf"]
+def prepare_ptf(ptfhost):
     # remove existing IPs from ptf host
     ptfhost.script('scripts/remove_ip.sh')
     # set unique MACs to ptf interfaces
@@ -110,7 +109,7 @@ def run_test_ipv6(ptfadapter, gather_facts):
     logger.info("\nSend Packet:\neth_dst: {}, eth_src: {}, ipv6 ip: {}".format(
         gather_facts['src_router_mac'], gather_facts['src_host_mac'], dst_host_ipv6)
     )
-    
+
     testutils.send(ptfadapter, int(gather_facts['src_port_ids'][0]), pkt)
 
     pkt = testutils.simple_udpv6_packet(
@@ -123,7 +122,7 @@ def run_test_ipv6(ptfadapter, gather_facts):
     logger.info("\nExpect Packet:\neth_dst: {}, eth_src: {}, ipv6 ip: {}".format(
         gather_facts['dst_host_mac'], gather_facts['dst_router_mac'], dst_host_ipv6)
     )
-    
+
     port_list = [int(port) for port in gather_facts['dst_port_ids']]
     testutils.verify_packet_any_port(ptfadapter, pkt, port_list, timeout=WAIT_EXPECTED_PACKET_TIMEOUT)
 
@@ -141,7 +140,7 @@ def run_test_ipv4(ptfadapter, gather_facts):
     logger.info("\nSend Packet:\neth_dst: {}, eth_src: {}, ipv6 ip: {}".format(
         gather_facts['src_router_mac'], gather_facts['src_host_mac'], dst_host_ipv4)
     )
-    
+
     testutils.send(ptfadapter, int(gather_facts['src_port_ids'][0]), pkt)
 
     pkt = testutils.simple_udp_packet(
@@ -154,7 +153,7 @@ def run_test_ipv4(ptfadapter, gather_facts):
     logger.info("\nExpect Packet:\neth_dst: {}, eth_src: {}, ipv6 ip: {}".format(
         gather_facts['dst_host_mac'], gather_facts['dst_router_mac'], dst_host_ipv4)
     )
-    
+
     port_list = [int(port) for port in gather_facts['dst_port_ids']]
     testutils.verify_packet_any_port(ptfadapter, pkt, port_list, timeout=WAIT_EXPECTED_PACKET_TIMEOUT)
 

--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -7,8 +7,7 @@ SERVER_FILE = 'platform_api_server.py'
 SERVER_PORT = 8000
 
 @pytest.fixture(scope='function')
-def start_platform_api_service(duthost, testbed_devices):
-    localhost = testbed_devices['localhost']
+def start_platform_api_service(duthost, localhost):
     res = localhost.wait_for(host=duthost.hostname, port=SERVER_PORT, state='started', delay=1, timeout=5)
     if 'exception' in res:
         supervisor_conf = [

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -53,13 +53,10 @@ class TestWatchdogAPI(object):
         return config
 
 
-    def test_arm_disarm_states(self, duthost, testbed_devices, platform_api_conn, conf):
+    def test_arm_disarm_states(self, duthost, localhost, platform_api_conn, conf):
         ''' arm watchdog with a valid timeout value, verify it is in armed state,
         disarm watchdog and verify it is in disarmed state
         '''
-
-        localhost = testbed_devices['localhost']
-
         watchdog_timeout = conf['valid_timeout']
         actual_timeout = watchdog.arm(platform_api_conn, watchdog_timeout)
 
@@ -160,10 +157,8 @@ class TestWatchdogAPI(object):
         assert actual_timeout == -1
 
     @pytest.mark.disable_loganalyzer
-    def test_reboot(self, duthost, testbed_devices, platform_api_conn, conf):
+    def test_reboot(self, duthost, localhost, platform_api_conn, conf):
         ''' arm the watchdog and verify it did its job after timeout expiration '''
-
-        localhost = testbed_devices['localhost']
 
         watchdog_timeout = conf['valid_timeout']
         actual_timeout = watchdog.arm(platform_api_conn, watchdog_timeout)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -104,29 +104,24 @@ def check_interfaces_and_services(dut, interfaces, reboot_type = None):
         check_sysfs(dut)
 
 
-def test_cold_reboot(duthost, testbed_devices, conn_graph_facts):
+def test_cold_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    localhost = testbed_devices["localhost"]
-
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_COLD)
 
 
-def test_fast_reboot(duthost, testbed_devices, conn_graph_facts):
+def test_fast_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    localhost = testbed_devices["localhost"]
-
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_FAST)
 
 
-def test_warm_reboot(duthost, testbed_devices, conn_graph_facts):
+def test_warm_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    localhost = testbed_devices["localhost"]
     asic_type = duthost.facts["asic_type"]
 
     if asic_type in ["mellanox"]:
@@ -167,17 +162,15 @@ def _power_off_reboot_helper(kwargs):
         psu_ctrl.turn_on_psu(psu["psu_id"])
 
 
-def test_power_off_reboot(duthost, testbed_devices, conn_graph_facts, psu_controller, power_off_delay):
+def test_power_off_reboot(duthost, localhost, conn_graph_facts, psu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
-    @param testbed_devices: Fixture initialize devices in testbed
     @param duthost: Fixture for DUT AnsibleHost object
+    @param localhost: Fixture for interacting with localhost through ansible
     @param conn_graph_facts: Fixture parse and return lab connection graph
     @param psu_controller: The python object of psu controller
     @param power_off_delay: Pytest fixture. The delay between turning off and on the PSU
     """
-    localhost = testbed_devices["localhost"]
-
     psu_ctrl = psu_controller
     if psu_ctrl is None:
         pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
@@ -207,12 +200,10 @@ def test_power_off_reboot(duthost, testbed_devices, conn_graph_facts, psu_contro
                          _power_off_reboot_helper, poweroff_reboot_kwargs)
 
 
-def test_watchdog_reboot(duthost, testbed_devices, conn_graph_facts):
+def test_watchdog_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
-    localhost = testbed_devices["localhost"]
-
     test_watchdog_supported = "python -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog(); exit()\""
 
     watchdog_supported = duthost.command(test_watchdog_supported,module_ignore_errors=True)["stderr"]
@@ -222,11 +213,9 @@ def test_watchdog_reboot(duthost, testbed_devices, conn_graph_facts):
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], REBOOT_TYPE_WATCHDOG)
 
 
-def test_continuous_reboot(duthost, testbed_devices, conn_graph_facts):
+def test_continuous_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform 3 cold reboot in a row
     """
-    localhost = testbed_devices["localhost"]
-
     for i in range(3):
         reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_COLD)

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -53,18 +53,16 @@ def restart_service_and_check(localhost, dut, service, interfaces):
         check_sysfs(dut)
 
 
-def test_restart_swss(duthost, testbed_devices, conn_graph_facts):
+def test_restart_swss(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to restart the swss service and check platform status
     """
-    localhost = testbed_devices["localhost"]
     restart_service_and_check(localhost, duthost, "swss", conn_graph_facts["device_conn"])
 
 
 @pytest.mark.skip(reason="Restarting syncd is not supported yet")
-def test_restart_syncd(duthost, testbed_devices, conn_graph_facts):
+def test_restart_syncd(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to restart the syncd service and check platform status
     """
-    localhost = testbed_devices["localhost"]
     restart_service_and_check(localhost, duthost, "syncd", conn_graph_facts["device_conn"])

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -3,12 +3,11 @@ import pytest
 PSU_STATUS_OK = 2
 
 @pytest.mark.bsl
-def test_snmp_numpsu(duthost, testbed_devices, creds):
+def test_snmp_numpsu(duthost, localhost, creds):
 
-    lhost = testbed_devices['localhost']
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = lhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
+    snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
     res = duthost.shell("psuutil numpsus")
     assert int(res[u'rc']) == 0, "Failed to get number of PSUs"
 
@@ -17,12 +16,11 @@ def test_snmp_numpsu(duthost, testbed_devices, creds):
 
 
 @pytest.mark.bsl
-def test_snmp_psu_status(duthost, testbed_devices, creds):
+def test_snmp_psu_status(duthost, localhost, creds):
 
-    lhost = testbed_devices['localhost']
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = lhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
+    snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
 
     for k, v in snmp_facts['snmp_psu'].items():
         if int(v['operstatus']) != PSU_STATUS_OK:

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -5,9 +5,8 @@ pytestmark = [
     pytest.mark.disable_loganalyzer,
 ]
 
-def test_ro_user(testbed_devices, duthost, creds, setup_tacacs):
+def test_ro_user(localhost, duthost, creds, setup_tacacs):
 
-    localhost = testbed_devices['localhost']
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     res = localhost.shell("sshpass -p {} ssh "\
                           "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\

--- a/tests/test_mgmtvrf.py
+++ b/tests/test_mgmtvrf.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='module',autouse=True)
-def setup_mvrf(duthost, testbed_devices, testbed, localhost):
+def setup_mvrf(duthost, testbed, localhost):
     '''
     Setup Management vrf configs before the start of testsuite
     '''
@@ -173,7 +173,7 @@ class TestReboot():
          inbound_test.test_snmp_fact(localhost)
 
 
-    def test_warmboot(self, duthost, localhost, testbed_devices, testbed):
+    def test_warmboot(self, duthost, localhost, testbed):
 
         duthost.command('sudo config save -y')
         reboot(duthost, localhost, reboot_type='warm')
@@ -181,13 +181,13 @@ class TestReboot():
         self.basic_check_after_reboot(duthost, localhost, testbed)
 
 
-    def test_reboot(self, duthost, localhost, testbed_devices, testbed):
+    def test_reboot(self, duthost, localhost, testbed):
         duthost.command('sudo config save -y')
         reboot(duthost, localhost)
         assert wait_until(300, 20, duthost.critical_services_fully_started), "Not all critical services are fully started"
         self.basic_check_after_reboot(duthost, localhost, testbed)
 
-    def test_fastboot(self, duthost, localhost, testbed_devices, testbed):
+    def test_fastboot(self, duthost, localhost, testbed):
 
         duthost.command('sudo config save -y')
         reboot(duthost, localhost,reboot_type='fast')

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -47,11 +47,10 @@ def check_bgp_facts(hostname, host):
     if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
         return "neighbor {} bgp not configured correctly".format(hostname)
 
-def test_neighbors_health(duthost, testbed_devices, nbrhosts, eos):
+def test_neighbors_health(duthost, localhost, nbrhosts, eos):
     """Check each neighbor device health"""
 
     fails = []
-    localhost = testbed_devices['localhost']
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
     for k, v in nei_meta.items():

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -220,31 +220,31 @@ def check_bgp_facts(duthost, cfg_facts):
 
 # FIXME later may move to "common.reboot"
 #
-# The reason to introduce a new 'reboot' here is due to 
+# The reason to introduce a new 'reboot' here is due to
 # the difference of fixture 'localhost' between the two 'reboot' functions.
-# 
-# 'common.reboot' request *ansible_fixtures.localhost*, 
+#
+# 'common.reboot' request *ansible_fixtures.localhost*,
 # but here it request *common.devices.Localhost*.
 def reboot(duthost, localhost, timeout=120, basic_check=True):
     duthost.shell("nohup reboot &")
 
     dut_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).address
-    
+
     logging.info('waiting for dut to go down')
-    res = localhost.wait_for(host=dut_ip, 
-                             port=22, 
-                             state="stopped", 
-                             delay=10, 
+    res = localhost.wait_for(host=dut_ip,
+                             port=22,
+                             state="stopped",
+                             delay=10,
                              timeout=timeout,
                              module_ignore_errors=True)
     if res.is_failed:
         raise Exception('DUT did not shutdown in {}s'.format(timeout))
 
     logging.info('waiting for dut to startup')
-    res = localhost.wait_for(host=dut_ip, 
-                             port=22, 
-                             state="started", 
-                             delay=10, 
+    res = localhost.wait_for(host=dut_ip,
+                             port=22,
+                             state="started",
+                             delay=10,
                              timeout=timeout,
                              module_ignore_errors=True)
     if res.is_failed:
@@ -382,10 +382,6 @@ def gen_vrf_neigh_file(vrf, ptfhost, render_file):
     ptfhost.template(src="vrf/vrf_neigh.j2", dest=render_file)
 
 # fixtures
-@pytest.fixture(scope="module")
-def localhost(testbed_devices):
-    return testbed_devices['localhost']
-
 @pytest.fixture(scope="module")
 def host_facts(duthost):
     return get_host_facts(duthost)
@@ -771,7 +767,7 @@ class TestVrfLoopbackIntf():
             for ip in ips:
                 if ip.version == 4:
                     # FIXME Within a vrf, currently ping(4) does not support using
-                    # an ip of loopback intface as source(it complains 'Cannot assign 
+                    # an ip of loopback intface as source(it complains 'Cannot assign
                     # requested address'). An alternative is ping the loopback address
                     # from ptf
                     ptfhost.shell("ip netns exec {} ping {} -c 3 -f -W2".format(g_vars['vlan_peer_vrf2ns_map']['Vrf1'], ip.ip))
@@ -784,7 +780,7 @@ class TestVrfLoopbackIntf():
             for ip in ips:
                 if ip.version == 4:
                     # FIXME Within a vrf, currently ping(4) does not support using
-                    # an ip of loopback intface as source(it complains 'Cannot assign 
+                    # an ip of loopback intface as source(it complains 'Cannot assign
                     # requested address'). An alternative is ping the loopback address
                     # from ptf
                     ptfhost.shell("ip netns exec {} ping {} -c 3 -f -W2".format(g_vars['vlan_peer_vrf2ns_map']['Vrf2'], ip.ip))
@@ -1391,7 +1387,7 @@ class TestVrfDeletion():
     def setup_vrf_restore(self, duthost, cfg_facts):
         self.restore_vrf(duthost)
         self.c_vars['restore_vrf'] = False  # Mark to skip restore vrf during teardown
-        
+
         # check bgp session state after restore
         assert wait_until(120, 10, check_bgp_facts, duthost, cfg_facts), \
                "Bgp sessions should be re-estabalished after restore Vrf1"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The testbed_devices fixture is not a good design. Multiple testbed device
objects are initialized in this fixture. It is not common that a test
script needs all the devices. This fixture may cause unnecessary overhead.
It would be better for test scripts to use the fixtures for different
devices on needed basis.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Changes:
1. Remove the definition of fixture testbed_devices.
2. Replace the call to testbed_devices fixture with other fixtures that
   fit better.

#### How did you verify/test it?
Test run all the affected scripts.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
