### PR TITLE
[telemetry] add telemetry certs on DUT

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -163,12 +163,12 @@
          set_fact:
             dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"
          when: telemetry_certs['dsmsroot_cer'] is defined
-                                                                                                                         - name: read directory path
+       
+       - name: read directory path
          set_fact:
              dir_path: "{{ telemetry_certs['dir_path'] }}"
          when: telemetry_certs['dir_path'] is defined
-
-       - name: Creates telemetry directory
+                                                                                                                         - name: Creates telemetry directory
          file:
            path: /etc/sonic/telemetry
            state: directory

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -159,7 +159,10 @@
             dsmsroot_csr: "{{ telemetry_certs['dsmsroot_csr'] }}"
          when: telemetry_certs['dsmsroot_csr'] is defined
 
-       - name: read dsmsroot cer                                                                                           set_fact:                                                                                                            dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"                                                          when: telemetry_certs['dsmsroot_cer'] is defined
+       - name: read dsmsroot cer
+         set_fact:
+            dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"
+         when: telemetry_certs['dsmsroot_cer'] is defined
                                                                                                                          - name: read directory path
          set_fact:                                                                                                             dir_path: "{{ telemetry_certs['dir_path'] }}"                                                                 when: telemetry_certs['dir_path'] is defined
 
@@ -211,11 +214,15 @@
          delegate_to: localhost
 
        - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
-         openssl_certificate:                                                                                                   path: "{{ dsmsroot_cer }}" 
-              privatekey_path: "{{ dsmsroot_key }} "                                                                            csr_path: "{{ dsmsroot_csr }} "
-              subject"
-                 commonName: ndastreamingclienttest.osdinfra.net                                                                provider: selfsigned
-         become: true                                                                                                      delegate_to: localhost
+         openssl_certificate:
+              path: "{{ dsmsroot_cer }}" 
+              privatekey_path: "{{ dsmsroot_key }} "
+              csr_path: "{{ dsmsroot_csr }} "
+              subject:
+                 commonName: ndastreamingclienttest.osdinfra.net
+              provider: selfsigned
+         become: true
+         delegate_to: localhost
 
        - name: Creates telemetry directory
          file:
@@ -374,11 +381,13 @@
       when: telemetry_certs['dir_path'] is defined
 
     - name: create dir on ptfhost
-      file:                                                                                                               path: "{{ dir_path }}"
+      file:
+        path: "{{ dir_path }}"
         state: directory
       become: true
 
-    - name: copy file to ptfhost                                                                                        copy:
-        src: "{{ dir_path }}"                                                                                             dest: "{{ dir_path }}"
+    - name: copy file to ptfhost
+      copy:
+         src: "{{ dir_path }}"                                                                                             dest: "{{ dir_path }}"
       become: yes
     

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -133,7 +133,6 @@
             dsmsroot_cer: ""
             dir_path: ""
 
-
        - name: read server key
          set_fact:
             server_key: "{{ telemetry_certs['server_key'] }}"
@@ -169,7 +168,7 @@
              dir_path: "{{ telemetry_certs['dir_path'] }}"
          when: telemetry_certs['dir_path'] is defined
        
-       - name: Creates telemetry directory
+       - name: Create telemetry directory
          file:
            path: "{{ dir_path }}"
            state: directory
@@ -197,6 +196,8 @@
              path: "{{ server_cer }}"
              privatekey_path: "{{ server_key }}"
              csr_path: "{{ server_csr }}"
+             subject:
+                commonName: ndastreamingclienttest.osdinfra.net
              provider: selfsigned
          become: true
          delegate_to: localhost

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -197,7 +197,7 @@
              privatekey_path: "{{ server_key }}"
              csr_path: "{{ server_csr }}"
              subject:
-                commonName: ndastreamingclienttest.osdinfra.net
+                commonName: ndastreamingservertest.osdinfra.net
              provider: selfsigned
          become: true
          delegate_to: localhost

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -168,9 +168,10 @@
          set_fact:
              dir_path: "{{ telemetry_certs['dir_path'] }}"
          when: telemetry_certs['dir_path'] is defined
