### PR TITLE
[Mellanox] Fix dip_sip test bug - added support for portchannels that consist of more than one interface

### DIFF
--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -41,8 +41,17 @@ def lag_facts(dut, mg_facts):
     facts['dst_router_ipv4'] = host_facts['ansible_' + dst_lag]['ipv4']['address']
     dst_ipv6 = host_facts['ansible_' + dst_lag]['ipv6']
     facts['dst_router_ipv6'] = [(item['address']) for item in dst_ipv6 if item['scope'] == 'global'][0]
-    facts['dst_port_ids'] = [mg_facts['minigraph_port_indices'][mg_facts['minigraph_portchannels'][dst_lag]['members'][0]]]
-    facts['src_port_ids'] = [mg_facts['minigraph_port_indices'][mg_facts['minigraph_portchannels'][src_lag]['members'][0]]]
+
+    dst_port_list = []
+    src_port_list = []
+    dst_len = len(mg_facts['minigraph_portchannels'][dst_lag]['members'])
+    src_len = len(mg_facts['minigraph_portchannels'][src_lag]['members'])
+    for i in range(dst_len):
+        dst_port_list.append(mg_facts['minigraph_port_indices'][mg_facts['minigraph_portchannels'][dst_lag]['members'][i]])
+    facts['dst_port_ids'] = dst_port_list
+    for i in range(src_len):
+        src_port_list.append(mg_facts['minigraph_port_indices'][mg_facts['minigraph_portchannels'][src_lag]['members'][i]])
+    facts['src_port_ids'] = src_port_list
 
     return facts
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Changed lag_facts function to support portchannels that consists of more than one interface.
After the change, the received packet is expected to arrive to any of those interfaces.

#### How did you verify/test it?
Run dip sip test with lag topology (t0/t1-lag).
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
