### PR TITLE
Add check and waiting for exabgp http server

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -7,7 +7,7 @@ import requests
 from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
-
+from common.utilities import wait_tcp_connection
 
 def generate_ips(num, prefix, exclude_ips):
     """
@@ -39,7 +39,7 @@ def announce_route(ptfip, neighbor, route, nexthop, port):
 
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthost, ptfhost):
+def common_setup_teardown(duthost, ptfhost, localhost):
 
     logging.info("########### Setup for bgp speaker testing ###########")
 
@@ -102,9 +102,16 @@ def common_setup_teardown(duthost, ptfhost):
                        peer_asn=mg_facts['minigraph_bgp_asn'],
                        port=str(port_num[i]))
 
+    # check exabgp http_api port is ready
+    http_ready = True
+    for i in range(0, 3):
+        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i])
+        if not http_ready:
+            break
+
     logging.info("########### Done setup for bgp speaker testing ###########")
 
-    yield ptfip, mg_facts, interface_facts, vlan_ips, speaker_ips, port_num
+    yield ptfip, mg_facts, interface_facts, vlan_ips, speaker_ips, port_num, http_ready
 
     logging.info("########### Teardown for bgp speaker testing ###########")
 
@@ -122,7 +129,8 @@ def common_setup_teardown(duthost, ptfhost):
 def test_bgp_speaker_bgp_sessions(common_setup_teardown, duthost, ptfhost, collect_techsupport):
     """Setup bgp speaker on T0 topology and verify bgp sessions are established
     """
-    ptfip, mg_facts, interface_facts, vlan_ips, speaker_ips, port_num = common_setup_teardown
+    ptfip, mg_facts, interface_facts, vlan_ips, speaker_ips, port_num, http_ready = common_setup_teardown
+    assert http_ready
 
     logging.info("Wait some time to verify that bgp sessions are established")
     time.sleep(20)
@@ -137,7 +145,8 @@ def test_bgp_speaker_announce_routes(common_setup_teardown, testbed, duthost, pt
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """
-    ptfip, mg_facts, interface_facts, vlan_ips, speaker_ips, port_num = common_setup_teardown
+    ptfip, mg_facts, interface_facts, vlan_ips, speaker_ips, port_num, http_ready = common_setup_teardown
+    assert http_ready
 
     logging.info("announce route")
     peer_range = mg_facts['minigraph_bgp_peers_with_range'][0]['ip_range'][0]

--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -5,6 +5,8 @@ import requests
 import pytest
 import logging
 import ipaddr as ipaddress
+from common.utilities import wait_tcp_connection
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,7 +21,6 @@ def announce_routes(ptfip, port, routes):
     url = "http://%s:%d" % (ptfip, port)
     data = { "commands": ";".join(messages) }
     r = requests.post(url, data=data)
-    print r
     assert r.status_code == 200
 
 
@@ -93,7 +94,7 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
     return routes
 
 
-def fib_t0(ptfhost, testbed):
+def fib_t0(ptfhost, testbed, localhost):
     logger.info("use fib_t0 to setup routes for topo {}".format(testbed['topo']['name']))
 
     podset_number = 200
@@ -137,6 +138,15 @@ def fib_t0(ptfhost, testbed):
                        local_asn = asn, \
                        peer_asn  = asn, \
                        port = port6)
+    # check if bgp http_api is ready
+    for k, v in testbed['topo']['properties']['configuration'].items():
+        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+
+        port = 5000 + vm_offset
+        assert wait_tcp_connection(localhost, ptfip, port)
+
+        port6 = 6000 + vm_offset
+        assert wait_tcp_connection(localhost, ptfip, port6)
 
     for k, v in testbed['topo']['properties']['configuration'].items():
         vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
@@ -154,7 +164,7 @@ def fib_t0(ptfhost, testbed):
         announce_routes(ptfip, port6, routes_v6)
 
 
-def fib_t1_lag(ptfhost, testbed):
+def fib_t1_lag(ptfhost, testbed, localhost):
     logger.info("use fib_t1_lag to setup routes for topo {}".format(testbed['topo']['name']))
 
     podset_number = 200
@@ -198,6 +208,15 @@ def fib_t1_lag(ptfhost, testbed):
                        local_asn = asn, \
                        peer_asn  = asn, \
                        port = port6)
+    # Check if bgp http_api port is ready
+    for k, v in testbed['topo']['properties']['configuration'].items():
+        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+
+        port = 5000 + vm_offset
+        assert wait_tcp_connection(localhost, ptfip, port)
+
+        port6 = 6000 + vm_offset
+        assert wait_tcp_connection(localhost, ptfip, port6)
 
     for k, v in testbed['topo']['properties']['configuration'].items():
 
@@ -229,11 +248,11 @@ def fib_t1_lag(ptfhost, testbed):
 
 
 @pytest.fixture(scope='module')
-def fib(ptfhost, testbed):
+def fib(ptfhost, testbed, localhost):
     logger.info("setup fib to topo {}".format(testbed['topo']['name']))
     if testbed['topo']['type'] == "t0":
-        fib_t0(ptfhost, testbed)
+        fib_t0(ptfhost, testbed, localhost)
     elif testbed['topo']['type'] == "t1":
-        fib_t1_lag(ptfhost, testbed)
+        fib_t1_lag(ptfhost, testbed, localhost)
     else:
         logger.error("unknonw topology {}".format(testbed['topo']['name']))

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -50,3 +50,21 @@ def wait_until(timeout, interval, condition, *args, **kwargs):
     if elapsed_time >= timeout:
         logging.debug("%s is still False after %d seconds, exit with False" % (condition.__name__, timeout))
         return False
+
+def wait_tcp_connection(client, server_hostname, listening_port, timeout_s = 30):
+    """
+    @summary: Wait until tcp connection is ready or timeout
+    @param client: The tcp client host instance
+    @param server_hostname: The tcp server hostname
+    @param listening_port: Port server is listening on
+    @param timeout: Maximum time to wait (30s in default)
+    """
+    res = client.wait_for(host=server_hostname,
+                          port=listening_port,
+                          state='started',
+                          timeout=timeout_s,
+                          module_ignore_errors=True)
+    if 'exception' in res:
+        logging.warn("Failed to establish TCP connection to %s:%d, timeout=%d" % (str(server_hostname), listening_port, timeout_s))
+        return False
+    return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add check and waiting for exabgp http server to get ready.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The exabgp plugin has a problem in handling **'started'** state:
The  start_exabgp method only checks the status returned by supervisorctl, 
```
def start_exabgp(module, name):
    refresh_supervisord(module)
    exec_command(module, cmd="supervisorctl start exabgp-%s" % name)

    for count in range(0, 60):
        time.sleep(1)
        status = get_exabgp_status(module, name)
        if u'RUNNING' == status:
            break
    assert u'RUNNING' == status
```
However, the http service (implemented in http_api.py) may be not ready at that time. As a result, the following call **announce_route** raises an exception. 
Actually, it takes more than 20 seconds for http server gets ready after running http_api.py in vtestbed.
#### How did you do it?
Add an End-to-End check and wait after **exabgp('started')**, until http server is ready.

#### How did you verify/test it?
Run **test_bgp_speaker.py** and **test_announce_routes.py** in my vtestbed.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.