### PR TITLE
Improve the pytest logging

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -56,7 +56,7 @@ timeout = 10
 
 # logging is off by default unless this path is defined
 # if so defined, consider logrotate
-log_path = $HOME/ansible.log
+# log_path = $HOME/ansible.log
 
 # default module name for /usr/bin/ansible
 #module_name = command

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -12,7 +12,6 @@ import logging
 import os
 import re
 import inspect
-import json
 import ipaddress
 from multiprocessing.pool import ThreadPool
 from datetime import datetime

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -11,6 +11,8 @@ import json
 import logging
 import os
 import re
+import inspect
+import json
 import ipaddress
 from multiprocessing.pool import ThreadPool
 from datetime import datetime
@@ -49,6 +51,14 @@ class AnsibleHostBase(object):
             raise UnsupportedAnsibleModule("Unsupported module")
 
     def _run(self, *module_args, **complex_args):
+
+        previous_frame = inspect.currentframe().f_back
+        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
+
+        logging.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}"\
+            .format(filename, function_name, line_number, self.hostname,
+                    self.module_name, json.dumps(module_args), json.dumps(complex_args)))
+
         module_ignore_errors = complex_args.pop('module_ignore_errors', False)
         module_async = complex_args.pop('module_async', False)
 
@@ -60,6 +70,9 @@ class AnsibleHostBase(object):
             return pool, result
 
         res = self.module(*module_args, **complex_args)[self.hostname]
+        logging.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}"\
+            .format(filename, function_name, line_number, self.hostname, self.module_name, json.dumps(res)))
+
         if res.is_failed and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
 
@@ -101,7 +114,7 @@ class SonicHost(AnsibleHostBase):
         if gather_facts:
             self.gather_facts()
 
-    def _get_critical_services_for_multi_npu():
+    def _get_critical_services_for_multi_npu(self):
         """
         Update the critical_services with the service names for multi-npu platforms
         """

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -10,3 +10,5 @@ markers:
     sanity_check: override the default sanity check settings
     topology: specify which topology testcase can be executed on: (t0, t1, ptf, etc)
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)
+
+log_format: %(asctime)s %(levelname)s %(filename)s:%(funcName)s:%(lineno)d: %(message)s

