### PR TITLE
Extend the fib fixture to support all t0 and t1 type topologies

### DIFF
--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -231,9 +231,9 @@ def fib_t1_lag(ptfhost, testbed):
 @pytest.fixture(scope='module')
 def fib(ptfhost, testbed):
     logger.info("setup fib to topo {}".format(testbed['topo']['name']))
-    if testbed['topo']['name'] == "t0":
+    if testbed['topo']['type'] == "t0":
         fib_t0(ptfhost, testbed)
-    elif testbed['topo']['name'] == "t1-lag":
+    elif testbed['topo']['type'] == "t1":
         fib_t1_lag(ptfhost, testbed)
     else:
         logger.error("unknonw topology {}".format(testbed['topo']['name']))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The original fib fixture only supports "t0" and "t1-lag" topologies.
This change extend the fib fixture to support all t0 and t1 type
topologies.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For topologies that are not exact "t0" or "t1-lag", there is no way to announce routes to them. The fib fixture need to be extended to support all variations of "t0" and "t1" type topologies.

#### How did you do it?
Change the topology name comparison to topology type comparison in the fib fixture code.

#### How did you verify/test it?
Run test_annoucne_routes.py on different variations of t0 and t1 topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
