### PR TITLE
[wr_arp] Fix use of inventory file

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -200,7 +200,8 @@ class TestWrArp:
             Returns:
                 None
         '''
-        invetory = duthost.host.options['inventory'].split('/')[-1]
+        hostVars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+        invetory = hostVars['inventory_file'].split('/')[-1]
         secrets = duthost.host.options['variable_manager']._hostvars[duthost.hostname]['secret_group_vars']
 
         prepareTestbedSshKeys(duthost, ptfhost, secrets[invetory]['sonicadmin_user'])


### PR DESCRIPTION
### Description of PR
Commit 9814959 introduced multiple inventory files that broke the
logic to retrieve secrets for specific inventory. Use inventory_file
defined in hostvars instead.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
