### PR TITLE
[Platform API][pytest] Add basic tests for SFP class

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -1,0 +1,130 @@
+"""
+This module provides an interface to remotely interact with SFP
+transceivers connected to the DUT via platform API
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sfp_api(conn, index, name, args=None):
+    if args is None:
+        args = []
+    conn.request('POST', '/platform/chassis/sfp/{}/{}'.format(index, name), json.dumps({'args': args}))
+    resp = conn.getresponse()
+    res = json.loads(resp.read())['res']
+    logger.info('Executing sfp API: "{}", index: {}, arguments: "{}", result: "{}"'.format(name, index, args, res))
+    return res
+
+
+#
+# Methods inherited from DeviceBase class
+#
+
+def get_name(conn, index):
+    return sfp_api(conn, index, 'get_name')
+
+
+def get_presence(conn, index):
+    return sfp_api(conn, index, 'get_presence')
+
+
+def get_model(conn, index):
+    return sfp_api(conn, index, 'get_model')
+
+
+def get_serial(conn, index):
+    return sfp_api(conn, index, 'get_serial')
+
+
+def get_status(conn, index):
+    return sfp_api(conn, index, 'get_status')
+
+#
+# Methods defined in SfpBase class
+#
+
+# NOTE: The get_change_event() method is not represented here because there is no reliable way
+# to test this method in an automated fashion.
+
+
+def get_transceiver_info(conn, index):
+    return sfp_api(conn, index, 'get_transceiver_info')
+
+
+def get_transceiver_bulk_status(conn, index):
+    return sfp_api(conn, index, 'get_transceiver_bulk_status')
+
+
+def get_transceiver_threshold_info(conn, index):
+    return sfp_api(conn, index, 'get_transceiver_threshold_info')
+
+
+def get_reset_status(conn, index):
+    return sfp_api(conn, index, 'get_reset_status')
+
+
+def get_rx_los(conn, index):
+    return sfp_api(conn, index, 'get_rx_los')
+
+
+def get_tx_fault(conn, index):
+    return sfp_api(conn, index, 'get_tx_fault')
+
+
+def get_tx_disable(conn, index):
+    return sfp_api(conn, index, 'get_tx_disable')
+
+
+def get_tx_disable_channel(conn, index):
+    return sfp_api(conn, index, 'get_tx_disable_channel')
+
+
+def get_lpmode(conn, index):
+    return sfp_api(conn, index, 'get_lpmode')
+
+
+def get_power_override(conn, index):
+    return sfp_api(conn, index, 'get_power_override')
+
+
+def get_temperature(conn, index):
+    return sfp_api(conn, index, 'get_temperature')
+
+
+def get_voltage(conn, index):
+    return sfp_api(conn, index, 'get_voltage')
+
+
+def get_tx_bias(conn, index):
+    return sfp_api(conn, index, 'get_tx_bias')
+
+
+def get_rx_power(conn, index):
+    return sfp_api(conn, index, 'get_rx_power')
+
+
+def get_tx_power(conn, index):
+    return sfp_api(conn, index, 'get_tx_power')
+
+
+def reset(conn, index):
+    return sfp_api(conn, index, 'reset')
+
+
+def tx_disable(conn, index, disable):
+    return sfp_api(conn, index, 'tx_disable', [disable])
+
+
+def tx_disable_channel(conn, index, channel_mask, disable):
+    return sfp_api(conn, index, 'tx_disable_channel', [channel_mask, disable])
+
+
+def set_lpmode(conn, index, lpmode):
+    return sfp_api(conn, index, 'set_lpmode', [lpmode])
+
+
+def set_power_override(conn, index, power_override, power_set):
+    return sfp_api(conn, index, 'set_power_override', [power_override, power_set])

--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -42,13 +42,13 @@ def get_serial(conn, index):
 def get_status(conn, index):
     return sfp_api(conn, index, 'get_status')
 
+
 #
 # Methods defined in SfpBase class
 #
 
 # NOTE: The get_change_event() method is not represented here because there is no reliable way
 # to test this method in an automated fashion.
-
 
 def get_transceiver_info(conn, index):
     return sfp_api(conn, index, 'get_transceiver_info')

--- a/tests/platform_tests/api/platform_api_test_base.py
+++ b/tests/platform_tests/api/platform_api_test_base.py
@@ -1,0 +1,34 @@
+import ast
+
+from common.helpers.assertions import pytest_assert
+
+
+class PlatformApiTestBase(object):
+    """Platform API test base class"""
+
+    failed_expectations = []
+
+    def expect(self, expr, err_msg):
+        """
+        A pytest method can call this method multiple times. It will accumulate
+        error messages for each expression which would have failed an
+        assertion in failed_expectations. When the test method is ready to
+        check if any of the previous expressions passed to this function would
+        have failed an assertion, it should call assert_expectations()
+        """
+        if not expr:
+            self.failed_expectations.append(err_msg)
+        return expr
+
+    def assert_expectations(self):
+        """
+        Checks if there are any error messages waiting in failed_expectations.
+        If so, it will fail an assert and pass a concatenation of all pending
+        error messages. It will also clear failed_expectations to prepare it
+        for the next use.
+        """
+        if len(self.failed_expectations) > 0:
+            err_msg = ", ".join(self.failed_expectations)
+            # TODO: When we move to Python 3.3+, we can use self.failed_expectations.clear() instead
+            del self.failed_expectations[:]
+            pytest_assert(False, err_msg)

--- a/tests/platform_tests/api/platform_api_test_base.py
+++ b/tests/platform_tests/api/platform_api_test_base.py
@@ -1,5 +1,3 @@
-import ast
-
 from common.helpers.assertions import pytest_assert
 
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
 ]
 
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -1,0 +1,384 @@
+import ast
+import logging
+import re
+
+import pytest
+
+from common.helpers.assertions import pytest_assert
+from common.helpers.platform_api import chassis, sfp
+
+from platform_api_test_base import PlatformApiTestBase
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
+]
+
+
+class TestSfpApi(PlatformApiTestBase):
+    """
+    This class contains test cases intended to verify the functionality and
+    proper platform vendor implementation of the SFP class of the SONiC
+    platform API.
+
+    NOTE: The tests in this class currently assume that transceivers are
+    connected to all ports of the DuT.
+    """
+
+    EXPECTED_XCVR_INFO_KEYS = [
+        'type',
+        'hardware_rev',
+        'serial',
+        'manufacturer',
+        'model',
+        'connector',
+        'encoding',
+        'ext_identifier',
+        'ext_rateselect_compliance',
+        'cable_length',
+        'nominal_bit_rate',
+        'specification_compliance',
+        'vendor_date',
+        'vendor_oui'
+    ]
+
+    EXPECTED_XCVR_BULK_STATUS_KEYS = [
+        'temperature',
+        'voltage',
+        'rx1power',
+        'tx1bias',
+        'tx1power'
+    ]
+
+    EXPECTED_XCVR_THRESHOLD_INFO_KEYS = [
+        'txpowerlowwarning',
+        'temphighwarning',
+        'temphighalarm',
+        'txbiashighalarm',
+        'vcchighalarm',
+        'txbiaslowalarm',
+        'rxpowerhighwarning',
+        'vcclowwarning',
+        'txbiaslowwarning',
+        'rxpowerlowalarm',
+        'vcchighwarning',
+        'txpowerhighwarning',
+        'rxpowerlowwarning',
+        'txbiashighwarning',
+        'vcclowalarm',
+        'txpowerhighalarm',
+        'templowalarm',
+        'rxpowerhighalarm',
+        'templowwarning',
+        'txpowerlowalarm'
+    ]
+
+    num_sfps = None
+
+    def is_xcvr_optical(self, xcvr_info_dict):
+        """Returns True if transceiver is optical, False if copper (DAC)"""
+        spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
+        compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code")
+        if compliance_code == "40GBASE-CR4":
+            return False
+        return True
+
+    # This fixture would probably be better scoped at the class level, but
+    # it relies on the platform_api_conn fixture, which is scoped at the function
+    # level, so we must do the same here to prevent a scope mismatch.
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, platform_api_conn):
+        if self.num_sfps is None:
+            try:
+                self.num_sfps = int(chassis.get_num_sfps(platform_api_conn))
+            except:
+                pytest.fail("num_sfps is not an integer")
+
+    #
+    # Functions to test methods inherited from DeviceBase class
+    #
+
+    def test_get_name(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_sfps):
+            name = sfp.get_name(platform_api_conn, i)
+            if self.expect(name is not None, "Unable to retrieve transceiver {} name".format(i)):
+                self.expect(isinstance(name, str), "Transceiver {} name appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_presence(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_sfps):
+            presence = sfp.get_presence(platform_api_conn, i)
+            if self.expect(presence is not None, "Unable to retrieve transceiver {} presence".format(i)):
+                if self.expect(isinstance(presence, bool), "Transceiver {} presence appears incorrect".format(i)):
+                    self.expect(presence is True, "Transceiver {} is not present".format(i))
+        self.assert_expectations()
+
+    def test_get_model(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_sfps):
+            model = sfp.get_model(platform_api_conn, i)
+            if self.expect(model is not None, "Unable to retrieve transceiver {} model".format(i)):
+                self.expect(isinstance(model, str), "Transceiver {} model appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_serial(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_sfps):
+            serial = sfp.get_serial(platform_api_conn, i)
+            if self.expect(serial is not None, "Unable to retrieve transceiver {} serial number".format(i)):
+                self.expect(isinstance(serial, str), "Transceiver {} serial number appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_status(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_sfps):
+            status = sfp.get_status(platform_api_conn, i)
+            if self.expect(status is not None, "Unable to retrieve transceiver {} status".format(i)):
+                self.expect(isinstance(status, bool), "Transceiver {} status appears incorrect".format(i))
+        self.assert_expectations()
+
+    #
+    # Functions to test methods defined in SfpBase class
+    #
+
+    def test_get_transceiver_info(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on transceiver info values
+        for i in range(self.num_sfps):
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                if self.expect(isinstance(info_dict, dict), "Transceiver {} info appears incorrect".format(i)):
+                    actual_keys = info_dict.keys()
+
+                    missing_keys = set(self.EXPECTED_XCVR_INFO_KEYS) - set(actual_keys)
+                    for key in missing_keys:
+                        self.expect(False, "Transceiver {} info does not contain field: '{}'".format(i, key))
+
+                    unexpected_keys = set(actual_keys) - set(self.EXPECTED_XCVR_INFO_KEYS)
+                    for key in unexpected_keys:
+                        self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
+        self.assert_expectations()
+
+    def test_get_transceiver_bulk_status(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_sfps):
+            bulk_status_dict = sfp.get_transceiver_bulk_status(platform_api_conn, i)
+            if self.expect(bulk_status_dict is not None, "Unable to retrieve transceiver {} bulk status".format(i)):
+                if self.expect(isinstance(bulk_status_dict, dict), "Transceiver {} bulk status appears incorrect".format(i)):
+                    # TODO: This set of keys should be present no matter how many channels are present on the xcvr
+                    #       If the xcvr has multiple channels, we should adjust the fields here accordingly
+                    actual_keys = bulk_status_dict.keys()
+
+                    missing_keys = set(self.EXPECTED_XCVR_BULK_STATUS_KEYS) - set(actual_keys)
+                    for key in missing_keys:
+                        self.expect(False, "Transceiver {} bulk status does not contain field: '{}'".format(i, key))
+        self.assert_expectations()
+
+    def test_get_transceiver_threshold_info(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on transceiver threshold info values
+        for i in range(self.num_sfps):
+            thold_info_dict = sfp.get_transceiver_threshold_info(platform_api_conn, i)
+            if self.expect(thold_info_dict is not None, "Unable to retrieve transceiver {} threshold info".format(i)):
+                if self.expect(isinstance(thold_info_dict, dict), "Transceiver {} threshold info appears incorrect".format(i)):
+                    actual_keys = thold_info_dict.keys()
+
+                    missing_keys = set(self.EXPECTED_XCVR_THRESHOLD_INFO_KEYS) - set(actual_keys)
+                    for key in missing_keys:
+                        self.expect(False, "Transceiver {} threshold info does not contain field: '{}'".format(i, key))
+
+                    unexpected_keys = set(actual_keys) - set(self.EXPECTED_XCVR_THRESHOLD_INFO_KEYS)
+                    for key in unexpected_keys:
+                        self.expect(False, "Transceiver {} threshold info contains unexpected field '{}'".format(i, key))
+        self.assert_expectations()
+
+    def test_get_reset_status(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            reset_status = sfp.get_reset_status(platform_api_conn, i)
+            if self.expect(reset_status is not None, "Unable to retrieve transceiver {} reset status".format(i)):
+                self.expect(isinstance(reset_status, bool), "Transceiver {} reset status appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_rx_los(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            rx_los = sfp.get_rx_los(platform_api_conn, i)
+            if self.expect(rx_los is not None, "Unable to retrieve transceiver {} RX loss-of-signal data".format(i)):
+                self.expect(isinstance(rx_los, list) and (all(isinstance(item, bool) for item in rx_los)),
+                            "Transceiver {} RX loss-of-signal data appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_tx_fault(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            tx_fault = sfp.get_tx_fault(platform_api_conn, i)
+            if self.expect(tx_fault is not None, "Unable to retrieve transceiver {} TX fault data".format(i)):
+                self.expect(isinstance(tx_fault, list) and (all(isinstance(item, bool) for item in tx_fault)),
+                            "Transceiver {} TX fault data appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_temperature(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            temp = sfp.get_temperature(platform_api_conn, i)
+            if self.expect(temp is not None, "Unable to retrieve transceiver {} temperatue".format(i)):
+                self.expect(isinstance(temp, float), "Transceiver {} temperature appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_voltage(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            voltage = sfp.get_voltage(platform_api_conn, i)
+            if self.expect(voltage is not None, "Unable to retrieve transceiver {} voltage".format(i)):
+                self.expect(isinstance(voltage, float), "Transceiver {} voltage appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_tx_bias(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            tx_bias = sfp.get_tx_bias(platform_api_conn, i)
+            if self.expect(tx_bias is not None, "Unable to retrieve transceiver {} TX bias data".format(i)):
+                self.expect(isinstance(tx_bias, list) and (all(isinstance(item, float) for item in tx_bias)),
+                            "Transceiver {} TX bias data appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_rx_power(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        # TODO: Should we should expect get_rx_power() to return None or a list of "N/A" strings
+        # if the transceiver is non-optical, e.g., DAC
+        for i in range(self.num_sfps):
+            # Determine whether the transceiver type supports RX power
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                continue
+
+            if not self.is_xcvr_optical(info_dict):
+                logger.warning("test_get_rx_power: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
+                continue
+
+            rx_power = sfp.get_rx_power(platform_api_conn, i)
+            if self.expect(rx_power is not None, "Unable to retrieve transceiver {} RX power data".format(i)):
+                self.expect(isinstance(rx_power, list) and (all(isinstance(item, float) for item in rx_power)),
+                            "Transceiver {} RX power data appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_tx_power(self, duthost, localhost, platform_api_conn):
+        # TODO: Do more sanity checking on the data we retrieve
+        for i in range(self.num_sfps):
+            tx_power = sfp.get_tx_power(platform_api_conn, i)
+            if self.expect(tx_power is not None, "Unable to retrieve transceiver {} TX power data".format(i)):
+                continue
+
+            # Determine whether the transceiver type supports RX power
+            # If the transceiver is non-optical, e.g., DAC, we should receive a list of "N/A" strings
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                continue
+
+            if not self.is_xcvr_optical(info_dict):
+                self.expect(isinstance(tx_power, list) and (all(item == "N/A" for item in tx_power)),
+                            "Transceiver {} TX power data appears incorrect".format(i))
+            else:
+                self.expect(isinstance(tx_power, list) and (all(isinstance(item, float) for item in tx_power)),
+                            "Transceiver {} TX power data appears incorrect".format(i))
+        self.assert_expectations()
+
+    def test_reset(self, duthost, localhost, platform_api_conn):
+        # TODO: Verify that the transceiver was actually reset
+        for i in range(self.num_sfps):
+            ret = sfp.reset(platform_api_conn, i)
+            self.expect(ret is True, "Failed to reset transceiver {}".format(i))
+        self.assert_expectations()
+
+    def test_tx_disable(self, duthost, localhost, platform_api_conn):
+        """This function tests both the get_tx_disable() and tx_disable() APIs"""
+        for i in range(self.num_sfps):
+            # First ensure that the transceiver type supports setting TX disable
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                continue
+
+            if not self.is_xcvr_optical(info_dict):
+                logger.warning("test_tx_disable: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
+                continue
+
+            for state in [True, False]:
+                ret = sfp.tx_disable(platform_api_conn, i, state)
+                if self.expect(ret is True, "Failed to {} TX disable for transceiver {}".format("set" if state is True else "clear", i)):
+                    tx_disable = sfp.get_tx_disable(platform_api_conn, i)
+                    if self.expect(tx_disable is not None, "Unable to retrieve transceiver {} TX disable data".format(i)):
+                        self.expect(isinstance(tx_disable, list) and (all(item == state) for item in tx_disable),
+                                    "Transceiver {} TX disable data is incorrect".format(i))
+        self.assert_expectations()
+
+    def test_tx_disable_channel(self, duthost, localhost, platform_api_conn):
+        """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
+        for i in range(self.num_sfps):
+            # First ensure that the transceiver type supports setting TX disable on individual channels
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                continue
+
+            if not self.is_xcvr_optical(info_dict):
+                logger.warning("test_tx_disable_channel: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
+                continue
+
+            # Test all TX disable combinations for a four-channel transceiver (i.e., 0x0 through 0xF)
+            # We iterate in reverse here so that we end with 0x0 (no channels disabled)
+            for expected_mask in range(0xF, 0x0, -1):
+                # Enable TX on all channels
+                ret = sfp.tx_disable_channel(platform_api_conn, i, 0xF, False)
+                self.expect(ret is True, "Failed to enable TX on all channels for transceiver {}".format(i))
+
+                ret = sfp.tx_disable_channel(platform_api_conn, i, expected_mask, True)
+                self.expect(ret is True, "Failed to disable TX channels using mask '{}' for transceiver {}".format(expected_mask, i))
+
+                tx_disable_chan_mask = sfp.get_tx_disable_channel(platform_api_conn, i)
+                if self.expect(tx_disable_chan_mask is not None, "Unable to retrieve transceiver {} TX disabled channel data".format(i)):
+                    self.expect(tx_disable_chan_mask == expected_mask, "Transceiver {} TX disabled channel data is incorrect".format(i))
+        self.assert_expectations()
+
+    def test_lpmode(self, duthost, localhost, platform_api_conn):
+        """This function tests both the get_lpmode() and set_lpmode() APIs"""
+        for i in range(self.num_sfps):
+            # First ensure that the transceiver type supports low-power mode
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                continue
+
+            if not self.is_xcvr_optical(info_dict):
+                logger.warning("test_lpmode: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
+                continue
+
+            # Enable and disable low-power mode on each transceiver
+            for state in [True, False]:
+                ret = sfp.set_lpmode(platform_api_conn, i, state)
+                self.expect(ret is True, "Failed to {} low-power mode for transceiver {}".format("enable" if state is True else "disable", i))
+                lpmode = sfp.get_lpmode(platform_api_conn, i)
+                if self.expect(lpmode is not None, "Unable to retrieve transceiver {} low-power mode".format(i)):
+                    self.expect(lpmode == state, "Transceiver {} low-power is incorrect".format(i))
+        self.assert_expectations()
+
+    def test_power_override(self, duthost, localhost, platform_api_conn):
+        """This function tests both the get_power_override() and set_power_override() APIs"""
+        for i in range(self.num_sfps):
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+                continue
+
+            if not self.is_xcvr_optical(info_dict):
+                logger.warning("test_power_override: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
+                continue
+
+            # Enable power override in both low-power and high-power modes
+            for state in [True, False]:
+                ret = sfp.set_power_override(platform_api_conn, i, True, state)
+                self.expect(ret is True, "Failed to {} power override for transceiver {}".format("enable" if state is True else "disable", i))
+                power_override = sfp.get_power_override(platform_api_conn, i)
+                if self.expect(power_override is not None, "Unable to retrieve transceiver {} power override data".format(i)):
+                    self.expect(power_override is True, "Transceiver {} power override data is incorrect".format(i))
+
+            # Disable power override
+            ret = sfp.set_power_override(platform_api_conn, i, False, None)
+            self.expect(ret is True, "Failed to disable power override for transceiver {}".format(i))
+            power_override = sfp.get_power_override(platform_api_conn, i)
+            if self.expect(power_override is not None, "Unable to retrieve transceiver {} power override data".format(i)):
+                self.expect(power_override is False, "Transceiver {} power override data is incorrect".format(i))
+        self.assert_expectations()


### PR DESCRIPTION
Add a basic test suite for the SFP class of the new platform API, utilizing the platform API HTTP server, including the following functions:
```
test_get_name
test_get_presence
test_get_model
test_get_serial
test_get_status
test_get_transceiver_info
test_get_transceiver_bulk_status
test_get_transceiver_threshold_info
test_get_reset_status
test_get_rx_los
test_get_tx_fault
test_get_temperature
test_get_voltage
test_get_tx_bias
test_get_rx_power
test_get_tx_power
test_reset
test_tx_disable
test_tx_disable_channel
test_lpmode
test_power_override
```

Also introduce a new `PlatformApiTestBase` base class with `expect()` and `assert_expectations()` methods to allow for accumulating errors before asserting.

Example test results summary (showing legitimate test failures):
```
======================================== test session starts ======================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 21 items

platform_tests/api/test_sfp.py F.FFF................[100%]

============================================= FAILURES ============================================
...
===================================== short test summary info =====================================
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_name - Failed: Unable to retrieve tr...
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_model - Failed: Unable to retrieve t...
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_serial - Failed: Unable to retrieve ...
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_get_status - Failed: Unable to retrieve ...
============================== 4 failed, 17 passed in 501.32 seconds ==============================

```