### PR TITLE
[vs] Fix dut_mgmt_port bind/unbind for vs testbed on ptf32 topology

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -741,10 +741,11 @@ def main():
             ptf_bp_ip_addr = module.params['ptf_bp_ip_addr']
             ptf_bp_ipv6_addr = module.params['ptf_bp_ipv6_addr']
 
+            if module.params['dut_mgmt_port']:
+                    net.bind_mgmt_port(mgmt_bridge, module.params['dut_mgmt_port'])
+
             if vms_exists:
                 net.add_veth_ports_to_docker()
-                if module.params['dut_mgmt_port']:
-                    net.bind_mgmt_port(mgmt_bridge, module.params['dut_mgmt_port'])
                 net.bind_fp_ports()
                 net.bind_vm_backplane()
                 net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
@@ -773,9 +774,10 @@ def main():
 
             net.init(vm_set_name, topo, vm_base, dut_fp_ports)
 
-            if vms_exists:
-                if module.params['dut_mgmt_port']:
+            if module.params['dut_mgmt_port']:
                     net.unbind_mgmt_port(module.params['dut_mgmt_port'])
+
+            if vms_exists:
                 net.unbind_vm_backplane()
                 net.unbind_fp_ports()
 

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -742,7 +742,7 @@ def main():
             ptf_bp_ipv6_addr = module.params['ptf_bp_ipv6_addr']
 
             if module.params['dut_mgmt_port']:
-                    net.bind_mgmt_port(mgmt_bridge, module.params['dut_mgmt_port'])
+                net.bind_mgmt_port(mgmt_bridge, module.params['dut_mgmt_port'])
 
             if vms_exists:
                 net.add_veth_ports_to_docker()
@@ -775,7 +775,7 @@ def main():
             net.init(vm_set_name, topo, vm_base, dut_fp_ports)
 
             if module.params['dut_mgmt_port']:
-                    net.unbind_mgmt_port(module.params['dut_mgmt_port'])
+                net.unbind_mgmt_port(module.params['dut_mgmt_port'])
 
             if vms_exists:
                 net.unbind_vm_backplane()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Faced an issue when tried to bring up ptf32 topology with virtual SONiC. The dut mgmt port was not added to mgmt bridge.
Summary: Fix dut_mgmt_port buind/unbind for vs testbed on ptf32 topology
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add possibility to setup vs testbed  with ptf32 topology
#### How did you do it?
See changes
#### How did you verify/test it?
Add define ptf32 testbed on my virtual setup
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
