### PR TITLE
Add `pdu_port` variable to the DUT host configuration

### DIFF
--- a/ansible/group_vars/pdu/pdu.yml
+++ b/ansible/group_vars/pdu/pdu.yml
@@ -1,0 +1,3 @@
+# snmp variables
+snmp_rocommunity: public
+snmp_rwcommunity: private

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,5 +1,5 @@
 [sonic_latest]
-switch1  ansible_host=10.0.0.100  sonic_version=v2  sonic_hwsku=Force10-S6000 pdu_host=pdu-1
+switch1  ansible_host=10.0.0.100  sonic_version=v2  sonic_hwsku=Force10-S6000 pdu_host=pdu-1 pdu_port=6
 switch2  ansible_host=10.0.0.101  sonic_version=v2  sonic_hwsku=ACS-MSN2700 pdu_host=pdu-1
 switch3  ansible_host=10.0.0.102  sonic_version=v2  sonic_hwsku=Force10-S6000   # LAG topo: 8 LAGs x 2 members/lag to spines; 16 ports to Tors
 switch4  ansible_host=10.0.0.103  sonic_version=v2  sonic_hwsku=AS7512 sonic_portsku=32x40 pdu_host=pdu-2

--- a/tests/common/plugins/psu_controller/README.md
+++ b/tests/common/plugins/psu_controller/README.md
@@ -36,7 +36,18 @@ pdu-1 ansible_host=192.168.99.2 protocol=snmp
 
 If 'protocol' variable is missed, it will take default value "snmp" in code.
 
-### 3. Extend PDU host configuration
+### 3. Add `pdu_port` variable to DUT host in inventory file
+
+In the inventory file, we can add the 'pdu_port' variable along with pdu_host to DUT host:
+
+```
+[sonic_latest]
+switch1  ansible_host=10.0.0.100  sonic_version=v2  sonic_hwsku=Force10-S6000 pdu_host=pdu-1 pdu_port=6
+```
+
+In the above example, `pdu_port` variable is added to DUT host `switch1` following after adding `pdu_host` variable.
+
+### 4. Extend PDU host configuration
 
 If we need to add more PDU configuration information, we can simply add more variables to the corresponding PDU host in the inventory file.
 
