### PR TITLE
[devices] Refactor critical services to be a DUT property

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -106,12 +106,13 @@ class SonicHost(AnsibleHostBase):
 
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
+
+    Attributes:
+        DEFAULT_CRITICAL_SERVICES: The default list of services that are considered critical to a
+            healthy SONiC device.
     """
 
-    # TODO: Because people are editing this variable in a bunch of places it should probably be
-    # revised to "DEFAULT_CRITICAL_SERVICES", and we should make critical_services a property of
-    # SonicHost
-    CRITICAL_SERVICES = ["swss", "syncd", "database", "teamd", "bgp", "pmon", "lldp", "snmp"]
+    DEFAULT_CRITICAL_SERVICES = ["swss", "syncd", "database", "teamd", "bgp", "pmon", "lldp", "snmp"]
 
     def __init__(self, ansible_adhoc, hostname):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
@@ -119,7 +120,9 @@ class SonicHost(AnsibleHostBase):
         self._os_version = self._get_os_version()
 
         if self.facts["num_npu"] > 1:
-            self._update_critical_services_for_multi_npu()
+            DEFAULT_CRITICAL_SERVICES = self._generate_critical_services_for_multi_npu()
+
+        self.reset_critical_services_tracking_list()
 
     @property
     def facts(self):
@@ -151,6 +154,42 @@ class SonicHost(AnsibleHostBase):
 
         return self._os_version
 
+    @property
+    def critical_services(self):
+        """
+        The critical services running on this SONiC device.
+
+        Note:
+            This list is used for tracking purposes ONLY. This list does not
+            show which critical services are currently running. See the
+            critical_services_status method for that info.
+
+        Returns:
+            list[str]: A list of the critical services (e.g. ["swss", "syncd"])
+        """
+
+        return self._critical_services
+
+    @critical_services.setter
+    def critical_services(self, var):
+        """
+        Updates the list of critical services running on this device.
+
+        Note:
+            This list is used for tracking purposes ONLY. Updating the list does
+            not actually modify any services running on the device.
+        """
+
+        self._critical_services = var
+        logging.debug(self._critical_services)
+
+    def reset_critical_services_tracking_list(self):
+        """
+        Resets the list of critical services to the default stored in DEFAULT_CRITICAL_SERVICES.
+        """
+
+        self.critical_services = self.DEFAULT_CRITICAL_SERVICES
+
     def _gather_facts(self):
         """
         Gather facts about the platform for this SONiC device.
@@ -181,18 +220,17 @@ class SonicHost(AnsibleHostBase):
         except:
             return 1
 
-    def _update_critical_services_for_multi_npu(self):
+    def _generate_critical_services_for_multi_npu(self):
         """
         Updates the critical services for this device with the services for multi-npu platforms.
         """
 
         m_service = []
-        for service in self.CRITICAL_SERVICES:
+        for service in self.DEFAULT_CRITICAL_SERVICES:
             for npu in self.facts["num_npu"]:
                 npu_service = service + npu
                 m_service.insert(npu, npu_service)
-        self.CRITICAL_SERVICES = m_service
-        logging.debug(self.CRITICAL_SERVICES)
+        return m_service
 
     def _get_platform_info(self):
         """
@@ -260,7 +298,7 @@ class SonicHost(AnsibleHostBase):
 
     def critical_services_status(self):
         result = {}
-        for service in self.CRITICAL_SERVICES:
+        for service in self.critical_services:
             result[service] = self.is_service_fully_started(service)
         return result
 
@@ -317,7 +355,7 @@ class SonicHost(AnsibleHostBase):
         @summary: Check whether all critical processes status for all critical services
         """
         result = {}
-        for service in self.CRITICAL_SERVICES:
+        for service in self.critical_services:
             result[service] = self.critical_process_status(service)
         return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,6 +229,14 @@ def duthost(ansible_adhoc, testbed, request):
     if stop_ssh_timeout is not None:
         enable_ssh_timout(duthost)
 
+@pytest.fixture(scope="module", autouse=True)
+def reset_critical_services_list(duthost):
+    """
+    Resets the critical services list between test modules to ensure that it is
+    left in a known state after tests finish running.
+    """
+
+    duthost.reset_critical_services_tracking_list()
 
 @pytest.fixture(scope="module")
 def localhost(ansible_adhoc):

--- a/tests/platform_tests/check_critical_services.py
+++ b/tests/platform_tests/check_critical_services.py
@@ -15,7 +15,7 @@ def _all_critical_services_fully_started(dut):
         logging.info("dut.critical_services_fully_started is False")
         return False
 
-    for service in dut.CRITICAL_SERVICES:
+    for service in dut.critical_services:
         status = dut.get_service_props(service)
         if status["ActiveState"] != "active":
             logging.info("ActiveState of %s is %s, expected: active" % (service, status["ActiveState"]))

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -253,7 +253,7 @@ def reboot(duthost, localhost, timeout=120, basic_check=True):
     # Basic check after reboot
     if basic_check:
         assert wait_until(timeout, 10, duthost.critical_services_fully_started), \
-               "All critical services should fully started!{}".format(duthost.CRITICAL_SERVICES)
+               "All critical services should fully started!{}".format(duthost.critical_services)
 
 def setup_vrf_cfg(duthost, localhost, cfg_facts):
     '''
@@ -398,7 +398,7 @@ def setup_vrf(testbed, duthost, ptfhost, localhost, host_facts):
     ptfhost.copy(src="ptftests", dest="/root")
 
     ## Setup dut
-    duthost.CRITICAL_SERVICES = ["swss", "syncd", "database", "teamd", "bgp"]  # Don't care about 'pmon' and 'lldp' here
+    duthost.critical_services = ["swss", "syncd", "database", "teamd", "bgp"]  # Don't care about 'pmon' and 'lldp' here
     cfg_t0 = get_cfg_facts(duthost)  # generate cfg_facts for t0 topo
 
     setup_vrf_cfg(duthost, localhost, cfg_t0)
@@ -946,7 +946,7 @@ class TestVrfWarmReboot():
 
         # basic check after warm reboot
         assert wait_until(300, 20, duthost.critical_services_fully_started), \
-               "All critical services should fully started!{}".format(duthost.CRITICAL_SERVICES)
+               "All critical services should fully started!{}".format(duthost.critical_services)
 
         up_ports = [p for p, v in cfg_facts['PORT'].items() if v.get('admin_status', None) == 'up' ]
         assert wait_until(300, 20, check_interface_status, duthost, up_ports), \


### PR DESCRIPTION
- Convert critical services from a constant to a property
- Add a fixture to reset critical services between successive tests

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Refactors critical services to be a DUT property rather than a constant.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There are tests that modify the critical services list to ignore certain services (e.g. LLDP) because they are disabled during test. To accurately reflect this behavior, I updated the CRITICAL_SERVICES field to be a property rather than a constant.

I also added a fixture to reset the critical services field to default between test modules to support #1748.

#### How did you do it?
Changed CRITICAL_SERVICES to a property and refactored the code that was using it.

#### How did you verify/test it?
Verified that get/set operations still work the same as before. Also checked w/ #1748 to ensure that critical services would be reset between test modules.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
