### PR TITLE
Fix unprintable RunAnsibleModuleFail exception

### DIFF
--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -26,7 +26,8 @@ class RunAnsibleModuleFail(AnsibleError):
         self.results = results
 
     def _to_string(self):
-        return "{}, Ansible Results =>\n{}".format(self.message, dump_ansible_results(self.results))
+        return unicode(u"{}, Ansible Results =>\n{}".format(self.message, dump_ansible_results(self.results)))\
+            .encode('ascii', 'backslashreplace')
 
     def __str__(self):
         return self._to_string()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Issue #1731 was not fully fixed by PR #1739. When RunAnsibleModuleFail exception
is raised by running ptf script, the unprintable exception issue was still observed.

The reason is that the ansible result may contain unicode string. Concatenating ascii
string with unicode string may raise uncaught exception and cause this issue.

The fix is to concatenate unicode string with the ansible result. Then encode it
to ascii string.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Issue #1731 was not fully fixed.

#### How did you do it?
The reason is that the ansible result may contain unicode string. Concatenating ascii
string with unicode string may raise uncaught exception and cause this issue.

The fix is to concatenate unicode string with the ansible result. Then encode it
to ascii string.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
