### PR TITLE
[link flap] disable log analysis for link flap test

### DIFF
--- a/tests/platform_tests/test_link_flap.py
+++ b/tests/platform_tests/test_link_flap.py
@@ -6,6 +6,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any')
 ]
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There are false positives with log analysis.

#### How did you do it?
disable log analysis for link_flap test.

#### How did you verify/test it?
Run link flap test with the change.
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

platform_tests/test_link_flap.py::test_link_flap PASSED                                                                                                                            [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
======================================================================== 1 passed, 2 warnings in 1240.17 seconds =========================================================================
INFO:tests.conftest:==================== platform_tests/test_link_flap.py::test_link_flap teardown done ====================