### PR TITLE
[pytest] setup some default options for pytest

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+norecursedirs = ptftests acstests
+addopts = -ra --allow_recover --showlocals --module-path ../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=test_vrf.py
 markers:
     acl: ACL tests
     bsl: BSL tests

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = ptftests acstests
-addopts = -ra --allow_recover --showlocals --module-path ../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=test_vrf.py
+addopts = -ra --module-path ../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=test_vrf.py
 markers:
     acl: ACL tests
     bsl: BSL tests

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-norecursedirs = ptftests


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
- acstests and ptftests are helper files that are used by tests but not test cases.
- nonrecursedir only works in pytest.ini, and it doesn't prevent testcase collection.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Collecting all test cases. Watch the number of test collected change with and without the options.

Without the nonrecursedir change, collection will fail due to files with duplicate names under these folders.

The other addopts changes the test behavior and also filters out non-testcase folders and hard failing tests.