-                                                                                                                         - name: Creates telemetry directory
+       
+       - name: Creates telemetry directory
          file:
-           path: /etc/sonic/telemetry
+           path: "{{ dir_path }}"
            state: directory
            mode: '0755'
          become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -197,7 +197,7 @@
              privatekey_path: "{{ server_key }}"
              csr_path: "{{ server_csr }}"
              subject:
-                commonName: ndastreamingservertest.osdinfra.net
+                commonName: ndastreamingservertest
              provider: selfsigned
          become: true
          delegate_to: localhost
@@ -223,7 +223,7 @@
               privatekey_path: "{{ dsmsroot_key }} "
               csr_path: "{{ dsmsroot_csr }} "
               subject:
-                 commonName: ndastreamingclienttest.osdinfra.net
+                 commonName: ndastreamingclienttest
               provider: selfsigned
          become: true
          delegate_to: localhost

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -123,6 +123,126 @@
     when: local_minigraph is defined and local_minigraph|bool == true
 
   - block:
+       - name: Init telemetry keys
+         set_fact:
+            server_key: ""
+            server_csr: ""
+            server_cer: ""
+            dsmsroot_key: ""
+            dsmsroot_csr: ""
+            dsmsroot_cer: ""
+            dir_path: ""
+
+
+       - name: read server key
+         set_fact:
+            server_key: "{{ telemetry_certs['server_key'] }}"
+         when: telemetry_certs['server_key'] is defined
+
+       - name: read server csr
+         set_fact:
+            server_csr: "{{ telemetry_certs['server_csr'] }}"
+         when: telemetry_certs['server_csr'] is defined
+
+       - name: read server cer
+         set_fact:
+            server_cer: "{{ telemetry_certs['server_cer'] }}"
+          when: telemetry_certs['server_cer'] is defined
+
+       - name: read dsmsroot key
+         set_fact:
+            dsmsroot_key: "{{ telemetry_certs['dsmsroot_key'] }}"
+         when: telemetry_certs['dsmsroot_key'] is defined
+
+       - name: read dsmsroot csr
+         set_fact:
+            dsmsroot_csr: "{{ telemetry_certs['dsmsroot_csr'] }}"
+         when: telemetry_certs['dsmsroot_csr'] is defined
+
+       - name: read dsmsroot cer                                                                                           set_fact:                                                                                                            dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"                                                          when: telemetry_certs['dsmsroot_cer'] is defined
+                                                                                                                         - name: read directory path
+         set_fact:                                                                                                             dir_path: "{{ telemetry_certs['dir_path'] }}"                                                                 when: telemetry_certs['dir_path'] is defined
+
+       - name: Creates telemetry directory
+         file:
+           path: /etc/sonic/telemetry
+           state: directory
+           mode: '0755'
+         become: true
+         delegate_to: localhost
+
+       - name: Create telemetry server private key
+         openssl_privatekey:
+            path: "{{ server_key }}"
+            size: 2048
+            mode: '0755'
+         become: true
+         delegate_to: localhost
+       
+       - name: create telemetry server csr
+         openssl_csr:
+            path: "{{ telemetry_certs['server_csr'] }}"
+            privatekey_path: "{{ server_key }}"
+         become: true
+         delegate_to: localhost
+
+       - name: Generate a Self Signed OpenSSL telemetry server certificate
+         openssl_certificate:
+             path: "{{ server_cer }}"
+             privatekey_path: "{{ server_key }}"
+             csr_path: "{{ server_csr }}"
+             provider: selfsigned
+         become: true
+         delegate_to: localhost
+
+       - name: Create telemetry dsmsroot private key
+         openssl_privatekey:
+             path: "{{ dsmsroot_key }}"
+             size: 2048
+             mode: '0755'
+         become: true
+         delegate_to: localhost
+
+       - name: create telemetry dsmsroot csr
+         openssl_csr:
+             path: "{{ dsmsroot_csr }}"
+             privatekey_path: "{{ dsmsroot_key }}"
+         become: true
+         delegate_to: localhost
+
+       - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
+         openssl_certificate:                                                                                                   path: "{{ dsmsroot_cer }}" 
+              privatekey_path: "{{ dsmsroot_key }} "                                                                            csr_path: "{{ dsmsroot_csr }} "
+              subject"
+                 commonName: ndastreamingclienttest.osdinfra.net                                                                provider: selfsigned
+         become: true                                                                                                      delegate_to: localhost
+
+       - name: Creates telemetry directory
+         file:
+           path: "{{ dir_path }}"
+           state: directory
+           mode: '0755'
+         become: true
+
+        - name: copy server_key from local to remote
+          copy:
+            src: "{{ server_key }}"
+            dest: "{{ server_key }}"
+          become: yes     
+
+        - name: copy server_cer from local to remote
+          copy:
+            src: "{{ server_cer }}"
+            dest: "{{ server_cer }}"
+          become: yes 
+
+        - name: copy dsmsroot_key from local to remote
+          copy:
+            src: "{{ dsmsroot_key }}"
+            dest: "{{ dsmsroot_key }}"
+          become: yes 
+
+  - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true
@@ -238,3 +358,27 @@
         shell: config save -y
         when: save is defined and save|bool == true
     when: deploy is defined and deploy|bool == true
