### PR TITLE
Fixed path to the arp responder jinja file

### DIFF
--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -3,7 +3,7 @@ import os
 import time
 
 from netaddr import IPAddress
-from tests.common.helpers.generators import generate_ips
+from common.helpers.generators import generate_ips
 
 
 PFC_GEN_FILE = "pfc_gen.py"
@@ -18,7 +18,7 @@ TESTS_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "../.."))
 ANSIBLE_ROOT = os.path.realpath(os.path.join(TESTS_ROOT, "../ansible"))
 
 ARP_RESPONDER = os.path.join(TESTS_ROOT, "scripts/arp_responder.py")
-ARP_RESPONDER_CONF = os.path.join(TESTS_ROOT, "scripts/arp_responder.conf.j2")
+ARP_RESPONDER_CONF = os.path.join(TESTS_ROOT, "templates/arp_responder.conf.j2")
 
 
 def get_fanout(fanout_graph_facts, setup):
@@ -159,6 +159,7 @@ def enable_pfc_asym(setup, duthost):
     finally:
         # Disable asymmetric PFC on all server interfaces
         duthost.shell("for item in {}; do config interface pfc asymmetric $item off; done".format(srv_ports))
+        time.sleep(5)
         for p_oid in setup["server_ports_oids"]:
             # Verify asymmetric PFC disabled
             assert pfc_asym_restored == duthost.command(get_pfc_mode.format(p_oid))["stdout"]


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fixed path to arp responder jinja file, which is used by pfc_asym test cases
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To fix path to the ARP responder config file.
Also added additional sleep to wait until PFC mode configuration on the interfaces will be applied.

#### How did you do it?

#### How did you verify/test it?
Tested on the local setup by running 'tests/pfc_asym/test_pfc_asym.py' tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
