### PR TITLE
[test_watchdog] fix wait_for ssh port stopped

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 TEST_CONFIG_FILE = os.path.join(os.path.split(__file__)[0], "watchdog.yml")
 TEST_WAIT_TIME_SECONDS = 2
+TIMEOUT_DEVIATION = 2
 
 class TestWatchdogAPI(object):
     ''' Hardware watchdog platform API test cases '''
@@ -68,7 +69,8 @@ class TestWatchdogAPI(object):
         assert not watchdog.is_armed(platform_api_conn)
 
         res = localhost.wait_for(host=duthost.hostname,
-                port=22, state="stopped", delay=5, timeout=watchdog_timeout,
+                port=22, state="stopped", delay=5,
+                timeout=watchdog_timeout + TIMEOUT_DEVIATION,
                 module_ignore_errors=True)
 
         assert 'exception' in res
@@ -165,9 +167,10 @@ class TestWatchdogAPI(object):
 
         assert actual_timeout != -1
 
-        res = localhost.wait_for(host=duthost.hostname, port=22, state="stopped", delay=2, timeout=actual_timeout,
+        res = localhost.wait_for(host=duthost.hostname, port=22, state="stopped", delay=2,
+                                 timeout=actual_timeout + TIMEOUT_DEVIATION,
                                  module_ignore_errors=True)
-        assert 'exception' in res
+        assert 'exception' not in res
 
         res = localhost.wait_for(host=duthost.hostname, port=22, state="started", delay=10, timeout=120,
                                  module_ignore_errors=True)


### PR DESCRIPTION
Fixes condition. If wait_for ssh port succeded execution it should not
have "exception" in res. Also, added TIMEOUT_DEVIATION set to 2 sec that
will be added to timeout value when executing wait_for. Watchdog
may have some deviation. In my test 16 sec timeout is actually 16.4 and
looks like wait_for will not try to test ssh port one more time if
timeout has exceeded in between checks. This change makes sure wait_for
has some more time to perform last check.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
