### PR TITLE
Add topology marker to testcases 

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.acl,
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('t1')
 ]
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -83,7 +84,7 @@ def setup(duthost, testbed):
     # get the list of port to be combined to ACL tables
     if testbed['topo']['name'] in ('t1', 't1-lag'):
         acl_table_ports += tor_ports
-    
+
     if testbed['topo']['name'] in ('t1-lag', 't1-64-lag', 't1-64-lag-clet'):
         acl_table_ports += port_channels
     else:

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -9,6 +9,10 @@ from ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 # Globals
 PTFRUNNER_QLEN = 1000
 VXLAN_CONFIG_FILE = '/tmp/vxlan_decap.json'
@@ -62,16 +66,16 @@ class TestWrArp:
             Get the IP which will be used by ferret script from the "ip route show type unicast"
             command output. The output looks as follows:
 
-            default proto 186 src 10.1.0.32 metric 20 
+            default proto 186 src 10.1.0.32 metric 20
                 nexthop via 10.0.0.57  dev PortChannel0001 weight 1
                 nexthop via 10.0.0.59  dev PortChannel0002 weight 1
                 nexthop via 10.0.0.61  dev PortChannel0003 weight 1
                 nexthop via 10.0.0.63  dev PortChannel0004 weight 1
-            10.0.0.56/31 dev PortChannel0001 proto kernel scope link src 10.0.0.56 
-            10.232.24.0/23 dev eth0 proto kernel scope link src 10.232.24.122 
-            100.1.0.29 via 10.0.0.57 dev PortChannel0001 proto 186 src 10.1.0.32 metric 20 
-            192.168.0.0/21 dev Vlan1000 proto kernel scope link src 192.168.0.1 
-            192.168.8.0/25 proto 186 src 10.1.0.32 metric 20 
+            10.0.0.56/31 dev PortChannel0001 proto kernel scope link src 10.0.0.56
+            10.232.24.0/23 dev eth0 proto kernel scope link src 10.232.24.122
+            100.1.0.29 via 10.0.0.57 dev PortChannel0001 proto 186 src 10.1.0.32 metric 20
+            192.168.0.0/21 dev Vlan1000 proto kernel scope link src 192.168.0.1
+            192.168.8.0/25 proto 186 src 10.1.0.32 metric 20
                 nexthop via 10.0.0.57  dev PortChannel0001 weight 1
                 nexthop via 10.0.0.59  dev PortChannel0002 weight 1
                 nexthop via 10.0.0.61  dev PortChannel0003 weight 1
@@ -80,11 +84,11 @@ class TestWrArp:
             ...
 
             We'll use the first subnet IP taken from zebra protocol as the base for the host IP.
-            As in the new SONiC image the proto will look as '186'(201911) or bgp (master) 
-            instead of 'zebra' (like it looks in 201811)the filtering output command below will pick 
+            As in the new SONiC image the proto will look as '186'(201911) or bgp (master)
+            instead of 'zebra' (like it looks in 201811)the filtering output command below will pick
             the first line containing either 'proto zebra' (or 'proto 186' or 'proto bgp')
             (except the one for the deafult route) and take host IP from the subnet IP. For the output
-            above 192.168.8.0/25 subnet will be taken and host IP given to ferret script will be 192.168.8.1               
+            above 192.168.8.0/25 subnet will be taken and host IP given to ferret script will be 192.168.8.1
         '''
         result = duthost.shell(
             cmd='''ip route show type unicast |
