### PR TITLE
[pytest] Make Copy [ptf,sai,acs]tests Fixture Session Scope

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -2,8 +2,8 @@ import json
 import logging
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from ptf_runner import ptf_runner
 

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -2,6 +2,8 @@ import json
 import logging
 import pytest
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from ptf_runner import ptf_runner
 
@@ -116,19 +118,6 @@ class TestWrArp:
         ptfhost.shell('supervisorctl reread && supervisorctl update')
 
     @pytest.fixture(scope='class', autouse=True)
-    def copyPtfDirectory(self, ptfhost):
-        '''
-            Copys PTF directory to PTF host. This class-scope fixture runs once before test start
-
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-
-            Returns:
-                None
-        '''
-        ptfhost.copy(src="ptftests", dest="/root")
-
-    @pytest.fixture(scope='class', autouse=True)
     def setupRouteToPtfhost(self, duthost, ptfhost):
         '''
             Sets routes up on DUT to PTF host. This class-scope fixture runs once before test start
@@ -175,19 +164,6 @@ class TestWrArp:
                 None
         '''
         ptfhost.script('./scripts/remove_ip.sh')
-
-    @pytest.fixture(scope='class', autouse=True)
-    def changePtfhostMacAddresses(self, ptfhost):
-        '''
-            Change MAC addresses (unique) on PTF host. This class-scope fixture runs once before test start
-
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-
-            Returns:
-                None
-        '''
-        ptfhost.script("./scripts/change_mac.sh")
 
     @pytest.fixture(scope='class', autouse=True)
     def prepareSshKeys(self, duthost, ptfhost):

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -2,8 +2,8 @@ import json
 import logging
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from ptf_runner import ptf_runner
 

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -4,8 +4,8 @@ import time
 import logging
 import requests
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
 

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -3,6 +3,9 @@ from netaddr import *
 import time
 import logging
 import requests
+
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from ptf_runner import ptf_runner
 
 
@@ -44,7 +47,6 @@ def common_setup_teardown(duthost, ptfhost):
     logging.info("ptfip=%s" % ptfip)
 
     ptfhost.script("./scripts/remove_ip.sh")
-    ptfhost.script("./scripts/change_mac.sh")
 
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     interface_facts = duthost.interface_facts()['ansible_facts']
@@ -171,8 +173,6 @@ def test_bgp_speaker_announce_routes(common_setup_teardown, testbed, duthost, pt
     logging.info("extra_vars: %s" % str(ptfhost.host.options['variable_manager'].extra_vars))
 
     ptfhost.template(src="bgp_speaker/bgp_speaker_route.j2", dest="/root/bgp_speaker_route.txt")
-
-    ptfhost.copy(src="ptftests", dest="/root")
 
     logging.info("run ptf test")
 

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -4,8 +4,8 @@ import time
 import logging
 import requests
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -5,8 +5,8 @@ import logging
 import pytest
 import time
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from common.reboot import reboot as rebootDut

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -5,6 +5,8 @@ import logging
 import pytest
 import time
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from common.reboot import reboot as rebootDut
@@ -287,12 +289,9 @@ class AdvancedReboot:
         ]
         self.__transferTestDataFiles(testDataFiles, self.ptfhost)
 
-        self.__runScript(['remove_ip.sh', 'change_mac.sh'], self.ptfhost)
+        self.__runScript(['remove_ip.sh'], self.ptfhost)
 
         self.__prepareTestbedSshKeys()
-
-        logger.info('Copy tests to the PTF container  {}'.format(self.ptfhost.hostname))
-        self.ptfhost.copy(src='ptftests', dest='/root')
 
         logger.info('Copy ARP responder to the PTF container  {}'.format(self.ptfhost.hostname))
         self.ptfhost.copy(src='scripts/arp_responder.py', dest='/opt')

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -5,8 +5,8 @@ import logging
 import pytest
 import time
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from common.reboot import reboot as rebootDut

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -19,8 +19,6 @@ ANSIBLE_ROOT = os.path.realpath(os.path.join(TESTS_ROOT, "../ansible"))
 
 ARP_RESPONDER = os.path.join(TESTS_ROOT, "scripts/arp_responder.py")
 ARP_RESPONDER_CONF = os.path.join(TESTS_ROOT, "scripts/arp_responder.conf.j2")
