### PR TITLE
[loganalyzer] Address whitespace issue and write marker to syslog after update

### DIFF
--- a/tests/common/plugins/loganalyzer/README.md
+++ b/tests/common/plugins/loganalyzer/README.md
@@ -85,7 +85,7 @@ loganalyzer.init() - can be called several times without calling "loganalyzer.an
     # Example 4
     # Update previously configured marker
     # Now start marker will have new prefix - test_bgp
-    loganalyzer.update_marker_prefix("test_bgp")
+    marker = loganalyzer.update_marker_prefix("test_bgp")
 
     def get_platform_info(dut):
         """

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -29,7 +29,7 @@ class LogAnalyzer:
         self.ansible_host = ansible_host
         self.dut_run_dir = dut_run_dir
         self.extracted_syslog = os.path.join(self.dut_run_dir, "syslog")
-        self.marker_prefix = marker_prefix
+        self.marker_prefix = marker_prefix.replace(' ', '_')
         self.ansible_loganalyzer = ansible_loganalyzer(self.marker_prefix, False)
 
         self.match_regex = []
@@ -88,7 +88,7 @@ class LogAnalyzer:
         """
         @summary: Update configured marker prefix
         """
-        self.marker_prefix = marker_prefix
+        self.marker_prefix = marker_prefix.replace(' ', '_')
         return self._setup_marker()
 
     def load_common_config(self):

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -89,6 +89,7 @@ class LogAnalyzer:
         @summary: Update configured marker prefix
         """
         self.marker_prefix = marker_prefix
+        return self._setup_marker()
 
     def load_common_config(self):
         """
@@ -137,6 +138,12 @@ class LogAnalyzer:
 
         self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
 
+        return self._setup_marker()
+
+    def _setup_marker(self):
+        """
+        Adds the marker to the syslog
+        """
         start_marker = ".".join((self.marker_prefix, time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())))
         cmd = "python {run_dir}/loganalyzer.py --action init --run_id {start_marker}".format(run_dir=self.dut_run_dir, start_marker=start_marker)
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

### Description of PR
1. Loganalyzer class currently includes a method to update a marker prefix after init. But it does not convert the user defined marker to a run id format or write it to the syslog. 
2. If a marker prefix is specified with whitespaces, replace them with underscore to avoid issues during test run.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### What is the motivation for the PR?
PFC functional tests use loganalyzer to detect/restore storm on multiple ports one after the other. Marker prefix needs to be updated multiple times after init

#### How did you verify/test it?
Test run on local pfc functional test scripts passed

