### PR TITLE
Improve the handling of VM kickstart failures

### DIFF
--- a/ansible/roles/vm_set/library/kickstart.py
+++ b/ansible/roles/vm_set/library/kickstart.py
@@ -204,15 +204,15 @@ def main():
     except ELoginPromptNotFound:
         result = {'kickstart_code': -1, 'changed': False, 'msg': 'Login prompt not found'}
     except EWrongDefaultPassword:
-        result = {'kickstart_code': 0, 'changed': False, 'msg': 'Wrong default password, kickstart of VM has been done'}
+        result = {'kickstart_code': -2, 'changed': False, 'msg': 'Wrong default password, kickstart of VM has been done'}
     except EOFError:
-        result = {'kickstart_code': -2, 'changed': False, 'msg': 'EOF during the chat'}
+        result = {'kickstart_code': -3, 'changed': False, 'msg': 'EOF during the chat'}
     except EMatchNotFound:
-        result = {'kickstart_code': -3, 'changed': False, 'msg': "Match for output isn't found"}
+        result = {'kickstart_code': -4, 'changed': False, 'msg': "Match for output isn't found"}
     except ENotInEnabled:
-        module.fail_json(msg='Not in enabled mode')
+        result = {'kickstart_code': -5, 'changed': False, 'msg': "Not in enabled mode"}
     except Exception, e:
-        module.fail_json(msg=str(e))
+        result = {'kickstart_code': -6, 'changed': False, 'msg': str(e)}
 
     module.exit_json(**result)
 

--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -22,9 +22,10 @@
               new_password={{ eos_password }}
               new_root_password={{ eos_root_password }}
     register: kickstart_output
-    until: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != -1'
+    until: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code == 0'
     retries: 5
     delay: 10
+    ignore_errors: true
 
   - name: Destroy vm {{ vm_name }} if it hangs
     virt: name={{ vm_name }}
@@ -32,6 +33,7 @@
           uri=qemu:///system
     when: kickstart_output.kickstart_code != 0
     become: yes
+    ignore_errors: true
 
   - name: Start vm again {{ vm_name }}
     virt: name={{ vm_name }}
@@ -39,6 +41,7 @@
           uri=qemu:///system
     when: kickstart_output.kickstart_code != 0
     become: yes
+    ignore_errors: true
 
   - name: Wait until vm {{ vm_name }} is loaded
     kickstart: telnet_port={{ serial_port }}
@@ -51,13 +54,15 @@
               new_password={{ eos_password }}
               new_root_password={{ eos_root_password }}
     register: kickstart_output_final
-    until: '"kickstart_code" in kickstart_output_final and kickstart_output_final.kickstart_code != -1'
+    until: '"kickstart_code" in kickstart_output_final and kickstart_output_final.kickstart_code == 0'
     retries: 5
     delay: 10
+    ignore_errors: true
     when: kickstart_output.kickstart_code != 0
 
-  - name: Fail if kickstart gives error again vm {{ vm_name }}
-    fail: msg="Two attempts to start vm weren't successful"
+  - name: Kickstart gives error again vm {{ vm_name }}
+    set_fact:
+      kickstart_failed_vms: "{{ kickstart_failed_vms + [vm_name] }}"
     when: '"kickstart_code" in kickstart_output_final and kickstart_output_final.kickstart_code != 0'
 
   - name: Set VM to autostart

--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -65,6 +65,9 @@
     backplane_tap: "{{ vm_name }}-back"
   with_items: "{{ VM_hosts }}"
 
+- set_fact:
+    kickstart_failed_vms: []
+
 - name: Kickstart VMs
   include_tasks: kickstart_vm.yml
   vars:
@@ -78,3 +81,11 @@
     mgmt_tap:  "{{ vm_name }}-m"
     backplane_tap: "{{ vm_name }}-back"
   with_items: "{{ VM_hosts }}"
+
+- block:
+    - name: Log all kickstart failed VMs
+      debug: msg="{{ kickstart_failed_vms }}"
+
+    - name: Fail if kickstart any VM failed
+      fail: msg="Please run start-vms again with -e 'respin_vms=["VMXXX"]' to retry the failed VMs"
+  when: kickstart_failed_vms | length > 0

--- a/ansible/roles/vm_set/tasks/start_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vm.yml
@@ -40,6 +40,7 @@
         uri=qemu:///system
   when: vm_name in respin_vms
   become: yes
+  ignore_errors: true
 
 - name: Start vm {{ vm_name }}
   virt: name={{ vm_name }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This commit improves the handling of VM kickstart failures

When we use the testbed-cli.sh tool to start a bunch of VMs,
occasionally some of the VMs failed to start during kickstart.
The current procedure is to destroy the VM and try to kickstart
it again. If the second try failed, then the whole starting
procedure will be stopped at the failed VM.

The testbed-cli.sh tool supports respin which is to destroy and
and start only the VMs specified in a list variable `respin_vms`.
We can re-run `testbed-cli.sh start-vms` and specify the VMs
that are not started in argument like `-e 'respin_vms=["VM0130","VM0131"]'`.
Then the scripts will try to destroy the specified VMs and start
them again. The problem is that if the failed VM is in the front
part of the list, then we need to specify all the VMs starting
from the failed one in the list in argument `respin_vms`. This
would be tedious.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Improve the handling of VM kickstart failures to make starting large number of VMs easier and quicker.

#### How did you do it?
Changes in this commit:
* If kickstart some VMs failed, record the failed VM in a list
  and continue kickstarting rest of the VMs.
* Upon done, check if any VM has been recorded in the list.
  If yes, log the VMs that were not started and explicitly fail
  the playbook.
* Optionally we can manually destroy/undefine the failed VMs and
  delete their disk files.
* We can use `ansible -m ping` to double check which VMs are not started.
* Then we can use the respin function to restart only the failed VMs.

#### How did you verify/test it?
Start 32 VMs, manually destroy some of the VMs during kickstart. The scripts can continue kickstarting rest of the VMs and log the failed VMs. Then use respin to quickly start only the failed VMs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