@@ -44,7 +55,7 @@ If we need to add more PDU configuration information, we can simply add more var
 
 ```
 [sonic_latest]
-switch1  ansible_host=10.0.0.100  sonic_version=v2  sonic_hwsku=Force10-S6000 pdu_host=pdu-1
+switch1  ansible_host=10.0.0.100  sonic_version=v2  sonic_hwsku=Force10-S6000 pdu_host=pdu-1 pdu_port=6
 switch2  ansible_host=10.0.0.101  sonic_version=v2  sonic_hwsku=ACS-MSN2700 pdu_host=pdu-1
 switch3  ansible_host=10.0.0.102  sonic_version=v2  sonic_hwsku=Force10-S6000   # LAG topo: 8 LAGs x 2 members/lag to spines; 16 ports to Tors
 switch4  ansible_host=10.0.0.103  sonic_version=v2  sonic_hwsku=AS7512 sonic_portsku=32x40 pdu_host=pdu-2

--- a/tests/common/plugins/psu_controller/__init__.py
+++ b/tests/common/plugins/psu_controller/__init__.py
@@ -3,17 +3,18 @@ import logging
 import pytest
 
 
-def psu_controller_factory(controller_ip, controller_protocol, dut_hostname):
+def psu_controller_factory(controller_ip, controller_protocol, dut_hostname, pdu_port):
     """
     @summary: Factory function for creating PSU controller according to different management protocol.
     @param controller_ip: IP address of the PSU controller host.
     @param controller_protocol: Management protocol supported by the PSU controller host.
     @param dut_hostname: Hostname of the DUT to be controlled by the PSU controller.
+    @param pdu_port: Port number of the PSU controller connected to the DUT.
     """
     logging.info("Creating psu controller object")
     if controller_protocol == "snmp":
         import snmp_psu_controllers
-        return snmp_psu_controllers.get_psu_controller(controller_ip, dut_hostname)
+        return snmp_psu_controllers.get_psu_controller(controller_ip, dut_hostname, pdu_port)
 
 
 @pytest.fixture(scope="module")
@@ -28,6 +29,7 @@ def psu_controller(duthost):
     logging.info("Creating psu_controller fixture")
     inv_mgr = duthost.host.options["inventory_manager"]
     pdu_host = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
+    pdu_port = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_port")
     if not pdu_host:
         logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create psu_controller" %
                      duthost.hostname)
@@ -48,7 +50,7 @@ def psu_controller(duthost):
         logging.info("No protocol is defined in inventory file for '%s'. Try to use default 'snmp'" % pdu_host)
         controller_protocol = "snmp"
 
-    controller = psu_controller_factory(controller_ip, controller_protocol, duthost.hostname)
+    controller = psu_controller_factory(controller_ip, controller_protocol, duthost.hostname, pdu_port)
 
     yield controller
 

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -108,7 +108,7 @@ class snmpPsuController(PsuControllerBase):
                     # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
                     self.pdu_ports.append(current_oid.replace(self.PORT_NAME_BASE_OID, ''))
 
-    def __init__(self, hostname, controller):
+    def __init__(self, hostname, controller, pdu_port):
         logging.info("Initializing " + self.__class__.__name__)
         PsuControllerBase.__init__(self)
         self.hostname = hostname
@@ -117,7 +117,10 @@ class snmpPsuController(PsuControllerBase):
         self.psuType = None
         self.get_psu_controller_type()
         self.psuCntrlOid()
-        self._get_pdu_ports()
+        if not pdu_port:
+            self._get_pdu_ports()
+        else:
+            self.pdu_ports.append(pdu_port)
         logging.info("Initialized " + self.__class__.__name__)
 
     def turn_on_psu(self, psu_id):
@@ -227,9 +230,9 @@ class snmpPsuController(PsuControllerBase):
         pass
 
 
-def get_psu_controller(controller_ip, dut_hostname):
+def get_psu_controller(controller_ip, dut_hostname, pdu_port):
     """
     @summary: Factory function to create the actual PSU controller object.
     @return: The actual PSU controller object. Returns None if something went wrong.
     """
-    return snmpPsuController(dut_hostname, controller_ip)
+    return snmpPsuController(dut_hostname, controller_ip, pdu_port)

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -26,9 +26,11 @@ class snmpPsuController(PsuControllerBase):
         """
         pSYSDESCR = ".1.3.6.1.2.1.1.1.0"
         SYSDESCR = "1.3.6.1.2.1.1.1.0"
+        SNMP_ROCOMMUNITY = pdu['snmp_rocommunity']
+        SNMP_RWCOMMUNITY = pdu['snmp_rwcommunity']
         psu = None
         cmdGen = cmdgen.CommandGenerator()
-        snmp_auth = cmdgen.CommunityData('public')
+        snmp_auth = cmdgen.CommunityData(SNMP_ROCOMMUNITY)
         errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161), timeout=5.0),
@@ -92,7 +94,7 @@ class snmpPsuController(PsuControllerBase):
         This method depends on this configuration to find out the PDU ports connected to PSUs of specific DUT.
         """
         cmdGen = cmdgen.CommandGenerator()
-        snmp_auth = cmdgen.CommunityData('public')
+        snmp_auth = cmdgen.CommunityData(SNMP_ROCOMMUNITY)
         errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161)),
@@ -143,7 +145,7 @@ class snmpPsuController(PsuControllerBase):
         port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[rfc1902.Integer(psu_id)]
         errorIndication, errorStatus, _, _ = \
         cmdgen.CommandGenerator().setCmd(
-            cmdgen.CommunityData('private'),
+            cmdgen.CommunityData(SNMP_RWCOMMUNITY),
             cmdgen.UdpTransportTarget((self.controller, 161)),
             (port_oid, rfc1902.Integer(self.CONTROL_ON)),
         )
@@ -172,7 +174,7 @@ class snmpPsuController(PsuControllerBase):
         port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[rfc1902.Integer(psu_id)]
         errorIndication, errorStatus, _, _ = \
         cmdgen.CommandGenerator().setCmd(
-            cmdgen.CommunityData('private'),
+            cmdgen.CommunityData(SNMP_RWCOMMUNITY),
             cmdgen.UdpTransportTarget((self.controller, 161)),
             (port_oid, rfc1902.Integer(self.CONTROL_OFF)),
         )
@@ -203,7 +205,7 @@ class snmpPsuController(PsuControllerBase):
         """
         results = []
         cmdGen = cmdgen.CommandGenerator()
-        snmp_auth = cmdgen.CommunityData('public')
+        snmp_auth = cmdgen.CommunityData(SNMP_ROCOMMUNITY)
         errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
             snmp_auth,
             cmdgen.UdpTransportTarget((self.controller, 161)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,6 +309,12 @@ def eos():
         eos = yaml.safe_load(stream)
         return eos
 
+@pytest.fixture(scope='session')
+def pdu():
+    """ read and yield pdu configuration """
+    with open('pdu/pdu.yml') as stream:
+        pdu = yaml.safe_load(stream)
+        return pdu
 
 @pytest.fixture(scope="module")
 def creds(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PDU portname isn't always configured with the connected DUT name and if it's not configured with device name, current _get_pdu_ports() will return None. So add an option to configure the PDU port to DUT host configuration in inventory file.
#### How did you do it?
Parse pdu port from dut configuration and use the port number instead of snmp query to get the PDU port number
#### How did you verify/test it?
Run tests/platform_tests/test_reboot.py and verify the pdu control.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
