### PR TITLE
Fix the issue of handling telemetry keys&certs during deploy-mg

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -221,31 +221,6 @@
         provider: selfsigned
       become: true
 
-    - name: Creates telemetry directory
-      file:
-        path: "{{ dir_path }}"
-        state: directory
-        mode: '0755'
-      become: true
-
-    - name: copy server_key from local to remote
-      copy:
-        src: "{{ server_key }}"
-        dest: "{{ server_key }}"
-      become: yes
-
-    - name: copy server_cer from local to remote
-      copy:
-        src: "{{ server_cer }}"
-        dest: "{{ server_cer }}"
-      become: yes
-
-    - name: copy dsmsroot_key from local to remote
-      copy:
-        src: "{{ dsmsroot_key }}"
-        dest: "{{ dsmsroot_key }}"
-      become: yes
-
   - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The telemetry keys and certs are directly generated on SONiC switch, not
on localhost. There is no need to copy the files from local to
remote. Even worse, trying to copy the keys and certs from
localhost to SONiC will fail with source file not found issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The change introduced in https://github.com/Azure/sonic-mgmt/pull/1716 broke the deploy-mg function.

#### How did you do it?
Remove the unnecessary steps for copying keys and certs from local to remote.

#### How did you verify/test it?
Test run the `testbed-cli.sh deploy-mg` on vs setup. Check on SONiC, the keys and certs can be found under /etc/sonic/telemetry.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
