### PR TITLE
[dhcp-relay] Validate route to DHCP server

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -96,8 +96,21 @@ def dut_dhcp_relay_data(duthost, ptfhost, testbed):
 
     return dhcp_relay_data_list
 
+@pytest.fixture(scope="module")
+def validate_dut_routes_exist(duthost, dut_dhcp_relay_data):
+    """Fixture to valid a route to each DHCP server exist
+    """
+    dhcp_servers = set()
+    for dhcp_relay in dut_dhcp_relay_data:
+        dhcp_servers |= set(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
 
-def test_dhcp_relay_default(duthost, ptfhost, dut_dhcp_relay_data):
+    for dhcp_server in dhcp_servers:
+        result = duthost.shell("ip route get {0}".format(dhcp_server))
+        assert result["rc"] == 0 and "{0} via".format(dhcp_server) in result["stdout"], \
+            "Failed to find route to DHCP server '{0}' with error '{1}".format(dhcp_server, result["stderr"])
+
+
+def test_dhcp_relay_default(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
     """Test DHCP relay functionality on T0 topology.
 
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
@@ -120,7 +133,7 @@ def test_dhcp_relay_default(duthost, ptfhost, dut_dhcp_relay_data):
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-def test_dhcp_relay_after_link_flap(duthost, ptfhost, dut_dhcp_relay_data):
+def test_dhcp_relay_after_link_flap(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
     """Test DHCP relay functionality on T0 topology after uplinks flap
 
        For each DHCP relay agent running on the DuT, with relay agent running, flap the uplinks,
@@ -158,7 +171,7 @@ def test_dhcp_relay_after_link_flap(duthost, ptfhost, dut_dhcp_relay_data):
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-def test_dhcp_relay_start_with_uplinks_down(duthost, ptfhost, dut_dhcp_relay_data):
+def test_dhcp_relay_start_with_uplinks_down(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
     """Test DHCP relay functionality on T0 topology when relay agent starts with uplinks down
 
        For each DHCP relay agent running on the DuT, bring the uplinks down, then restart the

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -1,3 +1,4 @@
+import ipaddress
 import pytest
 import time
 
@@ -105,8 +106,8 @@ def validate_dut_routes_exist(duthost, dut_dhcp_relay_data):
         dhcp_servers |= set(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
 
     for dhcp_server in dhcp_servers:
-        result = duthost.shell("ip route get {0}".format(dhcp_server))
-        assert result["rc"] == 0 and "{0} via".format(dhcp_server) in result["stdout"], \
+        rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
+        assert len(rtInfo["nexthops"]) > 0, \
             "Failed to find route to DHCP server '{0}' with error '{1}".format(dhcp_server, result["stderr"])
 
 


### PR DESCRIPTION
### Description of PR
Adding fixture to verify that routes to DHCP server are present
on DUT before starting the test. This will exclude one problem when
debugging DHCP relay test issues.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Help debugging DHC relay test cases errors

#### How did you do it?
Provided new fixture to verify route

#### How did you verify/test it?
```
py.test --inventory veos.vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --disable_loganalyzer --junitxml=tr.xml dhcp_relay/test_dhcp_relay.py
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
