### PR TITLE
add gnmi_get output test

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -37,8 +37,8 @@ def restart_telemetry(duthost):
     if str(status_value) == "disabled":
         logger.info(' telemetry is disabled. enabling it back...')
         duthost.shell('sudo config feature telemetry enabled', module_ignore_errors=False)['stdout_lines']
-        return bool("true")
-    return bool(false)
+        return True
+    return False
 
 # Test functions
 def test_config_db_parameters(duthost):
@@ -82,25 +82,26 @@ def test_telemetry_enabledbydefault(duthost):
             status_expected = "enabled";
             pytest_assert(str(v) == status_expected, "Telemetry feature is not enabled")
 
-def test_telemetry_gnmi_get(duthost, ptfhost):
-    """Run gnmi_get from ptfdocker and verify data streaming
+def test_telemetry_ouput(duthost, ptfhost):
+    """Run pyclient from ptfdocker and show gnmi server outputself.
+       For pyclient to work client_auth need to be set to false.
     """
-    certs_del_status = duthost.shell('/usr/bin/redis-cli -n 4 del "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
-    set_client_auth = duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)['stdout_lines']
+    set_client_auth = duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
     logger.info('start telemetry testing')
+    # For server to take effect of client_auth=false, server needs to be restarted
     restart_status = restart_telemetry(duthost)
-    if restart_status == bool("true"):
-        logger.info('telemetry process restarted. Now run gnmi_get on ptfdocker')
-        #Now run gnmi_get on ptfdocker
+    if restart_status:
+        logger.info('telemetry process restarted. Now run pyclient on ptfdocker')
         dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
-        cmd = '''
-              cd ~/etc/go/bin &&
-             ./gnmi_get -xpath_target COUNTERS_DB COUNTERS/Ethernet0 -target_addr {0}:8080 -insecure
-             '''.format(dut_ip)
-        show_gnmi_get_out = ptfhost.shell(cmd)[stdout]
-        logger.info("gnmi get output \n {}".format(show_gnmi_get_out))
+        # pyclient should be available on ptfhost. If not fail pytest.
+        file_exists = ptfhost.stat(path="~/gnxi/gnmi_cli_py/py_gnmicli.py")
+        pytest_assert(file_exists["stat"]["exists"] is True)
+        cmd = '~/gnxi/gnmi_cli_py/python py_gnmicli.py -g -t {0} -p 50051 -m get -x COUNTERS/Ethernet0 -xt COUNTERS_DB -o "ndastreamingservertest"'.format(dut_ip)
+        show_gnmi_out = ptfhost.shell(cmd)[stdout]
+        logger.info("gnmi server output \n {}".format(show_gnmi_out))
+    else:
+        logger.info('restart telemetry failed. Gnmi output is not verified')
 
     # Reset config back to original for telemetry process
-    duthost.shell('/usr/bin/redis-cli -n 4 hmset "TELEMETRY|certs" "ca_crt" "/etc/sonic/telemetry/dsmsroot.cer" "server_key" "/etc/sonic/telemetry/streamingtelemetryserver.key" "server_crt" "/etc/sonic/telemetry/streamingtelemetryserver.cer"', module_ignore_errors=False)['stdout_lines']
-    duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "true"', module_ignore_errors=False)['stdout_lines']
+    duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "true"', module_ignore_errors=False)
     restart_telemetry(duthost)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -5,6 +5,8 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+logger = logging.getLogger(__name__)
+
 # Helper functions
 def get_dict_stdout(gnmi_out, certs_out):
     """ Extracts dictionary from redis output.
@@ -24,10 +26,22 @@ def get_list_stdout(cmd_out):
         out_list.append(result)
     return out_list
 
+def restart_telemetry(duthost):
+    """ Restart telemetry process
+    """
+    duthost.shell('sudo config feature telemetry disabled', module_ignore_errors=False)['stdout_lines']
+    status_out = duthost.shell('show features | grep telemetry', module_ignore_errors=False)['stdout_lines']
+    status_value = get_list_stdout(status_out)
+    status_value_list = status_value[0].split()
+    status_value = status_value_list[1]
+    if str(status_value) == "disabled":
+        logger.info(' telemetry is disabled. enabling it back...')
+        duthost.shell('sudo config feature telemetry enabled', module_ignore_errors=False)['stdout_lines']
+        return bool("true")
+    return bool(false)
+
 # Test functions
 def test_config_db_parameters(duthost):
-    """Verifies required telemetry parameters from config_db.
-    """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
 
@@ -53,8 +67,6 @@ def test_config_db_parameters(duthost):
             pytest_assert(str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected))
 
 def test_telemetry_enabledbydefault(duthost):
-    """Verify telemetry should be enabled by default
-    """
     status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
     # Elements in list alternate between key and value. Separate them and combine into a dict.
@@ -65,3 +77,26 @@ def test_telemetry_enabledbydefault(duthost):
         if str(k) == "status":
             status_expected = "enabled";
             pytest_assert(str(v) == status_expected, "Telemetry feature is not enabled")
