### PR TITLE
[pfc_wd] Detach pfc_gen.py from terminal when run in background on Me…

### DIFF
--- a/ansible/roles/test/templates/pfc_storm_mlnx.j2
+++ b/ansible/roles/test/templates/pfc_storm_mlnx.j2
@@ -6,9 +6,9 @@ configure terminal
 docker exec {{ container_name }} /bin/bash
 cd /root/
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("ernet 1/", "") | replace("/", "_")}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} nohup python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("ernet 1/", "") | replace("/", "_")}} &
 {% else %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("ernet 1/", "") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} nohup python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("ernet 1/", "") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
 {% endif %}
 exit
 


### PR DESCRIPTION
…llanox fanout

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [*] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix the issue: PFC_WD test fail due to ```pfc_gen.py``` stuck. 
It was happening because ```pfc_gen.py``` was executed on fanout in background but wasn't detached from terminal. As a result next ```exit``` command stuck and ansible playbook tertminated with the SSH timeout exception.

#### How did you do it?
Added ```nohup``` for ```pfc_gen.py``` in order to detach it from the terminal.

#### How did you verify/test it?
Executed PFC_WD test and verified it passed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
N/A