-SAI_TESTS = os.path.join(ANSIBLE_ROOT, "roles/test/files/saitests")
-PTF_TESTS = os.path.join(ANSIBLE_ROOT, "roles/test/files/ptftests")
 
 
 def get_fanout(fanout_graph_facts, setup):
@@ -235,9 +233,6 @@ def setup(testbed, duthost, ptfhost, ansible_facts, minigraph_facts, request):
 
     # Remove portmap
     ptfhost.file(path=os.path.join(OS_ROOT_DIR, setup_params["ptf_test_params"]["port_map_file"]), state="absent")
-    # Remove SAI and PTF tests
-    ptfhost.file(path=os.path.join(OS_ROOT_DIR, "saitests"), state="absent")
-    ptfhost.file(path=os.path.join(OS_ROOT_DIR, "ptftests"), state="absent")
 
 
 class Setup(object):
@@ -263,7 +258,6 @@ class Setup(object):
         self.generate_non_server_ports()
         self.generate_router_mac()
         self.prepare_arp_responder()
-        self.copy_ptf_sai_tests()
         self.prepare_ptf_port_map()
         self.generate_priority()
         self.generate_pfc_to_dscp_map()
@@ -318,11 +312,6 @@ class Setup(object):
         self.ptfhost.template(src=ARP_RESPONDER_CONF, dest="/etc/supervisor/conf.d/arp_responder.conf", force=True)
         self.ptfhost.command('supervisorctl reread')
         self.ptfhost.command('supervisorctl update')
-
-    def copy_ptf_sai_tests(self):
-        """ Copy 'saitests' and 'ptftests' directory to the PTF host """
-        self.ptfhost.copy(src=SAI_TESTS, dest=OS_ROOT_DIR)
-        self.ptfhost.copy(src=PTF_TESTS, dest=OS_ROOT_DIR)
 
     def prepare_ptf_port_map(self):
         """ Copy 'ptf_portmap' file which is defined in inventory to the PTF host """

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -2,6 +2,7 @@ import json
 import logging
 import pytest
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
 from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
@@ -77,9 +78,6 @@ class PopulateFdb:
 
         logger.info("Copying VLan config file to {0}".format(self.ptfhost.hostname))
         self.ptfhost.copy(src=self.VLAN_CONFIG_FILE, dest="/tmp/")
