### PR TITLE
Use the creds fixture to get username and password

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -170,7 +170,7 @@ class TestWrArp:
         ptfhost.script('./scripts/remove_ip.sh')
 
     @pytest.fixture(scope='class', autouse=True)
-    def prepareSshKeys(self, duthost, ptfhost):
+    def prepareSshKeys(self, duthost, ptfhost, creds):
         '''
             Prepares testbed ssh keys by generating ssh key on ptf host and adding this key to known_hosts on duthost
             This class-scope fixture runs once before test start
@@ -182,15 +182,11 @@ class TestWrArp:
             Returns:
                 None
         '''
-        hostVars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
-        invetory = hostVars['inventory_file'].split('/')[-1]
-        secrets = duthost.host.options['variable_manager']._hostvars[duthost.hostname]['secret_group_vars']
-
-        prepareTestbedSshKeys(duthost, ptfhost, secrets[invetory]['sonicadmin_user'])
+        prepareTestbedSshKeys(duthost, ptfhost, creds['sonicadmin_user'])
 
     def testWrArp(self, request, duthost, ptfhost):
         '''
-            Control Plane Assistent test for Warm-Reboot.
+            Control Plane Assistant test for Warm-Reboot.
 
             The test first start Ferret server, implemented in Python. Then initiate Warm-Reboot procedure. While the
             host in Warm-Reboot test continuously sending ARP request to the Vlan member ports and expect to receive ARP

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -21,13 +21,13 @@ class AdvancedReboot:
     '''
     AdvancedReboot is used to perform reboot dut while running preboot/inboot operations
 
-    Thed class collects information about the current testbed. This information is used by test cases to build
+    This class collects information about the current testbed. This information is used by test cases to build
     inboot/preboot list. The class transfers number of configuration files to the dut/ptf in preparation for reboot test.
     Test cases can trigger test start utilizing runRebootTestcase API.
     '''
-    def __init__(self, request, duthost, ptfhost, localhost, testbed, **kwargs):
+    def __init__(self, request, duthost, ptfhost, localhost, testbed, creds, **kwargs):
         '''
-        Class contructor.
+        Class constructor.
         @param request: pytest request object
         @param duthost: AnsibleHost instance of DUT
         @param ptfhost: PTFHost for interacting with PTF through ansible
@@ -44,6 +44,7 @@ class AdvancedReboot:
         self.ptfhost = ptfhost
         self.localhost = localhost
         self.testbed = testbed
+        self.creds = creds
         self.__dict__.update(kwargs)
         self.__extractTestParam()
         self.rebootData = {}
@@ -121,11 +122,8 @@ class AdvancedReboot:
         self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
         self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
 
-        hostVars = self.duthost.host.options['variable_manager']._hostvars[self.duthost.hostname]
-        invetory = hostVars['inventory_file'].split('/')[-1]
-        secrets = hostVars['secret_group_vars']
-        self.rebootData['dut_username'] = secrets[invetory]['sonicadmin_user']
-        self.rebootData['dut_password'] = secrets[invetory]['sonicadmin_password']
+        self.rebootData['dut_username'] = creds['sonicadmin_user']
+        self.rebootData['dut_password'] = creds['sonicadmin_password']
 
         # Change network of the dest IP addresses (used by VM servers) to be different from Vlan network
         prefixLen = self.mgFacts['minigraph_vlan_interfaces'][0]['prefixlen'] - 3
@@ -449,7 +447,7 @@ class AdvancedReboot:
 
     def __restorePrevImage(self):
         '''
-        Resotre previous image and reboot DUT
+        Restore previous image and reboot DUT
         '''
         currentImage = self.duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
         if currentImage != self.currentImage:
@@ -481,7 +479,7 @@ class AdvancedReboot:
             self.__restorePrevImage()
 
 @pytest.fixture
-def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed):
+def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed, creds):
     '''
     Pytest test fixture that provides access to AdvancedReboot test fixture
         @param request: pytest request object
@@ -497,7 +495,7 @@ def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed):
         API that returns instances of AdvancedReboot class
         '''
         assert len(instances) == 0, "Only one instance of reboot data is allowed"
-        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, **kwargs)
+        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, creds, **kwargs)
         instances.append(advancedReboot)
         return advancedReboot
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The original code uses secrets['secret-group-vars'] to get username and password
of DUT. This is not the standard way for getting credentials. This PR uses the `creds`
fixture to get DUT username and password.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The method for getting credential in test_wr_arp and advanced_reboot is not standard. Replace it with using the `creds` fixture to get the username and password.

#### How did you do it?
* Replace the method of reading username and password from secrets['secret-group-vars'] with the standard `creds` fixture.
* Fixed some typos.

#### How did you verify/test it?
Test run `tests/arp/test_wr_arp.py` and `tests/platform_tests/test_advanced_reboot.py`.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
