### PR TITLE
Fix 'description' KeyError while checking bgp session state on VMs

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -6,7 +6,7 @@ from common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
-def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart):
+def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart, testbed):
     """
     Verify that DUT routes are preserved when peer performed graceful restart
     """
@@ -52,8 +52,10 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
     bgp_nbr = bgp_neighbors[str(bgp_nbr_ipv4)]
     nbr_hostname = bgp_nbr['name']
     nbrhost = nbrhosts[nbr_hostname]['host']
+    topo = testbed['topo']['properties']['configuration_properties']
+    exabgp_ips = [topo['common']['nhipv4'], topo['common']['nhipv6']]
     exabgp_sessions = ['exabgp_v4', 'exabgp_v6']
-    pytest_assert(nbrhost.check_bgp_session_state([], exabgp_sessions), \
+    pytest_assert(nbrhost.check_bgp_session_state(exabgp_ips, exabgp_sessions), \
             "exabgp sessions {} are not up before graceful restart".format(exabgp_sessions))
 
     # shutdown Rib agent, starting gr process
@@ -85,7 +87,7 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
         nbrhost.start_bgpd()
 
         # wait for exabgp sessions to establish
-        pytest_assert(wait_until(300, 10, nbrhost.check_bgp_session_state, [], exabgp_sessions), \
+        pytest_assert(wait_until(300, 10, nbrhost.check_bgp_session_state, exabgp_ips, exabgp_sessions), \
             "exabgp sessions {} are not coming back".format(exabgp_sessions))
     except:
         raise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

On VMs with older version (for example vEOS-lab-4.20.15M), there is no
'description' field in the output of 'show ip bgp summary'. The
EosHost::check_bgp_session_state method call will fail with 'KeyError'.

Other changes:
* Fix the issue of appending wrong item to the neigh_ok list.
* Convert IPv6 address to lower case before comparing

```
ARISTA01T1#show version
Arista vEOS
Hardware version:    
Serial number:       
System MAC address:  5254.0039.53f5

Software image version: 4.20.15M
Architecture:           i386
Internal build version: 4.20.15M-13793783.42015M
Internal build ID:      93912965-5173-490d-8662-ecb360cf75a0

Uptime:                 1 weeks, 4 days, 7 hours and 51 minutes
Total memory:           2016960 kB
Free memory:            1003088 kB

ARISTA01T1#show ip bgp summary | json
{
    "vrfs": {
        "default": {
            "routerId": "100.1.0.29",
            "peers": {
                "10.10.246.254": {
                    "msgSent": 14956,
                    "inMsgQueue": 0,
                    "prefixReceived": 6399,
                    "upDownTime": 1592633457.45427,
                    "version": 4,
                    "msgReceived": 27713,
                    "prefixAccepted": 6399,
                    "peerState": "Established",
                    "outMsgQueue": 0,
                    "underMaintenance": false,
                    "asn": "64600"
                },
                "10.0.0.56": {
                    "msgSent": 169117,
                    "inMsgQueue": 0,
                    "prefixReceived": 2,
                    "upDownTime": 1593332252.453814,
                    "version": 4,
                    "msgReceived": 184815,
                    "prefixAccepted": 2,
                    "peerState": "Established",
                    "outMsgQueue": 0,
                    "underMaintenance": false,
                    "asn": "65100"
                }
            },
            "vrf": "default",
            "asn": "64600"
        }
    }
}
```

```
ARISTA04T1#show ver
 cEOSLab
Hardware version:
Serial number:
System MAC address:  0a76.ab53.f828

Software image version: 4.23.2F
Architecture:           x86_64
Internal build version: 4.23.2F-15409035.4232F
Internal build ID:      8466ca7e-e60a-453e-8c2f-7b2cf6ad1960

cEOS tools version: 1.1

Uptime:                 2 weeks, 3 days, 8 hours and 36 minutes
Total memory:           65842360 kB
Free memory:            12013956 kB

ARISTA04T1#show ip bgp summary | json
{
    "vrfs": {
        "default": {
            "routerId": "100.1.0.32",
            "peers": {
                "10.10.246.254": {
                    "prefixReceived": 6399,
                    "description": "exabgp_v4",
                    "msgSent": 245,
                    "inMsgQueue": 0,
                    "underMaintenance": false,
                    "prefixInBest": 6399,
                    "upDownTime": 1593414858.49912,
                    "version": 4,
                    "msgReceived": 6642,
                    "prefixAccepted": 6399,
                    "peerState": "Established",
                    "outMsgQueue": 0,
                    "prefixInBestEcmp": 0,
                    "asn": "64600"
                },
                "10.0.0.62": {
                    "prefixReceived": 2,
                    "description": "65100",
                    "msgSent": 8011,
                    "inMsgQueue": 0,
                    "underMaintenance": false,
                    "prefixInBest": 2,
                    "upDownTime": 1593414853.498686,
                    "version": 4,
                    "msgReceived": 14421,
                    "prefixAccepted": 2,
                    "peerState": "Established",
                    "outMsgQueue": 0,
                    "prefixInBestEcmp": 0,
                    "asn": "65100"
                }
            },
            "vrf": "default",
            "asn": "64600"
        }
    }
}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_bgp_gr_helper.py script can pass on VMs with version like 4.23.2F. On older VM version, for example, 4.20.15M, 4.15.9M, the script failed with 'description' KeyError. This PR enables the script on VMs with older versions.

#### How did you do it?
Check if the output of 'show ip bgp summary' on VMs has field 'description'. If no, skip the checking of this field.

#### How did you verify/test it?
* Tested the script on both physical testbed and vsimage.
* Tested the script using VM version 4.23 and 4.20.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
