### PR TITLE
[advanced-reboot] Change Dest IP of VM/Server Originated Packets

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -127,7 +127,8 @@ class AdvancedReboot:
         self.rebootData['dut_username'] = secrets[invetory]['sonicadmin_user']
         self.rebootData['dut_password'] = secrets[invetory]['sonicadmin_password']
 
-        prefixLen = 18
+        # Change network of the dest IP addresses (used by VM servers) to be different from Vlan network
+        prefixLen = self.mgFacts['minigraph_vlan_interfaces'][0]['prefixlen'] - 3
         testNetwork = ipaddress.ip_address(self.mgFacts['minigraph_vlan_interfaces'][0]['addr']) + (1 << (32 - prefixLen))
         self.rebootData['default_ip_range'] = str(
             ipaddress.ip_interface(unicode(str(testNetwork) + '/{0}'.format(prefixLen))).network

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -129,7 +129,9 @@ class AdvancedReboot:
 
         prefixLen = 18
         testNetwork = ipaddress.ip_address(self.mgFacts['minigraph_vlan_interfaces'][0]['addr']) + (1 << (32 - prefixLen))
-        self.rebootData['default_ip_range'] = str(testNetwork) + '/{0}'.format(prefixLen)
+        self.rebootData['default_ip_range'] = str(
+            ipaddress.ip_interface(unicode(str(testNetwork) + '/{0}'.format(prefixLen))).network
+        )
         for intf in self.mgFacts['minigraph_lo_interfaces']:
             if ipaddress.ip_interface(intf['addr']).ip.version == 6:
                 self.rebootData['lo_v6_prefix'] = str(ipaddress.ip_interface(intf['addr'] + '/64').network)

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -127,10 +127,9 @@ class AdvancedReboot:
         self.rebootData['dut_username'] = secrets[invetory]['sonicadmin_user']
         self.rebootData['dut_password'] = secrets[invetory]['sonicadmin_password']
 
-        self.rebootData['default_ip_range'] = str(
-            ipaddress.ip_interface(self.mgFacts['minigraph_vlan_interfaces'][0]['addr'] + '/18').network
-        )
-
+        prefixLen = 18
+        testNetwork = ipaddress.ip_address(self.mgFacts['minigraph_vlan_interfaces'][0]['addr']) + (1 << (32 - prefixLen))
+        self.rebootData['default_ip_range'] = str(testNetwork) + '/{0}'.format(prefixLen)
         for intf in self.mgFacts['minigraph_lo_interfaces']:
             if ipaddress.ip_interface(intf['addr']).ip.version == 6:
                 self.rebootData['lo_v6_prefix'] = str(ipaddress.ip_interface(intf['addr'] + '/64').network)


### PR DESCRIPTION
### Description of PR
Change in PR:1653 changed prefix len and did not change the network
which would result in high chance of collision with DUT vlan IP.
This PR will change the network where VMs' IPs are generated.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
```
pytest platform_tests/test_advanced_reboot.py::test_fast_reboot --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-14 --module-path=../ansible/library --disable_loganalyzer --skip_sanity --reboot_limit=60 --new_sonic_image=http://100.127.20.23/installer/sonic/broadcom/internal-201811/sonic-broadcom.bin 
================================================================================================================================================== test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/host-acs-mgmt-repo/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                                                                                                                                                                         

platform_tests/test_advanced_reboot.py .                                                                                                                                                                                                                                                                           [100%]

========================================================================================================================================= 1 passed, 1 warnings in 662.78 seconds =========================================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
