### PR TITLE
Fix the platform_info test failure because of callback loader

### DIFF
--- a/tests/ansible_host.py
+++ b/tests/ansible_host.py
@@ -1,5 +1,9 @@
-from ansible.plugins import callback_loader
 from ansible.errors import AnsibleError
+
+try:
+    from ansible.plugins import callback_loader
+except ImportError:
+    from ansible.plugins.loader import callback_loader
 
 def dump_ansible_results(results, stdout_callback='yaml'):
     cb = callback_loader.get(stdout_callback)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
platform_info test on 201811 branch failed with following error
```
test_show_platform_summary
ImportError while loading conftest '/var/sonicbld/workspace/NewTests/platform_info/tests/conftest.py'.
conftest.py:9: in <module>
    from ansible_host import AnsibleHost
ansible_host.py:1: in <module>
    from ansible.plugins import callback_loader
E   ImportError: cannot import name callback_loader
```
Summary:
Fixes # (issue)
change to pick up the proper path for the callback_loader plugin path based on ansible version

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Import the callback_loader from the right path
#### How did you verify/test it?
Run test_platform_info.py
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
