### PR TITLE
Pfcwd: copy ptftests dir to ptf

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from common.fixtures.conn_graph_facts import conn_graph_facts
+from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>


### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Fix error seen in pytest nightly runs: 
"usage: usage: ptf [options] --test-dir TEST_DIR [tests]\nptf: error: invalid value for --test-dir: directory ptftests does not exist", 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Removed the existing ptftest dir from the ptf docker. Ran the test with the changes and it passed