### PR TITLE
[pytest][platform] Check serial, base MAC and EEPROM data against expected values

### DIFF
--- a/ansible/lab
+++ b/ansible/lab
@@ -1,5 +1,5 @@
 [sonic_sn2700_40]
-str-msn2700-01    ansible_host=10.251.0.188
+str-msn2700-01    ansible_host=10.251.0.188 serial="MT1234X56789" base_mac="24:8a:07:12:34:56" syseeprom_info="{'0xFE': '0xFBA1E964', '0x28': 'x86_64-mlnx_x86-r0', '0x29': '2016.11-5.1.0008-9600', '0x22': 'MSN2700-CS2FO', '0x23': 'MT1234X56789', '0x21': 'MSN2700', '0x26': '0', '0x24': '24:8a:07:12:34:56', '0x25': '12/07/2016', '0x2B': 'Mellanox', '0x2A': '128'}"
 
 [sonic_sn2700_40:vars]
 hwsku="ACS-MSN2700"

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -46,6 +46,12 @@ class TestChassisAPI(object):
         pytest_assert(base_mac is not None, "Failed to retrieve base MAC address")
         pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
 
+        if 'base_mac' in duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars:
+            expected_base_mac = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['base_mac']
+            pytest_assert(base_mac == expected_base_mac, "Base MAC address is incorrect")
+        else:
+            logger.warning('Inventory file does not contain base MAC address for {}'.format(duthost.hostname))
+
     def test_get_serial_number(self, duthost, localhost, platform_api_conn):
         # Ensure the serial number is sane
         # Note: It appears that when retrieving some variable-length fields,
@@ -57,6 +63,12 @@ class TestChassisAPI(object):
         serial = chassis.get_serial_number(platform_api_conn).rstrip('\x00')
         pytest_assert(serial is not None, "Failed to retrieve serial number")
         pytest_assert(re.match(REGEX_SERIAL_NUMBER, serial), "Serial number appears to be incorrect")
+
+        if 'serial' in duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars:
+            expected_serial = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['serial']
+            pytest_assert(serial == expected_serial, "Serial number is incorrect")
+        else:
+            logger.warning('Inventory file does not contain serial number for {}'.format(duthost.hostname))
 
     def test_get_system_eeprom_info(self, duthost, localhost, platform_api_conn):
         ''' Test that we can retrieve sane system EEPROM info from the DUT via the platform API
@@ -109,6 +121,12 @@ class TestChassisAPI(object):
         serial = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_SERIAL_NUMBER]
         pytest_assert(serial is not None, "Failed to retrieve serial number")
         pytest_assert(re.match(REGEX_SERIAL_NUMBER, serial), "Serial number appears to be incorrect")
+
+        if 'syseeprom_info' in duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars:
+            expected_syseeprom_info_dict = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['syseeprom_info']
+            pytest_assert(syseeprom_info_dict == expected_syseeprom_info_dict, "System EEPROM info is incorrect")
+        else:
+            logger.warning('Inventory file does not contain system EEPROM info for {}'.format(duthost.hostname))
 
     def test_get_reboot_cause(self, duthost, localhost, platform_api_conn):
         # TODO: Compare return values to potential combinations


### PR DESCRIPTION
Add "serial", "base_mac" and "syseeprom_info" attributes to DuT definition in inventory file; compare actual values obtained from device against these values in the respective tests in test_chassis.py.