-
-        logger.info("Copying ptftests to {0}".format(self.ptfhost.hostname))
-        self.ptfhost.copy(src="ptftests", dest="/root")
 
     def run(self):
         """

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,0 +1,82 @@
+import os
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+ROOT_DIR = "/root"
+ACS_TESTS = "acstests"
+PTF_TESTS = "ptftests"
+SAI_TESTS = "saitests"
+CHANGE_MAC_ADDRESS_SCRIPT = "scripts/change_mac.sh"
+
+@pytest.fixture(scope="session", autouse=True)
+def copy_acstests_directory(ptfhost):
+    """
+        Copys ACS tests directory to PTF host.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+
+        Returns:
+            None
+    """
+    logger.info("Copy ACS test files to PTF host '{0}'".format(ptfhost.hostname))
+    ptfhost.copy(src=ACS_TESTS, dest=ROOT_DIR)
+
+    yield
+
+    logger.info("Delete ACS test files from PTF host '{0}'".format(ptfhost.hostname))
+    ptfhost.file(path=os.path.join(ROOT_DIR, ACS_TESTS), state="absent")
+
+@pytest.fixture(scope="session", autouse=True)
+def copy_ptftests_directory(ptfhost):
+    """
+        Copys PTF tests directory to PTF host.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+
+        Returns:
+            None
+    """
+    logger.info("Copy PTF test files to PTF host '{0}'".format(ptfhost.hostname))
+    ptfhost.copy(src=PTF_TESTS, dest=ROOT_DIR)
+
+    yield
+
+    logger.info("Delete PTF test files from PTF host '{0}'".format(ptfhost.hostname))
+    ptfhost.file(path=os.path.join(ROOT_DIR, PTF_TESTS), state="absent")
+
+@pytest.fixture(scope="session", autouse=True)
+def copy_saitests_directory(ptfhost):
+    """
+        Copys SAI tests directory to PTF host.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+
+        Returns:
+            None
+    """
+    logger.info("Copy SAI test files to PTF host '{0}'".format(ptfhost.hostname))
+    ptfhost.copy(src=SAI_TESTS, dest=ROOT_DIR)
+
+    yield
+
+    logger.info("Delete SAI test files from PTF host '{0}'".format(ptfhost.hostname))
+    ptfhost.file(path=os.path.join(ROOT_DIR, SAI_TESTS), state="absent")
+
+@pytest.fixture(scope="session", autouse=True)
+def change_mac_addresses(ptfhost):
+    """
+        Change MAC addresses (unique) on PTF host.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+
+        Returns:
+            None
+    """
+    logger.info("Change interface MAC addresses on ptfhost '{0}'".format(ptfhost.hostname))
+    ptfhost.script(CHANGE_MAC_ADDRESS_SCRIPT)

--- a/tests/common/plugins/ansible_fixtures.py
+++ b/tests/common/plugins/ansible_fixtures.py
@@ -7,7 +7,7 @@ import pytest
 # fixtures we have to override the scope here in global conftest.py
 # Let's have it with module scope for now, so if something really breaks next test module run will have
 # this fixture reevaluated
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def ansible_adhoc(request):
     """Return an inventory initialization method."""
     plugin = request.config.pluginmanager.getplugin("ansible")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ def enable_ssh_timout(dut):
     time.sleep(5)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def duthost(ansible_adhoc, testbed, request):
     '''
     @summary: Shortcut fixture for getting DUT host. For a lengthy test case, test case module can
@@ -216,8 +216,8 @@ def duthost(ansible_adhoc, testbed, request):
     @param testbed: Ansible framework testbed information
     @param request: request parameters for duthost test fixture
     '''
-    stop_ssh_timeout = getattr(request.module, "pause_ssh_timeout", None)
-    dut_index = getattr(request.module, "dut_index", 0)
+    stop_ssh_timeout = getattr(request.session, "pause_ssh_timeout", None)
+    dut_index = getattr(request.session, "dut_index", 0)
     assert dut_index < len(testbed["duts"]), "DUT index '{0}' is out of bound '{1}'".format(dut_index, len(testbed["duts"]))
 
     duthost = SonicHost(ansible_adhoc, testbed["duts"][dut_index])
@@ -238,12 +238,12 @@ def reset_critical_services_list(duthost):
 
     duthost.reset_critical_services_tracking_list()
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def localhost(ansible_adhoc):
     return Localhost(ansible_adhoc)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def ptfhost(ansible_adhoc, testbed, duthost):
     if "ptf" in testbed:
         return PTFHost(ansible_adhoc, testbed["ptf"])

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -5,8 +5,8 @@
         Refactor ptfadapter so it can be leveraged in these test cases.
 """
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
 DEFAULT_NN_TARGET_PORT = 3
 

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -5,6 +5,9 @@
         Refactor ptfadapter so it can be leveraged in these test cases.
 """
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+
 DEFAULT_NN_TARGET_PORT = 3
 
 _REMOVE_IP_SCRIPT = "scripts/remove_ip.sh"
@@ -58,7 +61,6 @@ def configure_ptf(ptf, nn_target_port):
             nn_target_port (int): The port to run NN agent on.
     """
 
-    ptf.script(cmd=_REMOVE_IP_SCRIPT)
     ptf.script(cmd=_ADD_IP_SCRIPT)
 
     facts = {"nn_target_port": nn_target_port}
@@ -66,8 +68,6 @@ def configure_ptf(ptf, nn_target_port):
     ptf.template(src=_PTF_NN_TEMPLATE, dest=_PTF_NN_DEST)
 
     ptf.supervisorctl(name="ptf_nn_agent", state="restarted")
