### PR TITLE
[Mellanox] Fixes test_sfp_presence deprecated SFP sysfs

### DIFF
--- a/tests/platform_tests/mellanox/test_check_sfp_presence.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_presence.py
@@ -11,15 +11,10 @@ def test_check_sfp_presence(duthost, conn_graph_facts):
     """This test case is to check SFP presence status with CLI and sysfs.
     """
     ports_config = json.loads(duthost.command("sudo sonic-cfggen -d --var-json PORT")["stdout"])
-    sysfs_path = get_sfp_sysfs_path(duthost)
-    check_qsfp_sysfs_command = 'cat {}'.format(sysfs_path)
     check_intf_presence_command = 'show interface transceiver presence {}'
 
     logging.info("Use show interface status information")
     for intf in conn_graph_facts["device_conn"]:
-        intf_lanes = ports_config[intf]["lanes"]
-        sfp_id = int(intf_lanes.split(",")[0])/4 + 1
-
         check_presence_output = duthost.command(check_intf_presence_command.format(intf))
         assert check_presence_output["rc"] == 0, "Failed to read interface %s transceiver presence" % intf
         logging.info(str(check_presence_output["stdout_lines"][2]))
@@ -27,16 +22,4 @@ def test_check_sfp_presence(duthost, conn_graph_facts):
         logging.info(str(presence_list))
         assert intf in presence_list, "Wrong interface name in the output %s" % str(presence_list)
         assert 'Present' in presence_list, "Status is not expected, output %s" % str(presence_list)
-
-        check_sysfs_output = duthost.command(check_qsfp_sysfs_command.format(str(sfp_id)))
-        logging.info('output of check sysfs %s' % (str(check_sysfs_output)))
-        assert check_sysfs_output["rc"] == 0, "Failed to read sysfs of sfp%s." % str(sfp_id)
-        assert check_sysfs_output["stdout"] == '1', "Content of sysfs of sfp%s is not correct" % str(sfp_id)
-
-
-def get_sfp_sysfs_path(ans_host):
-    file_exists = ans_host.stat(path='/var/run/hw-management/qsfp')
-    if file_exists['stat']['exists'] == True:
-        return '/var/run/hw-management/qsfp/qsfp{}_status'
-    else:
-        return '/var/run/hw-management/sfp/sfp{}_status'
+        


### PR DESCRIPTION
Change-Id: Idfd75f2d4c47b9a67b0f4bc96b3c08b6fbd6fc4c
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes 'test_sfp_presence' deprecated SFP sysfs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Edit the test to suite current sysfs structure.

#### How did you verify/test it?
Run the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
