### PR TITLE
[sflow] skip sflow test when feature is not enabled

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -656,6 +656,26 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         return None
 
+    def get_feature_status(self):
+        """
+        Gets the list of features and states
+
+        Returns:
+            dict: feature status dict. { <feature name> : <status: enabled | disabled> }
+        """
+        feature_status = {}
+        command_output = self.shell('show features', module_ignore_errors=True)
+        if command_output['rc'] != 0:
+            return feature_status
+
+        features_stdout = command_output['stdout_lines']
+        lines = features_stdout[2:]
+        for x in lines:
+            result = x.encode('UTF-8')
+            r = result.split()
+            feature_status[r[0]] = r[1]
+        return feature_status
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -662,11 +662,12 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         Returns:
             dict: feature status dict. { <feature name> : <status: enabled | disabled> }
+            bool: status obtained successfully (True | False)
         """
         feature_status = {}
         command_output = self.shell('show features', module_ignore_errors=True)
         if command_output['rc'] != 0:
-            return feature_status
+            return feature_status, False
 
         features_stdout = command_output['stdout_lines']
         lines = features_stdout[2:]
@@ -674,7 +675,7 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             result = x.encode('UTF-8')
             r = result.split()
             feature_status[r[0]] = r[1]
-        return feature_status
+        return feature_status, True
 
 class EosHost(AnsibleHostBase):
     """

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 def setup(duthost, ptfhost):
     global var
     var = {}
+
+    feature_status = duthost.get_feature_status()
+    if 'sflow' not in feature_status or feature_status['sflow'] == 'disabled':
+        pytest.skip("sflow feature is not eanbled")
+
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     var['host_facts']  = duthost.setup()['ansible_facts']
     vlan_dict = mg_facts['minigraph_vlans']

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -22,7 +22,7 @@ def setup(duthost, ptfhost):
     global var
     var = {}
 
-    feature_status = duthost.get_feature_status()
+    feature_status, _ = duthost.get_feature_status()
     if 'sflow' not in feature_status or feature_status['sflow'] == 'disabled':
         pytest.skip("sflow feature is not eanbled")
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,5 +1,6 @@
 # Helper Functions
 import pytest
+from common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -18,7 +19,8 @@ def get_status_redisout(status_out):
 def test_show_features(duthost):
     """Verify show features command output against CONFIG_DB
     """
-    features_dict = duthost.get_feature_status()
+    features_dict, succeeded = duthost.get_feature_status()
+    pytest_assert(succeeded, "failed to obtain feature status")
     for cmd_key, cmd_value in features_dict.items():
         feature = str(cmd_key)
         status_out = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|{}"'.format(feature), module_ignore_errors=False)['stdout_lines']

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -5,18 +5,6 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def get_dict_stdout(cmd_out):
-    """Extract dictionary from show features command output
-    """
-    result = ""
-    out_dict = {}
-    cmd = cmd_out[2:]
-    for x in cmd:
-        result = x.encode('UTF-8')
-        r = result.split()
-        out_dict[r[0]] = r[1]
-    return out_dict
-
 def get_status_redisout(status_out):
     """Extract status value for feature in redis
     """
@@ -30,8 +18,7 @@ def get_status_redisout(status_out):
 def test_show_features(duthost):
     """Verify show features command output against CONFIG_DB
     """
-    features_stdout = duthost.shell('show features', module_ignore_errors=False)['stdout_lines']
-    features_dict = get_dict_stdout(features_stdout)
+    features_dict = duthost.get_feature_status()
     for cmd_key, cmd_value in features_dict.items():
         feature = str(cmd_key)
         status_out = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|{}"'.format(feature), module_ignore_errors=False)['stdout_lines']


### PR DESCRIPTION
Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
skip sflow test when feature is not enabled

#### How did you do it?
check feature status before test

#### How did you verify/test it?
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 15 items                                                                                                                                                                       

sflow/test_sflow.py::TestSflowCollector::test_sflow_config SKIPPED                                                                                                                 [  6%]
sflow/test_sflow.py::TestSflowCollector::test_collector_del_add SKIPPED                                                                                                            [ 13%]
sflow/test_sflow.py::TestSflowCollector::test_two_collectors SKIPPED                                                                                                               [ 20%]
sflow/test_sflow.py::TestSflowPolling::testPolling SKIPPED                                                                                                                         [ 26%]
sflow/test_sflow.py::TestSflowPolling::testDisablePolling SKIPPED                                                                                                                  [ 33%]
sflow/test_sflow.py::TestSflowPolling::testDifferntPollingInt SKIPPED                                                                                                              [ 40%]
sflow/test_sflow.py::TestSflowInterface::testIntfRemoval SKIPPED                                                                                                                   [ 46%]
sflow/test_sflow.py::TestSflowInterface::testIntfSamplingRate SKIPPED                                                                                                              [ 53%]
sflow/test_sflow.py::TestSflowInterface::testIntfChangeSamplingRate SKIPPED                                                                                                        [ 60%]
sflow/test_sflow.py::TestAgentId::testNonDefaultAgent SKIPPED                                                                                                                      [ 66%]
sflow/test_sflow.py::TestAgentId::testDelAgent SKIPPED                                                                                                                             [ 73%]
sflow/test_sflow.py::TestAgentId::testAddAgent SKIPPED                                                                                                                             [ 80%]
sflow/test_sflow.py::TestReboot::testRebootSflowEnable SKIPPED                                                                                                                     [ 86%]
sflow/test_sflow.py::TestReboot::testRebootSflowDisable SKIPPED                                                                                                                    [ 93%]
sflow/test_sflow.py::TestReboot::testFastreboot SKIPPED                                                                                                                            [100%]

======================================================================== 15 skipped, 2 warnings in 87.20 seconds =========================================================================


Feature query returned successfully:
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_features.py::test_show_features PASSED                                                                                                                                        [100%]

========================================================================= 1 passed, 2 warnings in 70.71 seconds ==========================================================================

Feature query returned failure:
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_features.py::test_show_features FAILED                                                                                                                                        [100%]

======================================================================================== FAILURES ========================================================================================
___________________________________________________________________________________ test_show_features ___________________________________________________________________________________

duthost = <tests.common.devices.SonicHost object at 0x7f69917b92d0>

    def test_show_features(duthost):
        """Verify show features command output against CONFIG_DB
        """
        features_dict, succeeded = duthost.get_feature_status()
>       pytest_assert(succeeded, "failed to obtain feature status")
E       Failed: failed to obtain feature status

duthost    = <tests.common.devices.SonicHost object at 0x7f69917b92d0>
features_dict = {}
succeeded  = False

test_features.py:23: Failed
==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/lastfailed
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ short test summary info =================================================================================
FAILED test_features.py::test_show_features - Failed: failed to obtain feature status
========================================================================= 1 failed, 3 warnings in 56.35 seconds ==========================================================================