-
-    ptf.copy(src="ptftests", dest="/root")
 
 def restore_ptf(ptf):
     """

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -7,8 +7,8 @@ from jinja2 import Template
 from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from common.plugins.fib import generate_routes
 

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -7,8 +7,8 @@ from jinja2 import Template
 from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from common.plugins.fib import generate_routes
 

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -7,6 +7,8 @@ from jinja2 import Template
 from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from ptf_runner import ptf_runner
 from common.plugins.fib import generate_routes
 
@@ -105,12 +107,8 @@ def gen_fib_info(ptfhost, testbed, cfg_facts):
 
 
 def prepare_ptf(ptfhost, testbed, cfg_facts):
-    logger.info("Remove IP and change MAC on PTF container")
+    logger.info("Remove IP on PTF container")
     ptfhost.script("./scripts/remove_ip.sh")
-    ptfhost.script("./scripts/change_mac.sh")
-
-    logger.info("Copy PTF scripts to PTF container")
-    ptfhost.copy(src="ptftests", dest="/root")
 
     gen_fib_info(ptfhost, testbed, cfg_facts)
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,8 +2,8 @@ import ipaddress
 import pytest
 import time
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,32 +2,10 @@ import ipaddress
 import pytest
 import time
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from ptf_runner import ptf_runner
 
-
-@pytest.fixture(scope="module", autouse=True)
-def copy_ptftests_directory(ptfhost):
-    """ Fixture which copies the ptftests directory to the PTF host. This fixture
-        is scoped to the module, as it only needs to be performed once before
-        the first test is run. It does not need to be run before each test.
-        We also set autouse=True to ensure this fixture gets instantiated before
-        the first test runs, even if we don't explicitly pass it to them, and since
-        there is no return value, there is no point in passing it into the functions.
-    """
-    ptfhost.copy(src="ptftests", dest="/root")
-
-@pytest.fixture(scope="module", autouse=True)
-def ptf_configure_unique_interface_mac_addresses(ptfhost, autouse=True):
-    """ Fixture which copies the change_mac.sh script to the PTF host and executes
-        it there, changing the MAC addresses of the PTF host's interfaces such that
-        each interface has a unique MAC address.
-
-        This fixture is scoped to the module, as it only needs to be performed once
-        before the first test is run.
-    """
-    ptfhost.copy(src="scripts/change_mac.sh", dest="/tmp")
-
-    ptfhost.shell("/bin/bash /tmp/change_mac.sh")
 
 @pytest.fixture(scope="module")
 def dut_dhcp_relay_data(duthost, ptfhost, testbed):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,8 +2,8 @@ import ipaddress
 import pytest
 import time
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1,9 +1,12 @@
 import os
 import time
 import pytest
+import ipaddr as ipaddress
+
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_acstests_directory
 from ptf_runner import ptf_runner
 from abc import abstractmethod
-import ipaddr as ipaddress
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))
@@ -14,18 +17,6 @@ EVERFLOW_TABLE_RULE_CREATE_TEMPLATE = 'acl_rule_persistent.json.j2'
 EVERFLOW_TABLE_RULE_CREATE_FILE = 'acl_rule_persistent.json'
 EVERFLOW_TABLE_RULE_DELETE_FILE = 'acl_rule_persistent-del.json'
 DUT_RUN_DIR = '/home/admin/everflow_tests'
-
-@pytest.fixture(scope="module", autouse=True)
-def copy_acstests_directory(ptfhost):
-    """ Fixture which copies the ptftests directory to the PTF host. This fixture
-        is scoped to the module, as it only needs to be performed once before
-        the first test is run. It does not need to be run before each test.
-        We also set autouse=True to ensure this fixture gets instantiated before
-        the first test runs, even if we don't explicitly pass it to them, and since
-        there is no return value, there is no point in passing it into the functions.
-    """
-    ptfhost.copy(src="acstests", dest="/root")
-    ptfhost.copy(src="ptftests", dest="/root")
 
 @pytest.fixture(scope='module')
 def setup_info(duthost, testbed):

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -3,8 +3,8 @@ import time
 import pytest
 import ipaddr as ipaddress
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import copy_acstests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_acstests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from abc import abstractmethod
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -3,8 +3,8 @@ import time
 import pytest
 import ipaddr as ipaddress
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import copy_acstests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import copy_acstests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from abc import abstractmethod
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -7,7 +7,7 @@ import itertools
 import logging
 import pprint
 
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 
 DEFAULT_FDB_ETHERNET_TYPE = 0x1234
 DUMMY_MAC_PREFIX = "02:11:22:33"

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -7,7 +7,7 @@ import itertools
 import logging
 import pprint
 
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
 DEFAULT_FDB_ETHERNET_TYPE = 0x1234
 DUMMY_MAC_PREFIX = "02:11:22:33"

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -7,6 +7,8 @@ import itertools
 import logging
 import pprint
 
+from common.fixtures.ptfhost_utils import change_mac_addresses
+
 DEFAULT_FDB_ETHERNET_TYPE = 0x1234
 DUMMY_MAC_PREFIX = "02:11:22:33"
 DUMMY_MAC_COUNT = 10
@@ -169,8 +171,6 @@ def test_fdb(ansible_adhoc, testbed, ptfadapter, duthost, ptfhost, pkt_type):
 
     # remove existing IPs from PTF host
     ptfhost.script('scripts/remove_ip.sh')
-    # set unique MACs to PTF interfaces
-    ptfhost.script('scripts/change_mac.sh')
     # reinitialize data plane due to above changes on PTF interfaces
     ptfadapter.reinit()
 

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -3,6 +3,7 @@ import pytest
 import time
 
 from common.helpers.assertions import pytest_assert
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm [py/import-and-import-from]
 
 logger = logging.getLogger(__name__)
 
@@ -124,19 +125,6 @@ class TestFdbMacExpire:
 
         logger.info("Copying fdb_info.txt config file to {0}".format(ptfhost.hostname))
         ptfhost.template(src="fdb/files/fdb.j2", dest=self.FDB_INFO_FILE)
-
-    @pytest.fixture(scope="class", autouse=True)
-    def copyPtfDirectory(self, ptfhost):
-        """
-            Copys PTF directory to PTF host.
-
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-
-            Returns:
-                None
-        """
-        ptfhost.copy(src="ptftests", dest="/root")
 
     @pytest.fixture(scope="class", autouse=True)
     def clearSonicFdbEntries(self, duthost):

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -3,7 +3,7 @@ import pytest
 import time
 
 from common.helpers.assertions import pytest_assert
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm [py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm [py/unused-import]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -3,7 +3,7 @@ import time
 import json
 import logging
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from datetime import datetime 
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -3,7 +3,7 @@ import time
 import json
 import logging
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from datetime import datetime 
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -2,6 +2,8 @@ import pytest
 import time
 import json
 import logging
+
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
 from ptf_runner import ptf_runner
 from datetime import datetime 
 
@@ -108,7 +110,6 @@ def test_fib(testbed, duthost, ptfhost, ipv4, ipv6, mtu):
     build_fib(duthost, config_facts, ofpname, t)
 
     ptfhost.copy(src=ofpname, dest="/root/fib_info.txt")
-    ptfhost.copy(src="ptftests", dest="/root")
     logging.info("run ptf test")
 
     # do not test load balancing for vs platform as kernel 4.9
@@ -152,7 +153,6 @@ def setup_hash(testbed, duthost, ptfhost, timestamp):
     build_fib(duthost, config_facts, ofpname, timestamp)
 
     ptfhost.copy(src=ofpname, dest="/root/fib_info.txt")
-    ptfhost.copy(src="ptftests", dest="/root")
     logging.info("run ptf test")
 
     # TODO

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -3,7 +3,7 @@ import ptf.testutils as testutils
 from ipaddress import ip_address
 import logging
 
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 
 TOPO_LIST = {'t0', 't1', 't1-lag'}
 PORTS_TOPO = {'t1'}

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -3,6 +3,8 @@ import ptf.testutils as testutils
 from ipaddress import ip_address
 import logging
 
+from common.fixtures.ptfhost_utils import change_mac_addresses
+
 TOPO_LIST = {'t0', 't1', 't1-lag'}
 PORTS_TOPO = {'t1'}
 LAG_TOPO = {'t0', 't1-lag'}
@@ -16,8 +18,6 @@ logger = logging.getLogger(__name__)
 def prepare_ptf(ptfhost):
     # remove existing IPs from ptf host
     ptfhost.script('scripts/remove_ip.sh')
-    # set unique MACs to ptf interfaces
-    ptfhost.script('scripts/change_mac.sh')
 
 
 def lag_facts(dut, mg_facts):

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -3,7 +3,7 @@ import ptf.testutils as testutils
 from ipaddress import ip_address
 import logging
 
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
 TOPO_LIST = {'t0', 't1', 't1-lag'}
 PORTS_TOPO = {'t1'}

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -1,6 +1,6 @@
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from datetime import datetime
 

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -1,5 +1,6 @@
 import pytest
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
 from ptf_runner import ptf_runner
 from datetime import datetime
 
@@ -8,9 +9,6 @@ def test_dir_bcast(duthost, ptfhost, testbed, fib):
     testbed_type = testbed['topo']['name']
     if testbed_type not in support_testbed_types:
         pytest.skip("Not support given test bed type %s" % testbed_type)
-
-    # Copy PTF test into PTF-docker
-    ptfhost.copy(src="ptftests", dest="/root")
 
     # Copy VLAN information file to PTF-docker
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -1,6 +1,6 @@
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from datetime import datetime
 

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -2,7 +2,7 @@ import pytest
 import time
 import logging
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from datetime import datetime
 

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -1,8 +1,9 @@
 import pytest
 import time
 import logging
-from ptf_runner import ptf_runner
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from ptf_runner import ptf_runner
 from datetime import datetime
 
 
@@ -15,7 +16,6 @@ def test_mtu(testbed, duthost, ptfhost, mtu):
     log_file = "/tmp/mtu_test.{}-{}.log".format(mtu,datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
 
     logging.info("Starting MTU test. PTF log file: %s" % log_file)
-    ptfhost.copy(src="ptftests", dest="/root")
 
     ptf_runner(ptfhost,
                "ptftests",

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -2,7 +2,7 @@ import pytest
 import time
 import logging
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from datetime import datetime
 

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -5,6 +5,7 @@ import time
 import logging
 import os
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
 from ptf_runner import ptf_runner
 from common.devices import AnsibleHostBase
 from common.fixtures.conn_graph_facts import conn_graph_facts
@@ -24,9 +25,6 @@ def common_setup_teardown(duthost, ptfhost, testbed):
         src = "../ansible/roles/test/files/acstests/%s" % test_file
         dst = "/tmp/%s" % test_file
         ptfhost.copy(src=src, dest=dst)
-
-    # Copy tests to the PTF-docker
-    ptfhost.copy(src="ptftests", dest="/root")
 
     # Inlucde testbed topology configuration
     testbed_type = testbed['topo']['name']

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -5,7 +5,7 @@ import time
 import logging
 import os
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from common.devices import AnsibleHostBase
 from common.fixtures.conn_graph_facts import conn_graph_facts

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -5,7 +5,7 @@ import time
 import logging
 import os
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from common.devices import AnsibleHostBase
 from common.fixtures.conn_graph_facts import conn_graph_facts

--- a/tests/pfc_asym/conftest.py
+++ b/tests/pfc_asym/conftest.py
@@ -2,6 +2,8 @@ import pytest
 
 from common.fixtures.conn_graph_facts import fanout_graph_facts
 from common.fixtures.pfc_asym import *
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_saitests_directory
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pfc_asym/conftest.py
+++ b/tests/pfc_asym/conftest.py
@@ -2,8 +2,8 @@ import pytest
 
 from common.fixtures.conn_graph_facts import fanout_graph_facts
 from common.fixtures.pfc_asym import *
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import copy_saitests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/import-and-import-from]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pfc_asym/conftest.py
+++ b/tests/pfc_asym/conftest.py
@@ -2,8 +2,8 @@ import pytest
 
 from common.fixtures.conn_graph_facts import fanout_graph_facts
 from common.fixtures.pfc_asym import *
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/unused-import]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 from common.fixtures.conn_graph_facts import conn_graph_facts
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 
 logger = logging.getLogger(__name__)

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from common.fixtures.conn_graph_facts import conn_graph_facts
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 
 logger = logging.getLogger(__name__)
@@ -48,9 +49,6 @@ def setup_pfc_test(duthost, ptfhost, conn_graph_facts):
         vlan_dev = mg_facts['minigraph_vlan_interfaces'][0]['attachto']
         vlan_ips = duthost.get_ip_in_range(num=1, prefix="{}/{}".format(vlan_addr, vlan_prefix), exclude_ips=[vlan_addr])['ansible_facts']['generated_ips']
         vlan_nw = vlan_ips[0].split('/')[0]
-
-        # set unique MACS to PTF interfaces
-        ptfhost.script("./scripts/change_mac.sh")
 
         duthost.shell("ip route flush {}/32".format(vlan_nw))
         duthost.shell("ip route add {}/32 dev {}".format(vlan_nw, vlan_dev))

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 from common.fixtures.conn_graph_facts import conn_graph_facts
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 
 logger = logging.getLogger(__name__)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -4,6 +4,9 @@ import pytest
 import re
 import yaml
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_acstests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from common.system_utils import docker
 
@@ -512,19 +515,6 @@ class QosSaiBase:
             "portSpeedCableLength": portSpeedCableLength,
         }
 
-    @pytest.fixture(scope='class', autouse=True)
-    def copyPtfDirectory(self, ptfhost):
-        """
-            Copys PTF directory to PTF host. This class-scope fixture runs once before test start
- 
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-
-            Returns:
-                None
-        """
-        ptfhost.copy(src="ptftests", dest="/root")
-
     @pytest.fixture(scope='class')
     def ptfPortMapFile(self, request, duthost, ptfhost):
         """
