### PR TITLE
Add support of running general Ansible modules on EosHost

### DIFF
--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -2,6 +2,7 @@ eos_default_login: "admin"
 eos_default_password: ""
 eos_login: admin
 eos_password: 123456
+eos_root_user: root
 eos_root_password: 123456
 
 sonic_login: "admin"

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -575,9 +575,20 @@ class EosHost(AnsibleHostBase):
     For running ansible module on the Eos switch
     """
 
-    def __init__(self, ansible_adhoc, hostname, net_user, net_passwd, shell_user=None, shell_passwd=None, gather_facts=False):
-        self.net_user = net_user
-        self.net_passwd = net_passwd
+    def __init__(self, ansible_adhoc, hostname, eos_user, eos_passwd, shell_user=None, shell_passwd=None, gather_facts=False):
+        '''Initialize an object for interacting with EoS type device using ansible modules
+
+        Args:
+            ansible_adhoc (): The pytest-ansible fixture
+            hostname (string): hostname of the EOS device
+            eos_user (string): Username for accessing the EOS CLI interface
+            eos_passwd (string): Password for the eos_user
+            shell_user (string, optional): Username for accessing the Linux shell CLI interface. Defaults to None.
+            shell_passwd (string, optional): Password for the shell_user. Defaults to None.
+            gather_facts (bool, optional): Whether to gather some basic facts. Defaults to False.
+        '''
+        self.eos_user = eos_user
+        self.eos_passwd = eos_passwd
         self.shell_user = shell_user
         self.shell_passwd = shell_passwd
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
@@ -587,10 +598,10 @@ class EosHost(AnsibleHostBase):
             evars = {
                 'ansible_connection':'network_cli',
                 'ansible_network_os':'eos',
-                'ansible_user': self.net_user,
-                'ansible_password': self.net_passwd,
-                'ansible_ssh_user': self.net_user,
-                'ansible_ssh_pass': self.net_passwd,
+                'ansible_user': self.eos_user,
+                'ansible_password': self.eos_passwd,
+                'ansible_ssh_user': self.eos_user,
+                'ansible_ssh_pass': self.eos_passwd,
                 'ansible_become_method': 'enable'
             }
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,10 +234,12 @@ def nbrhosts(ansible_adhoc, testbed, creds):
     vm_base = int(testbed['vm_base'][2:])
     devices = {}
     for k, v in testbed['topo']['properties']['topology']['VMs'].items():
-        devices[k] = {'host': EosHost(ansible_adhoc, \
-                                      "VM%04d" % (vm_base + v['vm_offset']), \
-                                      creds['eos_login'], \
-                                      creds['eos_password']),
+        devices[k] = {'host': EosHost(ansible_adhoc,
+                                      "VM%04d" % (vm_base + v['vm_offset']),
+                                      creds['eos_login'],
+                                      creds['eos_password'],
+                                      shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
+                                      shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None),
                       'conf': testbed['topo']['properties']['configuration'][k]}
     return devices
 
@@ -260,13 +262,14 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
             else:
                 host_vars = ansible_adhoc().options['inventory_manager'].get_host(fanout_host).vars
                 os_type = 'eos' if 'os' not in host_vars else host_vars['os']
-                if os_type == "eos":
-                    user = creds['fanout_admin_user']
-                    pswd = creds['fanout_admin_password']
-                elif os_type == "onyx":
-                    user = creds["fanout_mlnx_user"]
-                    pswd = creds["fanout_mlnx_password"]
-                fanout  = FanoutHost(ansible_adhoc, os_type, fanout_host, 'FanoutLeaf', user, pswd)
+                fanout  = FanoutHost(ansible_adhoc,
+                                    os_type,
+                                    fanout_host,
+                                    'FanoutLeaf',
+                                    creds['fanout_admin_user'],
+                                    creds["fanout_admin_password"],
+                                    shell_user=creds['fanout_root_user'] if 'fanout_root_user' in creds else None,
+                                    shell_passwd=creds['fanout_root_password'] if 'fanout_root_password' in creds else None)
                 fanout_hosts[fanout_host] = fanout
             fanout.add_port_map(dut_port, fanout_port)
     except:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,14 +262,20 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
             else:
                 host_vars = ansible_adhoc().options['inventory_manager'].get_host(fanout_host).vars
                 os_type = 'eos' if 'os' not in host_vars else host_vars['os']
+
+                eos_user = creds['fanout_eos_user'] if 'fanout_eos_user' in creds else creds['fanout_admin_user']
+                eos_password = creds['fanout_eos_password'] if 'fanout_eos_password' in creds else creds['fanout_admin_password']
+                shell_user = creds['fanout_shell_user'] if 'fanout_shell_user' in creds else creds['fanout_admin_user']
+                shell_password = creds['fanout_shell_password'] if 'fanout_shell_password' in creds else creds['fanout_admin_password']
+
                 fanout  = FanoutHost(ansible_adhoc,
                                     os_type,
                                     fanout_host,
                                     'FanoutLeaf',
-                                    creds['fanout_admin_user'],
-                                    creds["fanout_admin_password"],
-                                    shell_user=creds['fanout_root_user'] if 'fanout_root_user' in creds else None,
-                                    shell_passwd=creds['fanout_root_password'] if 'fanout_root_password' in creds else None)
+                                    eos_user,
+                                    eos_password,
+                                    shell_user=shell_user,
+                                    shell_passwd=shell_password)
                 fanout_hosts[fanout_host] = fanout
             fanout.add_port_map(dut_port, fanout_port)
     except:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The EOS hosts support two types of command line interface:
1. Linux shell
2. EOS shell

Currently the EosHost class can only support running eos_* ansible modules. This change is to add the support of running general Ansible modules that can only be executed under Linux shell.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Improved the EosHost class defined in tests/common/devices.py to make it accepts two sets of credential:
1. The first set of credential exposes the EOS CLI interface. When use this set of credential, we use ansible_connection `network_cli`.
2. The second set of credential exposes the linux shell of EOS.  When use this set of credential, we use ansible_connection `ssh`.

If name of the ansible module to be executed on EOS hosts starts with "eos_", then use ansible_connection `network_cli` to run the module. Otherwise, use ansible_connection `ssh` to run the module.

#### How did you verify/test it?
Use a simple script to run both eos_* ansible module and general ansible modules on the EOS hosts and fanout hosts.

For this PR to work, please add your own fanout credentials in the ansible variable files. For example, you can add a secrets.yml file under ansible/group_vars/all or ansible/group_vars/sonic. The fanout credentials can be defined in it, for example:

```
fanout_admin_user: <your_own_user>
fanout_admin_password: <your_own_password>
fanout_root_user: <your_own_root_user>
fanout_root_password: <your_own_root_password>
```

Credential set fanout_admin_user/fanout_admin_password should expose the EOS CLI interface. Credential set fanout_root_user/fanout_root_password should expose the Linux CLI shell.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
