### PR TITLE
Fix bgp_gr_helper test

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -6,7 +6,7 @@ from common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
-def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart):
+def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart, vm_host):
     """
     Verify that DUT routes are preserved when peer performed graceful restart
     """
@@ -52,9 +52,9 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
     bgp_nbr = bgp_neighbors[str(bgp_nbr_ipv4)]
     nbr_hostname = bgp_nbr['name']
     nbrhost = nbrhosts[nbr_hostname]['host']
-    exabgp_sessions = ['exabgp_v4', 'exabgp_v6']
-    pytest_assert(nbrhost.check_bgp_session_state([], exabgp_sessions), \
-            "exabgp sessions {} are not up before graceful restart".format(exabgp_sessions))
+    nbr_ips = [vm_host['ptf_bp_ip'].split('/')[0], vm_host['ptf_bp_ipv6'].split('/')[0]]
+    pytest_assert(nbrhost.check_bgp_session_state(nbr_ips), \
+            "exabgp sessions {} are not up before graceful restart".format(nbr_ips))
 
     # shutdown Rib agent, starting gr process
     logger.info("shutdown rib process on neighbor {}".format(nbr_hostname))
@@ -85,8 +85,8 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
         nbrhost.start_bgpd()
 
         # wait for exabgp sessions to establish
-        pytest_assert(wait_until(300, 10, nbrhost.check_bgp_session_state, [], exabgp_sessions), \
-            "exabgp sessions {} are not coming back".format(exabgp_sessions))
+        pytest_assert(wait_until(300, 10, nbrhost.check_bgp_session_state, nbr_ips), \
+            "exabgp sessions {} are not coming back".format(nbr_ips))
     except:
         raise
     finally:

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -741,16 +741,14 @@ class EosHost(AnsibleHostBase):
         out = self.eos_config(lines=['no agent Rib shutdown'])
         return out
 
-    def check_bgp_session_state(self, neigh_ips, neigh_desc, state="established"):
+    def check_bgp_session_state(self, neigh_ips, state="established"):
         """
         @summary: check if current bgp session equals to the target state
 
         @param neigh_ips: bgp neighbor IPs
-        @param neigh_desc: bgp neighbor description
         @param state: target state
         """
         neigh_ips_ok = []
-        neigh_desc_ok = []
         out_v4 = self.eos_command(
             commands=['show ip bgp summary | json'])
         logging.info("ip bgp summary: {}".format(out_v4))
@@ -763,17 +761,13 @@ class EosHost(AnsibleHostBase):
             if v['peerState'].lower() == state.lower():
                 if k in neigh_ips:
                     neigh_ips_ok.append(neigh_ips)
-                if v['description'] in neigh_desc:
-                    neigh_desc_ok.append(v['description'])
 
         for k, v in out_v6['stdout'][0]['vrfs']['default']['peers'].items():
             if v['peerState'].lower() == state.lower():
                 if k in neigh_ips:
                     neigh_ips_ok.append(neigh_ips)
-                if v['description'] in neigh_desc:
-                    neigh_desc_ok.append(v['description'])
 
-        if len(neigh_ips) == len(neigh_ips_ok) and len(neigh_desc) == len(neigh_desc_ok):
+        if len(neigh_ips) == len(neigh_ips_ok):
             return True
 
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,12 @@ def eos():
         eos = yaml.safe_load(stream)
         return eos
 
+@pytest.fixture(scope="module")
+def vm_host():
+    """ read vm_host configuration """
+    with open('../ansible/group_vars/vm_host/main.yml') as stream:
+        vm_host = yaml.safe_load(stream)
+        return vm_host
 
 @pytest.fixture(scope="module")
 def creds(duthost):


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR
Fixed **bgp_gr_helper** test

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
bgp_gr_helper test fails

#### How did you do it?
Do not use description check in check_bgp_session_state() of EosHost as "show ip bgp summary" output on Arista VM doesn't provide this field which causes crash on its access try. Instead use backplane IPs in order to check BGP session state on VM which can be get from a new vm_host fixture which loads the configuration for VM.

#### How did you verify/test it?
Tested it on BFN platform with t1-lag topo and 201911 SONiC image

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

