### PR TITLE
Fix ansible qos_sai failure on 201911/master image

### DIFF
--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -66,12 +66,12 @@
       supervisorctl: state=stopped name=bgpd
       delegate_to: "{{ ansible_host }}_bgp"
     
-    - name: Add iptables rule to drop BGP SYN Packet from peer so that we do not ACK back
-      shell: "iptables -A INPUT -j DROP -p tcp --destination-port bgp"
+    - name: Add iptables rule to drop BGP SYN Packet from peer so that we do not ACK back. Add at top so existing rules don't have precedence over it.
+      shell: "iptables -I INPUT 1 -j DROP -p tcp --destination-port bgp"
       become: true
 
-    - name: Add ip6tables rule to drop BGP SYN Packet from peer so that we do not ACK back
-      shell: "ip6tables -A INPUT -j DROP -p tcp --destination-port bgp"
+    - name: Add ip6tables rule to drop BGP SYN Packet from peer so that we do not ACK back. Add at top so existing rules don't have precedence over it.
+      shell: "ip6tables -I INPUT 1 -j DROP -p tcp --destination-port bgp"
       become: true
 
     - meta: flush_handlers

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -377,13 +377,15 @@ class QosSaiBase:
         def updateIptablesDropRule(duthost, ipVersion,  state='present'):
             duthost.iptables(
                 ip_version=ipVersion,
-                action="Append",
+                action="insert",
+                rule_num="1",
                 chain="INPUT",
                 jump="DROP",
                 protocol="tcp",
                 destination_port="bgp",
                 state=state
             )
+
 
         ipVersions  = [{"ipVersion": "ipv4"}, {"ipVersion": "ipv6"}]
 


### PR DESCRIPTION
As part of this PR#https://github.com/Azure/sonic-buildimage/pull/4412
we have added ACCEPT rules for BGP packets as default. Because of this
my earlier change of iptable rule added in qos_sai.yml to Drop BGP packets get ignored because of lower priority
and make test case fails since BGP packets impacts Buffer calculation assumption of testcases.

Fix is to add iptable rule to Drop BGP Packet from test case as highest
priority.

During cleanup highest priority rule will get deleted first.
