### PR TITLE
[Ansible] Start ptf_tgen in ptf container

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -70,3 +70,7 @@
 - name: Send arp ping packet to gw for flusing the ARP table
   command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
   become: yes
+
+- name: Start ptf_tgen service
+  include_tasks: start_ptf_tgen.yml
+  when: topo == 'fullmesh'

--- a/ansible/roles/vm_set/tasks/start_ptf_tgen.yml
+++ b/ansible/roles/vm_set/tasks/start_ptf_tgen.yml
@@ -1,0 +1,55 @@
+---
+- name: Include variables for PTF containers
+  include_vars:
+    dir: "{{ playbook_dir }}/group_vars/ptf_host/"
+
+- block:
+    - name: Set ptf host
+      set_fact:
+        ptf_host: "ptf_{{ vm_set_name }}"
+        ptf_host_ip: "{{ ptf_ip.split('/')[0] }}"
+
+    - name: Add ptf host
+      add_host:
+        hostname: "{{ ptf_host }}"
+        ansible_user: "{{ ptf_host_user }}"
+        ansible_ssh_host: "{{ ptf_host_ip }}"
+        ansible_ssh_pass: "{{ ptf_host_pass }}"
+        groups:
+          - ptf_host
+
+    - name: Check if ptf_tgen exists
+      supervisorctl:
+        name: ptf_tgen
+        state: present
+      become: True
+      delegate_to: "{{ ptf_host }}"
+      ignore_errors: True
+      register: ptf_tgen_state
+
+    - block:
+        - name: Copy scapy scripts to ptf host
+          copy:
+            src: "{{ item }}"
+            dest: "/ptf_tgen/"
+          with_fileglob:
+            - "{{ playbook_dir }}/../spytest/spytest/tgen/scapy/*"
+            - "{{ playbook_dir }}/../spytest/spytest/dicts.py"
+
+        - name: Create ptf_tgen service
+          copy:
+            src: "/ptf_tgen/service.sh"
+            dest: "/ptf_tgen/ptf_tgen.sh"
+            mode: "0755"
+            remote_src: yes
+
+        - name: Start ptf_tgen
+          supervisorctl:
+            name: ptf_tgen
+            state: restarted
+      become: True
+      delegate_to: "{{ ptf_host }}"
+      when: ptf_tgen_state is not failed
+  when:
+    - ptf_host_user is defined
+    - ptf_host_pass is defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Add following steps to `add_topo`:
1. Copy requried scripts to /ptf_tgen of `PTF` container.
2. Start the ptf_tgen supervisor process inside `PTF` container.

**NOTICE**: skip if
* `topo` is not `fullmesh`
* `ptf_tgen` supervisor process is present.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To get `PTF` ready for `spytest` after adding topology.

#### How did you do it?

#### How did you verify/test it?
```
# ./testbed-cli.sh -t testbed.csv  add-topo spytest /data/password.txt
```
after, inside `PTF` container, `ptf_tgen` is in `running` state.
```
root@383faa151543:/# supervisorctl 
ptf_nn_agent                     RUNNING   pid 15, uptime 18:02:26
ptf_tgen                         RUNNING   pid 348, uptime 18:01:19
sshd                             RUNNING   pid 14, uptime 18:02:26
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
