### PR TITLE
Fix the issue of using wrong port announcing IPv6 routes

### DIFF
--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -150,7 +150,8 @@ def fib_t0(ptfhost, testbed):
                                     spine_asn, leaf_asn_start, tor_asn_start,
                                     local_ip, local_ipv6)
 
-        announce_routes(ptfip, port, routes_v4 + routes_v6)
+        announce_routes(ptfip, port, routes_v4)
+        announce_routes(ptfip, port6, routes_v6)
 
 
 def fib_t1_lag(ptfhost, testbed):
@@ -211,7 +212,8 @@ def fib_t1_lag(ptfhost, testbed):
             routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                         None, leaf_asn_start, tor_asn_start,
                                         local_ip, local_ipv6, router_type="spine")
-            announce_routes(ptfip, port, routes_v4 + routes_v6)
+            announce_routes(ptfip, port, routes_v4)
+            announce_routes(ptfip, port6, routes_v6)
 
         elif 'tor' in v['properties']:
             routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

I used wrong port for announcing IPv6 routes in PR #1692. This PR is to fix that issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Use different PTF port for announcing IPv6 routes.

#### How did you verify/test it?
Run test_announce_routes.py. Verify that the DUT switch learned correct IPv6 routes from VMs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
