### PR TITLE
[ntp] Improve NTP test stability and reduce chatty output

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -41,7 +41,7 @@ def setup_ntp(ptfhost, duthost, creds):
         duthost.command("config ntp add %s" % ntp_server)
 
 def check_ntp_status(host):
-    res = host.command("ntpstat")
+    res = host.command("ntpstat", module_ignore_errors=True)
     if res['rc'] != 0:
        return False
     return True
@@ -52,4 +52,4 @@ def test_ntp(duthost, setup_ntp):
     duthost.service(name='ntp', state='stopped')
     duthost.command("ntpd -gq")
     duthost.service(name='ntp', state='restarted')
-    pytest_assert(wait_until(120, 5, check_ntp_status, duthost), "NTP not in sync")
+    pytest_assert(wait_until(300, 5, check_ntp_status, duthost), "NTP not in sync")


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Improve NTP test stability and reduce chatty output.

- NTP service could take a few minutes to sync with the server. extend wait time to 5 minutes.
- Allow ntp command to return none-zero return code and check in test instead of throwing exception.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
NTP service could take 3-4 minutes to sync with the ntp server. In my test, I saw sync done within 2 minutes but very rare. Majority took 3-4 minutes.

Allow ntpstat command to return non-zero code and deal with that in the test. So that we don't see follow chatty messages:

21:02:25 ERROR utilities.py:wait_until:39: Exception caught while checking check_ntp_status: run module command failed
21:02:31 ERROR utilities.py:wait_until:39: Exception caught while checking check_ntp_status: run module command failed


Test results:
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                                              

ntp/test_ntp.py::test_ntp PASSED         