### PR TITLE
[Mellanox SimX] update start vm playbook

### DIFF
--- a/ansible/roles/vm_set/library/mellanox_simx_port.py
+++ b/ansible/roles/vm_set/library/mellanox_simx_port.py
@@ -26,7 +26,7 @@ def main():
     fp_ports = []
     
     for i in range(1,33):
-        fp_ports.append("v000_port{}".format(i))
+        fp_ports.append("v000_p{}".format(i))
 
     mgmt_port = "tap0"
 

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -1,9 +1,3 @@
-- name: Create directory for SimX in docker(SID) images and disk images
-  file: path={{ item }} state=directory mode=0755
-  with_items:
-    - "{{ home_path }}/sid/images"
-    - "{{ home_path }}/sid/disks"
-
 - include_vars: group_vars/sonic/vars
 
 - set_fact:


### PR DESCRIPTION
Change-Id: I42eab8f0e63ee1c0b99e85ada2b7dd191585cc12
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
 - Cleanup unnecessary steps for Mellanox SimX start playbook.
 - Use new tap port naming convention

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Use new tap naming and cleanup the playbook.
#### How did you do it?

#### How did you verify/test it?
testbed-cli add-topo
testbed-cli remove-topo
#### Any platform specific information?
Only for virtual testbed type='simx'
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
