### PR TITLE
[pytest] Adds test metadata to pytest xml report

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,3 +339,28 @@ def collect_techsupport(request, duthost):
                 tar.extract(m, path="logs/{}/{}/".format(testname, duthost.hostname))
 
         logging.info("########### Collected tech support for test {} ###########".format(testname))
+
+__report_metadata_added = False
+
+@pytest.fixture(scope="module", autouse=True)
+def tag_test_report(request, pytestconfig, testbed, duthost, record_testsuite_property):
+    if not request.config.getoption("--junit-xml"):
+        return
+
+    # NOTE: This is a gnarly hack to deal with the fact that we only want to add this
+    # metadata to the test report once per session. Since the duthost fixture has
+    # module scope we can't give this fixture session scope.
+    global __report_metadata_added
+    if not __report_metadata_added:
+        # Test run information
+        record_testsuite_property("topology", testbed['topo']['name'])
+        record_testsuite_property("markers", pytestconfig.getoption("-m"))
+
+        # Device information
+        record_testsuite_property("host", duthost.hostname)
+        record_testsuite_property("asic", duthost.facts["asic_type"])
+        record_testsuite_property("platform", duthost.facts["platform"])
+        record_testsuite_property("hwsku", duthost.facts["hwsku"])
+        record_testsuite_property("os_version", duthost.os_version)
+
+        __report_metadata_added = True


### PR DESCRIPTION
- Adds DUT data to test report
- Adds testbed info to test report

Signed-off-by: Danny Allen <daall@microsoft.com>

**NOTE:** Depends on #1732

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Adds data about the test device and testbed setup to the XML test report.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The default JUnit test report only includes the results of the individual test cases, so unless you can associate the test report with a specific test run using an external system like Jenkins there's a lot of missing context in the test report.

We also hope to use this data to make it possible to filter/query from a set of test results based on attributes like the SKU being tested, OS version, etc.

#### How did you do it?
I took advantage of the built-in `record_testsuite_property` API in pytest to annotate the test report with this extra data.

#### How did you verify/test it?
I ran a few test cases with the `--junit-xml` flag turned on and checked that the XML had the extra attributes included.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
