### PR TITLE
[lag2] fix LAG LACP rate test on T1-LAG

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -153,15 +153,18 @@ class LagTest:
             vm_host = self.nbrhosts[peer_device]['host']
 
             # Make sure all lag members on VM are set to fast
-            logging.info("Changing lacp rate to fast for %s in %s" % (neighbor_lag_intfs[0], peer_device))
-            vm_host.set_interface_lacp_rate_mode(neighbor_lag_intfs[0], 'fast')
+            for neighbor_lag_member in neighbor_lag_intfs:
+                logging.info("Changing lacp rate to fast for %s in %s" % (neighbor_lag_member, peer_device))
+                vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, 'fast')
             lag_rate_current_setting = 'fast'
             time.sleep(5)
             for iface_behind_lag in iface_behind_lag_member:
                 self.__verify_lag_lacp_timing(1, iface_behind_lag)
 
             # Make sure all lag members on VM are set to slow
-            vm_host.set_interface_lacp_rate_mode(neighbor_lag_intfs[0], 'normal')
+            for neighbor_lag_member in neighbor_lag_intfs:
+                logging.info("Changing lacp rate to slow for %s in %s" % (neighbor_lag_member, peer_device))
+                vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, 'normal')
             lag_rate_current_setting = 'slow'
             time.sleep(5)
             for iface_behind_lag in iface_behind_lag_member:
@@ -169,7 +172,9 @@ class LagTest:
         finally:
             # Restore lag rate setting on VM in case of failure
             if lag_rate_current_setting == 'fast':
-                vm_host.set_interface_lacp_rate_mode(neighbor_lag_intfs[0], 'normal')
+                for neighbor_lag_member in neighbor_lag_intfs:
+                    logging.info("Changing lacp rate to slow for %s in %s" % (neighbor_lag_member, peer_device))
+                    vm_host.set_interface_lacp_rate_mode(neighbor_lag_member, 'normal')
 
     def run_single_lag_test(self, lag_name):
         logging.info("Start checking single lag for: %s" % lag_name)


### PR DESCRIPTION
Summary: For Port-Channels with 2 or more members only first one was set
to fast LACP rate, however the comment above the code is saying that the
intention is to set all LAG members rate to fast.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
