### PR TITLE
[service_acl] Wait until SSH is in 'stopped' state rather than waiting for 'started' state to timeout

### DIFF
--- a/ansible/roles/test/tasks/service_acl.yml
+++ b/ansible/roles/test/tasks/service_acl.yml
@@ -21,20 +21,14 @@
   become: true
   shell: "nohup /tmp/config_service_acls.sh < /dev/null > /dev/null 2>&1 &"
 
-- name: Sleep a bit to allow config_service_acls.sh to apply the new service ACLs
-  pause:
-    seconds: 5
-
 - name: Ensure the SSH port on the DuT becomes closed to us
   local_action: wait_for
   args:
     host: "{{ ansible_host }}"
     port: 22
-    state: started
+    state: stopped
     search_regex: "OpenSSH"
     timeout: 10
-  register: result
-  failed_when: "'Timeout when waiting for search string OpenSSH' not in result.msg"
 
 # Gather facts with SNMP version 2
 - name: Ensure attempt to gather basic SNMP facts about the device now times out


### PR DESCRIPTION
With the recent changes to caclmgrd, this check was not consistent, and could potentially fail with the following error:

```
TASK [test : Ensure the SSH port on the DuT becomes closed to us] ********************************************************************************************************************
Friday 26 June 2020  01:17:14 +0000 (0:00:05.323)       0:01:29.829 ***********
fatal: [sonic-dut-1]: FAILED! => {"msg": "The conditional check ''Timeout when waiting for search string OpenSSH' not in result.msg' failed. The error was: error while evaluating conditional ('Timeout when waiting for search string OpenSSH' not in result.msg): Unable to look up a name or access an attribute in template string ({% if 'Timeout when waiting for search string OpenSSH' not in result.msg %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'AnsibleUndefined' is not iterable"}
```

`result` could potentially be `AnsibleUndefined`.

This changes the logic to match that of the new pytest, which is a more appropriate method of checking that we are no longer able to SSH to the device, and no longer relies on parsing an error message (see https://github.com/Azure/sonic-mgmt/blob/master/tests/cacl/test_control_plane_acl.py#L34). Also remove unnecessary sleep, which also aligns more with the pytest version.