### PR TITLE
correct telemetry certs creation to include subject name

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -162,8 +162,9 @@
         state: directory
         mode: '0755'
       become: true
-    
-    - name: Generate server cert using openssl. This need to be copied and renamed as dsmsroot.cer on ptfdocker
+
+    # {{ server_cer }}/ streamingtelemetryserver.cer need to be copied on PTFDocker and renamed as dsmsroot.cer    
+    - name: Generate server cert using openssl.
       command: openssl req \
           -x509 \
           -sha256 \
@@ -174,7 +175,8 @@
           -out "{{ server_cer }}" 
       become: true
 
-    - name: Generate dsmsroot cert using openssl. This need to be copied and renamed as streamingtelemetryclient.cer on ptfdocker
+    # {{ dsmsroot_cer }}/ dsmsroot.cer need to be copied on PTFDocker and renamed as streamingtelemetryclient.cer
+    - name: Generate dsmsroot cert using openssl.
       command: openssl req \
           -x509 \
           -sha256 \

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -176,6 +176,7 @@
       become: true
 
     # {{ dsmsroot_cer }}/ dsmsroot.cer need to be copied on PTFDocker and renamed as streamingtelemetryclient.cer
+    # {{ dsms_key }}/ dsmsroot.key need to be copied and renamed as streamingtelemetryclient.key
     - name: Generate dsmsroot cert using openssl.
       command: openssl req \
           -x509 \

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -126,10 +126,8 @@
     - name: Init telemetry keys
       set_fact:
         server_key: ""
-        server_csr: ""
         server_cer: ""
         dsmsroot_key: ""
-        dsmsroot_csr: ""
         dsmsroot_cer: ""
         dir_path: ""
 
@@ -137,11 +135,6 @@
       set_fact:
         server_key: "{{ telemetry_certs['server_key'] }}"
       when: telemetry_certs['server_key'] is defined
-
-    - name: read server csr
-      set_fact:
-        server_csr: "{{ telemetry_certs['server_csr'] }}"
-      when: telemetry_certs['server_csr'] is defined
 
     - name: read server cer
       set_fact:
@@ -152,11 +145,6 @@
       set_fact:
         dsmsroot_key: "{{ telemetry_certs['dsmsroot_key'] }}"
       when: telemetry_certs['dsmsroot_key'] is defined
-
-    - name: read dsmsroot csr
-      set_fact:
-        dsmsroot_csr: "{{ telemetry_certs['dsmsroot_csr'] }}"
-      when: telemetry_certs['dsmsroot_csr'] is defined
 
     - name: read dsmsroot cer
       set_fact:
@@ -174,51 +162,27 @@
         state: directory
         mode: '0755'
       become: true
-
-    - name: Create telemetry server private key
-      openssl_privatekey:
-        path: "{{ server_key }}"
-        size: 2048
-        mode: '0755'
+    
+    - name: Generate server cert using openssl. This need to be copied and renamed as dsmsroot.cer on ptfdocker
+      command: openssl req \
+          -x509 \
+          -sha256 \
+          -nodes \
+          -newkey rsa:2048 \
+          -keyout "{{ server_key }}"
+          -subj "/CN=ndastreamingservertest"
+          -out "{{ server_cer }}" 
       become: true
 
