### PR TITLE
Qos SAI test restructure

### DIFF
--- a/ansible/group_vars/sonic/vars
+++ b/ansible/group_vars/sonic/vars
@@ -4,6 +4,10 @@ sonic_version: "v2"
 
 broadcom_hwskus: [ "Force10-S6000", "Accton-AS7712-32X", "Celestica-DX010-C32", "Seastone-DX010", "Celestica-E1031-T48S4"]
 
+broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S']
+broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', "Seastone-DX010" ]
+broadcom_th2_hwskus: ['Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
+
 mellanox_spc1_hwskus: [ 'ACS-MSN2700', 'ACS-MSN2740', 'ACS-MSN2100', 'ACS-MSN2410', 'ACS-MSN2010', 'Mellanox-SN2700', 'Mellanox-SN2700-D48C8' ]
 mellanox_spc2_hwskus: [ 'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800', 'Mellanox-SN3800-D112C8' ]
 mellanox_spc3_hwskus: [ 'ACS-MSN4700' ]

--- a/ansible/roles/test/tasks/qos_get_ports.yml
+++ b/ansible/roles/test/tasks/qos_get_ports.yml
@@ -143,6 +143,10 @@
     target_pg: '3-4'
     target_buffer_profile_type: 'ingress lossless'
 
+- name: Set lossless buffer profile
+  set_fact:
+    lossless_buffer_profile: "{{ buffer_profile }}"
+
 - name: Set lossless MAX buffer size
   set_fact:
     lossless_buffer_max_size: "{{buffer_headroom.stdout|int}}"

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -31,9 +31,9 @@
 
     - set_fact:
         defined_asic_list: ['td2', 'th', 'th2', 'spc1', 'spc2', 'spc3']
-        spc: "{{ lossless_buffer_profile }}"
+        speed_cablelen: "{{ lossless_buffer_profile }}"
 
-    - set_fact: spc="{{spc | regex_replace('BUFFER_PROFILE\|pg_lossless_(.*)_profile', '\\1')}}"
+    - set_fact: speed_cablelen="{{speed_cablelen | regex_replace('BUFFER_PROFILE\|pg_lossless_(.*)_profile', '\\1')}}"
 
     - name: Get asic type
       set_fact: asic_type="{{ item }}"
@@ -42,16 +42,16 @@
         - minigraph_hwsku in hostvars[inventory_hostname][sonic_asic_type + '_' + item + '_hwskus']
       with_items: "{{ defined_asic_list }}"
 
-    - debug: msg="asic type is {{ asic_type }}, portspeed_cablelen is {{ spc }}"
+    - debug: msg="asic type is {{ asic_type }}, portspeed_cablelen is {{ speed_cablelen }}"
 
     - name: check if the device has configured qos parameters
       fail: msg="device doesn't have configured qos parameters"
-      when: qos_params[asic_type] is not defined or qos_params[asic_type][spc] is not defined
+      when: qos_params[asic_type] is not defined or qos_params[asic_type][speed_cablelen] is not defined
 
     - name: set qos parameters for the device
       set_fact:
         qp: "{{qos_params[asic_type]}}"
-        qp_sc: "{{qos_params[asic_type][spc]}}"
+        qp_sc: "{{qos_params[asic_type][speed_cablelen]}}"
 
     - name: Ensure LLDP Daemon stopped
       become: yes

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -22,12 +22,36 @@
       minigraph_facts: host={{inventory_hostname}}
       become: no
 
+    - name: Get ports info.
+      include_tasks: roles/test/tasks/qos_get_ports.yml
+
+    - name: Check if lossless buffer profile is derived
+      fail: msg="Lossless Buffer profile could not be retreived"
+      when: lossless_buffer_profile is not defined or minigraph_hwsku is not defined
+
+    - set_fact:
+        defined_asic_list: ['td2', 'th', 'th2', 'spc1', 'spc2', 'spc3']
+        spc: "{{ lossless_buffer_profile }}"
+
+    - set_fact: spc="{{spc | regex_replace('BUFFER_PROFILE\|pg_lossless_(.*)_profile', '\\1')}}"
+
+    - name: Get asic type
+      set_fact: asic_type="{{ item }}"
+      when:
+        - hostvars[inventory_hostname][sonic_asic_type + '_' + item + '_hwskus'] is defined
+        - minigraph_hwsku in hostvars[inventory_hostname][sonic_asic_type + '_' + item + '_hwskus']
+      with_items: "{{ defined_asic_list }}"
+
+    - debug: msg="asic type is {{ asic_type }}, portspeed_cablelen is {{ spc }}"
+
     - name: check if the device has configured qos parameters
       fail: msg="device doesn't have configured qos parameters"
-      when: minigraph_hwsku is not defined or qos_params[minigraph_hwsku] is not defined
+      when: qos_params[asic_type] is not defined or qos_params[asic_type][spc] is not defined
 
     - name: set qos parameters for the device
-      set_fact: qp={{qos_params[minigraph_hwsku]}}
+      set_fact:
+        qp: "{{qos_params[asic_type]}}"
+        qp_sc: "{{qos_params[asic_type][spc]}}"
 
     - name: Ensure LLDP Daemon stopped
       become: yes
@@ -52,14 +76,15 @@
 
     - meta: flush_handlers
 
-    - block:
-        - name: Deploy script to DUT/syncd
-          copy: src=roles/test/files/mlnx/packets_aging.py dest=/root/packets_aging.py
+    - name: Deploy script to DUT/syncd
+      copy: src=roles/test/files/mlnx/packets_aging.py dest=/root/packets_aging.py
+      delegate_to: "{{ ansible_host }}_syncd"
+      when: minigraph_hwsku is defined and minigraph_hwsku in mellanox_hwskus
 
-        - name: Disable Mellanox packet aging
-          shell: python /root/packets_aging.py disable
-          register: result
-          failed_when: result.stderr != ''
+    - name: Disable Mellanox packet aging
+      shell: python /root/packets_aging.py disable
+      register: result
+      failed_when: result.stderr != ''
       delegate_to: "{{ ansible_host }}_syncd"
       when: minigraph_hwsku is defined and minigraph_hwsku in mellanox_hwskus
 
@@ -82,9 +107,6 @@
         - server='{{ansible_host}}'
         - port_map_file='/root/{{ptf_portmap | basename}}'
         - sonic_asic_type='{{sonic_asic_type}}'
-
-    - name: Get ports info.
-      include_tasks: roles/test/tasks/qos_get_ports.yml
 
     # Unpause all paused port
     - include_tasks: qos_sai_ptf.yml
@@ -120,39 +142,39 @@
     # XOFF limit
     - include_tasks: qos_sai_ptf.yml
       vars:
-        test_name: xoff limit ptf test dscp = {{qp.xoff_1.dscp}}, ecn = {{qp.xoff_1.ecn}}
+        test_name: xoff limit ptf test dscp = {{qp_sc.xoff_1.dscp}}, ecn = {{qp_sc.xoff_1.ecn}}
         test_path: sai_qos_tests.PFCtest
         test_params:
-        - dscp='{{qp.xoff_1.dscp}}'
-        - ecn='{{qp.xoff_1.ecn}}'
-        - pg='{{qp.xoff_1.pg}}'
+        - dscp='{{qp_sc.xoff_1.dscp}}'
+        - ecn='{{qp_sc.xoff_1.ecn}}'
+        - pg='{{qp_sc.xoff_1.pg}}'
         - buffer_max_size='{{lossless_buffer_max_size|int}}'
         - queue_max_size='{{lossless_queue_max_size|int}}'
         - dst_port_id='{{dst_port_id}}'
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.xoff_1.pkts_num_leak_out}}'
-        - pkts_num_trig_pfc='{{qp.xoff_1.pkts_num_trig_pfc}}'
-        - pkts_num_trig_ingr_drp='{{qp.xoff_1.pkts_num_trig_ingr_drp}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
+        - pkts_num_trig_pfc='{{qp_sc.xoff_1.pkts_num_trig_pfc}}'
+        - pkts_num_trig_ingr_drp='{{qp_sc.xoff_1.pkts_num_trig_ingr_drp}}'
 
     - include_tasks: qos_sai_ptf.yml
       vars:
