### PR TITLE
[everflow] provide j2 templates for pytest

### DIFF
--- a/tests/everflow/templates/acl_rule_persistent-del.json
+++ b/tests/everflow/templates/acl_rule_persistent-del.json
@@ -1,0 +1,1 @@
+../../../ansible/roles/test/tasks/everflow_testbed/del_config/acl_rule_persistent-del.json

--- a/tests/everflow/templates/acl_rule_persistent.json.j2
+++ b/tests/everflow/templates/acl_rule_persistent.json.j2
@@ -1,0 +1,1 @@
+../../../ansible/roles/test/tasks/everflow_testbed/apply_config/acl_rule_persistent.json.j2

--- a/tests/templates/acl_rule_persistent-del.json
+++ b/tests/templates/acl_rule_persistent-del.json
@@ -1,1 +1,0 @@
-../../ansible/roles/test/tasks/everflow_testbed/del_config/acl_rule_persistent-del.json

--- a/tests/templates/acl_rule_persistent.json.j2
+++ b/tests/templates/acl_rule_persistent.json.j2
@@ -1,1 +1,0 @@
-../../ansible/roles/test/tasks/everflow_testbed/apply_config/acl_rule_persistent.json.j2


### PR DESCRIPTION
Change-Id: Ia9826b092ba49a3b24853fbd2ea2351fc59d33a8
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

After recent [reorg tests info subfolder](https://github.com/Azure/sonic-mgmt/pull/1613) the everflow testcase setup failed, due to missing templates.
The templates were left in `test/templates`. Created symlinks in `tests/everflow/templates`

Summary:
Fixes # (issue)
```
 \"cmd\": [\"acl-loader\", \"update\", \"full\", \"/home/admin/everflow_tests/acl_rule_persistent.json\", \"--session_name=test_session_1\", \"--mirror_stage=egress\"], \"failed\": true, \"delta\": \"0:00:00.261270\", \"stderr\": \"Usage: acl-loader update full [OPTIONS] FILENAME\\\\n\\\\nError: Invalid value for \\\\\"filename\\\\\": Path \\\\\"/home/admin/everflow_tests/acl_rule_persistent.json\\\\\" does not exist.\", \"rc\": 2
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
