### PR TITLE
Fix various fib test issues

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -10,11 +10,8 @@ Usage:          Examples of how to use log analyzer
 #---------------------------------------------------------------------
 # Global imports
 #---------------------------------------------------------------------
-import ipaddress
 import logging
 import random
-import socket
-import sys
 
 import ptf
 import ptf.packet as scapy
@@ -92,7 +89,7 @@ class FibTest(BaseTest):
                      and down links.
          - pkt_action: expect to receive test traffic or not. Default: fwd
          - ipv4/ipv6: enable ipv4/ipv6 tests
-        
+
         Other test parameters:
          - ttl:             ttl of test pkts. Auto decrease 1 for expected pkts.
          - ip_options       enable ip option header in ipv4 pkts. Default: False(disable)
@@ -150,7 +147,7 @@ class FibTest(BaseTest):
             ip_ranges = self.fib.ipv4_ranges()
         else:
             ip_ranges = self.fib.ipv6_ranges()
-        
+
         for ip_range in ip_ranges:
             next_hop = self.fib[ip_range.get_first_ip()]
             self.check_ip_range(ip_range, next_hop, ipv4)
@@ -178,7 +175,7 @@ class FibTest(BaseTest):
 
         # Test traffic balancing across ECMP/LAG members
         if (self.test_balancing and self.pkt_action == self.ACTION_FWD
-                and len(exp_port_list) > 1  
+                and len(exp_port_list) > 1
                 and random.random() < self.balancing_test_ratio):
             logging.info("Check IP range balancing...")
             dst_ip = ip_range.get_random_ip()

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -12,9 +12,7 @@ from ipaddress import ip_address, ip_network
 
 import ptf
 import ptf.packet as scapy
-import ptf.dataplane as dataplane
 
-from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
 from ptf.testutils import *
@@ -78,7 +76,7 @@ class HashTest(BaseTest):
                 (matched_index, _) = self.check_ip_route(hash_key, in_port, dst_ip, exp_port_list)
                 hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
             logging.info("hit count map: {}".format(hit_count_map))
-            assert True if len(hit_count_map.keys()) > 1 else False
+            assert True if len(hit_count_map.keys()) == 1 else False
         else:
             for _ in range(0, self.BALANCING_TEST_TIMES):
                 logging.info("in_port: {}".format(in_port))
@@ -101,6 +99,20 @@ class HashTest(BaseTest):
 
         return (matched_port, received)
 