@@ -107,7 +111,7 @@ class TestWrArp:
 
         logger.info('Generate pem and key files for ssl')
         ptfhost.command(
-            cmd='''openssl req -new -x509 -keyout test.key -out test.pem -days 365 -nodes 
+            cmd='''openssl req -new -x509 -keyout test.key -out test.pem -days 365 -nodes
             -subj "/C=10/ST=Test/L=Test/O=Test/OU=Test/CN=test.com"''',
             chdir='/opt'
         )

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_bgp_facts(duthost):
     """compare the bgp facts between observed states and target state"""

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -4,6 +4,10 @@ import ipaddress
 from common.helpers.assertions import pytest_assert
 from common.utilities import wait_until
 
+pytestmark = [
+    pytest.mark.topology('t1')
+]
+
 logger = logging.getLogger(__name__)
 
 def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart):

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -8,6 +8,9 @@ from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/un
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
 
 def generate_ips(num, prefix, exclude_ips):
     """

--- a/tests/cacl/test_control_plane_acl.py
+++ b/tests/cacl/test_control_plane_acl.py
@@ -1,7 +1,8 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer globally
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
+    pytest.mark.topology('t1')
 ]
 
 SONIC_SSH_PORT  = 22

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -37,6 +37,10 @@ from ptf_runner import ptf_runner
 from common.system_utils import docker
 from common.broadcom_data import is_broadcom_device
 
+pytestmark = [
+    pytest.mark.topology('t1')
+]
+
 _COPPTestParameters = namedtuple("_COPPTestParameters",
                                  ["nn_target_port",
                                   "pkt_tx_count",

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 PTFRUNNER_QLEN = 1000
 FIB_INFO_DEST = "/root/fib_info.txt"
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def get_uplink_ports(topology, topo_type):
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -6,6 +6,9 @@ from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/un
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
 
 @pytest.fixture(scope="module")
 def dut_dhcp_relay_data(duthost, ptfhost, testbed):
@@ -20,7 +23,7 @@ def dut_dhcp_relay_data(duthost, ptfhost, testbed):
     host_facts = duthost.setup()['ansible_facts']
 
     # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
-    vlan_dict = mg_facts['minigraph_vlans'] 
+    vlan_dict = mg_facts['minigraph_vlans']
     for vlan_iface_name, vlan_info_dict in vlan_dict.items():
         # Gather information about the downlink VLAN interface this relay agent is listening on
         downlink_vlan_iface = {}
@@ -50,7 +53,7 @@ def dut_dhcp_relay_data(duthost, ptfhost, testbed):
         for iface_name, neighbor_info_dict in mg_facts['minigraph_neighbors'].items():
             if neighbor_info_dict['name'] in mg_facts['minigraph_devices']:
                 neighbor_device_info_dict = mg_facts['minigraph_devices'][neighbor_info_dict['name']]
-                if 'type' in neighbor_device_info_dict and neighbor_device_info_dict['type'] == 'LeafRouter': 
+                if 'type' in neighbor_device_info_dict and neighbor_device_info_dict['type'] == 'LeafRouter':
                     # If this uplink's physical interface is a member of a portchannel interface,
                     # we record the name of the portchannel interface here, as this is the actual
                     # interface the DHCP relay will listen on.

--- a/tests/drop_counters/test_configurable_drop_counters.py
+++ b/tests/drop_counters/test_configurable_drop_counters.py
@@ -23,6 +23,10 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import fanout_switch_port_lookup
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 PACKET_COUNT = 1000
 
 VLAN_INDEX = 0

--- a/tests/drop_counters/test_drop_counters.py
+++ b/tests/drop_counters/test_drop_counters.py
@@ -15,6 +15,10 @@ import netaddr
 
 from common.utilities import wait_until
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 PKT_NUMBER = 1000

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -9,6 +9,10 @@ import pprint
 
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 DEFAULT_FDB_ETHERNET_TYPE = 0x1234
 DUMMY_MAC_PREFIX = "02:11:22:33"
 DUMMY_MAC_COUNT = 10
@@ -17,7 +21,6 @@ FDB_WAIT_EXPECTED_PACKET_TIMEOUT = 5
 PKT_TYPES = ["ethernet", "arp_request", "arp_reply"]
 
 logger = logging.getLogger(__name__)
-
 
 def send_eth(ptfadapter, source_port, source_mac, dest_mac):
     """

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -5,6 +5,10 @@ import time
 from common.helpers.assertions import pytest_assert
 from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm [py/unused-import]
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 logger = logging.getLogger(__name__)
 
 class TestFdbMacExpire:
@@ -146,7 +150,7 @@ class TestFdbMacExpire:
     @pytest.fixture(scope="class", autouse=True)
     def validateDummyMacAbsent(self, duthost):
         """
-            Validates that test/dummy MAC entry is absent before the test runs 
+            Validates that test/dummy MAC entry is absent before the test runs
 
             Args:
                 duthost (AnsibleHost): Device Under Test (DUT)
@@ -202,7 +206,7 @@ class TestFdbMacExpire:
 
             Args:
                 request (Fixture): pytest request object
-                testbed (Fixture, dict): Map containing testbed information 
+                testbed (Fixture, dict): Map containing testbed information
                 duthost (AnsibleHost): Device Under Test (DUT)
                 ptfhost (AnsibleHost): Packet Test Framework (PTF)
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -5,11 +5,15 @@ import logging
 
 from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
-from datetime import datetime 
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
-# Usually src-mac, dst-mac, vlan-id are optional hash keys. Not all the platform supports these optional hash keys. Not enable these three by default. 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+# Usually src-mac, dst-mac, vlan-id are optional hash keys. Not all the platform supports these optional hash keys. Not enable these three by default.
 # HASH_KEYS = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'ingress-port', 'src-mac', 'dst-mac', 'ip-proto', 'vlan-id']
 HASH_KEYS = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'ingress-port', 'ip-proto']
 SRC_IP_RANGE = ['8.0.0.0', '8.255.255.255']
@@ -75,7 +79,7 @@ def get_vlan_untag_ports(config_facts):
             for port_name, tag_mode in vlan_member_info.items():
                 if tag_mode['tagging_mode'] == 'untagged':
                     vlan_untag_ports.append(port_name)
-    
+
     return vlan_untag_ports
 
 def get_router_interface_ports(config_facts, testbed):

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -6,6 +6,10 @@ from common.devices import AnsibleHostBase
 from common.utilities import wait
 from netaddr import IPAddress
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -11,6 +11,10 @@ LAG_TOPO = {'t0', 't1-lag'}
 DEFAULT_HLIM_TTL = 64
 WAIT_EXPECTED_PACKET_TIMEOUT = 5
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -4,6 +4,10 @@ from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/un
 from ptf_runner import ptf_runner
 from datetime import datetime
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 def test_dir_bcast(duthost, ptfhost, testbed, fib):
     support_testbed_types = frozenset(['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116'])
     testbed_type = testbed['topo']['name']

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -6,6 +6,9 @@ from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/un
 from ptf_runner import ptf_runner
 from datetime import datetime
 
+pytestmark = [
+    pytest.mark.topology('t1')
+]
 
 @pytest.mark.parametrize("mtu", [1514,9114])
 def test_mtu(testbed, duthost, ptfhost, mtu):

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -3,6 +3,10 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_topo(testbed):
     if testbed['topo']['type'] == 'ptf':

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -8,6 +8,7 @@ import pytest
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
 ]
 
 @pytest.fixture(scope="module")

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -11,6 +11,10 @@ from common.devices import AnsibleHostBase
 from common.fixtures.conn_graph_facts import conn_graph_facts
 from common.utilities import wait_until
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 @pytest.fixture(scope="module")
 def common_setup_teardown(duthost, ptfhost, testbed):
     logging.info("########### Setup for lag testing ###########")

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -2,6 +2,10 @@ import time
 import pytest
 import logging
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 def test_po_update(duthost):
     """
     test port channel add/deletion as well ip address configuration

--- a/tests/pfc_asym/test_pfc_asym.py
+++ b/tests/pfc_asym/test_pfc_asym.py
@@ -1,5 +1,9 @@
 from ptf_runner import ptf_runner
+import pytest
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
 
 def test_pfc_asym_off_tx_pfc(ptfhost, setup, pfc_storm_runner):
     """

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -15,7 +15,10 @@ CONFIG_TEST_EXPECT_INVALID_ACTION_RE = ".* Invalid PFC Watchdog action .*"
 CONFIG_TEST_EXPECT_INVALID_DETECT_TIME_RE = ".* Failed to parse PFC Watchdog .* detection_time .*"
 CONFIG_TEST_EXPECT_INVALID_RESTORE_TIME_RE = ".* Failed to parse PFC Watchdog .* restoration_time .*"
 
-pytestmark = [pytest.mark.disable_loganalyzer] # disable automatic fixture and invoke within each test
+pytestmark = [
+    pytest.mark.disable_loganalyzer, # disable automatic fixture and invoke within each test
+    pytest.mark.topology('any')
+]
 
 def create_run_dir():
     """

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -11,7 +11,10 @@ TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templ
 EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
 EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
 
-pytestmark = [pytest.mark.disable_loganalyzer]
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -19,7 +19,10 @@ WD_ACTION_MSG_PFX = { "dontcare": "Verify PFCWD detection when queue buffer is n
                       "forward": "Verify proper function of forward action"
                     }
 
-pytestmark = [pytest.mark.disable_loganalyzer]
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -7,6 +7,10 @@ from common.helpers.assertions import pytest_assert
 from common.helpers.pfc_storm import PFCStorm
 from files.pfcwd_helper import start_wd_on_ports
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -10,7 +10,8 @@ from common.helpers.platform_api import chassis
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
 ]
 
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -5,6 +5,10 @@ import yaml
 import pytest
 from common.helpers.platform_api import watchdog
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 TEST_CONFIG_FILE = os.path.join(os.path.split(__file__)[0], "watchdog.yml")

--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.broadcom
+    pytest.mark.broadcom,
+    pytest.mark.topology('any')
 ]
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -27,10 +28,10 @@ pause_ssh_timeout = True
 def test_ser(duthost):
     '''
     @summary: Broadcom SER injection test use Broadcom SER injection utility to insert SER
-              into different memory tables. Before the SER injection, Broadcom mem/sram scanners 
+              into different memory tables. Before the SER injection, Broadcom mem/sram scanners
               are started and syslog file location is marked.
               The test is invoked using:
-              pytest platform/broadcom/test_ser.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv 
+              pytest platform/broadcom/test_ser.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv
                                                    --host-pattern=vms12-t0-s6000-1 --module-path=../ansible/library
     @param duthost: Ansible framework testbed DUT device
     '''

--- a/tests/platform_tests/mellanox/test_check_sfp_presence.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_presence.py
@@ -4,8 +4,13 @@ Cross check show sfp presence with qsfp_status
 import logging
 import os
 import json
+import pytest
 
 from common.fixtures.conn_graph_facts import conn_graph_facts
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_check_sfp_presence(duthost, conn_graph_facts):
     """This test case is to check SFP presence status with CLI and sysfs.
@@ -22,4 +27,4 @@ def test_check_sfp_presence(duthost, conn_graph_facts):
         logging.info(str(presence_list))
         assert intf in presence_list, "Wrong interface name in the output %s" % str(presence_list)
         assert 'Present' in presence_list, "Status is not expected, output %s" % str(presence_list)
-        
+

--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -7,10 +7,13 @@ https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 import logging
 import os
 import json
-
+import pytest
 from common.fixtures.conn_graph_facts import conn_graph_facts
 from check_hw_mgmt_service import check_hw_management_service
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_check_sfp_using_ethtool(duthost, conn_graph_facts):
     """This test case is to check SFP using the ethtool.

--- a/tests/platform_tests/mellanox/test_check_sysfs.py
+++ b/tests/platform_tests/mellanox/test_check_sysfs.py
@@ -5,9 +5,12 @@ This script covers the test case 'Check SYSFS' in the SONiC platform test plan:
 https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
-
+import pytest
 from check_sysfs import check_sysfs
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_check_hw_mgmt_sysfs(duthost):
     """This test case is to check the symbolic links under /var/run/hw-management

--- a/tests/platform_tests/mellanox/test_hw_management_service.py
+++ b/tests/platform_tests/mellanox/test_hw_management_service.py
@@ -4,9 +4,12 @@ Verify that the hw-management service is running properly
 This script covers test case 'Ensure that the hw-management service is running properly' in the SONiC platform test
 plan: https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
-
+import pytest
 from check_hw_mgmt_service import check_hw_management_service
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_hw_management_service_status(duthost):
     """This test case is to verify that the hw-management service is running properly

--- a/tests/platform_tests/mellanox/test_thermal_control.py
+++ b/tests/platform_tests/mellanox/test_thermal_control.py
@@ -9,6 +9,10 @@ from common.utilities import wait_until
 from ..thermal_control_test_helper import *
 from mellanox_thermal_control_test_helper import MockerHelper, AbnormalFanMocker
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 THERMAL_CONTROL_TEST_WAIT_TIME = 65
 THERMAL_CONTROL_TEST_CHECK_INTERVAL = 5
 
@@ -69,7 +73,7 @@ def test_set_psu_fan_speed(duthost, mocker_factory):
     single_fan_mocker.mock_absence()
     assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME, THERMAL_CONTROL_TEST_CHECK_INTERVAL, check_cooling_cur_state, duthost, 10, operator.eq), \
         'Current cooling state is {}'.format(get_cooling_cur_state(duthost))
-    
+
     logging.info('Wait {} seconds for the policy to take effect...'.format(THERMAL_CONTROL_TEST_CHECK_INTERVAL))
     time.sleep(THERMAL_CONTROL_TEST_CHECK_INTERVAL)
     full_speeds = []

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -3,6 +3,10 @@ import pytest
 from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 @pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot):
     '''

--- a/tests/platform_tests/test_link_flap.py
+++ b/tests/platform_tests/test_link_flap.py
@@ -5,6 +5,10 @@ import pytest
 from common.platform.device_utils import fanout_switch_port_lookup
 from common.utilities import wait_until
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 class TestLinkFlap:
     def __get_dut_if_status(self, dut, ifname=None):
         if not ifname:
@@ -74,7 +78,6 @@ class TestLinkFlap:
                 fanout.no_shutdown(fanout_port)
 
 
-@pytest.mark.topology('any')
 @pytest.mark.platform('physical')
 def test_link_flap(duthost, fanouthosts):
     tlf = TestLinkFlap()

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -16,6 +16,10 @@ from common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from common.utilities import wait_until
 from thermal_control_test_helper import *
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 CMD_PLATFORM_SUMMARY = "show platform summary"
 CMD_PLATFORM_PSUSTATUS = "show platform psustatus"
 CMD_PLATFORM_FANSTATUS = "show platform fan"
@@ -513,7 +517,7 @@ def test_thermal_control_fan_status(duthost, mocker_factory):
             logging.info('Mocking the fault FAN back to normal...')
             single_fan_mocker.mock_status(True)
             check_cli_output_with_mocker(dut, single_fan_mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
-        
+
         loganalyzer.expect_regex = [LOG_EXPECT_FAN_OVER_SPEED_RE]
         with loganalyzer:
             logging.info('Mocking an over speed FAN...')

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -26,7 +26,10 @@ from common.platform.daemon_utils import check_pmon_daemon_status
 
 from check_critical_services import check_critical_services
 
-pytestmark = [pytest.mark.disable_loganalyzer]
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
 
 MAX_WAIT_TIME_FOR_INTERFACES = 300
 MAX_WAIT_TIME_FOR_REBOOT_CAUSE = 120

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -16,7 +16,10 @@ from check_critical_services import check_critical_services
 from check_transceiver_status import check_transceiver_basic
 from check_all_interface_info import check_interface_information
 
-pytestmark = [pytest.mark.disable_loganalyzer]
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
 
 
 def test_reload_configuration(duthost, conn_graph_facts):

--- a/tests/platform_tests/test_sensors.py
+++ b/tests/platform_tests/test_sensors.py
@@ -3,6 +3,10 @@ import logging
 
 from common.helpers.assertions import pytest_assert
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 def test_sensors(duthost, creds):
     # Get platform name
     platform = duthost.facts['platform']

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -16,8 +16,10 @@ from check_critical_services import check_critical_services
 from check_transceiver_status import check_transceiver_basic
 from check_all_interface_info import check_interface_information
 
-pytestmark = [pytest.mark.disable_loganalyzer]
-
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
 
 def restart_service_and_check(localhost, dut, service, interfaces):
     """

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -25,7 +25,8 @@ def teardown_module():
     ans_host.file(path=file_path, state='absent')
 
 pytestmark = [
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
 ]
 
 def parse_output(output_lines):

--- a/tests/platform_tests/test_syseeprom.py
+++ b/tests/platform_tests/test_syseeprom.py
@@ -10,9 +10,9 @@ import pytest
 CMD_PLATFORM_SYSEEPROM = "show platform syseeprom"
 
 pytestmark = [
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
 ]
-
 
 def test_show_platform_syseeprom(duthost):
     """

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -7,10 +7,13 @@ https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 import logging
 import re
 import os
-
+import pytest
 from check_transceiver_status import check_transceiver_status
 from common.fixtures.conn_graph_facts import conn_graph_facts
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_xcvr_info_in_db(duthost, conn_graph_facts):
     """

--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -7,6 +7,9 @@ from common.utilities import wait
 
 logger = logging.getLogger('__name__')
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def parse_column_positions(separation_line, separation_char='-'):
     '''Parse the position of each columns in the command output

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -3,6 +3,7 @@ from qos_fixtures import leaf_fanouts
 from qos_helpers import eos_to_linux_intf
 import os
 import time
+import pytest
 
 """
 This module implements test cases for PFC counters of SONiC.
@@ -12,6 +13,10 @@ The PFC Rx counter should NOT be updated when the switch receives a global flow 
 In each test case, we send a specific number of pause/unpause frames to a given priority queue of a given port at the
 device under test (DUT). Then we check the SONiC PFC Rx counters.
 """
+
+pytestmark = [
+    pytest.mark.topology('t0')
+]
 
 PFC_GEN_FILE_RELATIVE_PATH = r'../../ansible/roles/test/files/helpers/pfc_gen.py'
 """ Expected PFC generator path at the leaf fanout switch """

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -9,6 +9,10 @@ from common.fixtures.conn_graph_facts import conn_graph_facts
 from qos_fixtures import lossless_prio_dscp_map, leaf_fanouts
 from qos_helpers import ansible_stdout_to_str, eos_to_linux_intf, start_pause, stop_pause, setup_testbed, gen_testbed_t0, PFC_GEN_FILE, PFC_GEN_REMOTE_PATH
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 PFC_PKT_COUNT = 1000000000
 
 PTF_FILE_LOCAL_PATH = '../../ansible/roles/test/files/ptftests/pfc_pause_test.py'

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -27,6 +27,10 @@ from qos_sai_base import QosSaiBase
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 class TestQosSai(QosSaiBase):
     """
         TestQosSai derives from QosSaiBase and contains collection of QoS SAI test cases.

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -1,6 +1,11 @@
+import pytest
 import ipaddress
 import logging
 from common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -11,6 +11,10 @@ from common  import config_reload
 from common.utilities import wait_until
 from netaddr import *
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='module',autouse=True)
@@ -32,9 +36,9 @@ def setup(duthost, ptfhost):
     var['dut_intf_ips'] = ['20.1.1.1','30.1.1.1']
     var['mgmt_ip'] = mg_facts['minigraph_mgmt_interface']['addr']
     var['lo_ip'] =  mg_facts['minigraph_lo_interfaces'][0]['addr']
- 
+
     config_dut_ports(duthost,var['test_ports'][0:2],vlan=1000)
- 
+
     for port_channel, interfaces in mg_facts['minigraph_portchannels'].items():
         port = interfaces['members'][0]
         var['sflow_ports'][port] = {}
@@ -67,16 +71,16 @@ def setup_ptf(ptfhost, collector_ports):
     ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py", dest="/opt")
     ptfhost.shell('supervisorctl reread')
     ptfhost.shell('supervisorctl update')
-    for i in range(len(collector_ports)): 
-        ptfhost.shell('ifconfig eth%s %s/24' %(collector_ports[i],var['collector%s'%i]['ip_addr'])) 
+    for i in range(len(collector_ports)):
+        ptfhost.shell('ifconfig eth%s %s/24' %(collector_ports[i],var['collector%s'%i]['ip_addr']))
     ptfhost.copy(content=var['portmap'],dest="/tmp/sflow_ports.json")
 
 # ----------------------------------------------------------------------------------
 
 def config_dut_ports(duthost, ports, vlan):
-   # https://github.com/Azure/sonic-buildimage/issues/2665 
-   # Introducing config vlan member add and remove for the test port due to above mentioned PR. 
-   # Even though port is deleted from vlan , the port shows its master as Bridge upon assigning ip address. 
+   # https://github.com/Azure/sonic-buildimage/issues/2665
+   # Introducing config vlan member add and remove for the test port due to above mentioned PR.
+   # Even though port is deleted from vlan , the port shows its master as Bridge upon assigning ip address.
    # Hence config reload is done as workaround. ##FIXME
     for i in range(len(ports)):
         duthost.command('config vlan member add %s %s' %(vlan,ports[i]))
@@ -90,7 +94,7 @@ def config_dut_ports(duthost, ports, vlan):
 
 def get_ifindex(duthost, port):
      ifindex = duthost.shell('cat /sys/class/net/%s/ifindex' %port)['stdout']
-     return ifindex 
+     return ifindex
 # ----------------------------------------------------------------------------------
 
 def config_sflow(duthost, sflow_status='enable'):
@@ -100,17 +104,17 @@ def config_sflow(duthost, sflow_status='enable'):
 # ----------------------------------------------------------------------------------
 
 def config_sflow_interfaces(duthost, intf, **kwargs):
- 
+
     if 'status' in kwargs:
         duthost.shell('config sflow interface %s %s'%(kwargs['status'],intf))
-    if 'sample_rate' in kwargs: 
+    if 'sample_rate' in kwargs:
         duthost.shell('config sflow interface sample-rate %s %s' %(intf,kwargs['sample_rate']))
 
 # ----------------------------------------------------------------------------------
 
 def config_sflow_collector(duthost, collector, config):
      collector = var[collector]
-     if config == 'add': 
+     if config == 'add':
           duthost.shell('config sflow collector add %s %s --port %s ' %(collector['name'],collector['ip_addr'],collector['port']))
      elif config == 'del':
           duthost.shell('config sflow collector  del %s' %collector['name'])
@@ -127,13 +131,13 @@ def verify_show_sflow(duthost, status, **kwargs):
         assert re.search("sFlow AgentID:\s+%s"%kwargs['agent_id'],show_sflow), "Sflow Agent Id is not %s" %kwargs['agent_id']
     if 'collector' in kwargs:
         collector = kwargs['collector']
-        if len(collector) is None: 
+        if len(collector) is None:
             assert re.search("0 Collectors configured",show_sflow)," Expected 0 collectors , but collectors are present"
-        else: 
+        else:
             assert re.search("%s Collectors configured:"%len(collector),show_sflow) ,"Number of Sflow collectors should be %s"%len(collector)
-            for col  in collector: 
+            for col  in collector:
                 assert re.search("Name:\s+%s\s+IP addr:\s%s\s+UDP port:\s%s"%(var[col]['name'],var[col]['ip_addr'],var[col]['port']),show_sflow) , "col %s is not properly Configured" %col
-    
+
 # ----------------------------------------------------------------------------------
 
 def verify_sflow_interfaces(duthost, intf, status, sampling_rate):
@@ -181,12 +185,12 @@ def sflowbase_config(duthost, testbed):
 
 class TestSflowCollector():
     """
-    Test Sflow with 2 collectors , adding or removibg collector and verify collector samples 
+    Test Sflow with 2 collectors , adding or removibg collector and verify collector samples
     """
 
     def test_sflow_config(self, duthost, partial_ptf_runner):
-        # Enable sflow globally and enable sflow on 4 test interfaces 
-        # add single collector , send traffic and check samples are received in collector 
+        # Enable sflow globally and enable sflow on 4 test interfaces
+        # add single collector , send traffic and check samples are received in collector
         config_sflow(duthost,'enable')
         config_sflow_collector(duthost,'collector0','add')
         duthost.command("config sflow interface disable all")
@@ -195,7 +199,7 @@ class TestSflowCollector():
         verify_show_sflow(duthost,status='up',collector=['collector0'])
         for intf in var['sflow_ports']:
             verify_sflow_interfaces(duthost,intf,'up',512)
-        time.sleep(5) 
+        time.sleep(5)
         partial_ptf_runner(
               enabled_sflow_interfaces=var['sflow_ports'].keys(),
               active_collectors="['collector0']" )
@@ -218,16 +222,16 @@ class TestSflowCollector():
               enabled_sflow_interfaces=var['sflow_ports'].keys(),
               active_collectors="['collector0']" )
 