+
+- hosts: [ptf]
+  gather_facts: no
+   
+  tasks:
+
+    - name: Init dir_path
+      set_fact:
+         dir_path: ""
+
+    - name: read directory path
+      set_fact:
+         dir_path: "{{ telemetry_certs['dir_path'] }}"
+      when: telemetry_certs['dir_path'] is defined
+
+    - name: create dir on ptfhost
+      file:                                                                                                               path: "{{ dir_path }}"
+        state: directory
+      become: true
+
+    - name: copy file to ptfhost                                                                                        copy:
+        src: "{{ dir_path }}"                                                                                             dest: "{{ dir_path }}"
+      become: yes
+    

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -162,12 +162,12 @@
          set_fact:
             dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"
          when: telemetry_certs['dsmsroot_cer'] is defined
-       
+
        - name: read directory path
          set_fact:
              dir_path: "{{ telemetry_certs['dir_path'] }}"
          when: telemetry_certs['dir_path'] is defined
-       
+
        - name: Create telemetry directory
          file:
            path: "{{ dir_path }}"
@@ -183,7 +183,7 @@
             mode: '0755'
          become: true
          delegate_to: localhost
-       
+
        - name: create telemetry server csr
          openssl_csr:
             path: "{{ telemetry_certs['server_csr'] }}"
@@ -219,7 +219,7 @@
 
        - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
          openssl_certificate:
-              path: "{{ dsmsroot_cer }}" 
+              path: "{{ dsmsroot_cer }}"
               privatekey_path: "{{ dsmsroot_key }} "
               csr_path: "{{ dsmsroot_csr }} "
               subject:
@@ -239,19 +239,19 @@
           copy:
             src: "{{ server_key }}"
             dest: "{{ server_key }}"
-          become: yes     
+          become: yes
 
         - name: copy server_cer from local to remote
           copy:
             src: "{{ server_cer }}"
             dest: "{{ server_cer }}"
-          become: yes 
+          become: yes
 
         - name: copy dsmsroot_key from local to remote
           copy:
             src: "{{ dsmsroot_key }}"
             dest: "{{ dsmsroot_key }}"
-          become: yes 
+          become: yes
 
   - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
@@ -271,7 +271,7 @@
         delegate_to: localhost
 
       - name: debug print stat_result
-        debug: 
+        debug:
             msg: Stat result is {{ stat_result }}
 
       - name: Copy corresponding configlet files if exist
@@ -369,30 +369,3 @@
         shell: config save -y
         when: save is defined and save|bool == true
     when: deploy is defined and deploy|bool == true
