### PR TITLE
[Platform API][pytest] Add basic tests for PSU class

### DIFF
--- a/tests/common/helpers/platform_api/psu.py
+++ b/tests/common/helpers/platform_api/psu.py
@@ -1,0 +1,70 @@
+""" This module provides interface to interact with the psu of the DUT
+    via platform API remotely """
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def psu_api(conn, name, args=None):
+    if args is None:
+        args = []
+    conn.request('POST', '/platform/psu/{}'.format(name), json.dumps({'args': args}))
+    resp = conn.getresponse()
+    res = json.loads(resp.read())['res']
+    logger.info('Executing psu API: "{}", arguments: "{}", result: "{}"'.format(name, args, res))
+    return res
+
+
+def get_num_fans(conn):
+    return psu_api(conn, 'get_num_fans')
+
+
+def get_all_fans(conn):
+    return psu_api(conn, 'get_all_fans')
+
+
+def get_fan(conn):
+    return psu_api(conn, 'get_fan', [index])
+
+
+def get_voltage(conn):
+    return psu_api(conn, 'get_voltage')
+
+
+def get_current(conn):
+    return psu_api(conn, 'get_current')
+
+
+def get_power(conn):
+    return psu_api(conn, 'get_power')
+
+
+def get_powergood_status(conn):
+    return psu_api(conn, 'get_powergood_status')
+
+
+def set_status_led(conn):
+    return psu_api(conn, 'set_status_led')
+
+
+def get_status_led(conn):
+    return psu_api(conn, 'get_status_led')
+
+
+def get_temperature(conn):
+    return psu_api(conn, 'get_temperature')
+
+
+def get_temperature_high_threshold(conn):
+    return psu_api(conn, 'get_temperature_high_threshold')
+
+
+def get_voltage_high_threshold(conn):
+    return psu_api(conn, 'get_voltage_high_threshold')
+
+
+def get_voltage_low_threshold(conn):
+    return psu_api(conn, 'get_voltage_low_threshold')
+

--- a/tests/common/helpers/platform_api/psu.py
+++ b/tests/common/helpers/platform_api/psu.py
@@ -1,5 +1,7 @@
-""" This module provides interface to interact with the psu of the DUT
-    via platform API remotely """
+"""
+This module provides an interface to remotely interact with the power
+supply units of the DUT via platform API
+"""
 
 import json
 import logging
@@ -7,64 +9,64 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def psu_api(conn, name, args=None):
+def psu_api(conn, psu_id, name, args=None):
     if args is None:
         args = []
-    conn.request('POST', '/platform/psu/{}'.format(name), json.dumps({'args': args}))
+    conn.request('POST', '/platform/chassis/psu/{}/{}'.format(psu_id, name), json.dumps({'args': args}))
     resp = conn.getresponse()
     res = json.loads(resp.read())['res']
-    logger.info('Executing psu API: "{}", arguments: "{}", result: "{}"'.format(name, args, res))
+    logger.info('Executing PSU API: "{}", arguments: "{}", result: "{}"'.format(name, args, res))
     return res
 
 
