### PR TITLE
Fix the issue of checking test case topology

### DIFF
--- a/tests/common/plugins/custom_markers/__init__.py
+++ b/tests/common/plugins/custom_markers/__init__.py
@@ -46,11 +46,13 @@ def pytest_runtest_setup(item):
 def check_topology(item):
     # The closest marker is used here so that the module or class level
     # marker will be overrided by case level marker
-    toponames = item.get_closest_marker("topology")
-    if toponames:
+    topo_marks = [mark for mark in item.iter_markers(name="topology")]   # Get all 'topology' marks on the chain
+    if topo_marks:
+        topo_mark = topo_marks[0]   # The nearest mark overides others
         cfg_topos = item.config.getoption("--topology").split(',')
-        if all(topo not in toponames.args for topo in cfg_topos):
-            pytest.skip("test requires topology in {!r}".format(toponames))
+        if all(topo not in topo_mark.args for topo in cfg_topos):
+            pytest.skip("{} supports topologies: {}, specified topologies: {}"\
+                .format(item.nodeid, topo_mark.args, cfg_topos))
     else:
         warn_msg = "testcase {} is skipped when no topology marker is given".format(item.nodeid)
         warnings.warn(warn_msg)
@@ -61,30 +63,30 @@ def check_feature(item):
     if feature_names:
         cfg_features = item.config.getoption("--feature").split(',')
         if all(feature not in feature_names[0] for feature in cfg_features):
-            pytest.skip("test requires feature name in {!r}".format(feature_names))
+            pytest.skip("test {} requires feature name in {!r}".format(item.nodeid, feature_names))
     else:
-        pytest.skip("test does not match feature")
+        pytest.skip("test {} does not match feature".format(item.nodeid))
 
 def check_asic(item):
     asic = [mark.args[0] for mark in item.iter_markers(name="asic")]
     if asic:
         if item.config.getoption("--asic") not in asic:
-            pytest.skip("test requires asic in {!r}".format(asic))
+            pytest.skip("test {} requires asic in {!r}".format(item.nodeid, asic))
     else:
-        pytest.skip("test does not match asic type")
+        pytest.skip("test {} does not match asic type".format(item.nodeid))
 
 def check_conn_type(item):
     conn = [mark.args[0] for mark in item.iter_markers(name="connection_type")]
     if conn:
         if item.config.getoption("--connection_type") not in conn:
-            pytest.skip("test requires connection in {!r}".format(conn))
+            pytest.skip("test {} requires connection in {!r}".format(item.nodeid, conn))
     else:
-        pytest.skip("test does not match connection type")
+        pytest.skip("test {} does not match connection type".format(item.nodeid))
 
 def check_device_type(item):
     dev = [mark.args[0] for mark in item.iter_markers(name="device_type")]
     if dev:
         if item.config.getoption("--device_type") not in dev:
-            pytest.skip("test requires device type in {!r}".format(dev))
+            pytest.skip("test {} requires device type in {!r}".format(item.nodeid, dev))
     else:
-        pytest.skip("test does not match device type")
+        pytest.skip("test {} does not match device type".format(item.nodeid))

--- a/tests/common/plugins/custom_markers/__init__.py
+++ b/tests/common/plugins/custom_markers/__init__.py
@@ -51,8 +51,7 @@ def check_topology(item):
         topo_mark = topo_marks[0]   # The nearest mark overides others
         cfg_topos = item.config.getoption("--topology").split(',')
         if all(topo not in topo_mark.args for topo in cfg_topos):
-            pytest.skip("{} supports topologies: {}, specified topologies: {}"\
-                .format(item.nodeid, topo_mark.args, cfg_topos))
+            pytest.skip("test requires topology in {!r}".format(topo_mark))
     else:
         warn_msg = "testcase {} is skipped when no topology marker is given".format(item.nodeid)
         warnings.warn(warn_msg)
@@ -63,30 +62,30 @@ def check_feature(item):
     if feature_names:
         cfg_features = item.config.getoption("--feature").split(',')
         if all(feature not in feature_names[0] for feature in cfg_features):
-            pytest.skip("test {} requires feature name in {!r}".format(item.nodeid, feature_names))
+            pytest.skip("test requires feature name in {!r}".format(feature_names))
     else:
-        pytest.skip("test {} does not match feature".format(item.nodeid))
+        pytest.skip("test does not match feature")
 
 def check_asic(item):
     asic = [mark.args[0] for mark in item.iter_markers(name="asic")]
     if asic:
         if item.config.getoption("--asic") not in asic:
-            pytest.skip("test {} requires asic in {!r}".format(item.nodeid, asic))
+            pytest.skip("test requires asic in {!r}".format(asic))
     else:
-        pytest.skip("test {} does not match asic type".format(item.nodeid))
+        pytest.skip("test does not match asic type")
 
 def check_conn_type(item):
     conn = [mark.args[0] for mark in item.iter_markers(name="connection_type")]
     if conn:
         if item.config.getoption("--connection_type") not in conn:
-            pytest.skip("test {} requires connection in {!r}".format(item.nodeid, conn))
+            pytest.skip("test requires connection in {!r}".format(conn))
     else:
-        pytest.skip("test {} does not match connection type".format(item.nodeid))
+        pytest.skip("test does not match connection type")
 
 def check_device_type(item):
     dev = [mark.args[0] for mark in item.iter_markers(name="device_type")]
     if dev:
         if item.config.getoption("--device_type") not in dev:
-            pytest.skip("test {} requires device type in {!r}".format(item.nodeid, dev))
+            pytest.skip("test requires device type in {!r}".format(dev))
     else:
-        pytest.skip("test {} does not match device type".format(item.nodeid))
+        pytest.skip("test does not match device type")

--- a/tests/docs/pytest.org.md
+++ b/tests/docs/pytest.org.md
@@ -38,13 +38,17 @@ def pytest_runtest_setup(item):
 def check_topology(item):
     # The closest marker is used here so that the module or class level
     # marker will be overrided by case level marker
-    toponames = item.get_closest_marker("topology")
-    if toponames:
+    topo_marks = [mark for mark in item.iter_markers(name="topology")]   # Get all 'topology' marks on the chain
+    if topo_marks:
+        topo_mark = topo_marks[0]   # The nearest mark overides others
         cfg_topos = item.config.getoption("--topology").split(',')
-        if all(topo not in toponames.args for topo in cfg_topos):
-            pytest.skip("test requires topology in {!r}".format(toponames))
+        if all(topo not in topo_mark.args for topo in cfg_topos):
+            pytest.skip("{} supports topologies: {}, specified topologies: {}"\
+                .format(item.nodeid, topo_mark.args, cfg_topos))
     else:
-        pytest.skip("testcase {} is skipped when no topology marker is given".format(item.name))
+        warn_msg = "testcase {} is skipped when no topology marker is given".format(item.nodeid)
+        warnings.warn(warn_msg)
+        pytest.skip(warn_msg)
 ```
 
 Sample test file: test_topo.py
@@ -90,25 +94,23 @@ Test run
 
 ```
 py.test --inventory inv --host-pattern dut-1 --module-path ../ansible/library/ --testbed tb --testbed_file tb.csv --junit-xml=tr.xml --log-cli-level warn --topology t1 test_topo
-========================================================================================= test session starts =========================================================================================
+ --disable_loganalyzer --topology t1 test_topo.py
+================================= test session starts ==================================
 platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
 ansible: 2.8.7
-rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
-plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
-collected 5 items                                                                                                                                                                                     
+rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini
+plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2
+collected 4 items
 
-test_topo/test_notopo.py::test_notopo SKIPPED                                                                                                                                                   [ 20%]
-test_topo/test_topo.py::test_all PASSED                                                                                                                                                         [ 40%]
-test_topo/test_topo.py::test_t0 SKIPPED                                                                                                                                                         [ 60%]
-test_topo/test_topo.py::test_t1 PASSED                                                                                                                                                          [ 80%]
-test_topo/test_topo.py::test_any SKIPPED                                                                                                                                                        [100%]
+test_topo.py::test_all PASSED                                                    [ 25%]
+test_topo.py::test_t0 SKIPPED                                                    [ 50%]
+test_topo.py::test_t1 PASSED                                                     [ 75%]
+test_topo.py::test_any SKIPPED                                                   [100%]
 
