### PR TITLE
Add the topology mark missed in couple of scripts

### DIFF
--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -2,6 +2,10 @@ import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
 
+pytestmark = [
+    pytest.mark.topology('t1')
+]
+
 logger = logging.getLogger(__name__)
 
 def get_t2_neigh(testbed):

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -15,6 +15,10 @@ import netaddr
 from tests.common.utilities import wait_until
 from drop_packets import *
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 logger = logging.getLogger(__name__)
 
 PKT_NUMBER = 1000

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -6,6 +6,10 @@ import time
 from tests.common.utilities import wait_until
 from device_mocker import device_mocker_factory
 
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
 HEALTH_TABLE_NAME = 'SYSTEM_HEALTH_INFO'
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The topology mark is mandatory for all test scripts. Some of
the scripts don't have this mark somehow. This change is to
add topology mark to these scripts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Without topology mark in test script, these script will be skipped if `--topology` pytest cli argument is given.

#### How did you do it?
Add topology mark to the scripts.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