-    
+
     def test_two_collectors(self, sflowbase_config, duthost, partial_ptf_runner):
-        #add 2 collectors with 2 different udp ports and check samples are received in both collectors 
+        #add 2 collectors with 2 different udp ports and check samples are received in both collectors
         verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
         time.sleep(2)
         partial_ptf_runner(
               enabled_sflow_interfaces=var['sflow_ports'].keys(),
               active_collectors="['collector0','collector1']" )
 
-        # Remove second collector anc check samples are received in only 1st collector 
+        # Remove second collector anc check samples are received in only 1st collector
         config_sflow_collector(duthost,'collector1','del')
         verify_show_sflow(duthost,status='up',collector=['collector0'])
         time.sleep(5)
@@ -235,19 +239,19 @@ class TestSflowCollector():
               enabled_sflow_interfaces=var['sflow_ports'].keys(),
               active_collectors="['collector0']" )
 
-        #Re-add second collector and check if samples are received in both collectors again 
+        #Re-add second collector and check if samples are received in both collectors again
         config_sflow_collector(duthost,'collector1','add')
         verify_show_sflow(duthost,status='up',collector=['collector0','collector1'])
-        time.sleep(5)        
+        time.sleep(5)
         partial_ptf_runner(
               enabled_sflow_interfaces=var['sflow_ports'].keys(),
               active_collectors="['collector0','collector1']" )
 