--- a/tests/pytest.logging.md
+++ b/tests/pytest.logging.md
@@ -1,0 +1,156 @@
+# Overview
+
+It would be much easier to troubleshoot the root cause if the failed scripts can generate appropriate log messages. We often need the log messages to be detailed enough so that we can have all the information needed for debugging. But if the log messages have too much irrelevant information, the noise will make it difficult for us to locate the root cause. The logging need to be balanced between detail and concise.
+
+# Pytest logging
+Like most automation framework, pytest supports two typical logging methods:
+1. Output log messages to console.
+2. Save log messages to file.
+
+Reference: [pytest logging](https://docs.pytest.org/en/latest/logging.html)
+
+Different configuration options can be used to control the logging level, format and destination:
+* log_cli_level
+* log_cli_format
+* log_cli_date_format
+* log_file
+* log_file_level
+* log_file_format
+* log_file_date_format
+
+The configuration options can be specified in the configuration INI file or supplied to the `pytest` command line. You can configure live logging or file logging according to your requirements. In this document, we will use live logging as example.
+
+For the pytest scripts to show live logging, we can simply specify `--log-cli-level <level>` on CLI, for example:
+```
+pytest <scripts> <other_options> --log-cli-level debug
+```
+
+For the pytest scripts to log messages to file, we can specify arguments like `--log-file /tmp/test_log.txt --log-cli-level debug`.
+
+
+
+The pytest scripts depend on the pytest-ansible plugin to run ansible modules on the devices in testbed. However, the pytest-ansible plugin and ansible caused some troubles with logging. If we set `--capture no` (will talk about it later) and `--log-cli-level debug`, executing a simple ansible `command` module on duthost will result in below logs:
+
+```
+DEBUG    pytest_ansible.module_dispatcher.v28:v28.py:78 [vlab-01] shell: {'_raw_params': 'pwd'}
+Loading callback plugin unnamed of type old, v1.0 from /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py
+INFO     p=10040 u=johnar | :display.py:179 Loading callback plugin unnamed of type old, v1.0 from /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py
+DEBUG    pytest_ansible.module_dispatcher.v28:v28.py:127 Play({'gather_facts': 'no', 'tasks': [{'action': {'args': {'_raw_params': 'pwd'}, 'module': 'shell'}}], 'hosts': 'vlab-01', 'name': 'pytest-ansible'})
+DEBUG    pytest_ansible.module_dispatcher.v28:v28.py:133 TaskQueueManager({'stdout_callback': <pytest_ansible.module_dispatcher.v28.ResultAccumulator object at 0x7f9ab67d2f50>, 'passwords': {'conn_pass': None$
+ 'become_pass': None}, 'variable_manager': <ansible.vars.manager.VariableManager object at 0x7f9ab8619610>, 'inventory': <ansible.inventory.manager.InventoryManager object at 0x7f9ab8619210>, 'loader': <ansib$
+e.parsing.dataloader.DataLoader object at 0x7f9ab8619510>})
+Loading callback plugin profile_tasks of type aggregate, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/profile_tasks.py
+INFO     p=10040 u=johnar | :display.py:179 Loading callback plugin profile_tasks of type aggregate, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/profile_tasks.py
+META: ran handlers
+INFO     p=10040 u=johnar | :display.py:179 META: ran handlers
+Monday 01 June 2020  09:36:33 +0000 (0:00:00.852)       0:00:07.058 ***********
+INFO     p=10040 u=johnar | :display.py:179 Monday 01 June 2020  09:36:33 +0000 (0:00:00.852)       0:00:07.058 ***********
+Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
+INFO     p=10040 u=johnar | :display.py:179 Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
+Pipelining is enabled.
+INFO     p=10040 u=johnar | :display.py:179 Pipelining is enabled.
+<10.250.0.101> ESTABLISH SSH CONNECTION FOR USER: admin
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> ESTABLISH SSH CONNECTION FOR USER: admin
+<10.250.0.101> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)(-o)(StrictHostKeyChecking=no)
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: ansible.cfg set ssh_args: (-o)(ControlMaster=auto)(-o)(ControlPersist=120s)(-o)(UserKnownHostsFile=/dev/null)(-o)(StrictHostKeyChecking=no)
+<10.250.0.101> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled: (-o)(StrictHostKeyChecking=no)
+<10.250.0.101> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User="admin")
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set: (-o)(User="admin")
+<10.250.0.101> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=10)
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: ANSIBLE_TIMEOUT/timeout set: (-o)(ConnectTimeout=10)
+<10.250.0.101> SSH: PlayContext set ssh_common_args: ()
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: PlayContext set ssh_common_args: ()
+<10.250.0.101> SSH: PlayContext set ssh_extra_args: ()
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: PlayContext set ssh_extra_args: ()
+<10.250.0.101> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/var/johnar/.ansible/cp/e95704e219)
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/var/johnar/.ansible/cp/e95704e219)
+<10.250.0.101> SSH: EXEC sshpass -d10 ssh -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o StrictHostKeyChecking=no -o 'User="admin"' -o ConnectT
+imeout=10 -o ControlPath=/var/johnar/.ansible/cp/e95704e219 10.250.0.101 '/bin/sh -c '"'"'sudo -H -S  -p "[sudo via ansible, key=jwgphutgyvifmsnbveqtyuqzfidllhao] password:" -u root /bin/sh -c '"'"'"'"'"'"'"'"
+'echo BECOME-SUCCESS-jwgphutgyvifmsnbveqtyuqzfidllhao ; /usr/bin/python'"'"'"'"'"'"'"'"' && sleep 0'"'"''
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> SSH: EXEC sshpass -d10 ssh -vvv -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o StrictHost
+KeyChecking=no -o 'User="admin"' -o ConnectTimeout=10 -o ControlPath=/var/johnar/.ansible/cp/e95704e219 10.250.0.101 '/bin/sh -c '"'"'sudo -H -S  -p "[sudo via ansible, key=jwgphutgyvifmsnbveqtyuqzfidllhao] pa
+ssword:" -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-jwgphutgyvifmsnbveqtyuqzfidllhao ; /usr/bin/python'"'"'"'"'"'"'"'"' && sleep 0'"'"''
+Escalation succeeded
+INFO     p=10040 u=johnar | :display.py:179 Escalation succeeded
+<10.250.0.101> (0, '\n{"changed": true, "end": "2020-06-01 09:36:33.450915", "stdout": "/home/admin", "cmd": "pwd", "rc": 0, "start": "2020-06-01 09:36:33.442212", "stderr": "", "delta": "0:00:00.008703", "inv
+ocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "pwd", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newli
+ne": true, "stdin": null}}}\n', 'OpenSSH_7.2p2 Ubuntu-4ubuntu2.8, OpenSSL 1.0.2g  1 Mar 2016\r\ndebug1: Reading configuration data /var/johnar/.ssh/config\r\ndebug1: /var/johnar/.ssh/config line 1: Applying op
+tions for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLO
+CK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_al
+ive: entering\r\ndebug3: mux_client_request_alive: done pid = 10180\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client
+_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\n')
+INFO     p=10040 u=johnar | :display.py:179 <10.250.0.101> (0, '\n{"changed": true, "end": "2020-06-01 09:36:33.450915", "stdout": "/home/admin", "cmd": "pwd", "rc": 0, "start": "2020-06-01 09:36:33.442212", "
+stderr": "", "delta": "0:00:00.008703", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "pwd", "removes": null, "argv": null, "
+warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}}\n', 'OpenSSH_7.2p2 Ubuntu-4ubuntu2.8, OpenSSL 1.0.2g  1 Mar 2016\r\ndebug1: Reading configuration data /var/johnar/.ssh/config\r\ndebug1:
+ /var/johnar/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: Applying options for *\r\ndebug1: auto-mux: Trying exis
+ting master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_sessio
+n: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 10180\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session
+: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\n')
+META: ran handlers
+INFO     p=10040 u=johnar | :display.py:179 META: ran handlers
+META: ran handlers
+INFO     p=10040 u=johnar | :display.py:179 META: ran handlers
+DEBUG    pytest_ansible.module_dispatcher.v28:v28.py:141 {'unreachable': {}, 'contacted': {u'vlab-01': {'stderr_lines': [], u'changed': True, u'end': u'2020-06-01 09:36:33.450915', '_ansible_no_log': False, u'
+stdout': u'/home/admin', u'cmd': u'pwd', u'start': u'2020-06-01 09:36:33.442212', u'delta': u'0:00:00.008703', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_
+uses_shell': True, u'strip_empty_ends': True, u'_raw_params': u'pwd', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin_add_newline': True, u'stdin': None}}, 'stdout_lines': [u'/home/a
+dmin']}}}
+```
+
+This is too much and overwhelming, right? Among these log messages, we only care about two at debug level:
+```
+DEBUG    pytest_ansible.module_dispatcher.v28:v28.py:78 [vlab-01] shell: {'_raw_params': 'pwd'}
+DEBUG    pytest_ansible.module_dispatcher.v28:v28.py:141 {'unreachable': {}, 'contacted': {u'vlab-01': {'stderr_lines': [], u'changed': True, u'end': u'2020-06-01 09:36:33.450915', '_ansible_no_log': False, u'
+stdout': u'/home/admin', u'cmd': u'pwd', u'start': u'2020-06-01 09:36:33.442212', u'delta': u'0:00:00.008703', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_
+uses_shell': True, u'strip_empty_ends': True, u'_raw_params': u'pwd', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin_add_newline': True, u'stdin': None}}, 'stdout_lines': [u'/home/admin']}}}
+```
+The first message is what ansible module was called with what argument. The second message is the ansible module result.
+
+There are some issues in the logs.
+
+1. The pytest-ansible plugin outputs 4 messages for running each ansible module. We only care about two of them.
+2. Ansible itself output too much debug messages related with connecting to the target host. The pytest-ansible plugin calls ansible module with option `-vvvvv`. This causes ansible output the very detailed debugging information for establishing SSH connection to devices.
+3. The ansible log messages are duplicated. One copy is output by logger, the other copy is directly written to stdout.
+
+# Improvements
+
+We've made some improvements in the framework to address these issues.
+
+## Filter out the logs of pytest-ansible and ansible
+In sonic-mgmt/tests/conftest.py, we implemented an auto used fixture `config_logging`. This fixture tries to get the logger objects of pytest-ansible and ansible and set their logging level to WARNING. Then we won't see any log messages of pytest-ansible and ansible with level lower than WARNING.
+
+## Add code in tests/common/devices.py::AnsibleHostBase to log ansible calls
+Without pytest-ansible logs, we have no information about ansible module calls. But we do wish there are log messages for what ansible module is called and what is the result. So, we added some code in the AnsibleHostBase class to generate two messages for each ansible call:
+1. What and where an ansible module is called by who with what arguments.
+2. What is the result of calling the ansible module.
+
+These two messages are generated at DEBUG level.
+
+## Disable log_path configuration in ansible/ansible.cfg
+When this configuration is enabled, for the messages sent to stdout, ansible also send a copy to logger. This would cause duplicated log messages.
+
+## Suggest to enable --capture
+Pytest supports capturing all log messages sent to logger, stdout and stderr. The captured logs can be used for generating test reports. When capture is enabled, all the log messages sent to stdout and stderr will be captured and will not be output to console. In case of log-file, these log messages will not be saved to log file too. So, we suggest to have --capture enabled. Luckily, --capture is enabled by default.
+
+## Remove the log messages captured from stdout and stderr
+During testing, pytest captures all the messages sent to stdout, stderr and logger. The captured messages are stored in different sections like "stdout", "stderr" and "log". If `--show-capture` is not disabled, the for failed test cases, pytest will output all the sections of the captured logs.
+
+The "stdout" section mainly contains ansible debug messages for establishing connection. We don't really care about them and can remove it from the report. When we do need to check these messages, wen can disable capture by adding pytest option `--capture no`. Then the messages will be output to console. Somehow content of the "stderr" section is same as the "log" section. That's why the "stderr" section can be removed too.
+
+The code for removing these sections is added to hook function tests/conftest.py::pytest_runtest_makereport
+
+# Logging tips
+
+## Use logger instead of `print` in scripts
+
+Suggest to use logger to log debug messages in test scripts. The benefits of logger against `print` is that we can easily customize format, level, destination of the log messages sent to loggers.
+
+## Log useful information for important steps in test scripts
+
+In test scripts, we suggest to add some log messages for important steps. The target is that in case a test failed, we can easily tell what is wrong just by inspecting the test logs.
+
+## Set --log-cli-level=info and --log-file-level=debug
+One good practice is to set --log-cli-level=info and --log-file-level=debug. We can have a big picture of the test case execution status from the log messages output to console. The more detailed messages saved to log file can be useful for analyzing the test failures.
+
+## Enable --capture
+Pytest have log capturing enabled by default. Log capturing can intercept the ansible connection debug messages sent to stdout. Without this noise, the log messages would be more easier to read. We can set `--capture no` only when we need to troubleshooting ansible connection issues.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Currently the logging of pytest scripts has some issues:
1. The pytest-ansible plugin generates too much DEBUG level log messages. The execution of each ansible module generates 4-5 messages. The messages may be useful for debugging pytest-ansible itself, but not useful for debugging test scripts.
2. Because of pytest-ansible issue "https://github.com/ansible/pytest-ansible/issues/44 ansible singleton display.verbosity is always overwritten in module dispatcher", verbosity of ansible is set to "-vvvvv". Running each ansible module also generates many ansible debugging messages, for example SSH connection debug messages. These ansible debugging messages are sent to "stdout/stderr". If ansible configuration "log_path" is set, these messages will be sent to python logger too.
3. Pytest supports log capturing. All the logs sent to stdout, stderr and logger will be captured by pytest. When a test case failed and "--show-capture" is set to "yes" (default value), pytest will output a section of log messages for each of the stage and each of the capturing source. Too much log messages will be output to console. Somehow, the messages of stderr and logger are same. Since the logs sent to stdout are mainly ansible debug messages and unnecessary. Only the logs sent to logger are relevant and should be kept.

Improvements:
1. Added an auto used fixture "config_logging". 
 * This fixture gets the logger of "pytest_ansible" and sets its log level to WARNING. This will filter out the unnecessary pytest-ansible DEBUG level log messages.
 * This fixture gets the logger of ansible and sets its log level to WARNING. When log_path of ansible is set, all the DEBUG ansible messages will be sent to logger. This change can filter out the unnecessary ansible logs sent to logger.
2. Enhanced AnsibleHostBase to:
  a. Log a DEBUG level message whenever an ansible module is executed. The log message includes these information:
    * Hostname of the ansible host called the ansible module
    * Location of the ansible module is called, including filename, function name, line number
    * Name of the ansible module
    * Arguments of the ansible module
  b. Log a DEBUG level message whenever an ansible module result is got. The log message includes these information:
    * Hostname of the ansible host called the ansible module
    * Location of the ansible module is called, including filename, function name, line number
    * Name of the ansible module
    * Details of the ansible module execution result
3. In the "pytest_runtest_makereport" hook, added code to filter out the log messages sent to stdout and stderr in test report. Only keep the log messages sent to logger.
4. Disable ansible configuration "log_path" in ansible/ansible.cfg. All the ansible debug messages are already sent to stdout, it's not necessary to send them to logger again.
5. Improve the pytest log format to include more relevant information in each log message, including time, log level, filename, function name and line number.

If we do need to check the ansible debug messages, we can use below pytest cli configurations to show them on console:
* Configure "--capture no", and
* Configure --log-cli-level, for example "--log-cli-level debug"

With these changes, if we'd like to run a pytest script and observe only the relevant logs on console, suggest to use below pytest cli arguments:
* Enable capturing. 
  * Do not set "--capture". Capturing is set to "fd" by default.
  * Set "--log-cli-level debug" or "--log-cli-level info".
*  Do not show capture
  * Set "--show-capture no"


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
I prepared a simple script to test the logging enhancements:

```python
import logging
logger = logging.getLogger(__name__)
def test_case1(localhost, duthost, ptfhost):
    logger.info('Start testing')
    res = localhost.shell("pwd")
    logger.info(str(res))
    res = duthost.shell("pwd")
    logger.info(str(res))
    res = ptfhost.shell("pwd")
    logger.info(str(res))
    logger.info('Done testing')
```
Run the example script, only relevant logs were shown:
```

johnar@xiwang5-vm1:~/code/sonic-mgmt/tests$ pytest --inventory .veos.vtb --host-pattern vlab-01  --testbed vms-kvm-t1-lag --testbed_file vtestbed.csv --module-path ../ansible --showlocals test_example.py --skip_sanity --disable_loganalyzer --log-cli-level debug --show-capture no                  ======================================== test session starts =========================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1                                                                                                                                     --------------------------------------- live log sessionstart ----------------------------------------12:42:20 DEBUG plugin.py:pytest_report_header:168: pytest_report_header() called                      ---------------------------------------- live log collection -----------------------------------------12:42:20 DEBUG plugin.py:pytest_generate_tests:123: pytest_generate_tests() called                    
12:42:20 DEBUG plugin.py:pytest_collection_modifyitems:173: pytest_collection_modifyitems() called    12:42:20 DEBUG plugin.py:pytest_collection_modifyitems:174: items: [<Function test_case1>]                                                                                                                  
------------------------------------------- live log setup -------------------------------------------
12:42:21 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/common/devices.py::get_platform_info#156: [vlab-01] AnsibleModule::command, args=["show platform summary"], kwargs={}                  12:42:21 DEBUG registry.py:register_crypt_handler:294: registered 'md5_crypt' handler: <class 'passlib
.handlers.md5_crypt.md5_crypt'>                                                                       12:42:25 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/common/devices.py::get_platform_info#156: [vlab-01] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["show", "platform", "
summary"], "end": "2020-05-29 12:42:16.666675", "_ansible_no_log": false, "stdout": "Platform: x86_64-
kvm_x86_64-r0\nHwSKU: Force10-S6000\nASIC: vs", "changed": true, "rc": 0, "start": "2020-05-29 12:42:1
5.163734", "stderr": "", "delta": "0:00:01.502941", "invocation": {"module_args": {"warn": true, "exec
utable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "show platform summary",
 "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Platform: x86_64-kvm_x86_64-r0", "HwSKU: Force10-S6000", "ASIC: vs"], "ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "warnings": ["Platform linux on host vl
ab-01 is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information."]}                                                   12:42:25 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_npu_info#133: [vlab-01] AnsibleModule::shell, args=["cat /usr/share/sonic/device/x86_64-kvm_x86_64-r0/asic.conf"], kwargs={}                                                                                         12:42:26 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_npu_info#133: [vlab-01] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "cat /usr/share/sonic/device
/x86_64-kvm_x86_64-r0/asic.conf", "end": "2020-05-29 12:42:17.301307", "_ansible_no_log": false, "stdout": "NUM_ASIC=1", "changed": true, "rc": 0, "start": "2020-05-29 12:42:17.266537", "stderr": "", "del
ta": "0:00:00.034770", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "cat /usr/share/sonic/device/x86_64-kvm_x86_64-r0/asic
.conf", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "std
in": null}}, "stdout_lines": ["NUM_ASIC=1"]}                                                          12:42:26 DEBUG devices.py:gather_facts:175: SonicHost facts: {"platform": "x86_64-kvm_x86_64-r0", "hwsku": "Force10-S6000", "asic_type": "vs", "num_npu": 1}                                                
12:42:26 INFO conftest.py:creds:278: dut vlab-01 belongs to groups [u'lab', u'sonic']                 12:42:26 INFO conftest.py:creds:289: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml                                                                                                    12:42:26 INFO conftest.py:creds:289: skip empty var file ../ansible/group_vars/all/env.yml            
12:42:26 INFO __init__.py:sanity_check:53: Start pre-test sanity check                                12:42:26 INFO __init__.py:sanity_check:89: Sanity check settings: skip_sanity=True, check_items=set(['services', 'interfaces', 'processes', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False                                                                                          12:42:26 INFO __init__.py:sanity_check:92: Skip sanity check according to command line argument or con
figuration of test script.                                                                            
12:42:26 INFO __init__.py:loganalyzer:15: Add start marker into DUT syslog                            
12:42:26 DEBUG loganalyzer.py:init:136: Loganalyzer init                                              
12:42:26 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/logana
lyzer.py::init#138: [vlab-01] AnsibleModule::copy, args=[], kwargs={"dest": "/tmp/loganalyzer.py", "sr
c": "/var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/system_msg_handler.py"}

12:42:28 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#138: [vlab-01] AnsibleModule::copy Result => {"changed": false, "group": "root", "uid": 0, "dest": "/tmp/loganalyzer.py", "checksum": "6ba56c783494447b3b7a9a42ef79bf5eb88a06c1", "_ansible_n
o_log": false, "invocation": {"module_args": {"directory_mode": null, "force": false, "remote_src": null, "dest": "/tmp/loganalyzer.py", "access_time": null, "access_time_format": "%Y%m%d%H%M.%S", "_origi
nal_basename": "system_msg_handler.py", "state": "file", "follow": true, "owner": null, "path": "/tmp/loganalyzer.py", "src": null, "group": null, "modification_time": null, "unsafe_writes": null, "delimiter": null, "regexp": null, "seuser": null, "recurse": false, "serole": null, "_diff_peek": null, "content": null, "setype": null, "mode": null, "modification_time_format": "%Y%m%d%H%M.%S", "selevel": null, "attributes": null, "backup": null}}, "state": "file", "gid": 0, "mode": "0644", "path": "/tmp/loganalyzer.py", "owner": "root", "diff": {"after": {"path": "/tmp/loganalyzer.py"}, "before": {"path": "/
tmp/loganalyzer.py"}}, "size": 27384}
12:42:28 DEBUG loganalyzer.py:init:143: Adding start marker 'test_case1.2020-05-29-12:42:28'          12:42:28 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#144: [vlab-01] AnsibleModule::command, args=["python /tmp/loganalyzer.py --action init --run_id test_case1.2020-05-29-12:42:28"], kwargs={}                                                  12:42:28 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#144: [vlab-01] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["python",
"/tmp/loganalyzer.py", "--action", "init", "--run_id", "test_case1.2020-05-29-12:42:28"], "end": "2020-05-29 12:42:19.408953", "_ansible_no_log": false, "stdout": "", "changed": true, "rc": 0, "start": "2
020-05-29 12:42:19.309192", "stderr": "", "delta": "0:00:00.099761", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "python /tmp/loganalyzer.py --action init --run_id test_case1.2020-05-29-12:42:28", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": []} 
------------------------------------------- live log call --------------------------------------------
12:42:28 INFO test_example.py:test_case1:7: Start testing
12:42:29 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/test_example.py::test_case1#12: [vlab-01] AnsibleModule::shell, args=["pwd"], kwargs={}
12:42:29 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/test_example.py::test_case1#12: [vlab-01] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "pwd", "end": "2020-05-29 12:42:20.504733", "_ansible_no_log": false, "stdout": "/home/admin", "changed": true, "rc": 0, "start": "2020-05-29 12:42:20.501138", "stderr": "", "delta": "0:00:00.003595", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "pwd", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["/home/admin"]}
12:42:29 INFO test_example.py:test_case1:13: {'stderr_lines': [], u'cmd': u'pwd', u'end': u'2020-05-29 12:42:20.504733', '_ansible_no_log': False, u'stdout': u'/home/admin', u'changed': True, u'rc': 0, u'start': u'2020-05-29 12:42:20.501138', u'stderr': u'', u'delta': u'0:00:00.003595', u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'strip_empty_ends': True, u'_raw_params': u'pwd', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin_add_newline': True, u'stdin': None}}, 'stdout_lines': [u'/home/admin']}
12:42:29 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/test_example.py::test_case1#15: [ptf-01] AnsibleModule::shell, args=["pwd"], kwargs={}
12:42:31 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/test_example.py::test_case1#15: [ptf-01] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "pwd", "end": "2020-05-29 12:42:31.490373", "_ansible_no_log": false, "stdout": "/root", "changed": true, "rc": 0, "start": "2020-05-29 12:42:31.058753", "stderr": "", "delta": "0:00:00.431620", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "pwd", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["/root"], "ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "warnings": ["Platform linux on host ptf-01 is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information."]}
12:42:31 INFO test_example.py:test_case1:16: {'stderr_lines': [], u'cmd': u'pwd', u'end': u'2020-05-29 12:42:31.490373', '_ansible_no_log': False, u'stdout': u'/root', u'changed': True, u'rc': 0, u'start': u'2020-05-29 12:42:31.058753', u'stderr': u'', u'delta': u'0:00:00.431620', u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'strip_empty_ends': True, u'_raw_params': u'pwd', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin_add_newline': True, u'stdin': None}}, 'stdout_lines': [u'/root'], 'ansible_facts': {u'discovered_interpreter_python': u'/usr/bin/python'}, 'warnings': [u'Platform linux on host ptf-01 is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information.']}
12:42:31 INFO test_example.py:test_case1:18: Done testing
PASSED                                                                                         [100%]
----------------------------------------- live log teardown ------------------------------------------
12:42:31 INFO __init__.py:loganalyzer:26: Add end marker into DUT syslog
12:42:31 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#47: [vlab-01] AnsibleModule::copy, args=[], kwargs={"dest": "/tmp/loganalyzer.py", "src": "/var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/system_msg_handler.py"}
12:42:32 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#47: [vlab-01] AnsibleModule::copy Result => {"changed": false, "group": "root", "uid": 0, "dest": "/tmp/loganalyzer.py", "checksum": "6ba56c783494447b3b7a9a42ef79bf5eb88a06c1", "_ansible_no_log": false, "invocation": {"module_args": {"directory_mode": null, "force": false, "remote_src": null, "dest": "/tmp/loganalyzer.py", "access_time": null, "access_time_format": "%Y%m%d%H%M.%S", "_original_basename": "system_msg_handler.py", "state": "file", "follow": true, "owner": null, "path": "/tmp/loganalyzer.py", "src": null, "group": null, "modification_time": null, "unsafe_writes": null, "delimiter": null, "regexp": null, "seuser": null, "recurse": false, "serole": null, "_diff_peek": null, "content": null, "setype": null, "mode": null, "modification_time_format": "%Y%m%d%H%M.%S", "selevel": null, "attributes": null, "backup": null}}, "state": "file", "gid": 0, "mode": "0644", "path": "/tmp/loganalyzer.py", "owner": "root", "diff": {"after": {"path": "/tmp/loganalyzer.py"}, "before": {"path": "/tmp/loganalyzer.py"}}, "size": 27384}
12:42:32 DEBUG loganalyzer.py:_add_end_marker:51: Adding end marker 'test_case1.2020-05-29-12:42:28'
12:42:32 DEBUG devices.py:_run:58: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#52: [vlab-01] AnsibleModule::command, args=["python /tmp/loganalyzer.py --action add_end_marker --run_id test_case1.2020-05-29-12:42:28"], kwargs={}
12:42:32 DEBUG devices.py:_run:72: /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#52: [vlab-01] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["python", "/tmp/loganalyzer.py", "--action", "add_end_marker", "--run_id", "test_case1.2020-05-29-12:42:28"], "end": "2020-05-29 12:42:23.669901", "_ansible_no_log": false, "stdout": "", "changed": true, "rc": 0, "start": "2020-05-29 12:42:23.617009", "stderr": "", "delta": "0:00:00.052892", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "python /tmp/loganalyzer.py --action add_end_marker --run_id test_case1.2020-05-29-12:42:28", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": []}


===================================== 1 passed in 12.28 seconds ======================================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Please refer to file tests/pytest.logging.md for documentation.