### PR TITLE
[sonic image installer] remove config_db.json before booting into new image

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -23,6 +23,7 @@ Options:
 '''
 
 import sys
+from os import path
 from ansible.module_utils.basic import *
 
 def exec_command(module, cmd, ignore_error=False, msg="executing command"):
@@ -74,6 +75,12 @@ def install_new_sonic_image(module, new_image_url):
         exec_command(module, cmd="umount /tmp/tmpfs", ignore_error=True)
         exec_command(module, cmd="rm -rf /tmp/tmpfs", ignore_error=True)
 
+    # If sonic device is configured with minigraph, remove config_db.json
+    # to force next image to load minigraph.
+    if path.exists("/host/old_config/minigraph.xml"):
+        exec_command(module,
+                     cmd="rm /host/old_config/config_db.json",
+                     msg="Remove config_db.json in preference of minigraph.xml")
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

When minigraph.xml exists, config_db.json can be generated from it. In this case, before booting into an new image, remove the config_db.json from /host/old_config to force the new image to load minigraph.

This is needed when nightly testbed is moving from an higer version to a lower version.

If the system is configured by config_db.json without minigraph, then unfortunately we don't have a solution for booting back into an old incompatible image yet.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
On a DUT installed 201911 image. Use "ansible-playbook upgrade_sonic.yml" to install a 201811 image. Without the change, 201811 image boots up without management connectivity and in failure state. With the change, 201811 image boots up healthy.