### PR TITLE
Add support of running general Ansible modules on EosHost

### DIFF
--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -2,6 +2,7 @@ eos_default_login: "admin"
 eos_default_password: ""
 eos_login: admin
 eos_password: 123456
+eos_root_user: root
 eos_root_password: 123456
 
 sonic_login: "admin"

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -40,10 +40,10 @@ class AnsibleHostBase(object):
                 self.host = ansible_adhoc(become=True, connection=connection)[hostname]
         self.hostname = hostname
 
-    def __getattr__(self, item):
-        if self.host.has_module(item):
-            self.module_name = item
-            self.module = getattr(self.host, item)
+    def __getattr__(self, module_name):
+        if self.host.has_module(module_name):
+            self.module_name = module_name
+            self.module = getattr(self.host, module_name)
 
             return self._run
         else:
@@ -144,7 +144,7 @@ class SonicHost(AnsibleHostBase):
     def os_version(self):
         """
         The OS version running on this SONiC device.
-        
+
         Returns:
             str: The SONiC OS version (e.g. "20181130.31")
         """
@@ -623,8 +623,8 @@ class EosHost(AnsibleHostBase):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
         self.localhost = ansible_adhoc(inventory='localhost', connection='local', host_pattern="localhost")["localhost"]
 
-    def __getattr__(self, item):
-        if item.startswith('eos_'):
+    def __getattr__(self, module_name):
+        if module_name.startswith('eos_'):
             evars = {
                 'ansible_connection':'network_cli',
                 'ansible_network_os':'eos',
@@ -647,7 +647,7 @@ class EosHost(AnsibleHostBase):
                 'ansible_become_method': 'sudo'
             }
         self.host.options['variable_manager'].extra_vars.update(evars)