-    - name: create telemetry server csr
-      openssl_csr:
-        path: "{{ telemetry_certs['server_csr'] }}"
-        privatekey_path: "{{ server_key }}"
-      become: true
-
-    - name: Generate a Self Signed OpenSSL telemetry server certificate
-      openssl_certificate:
-        path: "{{ server_cer }}"
-        privatekey_path: "{{ server_key }}"
-        csr_path: "{{ server_csr }}"
-        subject:
-          commonName: ndastreamingservertest
-        provider: selfsigned
-      become: true
-
-    - name: Create telemetry dsmsroot private key
-      openssl_privatekey:
-        path: "{{ dsmsroot_key }}"
-        size: 2048
-        mode: '0755'
-      become: true
-
-    - name: create telemetry dsmsroot csr
-      openssl_csr:
-        path: "{{ dsmsroot_csr }}"
-        privatekey_path: "{{ dsmsroot_key }}"
-      become: true
-
-    - name: Generate a Self Signed OpenSSL telemetry dsmsroot certificate
-      openssl_certificate:
-        path: "{{ dsmsroot_cer }}"
-        privatekey_path: "{{ dsmsroot_key }}"
-        csr_path: "{{ dsmsroot_csr }}"
-        subject:
-          commonName: ndastreamingclienttest
-        provider: selfsigned
+    - name: Generate dsmsroot cert using openssl. This need to be copied and renamed as streamingtelemetryclient.cer on ptfdocker
+      command: openssl req \
+          -x509 \
+          -sha256 \
+          -nodes \
+          -newkey rsa:2048 \
+          -keyout "{{ dsmsroot_key }}"
+          -subj "/CN=ndastreamingclienttest"
+          -out "{{ dsmsroot_cer }}"
       become: true
 
   - block:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Correcting cert creation to include subject name 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
deploy-mg step is successful on vstestbed

<pre>PLAY RECAP ********************************************************************************************************************************************************************************************************
<font color="#C4A000">vlab-01</font>                    : <font color="#4E9A06">ok=36  </font> <font color="#C4A000">changed=8   </font> unreachable=0    failed=0    <font color="#06989A">skipped=13  </font> rescued=0    ignored=0   

Saturday 27 June 2020  01:15:15 +0000 (0:00:01.031)       0:01:25.234 ********* 
=============================================================================== 
execute cli &quot;config load_minigraph -y&quot; to apply new minigraph --------------------------------------------------------------------------------------------------------------------------------------------- 74.14s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:291 ----------------------------------------------------------------------------------------------------------------------------------------------
find interface name mapping and individual interface speed if defined -------------------------------------------------------------------------------------------------------------------------------------- 1.66s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:83 -----------------------------------------------------------------------------------------------------------------------------------------------
execute cli &quot;config save -y&quot; to save current minigraph as startup-config ----------------------------------------------------------------------------------------------------------------------------------- 1.03s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:304 ----------------------------------------------------------------------------------------------------------------------------------------------
create new minigraph file for SONiC device ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.88s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:194 ----------------------------------------------------------------------------------------------------------------------------------------------
execute cli &quot;config bgp startup all&quot; to bring up all bgp sessions for test --------------------------------------------------------------------------------------------------------------------------------- 0.64s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:295 ----------------------------------------------------------------------------------------------------------------------------------------------
Generate dsmsroot cert using openssl. This need to be copied and renamed as streamingtelemetryclient.cer on ptfdocker -------------------------------------------------------------------------------------- 0.63s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:177 ----------------------------------------------------------------------------------------------------------------------------------------------
Generate server cert using openssl. This need to be copied and renamed as dsmsroot.cer on ptfdocker -------------------------------------------------------------------------------------------------------- 0.46s
/var/pramoh/sonic-mgmt/ansible/config_sonic_basedon_testbed.yml:166 ----------------------------------------------------------------------------------------------------------------------------------------------
Gathering testbed information ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.44s
</pre>

Certs on duT:
<pre><font color="#8AE234"><b>dmin@vlab-01</b></font>:<font color="#729FCF"><b>/etc/sonic/telemetry</b></font>$ ls -l
total 16
-rw-r--r-- 1 root root 1135 Jun 26 22:56 dsmsroot.cer
-rw------- 1 root root 1704 Jun 26 22:56 dsmsroot.key
-rw-r--r-- 1 root root 1135 Jun 26 22:56 streamingtelemetryserver.cer
-rw------- 1 root root 1704 Jun 26 22:56 streamingtelemetryserver.key
</pre>

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