-        # Add third collector and check only 2 collectors can be configured 
+        # Add third collector and check only 2 collectors can be configured
         out = duthost.command("config sflow collector add collector2 192.168.0.5 ",module_ignore_errors=True)
         assert "Only 2 collectors can be configured, please delete one" in out['stdout']
-            
-        #remove first collector and check DUT sends samples to collector 2 woth non default port number (6344)  
+
+        #remove first collector and check DUT sends samples to collector 2 woth non default port number (6344)
         config_sflow_collector(duthost,'collector0','del')
         verify_show_sflow(duthost,status='up',collector=['collector1'])
         time.sleep(10)
@@ -261,12 +265,12 @@ class TestSflowCollector():
 
 class TestSflowPolling():
     """
-    Test Sflow polling with different polling interval and check whether the test interface sends one counter sample for every polling interval 
+    Test Sflow polling with different polling interval and check whether the test interface sends one counter sample for every polling interval
     Disable polling and check the dut doesn't send counter samples .
     """
 
     def testPolling(self, sflowbase_config, duthost, partial_ptf_runner):
-        duthost.shell("config sflow polling-interval 20")        
+        duthost.shell("config sflow polling-interval 20")
         verify_show_sflow(duthost,status='up',polling_int=20)
         partial_ptf_runner(
               polling_int=20,
@@ -311,7 +315,7 @@ class TestSflowInterface():
               active_collectors="['collector0','collector1']" )
 
     def testIntfSamplingRate(self, sflowbase_config, duthost, ptfhost, partial_ptf_runner):
