### PR TITLE
[reload config] use /bin/bash as shell for config reload

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -24,10 +24,10 @@ def config_reload(duthost, config_source='config_db', wait=120):
     logger.info('reloading {}'.format(config_source))
 
     if config_source == 'minigraph':
-        duthost.shell('config load_minigraph -y &>/dev/null')
+        duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
         duthost.shell('config save -y')
 
     if config_source == 'config_db':
-        duthost.shell('config reload -y &>/dev/null')
+        duthost.shell('config reload -y &>/dev/null', executable="/bin/bash")
 
     time.sleep(wait)

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -27,7 +27,7 @@ def test_reload_configuration(duthost, conn_graph_facts):
     asic_type = duthost.facts["asic_type"]
 
     logging.info("Reload configuration")
-    duthost.shell("sudo config reload -y &>/dev/null")
+    duthost.shell("sudo config reload -y &>/dev/null", executable="/bin/bash")
 
     logging.info("Wait until all critical services are fully started")
     check_critical_services(duthost)

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -184,7 +184,7 @@ def tearDown(vlan_ports_list, duthost, ptfhost, vlan_intfs_list, portchannel_int
     except RunAnsibleModuleFail as e:
         logger.error(e)
 
-    duthost.shell("config reload -y &>/dev/null")
+    duthost.shell("config reload -y &>/dev/null", executable="/bin/bash")
 
     # make sure Portchannels go up for post-test link sanity
     time.sleep(90)


### PR DESCRIPTION
This change was introduced in
https://github.com/Azure/sonic-mgmt/pull/1687 to fix connection reset
caused by 'config reload'. The fix was to redirect output to /dev/null.
Shell will interpret 'config reload -y &> /dev/null' as request to run
the command in the background instead of redirecting stdout/stderr to
/dev/null. It looks like not the redirection fixed the issue but the
fact that it was running in background. However, it introduced another
issue because config reload takes ~1.5m so that 90/120 sec wait time is
not enough time waiting for system to become ready.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

I ran vlan test and verified that test waits till config reload finishes. Before this change vlan test finishes, "config reload -y" running in background gets killed and leaves system with stopped swss. With this change vlan test behaves correctly.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
