### PR TITLE
Add separation lines in log file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -344,6 +344,27 @@ def creds(duthost):
     return creds
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    logger.info("="*20 + " {} setup ".format(item.nodeid) + "="*20)
+    yield
+    logger.info("="*20 + " {} setup done ".format(item.nodeid) + "="*20)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    logger.info("="*20 + " {} call ".format(item.nodeid) + "="*20)
+    yield
+    logger.info("="*20 + " {} call done ".format(item.nodeid) + "="*20)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item):
+    logger.info("="*20 + " {} teardown ".format(item.nodeid) + "="*20)
+    yield
+    logger.info("="*20 + " {} teardown done ".format(item.nodeid) + "="*20)
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In the log file generated by specifying `-log-file` argument, it is hard to tell
where the setup/call/teardown sections start and end. This commit uses
pytest hooks to print some separation lines when test setup/call/teardown
sections start and end. With this change, it is much easier to analyze test
log files.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To make analyzing log files easier.

#### How did you do it?
Use pytest hook functions to print visually obvious separation lines when each setup/call/teardown section starts and ends.

#### How did you verify/test it?

Prepared a simple script like below:
```
import logging

logger = logging.getLogger(__name__)

def test_case1(duthost):
    duthost.shell("mv notexit2 notexit3")

def test_case2(duthost):
    duthost.command("pwd")
```