+
+def test_telemetry_gnmi_get(duthost, ptfhost):
+    """Run gnmi_get from ptfdocker and verify data streaming
+    """
+    certs_del_status = duthost.shell('/usr/bin/redis-cli -n 4 del "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
+    set_client_auth = duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)['stdout_lines']
+    logger.info('start telemetry testing')
+    restart_status = restart_telemetry(duthost)
+    if restart_status == bool("true"):
+        logger.info('telemetry process restarted. Now run gnmi_get on ptfdocker')
+        #Now run gnmi_get on ptfdocker
+        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
+        logger.info("dut ip={}".format(dut_ip))
+        cmd = '''
+              cd ~/etc/go/bin &&
+             ./gnmi_get -xpath_target COUNTERS_DB COUNTERS/Ethernet0 -target_addr {0}:8080 -insecure
+             '''.format(dut_ip)
+        show_gnmi_get_out = ptfhost.shell(cmd)[stdout]
+        logger.info("gnmi get output \n {}".format(show_gnmi_get_out))
+    # Reset config back to original for telemetry process
+    duthost.shell('/usr/bin/redis-cli -n 4 hmset "TELEMETRY|certs" "ca_crt" "/etc/sonic/telemetry/dsmsroot.cer" "server_key" "/etc/sonic/telemetry/streamingtelemetryserver.key" "server_crt" "/etc/sonic/telemetry/streamingtelemetryserver.cer"', module_ignore_errors=False)['stdout_lines']
+    duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "true"', module_ignore_errors=False)['stdout_lines']
+    restart_telemetry(duthost) 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -89,4 +89,5 @@ def test_telemetry_ouput(duthost, ptfhost):
     pytest_assert(file_exists["stat"]["exists"] is True)
     cmd = 'python /gnxi/gnmi_cli_py/py_gnmicli.py -g -t {0} -p 50051 -m get -x COUNTERS/Ethernet0 -xt COUNTERS_DB -o "ndastreamingservertest"'.format(dut_ip)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
-    logger.info("gnmi server output \n {}".format(show_gnmi_out))
+    logger.info("GNMI server output:")
+    logger.info(repr(show_gnmi_out))

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -42,7 +42,7 @@ def restart_telemetry(duthost):
 
 # Test functions
 def test_config_db_parameters(duthost):
-     """Verifies required telemetry parameters from config_db.
+    """Verifies required telemetry parameters from config_db.
     """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -42,6 +42,8 @@ def restart_telemetry(duthost):
 
 # Test functions
 def test_config_db_parameters(duthost):
+     """Verifies required telemetry parameters from config_db.
+    """
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
 
@@ -67,6 +69,8 @@ def test_config_db_parameters(duthost):
             pytest_assert(str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected))
 
 def test_telemetry_enabledbydefault(duthost):
+     """Verify telemetry should be enabled by default
+    """
     status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
     # Elements in list alternate between key and value. Separate them and combine into a dict.
@@ -88,8 +92,7 @@ def test_telemetry_gnmi_get(duthost, ptfhost):
     if restart_status == bool("true"):
         logger.info('telemetry process restarted. Now run gnmi_get on ptfdocker')
         #Now run gnmi_get on ptfdocker
-        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
-        logger.info("dut ip={}".format(dut_ip))
+        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']    
         cmd = '''
               cd ~/etc/go/bin &&
              ./gnmi_get -xpath_target COUNTERS_DB COUNTERS/Ethernet0 -target_addr {0}:8080 -insecure
@@ -99,4 +102,4 @@ def test_telemetry_gnmi_get(duthost, ptfhost):
     # Reset config back to original for telemetry process
     duthost.shell('/usr/bin/redis-cli -n 4 hmset "TELEMETRY|certs" "ca_crt" "/etc/sonic/telemetry/dsmsroot.cer" "server_key" "/etc/sonic/telemetry/streamingtelemetryserver.key" "server_crt" "/etc/sonic/telemetry/streamingtelemetryserver.cer"', module_ignore_errors=False)['stdout_lines']
     duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "true"', module_ignore_errors=False)['stdout_lines']
-    restart_telemetry(duthost) 
+    restart_telemetry(duthost)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -69,7 +69,7 @@ def test_config_db_parameters(duthost):
             pytest_assert(str(value) == server_crt_expected, "'server_crt' value is not '{}'".format(server_crt_expected))
 
 def test_telemetry_enabledbydefault(duthost):
-     """Verify telemetry should be enabled by default
+    """Verify telemetry should be enabled by default
     """
     status = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
@@ -92,13 +92,14 @@ def test_telemetry_gnmi_get(duthost, ptfhost):
     if restart_status == bool("true"):
         logger.info('telemetry process restarted. Now run gnmi_get on ptfdocker')
         #Now run gnmi_get on ptfdocker
