### PR TITLE
[pytest] Add Option to Control Collect Techsupport

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def pytest_addoption(parser):
     parser.addoption("--logs_since", action="store", type=int,
                     help="number of minutes for show techsupport command")
     parser.addoption("--collect_techsupport", action="store", default=True, type=bool,
-                    help="number of minutes for show techsupport command")
+                    help="Enable/Disable tech support collection. Default is enabled (True)")
 
     ############################
     #   sanity_check options   #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,8 @@ def pytest_addoption(parser):
                     help="Change default loops delay")
     parser.addoption("--logs_since", action="store", type=int,
                     help="number of minutes for show techsupport command")
+    parser.addoption("--collect_techsupport", action="store", default=False, type=bool,
+                    help="number of minutes for show techsupport command")
 
     ############################
     #   sanity_check options   #
@@ -358,7 +360,7 @@ def collect_techsupport(request, duthost):
     # request.node is an "item" because we use the default
     # "function" scope
     testname = request.node.name
-    if request.node.rep_call.failed:
+    if request.config.getoption("--collect_techsupport") and request.node.rep_call.failed:
         res = duthost.shell("generate_dump")
         fname = res['stdout']
         duthost.fetch(src=fname, dest="logs/{}".format(testname))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def pytest_addoption(parser):
                     help="Change default loops delay")
     parser.addoption("--logs_since", action="store", type=int,
                     help="number of minutes for show techsupport command")
-    parser.addoption("--collect_techsupport", action="store", default=False, type=bool,
+    parser.addoption("--collect_techsupport", action="store", default=True, type=bool,
                     help="number of minutes for show techsupport command")
 
     ############################


### PR DESCRIPTION
### Description of PR

Summary:
Adding an option to enable/disable techsupport collection from the command
line. Default is enabled.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
tech support takes long time and so we need an option to disable it.

#### How did you do it?
Added an option to disable the collection of the techsupport

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
