### PR TITLE
[wr_arp][pytest] Fixed wr_arp test

### DIFF
--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -28,7 +28,7 @@ class ArpTest(BaseTest):
     def __init__(self):
         BaseTest.__init__(self)
 
-        log_file_name = '/root/wr_arp_test.log'
+        log_file_name = '/tmp/wr_arp_test.log'
         self.log_fp = open(log_file_name, 'a')
         self.log_fp.write("\nNew test:\n")
 
@@ -46,6 +46,7 @@ class ArpTest(BaseTest):
         current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         print "%s : %s" % (current_time, message)
         self.log_fp.write("%s : %s\n" % (current_time, message))
+        self.log_fp.flush()
 
         return
 
@@ -100,6 +101,16 @@ class ArpTest(BaseTest):
                 self.log('Unsupported cmd: %s' % cmd)
                 q_to.put("error: unsupported cmd: %s" % cmd)
         self.log("Quiting from dut_thr")
+        return
+
+    def test_port_thr(self):
+        self.log("test_port_thr started")
+        while time.time() < self.stop_at:
+            for test in self.tests:
+                for port in test['acc_ports']:
+                    nr_rcvd = self.testPort(port)
+                    records[port][time.time()] = nr_rcvd
+        self.log("Quiting from test_port_thr")
         return
 
     def readMacs(self):
@@ -242,21 +253,22 @@ class ArpTest(BaseTest):
             self.assertTrue(False, "DUT returned error for first uptime request")
 
         records = defaultdict(dict)
-        stop_at = time.time() + self.how_long
-        rebooted = False
-        while time.time() < stop_at:
-            for test in self.tests:
-                for port in test['acc_ports']:
-                    nr_rcvd = self.testPort(port)
-                    records[port][time.time()] = nr_rcvd
-            if not rebooted:
-                result = self.req_dut('WR')
-                if result.startswith('ok'):
-                    rebooted = True
-                else:
-                    self.log("Error in WR")
-                    self.req_dut('quit')
-                    self.assertTrue(False, "Error in WR")
+        self.stop_at = time.time() + self.how_long
+
+        test_port_thr = threading.Thread(target=self.test_port_thr)
+        test_port_thr.setDaemon(True)
+        test_port_thr.start()
+
+        self.log("Issuing WR command")
+        result = self.req_dut('WR')
+        if result.startswith('ok'):
+            self.log("WR OK!")
+        else:
+            self.log("Error in WR")
+            self.req_dut('quit')
+            self.assertTrue(False, "Error in WR")
+
+        test_port_thr.join()
 
         uptime_after = self.req_dut('uptime')
         if uptime_after.startswith('error'):

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -109,7 +109,7 @@ class ArpTest(BaseTest):
             for test in self.tests:
                 for port in test['acc_ports']:
                     nr_rcvd = self.testPort(port)
-                    records[port][time.time()] = nr_rcvd
+                    self.records[port][time.time()] = nr_rcvd
         self.log("Quiting from test_port_thr")
         return
 
@@ -252,7 +252,7 @@ class ArpTest(BaseTest):
             self.req_dut('quit')
             self.assertTrue(False, "DUT returned error for first uptime request")
 
-        records = defaultdict(dict)
+        self.records = defaultdict(dict)
         self.stop_at = time.time() + self.how_long
 
         test_port_thr = threading.Thread(target=self.test_port_thr)
@@ -286,7 +286,7 @@ class ArpTest(BaseTest):
 
         # check that every port didn't have pauses more than 25 seconds
         pauses = defaultdict(list)
-        for port, data in records.items():
+        for port, data in self.records.items():
             was_active = True
             last_inactive = None
             for t in sorted(data.keys()):

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -268,6 +268,8 @@ class ArpTest(BaseTest):
             self.req_dut('quit')
             self.assertTrue(False, "Error in WR")
 
+        self.assertTrue(time.time() < self.stop_at, "warm-reboot took to long")
+
         test_port_thr.join()
 
         uptime_after = self.req_dut('uptime')

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -57,7 +57,7 @@ class TestWrArp:
         ptfhost.copy(src="arp/files/ferret.py", dest="/opt")
 
         result = duthost.shell(
-            cmd='''ip route show proto zebra type unicast |
+            cmd='''ip route show proto 186 type unicast |
             sed -e '/default/d' -ne '/0\//p' |
             head -n 1 |
             sed -ne 's/0\/.*$/1/p'
@@ -144,7 +144,7 @@ class TestWrArp:
             Returns:
                 None
         '''
-        ptfhost.script(src='scripts/remove_ip.sh')
+        ptfhost.script('./scripts/remove_ip.sh')
 
     @pytest.fixture(scope='class', autouse=True)
     def changePtfhostMacAddresses(self, ptfhost):
@@ -157,7 +157,7 @@ class TestWrArp:
             Returns:
                 None
         '''
-        ptfhost.script(src="scripts/change_mac.sh")
+        ptfhost.script("./scripts/change_mac.sh")
 
     @pytest.fixture(scope='class', autouse=True)
     def prepareSshKeys(self, duthost, ptfhost):

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -57,8 +57,8 @@ class TestWrArp:
         ptfhost.copy(src="arp/files/ferret.py", dest="/opt")
 
         result = duthost.shell(
-            cmd='''ip route show proto 186 type unicast |
-            sed -e '/default/d' -ne '/0\//p' |
+            cmd='''ip route show type unicast |
+            sed -e '/proto 186\|proto zebra/!d' -e '/default/d' -ne '/0\//p' |
             head -n 1 |
             sed -ne 's/0\/.*$/1/p'
             '''

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -78,14 +78,15 @@ class TestWrArp:
             ...
 
             We'll use the first subnet IP taken from zebra protocol as the base for the host IP.
-            As in the new SONiC image the proto will look as '186' instead of 'zebra' (like it looks in 201811)
-            the filtering output command below will pick the first line containing either 'zebra' or '186' 
+            As in the new SONiC image the proto will look as '186'(201911) or bgp (master) 
+            instead of 'zebra' (like it looks in 201811)the filtering output command below will pick 
+            the first line containing either 'proto zebra' (or 'proto 186' or 'proto bgp')
             (except the one for the deafult route) and take host IP from the subnet IP. For the output
             above 192.168.8.0/25 subnet will be taken and host IP given to ferret script will be 192.168.8.1               
         '''
         result = duthost.shell(
             cmd='''ip route show type unicast |
-            sed -e '/proto 186\|proto zebra/!d' -e '/default/d' -ne '/0\//p' |
+            sed -e '/proto 186\|proto zebra\|proto bgp/!d' -e '/default/d' -ne '/0\//p' |
             head -n 1 |
             sed -ne 's/0\/.*$/1/p'
             '''


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR

Summary:
Fixes # (issue)
The test fails due to several reasons after migration to pytest.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ *] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Use the proper "ip route show" command to get the DIP from the DUT. 
Pass the correct path to scripts which have to be executed on PTF host.
Call testPort() function from the separate thread in PTF part so that the ARP packets can be generated while warm-reboot script is executed. 

#### How did you verify/test it?
Run wr_arp test on BFN platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

