### PR TITLE
Fix import in platform_api_server

### DIFF
--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
-import sonic_platform
+import sonic_platform.platform
 
 SYSLOG_IDENTIFIER = os.path.basename(__file__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The platform_api_server failed to start in pmon container due to an import issue, which leads to a series of test error. This PR do a minor change in import.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix the issue that platform_api_server is not able to start in pmon container. 
#### How did you do it?
Do a minor change in import.
#### How did you verify/test it?
Test on a Arista-7260cx3 DUT. 
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Not related.