------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
-======================================================================================= short test summary info =======================================================================================
-SKIPPED [1] /data/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:55: testcase test_notopo is skipped when no topology marker is given
-SKIPPED [1] /data/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:53: test requires topology in Mark(name='topology', args=('any',), kwargs={})
-SKIPPED [1] /data/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:53: test requires topology in Mark(name='topology', args=('t0',), kwargs={})
-
+=============================== short test summary info ================================
+SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_topo.py::test_any supports topologies: ('any',), specified topologies: ['t1']
+SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_topo.py::test_t0 supports topologies: ('t0',), specified topologies: ['t1']
+========================= 2 passed, 2 skipped in 10.24 seconds =========================
 ```
 ## Test file organization
 - Have 2 broad categories (platform and feature). Feature specific tests and their helpers go into specific feature folders.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The current implementation has issue with getting the closest 'topology' mark when the test case is parameterized. The reason is that item.get_closest_marker() uses `next` underhood. When the test case is parameterized, this call may return unexpected marker. Test case would be skipped as unexpected with wrong reason message.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix the issue of checking test case topology when test case is parameterized.

#### How did you do it?
* All get the full list of `topology` markers on the chain for each test case.
* Compare the closest marker with the specified topology.
* Add item.nodeid in skip message to ensure that the skip message is logged for each skipped test case

#### How did you verify/test it?
Example script test_mark.py:
```
import pytest

pytestmark = [
    pytest.mark.topology('t1')
]

@pytest.fixture(scope="module", params=["param1_value1", "param1_value2"])
def param1(request):
    return request.param

def test_case1_1(param1):
    assert True

@pytest.mark.topology('t0')
def test_case1_2(param1):
    assert True

@pytest.mark.topology('t1')
def test_case1_3(param1):
    assert True

@pytest.mark.topology('any')
def test_case1_4(param1):
    assert True

@pytest.mark.parametrize("param2", ["param2_value1", "param2_value2"])
def test_case2_1(param2):
    assert True

@pytest.mark.topology('t0')
@pytest.mark.parametrize("param2", ["param2_value1", "param2_value2"])
def test_case2_2(param2):
    assert True

@pytest.mark.topology('t1')
@pytest.mark.parametrize("param2", ["param2_value1", "param2_value2"])
def test_case2_3(param2):
    assert True

@pytest.mark.topology('any')
@pytest.mark.parametrize("param2", ["param2_value1", "param2_value2"])
def test_case2_4(param2):
    assert True

def test_case3_1():
    assert True

@pytest.mark.topology('tx')
def test_case3_2():
    assert True

@pytest.mark.topology('tx')
def test_case3_3(duthost):
    assert True

@pytest.mark.topology('tx')
def test_case3_4(duthost):
    assert True
```

Test result:
```
johnar@e88ba1fda5a2:~/code/sonic-mgmt/tests$ pytest --inventory veos.vtb --host-pattern vlab-01  --testbed vms-kvm-t0 --testbed_file vtestbed.csv --showlocals --assert plain --log-cli-level warn --skip_sanity
 --disable_loganalyzer --topology t0,any test_mark.py
============================================================================================= test session starts ==============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini
plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2
collected 20 items                                                                                                                                                                                             

test_mark.py::test_case1_1[param1_value1] SKIPPED                                                                                                                                                        [  5%]
test_mark.py::test_case1_2[param1_value1] PASSED                                                                                                                                                         [ 10%]
test_mark.py::test_case1_3[param1_value1] SKIPPED                                                                                                                                                        [ 15%]
test_mark.py::test_case1_4[param1_value1] PASSED                                                                                                                                                         [ 20%]
test_mark.py::test_case1_1[param1_value2] SKIPPED                                                                                                                                                        [ 25%]
test_mark.py::test_case1_2[param1_value2] PASSED                                                                                                                                                         [ 30%]
test_mark.py::test_case1_3[param1_value2] SKIPPED                                                                                                                                                        [ 35%]
test_mark.py::test_case1_4[param1_value2] PASSED                                                                                                                                                         [ 40%]
test_mark.py::test_case2_1[param2_value1] SKIPPED                                                                                                                                                        [ 45%]
test_mark.py::test_case2_1[param2_value2] SKIPPED                                                                                                                                                        [ 50%]
test_mark.py::test_case2_2[param2_value1] PASSED                                                                                                                                                         [ 55%]
test_mark.py::test_case2_2[param2_value2] PASSED                                                                                                                                                         [ 60%]
test_mark.py::test_case2_3[param2_value1] SKIPPED                                                                                                                                                        [ 65%]
test_mark.py::test_case2_3[param2_value2] SKIPPED                                                                                                                                                        [ 70%]
test_mark.py::test_case2_4[param2_value1] PASSED                                                                                                                                                         [ 75%]
test_mark.py::test_case2_4[param2_value2] PASSED                                                                                                                                                         [ 80%]
test_mark.py::test_case3_1 SKIPPED                                                                                                                                                                       [ 85%]
test_mark.py::test_case3_2 SKIPPED                                                                                                                                                                       [ 90%]
test_mark.py::test_case3_3 SKIPPED                                                                                                                                                                       [ 95%]
test_mark.py::test_case3_4 SKIPPED                                                                                                                                                                       [100%]

