### PR TITLE
Fix critical_processes_list in devices.py

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -337,7 +337,8 @@ class SonicHost(AnsibleHostBase):
         # get critical process list for the service
         output = self.command("docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'".format(service), module_ignore_errors=True)
         for l in output['stdout'].split():
-            critical_process_list.append(l.split(':')[1].rstrip())
+            # If ':' exists, the second field is got. Otherwise the only field is got.
+            critical_process_list.append(l.split(':')[-1].rstrip())
         if len(critical_process_list) == 0:
             return result
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -337,7 +337,7 @@ class SonicHost(AnsibleHostBase):
         # get critical process list for the service
         output = self.command("docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes'".format(service), module_ignore_errors=True)
         for l in output['stdout'].split():
-            critical_process_list.append(l.rstrip())
+            critical_process_list.append(l.split(':')[1].rstrip())
         if len(critical_process_list) == 0:
             return result
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix issue in 
The critical_process_list got in critical_process_status method is malformated. This commit fix the issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The critical_process_status in sanity_check gets critital list with command **cat /etc/supervisor/critical_processes**. However, the output of the command is like following:
```
root:/# cat /etc/supervisor/critical_processes
program:ledd
program:xcvrd
program:psud
```
There is a leading *program* in each line, and as a result, the following operation
```
if pname in critical_process_list:
                    result['running_critical_process'].append(pname)
```
will always get an empty list, and critital processes are not checked correctly. 
```
 "processes_status": {
            "lldp": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "pmon": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "database": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "snmp": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "bgp": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "teamd": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "syncd": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }, 
            "swss": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": []
            }
        }
```
#### How did you do it?
Update code in get critical_process_list.
#### How did you verify/test it?
Verify in on Arista-7260cx3, and the running_critical_process is no longer empty
```
"swss": {
                "status": true, 
                "exited_critical_process": [], 
                "running_critical_process": [
                    "buffermgrd", 
                    "intfmgrd", 
                    "nbrmgrd", 
                    "neighsyncd", 
                    "orchagent", 
                    "portmgrd", 
                    "portsyncd", 
                    "vlanmgrd", 
                    "vrfmgrd", 
                    "vxlanmgrd"
                ]
            }
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A