-        test_name: xoff limit ptf test dscp = {{qp.xoff_2.dscp}}, ecn = {{qp.xoff_2.ecn}}
+        test_name: xoff limit ptf test dscp = {{qp_sc.xoff_2.dscp}}, ecn = {{qp_sc.xoff_2.ecn}}
         test_path: sai_qos_tests.PFCtest
         test_params:
-        - dscp='{{qp.xoff_2.dscp}}'
-        - ecn='{{qp.xoff_2.ecn}}'
-        - pg='{{qp.xoff_2.pg}}'
+        - dscp='{{qp_sc.xoff_2.dscp}}'
+        - ecn='{{qp_sc.xoff_2.ecn}}'
+        - pg='{{qp_sc.xoff_2.pg}}'
         - buffer_max_size='{{lossless_buffer_max_size|int}}'
         - queue_max_size='{{lossless_queue_max_size|int}}'
         - dst_port_id='{{dst_port_id}}'
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.xoff_2.pkts_num_leak_out}}'
-        - pkts_num_trig_pfc='{{qp.xoff_2.pkts_num_trig_pfc}}'
-        - pkts_num_trig_ingr_drp='{{qp.xoff_2.pkts_num_trig_ingr_drp}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
+        - pkts_num_trig_pfc='{{qp_sc.xoff_2.pkts_num_trig_pfc}}'
+        - pkts_num_trig_ingr_drp='{{qp_sc.xoff_2.pkts_num_trig_ingr_drp}}'
 
     # XON limit
     - include_tasks: qos_sai_ptf.yml
@@ -172,7 +194,7 @@
         - dst_port_3_ip='{{dst_port_3_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.xon_1.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
         - pkts_num_trig_pfc='{{qp.xon_1.pkts_num_trig_pfc}}'
         - pkts_num_dismiss_pfc='{{qp.xon_1.pkts_num_dismiss_pfc}}'
 
@@ -193,29 +215,29 @@
         - dst_port_3_ip='{{dst_port_3_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.xon_2.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
         - pkts_num_trig_pfc='{{qp.xon_2.pkts_num_trig_pfc}}'
         - pkts_num_dismiss_pfc='{{qp.xon_2.pkts_num_dismiss_pfc}}'
 
     # Headroom pool size
     - include_tasks: qos_sai_ptf.yml
       vars:
-        test_name: headroom pool size ptf test ecn = {{qp.hdrm_pool_size.ecn}}
+        test_name: headroom pool size ptf test ecn = {{qp_sc.hdrm_pool_size.ecn}}
         test_path: sai_qos_tests.HdrmPoolSizeTest
         test_params:
         - testbed_type='{{testbed_type}}'
