### PR TITLE
Add variables for fanout creds and fix FanoutHost shutdown/no_shutdown issue

### DIFF
--- a/ansible/group_vars/fanout/secrets.yml
+++ b/ansible/group_vars/fanout/secrets.yml
@@ -1,6 +1,16 @@
+# Please update the actual username and password according to your lab configuration
+
 ansible_ssh_user: user
 ansible_ssh_pass: password
 fanout_mlnx_user: admin
 fanout_mlnx_password: admin
 fanout_sonic_user: admin
 fanout_sonic_password: password
+
+# Credential for accessing the network cli interface
+fanout_network_user: netadmin
+fanout_network_password: netpassword
+
+# Credential for accessing the Linux shell
+fanout_shell_user: shelladmin
+fanout_shell_password: shellpassword

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -641,7 +641,7 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             if nbinfo['bgpStateIs'].lower() == "passiveNSF".lower():
                 return True
         return False
-    
+
     def get_dut_iface_mac(self, iface_name):
         """
         Gets the MAC address of specified interface.
@@ -889,10 +889,10 @@ class FanoutHost():
         return self.type
 
     def shutdown(self, interface_name):
-        return self.host.shutdown(interface_name)[self.hostname]
+        return self.host.shutdown(interface_name)
 
     def no_shutdown(self, interface_name):
-        return self.host.no_shutdown(interface_name)[self.hostname]
+        return self.host.no_shutdown(interface_name)
 
     def __str__(self):
         return "{ os: '%s', hostname: '%s', device_type: '%s' }" % (self.os, self.hostname, self.type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PR #1742 introduced two sets of fanout variables as credentials for accessing
the fanout network cli and linux shell. This change explicitly define the variables
in ansible/group_vars/fanout/secrets.yml.

After this PR is merged, please remember to update the credentials in
ansible/group_vars/fanout/secrets.yml file to the actual values of your
lab configuration.

Another change in this PR is to fix the issue of getting results of
FanoutHost shutdown and no_shutdown methods. The results
are directly returned by inner function call. It's unnecessary and
wrong to get results using dictionary `key self.hostname`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Explicitly define variables introduced by #1742 in ansible/group_vars/fanout/secrets.yml and fix issue in FanoutHost shutdown/no_shutdown methods.

#### How did you do it?
* Explicitly define variables `fanout_network_user`, `fanout_network_password`, `fanout_shell_user` and `fanout_shell_password` in `ansible/group_vars/fanout/secrets.yml`.
* Directly return the inner function call result. Do not get value using dictionary key `self.hostname`.

#### How did you verify/test it?
* Test run the methods of FanouHost
* Test run calling ansible modules based on network_cli and linux shell.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