-       
+
         #re-add ports with different sampling rate
         sflow_int = sorted(var['sflow_ports'].keys())
         test_intf = sflow_int[0]
@@ -329,13 +333,13 @@ class TestSflowInterface():
         partial_ptf_runner(
               enabled_sflow_interfaces=sflow_int,
               active_collectors="['collector0','collector1']" )
-  
+
     def testIntfChangeSamplingRate(self, sflowbase_config, duthost, partial_ptf_runner, ptfhost):
 
         sflow_int = sorted(var['sflow_ports'].keys())
         test_intf = sflow_int[0]
         test_intf1 =  sflow_int[1]
-        # revert the sampling rate to 512 on both ports 
+        # revert the sampling rate to 512 on both ports
         config_sflow_interfaces(duthost,test_intf,sample_rate=512)
         config_sflow_interfaces(duthost,test_intf1,sample_rate=512)
         var['sflow_ports'][test_intf]['sample_rate'] = 512
@@ -352,9 +356,9 @@ class TestSflowInterface():
 
 class TestAgentId():
     """
-    Add loopback0 ip as the agent id and check the samples are received with intended agent-id. 
+    Add loopback0 ip as the agent id and check the samples are received with intended agent-id.
     Remove agent-ip and check whether samples are received with previously cofigured agent ip.
-    Add eth0 ip as the agent ip and check the samples are received with intended agent-id. 
+    Add eth0 ip as the agent ip and check the samples are received with intended agent-id.
     """
 
     def testNonDefaultAgent(self, sflowbase_config, duthost, partial_ptf_runner):