-        - dscps={{qp.hdrm_pool_size.dscps}}
-        - ecn={{qp.hdrm_pool_size.ecn}}
-        - pgs={{qp.hdrm_pool_size.pgs}}
-        - src_port_ids={{qp.hdrm_pool_size.src_port_ids}}
-        - src_port_ips=[{% for pid in qp.hdrm_pool_size.src_port_ids %}{% if not loop.last %}'{{testing_ports_ip[pid|string]}}', {% else %}'{{testing_ports_ip[pid|string]}}'{% endif %}{% endfor %}]
-        - dst_port_id={{qp.hdrm_pool_size.dst_port_id}}
-        - dst_port_ip='{{testing_ports_ip[qp.hdrm_pool_size.dst_port_id|string]}}'
-        - pgs_num={{qp.hdrm_pool_size.pgs_num }}
-        - pkts_num_leak_out={{qp.hdrm_pool_size.pkts_num_leak_out}}
-        - pkts_num_trig_pfc={{qp.hdrm_pool_size.pkts_num_trig_pfc}}
-        - pkts_num_hdrm_full={{qp.hdrm_pool_size.pkts_num_hdrm_full}}
-        - pkts_num_hdrm_partial={{qp.hdrm_pool_size.pkts_num_hdrm_partial}}
+        - dscps={{qp_sc.hdrm_pool_size.dscps}}
+        - ecn={{qp_sc.hdrm_pool_size.ecn}}
+        - pgs={{qp_sc.hdrm_pool_size.pgs}}
+        - src_port_ids={{qp_sc.hdrm_pool_size.src_port_ids}}
+        - src_port_ips=[{% for pid in qp_sc.hdrm_pool_size.src_port_ids %}{% if not loop.last %}'{{testing_ports_ip[pid|string]}}', {% else %}'{{testing_ports_ip[pid|string]}}'{% endif %}{% endfor %}]
+        - dst_port_id={{qp_sc.hdrm_pool_size.dst_port_id}}
+        - dst_port_ip='{{testing_ports_ip[qp_sc.hdrm_pool_size.dst_port_id|string]}}'
+        - pgs_num={{qp_sc.hdrm_pool_size.pgs_num }}
+        - pkts_num_leak_out={{qp_sc.pkts_num_leak_out}}
+        - pkts_num_trig_pfc={{qp_sc.hdrm_pool_size.pkts_num_trig_pfc}}
+        - pkts_num_hdrm_full={{qp_sc.hdrm_pool_size.pkts_num_hdrm_full}}
+        - pkts_num_hdrm_partial={{qp_sc.hdrm_pool_size.pkts_num_hdrm_partial}}
       when: minigraph_hwsku is defined and
             minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64']
 
@@ -236,7 +258,7 @@
         - dst_port_2_ip='{{dst_port_2_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.lossy_queue_1.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
         - pkts_num_trig_egr_drp='{{qp.lossy_queue_1.pkts_num_trig_egr_drp}}'
 
     # DSCP to queue mapping
@@ -269,7 +291,7 @@
         - q5_num_of_pkts='{{qp.wrr.q5_num_of_pkts}}'
         - q6_num_of_pkts='{{qp.wrr.q6_num_of_pkts}}'
         - limit='{{qp.wrr.limit}}'
-        - pkts_num_leak_out='{{qp.wrr.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
     - debug:
         var: out.stdout_lines
 
@@ -291,7 +313,7 @@
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.wm_pg_shared_lossless.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
         - pkts_num_fill_min='{{qp.wm_pg_shared_lossless.pkts_num_fill_min}}'
         - pkts_num_fill_shared='{{qp.wm_pg_shared_lossless.pkts_num_trig_pfc}}'
         - cell_size='{{qp.wm_pg_shared_lossless.cell_size}}'
@@ -320,7 +342,7 @@
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.wm_pg_shared_lossy.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
         - pkts_num_fill_min='{{qp.wm_pg_shared_lossy.pkts_num_fill_min}}'
         - pkts_num_fill_shared='{{qp.wm_pg_shared_lossy.pkts_num_trig_egr_drp|int - 1}}'
         - cell_size='{{qp.wm_pg_shared_lossy.cell_size}}'
@@ -342,17 +364,17 @@
         test_name: PG headroom watermark test
         test_path: sai_qos_tests.PGHeadroomWatermarkTest
         test_params:
-        - dscp='{{qp.wm_pg_headroom.dscp}}'
-        - ecn='{{qp.wm_pg_headroom.ecn}}'
-        - pg='{{qp.wm_pg_headroom.pg}}'
+        - dscp='{{qp_sc.wm_pg_headroom.dscp}}'
+        - ecn='{{qp_sc.wm_pg_headroom.ecn}}'
+        - pg='{{qp_sc.wm_pg_headroom.pg}}'
         - dst_port_id='{{dst_port_id}}'
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.wm_pg_headroom.pkts_num_leak_out}}'
-        - pkts_num_trig_pfc='{{qp.wm_pg_headroom.pkts_num_trig_pfc}}'
-        - pkts_num_trig_ingr_drp='{{qp.wm_pg_headroom.pkts_num_trig_ingr_drp}}'
-        - cell_size='{{qp.wm_pg_headroom.cell_size}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
+        - pkts_num_trig_pfc='{{qp_sc.wm_pg_headroom.pkts_num_trig_pfc}}'
+        - pkts_num_trig_ingr_drp='{{qp_sc.wm_pg_headroom.pkts_num_trig_ingr_drp}}'
+        - cell_size='{{qp_sc.wm_pg_headroom.cell_size}}'
     - debug:
         var: out.stdout_lines
 
@@ -367,17 +389,17 @@
         test_name: Queue shared watermark test, lossless traffic
         test_path: sai_qos_tests.QSharedWatermarkTest
         test_params:
