### PR TITLE
Support for not using all ports on hardware DUT for testing

### DIFF
--- a/ansible/roles/vm_set/library/kvm_port.py
+++ b/ansible/roles/vm_set/library/kvm_port.py
@@ -36,8 +36,8 @@ def main():
         module.fail_json(msg="failed to iflist dom %s" % vmname)
 
     mgmt_port = None
-    fp_ports = []
-
+    fp_ports = {}
+    cur_fp_idx = 0
     for l in output.split('\n'):
         fds = re.split('\s+', l)
         if len(fds) != 5:
@@ -46,7 +46,8 @@ def main():
             if mgmt_port == None:
                 mgmt_port = fds[0]
             else:
-                fp_ports.append(fds[0])
+                fp_ports[cur_fp_idx] = fds[0]
+                cur_fp_idx = cur_fp_idx + 1
 
     if mgmt_port == None:
         module.fail_json(msg="failed to find mgmt port")

--- a/ansible/roles/vm_set/library/mellanox_simx_port.py
+++ b/ansible/roles/vm_set/library/mellanox_simx_port.py
@@ -23,10 +23,10 @@ def main():
     ))
 
     mgmt_port = None
-    fp_ports = []
+    fp_ports = {}
     
     for i in range(1,33):
-        fp_ports.append("v000_port{}".format(i))
+        fp_ports[i-1] = ("v000_port{}".format(i))
 
     mgmt_port = "tap0"
 

--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -144,10 +144,10 @@ def main():
     cur_fp_idx = 0        
     for vlan_id in vlan_ids:
       if 'vlan_base' in module.params and module.params['vlan_base'] != 0:        
-        fp_ports[vlan_id - module.params['vlan_base']] = "%s.%d" % (external_port, vlan_id)
+          fp_ports[vlan_id - module.params['vlan_base']] = "%s.%d" % (external_port, vlan_id)
       else:
-        fp_ports[cur_fp_idx] =  "%s.%d" % (external_port, vlan_id)
-        cur_fp_idx = cur_fp_idx + 1
+          fp_ports[cur_fp_idx] =  "%s.%d" % (external_port, vlan_id)
+          cur_fp_idx = cur_fp_idx + 1
         
     module.exit_json(changed=False, ansible_facts={'dut_fp_ports': fp_ports})
 

--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -141,9 +141,14 @@ def main():
     elif cmd == "remove":
         vp.remove_vlan_ports()
 
+    cur_fp_idx = 0        
     for vlan_id in vlan_ids:
+      if 'vlan_base' in module.params and module.params['vlan_base'] != 0:        
         fp_ports[vlan_id - module.params['vlan_base']] = "%s.%d" % (external_port, vlan_id)
-
+      else:
+        fp_ports[cur_fp_idx] =  "%s.%d" % (external_port, vlan_id)
+        cur_fp_idx = cur_fp_idx + 1
+        
     module.exit_json(changed=False, ansible_facts={'dut_fp_ports': fp_ports})
 
 if __name__ == "__main__":

--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -123,6 +123,7 @@ def main():
         cmd=dict(required=True, choices=['create', 'remove', 'list']),
         external_port = dict(required=True, type='str'),
         vlan_ids=dict(required=True, type='list'),
+        vlan_base=dict(type='int', default=0)
     ))
 
     cmd = module.params['cmd']
@@ -130,7 +131,7 @@ def main():
     vlan_ids = module.params['vlan_ids']
     vlan_ids.sort()
 
-    fp_ports = []
+    fp_ports = {}
 
     vp = VlanPort(external_port, vlan_ids)
 
@@ -141,7 +142,7 @@ def main():
         vp.remove_vlan_ports()
 
     for vlan_id in vlan_ids:
-        fp_ports.append("%s.%d" % (external_port, vlan_id))
+        fp_ports[vlan_id - module.params['vlan_base']] = "%s.%d" % (external_port, vlan_id)
 
     module.exit_json(changed=False, ansible_facts={'dut_fp_ports': fp_ports})
 

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -363,7 +363,7 @@ class VMTopology(object):
                 injected_iface = INJECTED_INTERFACES_TEMPLATE % (self.vm_set_name, vlan)
                 br_name = OVS_FP_BRIDGE_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                 vm_iface = OVS_FP_TAP_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
-                self.bind_ovs_ports(br_name,  self.dut_fp_ports[str(vlan)], injected_iface, vm_iface, disconnect_vm)
+                self.bind_ovs_ports(br_name, self.dut_fp_ports[str(vlan)], injected_iface, vm_iface, disconnect_vm)
 
         return
 

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -363,7 +363,7 @@ class VMTopology(object):
                 injected_iface = INJECTED_INTERFACES_TEMPLATE % (self.vm_set_name, vlan)
                 br_name = OVS_FP_BRIDGE_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                 vm_iface = OVS_FP_TAP_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
