### PR TITLE
[loganalyzer] Enhance Loganalyzer Fixture With Custom Regex

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -14,11 +14,13 @@ def loganalyzer(duthost, request):
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
     logging.info("Add start marker into DUT syslog")
     marker = loganalyzer.init()
+    logging.info("Load config and analyze log")
+    # Read existed common regular expressions located with legacy loganalyzer module
+    loganalyzer.load_common_config()
+
     yield loganalyzer
+
     if not request.config.getoption("--disable_loganalyzer") and "disable_loganalyzer" not in request.keywords:
-        logging.info("Load config and analyze log")
-        # Read existed common regular expressions located with legacy loganalyzer module
-        loganalyzer.load_common_config()
         # Parse syslog and process result. Raise "LogAnalyzerError" exception if: total match or expected missing
         # match is not equal to zero
         loganalyzer.analyze(marker)

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -15,7 +15,7 @@ ANSIBLE_LOGANALYZER_MODULE = system_msg_handler.__file__.replace(r".pyc", ".py")
 COMMON_MATCH = join(split(__file__)[0], "loganalyzer_common_match.txt")
 COMMON_IGNORE = join(split(__file__)[0], "loganalyzer_common_ignore.txt")
 COMMON_EXPECT = join(split(__file__)[0], "loganalyzer_common_expect.txt")
-SYSLOG_TMP_FOLDER = "/tmp/pytest-run/syslog"
+SYSLOG_TMP_FOLDER = "/tmp/syslog"
 
 
 class LogAnalyzerError(Exception):


### PR DESCRIPTION
### Description of PR
Summary:
Loganalyzer has build int regex to match log files against. Some
test cases while appropriately disabling some services, they fail
loganalyzer scrutiny if it happens to match one of those regex's.
This PR add ability for individual test cases to manipulate
loganalyzer regex's.

signed-of-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
Fixes # (issue)
### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
