### PR TITLE
fix regexp for parsing lines in 'show interface counter' in show_interface ansible module

### DIFF
--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -128,7 +128,7 @@ class ShowInterfaceModule(object):
         return
 
     def collect_interface_counter(self):
-        regex_int = re.compile(r'(\S+)\s+(\w)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)')
+        regex_int = r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)')        
         self.int_counter = {}
         try:
             rc, self.out, err = self.module.run_command('show interface counter', executable='/bin/bash', use_unsafe_shell=True)

--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -128,7 +128,7 @@ class ShowInterfaceModule(object):
         return
 
     def collect_interface_counter(self):
-        regex_int = r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)')        
+        regex_int = re.compile(r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)')
         self.int_counter = {}
         try:
             rc, self.out, err = self.module.run_command('show interface counter', executable='/bin/bash', use_unsafe_shell=True)

--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -128,7 +128,7 @@ class ShowInterfaceModule(object):
         return
 
     def collect_interface_counter(self):
-        regex_int = re.compile(r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)')
+        regex_int = re.compile(r'\s*(\S+)\s+(\w)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)\s+([,\d]+)\s+(N\/A|[.0-9]+ B/s)\s+(\S+)\s+([,\d]+)\s+(\S+)\s+([,\d]+)')
         self.int_counter = {}
         try:
             rc, self.out, err = self.module.run_command('show interface counter', executable='/bin/bash', use_unsafe_shell=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

ansible module 'show_interface' with command='counter',  uses a regexp to parse each of the lines of 'show interface counter'. However, the regexp fails:
-  when have 'N/A' in 'RX_BPS', 'RX_UTIL', 'RX_DRP', 'TX_BPS', 'TX_UTIL', and 'TX_DRP'
- 'RX_BPS' and 'TX_BPS' as these fields have 'space' in between the value and 'B/s' - example - '0.00 B/s
- The line for a port could start with a 'space'  
- The  counts could have ',' in them

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach


#### What is the motivation for this PR?

#### How did you do it?

Updated regexp to work with table which would have above mentioned values:
- Added \s* to the beginning of the regexp.
- The regexp fixed for fields above to support 'N/A' (using \S+).
- For 'TX_BPS' and 'RX_BPS' - regexp include 'N\/A'|[.0-9]+ B/s'
- For all \d, include ',' as well.

#### How did you verify/test it?

Did not find any existing test that used 'show_interface' ansible module with command='counter'. 
Tested against DUT which has the following output:
```
admin@srlinuxvod1:~$ show interface counter
Last cached time was 2016-11-04 08:11:31.009303
     IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  --------  ---------  --------  --------  --------  -------  --------  ---------  --------  --------  --------
 Ethernet1        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet2        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet3        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet4        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet5        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet6        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet7        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet8        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
 Ethernet9        U        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
Ethernet10        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
Ethernet11        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0
Ethernet12        X        0  0.00 B/s      0.00%         0       N/A         0        0  0.00 B/s      0.00%         0       N/A         0

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