-        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']    
+        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
         cmd = '''
               cd ~/etc/go/bin &&
              ./gnmi_get -xpath_target COUNTERS_DB COUNTERS/Ethernet0 -target_addr {0}:8080 -insecure
              '''.format(dut_ip)
         show_gnmi_get_out = ptfhost.shell(cmd)[stdout]
         logger.info("gnmi get output \n {}".format(show_gnmi_get_out))
+
     # Reset config back to original for telemetry process
     duthost.shell('/usr/bin/redis-cli -n 4 hmset "TELEMETRY|certs" "ca_crt" "/etc/sonic/telemetry/dsmsroot.cer" "server_key" "/etc/sonic/telemetry/streamingtelemetryserver.key" "server_crt" "/etc/sonic/telemetry/streamingtelemetryserver.cer"', module_ignore_errors=False)['stdout_lines']
     duthost.shell('/usr/bin/redis-cli -n 4 hset "TELEMETRY|gnmi" "client_auth" "true"', module_ignore_errors=False)['stdout_lines']

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -36,7 +36,7 @@ def setup_telemetry_forpyclient(duthost):
     client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "TELEMETRY|gnmi" "client_auth"', module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
     if client_auth == "true":
-        set_client_auth = duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "TELEMETRY|gnmi" "client_auth" "false"', module_ignore_errors=False)
         duthost.service(name="telemetry", state="restarted")
     else:
         logger.info('client auth is false. No need to restart telemetry')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Run pyclient available on ptfdocker to verify output from gnmi server on sonic duT

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ -] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR to verify gnmi server end to end testing
1. Change settings for gnmi_server to client_auth=false. This is needed for pyclient to work.
2. run pyclient  on ptfdocker
3. reset settings to original client_auth=true.
#### How did you do it?

#### How did you verify/test it?

pytest logs:
```
------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------
23:04:53 INFO __init__.py:loganalyzer:15: Add start marker into DUT syslog
------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------
23:04:54 INFO test_telemetry.py:test_telemetry_ouput:77: start telemetry output testing
23:04:58 INFO test_telemetry.py:test_telemetry_ouput:81: telemetry process restarted. Now run pyclient on ptfdocker

  name: "COUNTERS"
}
elem {
  name: "Ethernet0"
}
The GetResponse is below
-------------------------

{
  "SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS": "0",
  "SAI_PORT_STAT_PFC_0_RX_PKTS": "0",
  "SAI_PORT_STAT_IF_OUT_ERRORS": "0",
  "SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS": "0",
  "SAI_PORT_STAT_PFC_3_TX_PKTS": "0",
  "SAI_PORT_STAT_PFC_1_TX_PKTS": "0",
  "SAI_PORT_STAT_PFC_5_RX_PKTS": "0",
  "SAI_PORT_STAT_IF_IN_ERRORS": "0",
  "SAI_PORT_STAT_PFC_7_RX_PKTS": "0",
  "SAI_PORT_STAT_IF_IN_DISCARDS": "0",
  "SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS": "0",
  "SAI_PORT_STAT_PFC_3_RX_PKTS": "0",
  "SAI_PORT_STAT_PAUSE_TX_PKTS": "0",
  "SAI_PORT_STAT_IF_IN_BROADCAST_PKTS": "0",
  "SAI_PORT_STAT_PFC_2_TX_PKTS": "0",
  "SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS": "0",
  "SAI_PORT_STAT_PFC_5_TX_PKTS": "0",
  "SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS": "0",
  "SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS": "0",
  "SAI_PORT_STAT_PAUSE_RX_PKTS": "0",
  "SAI_PORT_STAT_IF_OUT_DISCARDS": "0",
  "SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS": "0",
  "SAI_PORT_STAT_IF_OUT_OCTETS": "0",
  "SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS": "0",
  "SAI_PORT_STAT_PFC_6_RX_PKTS": "0",
  "SAI_PORT_STAT_PFC_1_RX_PKTS": "0",
  "SAI_PORT_STAT_PFC_6_TX_PKTS": "0",
  "SAI_PORT_STAT_PFC_7_TX_PKTS": "0",
  "SAI_PORT_STAT_IF_OUT_UCAST_PKTS": "0",
  "SAI_PORT_STAT_PFC_4_RX_PKTS": "0",
  "SAI_PORT_STAT_IF_IN_UCAST_PKTS": "0",
  "SAI_PORT_STAT_IF_IN_OCTETS": "0",
  "SAI_PORT_STAT_IF_OUT_QLEN": "0",
  "SAI_PORT_STAT_PFC_2_RX_PKTS": "0",
  "SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS": "0",
  "SAI_PORT_STAT_PFC_4_TX_PKTS": "0",
  "SAI_PORT_STAT_PFC_0_TX_PKTS": "0",
  "SAI_PORT_STAT_IP_IN_UCAST_PKTS": "0",
  "SAI_PORT_STAT_IF_IN_MULTICAST_PKTS": "0"
}
PASSED                                                                                                                                                                            [100%]
----------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------
23:05:06 INFO __init__.py:loganalyzer:26: Add end marker into DUT syslog

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
