### PR TITLE
Fix test_portstat_clear

### DIFF
--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -98,23 +98,32 @@ def reset_portstat(duthost):
 
 @pytest.mark.parametrize('command', ['portstat -c', 'portstat --clear'])
 def test_portstat_clear(duthost, command):
-
+    wait(30, 'Wait for DUT to receive/send some packets')
     before_portstat = parse_portstat(duthost.command('portstat')['stdout_lines'])
     pytest_assert(before_portstat, 'No parsed command output')
 
     duthost.command(command)
-    wait(5, 'Wait for portstat counters to refresh')
+    wait(1, 'Wait for portstat counters to refresh')
 
     after_portstat = parse_portstat(duthost.command('portstat')['stdout_lines'])
     pytest_assert(after_portstat, 'No parsed command output')
 
+    """
+    Assert only when rx/tx count is no smaller than COUNT_THRES because DUT may send or receive
+    some packets during test after port status are clear
+    """
+    COUNT_THRES = 10
     for intf in before_portstat:
-        pytest_assert(int(before_portstat[intf]['rx_ok']) >= int(after_portstat[intf]['rx_ok']),
-                      'Value of RX_OK after clear should be lesser')
-
-        pytest_assert(int(before_portstat[intf]['tx_ok']) >= int(after_portstat[intf]['rx_ok']),
-                      'Value of RX_OK after clear should be lesser')
-
+        rx_ok_before = int(before_portstat[intf]['rx_ok'].replace(',',''))
+        rx_ok_after = int(after_portstat[intf]['rx_ok'].replace(',',''))
+        tx_ok_before = int(before_portstat[intf]['tx_ok'].replace(',',''))
+        tx_ok_after = int(after_portstat[intf]['tx_ok'].replace(',',''))
+        if int(rx_ok_before >= COUNT_THRES):
+            pytest_assert(rx_ok_before >= rx_ok_after,
+                          'Value of RX_OK after clear should be lesser')
+        if int(tx_ok_before >= COUNT_THRES):
+            pytest_assert(tx_ok_before >= tx_ok_after,
+                          'Value of TX_OK after clear should be lesser')
 
 @pytest.mark.parametrize('command', ['portstat -D', 'portstat --delete-all'])
 def test_portstat_delete_all(duthost, command):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test_portstat_clear case occasionally failed because  it waits 5 seconds between running **portstat --clear** and retriving updated portstat, and some packets are probably be received or transmitted. As the result, the assertion is likely to fail, especially when rx/tx count before clear is relatively small. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To improve the stability of test_portstat_clear.
#### How did you do it?
Two strategies:
* Shorten the waiting time before retvieing portstat after running clear;
* The test is pass if the base count of rx/tx is too small (less than 10 in this case).
#### How did you verify/test it?
Run this case in a t0 testbed.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Not related.