-def get_num_fans(conn):
-    return psu_api(conn, 'get_num_fans')
+def get_num_fans(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_num_fans')
 
 
-def get_all_fans(conn):
-    return psu_api(conn, 'get_all_fans')
+def get_all_fans(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_all_fans')
 
 
-def get_fan(conn):
-    return psu_api(conn, 'get_fan', [index])
+def get_fan(conn, psu_id, index):
+    return psu_api(conn, psu_id, 'get_fan', [index])
 
 
-def get_voltage(conn):
-    return psu_api(conn, 'get_voltage')
+def get_voltage(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_voltage')
 
 
-def get_current(conn):
-    return psu_api(conn, 'get_current')
+def get_current(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_current')
 
 
-def get_power(conn):
-    return psu_api(conn, 'get_power')
+def get_power(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_power')
 
 
-def get_powergood_status(conn):
-    return psu_api(conn, 'get_powergood_status')
+def get_powergood_status(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_powergood_status')
 
 
-def set_status_led(conn):
-    return psu_api(conn, 'set_status_led')
+def set_status_led(conn, psu_id, color):
+    return psu_api(conn, psu_id, 'set_status_led', [color])
 
 
-def get_status_led(conn):
-    return psu_api(conn, 'get_status_led')
+def get_status_led(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_status_led')
 
 
-def get_temperature(conn):
-    return psu_api(conn, 'get_temperature')
+def get_temperature(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_temperature')
 
 
-def get_temperature_high_threshold(conn):
-    return psu_api(conn, 'get_temperature_high_threshold')
+def get_temperature_high_threshold(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_temperature_high_threshold')
 
 
-def get_voltage_high_threshold(conn):
-    return psu_api(conn, 'get_voltage_high_threshold')
+def get_voltage_high_threshold(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_voltage_high_threshold')
 
 
-def get_voltage_low_threshold(conn):
-    return psu_api(conn, 'get_voltage_low_threshold')
+def get_voltage_low_threshold(conn, psu_id):
+    return psu_api(conn, psu_id, 'get_voltage_low_threshold')
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -1,0 +1,125 @@
+import logging
+import re
+
+import pytest
+import yaml
+
+from common.helpers.assertions import pytest_assert
+from common.helpers.platform_api import psu
+from common.helpers.platform_api import chassis
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+]
+
+STATUS_LED_COLOR_GREEN = "green"
+STATUS_LED_COLOR_AMBER = "amber"
+STATUS_LED_COLOR_RED = "red"
+STATUS_LED_COLOR_OFF = "off"
+
+class TestPSUAPI(object):
+    ''' Platform API test cases for the PSU class'''
+
+    def test_fans(self, duthost, localhost, platform_api_conn):
+        ''' PSU fan test '''
+        try:
+            num_psus = int(chassis.get_num_psus(platform_api_conn))
+        except:
+            pytest_assert("num_psus is not integer!")
+
+        for psu_id in range(num_psus):
+            psu = chassis.get_psu(platform_api_conn, psu_id)
+            try:
+                num_fans = int(psu.get_num_fans(platform_api_conn))
+            except:
+                pytest.fail("num_fans is not an integer!")
+
+            fan_list = psu.get_all_fans(platform_api_conn)
+            pytest_assert(fan_list is not None, "Failed to retrieve fans")
+            pytest_assert(isinstance(fan_list, list) and len(fan_list) == num_fans, "Fans appear to be incorrect")
+
+            for i in range(num_fans):
+                fan = psu.get_fan(platform_api_conn, i)
+                pytest_assert(fan and fan == fan_list[i], "Fan {} is incorrect".format(i))
+
+
+    def test_power(self, duthost, localhost, platform_api_conn):
+        ''' PSU power test '''
+        try:
+            num_psus = int(chassis.get_num_psus(platform_api_conn))
+        except:
+            pytest_assert("num_psus is not integer!")
+
+        for psu_id in range(num_psus):
+            psu = chassis.get_psu(platform_api_conn, psu_id)
+            voltage = psu.get_voltage(platform_api_conn)
+            current = psu.get_current(platform_api_conn)
+            power = psu.get_power(platform_api_conn)
+            pytest_assert(abs(power - (voltage*current)) > power*0.1, "Power is too off compared to the voltage and current reading")
+
+            powergood_status = psu.get_powergood_status(platform_api_conn)
+            pytest_assert(powergood_status is not True, "PSU Powergood status test returns failed")
+
+            try:
+                high_threshold = psu.get_voltage_high_threshold(platform_api_conn)
+                low_threshold = psu.get_voltage_low_threshold(platform_api_conn)
+            except NotImplementedError:
+                logger.warning('get_voltage_high/low_threshold is not implemented yet') 
+            else:
+                if high_threshold is not None and low_threshold is not None:
+                    pytest_assert(voltage > high_threshold or voltage < low_threshold, "Voltage is not in valid range")
+
+
+    def test_temperature(self, duthost, localhost, platform_api_conn):
+        ''' PSU temperature test '''
+        try:
+            num_psus = int(chassis.get_num_psus(platform_api_conn))
+        except:
+            pytest_assert("num_psus is not integer!")
+
+        for psu_id in range(num_psus):
+            psu = chassis.get_psu(platform_api_conn, psu_id)
+            try:
+                temperature = psu.get_temperature(platform_api_conn)
+            except NotImplementedError:
+                logger.warning('get_temperature is not implemented yet') 
+            else:
+                try:
+                    temp_threshold = psu.get_temperature_high_threshold(platform_api_conn)
+                except NotImplementedError:
+                    logger.warning('get_temperature_high_threshold is not implemented yet') 
+                else:
+                    pytest_assert(temperature > temp_threshold, "temperature is not in valid range")
+
+
+    def test_led(self, duthost, localhost, platform_api_conn):
+        ''' PSU status led test '''
+        LED_COLOR_LIST = [
+            STATUS_LED_COLOR_GREEN,
+            STATUS_LED_COLOR_AMBER,
+            STATUS_LED_COLOR_RED,
+            STATUS_LED_COLOR_OFF
+        ]
+        try:
+            num_psus = int(chassis.get_num_psus(platform_api_conn))
+        except:
+            pytest_assert("num_psus is not integer!")
+
+        for psu_id in range(num_psus):
+            psu = chassis.get_psu(platform_api_conn, psu_id)
+
+            for color in LED_COLOR_LIST:
+                try:
+                    result = psu.set_status_led(platform_api_conn, color)
+                except NotImplementedError:
+                    logger.warning('set_status_led is not implemented yet') 
+                else:
+                    if result is True:
+                        color_status = psu.get_status_led(platform_api_conn)
+                        pytest_assert(color == color_status, "get_status_led doesn't return {}".format(color))
+                    else:
+                        pytest_assert("set_status_led for {} return False")
+

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -20,7 +20,7 @@ STATUS_LED_COLOR_AMBER = "amber"
 STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
-class TestPSUAPI(object):
+class TestPsuApi(object):
     ''' Platform API test cases for the PSU class'''
 
     def test_fans(self, duthost, localhost, platform_api_conn):
@@ -38,12 +38,12 @@ class TestPSUAPI(object):
                 pytest.fail("num_fans is not an integer!")
 
             fan_list = psu.get_all_fans(platform_api_conn)
-            pytest_assert(fan_list is not None, "Failed to retrieve fans")
-            pytest_assert(isinstance(fan_list, list) and len(fan_list) == num_fans, "Fans appear to be incorrect")
+            pytest_assert(fan_list is not None, "Failed to retrieve fans of PSU {}".format(psu_id))
+            pytest_assert(isinstance(fan_list, list) and len(fan_list) == num_fans, "Fans of PSU {} appear to be incorrect".format(psu_id))
 
             for i in range(num_fans):
                 fan = psu.get_fan(platform_api_conn, i)
-                pytest_assert(fan and fan == fan_list[i], "Fan {} is incorrect".format(i))
+                pytest_assert(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
 
 
     def test_power(self, duthost, localhost, platform_api_conn):
@@ -58,19 +58,17 @@ class TestPSUAPI(object):
             voltage = psu.get_voltage(platform_api_conn)
             current = psu.get_current(platform_api_conn)
             power = psu.get_power(platform_api_conn)
-            pytest_assert(abs(power - (voltage*current)) > power*0.1, "Power is too off compared to the voltage and current reading")
+            pytest_assert(abs(power - (voltage*current)) > power*0.1, "PSU {} reading does not make sense \
+                (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
 
             powergood_status = psu.get_powergood_status(platform_api_conn)
-            pytest_assert(powergood_status is not True, "PSU Powergood status test returns failed")
+            pytest_assert(powergood_status is not None, "Failed to retrieve operational status of PSU {}".format(psu_id))
+            pytest_assert(powergood_status is not True, "PSU {} is not operational".format(psu_id))
 
-            try:
-                high_threshold = psu.get_voltage_high_threshold(platform_api_conn)
-                low_threshold = psu.get_voltage_low_threshold(platform_api_conn)
-            except NotImplementedError:
-                logger.warning('get_voltage_high/low_threshold is not implemented yet') 
-            else:
-                if high_threshold is not None and low_threshold is not None:
-                    pytest_assert(voltage > high_threshold or voltage < low_threshold, "Voltage is not in valid range")
+            high_threshold = psu.get_voltage_high_threshold(platform_api_conn)
+            low_threshold = psu.get_voltage_low_threshold(platform_api_conn)
+            pytest_assert(high_threshold is not None and low_threshold is not None, "Failed to retrieve the voltage threshold values of PSU {}".format(psu_id))
+            pytest_assert(voltage > high_threshold or voltage < low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
 
 
     def test_temperature(self, duthost, localhost, platform_api_conn):
@@ -82,17 +80,12 @@ class TestPSUAPI(object):
 
         for psu_id in range(num_psus):
             psu = chassis.get_psu(platform_api_conn, psu_id)
-            try:
-                temperature = psu.get_temperature(platform_api_conn)
-            except NotImplementedError:
-                logger.warning('get_temperature is not implemented yet') 
-            else:
-                try:
-                    temp_threshold = psu.get_temperature_high_threshold(platform_api_conn)
-                except NotImplementedError:
-                    logger.warning('get_temperature_high_threshold is not implemented yet') 
-                else:
-                    pytest_assert(temperature > temp_threshold, "temperature is not in valid range")
+            temperature = psu.get_temperature(platform_api_conn)
+            pytest_assert(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id))
+
+            temp_threshold = psu.get_temperature_high_threshold(platform_api_conn)
+            pytest_assert(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id))
+            pytest_assert(temperature > temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
 
 
     def test_led(self, duthost, localhost, platform_api_conn):
@@ -112,14 +105,10 @@ class TestPSUAPI(object):
             psu = chassis.get_psu(platform_api_conn, psu_id)
 
             for color in LED_COLOR_LIST:
-                try:
-                    result = psu.set_status_led(platform_api_conn, color)
-                except NotImplementedError:
-                    logger.warning('set_status_led is not implemented yet') 
-                else:
-                    if result is True:
-                        color_status = psu.get_status_led(platform_api_conn)
-                        pytest_assert(color == color_status, "get_status_led doesn't return {}".format(color))
-                    else:
-                        pytest_assert("set_status_led for {} return False")
+                result = psu.set_status_led(platform_api_conn, color)
+                pytest_assert(result is not None, "Failed to perform set_status_led of PSU {}".format(psu_id))
+                pytest_assert(result is not True, "Failed to set status_led of PSU {}".format(psu_id))
+
+                color_status = psu.get_status_led(platform_api_conn)
+                pytest_assert(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -31,18 +31,17 @@ class TestPsuApi(object):
             pytest_assert("num_psus is not integer!")
 
         for psu_id in range(num_psus):
-            psu = chassis.get_psu(platform_api_conn, psu_id)
             try:
-                num_fans = int(psu.get_num_fans(platform_api_conn))
+                num_fans = int(psu.get_num_fans(platform_api_conn, psu_id))
             except:
                 pytest.fail("num_fans is not an integer!")
 
-            fan_list = psu.get_all_fans(platform_api_conn)
+            fan_list = psu.get_all_fans(platform_api_conn, psu_id)
             pytest_assert(fan_list is not None, "Failed to retrieve fans of PSU {}".format(psu_id))
             pytest_assert(isinstance(fan_list, list) and len(fan_list) == num_fans, "Fans of PSU {} appear to be incorrect".format(psu_id))
 
             for i in range(num_fans):
-                fan = psu.get_fan(platform_api_conn, i)
+                fan = psu.get_fan(platform_api_conn, psu_id, i)
                 pytest_assert(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
 
 
@@ -54,21 +53,20 @@ class TestPsuApi(object):
             pytest_assert("num_psus is not integer!")
 
         for psu_id in range(num_psus):
-            psu = chassis.get_psu(platform_api_conn, psu_id)
-            voltage = psu.get_voltage(platform_api_conn)
-            current = psu.get_current(platform_api_conn)
-            power = psu.get_power(platform_api_conn)
-            pytest_assert(abs(power - (voltage*current)) > power*0.1, "PSU {} reading does not make sense \
+            voltage = psu.get_voltage(platform_api_conn, psu_id)
+            current = psu.get_current(platform_api_conn, psu_id)
+            power = psu.get_power(platform_api_conn, psu_id)
+            pytest_assert(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
                 (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
 
-            powergood_status = psu.get_powergood_status(platform_api_conn)
+            powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
             pytest_assert(powergood_status is not None, "Failed to retrieve operational status of PSU {}".format(psu_id))
-            pytest_assert(powergood_status is not True, "PSU {} is not operational".format(psu_id))
+            pytest_assert(powergood_status is True, "PSU {} is not operational".format(psu_id))
 
-            high_threshold = psu.get_voltage_high_threshold(platform_api_conn)
-            low_threshold = psu.get_voltage_low_threshold(platform_api_conn)
+            high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
+            low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
             pytest_assert(high_threshold is not None and low_threshold is not None, "Failed to retrieve the voltage threshold values of PSU {}".format(psu_id))
-            pytest_assert(voltage > high_threshold or voltage < low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
+            pytest_assert(voltage < high_threshold and voltage > low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
 
 
     def test_temperature(self, duthost, localhost, platform_api_conn):
@@ -79,13 +77,12 @@ class TestPsuApi(object):
             pytest_assert("num_psus is not integer!")
 
         for psu_id in range(num_psus):
-            psu = chassis.get_psu(platform_api_conn, psu_id)
-            temperature = psu.get_temperature(platform_api_conn)
+            temperature = psu.get_temperature(platform_api_conn, psu_id)
             pytest_assert(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id))
 
-            temp_threshold = psu.get_temperature_high_threshold(platform_api_conn)
+            temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
             pytest_assert(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id))
-            pytest_assert(temperature > temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
+            pytest_assert(temperature < temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
 
 
     def test_led(self, duthost, localhost, platform_api_conn):
@@ -102,13 +99,11 @@ class TestPsuApi(object):
             pytest_assert("num_psus is not integer!")
 
         for psu_id in range(num_psus):
-            psu = chassis.get_psu(platform_api_conn, psu_id)
-
             for color in LED_COLOR_LIST:
-                result = psu.set_status_led(platform_api_conn, color)
+                result = psu.set_status_led(platform_api_conn, psu_id, color)
                 pytest_assert(result is not None, "Failed to perform set_status_led of PSU {}".format(psu_id))
-                pytest_assert(result is not True, "Failed to set status_led of PSU {}".format(psu_id))
+                pytest_assert(result is True, "Failed to set status_led of PSU {}".format(psu_id))
 
-                color_status = psu.get_status_led(platform_api_conn)
+                color_status = psu.get_status_led(platform_api_conn, psu_id)
                 pytest_assert(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -5,12 +5,15 @@ import pytest
 import yaml
 
 from common.helpers.assertions import pytest_assert
-from common.helpers.platform_api import psu
-from common.helpers.platform_api import chassis
+from common.helpers.platform_api import chassis, psu
+
+from platform_api_test_base import PlatformApiTestBase
+
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
+    pytest.mark.topology('any'),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
 ]
@@ -20,69 +23,68 @@ STATUS_LED_COLOR_AMBER = "amber"
 STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
-class TestPsuApi(object):
+class TestPsuApi(PlatformApiTestBase):
     ''' Platform API test cases for the PSU class'''
+
+    num_psus = None
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, platform_api_conn):
+        if self.num_psus is None:
+            try:
+                self.num_psus = int(chassis.get_num_psus(platform_api_conn))
+            except:
+                pytest.fail("num_psus is not an integer")
+
 
     def test_fans(self, duthost, localhost, platform_api_conn):
         ''' PSU fan test '''
-        try:
-            num_psus = int(chassis.get_num_psus(platform_api_conn))
-        except:
-            pytest_assert("num_psus is not integer!")
-
-        for psu_id in range(num_psus):
+        for psu_id in range(self.num_psus):
             try:
                 num_fans = int(psu.get_num_fans(platform_api_conn, psu_id))
             except:
                 pytest.fail("num_fans is not an integer!")
 
             fan_list = psu.get_all_fans(platform_api_conn, psu_id)
-            pytest_assert(fan_list is not None, "Failed to retrieve fans of PSU {}".format(psu_id))
-            pytest_assert(isinstance(fan_list, list) and len(fan_list) == num_fans, "Fans of PSU {} appear to be incorrect".format(psu_id))
+            if self.expect(fan_list is not None, "Failed to retrieve fans of PSU {}".format(psu_id)):
+                self.expect(isinstance(fan_list, list) and len(fan_list) == num_fans, "Fans of PSU {} appear to be incorrect".format(psu_id))
 
             for i in range(num_fans):
                 fan = psu.get_fan(platform_api_conn, psu_id, i)
-                pytest_assert(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
+                self.expect(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
+        self.assert_expectations()
 
 
     def test_power(self, duthost, localhost, platform_api_conn):
         ''' PSU power test '''
-        try:
-            num_psus = int(chassis.get_num_psus(platform_api_conn))
-        except:
-            pytest_assert("num_psus is not integer!")
-
-        for psu_id in range(num_psus):
+        for psu_id in range(self.num_psus):
             voltage = psu.get_voltage(platform_api_conn, psu_id)
             current = psu.get_current(platform_api_conn, psu_id)
             power = psu.get_power(platform_api_conn, psu_id)
-            pytest_assert(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
+            self.expect(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
                 (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
 
             powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
-            pytest_assert(powergood_status is not None, "Failed to retrieve operational status of PSU {}".format(psu_id))
-            pytest_assert(powergood_status is True, "PSU {} is not operational".format(psu_id))
+            if self.expect(powergood_status is not None, "Failed to retrieve operational status of PSU {}".format(psu_id)):
+                self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
 
             high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
             low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
-            pytest_assert(high_threshold is not None and low_threshold is not None, "Failed to retrieve the voltage threshold values of PSU {}".format(psu_id))
-            pytest_assert(voltage < high_threshold and voltage > low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
+            if self.expect(high_threshold is not None and low_threshold is not None, "Failed to retrieve the voltage threshold values of PSU {}".format(psu_id)):
+                self.expect(voltage < high_threshold and voltage > low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
+        self.assert_expectations()
 
 
     def test_temperature(self, duthost, localhost, platform_api_conn):
         ''' PSU temperature test '''
-        try:
-            num_psus = int(chassis.get_num_psus(platform_api_conn))
-        except:
-            pytest_assert("num_psus is not integer!")
-
-        for psu_id in range(num_psus):
+        for psu_id in range(self.num_psus):
             temperature = psu.get_temperature(platform_api_conn, psu_id)
-            pytest_assert(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id))
+            self.expect(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id))
 
             temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
-            pytest_assert(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id))
-            pytest_assert(temperature < temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
+            if self.expect(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id)):
+                self.expect(temperature < temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
+        self.assert_expectations()
 
 
     def test_led(self, duthost, localhost, platform_api_conn):
@@ -93,17 +95,14 @@ class TestPsuApi(object):
             STATUS_LED_COLOR_RED,
             STATUS_LED_COLOR_OFF
         ]
-        try:
-            num_psus = int(chassis.get_num_psus(platform_api_conn))
-        except:
-            pytest_assert("num_psus is not integer!")
 
-        for psu_id in range(num_psus):
+        for psu_id in range(self.num_psus):
             for color in LED_COLOR_LIST:
                 result = psu.set_status_led(platform_api_conn, psu_id, color)
-                pytest_assert(result is not None, "Failed to perform set_status_led of PSU {}".format(psu_id))
-                pytest_assert(result is True, "Failed to set status_led of PSU {}".format(psu_id))
+                if self.expect(result is not None, "Failed to perform set_status_led of PSU {}".format(psu_id)):
+                    self.expect(result is True, "Failed to set status_led of PSU {}".format(psu_id))
 
                 color_status = psu.get_status_led(platform_api_conn, psu_id)
-                pytest_assert(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
+                self.expect(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
+        self.assert_expectations()
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -51,7 +51,8 @@ class TestPsuApi(PlatformApiTestBase):
 
             for i in range(num_fans):
                 fan = psu.get_fan(platform_api_conn, psu_id, i)
-                self.expect(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
+                if self.expect(fan is not None, "Failed to retrieve fan {} of PSU {}".format(i, psu_id)):
+                    self.expect(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
         self.assert_expectations()
 
 
@@ -95,8 +96,8 @@ class TestPsuApi(PlatformApiTestBase):
 
             temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
             if self.expect(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id)):
-                self.expect(isinstance(temp_threshold, float), "PSU {} temperature high threshold appears incorrect".format(psu_id))
-                self.expect(temperature < temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
+                if self.expect(isinstance(temp_threshold, float), "PSU {} temperature high threshold appears incorrect".format(psu_id)):
+                    self.expect(temperature < temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
         self.assert_expectations()
 
 
@@ -116,6 +117,8 @@ class TestPsuApi(PlatformApiTestBase):
                     self.expect(result is True, "Failed to set status_led of PSU {}".format(psu_id))
 
                 color_status = psu.get_status_led(platform_api_conn, psu_id)
-                self.expect(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
+                if self.expect(color_status is not None, "Failed to retrieve status_led of PSU {}".format(psu_id)):
+                    if self.expect(isinstance(color_status, str), "PSU {} status led color appears incorrect".format(psu_id)):
+                        self.expect(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -116,9 +116,9 @@ class TestPsuApi(PlatformApiTestBase):
                 if self.expect(result is not None, "Failed to perform set_status_led of PSU {}".format(psu_id)):
                     self.expect(result is True, "Failed to set status_led of PSU {}".format(psu_id))
 
-                color_status = psu.get_status_led(platform_api_conn, psu_id)
-                if self.expect(color_status is not None, "Failed to retrieve status_led of PSU {}".format(psu_id)):
-                    if self.expect(isinstance(color_status, str), "PSU {} status led color appears incorrect".format(psu_id)):
-                        self.expect(color == color_status, "Retrived the status_led {} not {} from PSU {}".format(color_status, color, psu_id))
+                color_actual = psu.get_status_led(platform_api_conn, psu_id)
+                if self.expect(color_actual is not None, "Failed to retrieve status_led of PSU {}".format(psu_id)):
+                    if self.expect(isinstance(color_actual, str), "PSU {} status LED color appears incorrect".format(psu_id)):
+                        self.expect(color == color_actual, "Retrived the status_led {} not {} from PSU {}".format(color_actual, color, psu_id))
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -59,18 +59,24 @@ class TestPsuApi(PlatformApiTestBase):
         ''' PSU power test '''
         for psu_id in range(self.num_psus):
             voltage = psu.get_voltage(platform_api_conn, psu_id)
+            self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id))
             current = psu.get_current(platform_api_conn, psu_id)
+            self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id))
             power = psu.get_power(platform_api_conn, psu_id)
-            self.expect(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
-                (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
+            self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id))
+            if current is not None and voltage is not None and power is not None:
+                self.expect(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
+                    (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
 
             powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
             if self.expect(powergood_status is not None, "Failed to retrieve operational status of PSU {}".format(psu_id)):
                 self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
 
             high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
+            self.expect(high_threshold is not None, "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id))
             low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
-            if self.expect(high_threshold is not None and low_threshold is not None, "Failed to retrieve the voltage threshold values of PSU {}".format(psu_id)):
+            self.expect(low_threshold is not None, "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id))
+            if high_threshold is not None and low_threshold is not None:
                 self.expect(voltage < high_threshold and voltage > low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -114,7 +114,7 @@ class TestPsuApi(PlatformApiTestBase):
             for color in LED_COLOR_LIST:
                 result = psu.set_status_led(platform_api_conn, psu_id, color)
                 if self.expect(result is not None, "Failed to perform set_status_led of PSU {}".format(psu_id)):
-                    self.expect(result is True, "Failed to set status_led of PSU {}".format(psu_id))
+                    self.expect(result is True, "Failed to set status_led of PSU {} to {}".format(psu_id, color))
 
                 color_actual = psu.get_status_led(platform_api_conn, psu_id)
                 if self.expect(color_actual is not None, "Failed to retrieve status_led of PSU {}".format(psu_id)):

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -85,7 +85,8 @@ class TestPsuApi(PlatformApiTestBase):
         ''' PSU temperature test '''
         for psu_id in range(self.num_psus):
             temperature = psu.get_temperature(platform_api_conn, psu_id)
-            self.expect(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id))
+            if self.expect(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id)):
+                self.expect(isinstance(temperature, float), "PSU {} temperature appears incorrect".format(psu_id))
 
             temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
             if self.expect(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id)):

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -59,11 +59,14 @@ class TestPsuApi(PlatformApiTestBase):
         ''' PSU power test '''
         for psu_id in range(self.num_psus):
             voltage = psu.get_voltage(platform_api_conn, psu_id)
-            self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id))
+            if self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id)):
+                self.expect(isinstance(voltage, float), "PSU {} voltage appears incorrect".format(psu_id))
             current = psu.get_current(platform_api_conn, psu_id)
-            self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id))
+            if self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id)):
+                self.expect(isinstance(current, float), "PSU {} current appears incorrect".format(psu_id))
             power = psu.get_power(platform_api_conn, psu_id)
-            self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id))
+            if self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id)):
+                self.expect(isinstance(power, float), "PSU {} power appears incorrect".format(psu_id))
             if current is not None and voltage is not None and power is not None:
                 self.expect(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
                     (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
@@ -73,9 +76,11 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
 
             high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
-            self.expect(high_threshold is not None, "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id))
+            if self.expect(high_threshold is not None, "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id)):
+                self.expect(isinstance(high_threshold, float), "PSU {} voltage high threshold appears incorrect".format(psu_id))
             low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
-            self.expect(low_threshold is not None, "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id))
+            if self.expect(low_threshold is not None, "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id)):
+                self.expect(isinstance(low_threshold, float), "PSU {} voltage low threshold appears incorrect".format(psu_id))
             if high_threshold is not None and low_threshold is not None:
                 self.expect(voltage < high_threshold and voltage > low_threshold, "Voltage {} of PSU {} is not in between {} and {}".format(voltage, psu_id, low_threshold, high_threshold))
         self.assert_expectations()
@@ -90,6 +95,7 @@ class TestPsuApi(PlatformApiTestBase):
 
             temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
             if self.expect(temp_threshold is not None, "Failed to retrieve temperature threshold of PSU {}".format(psu_id)):
+                self.expect(isinstance(temp_threshold, float), "PSU {} temperature high threshold appears incorrect".format(psu_id))
                 self.expect(temperature < temp_threshold, "Temperature {} of PSU {} is over the threshold {}".format(temperature, psu_id, temp_threshold))
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -119,6 +119,6 @@ class TestPsuApi(PlatformApiTestBase):
                 color_actual = psu.get_status_led(platform_api_conn, psu_id)
                 if self.expect(color_actual is not None, "Failed to retrieve status_led of PSU {}".format(psu_id)):
                     if self.expect(isinstance(color_actual, str), "PSU {} status LED color appears incorrect".format(psu_id)):
-                        self.expect(color == color_actual, "Retrived the status_led {} not {} from PSU {}".format(color_actual, color, psu_id))
+                        self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {}) from PSU {}".format(color, color_actual, psu_id))
         self.assert_expectations()
 


### PR DESCRIPTION
Add a basic test suite for the Psu class of the new platform API, utilizing the platform API HTTP server, including the following functions:
```
test_fans
test_power
test_temperature
test_led
```

Example test results summary:
```
========================================================================== short test summary info ===========================================================================
FAILED platform_tests/api/test_psu.py::TestPsuApi::test_power - Failed: Failed to retrieve the voltage threshold values of PSU 0
FAILED platform_tests/api/test_psu.py::TestPsuApi::test_temperature - Failed: Failed to retrieve temperature of PSU 0
FAILED platform_tests/api/test_psu.py::TestPsuApi::test_led - Failed: Failed to set status_led of PSU 0
==================================================================== 3 failed, 1 passed in 46.80 seconds =====================================================================
```
This result could be returned when these apis are not implemented yet in the platform api on DUT.
- get_voltage_high_threshold and get_voltage_low_threshold for test_power.
- get_temperature for test_temperature.
- set_status_led for test_led.
