### PR TITLE
[vtestbed] Add another t0 testbed to virtual inventory

### DIFF
--- a/ansible/lab
+++ b/ansible/lab
@@ -9,6 +9,7 @@ iface_speed='40000'
 lab-s6000-01      ansible_host=10.251.0.189
 vlab-01           ansible_host=10.250.0.101
 vlab-03           ansible_host=10.250.0.105
+vlab-04           ansible_host=10.250.0.109
 
 [sonic_s6000:vars]
 hwsku="Force10-S6000"

--- a/ansible/veos.vtb
+++ b/ansible/veos.vtb
@@ -59,5 +59,6 @@ topologies=['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't0', 't0-16', 't0-56
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000 serial_port=9000
 vlab-02 ansible_host=10.250.0.102 type=kvm hwsku=Force10-S6100 serial_port=9000
 vlab-03 ansible_host=10.250.0.105 type=kvm hwsku=Force10-S6000 serial_port=9001
+vlab-04 ansible_host=10.250.0.109 type=kvm hwsku=Force10-S6000 serial_port=9000
 vlab-simx-01 ansible_host=10.250.0.103 type=simx hwsku=MSN2700
 vlab-simx-02 ansible_host=10.250.0.104 type=simx hwsku=MSN3700

--- a/ansible/vtestbed.csv
+++ b/ansible/vtestbed.csv
@@ -2,3 +2,4 @@
 vms-kvm-t0,vms6-1,t0,docker-ptf,ptf-unknown,10.250.0.102/24,server_1,VM0100,[vlab-01],Tests virtual switch vm
 vms-kvm-t0-64,vms6-1,t0-64,docker-ptf,ptf-unknown,10.250.0.102/24,server_1,VM0100,[vlab-02],Tests virtual switch vm
 vms-kvm-t1-lag,vms6-2,t1-lag,docker-ptf,ptf-unknown,10.250.0.106/24,server_1,VM0104,[vlab-03],Tests virtual switch vm
+vms-kvm-t0-2,vms6-3,t0,docker-ptf,ptf-unknown,10.250.0.110/24,server_1,VM0128,[vlab-04],Tests virtual switch vm

--- a/tests/veos.vtb
+++ b/tests/veos.vtb
@@ -64,6 +64,8 @@ vlab-03
 vlab-01 ansible_host=10.250.0.101 type=kvm hwsku=Force10-S6000 ansible_password=password ansible_user=admin
 vlab-02 ansible_host=10.250.0.102 type=kvm hwsku=Force10-S6100 ansible_password=password
 vlab-03 ansible_host=10.250.0.105 type=kvm hwsku=Force10-S6000 ansible_password=password ansible_user=admin
+vlab-04 ansible_host=10.250.0.109 type=kvm hwsku=Force10-S6000 ansible_password=password ansible_user=admin
 
 ptf-01 ansible_host=10.250.0.102 ansible_user=root ansible_password=root
 ptf-02 ansible_host=10.250.0.106 ansible_user=root ansible_password=root
+ptf-03 ansible_host=10.250.0.110 ansible_user=root ansible_password=root

--- a/tests/vtestbed.csv
+++ b/tests/vtestbed.csv
@@ -2,3 +2,4 @@
 vms-kvm-t0,vms6-1,t0,docker-ptf,ptf-01,10.250.0.102/24,server_1,VM0100,[vlab-01],Tests virtual switch vm
 vms-kvm-t0-64,vms6-1,t0-64,docker-ptf,ptf-01,10.250.0.102/24,server_1,VM0100,[vlab-02],Tests virtual switch vm
 vms-kvm-t1-lag,vms6-2,t1-lag,docker-ptf,ptf-02,10.250.0.106/24,server_1,VM0104,[vlab-03],Tests virtual switch vm
+vms-kvm-t0-2,vms6-3,t0,docker-ptf,ptf-03,10.250.0.110/24,server_1,VM0128,[vlab-04],Tests virtual switch vm


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Adds another t0 topology to the testbed we can use for running KVM tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We want to be able to run multiple KVM tests on the same runner concurrently, so we need a second t0 topology defined that we can use for running the tests.

#### How did you do it?
Updated the inventory/testbed files.

#### How did you verify/test it?
Deployed the new system using ansible.

