### PR TITLE
[qos-sai] Update Loganalyzer Ignore Regex List

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -449,6 +449,28 @@ class QosSaiBase:
         for service in services:
             updateDockerService(duthost, action="start", **service)
 
+    @pytest.fixture(autouse=True)
+    def updateLoganalyzerExceptions(self, duthost, loganalyzer):
+        """
+            Update loganalyzer ignore regex list
+
+            Args:
+                duthost (AnsibleHost): Device Under Test (DUT)
+                loganalyzer (Fixture): log analyzer fixture
+
+            Returns:
+                None
+        """
+        ignoreRegex = [
+            ".*ERR monit.*'lldpd_monitor' process is not running",
+            ".*ERR monit.*'lldp_syncd' process is not running",
+            ".*ERR monit.*'bgpd' process is not running",
+            ".*ERR monit.*'bgpcfgd' process is not running",
+        ]
+        loganalyzer.ignore_regex.extend(ignoreRegex)
+
+        yield
+
     @pytest.fixture(scope='class', autouse=True)
     def disablePacketAging(self, duthost, stopServices):
         """


### PR DESCRIPTION
### Description of PR
Summary:
Loganalyzer looks for predefined expression in log files. QoS SAI
test cases do stop few services before executing the test case.
Loganalyzer then reports these as failures. This PR build update
loganalyzer ignore regex.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
With this change
```
tests$ pytest qos/test_qos_sai.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-14 --module-path=../ansible/library --skip_sanity -vvvv --show-capture=stdout
================================================================================================================================================== test session starts ==================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/host-acs-mgmt-repo/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                                                                                                                                                                        

qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] PASSED                                                                                                                                                                                                                                            [100%]

============================================================================================================================================== 1 passed in 402.36 seconds ===============================================================================================================================================
```
without this change
```
tests$ pytest qos/test_qos_sai.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-14 --module-path=../ansible/library --skip_sanity -vvvv --show-capture=stdout
================================================================================================================================================== test session starts ==================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/host-acs-mgmt-repo/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                                                                                                                                                                        

qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] PASSED                                                                                                                                                                                                                                            [100%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] ERROR                                                                                                                                                                                                                                             [100%]

======================================================================================================================================================== ERRORS =========================================================================================================================================================
____________________________________________________________________________________________________________________________ ERROR at teardown of TestQosSai.testQosSaiPfcXoffLimit[xoff_1] _____________________________________________________________________________________________________________________________

duthost = <tests.common.devices.SonicHost object at 0x7fe0f2c5d2d0>, request = <SubRequest 'loganalyzer' for <Function testQosSaiPfcXoffLimit[xoff_1]>>

    @pytest.fixture(autouse=True)
    def loganalyzer(duthost, request):
        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
        logging.info("Add start marker into DUT syslog")
        marker = loganalyzer.init()
        logging.info("Load config and analyze log")
        # Read existed common regular expressions located with legacy loganalyzer module
        loganalyzer.load_common_config()
    
        yield loganalyzer
    
        if not request.config.getoption("--disable_loganalyzer") and "disable_loganalyzer" not in request.keywords:
            # Parse syslog and process result. Raise "LogAnalyzerError" exception if: total match or expected missing
            # match is not equal to zero
>           loganalyzer.analyze(marker)

common/plugins/loganalyzer/__init__.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
common/plugins/loganalyzer/loganalyzer.py:242: in analyze
    self._verify_log(analyzer_summary)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7fe0f0c688c0>
result = {'expect_messages': {'/tmp/syslog.2020-06-19-23:44:22': []}, 'match_files': {'/tmp/syslog.2020-06-19-23:44:22': {'expe...]: 'bgpcfgd' process is not running\n"]}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 1}, ...}

    def _verify_log(self, result):
        """
        Verify that total match and expected missing match equals to zero or raise exception otherwise.
        Verify that expected_match is not equal to zero when there is configured expected regexp in self.expect_regex list
        """
        if not result:
            raise LogAnalyzerError("Log analyzer failed - no result.")
        if result["total"]["match"] != 0 or result["total"]["expected_missing_match"] != 0:
>           raise LogAnalyzerError(result)
E           LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-06-19-23:44:22': ["Jun 19 23:43:47.796465 str-s6000-acs-14 ERR monit[448]: 'bgpcfgd' process is not running\n"]}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 1}, 'match_files': {'/tmp/syslog.2020-06-19-23:44:22': {'expected_match': 0, 'match': 1}}, 'expect_messages': {'/tmp/syslog.2020-06-19-23:44:22': []}, 'unused_expected_regexp': []}

common/plugins/loganalyzer/loganalyzer.py:81: LogAnalyzerError
================================================================================================================================================ short test summary info ================================================================================================================================================
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-06-19-23:44:22': ["Jun 19 23:43:47.796465 str-s6000-acs-14 ERR monit[448]: 'bgpcfgd' process is not running\n"]}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match':...
========================================================================================================================================== 1 passed, 1 error in 406.37 seconds ==========================================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
