### PR TITLE
[pytest/snmp_cpu]: query nproc when ansible facts does not have vcpu …

### DIFF
--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -1,6 +1,8 @@
 import pytest
 import time
+import logging
 
+logger = logging.getLogger(__name__)
 
 @pytest.mark.bsl
 def test_snmp_cpu(duthost, localhost, creds):
@@ -17,7 +19,13 @@ def test_snmp_cpu(duthost, localhost, creds):
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     host_facts = duthost.setup()['ansible_facts']
-    host_vcpus = int(host_facts['ansible_processor_vcpus'])
+    if host_facts.has_key("ansible_processor_vcpus"):
+        host_vcpus = int(host_facts['ansible_processor_vcpus'])
+    else:
+        res = duthost.shell("nproc")
+        host_vcpus = int(res['stdout'])
+
+    logger.info("found {} cpu on the dut".format(host_vcpus))
 
     # Gather facts with SNMP version 2
     snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"], is_dell=True)['ansible_facts']


### PR DESCRIPTION
…info

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
sometimes, ansible facts does not gather vcpu information. in this case, use nproc to query the cpu number directly.

#### How did you verify/test it?
run test on vs platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
