### PR TITLE
[Ansible] Add ptf_host credential variables

### DIFF
--- a/ansible/group_vars/ptf_host/secrets.yml
+++ b/ansible/group_vars/ptf_host/secrets.yml
@@ -1,0 +1,4 @@
+---
+# Please update the actual ptf username and password based on your lab config
+ptf_host_user: root
+ptf_host_pass: root


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
As the subject, add missing credentials for `ptf` host.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
