### PR TITLE
Add topology-marker override logic 

### DIFF
--- a/tests/common/plugins/custom_markers/__init__.py
+++ b/tests/common/plugins/custom_markers/__init__.py
@@ -43,13 +43,15 @@ def pytest_runtest_setup(item):
         check_device_type(item)
 
 def check_topology(item):
-    toponames = [mark.args for mark in item.iter_markers(name="topology")]
+    # The closest marker is used here so that the module or class level
+    # marker will be overrided by case level marker
+    toponames = item.get_closest_marker("topology")
     if toponames:
         cfg_topos = item.config.getoption("--topology").split(',')
-        if all(topo not in toponames[0] for topo in cfg_topos):
+        if all(topo not in toponames.args for topo in cfg_topos):
             pytest.skip("test requires topology in {!r}".format(toponames))
     else:
-        pytest.skip("test does not match topology")
+        pytest.skip("testcase {} is skipped when no topology marker is given".format(item.name))
 
 def check_feature(item):
     feature_names = [mark.args for mark in item.iter_markers(name="feature")]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add marker override logic in test framework.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We need to find a easier way to organize testcases according to topologies. 
#### How did you do it?
Update check_topology in tests/common/plugins/custom_markers/_ _init_ _.py.
Basicly, topology marker is given to a module, but the higher level topology marker is overrided when a lower topology marker is given. For example, the testcase level marker overrides the marker on module level. 
#### How did you verify/test it?
Run testcases with different topo markers.
#### Any platform specific information?
No. 
#### Supported testbed topology if it's a new test case?
No. 
### Documentation 
https://github.com/Azure/sonic-mgmt/blob/master/tests/docs/pytest.org.md (updated in this pr)
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