-        - dscp='{{qp.wm_q_shared_lossless.dscp}}'
-        - ecn='{{qp.wm_q_shared_lossless.ecn}}'
-        - queue='{{qp.wm_q_shared_lossless.queue}}'
+        - dscp='{{qp_sc.wm_q_shared_lossless.dscp}}'
+        - ecn='{{qp_sc.wm_q_shared_lossless.ecn}}'
+        - queue='{{qp_sc.wm_q_shared_lossless.queue}}'
         - dst_port_id='{{dst_port_id}}'
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.wm_q_shared_lossless.pkts_num_leak_out}}'
-        - pkts_num_fill_min='{{qp.wm_q_shared_lossless.pkts_num_fill_min}}'
-        - pkts_num_trig_drp='{{qp.wm_q_shared_lossless.pkts_num_trig_ingr_drp}}'
-        - cell_size='{{qp.wm_q_shared_lossless.cell_size}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
+        - pkts_num_fill_min='{{qp_sc.wm_q_shared_lossless.pkts_num_fill_min}}'
+        - pkts_num_trig_drp='{{qp_sc.wm_q_shared_lossless.pkts_num_trig_ingr_drp}}'
+        - cell_size='{{qp_sc.wm_q_shared_lossless.cell_size}}'
     - debug:
         var: out.stdout_lines
 
