### PR TITLE
[ansible] Add run_once to tasks in pre_tasks 

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -80,30 +80,33 @@
 - hosts: servers:&eos
   gather_facts: no
   pre_tasks:
-  - name: Check that variable topo is defined
-    fail: msg="Define topo variable with -e topo=something"
-    when: topo is not defined
+    - block:
+        - name: Check that variable topo is defined
+          fail: msg="Define topo variable with -e topo=something"
+          when: topo is not defined
 
-  - name: Check if it is a known topology
-    fail: msg="Unknown topology {{ topo }}"
-    when: topo not in topologies
+        - name: Check if it is a known topology
+          fail: msg="Unknown topology {{ topo }}"
+          when: topo not in topologies
 
-  - name: Check that variable VM_base is defined
-    fail: msg="Define VM_base variable with -e VM_base=something"
-    when: VM_base is not defined
+        - name: Check that variable VM_base is defined
+          fail: msg="Define VM_base variable with -e VM_base=something"
+          when: VM_base is not defined
 
-  - name: Load topo variables
-    include_vars: "vars/topo_{{ topo }}.yml"
+        - name: Load topo variables
+          include_vars: "vars/topo_{{ topo }}.yml"
 
-  - name: Find current server group
-    set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
+        - name: Find current server group
+          set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
 
-  - name: Extract VM names from the inventory
-    set_fact: VM_hosts={{ groups[current_server] | filter_by_prefix('VM') }}
+        - name: Extract VM names from the inventory
+          set_fact: VM_hosts={{ groups[current_server] | filter_by_prefix('VM') }}
 
-  - name: Generate vm list of target VMs
-    set_fact: VM_targets={{ VM_hosts | filter_vm_targets(topology['VMs'], VM_base) }}
-    when: topology['VMs'] is defined
+        - name: Generate vm list of target VMs
+          set_fact: VM_targets={{ VM_hosts | filter_vm_targets(topology['VMs'], VM_base) }}
+          when: topology['VMs'] is defined
+      run_once: True
+      delegate_to: localhost
 
   roles:
     - { role: eos, when: topology.VMs is defined and inventory_hostname in VM_targets } # role eos will be executed in any case, and when will evaluate with every task


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

During `add_topo`, it is unnecessary to run the variable checking and
definition tasks in `pre_tasks` against all hosts. Running once is
sufficient.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
* Ansible log snippet before:
```
2020-06-20 08:27:53,376 p=7126 u=johnar |  TASK [Check that variable topo is defined] ******************************************************************************************************************************************************************************
2020-06-20 08:27:53,377 p=7126 u=johnar |  Saturday 20 June 2020  08:27:53 +0000 (0:00:01.009)       0:05:56.400 *********
2020-06-20 08:27:53,425 p=7126 u=johnar |  skipping: [VM0100]
2020-06-20 08:27:53,441 p=7126 u=johnar |  skipping: [VM0101]
2020-06-20 08:27:53,499 p=7126 u=johnar |  skipping: [VM0103]
2020-06-20 08:27:53,517 p=7126 u=johnar |  skipping: [VM0102]
2020-06-20 08:27:53,536 p=7126 u=johnar |  skipping: [VM0104]
2020-06-20 08:27:53,555 p=7126 u=johnar |  skipping: [VM0105]
2020-06-20 08:27:53,574 p=7126 u=johnar |  skipping: [VM0106]
2020-06-20 08:27:53,592 p=7126 u=johnar |  skipping: [VM0107]
2020-06-20 08:27:53,612 p=7126 u=johnar |  skipping: [VM0108]
2020-06-20 08:27:53,638 p=7126 u=johnar |  skipping: [VM0109]
2020-06-20 08:27:53,655 p=7126 u=johnar |  skipping: [VM0111]
2020-06-20 08:27:53,672 p=7126 u=johnar |  skipping: [VM0110]
2020-06-20 08:27:53,691 p=7126 u=johnar |  skipping: [VM0112]
2020-06-20 08:27:53,708 p=7126 u=johnar |  skipping: [VM0113]
2020-06-20 08:27:53,725 p=7126 u=johnar |  skipping: [VM0114]
2020-06-20 08:27:53,745 p=7126 u=johnar |  skipping: [VM0115]
2020-06-20 08:27:53,766 p=7126 u=johnar |  skipping: [VM0116]
2020-06-20 08:27:53,787 p=7126 u=johnar |  skipping: [VM0117]
2020-06-20 08:27:53,817 p=7126 u=johnar |  skipping: [VM0118]
2020-06-20 08:27:53,839 p=7126 u=johnar |  skipping: [VM0119]
2020-06-20 08:27:53,864 p=7126 u=johnar |  skipping: [VM0120]
2020-06-20 08:27:53,882 p=7126 u=johnar |  skipping: [VM0121]
2020-06-20 08:27:53,904 p=7126 u=johnar |  skipping: [VM0122]
2020-06-20 08:27:53,923 p=7126 u=johnar |  skipping: [VM0123]
2020-06-20 08:27:53,947 p=7126 u=johnar |  skipping: [VM0124]
2020-06-20 08:27:53,970 p=7126 u=johnar |  skipping: [VM0125]
2020-06-20 08:27:54,007 p=7126 u=johnar |  skipping: [VM0127]
2020-06-20 08:27:54,037 p=7126 u=johnar |  skipping: [VM0126]
2020-06-20 08:27:54,041 p=7126 u=johnar |  skipping: [VM0128]
2020-06-20 08:27:54,046 p=7126 u=johnar |  skipping: [VM0129]
2020-06-20 08:27:54,049 p=7126 u=johnar |  skipping: [VM0130]
2020-06-20 08:27:54,136 p=7126 u=johnar |  skipping: [VM0131]
...
```
* ansible log snippet after:
```
TASK [Check that variable topo is defined] *****************************************************************************************************************************************************************
Thursday 02 July 2020  03:07:53 +0000 (0:00:00.881)       0:06:03.282 ********* 
skipping: [VM0100]
```
#### How did you do it?

#### How did you verify/test it?
```
./testbed-cli.sh -t vtestbed.csv -m veos.vtb -k ceos add-topo vms-kvm-t0 /data/password.txt
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
