### PR TITLE
[reboot] ignore module failure when checking SSH port status

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -111,7 +111,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
                              state='absent',
                              search_regex=SONIC_SSH_REGEX,
                              delay=delay,
-                             timeout=timeout)
+                             timeout=timeout,
+                             module_ignore_errors=True)
 
     if 'failed' in res:
         if reboot_res.ready():
@@ -128,8 +129,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
                              state='started',
                              search_regex=SONIC_SSH_REGEX,
                              delay=delay,
-                             timeout=timeout
-    )
+                             timeout=timeout,
+                             module_ignore_errors=True)
     if 'failed' in res:
         raise Exception('DUT did not startup')
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -46,7 +46,7 @@ reboot_ctrl_dict = {
     },
     REBOOT_TYPE_WARM: {
         "command": "warm-reboot",
-        "timeout": 210,
+        "timeout": 300,
         "wait": 90,
         "cause": "warm-reboot",
         "test_reboot_cause_only": False


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Reboot test has been failing recently.

#### How did you do it?
Without ignoring module failures, any command failure would be translated into exception.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Reboot test was failing waiting for switch to reboot or come back without this change. With this change. Reboot test made further progress:
(warm reboot test issue was addressed in second commit. watchdog reboot test failed due to image issue on the platform I ran test on).

============================================================================================= test session starts =============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 7 items                                                                                                                                                                                             

platform_tests/test_reboot.py::test_cold_reboot PASSED                                                                                                                                                  [ 14%]
platform_tests/test_reboot.py::test_fast_reboot PASSED                                                                                                                                                  [ 28%]
platform_tests/test_reboot.py::test_warm_reboot FAILED                                                                                                                                                  [ 42%]
platform_tests/test_reboot.py::test_power_off_reboot[15] SKIPPED                                                                                                                                        [ 57%]
platform_tests/test_reboot.py::test_power_off_reboot[5] SKIPPED                                                                                                                                         [ 71%]
platform_tests/test_reboot.py::test_watchdog_reboot FAILED                                                                                                                                              [ 85%]
platform_tests/test_reboot.py::test_continuous_reboot PASSED                                                                                                                                            [100%]

================================================================================================== FAILURES ===================================================================================================