-                self.bind_ovs_ports(br_name, self.dut_fp_ports[vlan], injected_iface, vm_iface, disconnect_vm)
+                self.bind_ovs_ports(br_name,  self.dut_fp_ports[str(vlan)], injected_iface, vm_iface, disconnect_vm)
 
         return
 
@@ -471,7 +471,7 @@ class VMTopology(object):
         """inject dut port into the ptf docker"""
         self.update()
         for vlan in self.host_interfaces:
-            self.add_dut_if_to_docker(PTF_FP_IFACE_TEMPLATE % vlan, self.dut_fp_ports[vlan])
+            self.add_dut_if_to_docker(PTF_FP_IFACE_TEMPLATE % vlan,  self.dut_fp_ports[str(vlan)])
 
         return
 
@@ -479,7 +479,7 @@ class VMTopology(object):
         """deject dut port from the ptf docker"""
         self.update()
         for vlan in self.host_interfaces:
-            self.remove_dut_if_from_docker(PTF_FP_IFACE_TEMPLATE % vlan, self.dut_fp_ports[vlan])
+            self.remove_dut_if_from_docker(PTF_FP_IFACE_TEMPLATE % vlan,  self.dut_fp_ports[str(vlan)])
 
     @staticmethod
     def iface_up(iface_name, pid=None):
@@ -676,7 +676,7 @@ def main():
             ptf_bp_ip_addr=dict(required=False, type='str'),
             ptf_bp_ipv6_addr=dict(required=False, type='str'),
             mgmt_bridge=dict(required=False, type='str'),
-            dut_fp_ports=dict(required=False, type='list'),
+            dut_fp_ports=dict(required=False, type='dict'),
             dut_mgmt_port=dict(required=False, type='str'),
             fp_mtu=dict(required=False, type='int', default=DEFAULT_MTU),
             max_fp_num=dict(required=False, type='int', default=NUM_FP_VLANS_PER_FP),

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -471,7 +471,7 @@ class VMTopology(object):
         """inject dut port into the ptf docker"""
         self.update()
         for vlan in self.host_interfaces:
-            self.add_dut_if_to_docker(PTF_FP_IFACE_TEMPLATE % vlan,  self.dut_fp_ports[str(vlan)])
+            self.add_dut_if_to_docker(PTF_FP_IFACE_TEMPLATE % vlan, self.dut_fp_ports[str(vlan)])
 
         return
 
@@ -479,7 +479,7 @@ class VMTopology(object):
         """deject dut port from the ptf docker"""
         self.update()
         for vlan in self.host_interfaces:
-            self.remove_dut_if_from_docker(PTF_FP_IFACE_TEMPLATE % vlan,  self.dut_fp_ports[str(vlan)])
+            self.remove_dut_if_from_docker(PTF_FP_IFACE_TEMPLATE % vlan, self.dut_fp_ports[str(vlan)])
 
     @staticmethod
     def iface_up(iface_name, pid=None):

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -35,6 +35,11 @@
   command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.conf.all.disable_ipv6=0
   become: yes
 
+- name: Set default value for vlan_base
+  set_fact:
+    vlan_base: 0
+  when: vlan_base is not defined
+
 - name: Set front panel/mgmt port for dut
   include_tasks: set_dut_port.yml
 
@@ -42,6 +47,7 @@
   vlan_port:
     external_port: "{{ external_port }}"
     vlan_ids: "{{ device_vlan_list }}"
+    vlan_base: "{{ vlan_base }}"
     cmd: "create"
   become: yes
   when: external_port is defined

--- a/ansible/roles/vm_set/tasks/connect_vms.yml
+++ b/ansible/roles/vm_set/tasks/connect_vms.yml
@@ -1,3 +1,8 @@
+- name: Set default value for vlan_base
+  set_fact:
+    vlan_base: 0
+  when: vlan_base is not defined
+
 - name: Set front panel/mgmt port for dut
   include_tasks: set_dut_port.yml
 

--- a/ansible/roles/vm_set/tasks/disconnect_vms.yml
+++ b/ansible/roles/vm_set/tasks/disconnect_vms.yml
@@ -1,3 +1,8 @@
+- name: Set default value for vlan_base
+  set_fact:
+    vlan_base: 0
+  when: vlan_base is not defined
+
 - name: Set front panel/mgmt port for dut
   include_tasks: set_dut_port.yml
 

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -1,3 +1,8 @@
+- name: Set default value for vlan_base
+  set_fact:
+    vlan_base: 0
+  when: vlan_base is not defined
+
 - name: Set front panel/mgmt port for dut
   include_tasks: set_dut_port.yml
 
@@ -20,6 +25,7 @@
   vlan_port:
     external_port: "{{ external_port }}"
     vlan_ids: "{{ device_vlan_list }}"
+    vlan_base: "{{ vlan_base }}"
     cmd: "remove"
   become: yes
   when: external_port is defined

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -25,6 +25,11 @@
     privileged: yes
   become: yes
 