=========================================================================================== short test summary info ============================================================================================
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_1[param1_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_1[param1_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_2 supports topologies: ('tx',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_1 supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_3[param1_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_3[param2_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_4 supports topologies: ('tx',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_3[param2_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_1[param2_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_1[param2_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_3[param1_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_3 supports topologies: ('tx',), specified topologies: ['t0', 'any']
==================================================================================== 8 passed, 12 skipped in 25.49 seconds =====================================================================================
johnar@e88ba1fda5a2:~/code/sonic-mgmt/tests$
johnar@e88ba1fda5a2:~/code/sonic-mgmt/tests$ pytest --inventory veos.vtb --host-pattern vlab-01  --testbed vms-kvm-t0 --testbed_file vtestbed.csv --showlocals --assert plain --log-cli-level warn --skip_sanity
 --disable_loganalyzer --topology t0,any test_mark.py
============================================================================================= test session starts ==============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini
plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2
collected 20 items                                                                                                                                                                                             

test_mark.py::test_case1_1[param1_value1] SKIPPED                                                                                                                                                        [  5%]
test_mark.py::test_case1_2[param1_value1] PASSED                                                                                                                                                         [ 10%]
test_mark.py::test_case1_3[param1_value1] SKIPPED                                                                                                                                                        [ 15%]
test_mark.py::test_case1_4[param1_value1] PASSED                                                                                                                                                         [ 20%]
test_mark.py::test_case1_1[param1_value2] SKIPPED                                                                                                                                                        [ 25%]
test_mark.py::test_case1_2[param1_value2] PASSED                                                                                                                                                         [ 30%]
test_mark.py::test_case1_3[param1_value2] SKIPPED                                                                                                                                                        [ 35%]
test_mark.py::test_case1_4[param1_value2] PASSED                                                                                                                                                         [ 40%]
test_mark.py::test_case2_1[param2_value1] SKIPPED                                                                                                                                                        [ 45%]
test_mark.py::test_case2_1[param2_value2] SKIPPED                                                                                                                                                        [ 50%]
test_mark.py::test_case2_2[param2_value1] PASSED                                                                                                                                                         [ 55%]
test_mark.py::test_case2_2[param2_value2] PASSED                                                                                                                                                         [ 60%]
test_mark.py::test_case2_3[param2_value1] SKIPPED                                                                                                                                                        [ 65%]
test_mark.py::test_case2_3[param2_value2] SKIPPED                                                                                                                                                        [ 70%]
test_mark.py::test_case2_4[param2_value1] PASSED                                                                                                                                                         [ 75%]
test_mark.py::test_case2_4[param2_value2] PASSED                                                                                                                                                         [ 80%]
test_mark.py::test_case3_1 SKIPPED                                                                                                                                                                       [ 85%]
test_mark.py::test_case3_2 SKIPPED                                                                                                                                                                       [ 90%]
test_mark.py::test_case3_3 SKIPPED                                                                                                                                                                       [ 95%]
test_mark.py::test_case3_4 SKIPPED                                                                                                                                                                       [100%]

=========================================================================================== short test summary info ============================================================================================
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_1[param1_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_1[param1_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_2 supports topologies: ('tx',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_1 supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_3[param1_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_3[param2_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_4 supports topologies: ('tx',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_3[param2_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_1[param2_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case2_1[param2_value1] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case1_3[param1_value2] supports topologies: ('t1',), specified topologies: ['t0', 'any']
SKIPPED [1] /var/johnar/code/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:56: test_mark.py::test_case3_3 supports topologies: ('tx',), specified topologies: ['t0', 'any']
==================================================================================== 8 passed, 12 skipped in 25.49 seconds =====================================================================================
johnar@e88ba1fda5a2:~/code/sonic-mgmt/tests$
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
