### PR TITLE
Add "-x" bash option to run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 function show_help_and_exit()
 {
@@ -71,7 +71,7 @@ function setup_environment()
 
     export ANSIBLE_CONFIG=${BASE_PATH}/ansible
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
-} 
+}
 
 function setup_test_options()
 {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 function show_help_and_exit()
 {
@@ -20,6 +20,7 @@ function show_help_and_exit()
     echo "    -s             : specify list of scripts to skip (default: none)"
     echo "    -t             : specify toplogy: t0|t1|any|combo like t0,any (*)"
     echo "    -u             : bypass util group"
+    echo "    -x             : print commands and their arguments as they are executed"
 
     exit $1
 }
@@ -202,7 +203,7 @@ function run_individual_tests()
 
 setup_environment
 
-while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:u" opt; do
+while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:u:x" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -251,6 +252,9 @@ while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:u" opt; do
             ;;
         u )
             BYPASS_UTIL="True"
+            ;;
+        x )
+            set -x
             ;;
     esac
 done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add "-x" bash option to run_tests.sh

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
With the "-x" option, running the run_tests.sh script will have all the executed command output to console. It would be much helpful for troubleshooting.

#### How did you do it?
Add "-x" bash option to run_tests.sh.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