+- name: Set default value for vlan_base
+  set_fact:
+    vlan_base: 0
+  when: vlan_base is not defined
+
 - name: Set front panel/mgmt port for dut
   include_tasks: set_dut_port.yml
 

--- a/ansible/roles/vm_set/tasks/set_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/set_dut_port.yml
@@ -2,6 +2,7 @@
   vlan_port:
     external_port: "{{ external_port }}"
     vlan_ids: "{{ device_vlan_list }}"
+    vlan_base: "{{ vlan_base }}"
     cmd: "list"
   become: yes
   when: external_port is defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Support for not using all ports on hardware DUT for testing and thus not connecting all the ports to a fanout switch.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently, it is required that all ports on DUT are in use and are connected to a fanout.
However, there is a need to be able to run tests where all ports are not in use. Specifically, when dealing with
- new hardware boxes
- boxes with a front panel port used for in-band management
- boxes with lots of ports and multiple asics, were every port on every asic is not required to be covered
- chassis as a DUT, where the number of ports can be in hundreds
- higher bandwidth ports like 400G 
    - hard to go from 400G down to 1/10G
 
Also, majority of the basic functional testing can be done without testing all the ports on the DUT.

#### How did you do it?
To support above in orchestration, following changes were made:
- dut_fp_ports  is changed to be a dictionary instead of a list, and 
- vlan_base as an optional ansible variable passed into testbed-cli.sh.

In current orchestration in add-topo, the dut_fp_ports is a list of nic’s on the testbed server corresponding to the ports on the DUT. In the topology file, the 'host_interfaces' and 'vlans' for VM's are defined as an offset from the 'vlan_base'.  When we 'bind' the topology (using vm_topology module),  it uses this offset as the index into the dut_fp_ports to get the corresponding nic on the testbed server to the DUT's port. So, when having lesser number of elements in dut_fp_ports than the offsets defined in the topology results in index of out bound exception.
 
By changing dut_fp_ports to be a dictionary with key being this offset from 'vlan_base' and the value being the actual nic on the testbed server corresponding to the DUT's port, we avoid the above issue. This 'vlan_base' defaults to 0 (to give backward compatability) and can be specified as an extra ansible arg (using -e option). If it is not specified (has value 0), then the key is the same as the index in the original dut_fp_ports list. 
 
For example, let's consider that we have a topology with only 2 ports (3 and 51) on the DUT connected to the fanout, with fanout vlans 103 and 151 respectively, 
'vlan_base' of 100, and the trunk port on the testbed server being 'eno2'. Then dut_fp_ports would look like:
```
        {
          '3' :  'eno2.103',
          `51' : 'eno2.151
        }
```
For a topology where we 32 ports connected to fanout with vlans 100 - 132 on trunk port eno2, and vlan_base is not specified, then the resulting dut_fp_ports would be 

```
     {
       '0':  'eno2.100',
       '1':  'eno2.101',
       '2':  'eno2.102',
        .
        .
        '31': 'eno2.132'
     }
```

#### How did you verify/test it?
- Ran add/remove-topo against KVM SONiC DUT and ceos containers against t0 topology and validated BGP and ptf connectivity
```
    ./testbed-cli.sh -t vtestbed.csv -m veos.vtb -k ceos add-topo vms-kvm-t0 password.txt 
    ./testbed-cli.sh -t vtestbed.csv -m veos.vtb deploy-mg vms-kvm-t0 lab password.txt
    ansible-playbook -i lab -l vlab-01 test_sonic.yml -e testbed_name=vms-kvm-t0 -e testcase_name=fdb -e testbed_file=vtestbed.csv 
    ./testbed-cli.sh -t vtestbed.csv -m veos.vtb -k ceos remove-topo vms-kvm-t0 password.txt
```

- Ran add/remove-topo against a SONiC DUT with all ports connected to a fanout against t0 topology and validated BGP and ptf connectivity
```
    ./testbed-cli.sh -t testbed.csv -m veos.vtb -k ceos add-topo vms-s6100-t0 password.txt
    ./testbed-cli.sh -t testbed.csv -m veos.vtb deploy-mg vms-s6100-t0 lab password.txt
    ./testbed-cli.sh -t testbed.csv -m veos.vtb -k ceos remove-topo vms-s6100-t0 password.txt
```

- Ran add/remove-topo against a SONiC DUT with only 2 ports connected to fanout against
topology defining only 1 VM and 1 'host-interfaces' and validated BGP and ptf connectivity
```
    ./testbed-cli.sh -t testbed.csv -m veos.vtb -k ceos add-topo vms-s6100-2p password.txt -e vlan_base=100
    ./testbed-cli.sh -t testbed.csv -m veos.vtb deploy-mg vms-s6100-2p lab password.txt
    ./testbed-cli.sh -t testbed.csv -m veos.vtb -k ceos remove-topo vms-s6100-2p password.txt -e vlan_base=100
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
