### PR TITLE
[Platform API] HTTP server provides default JSON serialization for unserializable objects

### DIFF
--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -1,12 +1,30 @@
-import json
 import argparse
 import inspect
-import sonic_platform
-
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+import json
+import os
+import syslog
 from io import BytesIO
 
+from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+
+import sonic_platform
+
+SYSLOG_IDENTIFIER = os.path.basename(__file__)
+
 platform = sonic_platform.platform.Platform()
+
+
+def obj_serialize(obj):
+    ''' JSON serializer for objects not serializable by default json library code
+        We simply return a dictionary containing the object's class and module
+    '''
+    syslog.syslog(syslog.LOG_WARNING, 'Unserializable object: {}.{}'.format(obj.__module__, obj.__class__.__name__))
+
+    data = {
+        '__class__': obj.__class__.__name__,
+        '__module__': obj.__module__
+    }
+    return data
 
 
 class PlatformAPITestService(BaseHTTPRequestHandler):
@@ -61,7 +79,7 @@ class PlatformAPITestService(BaseHTTPRequestHandler):
         res = getattr(obj, api)(*args)
 
         response = BytesIO()
-        response.write(json.dumps({'res': res}))
+        response.write(json.dumps({'res': res}, default=obj_serialize))
 
         self.wfile.write(response.getvalue())
 
@@ -70,5 +88,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--port', type=int, help='port to listent to', required=True)
     args = parser.parse_args()
+
+    syslog.openlog(SYSLOG_IDENTIFIER)
+
     httpd = HTTPServer(('', args.port), PlatformAPITestService)
     httpd.serve_forever()
+
+    syslog.closelog()

--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -86,7 +86,7 @@ class PlatformAPITestService(BaseHTTPRequestHandler):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', type=int, help='port to listent to', required=True)
+    parser.add_argument('-p', '--port', type=int, help='port to listen to', required=True)
     args = parser.parse_args()
 
     syslog.openlog(SYSLOG_IDENTIFIER)


### PR DESCRIPTION
Previously, if the server encountered an unserializable object, it would throw an exception similar to the following and return `None`:

```
TypeError: <sonic_platform.fan.Fan object at 0x7fe6f4d12790> is not JSON serializable
```

With this change, if the server encounters an unserializable object, it will log a warning to the syslog on the DuT and return a JSON object with the following contents to allow the calling test to work properly:

```
{
    '__class__': <class name>,
    '__module__': <module name>
}
```