@@ -538,7 +528,6 @@ class QosSaiBase:
             Returns:
                 filename (str): returns the filename copied to PTF host
         """
-        ptfhost.copy(src="ptftests", dest="/root")
         portMapFile = request.config.getoption("--ptf_portmap")
         if not portMapFile:
             portMapFile = self.DEFAULT_PORT_INDEX_TO_ALIAS_MAP_FILE
@@ -555,19 +544,6 @@ class QosSaiBase:
         ptfhost.copy(src=portMapFile, dest="/root/")
 
         yield "/root/{}".format(portMapFile.split('/')[-1])
-
-    @pytest.fixture(scope='class', autouse=True)
-    def copySaiTests(self, ptfhost):
-        """
-            Copys SAI directory to PTF host. This class-scope fixture runs once before test start
- 
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
- 
-            Returns:
-                None
-        """
-        ptfhost.copy(src="saitests", dest="/root")
 
     @pytest.fixture(scope='class', autouse=True)
     def dutTestParams(self, duthost, testbed, ptfPortMapFile):
@@ -596,19 +572,6 @@ class QosSaiBase:
                 "sonic_asic_type": duthost.facts['asic_type'],
             }
         }
-
-    @pytest.fixture(scope='class', autouse=True)
-    def changePtfhostMacAddresses(self, ptfhost):
-        """
-            Change MAC addresses (unique) on PTF host. This class-scope fixture runs once before test start
- 
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
- 
-            Returns:
-                None
-        """
-        ptfhost.script("scripts/change_mac.sh")
 
     @pytest.fixture(scope='class')
     def releaseAllPorts(self, ptfhost, dutTestParams, updateIptables):

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -4,9 +4,9 @@ import pytest
 import re
 import yaml
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import copy_acstests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import copy_acstests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from common.system_utils import docker
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -4,9 +4,9 @@ import pytest
 import re
 import yaml
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import copy_acstests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_acstests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from common.system_utils import docker
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -4,7 +4,7 @@ import time
 import json
 import re
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from common import reboot
 from common  import config_reload

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -4,7 +4,7 @@ import time
 import json
 import re
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from common import reboot
 from common  import config_reload

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -3,6 +3,8 @@ import logging
 import time
 import json
 import re
+
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
 from ptf_runner import ptf_runner
 from common import reboot
 from common  import config_reload
@@ -62,7 +64,6 @@ def setup_ptf(ptfhost, collector_ports):
     extra_vars = {'arp_responder_args' : '--conf /tmp/sflow_arpresponder.conf'}
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
     ptfhost.template(src="../ansible/roles/test/templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
-    ptfhost.copy(src="ptftests", dest=root_dir)
     ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py", dest="/opt")
     ptfhost.shell('supervisorctl reread')
     ptfhost.shell('supervisorctl update')

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -15,6 +15,8 @@ from functools import partial
 
 import pytest
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from ptf_runner import ptf_runner
 from common.utilities import wait_until
 
@@ -392,11 +394,6 @@ def cfg_facts(duthost):
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_vrf(testbed, duthost, ptfhost, localhost, host_facts):
-    # --------------------- setup -----------------------
-    ## Setup ptf
-    ptfhost.script("scripts/change_mac.sh")
-    ptfhost.copy(src="ptftests", dest="/root")
-
     ## Setup dut
     duthost.critical_services = ["swss", "syncd", "database", "teamd", "bgp"]  # Don't care about 'pmon' and 'lldp' here
     cfg_t0 = get_cfg_facts(duthost)  # generate cfg_facts for t0 topo

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -15,8 +15,8 @@ from functools import partial
 
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 from common.utilities import wait_until
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -15,8 +15,8 @@ from functools import partial
 
 import pytest
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 from common.utilities import wait_until
 

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -6,6 +6,8 @@ import pytest
 from jinja2 import Template
 from netaddr import IPAddress
 
+from common.fixtures.ptfhost_utils import copy_ptftests_directory
+from common.fixtures.ptfhost_utils import change_mac_addresses
 from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
@@ -21,9 +23,8 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts):
     @param mg_facts: Minigraph facts
     @param dut_facts: Host facts of DUT
     """
