### PR TITLE
[acl] Disable Egress ACL tests on unsupported platforms

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -119,13 +119,22 @@ def setup(duthost, testbed):
     duthost.command('rm -rf {}'.format(DUT_TMP_DIR))
 
 
-@pytest.fixture(scope='module', params=['ingress', 'egress'])
-def stage(request):
+@pytest.fixture(scope="module", params=["ingress", "egress"])
+def stage(request, duthost):
     """
-    small fixture to parametrize test for ingres/egress stage testing
-    :param request: pytest request
-    :return: stage parameter
+    Parametrize tests for Ingress/Egress stage testing.
+
+    Args:
+        request: Pytest request fixture
+        duthost: DUT fixture
+
+    Returns:
+        str: The ACL stage to be tested.
+
     """
+    if request.param == "egress" and duthost.facts["asic_type"] in ["broadcom"]:
+        pytest.skip("Egress ACL stage not currently supported on {} ASIC"
+                    .format(duthost.facts["asic_type"]))
 
     return request.param
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Disable Egress ACL tests on unsupported platforms.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The ACL tests don't currently consider the ASIC capabilities when setting up the tests, so they attempt to configure Egress ACLs on devices that do not support them. So, the tests fail when running on some devices.

#### How did you do it?
I added an ASIC check to the stage fixture. The supported ACL stages are not currently stored anywhere in Redis so it is hard-coded for now.

#### How did you verify/test it?
Ran the tests on a BRCM device and the Egress test cases are skipped.

#### Any platform specific information?
Currently specific to BRCM devices, I am not sure if there are other platforms where Egress ACLs are not currently supported.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
