### PR TITLE
[vlan] fix unintentionally addidng portchannel member as vlan member

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -151,7 +151,7 @@ def setup_vlan(ptfadapter, duthost, ptfhost, vlan_ports_list, vlan_intfs_list, c
         }
 
         ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
-        ptfhost.template(src='arp_responder.conf.j2', dest='/tmp')
+        ptfhost.template(src='templates/arp_responder.conf.j2', dest='/tmp')
         ptfhost.command("cp /tmp/arp_responder.conf.j2 /etc/supervisor/conf.d/arp_responder.conf")
 
         ptfhost.command('supervisorctl reread')

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -37,6 +37,9 @@ def vlan_ports_list(cfg_facts, ptfhost):
     config_port_indices = cfg_facts['port_index_map']
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
 
+    config_port_channel_members = [port_channel[1]['members'] for port_channel in config_portchannels.items()]
+    config_port_channel_member_ports = list(itertools.chain.from_iterable(config_port_channel_members))
+
     pvid_cycle = itertools.cycle(vlan_id_list)
 
     # when running on t0 we can use the portchannel members
@@ -53,8 +56,10 @@ def vlan_ports_list(cfg_facts, ptfhost):
                     } for vid in vlan_id_list }
             })
 
-    ports = [ port for port in config_ports
-        if config_port_indices[port] in ptf_ports_available_in_topo and config_ports[port].get('admin_status', 'down') == 'up' ]
+    ports = [port for port in config_ports
+        if config_port_indices[port] in ptf_ports_available_in_topo
+        and config_ports[port].get('admin_status', 'down') == 'up'
+        and port not in config_port_channel_member_ports]
 
     for port in ports[:4]:
         vlan_ports_list.append({


### PR DESCRIPTION
Change-Id: I92950baa343082c6725a1d516a9343b12f50012d
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #1882 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the vlan test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
