### PR TITLE
Fix warning "provided hosts list is empty, only localhost is available"

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -29,7 +29,7 @@ class AnsibleHostBase(object):
 
     def __init__(self, ansible_adhoc, hostname, connection=None):
         if hostname == 'localhost':
-            self.host = ansible_adhoc(inventory='localhost', connection='local', host_pattern=hostname)[hostname]
+            self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
         else:
             if connection is None:
                 self.host = ansible_adhoc(become=True)[hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

When run pytest scripts, a warning is always shown:

```
test_example.py::test_case1
  /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py:70: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

With this fix, the warning is no longer displayed. Fixture localhost still works fine.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Remove the "inventory='localhost'" argument when calling the ansible_adhoc fixture to create a localhost ansible object. The inventory supplied in pytest cli argument will be used.

#### How did you verify/test it?
Test run scripts depend on the localhost fixture. The localhost fixture works fine. The warning is not displayed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
