### PR TITLE
[spytest] Support junit-xml

### DIFF
--- a/spytest/spytest/framework.py
+++ b/spytest/spytest/framework.py
@@ -507,7 +507,8 @@ class Context(object):
                 res["TimeTaken"] = "0:00:00"
             row = ["", res["Module"], func, res["Result"], res["TimeTaken"],
                    res["ExecutedOn"], res["Description"]]
-            item.user_properties.append(row)
+            # FIXME: temporarily remove to support junit-xml
+            # item.user_properties.append(row)
         if not self.slave_id:
             self.run_progress_report(self.all_tc_executed)
         return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Currently, run Spytest together with `junit-xml` option will result into
ValueError. This is because that Spytest tries to add user properties
that stores results for testcases related to the test function.
Temporarily removing this to enable `junit-xml`.

Signed-off-by: lolyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
run spytest with --junit-xml
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
