### PR TITLE
Remove Flask banner in http_api.py

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -64,6 +64,10 @@ http_api_py = '''\
 from flask import Flask, request
 import sys
 
+#Disable banner msg from app.run, or the output might be caught by exabgp and run as command
+cli = sys.modules['flask.cli']
+cli.show_server_banner = lambda *x: None
+
 app = Flask(__name__)
 
 # Setup a command route to listen for prefix advertisements
@@ -179,7 +183,7 @@ def setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, p
                     group_updates=group_updates)
     with open("/etc/exabgp/%s.conf" % name, 'w') as out_file:
         out_file.write(data)
- 
+
 def remove_exabgp_conf(name):
     try:
         os.remove("/etc/exabgp/%s.conf" % name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Remove Flask banner in http_api.py app.run()
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Flask prints some message as banner when app.run is called, like this:
```
 * Serving Flask app "http_api" (lazy loading)
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: off
```
These messages are caught by exabgp and run as command, which will produce WARN log:
```
Wed, 24 Jun 2020 09:11:21 | INFO     | 7397   | processes     | Command from process http-api :  * Serving Flask app "http_api" (lazy loading) 
Wed, 24 Jun 2020 09:11:21 | WARNING  | 7397   | reactor       | Command from process not understood : * Serving Flask app "http_api" ( lazy loading )
Wed, 24 Jun 2020 09:11:21 | INFO     | 7397   | processes     | Command from process http-api :  * Environment: production 
Wed, 24 Jun 2020 09:11:21 | WARNING  | 7397   | reactor       | Command from process not understood : * Environment: production
Wed, 24 Jun 2020 09:11:21 | INFO     | 7397   | processes     | Command from process http-api :    WARNING: Do not use the development server in a production environment. 
Wed, 24 Jun 2020 09:11:21 | WARNING  | 7397   | reactor       | Command from process not understood : WARNING: Do not use the development server in a production environment.
Wed, 24 Jun 2020 09:11:21 | INFO     | 7397   | processes     | Command from process http-api :    Use a production WSGI server instead. 
Wed, 24 Jun 2020 09:11:21 | WARNING  | 7397   | reactor       | Command from process not understood : Use a production WSGI server instead.
Wed, 24 Jun 2020 09:11:21 | INFO     | 7397   | processes     | Command from process http-api :  * Debug mode: off 
Wed, 24 Jun 2020 09:11:21 | WARNING  | 7397   | reactor       | Command from process not understood : * Debug mode: off
```
#### How did you do it?
Override show_server_banner method in Flask to disable banner.
#### How did you verify/test it?
Run test_announce_routes.py and test_bgp_speaker.py to verify exabgp works normally, and WARN message is not produced any more.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Not related.