@@ -372,7 +376,7 @@ class TestAgentId():
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost,status='up',agent_id='default')
         time.sleep(5)
-        #Verify  whether the samples are received with previously configured agent ip 
+        #Verify  whether the samples are received with previously configured agent ip
         partial_ptf_runner(
               polling_int=20,
               agent_id=var['lo_ip'],

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -9,6 +9,10 @@ from log_messages import *
 import logging
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 SUCCESS_CODE = 0
 DEFAULT_LOOP_RANGE = 10
 DEFAULT_LOOP_DELAY = 10

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -4,6 +4,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 @pytest.mark.bsl
 def test_snmp_cpu(duthost, localhost, creds):
     """

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -1,5 +1,8 @@
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 @pytest.mark.bsl
 def test_snmp_interfaces(duthost, localhost, creds):

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,5 +1,8 @@
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_topo(testbed):

--- a/tests/snmp/test_snmp_pfc_counters.py
+++ b/tests/snmp/test_snmp_pfc_counters.py
@@ -1,5 +1,9 @@
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 def test_snmp_pfc_counters(duthost, localhost, creds):
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -2,6 +2,10 @@ import pytest
 
 PSU_STATUS_OK = 2
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 @pytest.mark.bsl
 def test_snmp_numpsu(duthost, localhost, creds):
 

--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -1,5 +1,8 @@
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 def test_snmp_queues(duthost, localhost, creds, collect_techsupport):
 

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -3,6 +3,7 @@ import pytest
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
 ]
 
 def test_ro_user(localhost, duthost, creds, setup_tacacs):

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -3,7 +3,8 @@ import crypt
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
 ]
 
 def test_rw_user(duthost, creds, setup_tacacs):
@@ -14,7 +15,7 @@ def test_rw_user(duthost, creds, setup_tacacs):
         {'ansible_user':creds['tacacs_rw_user'], 'ansible_password':creds['tacacs_rw_user_passwd']})
 
     res = duthost.shell("cat /etc/passwd")
-    
+
     for l in res['stdout_lines']:
         fds = l.split(':')
         if fds[0] == "testadmin":

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,4 +1,9 @@
+import pytest
 from common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 # Helper functions
 def get_dict_stdout(gnmi_out, certs_out):
@@ -26,7 +31,7 @@ def test_config_db_parameters(duthost):
     gnmi = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|gnmi"', module_ignore_errors=False)['stdout_lines']
     pytest_assert(gnmi is not None, "TELEMETRY|gnmi does not exist in config_db")
 
-    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']    
+    certs = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "TELEMETRY|certs"', module_ignore_errors=False)['stdout_lines']
     pytest_assert(certs is not None, "TELEMETRY|certs does not exist in config_db")
 
     d = get_dict_stdout(gnmi, certs)

--- a/tests/test_announce_routes.py
+++ b/tests/test_announce_routes.py
@@ -1,5 +1,9 @@
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('util') #special marker
+]
+
 def test_announce_routes(fib):
     """Simple test case that utilize fib to announce route in order to a newly setup test bed receive
        BGP routes from remote devices

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,4 +1,10 @@
 # Helper Functions
+import pytest
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 def get_dict_stdout(cmd_out):
     """Extract dictionary from show features command output
     """

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,6 +1,10 @@
 from netaddr import IPAddress
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 def test_interfaces(duthost):
     """compare the interfaces between observed states and target state"""
 

--- a/tests/test_mgmtvrf.py
+++ b/tests/test_mgmtvrf.py
@@ -6,6 +6,10 @@ from common.utilities import wait_until
 import re
 import logging
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -6,6 +6,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('util') #special marker
 ]
 
 def check_snmp(hostname, mgmt_addr, localhost, community):

