### PR TITLE
make sure only syncd is match on pgrep

### DIFF
--- a/ansible/roles/test/tasks/restart_syncd.yml
+++ b/ansible/roles/test/tasks/restart_syncd.yml
@@ -15,7 +15,7 @@
     seconds: 10
 
 - name: Look for syncd process
-  shell: pgrep "\<syncd\>" -a
+  shell: pgrep syncd -a -x
   register: syncd_out
   ignore_errors: yes
 


### PR DESCRIPTION
make sure only syncd is match on pgrep. Without this even /usr/bin/syncd.sh were getting O/P of pgrep command making test case case fail as we expect no O/P once syncd is terminated.

Fix for Issue https://github.com/Azure/sonic-buildimage/pull/4530

Fix is to use -x option of pgrep to exact match on syncd.
 -x, --exact
              Only match processes whose names (or command line if -f is specified) exactly match the pattern.


Verified Manually syncd process gets terminated with no core.
also run testcase "restart_syncd"



