### PR TITLE
[tests/conftest.py] Add parameter for collecting dump: "since yesterday"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,7 @@ def collect_techsupport(request, duthost):
     # "function" scope
     testname = request.node.name
     if request.config.getoption("--collect_techsupport") and request.node.rep_call.failed:
-        res = duthost.shell("generate_dump")
+        res = duthost.shell("generate_dump -s yesterday")
         fname = res['stdout']
         duthost.fetch(src=fname, dest="logs/{}".format(testname))
         tar = tarfile.open("logs/{}/{}/{}".format(testname, duthost.hostname, fname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
The sonic dump will be collected when a test case fails.
However, it can be very time-consuming to collect dump in a switch with a lot of log files.
To collect dump since yesterday prevents DUT from consuming too much time on it.

Signed-off-by: Stephen Sun <stephens@mellanox.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To reduce the time consumed by collecting sonic dump when a test case fails

#### How did you do it?
Add "s yesterday"

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
