### PR TITLE
Announce current podset IPv6 routes from ToR to T1 router

### DIFF
--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -238,7 +238,11 @@ def fib_t1_lag(ptfhost, testbed, localhost):
             routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
                                         None, leaf_asn_start, tor_asn_start,
                                         local_ip, local_ipv6, router_type="tor")
+            routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
+                                        None, leaf_asn_start, tor_asn_start,
+                                        local_ip, local_ipv6, router_type="tor")
             announce_routes(ptfip, port, routes_v4)
+            announce_routes(ptfip, port6, routes_v6)
 
         if 'vips' in v:
             routes_vips = []

--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -224,23 +224,18 @@ def fib_t1_lag(ptfhost, testbed, localhost):
         port = 5000 + vm_offset
         port6 = 6000 + vm_offset
 
+        router_type = None
         if 'spine' in v['properties']:
-            routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
-                                        None, leaf_asn_start, tor_asn_start,
-                                        local_ip, local_ipv6, router_type="spine")
-            routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
-                                        None, leaf_asn_start, tor_asn_start,
-                                        local_ip, local_ipv6, router_type="spine")
-            announce_routes(ptfip, port, routes_v4)
-            announce_routes(ptfip, port6, routes_v6)
-
+            router_type = 'spine'
         elif 'tor' in v['properties']:
+            router_type = 'tor'
+        if router_type:
             routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
                                         None, leaf_asn_start, tor_asn_start,
-                                        local_ip, local_ipv6, router_type="tor")
+                                        local_ip, local_ipv6, router_type=router_type)
             routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                         None, leaf_asn_start, tor_asn_start,
-                                        local_ip, local_ipv6, router_type="tor")
+                                        local_ip, local_ipv6, router_type=router_type)
             announce_routes(ptfip, port, routes_v4)
             announce_routes(ptfip, port6, routes_v6)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Currently for T1 type topology, the fib fixture does not announce IPv6 routes of current podset from downlink ToR routers. However, the test_decap.py script expects IPv6 routers from ToR routers. Because of this issue, the test_decap.py script failed on T1 type topology.

The solution is to announce the IPv6 routes of current podset from downlink ToR routers to T1 router, just like the IPv4 routes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix the issue that test_decap.py failed on T1 type topology.

#### How did you do it?
Update the fib fixture to announce IPv6 routes of current podset from downlink ToR routers to T1 router for T1 type topology.

#### How did you verify/test it?
Tested test_decap on both T0 and T1 topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
