### PR TITLE
[kvm] Allow user to specify location for KVM image files

### DIFF
--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -1,12 +1,16 @@
+- set_fact:
+    sonic_vm_storage_location: "{{ home_path }}/sonic-vm"
+    when: sonic_vm_storage_location is not defined
+
 - name: Create directory for vm images and vm disks
   file: path={{ item }} state=directory mode=0755
   with_items:
-    - "sonic-vm/images"
-    - "sonic-vm/disks"
+    - "{{ sonic_vm_storage_location }}/images"
+    - "{{ sonic_vm_storage_location }}/disks"
 
 - set_fact:
-    src_disk_image: "{{ home_path }}/sonic-vm/images/sonic-vs.img"
-    disk_image: "{{ home_path }}/sonic-vm/disks/sonic_{{ dut_name }}.img"
+    src_disk_image: "{{ sonic_vm_storage_location }}/images/sonic-vs.img"
+    disk_image: "{{ sonic_vm_storage_location }}/disks/sonic_{{ dut_name }}.img"
     mgmt_ip_address: " {{ hostvars[dut_name]['ansible_host'] }}"
     mgmt_gw: "{{ vm_mgmt_gw | default(mgmt_gw) }}"
     serial_port: "{{ hostvars[dut_name]['serial_port'] }}"


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Allow user to specify location for KVM image files when running add-topo or refresh-dut.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We would like to run multiple KVM tests on a single Jenkins worker. This change allows us to set up the DUTs concurrently without the images from different test runs colliding with each other.

#### How did you do it?
I added an extra variable to the ansible playbook to allow the user to specify a location. If they do not, it will use the existing path.

#### How did you verify/test it?
I ran the setup locally in the following configurations:
- add-topo w/ default
- add-topo w/ path specified
- refresh-dut w/ default
- refresh-dut w/ path specified

#### Any platform specific information?
This change should only impact SONiC VMs.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