@@ -399,7 +421,7 @@
         - dst_port_ip='{{dst_port_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-        - pkts_num_leak_out='{{qp.wm_q_shared_lossy.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
         - pkts_num_fill_min='{{qp.wm_q_shared_lossy.pkts_num_fill_min}}'
         - pkts_num_trig_drp='{{qp.wm_q_shared_lossy.pkts_num_trig_egr_drp}}'
         - cell_size='{{qp.wm_q_shared_lossy.cell_size}}'
@@ -451,7 +473,7 @@
         - q5_num_of_pkts='{{qp.wrr_chg.q5_num_of_pkts}}'
         - q6_num_of_pkts='{{qp.wrr_chg.q6_num_of_pkts}}'
         - limit='{{qp.wrr_chg.limit}}'
-        - pkts_num_leak_out='{{qp.wrr_chg.pkts_num_leak_out}}'
+        - pkts_num_leak_out='{{qp_sc.pkts_num_leak_out}}'
     - debug:
         var: out.stdout_lines
 

--- a/ansible/vars/qos.yml
+++ b/ansible/vars/qos.yml
@@ -17,23 +17,47 @@
 #   xoff_1 for 50G
 #   xoff_2 for 100G
 qos_params:
-    ACS-MSN2700:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
+    spc1:
+        40000_5m:
+            pkts_num_leak_out: 0
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 22038
+                pkts_num_trig_ingr_drp: 22115
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 22038
+                pkts_num_trig_ingr_drp: 22115
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 22038
+                pkts_num_trig_ingr_drp: 22115
+                cell_size: 96
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 0
+                pkts_num_trig_ingr_drp: 22115
+                cell_size: 96
         xon_1:
             dscp: 3
             ecn: 1
             pg: 3
+            pkts_num_trig_pfc: 22038
+            pkts_num_dismiss_pfc: 21847
         xon_2:
             dscp: 4
             ecn: 1
             pg: 4
+            pkts_num_trig_pfc: 22038
+            pkts_num_dismiss_pfc: 21847
         ecn_1:
             dscp: 8
             ecn: 0
@@ -62,10 +86,32 @@ qos_params:
             limit: 182320
             min_limit: 0
             cell_size: 96
-        lossy_queue:
+        lossy_queue_1:
             dscp: 8
             ecn: 1
-            pg: 1
+            pg: 0
+            pkts_num_trig_egr_drp: 67965
+        wm_pg_shared_lossless:
+            dscp: 3
+            ecn: 1
+            pg: 3
+            pkts_num_fill_min: 6
+            pkts_num_trig_pfc: 22038
+            cell_size: 96
+        wm_pg_shared_lossy:
+            dscp: 1
+            ecn: 1
+            pg: 0
+            pkts_num_fill_min: 0
+            pkts_num_trig_egr_drp: 67965
+            cell_size: 96
+        wm_q_shared_lossy:
+            dscp: 1
+            ecn: 1
+            queue: 1
+            pkts_num_fill_min: 0
+            pkts_num_trig_egr_drp: 67965
+            cell_size: 96
         wrr:
             ecn: 1
             q0_num_of_pkts: 600
@@ -73,160 +119,93 @@ qos_params:
             q3_num_of_pkts: 500
             q4_num_of_pkts: 500
             limit: 80
-    Mellanox-SN2700:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 11115
-            pkts_num_trig_ingr_drp: 11213
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 11115
-            pkts_num_trig_ingr_drp: 11213
+    td2:
+        40000_5m:
+            pkts_num_leak_out: 48
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 0
+                pkts_num_trig_ingr_drp: 5164
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+                pkts_num_fill_egr_min: 0
+                cell_size: 208
+        40000_300m:
+            pkts_num_leak_out: 48
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 0
+                pkts_num_trig_ingr_drp: 5164
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+                pkts_num_fill_egr_min: 0
+                cell_size: 208
         xon_1:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 11115
-            pkts_num_dismiss_pfc: 10924
-        xon_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 11115
-            pkts_num_dismiss_pfc: 10924
-        ecn_1:
-            dscp: 8
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 96
-        ecn_2:
-            dscp: 8
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 96
-        ecn_3:
-            dscp: 0
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 96
-        ecn_4:
-            dscp: 0
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 96
-        lossy_queue:
-            dscp: 8
-            ecn: 1
-            pg: 1
-            pkts_num_leak_out: 0
-            pkts_num_trig_egr_drp: 48547
-        wrr:
-            ecn: 1
-            q0_num_of_pkts: 600
-            q1_num_of_pkts: 400
-            q3_num_of_pkts: 500
-            q4_num_of_pkts: 500
-            limit: 80
-            pkts_num_leak_out: 0
-    ACS-MSN2740:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-        xon_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-        xon_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-        ecn_1:
-            dscp: 8
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 96
-        ecn_2:
-            dscp: 8
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 96
-        ecn_3:
-            dscp: 0
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 96
-        ecn_4:
-            dscp: 0
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 96
-        lossy_queue:
-            dscp: 8
-            ecn: 1
-            pg: 1
-        wrr:
-            ecn: 1
-            q0_num_of_pkts: 600
-            q1_num_of_pkts: 400
-            q3_num_of_pkts: 500
-            q4_num_of_pkts: 500
-            limit: 80
-    Arista-7050-QX-32S:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-        xon_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 48
             pkts_num_trig_pfc: 4898
             pkts_num_dismiss_pfc: 12
         xon_2:
             dscp: 4
             ecn: 1
             pg: 4
-            pkts_num_leak_out: 48
             pkts_num_trig_pfc: 4898
             pkts_num_dismiss_pfc: 12
         ecn_1:
@@ -261,7 +240,6 @@ qos_params:
             dscp: 8
             ecn: 1
             pg: 0
-            pkts_num_leak_out: 48
             pkts_num_trig_egr_drp: 31322
         wrr:
             ecn: 1
@@ -273,7 +251,6 @@ qos_params:
             q5_num_of_pkts: 140
             q6_num_of_pkts: 140
             limit: 80
-            pkts_num_leak_out: 48
         wrr_chg:
             ecn: 1
             q0_num_of_pkts: 80
@@ -284,14 +261,12 @@ qos_params:
             q5_num_of_pkts: 80
             q6_num_of_pkts: 80
             limit: 80
-            pkts_num_leak_out: 48
             lossy_weight: 8
             lossless_weight: 30
         wm_pg_shared_lossless:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_leak_out: 48
             pkts_num_fill_min: 6
             pkts_num_trig_pfc: 4898
             cell_size: 208
@@ -299,230 +274,139 @@ qos_params:
             dscp: 1
             ecn: 1
             pg: 0
-            pkts_num_leak_out: 48
             pkts_num_fill_min: 0
             pkts_num_trig_egr_drp: 31322
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 48
-            pkts_num_fill_min: 0
-            pkts_num_trig_ingr_drp: 5164
             cell_size: 208
         wm_q_shared_lossy:
             dscp: 1
             ecn: 1
             queue: 1
-            pkts_num_leak_out: 48
             pkts_num_fill_min: 8
             pkts_num_trig_egr_drp: 31322
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 48
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-            pkts_num_fill_egr_min: 0
             cell_size: 208
         wm_buf_pool_lossy:
             dscp: 8
             ecn: 1
             pg: 0
             queue: 0
-            pkts_num_leak_out: 48
             pkts_num_fill_ingr_min: 0
             pkts_num_trig_egr_drp: 31322
             pkts_num_fill_egr_min: 8
             cell_size: 208
-    Force10-S6000:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
+    th:
+        40000_300m:
+            pkts_num_leak_out: 19
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7063
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7063
+            hdrm_pool_size:
+                dscps: [3, 4]
+                ecn: 1
+                pgs: [3, 4]
+                src_port_ids: [25, 26, 27, 40, 41]
+                dst_port_id: 24
+                pgs_num: 10
+                pkts_num_trig_pfc: 1194
+                pkts_num_hdrm_full: 520
+                pkts_num_hdrm_partial: 361
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7063
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 8
+                pkts_num_trig_ingr_drp: 7063
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7063
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
+        100000_300m:
+            pkts_num_leak_out: 36
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7835
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7835
+            hdrm_pool_size:
+                dscps: [3, 4]
+                ecn: 1
+                pgs: [3, 4]
+                src_port_ids: [17, 18]
+                dst_port_id: 16
+                pgs_num: 4
+                pkts_num_trig_pfc: 2620
+                pkts_num_hdrm_full: 1292
+                pkts_num_hdrm_partial: 1165
+            wm_pg_shared_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_fill_min: 6
+                pkts_num_trig_pfc: 6542
+                cell_size: 208
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7835
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 8
+                pkts_num_trig_ingr_drp: 7835
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7835
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
         xon_1:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_dismiss_pfc: 12
-        xon_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_dismiss_pfc: 12
-        ecn_1:
-            dscp: 8
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_2:
-            dscp: 8
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        ecn_3:
-            dscp: 0
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_4:
-            dscp: 0
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        lossy_queue_1:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 48
-            pkts_num_trig_egr_drp: 31322
-        wrr:
-            ecn: 1
-            q0_num_of_pkts: 140
-            q1_num_of_pkts: 140
-            q2_num_of_pkts: 140
-            q3_num_of_pkts: 150
-            q4_num_of_pkts: 150
-            q5_num_of_pkts: 140
-            q6_num_of_pkts: 140
-            limit: 80
-            pkts_num_leak_out: 48
-        wrr_chg:
-            ecn: 1
-            q0_num_of_pkts: 80
-            q1_num_of_pkts: 80
-            q2_num_of_pkts: 80
-            q3_num_of_pkts: 300
-            q4_num_of_pkts: 300
-            q5_num_of_pkts: 80
-            q6_num_of_pkts: 80
-            limit: 80
-            pkts_num_leak_out: 48
-            lossy_weight: 8
-            lossless_weight: 30
-        wm_pg_shared_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 48
-            pkts_num_fill_min: 6
-            pkts_num_trig_pfc: 4898
-            cell_size: 208
-        wm_pg_shared_lossy:
-            dscp: 1
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 48
-            pkts_num_fill_min: 0
-            pkts_num_trig_egr_drp: 31322
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 48
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 48
-            pkts_num_fill_min: 0
-            pkts_num_trig_ingr_drp: 5164
-            cell_size: 208
-        wm_q_shared_lossy:
-            dscp: 1
-            ecn: 1
-            queue: 1
-            pkts_num_leak_out: 48
-            pkts_num_fill_min: 8
-            pkts_num_trig_egr_drp: 31322
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 48
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 4898
-            pkts_num_trig_ingr_drp: 5164
-            pkts_num_fill_egr_min: 0
-            cell_size: 208
-        wm_buf_pool_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            queue: 0
-            pkts_num_leak_out: 48
-            pkts_num_fill_ingr_min: 0
-            pkts_num_trig_egr_drp: 31322
-            pkts_num_fill_egr_min: 8
-            cell_size: 208
-    Force10-S6100:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 19
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7063
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 19
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7063
-        xon_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 19
             pkts_num_trig_pfc: 6542
             pkts_num_dismiss_pfc: 11
         xon_2:
             dscp: 4
             ecn: 1
             pg: 4
-            pkts_num_leak_out: 19
             pkts_num_trig_pfc: 6542
             pkts_num_dismiss_pfc: 11
         ecn_1:
@@ -557,7 +441,6 @@ qos_params:
             dscp: 8
             ecn: 1
             pg: 0
-            pkts_num_leak_out: 19
             pkts_num_trig_egr_drp: 9887
         wrr:
             ecn: 1
@@ -569,7 +452,6 @@ qos_params:
             q5_num_of_pkts: 140
             q6_num_of_pkts: 140
             limit: 80
-            pkts_num_leak_out: 19
         wrr_chg:
             ecn: 1
             q0_num_of_pkts: 80
@@ -580,25 +462,12 @@ qos_params:
             q5_num_of_pkts: 80
             q6_num_of_pkts: 80
             limit: 80
-            pkts_num_leak_out: 19
             lossy_weight: 8
             lossless_weight: 30
-        hdrm_pool_size:
-            dscps: [3, 4]
-            ecn: 1
-            pgs: [3, 4]
-            src_port_ids: [25, 26, 27, 40, 41]
-            dst_port_id: 24
-            pgs_num: 10
-            pkts_num_leak_out: 19
-            pkts_num_trig_pfc: 1194
-            pkts_num_hdrm_full: 520
-            pkts_num_hdrm_partial: 361
         wm_pg_shared_lossless:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_leak_out: 19
             pkts_num_fill_min: 6
             pkts_num_trig_pfc: 6542
             cell_size: 208
@@ -606,400 +475,132 @@ qos_params:
             dscp: 8
             ecn: 1
             pg: 0
-            pkts_num_leak_out: 19
             pkts_num_fill_min: 0
             pkts_num_trig_egr_drp: 9887
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 19
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7063
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 19
-            pkts_num_fill_min: 8
-            pkts_num_trig_ingr_drp: 7063
             cell_size: 208
         wm_q_shared_lossy:
             dscp: 8
             ecn: 1
             queue: 0
-            pkts_num_leak_out: 19
             pkts_num_fill_min: 8
             pkts_num_trig_egr_drp: 9887
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 19
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7063
-            pkts_num_fill_egr_min: 8
             cell_size: 208
         wm_buf_pool_lossy:
             dscp: 8
             ecn: 1
             pg: 0
             queue: 0
-            pkts_num_leak_out: 19
             pkts_num_fill_ingr_min: 0
             pkts_num_trig_egr_drp: 9887
             pkts_num_fill_egr_min: 8
             cell_size: 208
-    Arista-7060CX-32S-C32:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
+    th2:
+        40000_300m:
+            pkts_num_leak_out: 0
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 4978
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 4978
+            hdrm_pool_size:
+                dscps: [3, 4]
+                ecn: 1
+                pgs: [3, 4]
+                src_port_ids: [6, 7, 8, 9, 10, 38, 39, 40, 41, 42]
+                dst_port_id: 32
+                pgs_num: 19
+                pkts_num_trig_pfc: 1490
+                pkts_num_hdrm_full: 520
+                pkts_num_hdrm_partial: 47
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 4978
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 0
+                pkts_num_trig_ingr_drp: 4978
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 4978
+                pkts_num_fill_egr_min: 16
+                cell_size: 208
+        50000_300m:
+            pkts_num_leak_out: 0
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 5140
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 5140
+            hdrm_pool_size:
+                dscps: [3, 4]
+                ecn: 1
+                pgs: [3, 4]
+                src_port_ids: [1, 2, 3, 4, 5, 6, 7]
+                dst_port_id: 0
+                pgs_num: 14
+                pkts_num_trig_pfc: 1826
+                pkts_num_hdrm_full: 682
+                pkts_num_hdrm_partial: 542
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 5140
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 0
+                pkts_num_trig_ingr_drp: 5140
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 4457
+                pkts_num_trig_ingr_drp: 5140
+                pkts_num_fill_egr_min: 16
+                cell_size: 208
         xon_1:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_dismiss_pfc: 11
-        xon_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_dismiss_pfc: 11
-        ecn_1:
-            dscp: 8
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_2:
-            dscp: 8
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        ecn_3:
-            dscp: 0
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_4:
-            dscp: 0
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        lossy_queue_1:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 36
-            pkts_num_trig_egr_drp: 9887
-        wrr:
-            ecn: 1
-            q0_num_of_pkts: 140
-            q1_num_of_pkts: 140
-            q2_num_of_pkts: 140
-            q3_num_of_pkts: 150
-            q4_num_of_pkts: 150
-            q5_num_of_pkts: 140
-            q6_num_of_pkts: 140
-            limit: 80
-            pkts_num_leak_out: 36
-        wrr_chg:
-            ecn: 1
-            q0_num_of_pkts: 80
-            q1_num_of_pkts: 80
-            q2_num_of_pkts: 80
-            q3_num_of_pkts: 300
-            q4_num_of_pkts: 300
-            q5_num_of_pkts: 80
-            q6_num_of_pkts: 80
-            limit: 80
-            pkts_num_leak_out: 36
-            lossy_weight: 8
-            lossless_weight: 30
-        hdrm_pool_size:
-            dscps: [3, 4]
-            ecn: 1
-            pgs: [3, 4]
-            src_port_ids: [17, 18]
-            dst_port_id: 16
-            pgs_num: 4
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 2620
-            pkts_num_hdrm_full: 1292
-            pkts_num_hdrm_partial: 1165
-        wm_pg_shared_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 6
-            pkts_num_trig_pfc: 6542
-            cell_size: 208
-        wm_pg_shared_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 0
-            pkts_num_trig_egr_drp: 9887
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 8
-            pkts_num_trig_ingr_drp: 7835
-            cell_size: 208
-        wm_q_shared_lossy:
-            dscp: 8
-            ecn: 1
-            queue: 0
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 8
-            pkts_num_trig_egr_drp: 9887
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 36
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-            pkts_num_fill_egr_min: 8
-            cell_size: 208
-        wm_buf_pool_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            queue: 0
-            pkts_num_leak_out: 36
-            pkts_num_fill_ingr_min: 0
-            pkts_num_trig_egr_drp: 9887
-            pkts_num_fill_egr_min: 8
-            cell_size: 208
-    Celestica-DX010-C32:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-        xon_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_dismiss_pfc: 11
-        xon_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_dismiss_pfc: 11
-        ecn_1:
-            dscp: 8
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_2:
-            dscp: 8
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        ecn_3:
-            dscp: 0
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_4:
-            dscp: 0
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        lossy_queue_1:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 36
-            pkts_num_trig_egr_drp: 9887
-        wrr:
-            ecn: 1
-            q0_num_of_pkts: 140
-            q1_num_of_pkts: 140
-            q2_num_of_pkts: 140
-            q3_num_of_pkts: 150
-            q4_num_of_pkts: 150
-            q5_num_of_pkts: 140
-            q6_num_of_pkts: 140
-            limit: 80
-            pkts_num_leak_out: 36
-        wrr_chg:
-            ecn: 1
-            q0_num_of_pkts: 80
-            q1_num_of_pkts: 80
-            q2_num_of_pkts: 80
-            q3_num_of_pkts: 300
-            q4_num_of_pkts: 300
-            q5_num_of_pkts: 80
-            q6_num_of_pkts: 80
-            limit: 80
-            pkts_num_leak_out: 36
-            lossy_weight: 8
-            lossless_weight: 30
-        hdrm_pool_size:
-            dscps: [3, 4]
-            ecn: 1
-            pgs: [3, 4]
-            src_port_ids: [17, 18]
-            dst_port_id: 16
-            pgs_num: 4
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 2620
-            pkts_num_hdrm_full: 1292
-            pkts_num_hdrm_partial: 1165
-        wm_pg_shared_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 6
-            pkts_num_trig_pfc: 6542
-            cell_size: 208
-        wm_pg_shared_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 0
-            pkts_num_trig_egr_drp: 9887
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 36
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 8
-            pkts_num_trig_ingr_drp: 7835
-            cell_size: 208
-        wm_q_shared_lossy:
-            dscp: 8
-            ecn: 1
-            queue: 0
-            pkts_num_leak_out: 36
-            pkts_num_fill_min: 8
-            pkts_num_trig_egr_drp: 9887
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 36
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 6542
-            pkts_num_trig_ingr_drp: 7835
-            pkts_num_fill_egr_min: 8
-            cell_size: 208
-        wm_buf_pool_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            queue: 0
-            pkts_num_leak_out: 36
-            pkts_num_fill_ingr_min: 0
-            pkts_num_trig_egr_drp: 9887
-            pkts_num_fill_egr_min: 8
-            cell_size: 208
-    Arista-7260CX3-Q64:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 4978
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 4978
-        xon_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
             pkts_num_trig_pfc: 4457
             pkts_num_dismiss_pfc: 12
         xon_2:
             dscp: 4
             ecn: 1
             pg: 4
-            pkts_num_leak_out: 0
             pkts_num_trig_pfc: 4457
             pkts_num_dismiss_pfc: 12
         ecn_1:
@@ -1034,7 +635,6 @@ qos_params:
             dscp: 8
             ecn: 1
             pg: 0
-            pkts_num_leak_out: 0
             pkts_num_trig_egr_drp: 10692
         wrr:
             ecn: 1
@@ -1046,7 +646,6 @@ qos_params:
             q5_num_of_pkts: 140
             q6_num_of_pkts: 140
             limit: 80
-            pkts_num_leak_out: 0
         wrr_chg:
             ecn: 1
             q0_num_of_pkts: 80
@@ -1057,25 +656,12 @@ qos_params:
             q5_num_of_pkts: 80
             q6_num_of_pkts: 80
             limit: 80
-            pkts_num_leak_out: 0
             lossy_weight: 8
             lossless_weight: 30
-        hdrm_pool_size:
-            dscps: [3, 4]
-            ecn: 1
-            pgs: [3, 4]
-            src_port_ids: [6, 7, 8, 9, 10, 38, 39, 40, 41, 42]
-            dst_port_id: 32
-            pgs_num: 19
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 1490
-            pkts_num_hdrm_full: 520
-            pkts_num_hdrm_partial: 47
         wm_pg_shared_lossless:
             dscp: 3
             ecn: 1
             pg: 3
-            pkts_num_leak_out: 0
             pkts_num_fill_min: 6
             pkts_num_trig_pfc: 4457
             cell_size: 208
@@ -1083,210 +669,21 @@ qos_params:
             dscp: 8
             ecn: 1
             pg: 0
-            pkts_num_leak_out: 0
             pkts_num_fill_min: 0
             pkts_num_trig_egr_drp: 10692
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 4978
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 0
-            pkts_num_fill_min: 0
-            pkts_num_trig_ingr_drp: 4978
             cell_size: 208
         wm_q_shared_lossy:
             dscp: 8
             ecn: 1
             queue: 0
-            pkts_num_leak_out: 0
             pkts_num_fill_min: 8
             pkts_num_trig_egr_drp: 10692
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 0
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 4978
-            pkts_num_fill_egr_min: 16
             cell_size: 208
         wm_buf_pool_lossy:
             dscp: 8
             ecn: 1
             pg: 0
             queue: 0
-            pkts_num_leak_out: 0
-            pkts_num_fill_ingr_min: 0
-            pkts_num_trig_egr_drp: 10692
-            pkts_num_fill_egr_min: 16
-            cell_size: 208
-    Arista-7260CX3-D108C8:
-        xoff_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 5140
-        xoff_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 5140
-        xon_1:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_dismiss_pfc: 12
-        xon_2:
-            dscp: 4
-            ecn: 1
-            pg: 4
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_dismiss_pfc: 12
-        ecn_1:
-            dscp: 8
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_2:
-            dscp: 8
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        ecn_3:
-            dscp: 0
-            ecn: 0
-            num_of_pkts: 5000
-            limit: 182000
-            min_limit: 180000
-            cell_size: 208
-        ecn_4:
-            dscp: 0
-            ecn: 1
-            num_of_pkts: 2047
-            limit: 182320
-            min_limit: 0
-            cell_size: 208
-        lossy_queue_1:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 0
-            pkts_num_trig_egr_drp: 10692
-        wrr:
-            ecn: 1
-            q0_num_of_pkts: 140
-            q1_num_of_pkts: 140
-            q2_num_of_pkts: 140
-            q3_num_of_pkts: 150
-            q4_num_of_pkts: 150
-            q5_num_of_pkts: 140
-            q6_num_of_pkts: 140
-            limit: 80
-            pkts_num_leak_out: 0
-        wrr_chg:
-            ecn: 1
-            q0_num_of_pkts: 80
-            q1_num_of_pkts: 80
-            q2_num_of_pkts: 80
-            q3_num_of_pkts: 300
-            q4_num_of_pkts: 300
-            q5_num_of_pkts: 80
-            q6_num_of_pkts: 80
-            limit: 80
-            pkts_num_leak_out: 0
-            lossy_weight: 8
-            lossless_weight: 30
-        hdrm_pool_size:
-            dscps: [3, 4]
-            ecn: 1
-            pgs: [3, 4]
-            src_port_ids: [1, 2, 3, 4, 5, 6, 7]
-            dst_port_id: 0
-            pgs_num: 14
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 1826
-            pkts_num_hdrm_full: 682
-            pkts_num_hdrm_partial: 542
-        wm_pg_shared_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_fill_min: 6
-            pkts_num_trig_pfc: 4457
-            cell_size: 208
-        wm_pg_shared_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            pkts_num_leak_out: 0
-            pkts_num_fill_min: 0
-            pkts_num_trig_egr_drp: 10692
-            cell_size: 208
-        wm_pg_headroom:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            pkts_num_leak_out: 0
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 5140
-            cell_size: 208
-        wm_q_shared_lossless:
-            dscp: 3
-            ecn: 1
-            queue: 3
-            pkts_num_leak_out: 0
-            pkts_num_fill_min: 0
-            pkts_num_trig_ingr_drp: 5140
-            cell_size: 208
-        wm_q_shared_lossy:
-            dscp: 8
-            ecn: 1
-            queue: 0
-            pkts_num_leak_out: 0
-            pkts_num_fill_min: 8
-            pkts_num_trig_egr_drp: 10692
-            cell_size: 208
-        wm_buf_pool_lossless:
-            dscp: 3
-            ecn: 1
-            pg: 3
-            queue: 3
-            pkts_num_leak_out: 0
-            pkts_num_fill_ingr_min: 6
-            pkts_num_trig_pfc: 4457
-            pkts_num_trig_ingr_drp: 5140
-            pkts_num_fill_egr_min: 16
-            cell_size: 208
-        wm_buf_pool_lossy:
-            dscp: 8
-            ecn: 1
-            pg: 0
-            queue: 0
-            pkts_num_leak_out: 0
             pkts_num_fill_ingr_min: 0
             pkts_num_trig_egr_drp: 10692
             pkts_num_fill_egr_min: 16


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
Organize Qos SAI test vars based on asic type and include port speed and cable length definition. The test depended on pg headroom are specified under portspeed/cable length and all others are specified under the asic.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Ran the test on Th and Th2 for one port speed /cable length