### PR TITLE
[pytest]: parsing multiple whitespaces correct for ip route info

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -586,7 +586,7 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         # parse nexthops
         for l in rt:
-            m = re.search(r"(default|nexthop) via (\S+) dev (\S+)", l)
+            m = re.search(r"(default|nexthop)\s+via\s+(\S+)\s+dev\s+(\S+)", l)
             if m:
                 rtinfo['nexthops'].append((ipaddress.ip_address(m.group(2)), m.group(3)))
 


### PR DESCRIPTION
4.9 kernel has extra whitespaces in the ip route info output.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
fix bug in get_ip_route_info for parsing output from 4.9 kernel

#### How did you do it?

#### How did you verify/test it?
run test_default_route.py on 201911 release

```
INFO     root:devices.py:575 route raw info for 0.0.0.0: [u'default proto 186 src 10.1.0.32 metric 20 ', u'\tnexthop via 10.0.0.57  dev PortChannel0001 weight 1', u'\tnexthop via 10.0.0.59  dev PortChannel0002 weight 1', u'\tnexthop via 10.0.0.61  dev PortChannel0003 weight 1', u'\tnexthop via 10.0.0.63  dev PortChannel0004 weight 1']
INFO     root:devices.py:593 route parsed info for 0.0.0.0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.57'), u'PortChannel0001'), (IPv4Address(u'10.0.0.59'), u'PortChannel0002'), (IPv4Address(u'10.0.0.61'), u'PortChannel0003'), (IPv4Address(u'10.0.0.63'), u'PortChannel0004')]}
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
