### PR TITLE
[pytest ini] remove norecursedirs option

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra --module-path ../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=test_vrf.py
+addopts = -ra --module-path=../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=test_vrf.py
 markers:
     acl: ACL tests
     bsl: BSL tests

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-norecursedirs = ptftests acstests
 addopts = -ra --module-path ../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=test_vrf.py
 markers:
     acl: ACL tests


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
The norecursedirs option somehow conflicts with addopts and disabled --ignored.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
use --colect-only to test how many test cases were collected. Making sure no test from acstests and/or ptftests were collected.