### PR TITLE
Fix PFC ansible testcase config error of poll time greater than detection/restoration time.

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -144,6 +144,10 @@
         pfc_wd_restore_time_large: 3000
         pfc_wd_poll_time: 400
 
+    - name: Stop PFC watchdog if enable by default before setting poll interval.
+      shell: "pfcwd stop"
+      become: yes
+        
     - name: Set polling interval {{ pfc_wd_poll_time }}.
       shell: "pfcwd interval {{ pfc_wd_poll_time }}"
       become: yes


### PR DESCRIPTION
Summary:

After this PR#https://github.com/Azure/sonic-utilities/pull/838
there is check pfc_wd poll_time <= pfc_wd_detection/restoration_time.
So make sure in testscript before setting poll interval stop
pfc wd if enable by default because default detection/restoration time
can be < poll time interval making script failure.

Verify:
After making changes test-case config went fine and test passes.
