### PR TITLE
[conn_graph_facts] Get graph facts for all fanouts connected to the DUT

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -10,8 +10,11 @@ def conn_graph_facts(duthost, localhost):
   
 @pytest.fixture(scope="module")
 def fanout_graph_facts(localhost, duthost, conn_graph_facts):
-    fanout_host = conn_graph_facts["device_conn"]["Ethernet0"]["peerdevice"]
-    facts = get_graph_facts(duthost, localhost, fanout_host)
+    facts = dict()
+    for intf in conn_graph_facts["device_conn"]:
+        fanout = conn_graph_facts["device_conn"][intf]["peerdevice"]
+        if fanout not in facts:
+            facts[fanout] = get_graph_facts(duthost, localhost, fanout)
     return facts
 
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
A DUT might be connected to multiple fanouts. The current code assumes there is only a single fanout connected to the DUT.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

Tested using a sample script and retrieved fanout graph facts for a DUT with multiple fanouts