+    def _get_ip_proto(self, ipv6=False):
+        # ip_proto 2 is IGMP, should not be forwarded by router
+        # ip_proto 254 is experimental
+        # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
+        skip_ports = [2, 254]
+        if ipv6:
+            # Skip ip_proto 0 for IPv6
+            skip_ports.append(0)
+
+        while True:
+            ip_proto = random.randint(0, 255)
+            if ip_proto not in skip_ports:
+                return ip_proto
+
     def check_ipv4_route(self, hash_key, in_port, dst_port_list):
         '''
         @summary: Check IPv4 route works.
@@ -116,7 +128,7 @@ class HashTest(BaseTest):
         src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) if hash_key == 'src-mac' else base_mac
         dst_mac = random.choice(self.dst_macs) if hash_key == 'dst-mac' else self.router_mac
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
-        ip_proto = random.randint(100, 200) if hash_key == 'ip-proto' else None
+        ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
 
         pkt = simple_tcp_packet(pktlen=100 if vlan_id == 0 else 104,
                             eth_dst=dst_mac,
@@ -144,7 +156,7 @@ class HashTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
 
         send_packet(self, in_port, pkt)
-        logging.info("Sending packet from port " + str(in_port) + " to " + ip_dst)
+        logging.info("Sent packet {} from port {} to {}".format(repr(pkt), str(in_port), str(ip_dst)))
 
         return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
     #---------------------------------------------------------------------
@@ -165,7 +177,7 @@ class HashTest(BaseTest):
         src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) if hash_key == 'src-mac' else base_mac
         dst_mac = random.choice(self.dst_macs) if hash_key == 'dst-mac' else self.router_mac
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
-        ip_proto = random.randint(100, 200) if hash_key == "ip-proto" else None
+        ip_proto = self._get_ip_proto(ipv6=True) if hash_key == "ip-proto" else None
 
         pkt = simple_tcpv6_packet(pktlen=100 if vlan_id == 0 else 104,
                                 eth_dst=dst_mac,
@@ -194,7 +206,7 @@ class HashTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
 
         send_packet(self, in_port, pkt)
-        logging.info("Sending packet from port " + str(in_port) + " to " + ip_dst)
+        logging.info("Sent packet {} from port {} to {}".format(repr(pkt), str(in_port), str(ip_dst)))
 
         return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
     #---------------------------------------------------------------------

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -2,6 +2,7 @@ import pytest
 import time
 import json
 import logging
+import tempfile
 
 from common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from ptf_runner import ptf_runner
@@ -22,23 +23,30 @@ SRC_IPV6_RANGE = ['20D0:A800:0:00::', '20D0:A800:0:00::FFFF']
 DST_IPV6_RANGE = ['20D0:A800:0:01::', '20D0:A800:0:01::FFFF']
 VLANIDS = range(1032, 1279)
 VLANIP = '192.168.{}.1/24'
+PTF_QLEN = 2000
 
-g_vars = {}
 
-def build_fib(duthost, config_facts, fibfile, t):
+@pytest.fixture(scope="module")
+def config_facts(duthost):
+    return duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+
+
+@pytest.fixture(scope='module')
+def build_fib(duthost, ptfhost, config_facts):
+
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 
-    duthost.shell("redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(t))
-    duthost.fetch(src="/tmp/fib.{}.txt".format(t), dest="/tmp/fib")
+    duthost.shell("redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(timestamp))
+    duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
 
     po = config_facts.get('PORTCHANNEL', {})
     ports = config_facts.get('PORT', {})
 
-    with open("/tmp/fib/{}/tmp/fib.{}.txt".format(duthost.hostname, t)) as fp, \
-         open(fibfile, 'w') as ofp:
+    tmp_fib_info = tempfile.NamedTemporaryFile()
+    with open("/tmp/fib/{}/tmp/fib.{}.txt".format(duthost.hostname, timestamp)) as fp:
         fib = json.load(fp)
-
         for k, v in fib.items():
             skip = False
             prefix = k.split(':', 1)[1]
@@ -56,16 +64,20 @@ def build_fib(duthost, config_facts, fibfile, t):
                         logger.info("Route point to non front panel port {}:{}".format(k, v))
                         skip = True
             # skip direct attached subnet
-            if nh == '0.0.0.0' or nh == '::':
+            if nh == '0.0.0.0' or nh == '::' or nh == "":
                 skip = True
 
             if not skip:
-                ofp.write("{}".format(prefix))
+                tmp_fib_info.write("{}".format(prefix))
                 for op in oports:
-                    ofp.write(" [{}]".format(" ".join(op)))
-                ofp.write("\n")
+                    tmp_fib_info.write(" [{}]".format(" ".join(op)))
+                tmp_fib_info.write("\n")
             else:
-                ofp.write("{} []\n".format(prefix))
+                tmp_fib_info.write("{} []\n".format(prefix))
+    tmp_fib_info.flush()
+
+    ptfhost.copy(src=tmp_fib_info.name, dest="/root/fib_info.txt")
+
 
 def get_vlan_untag_ports(config_facts):
     """
@@ -81,6 +93,7 @@ def get_vlan_untag_ports(config_facts):
                     vlan_untag_ports.append(port_name)
 
     return vlan_untag_ports
+
 
 def get_router_interface_ports(config_facts, testbed):
     """
@@ -102,31 +115,23 @@ def get_router_interface_ports(config_facts, testbed):
 
     return router_interface_ports
 
+
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, True, 1514)])
-def test_fib(testbed, duthost, ptfhost, ipv4, ipv6, mtu):
+def test_basic_fib(testbed, duthost, ptfhost, ipv4, ipv6, mtu, config_facts, build_fib):
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-
-    t = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-
-    ofpname = "/tmp/fib/{}/tmp/fib_info.{}.txt".format(duthost.hostname, t)
-
-    build_fib(duthost, config_facts, ofpname, t)
-
-    ptfhost.copy(src=ofpname, dest="/root/fib_info.txt")
-    logging.info("run ptf test")
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
     # do not test load balancing for vs platform as kernel 4.9
     # can only do load balance base on L3
-    meta = config_facts.get('DEVICE_METADATA')
-    if meta['localhost']['platform'] == 'x86_64-kvm_x86_64-r0':
+    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
         test_balancing = False
     else:
         test_balancing = True
 
+    logging.info("run ptf test")
     testbed_type = testbed['topo']['name']
     router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
-    log_file = "/tmp/fib_test.FibTest.ipv4.{}.ipv6.{}.{}.log".format(ipv4, ipv6, t)
+    log_file = "/tmp/fib_test.FibTest.ipv4.{}.ipv6.{}.{}.log".format(ipv4, ipv6, timestamp)
     logging.info("PTF log file: %s" % log_file)
     ptf_runner(ptfhost,
                 "ptftests",
@@ -140,45 +145,42 @@ def test_fib(testbed, duthost, ptfhost, ipv4, ipv6, mtu):
                         "testbed_mtu": mtu,
                         "test_balancing": test_balancing },
                 log_file=log_file,
+                qlen=PTF_QLEN,
                 socket_recv_size=16384)
 
+
 @pytest.fixture(scope="module")
-def timestamp():
-    yield datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+def setup_hash(testbed, duthost, config_facts):
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
-@pytest.fixture(scope="function")
-def setup_hash(testbed, duthost, ptfhost, timestamp):
-    global g_vars
-
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-
-    ofpname = "/tmp/fib/{}/tmp/fib_info.{}.txt".format(duthost.hostname, timestamp)
-
-    build_fib(duthost, config_facts, ofpname, timestamp)
-
-    ptfhost.copy(src=ofpname, dest="/root/fib_info.txt")
-    logging.info("run ptf test")
+    setup_info = {}
 
     # TODO
-    if 'dst-mac' in HASH_KEYS:
-        HASH_KEYS.remove('dst-mac')
+    hash_keys = HASH_KEYS[:]    # Copy from global var to avoid side effects of multiple iterations
+    if 'dst-mac' in hash_keys:
+        hash_keys.remove('dst-mac')
 
     # do not test load balancing on L4 port on vs platform as kernel 4.9
     # can only do load balance base on L3
-    meta = config_facts.get('DEVICE_METADATA')
-    if meta['localhost']['platform'] == 'x86_64-kvm_x86_64-r0':
-        HASH_KEYS.remove('src-port')
-        HASH_KEYS.remove('dst-port')
+    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        if 'src-port' in hash_keys:
+            hash_keys.remove('src-port')
+        if 'dst-port' in hash_keys:
+            hash_keys.remove('dst-port')
+    if duthost.facts['asic_type'] in ["mellanox"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+    setup_info['hash_keys'] = hash_keys
 
-    g_vars['testbed_type'] = testbed['topo']['name']
-    g_vars['router_mac'] = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+    setup_info['testbed_type'] = testbed['topo']['name']
+    setup_info['router_mac'] = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
 
     vlan_untag_ports = get_vlan_untag_ports(config_facts)
     in_ports_name = get_router_interface_ports(config_facts, testbed)
-    g_vars['in_ports'] = [config_facts.get('port_index_map', {})[p] for p in in_ports_name]
+    setup_info['in_ports'] = [config_facts.get('port_index_map', {})[p] for p in in_ports_name]
 
     # add some vlan for hash_key vlan-id test
-    if 't0' in g_vars['testbed_type'] and 'vlan-id' in HASH_KEYS:
+    if 't0' in setup_info['testbed_type'] and 'vlan-id' in hash_keys:
         for vlan in VLANIDS:
             duthost.shell('config vlan add {}'.format(vlan))
             for port in vlan_untag_ports:
@@ -186,10 +188,10 @@ def setup_hash(testbed, duthost, ptfhost, timestamp):
             duthost.shell('config interface ip add Vlan{} '.format(vlan) + VLANIP.format(vlan%256))
         time.sleep(5)
 
-    yield
+    yield setup_info
 
     # remove added vlan
-    if 't0' in g_vars['testbed_type'] and 'vlan-id' in HASH_KEYS:
+    if 't0' in setup_info['testbed_type'] and 'vlan-id' in hash_keys:
         for vlan in VLANIDS:
             duthost.shell('config interface ip remove Vlan{} '.format(vlan) + VLANIP.format(vlan%256))
             for port in vlan_untag_ports:
@@ -197,44 +199,35 @@ def setup_hash(testbed, duthost, ptfhost, timestamp):
             duthost.shell('config vlan del {}'.format(vlan))
         time.sleep(5)
 
-def test_hash_ipv4(setup_hash, ptfhost, timestamp):
-    log_file = "/tmp/hash_test.HashTest.ipv4.{}.log".format(timestamp)
+
+@pytest.fixture(params=["ipv4", "ipv6"])
+def ipver(request):
+    return request.param
+
+
+def test_hash(setup_hash, ptfhost, build_fib, ipver):
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    log_file = "/tmp/hash_test.HashTest.{}.{}.log".format(ipver, timestamp)
     logging.info("PTF log file: %s" % log_file)
-    src_ip_range = SRC_IP_RANGE
-    dst_ip_range = DST_IP_RANGE
+    if ipver == "ipv4":
+        src_ip_range = SRC_IP_RANGE
+        dst_ip_range = DST_IP_RANGE
+    elif ipver == "ipv6":
+        src_ip_range = SRC_IPV6_RANGE
+        dst_ip_range = DST_IPV6_RANGE
 
     ptf_runner(ptfhost,
             "ptftests",
             "hash_test.HashTest",
             platform_dir="ptftests",
-            params={"testbed_type": g_vars['testbed_type'],
-                    "router_mac": g_vars['router_mac'],
+            params={"testbed_type": setup_hash['testbed_type'],
+                    "router_mac": setup_hash['router_mac'],
                     "fib_info": "/root/fib_info.txt",
                     "src_ip_range": ",".join(src_ip_range),
                     "dst_ip_range": ",".join(dst_ip_range),
-                    "in_ports": g_vars['in_ports'],
+                    "in_ports": setup_hash['in_ports'],
                     "vlan_ids": VLANIDS,
-                    "hash_keys": HASH_KEYS },
+                    "hash_keys": setup_hash['hash_keys']},
             log_file=log_file,
-            socket_recv_size=16384)
-
-def test_hash_ipv6(setup_hash, ptfhost, timestamp):
-    log_file = "/tmp/hash_test.HashTest.ipv6.{}.log".format(timestamp)
-    logging.info("PTF log file: %s" % log_file)
-    src_ip_range = SRC_IPV6_RANGE
-    dst_ip_range = DST_IPV6_RANGE
-
-    ptf_runner(ptfhost,
-            "ptftests",
-            "hash_test.HashTest",
-            platform_dir="ptftests",
-            params={"testbed_type": g_vars['testbed_type'],
-                    "router_mac": g_vars['router_mac'],
-                    "fib_info": "/root/fib_info.txt",
-                    "src_ip_range": ",".join(src_ip_range),
-                    "dst_ip_range": ",".join(dst_ip_range),
-                    "in_ports": g_vars['in_ports'],
-                    "vlan_ids": VLANIDS,
-                    "hash_keys": HASH_KEYS },
-            log_file=log_file,
+            qlen=PTF_QLEN,
             socket_recv_size=16384)

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -123,7 +123,7 @@ def test_basic_fib(testbed, duthost, ptfhost, ipv4, ipv6, mtu, config_facts, bui
 
     # do not test load balancing for vs platform as kernel 4.9
     # can only do load balance base on L3
-    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+    if duthost.facts['asic_type'] in ["vs"]:
         test_balancing = False
     else:
         test_balancing = True
@@ -162,7 +162,7 @@ def setup_hash(testbed, duthost, config_facts):
 
     # do not test load balancing on L4 port on vs platform as kernel 4.9
     # can only do load balance base on L3
-    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+    if duthost.facts['asic_type'] in ["vs"]:
         if 'src-port' in hash_keys:
             hash_keys.remove('src-port')
         if 'dst-port' in hash_keys:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test_fib script has some issues and always fails on various platforms and branches. This PR is to fix the various issues of this script.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Justifications for some of the changes
* Refactor to replace the global variable g_vars with fixtures
  * The global variable can cause side effect when run on vsimage.
* Increase ptf --qlen to ensure that all packets are captured
  * With default qlen 100, the pcap file captured on PTF docker is always corrpted.
* Combine test_hash_ipv4 and test_hash_ipv6 into parameterized case test_hash
  * For better code reuse
* Rename case test_fib to test_basic_fib  
  * Without this change, case name is same as the script name. Select subcase using "-k test_fib" will result in the execution of the whole script.

#### How did you do it?
* Refactor to replace the global variable g_vars with fixtures
* Optimize the fixtures to reduce repetitive execution
* Increase ptf --qlen to ensure that all packets are captured
* Combine test_hash_ipv4 and test_hash_ipv6 into parameterized
  case test_hash
* Rename case test_fib to test_basic_fib
* Change 'ingress-port' test to negative check since supporting
  of 'ingress-ports' has been removed.
* Skip 'ip-proto' check on Mellanox ASIC since it is not supported
* Widen 'ip-proto' range from (100,200) to (0, 255) to ensure hash
  balancing
* Skip route when its next hop is empty string
* Remove unused imports

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
