### PR TITLE
[kvm] Add VS marker for current set of KVM-compatible test cases

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -1,7 +1,8 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_bgp_facts(duthost):

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -5,7 +5,8 @@ from common.helpers.assertions import pytest_assert
 from common.utilities import wait_until
 
 pytestmark = [
-    pytest.mark.topology('t1')
+    pytest.mark.topology('t1'),
+    pytest.mark.device_type('vs')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -10,7 +10,8 @@ from ptf_runner import ptf_runner
 from common.utilities import wait_tcp_connection
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('vs')
 ]
 
 def generate_ips(num, prefix, exclude_ips):

--- a/tests/cacl/test_control_plane_acl.py
+++ b/tests/cacl/test_control_plane_acl.py
@@ -2,7 +2,8 @@ import pytest
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 SONIC_SSH_PORT  = 22

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -7,7 +7,8 @@ from common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/un
 from ptf_runner import ptf_runner
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.fixture(scope="module")

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -4,7 +4,8 @@ import pytest
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -8,7 +8,8 @@ import pytest
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.fixture(scope="module")

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -3,7 +3,8 @@ import pytest
 import logging
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_po_update(duthost):

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -4,7 +4,8 @@ import logging
 from common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -5,7 +5,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.mark.bsl

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -1,7 +1,8 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.mark.bsl

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,7 +1,8 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/snmp/test_snmp_pfc_counters.py
+++ b/tests/snmp/test_snmp_pfc_counters.py
@@ -1,7 +1,8 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_snmp_pfc_counters(duthost, localhost, creds):

--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -1,7 +1,8 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_snmp_queues(duthost, localhost, creds, collect_techsupport):

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -3,7 +3,8 @@ import pytest
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_ro_user(localhost, duthost, creds, setup_tacacs):

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -4,7 +4,8 @@ import crypt
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_rw_user(duthost, creds, setup_tacacs):

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -2,7 +2,8 @@ from netaddr import IPAddress
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
 ]
 
 def test_interfaces(duthost):


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Adds the "VS" device type marker to the PR tests we currently run on KVM.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We would like the PR tests to use the same infrastructure to run the tests as we do locally and for nightly regression tests with physical DUTs, so we're adding the "vs" marker to the KVM tests so we can run them using the marker rather than a static list.

#### How did you do it?
Added the markers to the files listed here: https://github.com/Azure/sonic-build-tools/blob/master/scripts/vs/buildimage-vs-image/runtest.sh

#### How did you verify/test it?
Ran the tests locally and confirmed everything was skipped except for the 22 marked test cases. [DRAFT NOTE: still running]

#### Any platform specific information?
KVM

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
