### PR TITLE
[dhcp-relay] Fix Undefined Var in Assertion When Verifying Dut Routes

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -85,8 +85,7 @@ def validate_dut_routes_exist(duthost, dut_dhcp_relay_data):
 
     for dhcp_server in dhcp_servers:
         rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
-        assert len(rtInfo["nexthops"]) > 0, \
-            "Failed to find route to DHCP server '{0}' with error '{1}".format(dhcp_server, result["stderr"])
+        assert len(rtInfo["nexthops"]) > 0, "Failed to find route to DHCP server '{0}'".format(dhcp_server)
 
 
 def test_dhcp_relay_default(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):


### PR DESCRIPTION
### Description of PR
Summary:
commit be3b7bb2 introduced route verification method and intorduced
a bug in its assertion where result var is not defined. This PR
removes reference to undefined var.

Fixes #1792
singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Removed reference to undefined var

#### How did you verify/test it?
```
tests$ pytest dhcp_relay/test_dhcp_relay.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-14 --module-path=../ansible/library --disable_loganalyzer
================================================================================================================================================== test session starts ==================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/host-acs-mgmt-repo/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 3 items                                                                                                                                                                                                                                                                                                       

dhcp_relay/test_dhcp_relay.py ...                                                                                                                                                                                                                                                                                 [100%]

============================================================================================================================================== 3 passed in 332.97 seconds ===============================================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
