### PR TITLE
Fixing COPP test cases that do not involve policer 

### DIFF
--- a/ansible/swap_syncd.yml
+++ b/ansible/swap_syncd.yml
@@ -47,7 +47,14 @@
       become: true
       sysctl:
         name: "net.core.rmem_max"
-        value: 509430500
+        value: 609430500
+        sysctl_set: yes
+
+    - name: Set sysctl SENDBUF parameter for tests
+      become: true
+      sysctl:
+        name: "net.core.wmem_max"
+        value: 609430500
         sysctl_set: yes
 
     - name: Gather SONiC base image version

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -141,7 +141,10 @@ def swap_syncd(dut):
     delete_container(dut, "syncd")
 
     # Set sysctl RCVBUF parameter for tests
-    dut.command("sysctl -w net.core.rmem_max=509430500")
+    dut.command("sysctl -w net.core.rmem_max=609430500")
+
+    # Set sysctl SENDBUF parameter for tests
+    dut.command("sysctl -w net.core.wmem_max=609430500")
 
     # TODO: Getting the base image version should be a common utility
     output = dut.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")

--- a/tests/templates/ptf_nn_agent.conf.dut.j2
+++ b/tests/templates/ptf_nn_agent.conf.dut.j2
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-{{ nn_target_port }}@{{ nn_target_interface }} --set-nn-rcv-buffer=109430400 --set-iface-rcv-buffer=109430400 --set-nn-snd-buffer=109430400 --set-iface-snd-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-{{ nn_target_port }}@{{ nn_target_interface }} --set-nn-rcv-buffer=609430400 --set-iface-rcv-buffer=609430400 --set-nn-snd-buffer=609430400 --set-iface-snd-buffer=609430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log


### PR DESCRIPTION
For COPP test cases that do not have policer bind and send 100K+ packets to CPU
ptf_nn_agent is not able to account for all the packets. Based on this
thread https://github.com/Azure/sonic-mgmt/issues/308
I have increased both send/receive socket buffer both on Kernel and
socket side. 

Issue is Seen on Broadcom based Dell-6000 platform.

After changing this all test case passed.