--- a/tests/test_procdockerstatsd.py
+++ b/tests/test_procdockerstatsd.py
@@ -1,4 +1,9 @@
 from common.helpers.assertions import pytest_assert
+import pytest
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 # Helper Functions
 def get_count_fromredisout(keys_out):

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -33,6 +33,10 @@ from common.utilities import wait_until
     So, we prefer a fixture rather than xunit-style setup/teardown functions.
 """
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 # global variables
 g_vars = {}
 

--- a/tests/test_vrf_attr.py
+++ b/tests/test_vrf_attr.py
@@ -1,15 +1,18 @@
 import pytest
 
 from test_vrf import (
-    g_vars, 
-    setup_vrf, 
-    host_facts, 
-    cfg_facts, 
-    gen_vrf_neigh_file, 
+    g_vars,
+    setup_vrf,
+    host_facts,
+    cfg_facts,
+    gen_vrf_neigh_file,
     partial_ptf_runner
 )
-from ptf_runner import ptf_runner                     
+from ptf_runner import ptf_runner
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
 
 # tests
 class TestVrfAttrSrcMac():

--- a/tests/testbed_setup/test_populate_fdb.py
+++ b/tests/testbed_setup/test_populate_fdb.py
@@ -2,6 +2,10 @@ import pytest
 
 from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 def test_populate_fdb(populate_fdb):
     """
         Populates DUT FDB entries

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 vlan_id_list = [ 100, 200 ]
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
 
 @pytest.fixture(scope="module")
 def cfg_facts(duthost):

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -10,6 +10,10 @@ from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/un
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 logger = logging.getLogger(__name__)
 
 VTEP2_IP = "8.8.8.8"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add topology marker to testcases  to support organising testcases according to topology.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To organise testcases according to topology so that we could run certain testcases on certain topology.
#### How did you do it?
Add topology marker to each testcase.
```
pytestmark = [ 
    pytest.mark.topology('t0', 't1')
] 
```

#### How did you verify/test it?
The framework has been verified in another PR.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Please refer to https://github.com/Azure/sonic-mgmt/blob/master/tests/docs/pytest.org.md.