Run this script and check its result:
```
johnar@xiwang5-vm1:~/code/sonic-mgmt/tests$ pytest --inventory veos.vtb --host-pattern vlab-01  --testbed vms-kvm-t0 --testbed_file vt
estbed.csv --showlocals --assert plain test_sep_lines.py --log-file test_sep_lines.log --log-file-level debug --skip_sanity --disable_
loganalyzer                                                                                                                           
======================================================== test session starts =========================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1                                                               
ansible: 2.8.7                                                                                                                        
rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini                                                                       
plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2                                                                      
collected 2 items                                                                                                                     
                                                                                                                                      
test_sep_lines.py Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callba
ck/json.pyc                                                                                                                           
Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc       
F.                                                                                                           [100%]                   
                                                                                                                                      
============================================================== FAILURES ==============================================================
_____________________________________________________________ test_case1 _____________________________________________________________
                                                                                                                                      
duthost = <tests.common.devices.SonicHost object at 0x7ff276a44ad0>                                                                   
                                                                                                                                      
    def test_case1(duthost):                                                                                                          
>       duthost.shell("mv notexit2 notexit3")                                                                                         
                                                                                                                                      
duthost    = <tests.common.devices.SonicHost object at 0x7ff276a44ad0>                                                                
                                                                                                                                      
test_sep_lines.py:6:                                                                                                                  
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
                                                                                                                                      
self = <tests.common.devices.SonicHost object at 0x7ff276a44ad0>, module_args = ('mv notexit2 notexit3',), complex_args = {}          
previous_frame = <frame object at 0x7ff274b7db30>, filename = '/var/johnar/code/sonic-mgmt/tests/test_sep_lines.py', line_number = 6  
function_name = 'test_case1', lines = ['    duthost.shell("mv notexit2 notexit3")\n'], index = 0, module_ignore_errors = False        
module_async = False                                                                                                                  
                                                                                                                                      
    def _run(self, *module_args, **complex_args):                                                                                     
                                                                                                                                      
        previous_frame = inspect.currentframe().f_back                                                                                
        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)                                     
                                                                                                                                      
        logging.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}"\                                                        
            .format(filename, function_name, line_number, self.hostname,                                                              
                    self.module_name, json.dumps(module_args), json.dumps(complex_args)))                                             
                                                                                                                                      
        module_ignore_errors = complex_args.pop('module_ignore_errors', False)                                                        
        module_async = complex_args.pop('module_async', False)                                                                        
                                                                                                                                      
        if module_async:                                                                                                              
            def run_module(module_args, complex_args):                                                                                
                return self.module(*module_args, **complex_args)[self.hostname]                                                       
            pool = ThreadPool()                                                                                                       
            result = pool.apply_async(run_module, (module_args, complex_args))                                                        
            return pool, result                                                                                                       
                                                                                                                                      
        res = self.module(*module_args, **complex_args)[self.hostname]                                                                
        logging.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}"\                                                               
            .format(filename, function_name, line_number, self.hostname, self.module_name, json.dumps(res)))
                                                                                                                                      
        if res.is_failed and not module_ignore_errors:                                                                                
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)                                          
E           RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {
E               "changed": true, 
E               "cmd": "mv notexit2 notexit3", 
E               "delta": "0:00:00.004891", 
E               "end": "2020-06-25 03:39:53.837150", 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "mv notexit2 notexit3", 
E                       "_uses_shell": true, 
E                       "argv": null, 
E                       "chdir": null, 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2020-06-25 03:39:53.832259", 
E               "stderr": "mv: cannot stat 'notexit2': No such file or directory", 
E               "stderr_lines": [
E                   "mv: cannot stat 'notexit2': No such file or directory"
E               ], 
E               "stdout": "", 
E               "stdout_lines": []
E           }

complex_args = {}
filename   = '/var/johnar/code/sonic-mgmt/tests/test_sep_lines.py'
function_name = 'test_case1'
index      = 0
line_number = 6
lines      = ['    duthost.shell("mv notexit2 notexit3")\n']
module_args = ('mv notexit2 notexit3',)
module_async = False
module_ignore_errors = False
previous_frame = <frame object at 0x7ff274b7db30>
res        = {'stderr_lines': [u"mv: cannot stat 'notexit2': No such file or directory"], u...': True, u'stdin': None}}, 'stdout_lines
': [], u'msg': u'non-zero return code'}
self       = <tests.common.devices.SonicHost object at 0x7ff276a44ad0>

common/devices.py:82: RunAnsibleModuleFail
====================================================== short test summary info =======================================================
FAILED test_sep_lines.py::test_case1 - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
================================================= 1 failed, 1 passed in 9.89 seconds =================================================
INFO:tests.conftest:==================== test_sep_lines.py::test_case2 teardown done ====================
johnar@xiwang5-vm1:~/code/sonic-mgmt/tests$
johnar@xiwang5-vm1:~/code/sonic-mgmt/tests$ cat test_sep_lines.log
DEBUG    pytest_ansible.plugin:plugin.py:168 pytest_report_header() called
DEBUG    pytest_ansible.plugin:plugin.py:123 pytest_generate_tests() called
DEBUG    pytest_ansible.plugin:plugin.py:123 pytest_generate_tests() called
DEBUG    pytest_ansible.plugin:plugin.py:173 pytest_collection_modifyitems() called
DEBUG    pytest_ansible.plugin:plugin.py:174 items: [<Function test_case1>, <Function test_case2>]
INFO     tests.conftest:conftest.py:349 ==================== test_sep_lines.py::test_case1 setup ====================
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_platform_info#247: [vlab-01] AnsibleModule::comm
and, args=["show platform summary"], kwargs={}
DEBUG    passlib.registry:registry.py:294 registered 'md5_crypt' handler: <class 'passlib.handlers.md5_crypt.md5_crypt'>
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_platform_info#247: [vlab-01] AnsibleModule::comm
and Result => {"stderr_lines": [], "cmd": ["show", "platform", "summary"], "end": "2020-06-25 03:39:50.205646", "_ansible_no_log": fal
se, "stdout": "Platform: x86_64-kvm_x86_64-r0\nHwSKU: Force10-S6000\nASIC: vs", "changed": true, "rc": 0, "start": "2020-06-25 03:39:4
9.407627", "stderr": "", "delta": "0:00:00.798019", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": fa
lse, "strip_empty_ends": true, "_raw_params": "show platform summary", "removes": null, "argv": null, "creates": null, "chdir": null,
"stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Platform: x86_64-kvm_x86_64-r0", "HwSKU: Force10-S6000", "ASIC: vs"], "a
nsible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "warnings": ["Platform linux on host vlab-01 is using the discove
red Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change this. See https://docs.a
nsible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information."]}
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_npu_count#215: [vlab-01] AnsibleModule::shell, a
rgs=["cat /usr/share/sonic/device/x86_64-kvm_x86_64-r0/asic.conf"], kwargs={}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_npu_count#215: [vlab-01] AnsibleModule::shell Re
sult => {"stderr_lines": [], "cmd": "cat /usr/share/sonic/device/x86_64-kvm_x86_64-r0/asic.conf", "end": "2020-06-25 03:39:50.708984",
 "_ansible_no_log": false, "stdout": "NUM_ASIC=1", "changed": true, "rc": 0, "start": "2020-06-25 03:39:50.701175", "stderr": "", "del
ta": "0:00:00.007809", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true,
 "_raw_params": "cat /usr/share/sonic/device/x86_64-kvm_x86_64-r0/asic.conf", "removes": null, "argv": null, "creates": null, "chdir":
 null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["NUM_ASIC=1"]}
DEBUG    root:devices.py:216 [u'NUM_ASIC=1']
DEBUG    root:devices.py:221 num_npu = 1
DEBUG    root:devices.py:205 Gathered SonicHost facts: {"platform": "x86_64-kvm_x86_64-r0", "hwsku": "Force10-S6000", "asic_type": "vs
", "num_npu": 1}
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_os_version#263: [vlab-01] AnsibleModule::command
, args=["sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version"], kwargs={}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/devices.py::_get_os_version#263: [vlab-01] AnsibleModule::command
 Result => {"stderr_lines": [], "cmd": ["sonic-cfggen", "-y", "/etc/sonic/sonic_version.yml", "-v", "build_version"], "end": "2020-06-
25 03:39:51.492900", "_ansible_no_log": false, "stdout": "master.348-0542afb6", "changed": true, "rc": 0, "start": "2020-06-25 03:39:5
1.107554", "stderr": "", "delta": "0:00:00.385346", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": fa
lse, "strip_empty_ends": true, "_raw_params": "sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version", "removes": null, "argv"
: null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["master.348-0542afb6"]}
DEBUG    root:devices.py:187 ['swss', 'syncd', 'database', 'teamd', 'bgp', 'pmon', 'lldp', 'snmp']
DEBUG    root:devices.py:187 ['swss', 'syncd', 'database', 'teamd', 'bgp', 'pmon', 'lldp', 'snmp']
INFO     tests.conftest:conftest.py:332 dut vlab-01 belongs to groups [u'lab', u'sonic', 'fanout']
INFO     root:conftest.py:343 skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
INFO     root:conftest.py:343 skip empty var file ../ansible/group_vars/all/env.yml
INFO     common.plugins.sanity_check:__init__.py:45 Start pre-test sanity check
INFO     common.plugins.sanity_check:__init__.py:81 Sanity check settings: skip_sanity=True, check_items=set(['services', 'interfaces'
, 'processes', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False
INFO     common.plugins.sanity_check:__init__.py:84 Skip sanity check according to command line argument or configuration of test scri
pt.
INFO     root:__init__.py:15 Add start marker into DUT syslog
DEBUG    root:loganalyzer.py:137 Loganalyzer init
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#139: [vlab-01] AnsibleMo
dule::copy, args=[], kwargs={"dest": "/tmp/loganalyzer.py", "src": "/var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/syste
m_msg_handler.py"}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#139: [vlab-01] AnsibleModule::copy Result => {"changed": false, "group": "root", "uid": 0, "dest": "/tmp/loganalyzer.py", "checksum": "6ba56c783494447b3b7a9a42ef79bf5eb88a06c1", "_ansible_no_log": false, "invocation": {"module_args": {"directory_mode": null, "force": false, "remote_src": null, "dest": "/tmp/loganalyzer.py", "access_time": null, "access_time_format": "%Y%m%d%H%M.%S", "_original_basename": "system_msg_handler.py", "state": "file", "follow": true, "owner": null, "path": "/tmp/loganalyzer.py", "src": null, "group": null, "modification_time": null, "unsafe_writes": null, "delimiter": null, "regexp": null, "seuser": null, "recurse": false, "serole": null, "_diff_peek": null,
 "content": null, "setype": null, "mode": null, "modification_time_format": "%Y%m%d%H%M.%S", "selevel": null, "attributes": null, "bac
kup": null}}, "state": "file", "gid": 0, "mode": "0644", "path": "/tmp/loganalyzer.py", "owner": "root", "diff": {"after": {"path": "/
tmp/loganalyzer.py"}, "before": {"path": "/tmp/loganalyzer.py"}}, "size": 27384}
DEBUG    root:loganalyzer.py:150 Adding start marker 'test_case1.2020-06-25-03:39:55'
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_setup_marker#151: [vlab-01]
AnsibleModule::command, args=["python /tmp/loganalyzer.py --action init --run_id test_case1.2020-06-25-03:39:55"], kwargs={}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_setup_marker#151: [vlab-01]
AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["python", "/tmp/loganalyzer.py", "--action", "init", "--run_id", "test_case1.2020-06-25-03:39:55"], "end": "2020-06-25 03:39:53.463098", "_ansible_no_log": false, "stdout": "", "changed": true, "rc": 0, "start": "2020-06-25 03:39:53.381515", "stderr": "", "delta": "0:00:00.081583", "invocation": {"module_args": {"warn": true, "executable"
: null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "python /tmp/loganalyzer.py --action init --run_id test_case1.2
020-06-25-03:39:55", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdou
t_lines": []}
INFO     root:__init__.py:17 Load config and analyze log
INFO     tests.conftest:conftest.py:351 ==================== test_sep_lines.py::test_case1 setup done ====================
INFO     tests.conftest:conftest.py:356 ==================== test_sep_lines.py::test_case1 call ====================
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/test_sep_lines.py::test_case1#6: [vlab-01] AnsibleModule::shell, args=["mv notexit2 notexit3"], kwargs={}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/test_sep_lines.py::test_case1#6: [vlab-01] AnsibleModule::shell Result => {"stderr_lines": ["mv: cannot stat 'notexit2': No such file or directory"], "cmd": "mv notexit2 notexit3", "end": "2020-06-25 03:39:53.837150", "_ansible_no_log": false, "stdout": "", "changed": true, "start": "2020-06-25 03:39:53.832259", "delta": "0:00:00.004891", "stderr": "mv: cannot stat 'notexit2': No such file or directory", "rc": 1, "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "mv notexit2 notexit3", "removes": null, "argv": null, "creates"
: null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": [], "msg": "non-zero return code"}
INFO     tests.conftest:conftest.py:358 ==================== test_sep_lines.py::test_case1 call done ====================
INFO     tests.conftest:conftest.py:363 ==================== test_sep_lines.py::test_case1 teardown ====================
INFO     root:__init__.py:28 Add end marker into DUT syslog
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#47: [vlab-01] AnsibleModule::copy, args=[], kwargs={"dest": "/tmp/loganalyzer.py", "src": "/var/johnar/code/sonic-mgmt/tests/common/plugins/loganal
yzer/system_msg_handler.py"}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#47: [vlab-01] AnsibleModule::copy Result => {"changed": false, "group": "root", "uid": 0, "dest": "/tmp/loganalyzer.py", "checksum": "6ba56c783494447b3b7a9a42ef79bf5eb88a06c1", "_ansible_no_log": false, "invocation": {"module_args": {"directory_mode": null, "force": false, "remote_src": null, "dest": "/tmp/loganalyzer.py", "access_time": null, "access_time_format": "%Y%m%d%H%M.%S", "_original_basename": "system_
msg_handler.py", "state": "file", "follow": true, "owner": null, "path": "/tmp/loganalyzer.py", "src": null, "group": null, "modification_time": null, "unsafe_writes": null, "delimiter": null, "regexp": null, "seuser": null, "recurse": false, "serole": null, "_diff_pe
ek": null, "content": null, "setype": null, "mode": null, "modification_time_format": "%Y%m%d%H%M.%S", "selevel": null, "attributes":
null, "backup": null}}, "state": "file", "gid": 0, "mode": "0644", "path": "/tmp/loganalyzer.py", "owner": "root", "diff": {"after": {
"path": "/tmp/loganalyzer.py"}, "before": {"path": "/tmp/loganalyzer.py"}}, "size": 27384}
DEBUG    root:loganalyzer.py:51 Adding end marker 'test_case1.2020-06-25-03:39:55'
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#52: [vlab-01]
 AnsibleModule::command, args=["python /tmp/loganalyzer.py --action add_end_marker --run_id test_case1.2020-06-25-03:39:55"], kwargs={
}
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#52: [vlab-01]
 AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["python", "/tmp/loganalyzer.py", "--action", "add_end_marker", "--run_i
d", "test_case1.2020-06-25-03:39:55"], "end": "2020-06-25 03:39:54.892501", "_ansible_no_log": false, "stdout": "", "changed": true, "
rc": 0, "start": "2020-06-25 03:39:54.833886", "stderr": "", "delta": "0:00:00.058615", "invocation": {"module_args": {"warn": true, "
executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "python /tmp/loganalyzer.py --action add_end_marker
--run_id test_case1.2020-06-25-03:39:55", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "s
tdin": null}}, "stdout_lines": []}
INFO     tests.conftest:conftest.py:365 ==================== test_sep_lines.py::test_case1 teardown done ====================
INFO     tests.conftest:conftest.py:349 ==================== test_sep_lines.py::test_case2 setup ====================
INFO     root:__init__.py:15 Add start marker into DUT syslog                                                                         DEBUG    root:loganalyzer.py:137 Loganalyzer init                                                                                     DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#139: [vlab-01] AnsibleModule::copy, args=[], kwargs={"dest": "/tmp/loganalyzer.py", "src": "/var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/system_msg_handler.py"}                                                                                                                    
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::init#139: [vlab-01] AnsibleMo
dule::copy Result => {"changed": false, "group": "root", "uid": 0, "dest": "/tmp/loganalyzer.py", "checksum": "6ba56c783494447b3b7a9a4
2ef79bf5eb88a06c1", "_ansible_no_log": false, "invocation": {"module_args": {"directory_mode": null, "force": false, "remote_src": nul
l, "dest": "/tmp/loganalyzer.py", "access_time": null, "access_time_format": "%Y%m%d%H%M.%S", "_original_basename": "system_msg_handle
r.py", "state": "file", "follow": true, "owner": null, "path": "/tmp/loganalyzer.py", "src": null, "group": null, "modification_time":
 null, "unsafe_writes": null, "delimiter": null, "regexp": null, "seuser": null, "recurse": false, "serole": null, "_diff_peek": null,
 "content": null, "setype": null, "mode": null, "modification_time_format": "%Y%m%d%H%M.%S", "selevel": null, "attributes": null, "bac
kup": null}}, "state": "file", "gid": 0, "mode": "0644", "path": "/tmp/loganalyzer.py", "owner": "root", "diff": {"after": {"path": "/tmp/loganalyzer.py"}, "before": {"path": "/tmp/loganalyzer.py"}}, "size": 27384}                                                      DEBUG    root:loganalyzer.py:150 Adding start marker 'test_case2.2020-06-25-03:39:57'                                                 
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_setup_marker#151: [vlab-01] 
AnsibleModule::command, args=["python /tmp/loganalyzer.py --action init --run_id test_case2.2020-06-25-03:39:57"], kwargs={}          
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_setup_marker#151: [vlab-01]
AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["python", "/tmp/loganalyzer.py", "--action", "init", "--run_id", "test_c
ase2.2020-06-25-03:39:57"], "end": "2020-06-25 03:39:56.152620", "_ansible_no_log": false, "stdout": "", "changed": true, "rc": 0, "st
art": "2020-06-25 03:39:56.094543", "stderr": "", "delta": "0:00:00.058077", "invocation": {"module_args": {"warn": true, "executable"
: null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "python /tmp/loganalyzer.py --action init --run_id test_case2.2020-06-25-03:39:57", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdou
t_lines": []}                                                                                                                         INFO     root:__init__.py:17 Load config and analyze log                                                                              INFO     tests.conftest:conftest.py:351 ==================== test_sep_lines.py::test_case2 setup done ====================            INFO     tests.conftest:conftest.py:356 ==================== test_sep_lines.py::test_case2 call ====================                  DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/test_sep_lines.py::test_case2#9: [vlab-01] AnsibleModule::command, args=
["pwd"], kwargs={}                                                                                                   
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/test_sep_lines.py::test_case2#9: [vlab-01] AnsibleModule::command Result
 => {"stderr_lines": [], "cmd": ["pwd"], "end": "2020-06-25 03:39:56.532227", "_ansible_no_log": false, "stdout": "/home/admin", "chan
ged": true, "rc": 0, "start": "2020-06-25 03:39:56.524936", "stderr": "", "delta": "0:00:00.007291", "invocation": {"module_args": {"w
arn": true, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "pwd", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["/home/admin"]}                           
INFO     tests.conftest:conftest.py:358 ==================== test_sep_lines.py::test_case2 call done ====================
INFO     tests.conftest:conftest.py:363 ==================== test_sep_lines.py::test_case2 teardown ====================              INFO     root:__init__.py:28 Add end marker into DUT syslog                                                                           DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#47: [vlab-01] AnsibleModule::copy, args=[], kwargs={"dest": "/tmp/loganalyzer.py", "src": "/var/johnar/code/sonic-mgmt/tests/common/plugins/loganal
yzer/system_msg_handler.py"}                                                                                                          DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#47: [vlab-01]
 AnsibleModule::copy Result => {"changed": false, "group": "root", "uid": 0, "dest": "/tmp/loganalyzer.py", "checksum": "6ba56c7834944
47b3b7a9a42ef79bf5eb88a06c1", "_ansible_no_log": false, "invocation": {"module_args": {"directory_mode": null, "force": false, "remote
_src": null, "dest": "/tmp/loganalyzer.py", "access_time": null, "access_time_format": "%Y%m%d%H%M.%S", "_original_basename": "system_
msg_handler.py", "state": "file", "follow": true, "owner": null, "path": "/tmp/loganalyzer.py", "src": null, "group": null, "modificat
ion_time": null, "unsafe_writes": null, "delimiter": null, "regexp": null, "seuser": null, "recurse": false, "serole": null, "_diff_pe
ek": null, "content": null, "setype": null, "mode": null, "modification_time_format": "%Y%m%d%H%M.%S", "selevel": null, "attributes": 
null, "backup": null}}, "state": "file", "gid": 0, "mode": "0644", "path": "/tmp/loganalyzer.py", "owner": "root", "diff": {"after": {
"path": "/tmp/loganalyzer.py"}, "before": {"path": "/tmp/loganalyzer.py"}}, "size": 27384}                                            
DEBUG    root:loganalyzer.py:51 Adding end marker 'test_case2.2020-06-25-03:39:57'                                                    
DEBUG    root:devices.py:65 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#52: [vlab-01]
 AnsibleModule::command, args=["python /tmp/loganalyzer.py --action add_end_marker --run_id test_case2.2020-06-25-03:39:57"], kwargs={
}                                                                                                                                    
DEBUG    root:devices.py:79 /var/johnar/code/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::_add_end_marker#52: [vlab-01]
 AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["python", "/tmp/loganalyzer.py", "--action", "add_end_marker", "--run_i
d", "test_case2.2020-06-25-03:39:57"], "end": "2020-06-25 03:39:57.659116", "_ansible_no_log": false, "stdout": "", "changed": true, "
rc": 0, "start": "2020-06-25 03:39:57.564230", "stderr": "", "delta": "0:00:00.094886", "invocation": {"module_args": {"warn": true, "
executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "python /tmp/loganalyzer.py --action add_end_marker
--run_id test_case2.2020-06-25-03:39:57", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "s
tdin": null}}, "stdout_lines": []}                                                                                                    
INFO     tests.conftest:conftest.py:365 ==================== test_sep_lines.py::test_case2 teardown done ====================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
