### PR TITLE
[ixia/Keysight] Initialized user & pswd  variables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,7 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
             if fanout_host in fanout_hosts.keys():
                 fanout  = fanout_hosts[fanout_host]
             else:
+                user = pswd = None
                 host_vars = ansible_adhoc().options['inventory_manager'].get_host(fanout_host).vars
                 os_type = 'eos' if 'os' not in host_vars else host_vars['os']
                 if os_type == "eos":


### PR DESCRIPTION
[ixia/Keysight] Note that  if these variables 'user' and 'pswd' are not initialized, they will encounter an exception after the following code fragment, when control does not enter if/else part (reason variable not defined). 
if os_type == "eos":
    :
elif os_type == "onyx":
    :
I got this exception while adopting the fanouthosts fixture. Ixia chassis do not require user / pswd.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
