### PR TITLE
[Platform API] HTTP server handles NotImplementedError

### DIFF
--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -76,7 +76,12 @@ class PlatformAPITestService(BaseHTTPRequestHandler):
         api = path.pop()
         args = request['args']
 
-        res = getattr(obj, api)(*args)
+        res = None
+
+        try:
+            res = getattr(obj, api)(*args)
+        except NotImplementedError as e:
+            syslog.syslog(syslog.LOG_WARNING, "API '{}' not implemented".format(api))
 
         response = BytesIO()
         response.write(json.dumps({'res': res}, default=obj_serialize))


### PR DESCRIPTION
Previously, if the HTTP server attempted to execute a non-implemented API, the API would throw `NotImplementedError`, but the HTTP server did not handle this exception, thus it would not send a proper HTTP response, causing the pytests to fail with `BadStatusLine`. Example:

```
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_name - BadStatusLine: ''
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_model - BadStatusLine: ''
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_serial - BadStatusLine: ''
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_status - BadStatusLine: ''
```

With this change, the HTTP server handles the exception and now sends a proper HTTP response containing `None`, which allows the pytests to interpret the failure properly. Example:

```
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_name - Failed: Unable to retrieve transceiver 0 name
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_model - Failed: Unable to retrieve transceiver 0 model
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_serial - Failed: Unable to retrieve transceiver 0 model
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_status - Failed: Unable to retrieve transceiver 0 status
```

The server will now also log a warning on the DuT.