### PR TITLE
[Mellanox Platform] Update the platform test sysfs check after thermal control implemented

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -5,8 +5,6 @@ This script contains re-usable functions for checking status of hw-management re
 """
 import logging
 
-from check_hw_mgmt_service import wait_until_fan_speed_set_to_default
-
 
 def check_sysfs(dut):
     """

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -23,7 +23,7 @@ def check_sysfs(dut):
     file_asic = dut.command("cat /var/run/hw-management/thermal/asic")
     try:
         asic_temp = float(file_asic["stdout"]) / 1000
-        assert 0 < asic_temp < 90, "Abnormal ASIC temperature: %s" % file_asic["stdout"]
+        assert 0 < asic_temp < 105, "Abnormal ASIC temperature: %s" % file_asic["stdout"]
     except Exception as e:
         assert False, "Bad content in /var/run/hw-management/thermal/asic: %s" % repr(e)
 
@@ -72,8 +72,8 @@ def check_sysfs(dut):
         except Exception as e:
             assert "Get content from %s failed, exception: %s" % (fan_speed_get, repr(e))
 
-        max_tolerance_speed = ((float(fan_set_speed)/256)*fan_max_speed)*(1 + 0.3)
-        min_tolerance_speed = ((float(fan_set_speed)/256)*fan_max_speed)*(1 - 0.3)
+        max_tolerance_speed = ((float(fan_set_speed)/256)*fan_max_speed)*(1 + 0.5)
+        min_tolerance_speed = ((float(fan_set_speed)/256)*fan_max_speed)*(1 - 0.5)
         assert min_tolerance_speed < fan_speed < max_tolerance_speed, "Speed out of tolerance speed range (%d, %d)" \
                                                                       % (min_tolerance_speed, max_tolerance_speed)
 

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -19,16 +19,11 @@ def check_sysfs(dut):
 
     logging.info("Check content of some key files")
 
-    assert not wait_until_fan_speed_set_to_default(dut, timeout=120), \
-        "Content of /var/run/hw-management/thermal/pwm1 should be 153"
-
-    file_suspend = dut.command("cat /var/run/hw-management/config/suspend")
-    assert file_suspend["stdout"] == "1", "Content of /var/run/hw-management/config/suspend should be 1"
 
     file_asic = dut.command("cat /var/run/hw-management/thermal/asic")
     try:
         asic_temp = float(file_asic["stdout"]) / 1000
-        assert 0 < asic_temp < 85, "Abnormal ASIC temperature: %s" % file_asic["stdout"]
+        assert 0 < asic_temp < 90, "Abnormal ASIC temperature: %s" % file_asic["stdout"]
     except Exception as e:
         assert False, "Bad content in /var/run/hw-management/thermal/asic: %s" % repr(e)
 
@@ -67,7 +62,6 @@ def check_sysfs(dut):
 
         fan_speed_set = "/var/run/hw-management/thermal/fan{}_speed_set".format(fan_id)
         fan_speed_set_content = dut.command("cat %s" % fan_speed_set)
-        assert fan_speed_set_content["stdout"] == "153", "Fan speed should be set to 60%, 153/255"
         fan_set_speed = int(fan_speed_set_content["stdout"])
 
         fan_speed_get = "/var/run/hw-management/thermal/fan{}_speed_get".format(fan_id)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
After thermal control is implemented on the Mellanox platform, some changes needed accordingly to the current platform check sysfs test.

1. FAN speed is not always set to 60%, it's dynamically adjusted by the algorithm, the assumption that FAN speed shall keep at 60% is not true anymore. In some platforms when fan speed running at a low level (e.g. 20%), the real fan speed deviation could be larger, so adjust the way to check the fan speed tolerance.

2. The check for " /var/run/hw-management/config/suspend" should be '1' is not relevant anymore, the code shall be removed.

3. On Spectrum 3 platform, the ASIC temp can reach to higher than 85C(critical threshold is 110C), so use "max hot" temperature(105C)  defined in our algorithm to check against the ASIC temp. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Improve the current Mellanox platform test according to the latest Mellanox thermal control implementation.

#### How did you do it?
remove the code that expects fan speed should always be 60%
remove the check to " /var/run/hw-management/config/suspend"
relax the ASIC high temp from 85 to max high(105C)

#### How did you verify/test it?
run platform test on Mellanox platform

#### Any platform specific information?
These change only take effect on Mellanox platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