-        return super(EosHost, self).__getattr__(item)
+        return super(EosHost, self).__getattr__(module_name)
 
     def shutdown(self, interface_name):
         out = self.eos_config(
@@ -817,8 +817,8 @@ class FanoutHost():
             self.os = 'eos'
             self.host = EosHost(ansible_adhoc, hostname, user, passwd, shell_user=shell_user, shell_passwd=shell_passwd)
 
-    def __getattr__(self, item):
-        return getattr(self.host, item)
+    def __getattr__(self, module_name):
+        return getattr(self.host, module_name)
 
     def get_fanout_os(self):
         return self.os

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -567,6 +567,7 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         output = dut.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
         return output["stdout_lines"][0].strip()
 
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch
@@ -574,54 +575,83 @@ class EosHost(AnsibleHostBase):
     For running ansible module on the Eos switch
     """
 
-    def __init__(self, ansible_adhoc, hostname, user, passwd, gather_facts=False):
-        AnsibleHostBase.__init__(self, ansible_adhoc, hostname, connection="network_cli")
-        evars = { 'ansible_connection':'network_cli', \
-                  'ansible_network_os':'eos', \
-                  'ansible_user': user, \
-                  'ansible_password': passwd, \
-                  'ansible_ssh_user': user, \
-                  'ansible_ssh_pass': passwd, \
-                  'ansible_become_method': 'enable' }
-        self.host.options['variable_manager'].extra_vars.update(evars)
+    def __init__(self, ansible_adhoc, hostname, eos_user, eos_passwd, shell_user=None, shell_passwd=None, gather_facts=False):
+        '''Initialize an object for interacting with EoS type device using ansible modules
+
+        Args:
+            ansible_adhoc (): The pytest-ansible fixture
+            hostname (string): hostname of the EOS device
+            eos_user (string): Username for accessing the EOS CLI interface
+            eos_passwd (string): Password for the eos_user
+            shell_user (string, optional): Username for accessing the Linux shell CLI interface. Defaults to None.
+            shell_passwd (string, optional): Password for the shell_user. Defaults to None.
+            gather_facts (bool, optional): Whether to gather some basic facts. Defaults to False.
+        '''
+        self.eos_user = eos_user
+        self.eos_passwd = eos_passwd
+        self.shell_user = shell_user
+        self.shell_passwd = shell_passwd
+        AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
         self.localhost = ansible_adhoc(inventory='localhost', connection='local', host_pattern="localhost")["localhost"]
 
+    def __getattr__(self, item):
+        if item.startswith('eos_'):
+            evars = {
+                'ansible_connection':'network_cli',
+                'ansible_network_os':'eos',
+                'ansible_user': self.eos_user,
+                'ansible_password': self.eos_passwd,
+                'ansible_ssh_user': self.eos_user,
+                'ansible_ssh_pass': self.eos_passwd,
+                'ansible_become_method': 'enable'
+            }
+        else:
+            if not self.shell_user or not self.shell_passwd:
+                raise Exception("Please specify shell_user and shell_passwd for {}".format(self.hostname))
+            evars = {
+                'ansible_connection':'ssh',
+                'ansible_network_os':'linux',
+                'ansible_user': self.shell_user,
+                'ansible_password': self.shell_passwd,
+                'ansible_ssh_user': self.shell_user,
+                'ansible_ssh_pass': self.shell_passwd,
+                'ansible_become_method': 'sudo'
+            }
+        self.host.options['variable_manager'].extra_vars.update(evars)
+        return super(EosHost, self).__getattr__(item)
+
     def shutdown(self, interface_name):
-        out = self.host.eos_config(
+        out = self.eos_config(
             lines=['shutdown'],
             parents='interface %s' % interface_name)
         logging.info('Shut interface [%s]' % interface_name)
         return out
 
     def no_shutdown(self, interface_name):
-        out = self.host.eos_config(
+        out = self.eos_config(
             lines=['no shutdown'],
             parents='interface %s' % interface_name)
         logging.info('No shut interface [%s]' % interface_name)
         return out
 
     def check_intf_link_state(self, interface_name):
-        show_int_result = self.host.eos_command(
-            commands=['show interface %s' % interface_name])[self.hostname]
+        show_int_result = self.eos_command(
+            commands=['show interface %s' % interface_name])
         return 'Up' in show_int_result['stdout_lines'][0]
 
-    def command(self, cmd):
-        out = self.host.eos_command(commands=[cmd])
-        return out
-
     def set_interface_lacp_rate_mode(self, interface_name, mode):
-        out = self.host.eos_config(
+        out = self.eos_config(
             lines=['lacp rate %s' % mode],
             parents='interface %s' % interface_name)
         logging.info("Set interface [%s] lacp rate to [%s]" % (interface_name, mode))
         return out
 
     def kill_bgpd(self):
-        out = self.host.eos_config(lines=['agent Rib shutdown'])
+        out = self.eos_config(lines=['agent Rib shutdown'])
         return out
 
     def start_bgpd(self):
-        out = self.host.eos_config(lines=['no agent Rib shutdown'])
+        out = self.eos_config(lines=['no agent Rib shutdown'])
         return out
 
     def check_bgp_session_state(self, neigh_ips, neigh_desc, state="established"):
@@ -634,12 +664,12 @@ class EosHost(AnsibleHostBase):
         """
         neigh_ips_ok = []
         neigh_desc_ok = []
-        out_v4 = self.host.eos_command(
-            commands=['show ip bgp summary | json'])[self.hostname]
+        out_v4 = self.eos_command(
+            commands=['show ip bgp summary | json'])
         logging.info("ip bgp summary: {}".format(out_v4))
 
-        out_v6 = self.host.eos_command(
-            commands=['show ipv6 bgp summary | json'])[self.hostname]
+        out_v6 = self.eos_command(
+            commands=['show ipv6 bgp summary | json'])
         logging.info("ipv6 bgp summary: {}".format(out_v6))
 
         for k, v in out_v4['stdout'][0]['vrfs']['default']['peers'].items():
@@ -742,7 +772,7 @@ class FanoutHost():
     For running ansible module on the Fanout switch
     """
 
-    def __init__(self, ansible_adhoc, os, hostname, device_type, user, passwd):
+    def __init__(self, ansible_adhoc, os, hostname, device_type, user, passwd, shell_user=None, shell_passwd=None):
         self.hostname = hostname
         self.type = device_type
         self.host_to_fanout_port_map = {}
@@ -756,7 +786,10 @@ class FanoutHost():
         else:
             # Use eos host if the os type is unknown
             self.os = 'eos'
-            self.host = EosHost(ansible_adhoc, hostname, user, passwd)
+            self.host = EosHost(ansible_adhoc, hostname, user, passwd, shell_user=shell_user, shell_passwd=shell_passwd)
+
+    def __getattr__(self, item):
+        return getattr(self.host, item)
 
     def get_fanout_os(self):
         return self.os
@@ -769,9 +802,6 @@ class FanoutHost():
 
     def no_shutdown(self, interface_name):
         return self.host.no_shutdown(interface_name)[self.hostname]
-
-    def command(self, cmd):
-        return self.host.command(cmd)[self.hostname]
 
     def __str__(self):
         return "{ os: '%s', hostname: '%s', device_type: '%s' }" % (self.os, self.hostname, self.type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,10 +249,12 @@ def nbrhosts(ansible_adhoc, testbed, creds):
     vm_base = int(testbed['vm_base'][2:])
     devices = {}
     for k, v in testbed['topo']['properties']['topology']['VMs'].items():
-        devices[k] = {'host': EosHost(ansible_adhoc, \
-                                      "VM%04d" % (vm_base + v['vm_offset']), \
-                                      creds['eos_login'], \
-                                      creds['eos_password']),
+        devices[k] = {'host': EosHost(ansible_adhoc,
+                                      "VM%04d" % (vm_base + v['vm_offset']),
+                                      creds['eos_login'],
+                                      creds['eos_password'],
+                                      shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
+                                      shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None),
                       'conf': testbed['topo']['properties']['configuration'][k]}
     return devices
 
@@ -275,13 +277,20 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
             else:
                 host_vars = ansible_adhoc().options['inventory_manager'].get_host(fanout_host).vars
                 os_type = 'eos' if 'os' not in host_vars else host_vars['os']
-                if os_type == "eos":
-                    user = creds['fanout_admin_user']
-                    pswd = creds['fanout_admin_password']
-                elif os_type == "onyx":
-                    user = creds["fanout_mlnx_user"]
-                    pswd = creds["fanout_mlnx_password"]
-                fanout  = FanoutHost(ansible_adhoc, os_type, fanout_host, 'FanoutLeaf', user, pswd)
+
+                eos_user = creds['fanout_eos_user'] if 'fanout_eos_user' in creds else creds['fanout_admin_user']
+                eos_password = creds['fanout_eos_password'] if 'fanout_eos_password' in creds else creds['fanout_admin_password']
+                shell_user = creds['fanout_shell_user'] if 'fanout_shell_user' in creds else creds['fanout_admin_user']
+                shell_password = creds['fanout_shell_password'] if 'fanout_shell_password' in creds else creds['fanout_admin_password']
+
+                fanout  = FanoutHost(ansible_adhoc,
+                                    os_type,
+                                    fanout_host,
+                                    'FanoutLeaf',
+                                    eos_user,
+                                    eos_password,
+                                    shell_user=shell_user,
+                                    shell_passwd=shell_password)
                 fanout_hosts[fanout_host] = fanout
             fanout.add_port_map(dut_port, fanout_port)
     except:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,8 +278,11 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
                 host_vars = ansible_adhoc().options['inventory_manager'].get_host(fanout_host).vars
                 os_type = 'eos' if 'os' not in host_vars else host_vars['os']
 
-                eos_user = creds['fanout_eos_user'] if 'fanout_eos_user' in creds else creds['fanout_admin_user']
-                eos_password = creds['fanout_eos_password'] if 'fanout_eos_password' in creds else creds['fanout_admin_password']
+                # `fanout_network_user` and `fanout_network_password` are for accessing the non-shell CLI of fanout
+                # Ansible will use this set of credentail for establishing `network_cli` connection with device
+                # when applicable.
+                network_user = creds['fanout_network_user'] if 'fanout_network_user' in creds else creds['fanout_admin_user']
+                network_password = creds['fanout_network_password'] if 'fanout_network_password' in creds else creds['fanout_admin_password']
                 shell_user = creds['fanout_shell_user'] if 'fanout_shell_user' in creds else creds['fanout_admin_user']
                 shell_password = creds['fanout_shell_password'] if 'fanout_shell_password' in creds else creds['fanout_admin_password']
 
@@ -287,8 +290,8 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
                                     os_type,
                                     fanout_host,
                                     'FanoutLeaf',
-                                    eos_user,
-                                    eos_password,
+                                    network_user,
+                                    network_password,
                                     shell_user=shell_user,
                                     shell_passwd=shell_password)
                 fanout_hosts[fanout_host] = fanout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is a re-submit of PR #1721 which was reverted because of an issue.

* Add support of running general Ansible modules on EosHost

The EOS hosts support two types of command line interface:
1. Linux shell
2. EOS shell

This change is to add the support of running general Ansible modules
that can only be executed under Linux shell.

* If not able to get the explicitly defined username and
password, fallback to use the value of "fanout_admin_user"
and "fanout_admin_password". It is unlikely to break the
existing code.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This change is to add the support of running general Ansible modules that can only be executed under Linux shell.

#### How did you do it?
Improved the EosHost class defined in tests/common/devices.py to make it accepts two sets of credential:

The first set of credential exposes the EOS CLI interface. When use this set of credential, we use ansible_connection network_cli.
The second set of credential exposes the linux shell of EOS. When use this set of credential, we use ansible_connection ssh.
If name of the ansible module to be executed on EOS hosts starts with "eos_", then use ansible_connection network_cli to run the module. Otherwise, use ansible_connection ssh to run the module.

#### How did you verify/test it?
Test run the test scripts that depend on EosHost.

#### Any platform specific information?
Only EoSHost is enhanced. The OnyxHost may need to be enhanced in the similar way.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