-
-- hosts: [ptf]
-  gather_facts: no
-   
-  tasks:
-
-    - name: Init dir_path
-      set_fact:
-         dir_path: ""
-
-    - name: read directory path
-      set_fact:
-         dir_path: "{{ telemetry_certs['dir_path'] }}"
-      when: telemetry_certs['dir_path'] is defined
-
-    - name: create dir on ptfhost
-      file:
-        path: "{{ dir_path }}"
-        state: directory
-      become: true
-
-    - name: copy file to ptfhost
-      copy:
-         src: "{{ dir_path }}"
-         dest: "{{ dir_path }}"
-      become: yes
-    

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -164,7 +164,9 @@
             dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"
          when: telemetry_certs['dsmsroot_cer'] is defined
                                                                                                                          - name: read directory path
-         set_fact:                                                                                                             dir_path: "{{ telemetry_certs['dir_path'] }}"                                                                 when: telemetry_certs['dir_path'] is defined
+         set_fact:
+             dir_path: "{{ telemetry_certs['dir_path'] }}"
+         when: telemetry_certs['dir_path'] is defined
 
        - name: Creates telemetry directory
          file:
@@ -388,6 +390,7 @@
 
     - name: copy file to ptfhost
       copy:
-         src: "{{ dir_path }}"                                                                                             dest: "{{ dir_path }}"
+         src: "{{ dir_path }}"
+         dest: "{{ dir_path }}"
       become: yes
     

--- a/ansible/group_vars/all/telemetry_certs.yml
+++ b/ansible/group_vars/all/telemetry_certs.yml
@@ -7,6 +7,4 @@ telemetry_certs:
     dsmsroot_key: "/etc/sonic/telemetry/dsmsroot.key"
     dsmsroot_csr: "/etc/sonic/telemetry/dsmsroot.csr"
     dsmsroot_cer: "/etc/sonic/telemetry/dsmsroot.cer"
-    client_key: "/etc/sonic/telemetry/streamingtelemetryclient.key"
-    client_cer: "/etc/sonic/telemetry/streamingtelemetryclient.cer"
     dir_path: "/etc/sonic/telemetry"

--- a/ansible/group_vars/all/telemetry_certs.yml
+++ b/ansible/group_vars/all/telemetry_certs.yml
@@ -1,0 +1,12 @@
+# Configure telemetry server and dsmsroot key,cer
+
+telemetry_certs:
+    server_key: "/etc/sonic/telemetry/streamingtelemetryserver.key"
+    server_csr: "/etc/sonic/telemetry/streamingtelemetryserver.csr"
+    server_cer: "/etc/sonic/telemetry/streamingtelemetryserver.cer"
+    dsmsroot_key: "/etc/sonic/telemetry/dsmsroot.key"
+    dsmsroot_csr: "/etc/sonic/telemetry/dsmsroot.csr"
+    dsmsroot_cer: "/etc/sonic/telemetry/dsmsroot.cer"
+    client_key: "/etc/sonic/telemetry/streamingtelemetryclient.key"
+    client_cer: "/etc/sonic/telemetry/streamingtelemetryclient.cer"
+    dir_path: "/etc/sonic/telemetry"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adding server and dsmsroot certs to start telemetry in auth mode
1. Declare server key/cer/csr under /group/all/vars inside telemetry_certs.yml 
2. Create variables to hold values from telemetry_certs.yml 
3. Create server and dsmsroot certs using private key and csr
4. Copy all certs on localhost
5. Copy certs from localhost to SONiC DUT


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
using deploy-mg on virtual test bed

Certs copied on SONiC DUT as shown below:
    admin@vlab-01:/etc/sonic/telemetry$ ls -l
         total 12
         -rw-r--r-- 1 root root 1679 Jun  1 05:35 dsmsroot.key
          -rw-r--r-- 1 root root  944 Jun  1 05:35 streamingtelemetryserver.cer
          -rw-r--r-- 1 root root 1675 May 30 02:08 streamingtelemetryserver.key
          admin@vlab-01:/etc/sonic/telemetry$ 
      

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
