### PR TITLE
Convert whitespace string in test node name to '_' to avoid loganalyzer init issue

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def loganalyzer(duthost, request):
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name.replace(' ', '_'))
     logging.info("Add start marker into DUT syslog")
     marker = loganalyzer.init()
     yield loganalyzer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For pytest parameterized test case, if the param value has whitespace in its param
value, the loganalyzer init command line will fail because the whitespaces confues
loganalyzer from parsing the command line arguments.

The fix is to convert all whitespaces in test node name to '_'. Loganalyzer will use
the new test node name in run_id as test case identifier.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For pytest parametrized test cases, if param value has whitespace in it, then loganalyzer init will fail with exception like below:
```
E           RunAnsibleModuleFail: run module command failed                                                                                                                                                      
E           Ansible Results => changed=true                                                                                                                                                                      
E             cmd:                                                                                                                                                                                               
E             - python                                                                                                                                                                                           
E             - /tmp/loganalyzer.py                                                                                                                                                                              
E             - --action                                                                                                                                                                                         
E             - init                                                                                                                                                                                             
E             - --run_id                                                                                                                                                                                         
E             - test_portstat_clear[portstat                                                                                                                                                                     
E             - -c].2020-06-08-13:04:17                                                                                                                                                                          
E             delta: '0:00:00.033181'                                                                                                                                                                            
E             end: '2020-06-08 13:04:12.252245'                                                                                                                                                                  
E             invocation:                                                                                                                                                                                        
E               module_args:                                                                                                                                                                                     
E                 _raw_params: python /tmp/loganalyzer.py --action init --run_id test_portstat_clear[portstat -c].2020-06-08-13:04:17                                                                            
E                 _uses_shell: false                                                                                                                                                                             
E                 argv: null                                                                                                                                                                                     
E                 chdir: null                                                                                                                                                                                    E                 creates: null                                                                                                                                                                                  
E                 executable: null                                                                                                                                                                               
E                 removes: null                                                                                                                                                                                  
E                 stdin: null                                                                                                                                                                                    
E                 stdin_add_newline: true                                                                                                                                                                        
E                 strip_empty_ends: true                                                                                                                                                                         E                 warn: true                                                                                                                                                                                     
E             msg: non-zero return code                                                                                                                                                                          
E             rc: 250                                                                                                                                                                                            
E             start: '2020-06-08 13:04:12.219064'                                                                                                                                                                
E             stderr: ''                                                                                                                                                                                         
E             stderr_lines: <omitted>                                                                                                                                                                            E             stdout: |-                                                                                                                                                                                         
E               Invalid option specified                                                                                                                                                                         
E               loganalyzer input parameters:                                                                                                                                                                    
E               --help                           Print usage                                                                                                                                                     E               --verbose                        Print verbose output during the run                                                                                                                             
E               --action                         init|analyze - action to perform.                                                                                                                               
E                                                init - initialize analysis by placing start-marker                                                                                                              
E                                                to all log files specified in --logs parameter.                                                                                                                 
E                                                analyze - perform log analysis of files specified in --logs parameter.                                                                                          
E                                                add_end_marker - add end marker to all log files specified in --logs parameter.                                                                                 E               --out_dir path                   Directory path where to place output files,                                                                                                                     
E                                                must be present when --action == analyze                                                                                                                        
E               --logs path{,path}               List of full paths to log files to be analyzed.                                                                                                                 
E                                                Implicitly system log file will be also processed                                                                                                               
E               --run_id string                  String passed to loganalyzer, uniquely identifying                                                                                                              
E                                                analysis session. Used to construct start/end markers.                                                                                                          
E               --match_files_in path{,path}     List of paths to files containing strings. A string from log file                                                                                               
E                                                By default syslog will be always analyzed and should be passed by match_files_in.                                                                               
E                                                matching any string from match_files_in will be collected and                                                                                                   
E                                                reported. Must be present when action == analyze                                                                                                                
E               --ignore_files_in path{,path}    List of paths to files containing string.                                                                                                                       
E                                                A string from log file matching any string from these                                                                                                           
E                                                files will be ignored during analysis. Must be present                                                                                                          E                                                when action == analyze.                                                                                                                                         
E               --expect_files_in path{,path}    List of path to files containing string.                                                                                                                        
E                                                All the strings from these files will be expected to present                                                                                                    
E                                                in one of specified log files during the analysis. Must be present                                                                                              E                                                when action == analyze.                                                                                                                                         E             stdout_lines: <omitted>                                                                             
```

The loganalyzer command line is confused by the whitespace and can not parse arguments properly:
`python /tmp/loganalyzer.py --action init --run_id test_portstat_clear[portstat -c].2020-06-08-13:04:17`

This PR is to fix this issue.

#### How did you do it?
Convert all the whitespace in test node name to '_'.

#### How did you verify/test it?
Test run a parametrized pytest case with whitespace in param values.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
