### PR TITLE
[reload config] redirect reload config output to /dev/null

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -24,10 +24,10 @@ def config_reload(duthost, config_source='config_db', wait=120):
     logger.info('reloading {}'.format(config_source))
 
     if config_source == 'minigraph':
-        duthost.command('config load_minigraph -y')
-        duthost.command('config save -y')
+        duthost.shell('config load_minigraph -y &>/dev/null')
+        duthost.shell('config save -y')
 
     if config_source == 'config_db':
-        duthost.command('config reload -y')
+        duthost.shell('config reload -y &>/dev/null')
 
     time.sleep(wait)

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -27,7 +27,7 @@ def test_reload_configuration(duthost, conn_graph_facts):
     asic_type = duthost.facts["asic_type"]
 
     logging.info("Reload configuration")
-    duthost.command("sudo config reload -y")
+    duthost.shell("sudo config reload -y &>/dev/null")
 
     logging.info("Wait until all critical services are fully started")
     check_critical_services(duthost)

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -184,7 +184,7 @@ def tearDown(vlan_ports_list, duthost, ptfhost, vlan_intfs_list, portchannel_int
     except RunAnsibleModuleFail as e:
         logger.error(e)
 
-    duthost.command("config reload -y")
+    duthost.shell("config reload -y &>/dev/null")
 
     # make sure Portchannels go up for post-test link sanity
     time.sleep(90)


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
config reload command will restart interface-config service, which
will reset eth0. Which will reset the connection issues config
reload if the output is coming to stdio/stderr. It in turn could
cause the pytest to stuck for long time.

change .command to .shell so that we could redirect output to /dev/null (command doesn't allow &> operation).

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
This is a first step enhancement of config reload/load_minigraph operations. This change greatly reduced the chance of these commands getting stuck. However, I believe they still get stuck from time to time. Some further enhancement is needed to fully address the issue.