### PR TITLE
Fix the issue of unprintable RunAnsibleModuleFail object

### DIFF
--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -1,17 +1,20 @@
 """
 Customize exceptions
 """
-from ansible.plugins.loader import callback_loader
 from ansible.errors import AnsibleError
+from ansible.plugins.loader import callback_loader
 
 
 class UnsupportedAnsibleModule(Exception):
     pass
 
 
-def dump_ansible_results(results, stdout_callback='yaml'):
-    cb = callback_loader.get(stdout_callback)
-    return cb._dump_results(results) if cb else results
+def dump_ansible_results(results, stdout_callback='json'):
+    try:
+        cb = callback_loader.get(stdout_callback)
+        return cb._dump_results(results) if cb else results
+    except Exception:
+        return str(results)
 
 
 class RunAnsibleModuleFail(AnsibleError):
@@ -22,8 +25,15 @@ class RunAnsibleModuleFail(AnsibleError):
         super(RunAnsibleModuleFail, self).__init__(msg)
         self.results = results
 
+    def _to_string(self):
+        return "{}, Ansible Results =>\n{}".format(self.message, dump_ansible_results(self.results))
+
     def __str__(self):
-        return "{}\nAnsible Results => {}".format(self.message, dump_ansible_results(self.results))
+        return self._to_string()
+
+    def __repr__(self):
+        return self._to_string()
+
 
 class MissingInputError(Exception):
     pass


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #1731

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix issue #1731 

#### How did you do it?
The possible reason is that exception is raised in __str__ method of the RunAnsibleModuleFail class. The change is to catch any possible error of json.dumps while converting the ansible module result to human friendly string. If the json.dumps call failed, use the safer builtin str() function to convert the ansible result to a less human friendly string as a fall back method.

#### How did you verify/test it?
The original issue is not reproducible on my side. That's why I make this PR as a draft at this point.

What I tested:
* Create a simple pytest script to run ansible module that will fail on purpose.
* Run the script.
* Verify that appropriate exception is logged.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
