### PR TITLE
[qos-sai] Fix use of deprecated get_asic_type API

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -497,7 +497,7 @@ class QosSaiBase:
         with open(r"qos/files/qos.yml") as file:
             qosConfigs = yaml.load(file, Loader=yaml.FullLoader)
 
-        vendor = duthost.get_asic_type()
+        vendor = duthost.facts["asic_type"]
         hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
         dutAsic = None
         for asic in self.SUPPORTED_ASIC_LIST:
@@ -538,7 +538,6 @@ class QosSaiBase:
             Returns:
                 filename (str): returns the filename copied to PTF host
         """
-        ptfhost.copy(src="ptftests", dest="/root")
         portMapFile = request.config.getoption("--ptf_portmap")
         if not portMapFile:
             portMapFile = self.DEFAULT_PORT_INDEX_TO_ALIAS_MAP_FILE


### PR DESCRIPTION
### Description of PR
Summary:

Commit 93566131 reworked some of the DUT host properties and deprecated
get_asic_type. This code removes the deprecated API and use duthost
property.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fixing a bug

#### How did you do it?
Replaced call to deprecated API with object property

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