-    logger.info("Remove IP and change MAC")
+    logger.info("Remove IP")
     ptfhost.script("./scripts/remove_ip.sh")
-    ptfhost.script("./scripts/change_mac.sh")
 
     logger.info("Prepare arp_responder")
     ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py", dest="/opt")
@@ -46,9 +47,6 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts):
         "dut_mac": dut_facts["ansible_Ethernet0"]["macaddress"]
     }
     ptfhost.copy(content=json.dumps(vxlan_decap, indent=2), dest="/tmp/vxlan_decap.json")
-
-    logger.info("Copy PTF scripts to PTF container")
-    ptfhost.copy(src="ptftests", dest="/root")
 
 
 def generate_vxlan_config_files(duthost, mg_facts):

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -6,8 +6,8 @@ import pytest
 from jinja2 import Template
 from netaddr import IPAddress
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
-from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -6,8 +6,8 @@ import pytest
 from jinja2 import Template
 from netaddr import IPAddress
 
-from common.fixtures.ptfhost_utils import copy_ptftests_directory
-from common.fixtures.ptfhost_utils import change_mac_addresses
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/import-and-import-from]
+from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/import-and-import-from]
 from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Description of PR
Summary:
A number of test cases are copying ptf/acs/sai tests to ptfhost via
module or class scoped fixture. This PR make copying once per session.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Minimize number of copies when running multiple test cases in one session

#### How did you do it?
relocated copying fixtures to common place with scope session.

#### How did you verify/test it?
Ran regression test suite on internal Jenkins with and without this change:
Without Change: Test Result: 179 failures (+7) , 473 skipped (±0) 734 tests (+2)
With Change: 172 failures (-6) , 473 skipped (±0) 732 tests (+2)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
