### PR TITLE
[util tests] add markers to help reduce util group execution logs

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-addopts = -ra --module-path=../ansible/library/ --show-capture=no --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=test_vrf.py
 markers:
     acl: ACL tests
     bsl: BSL tests
@@ -7,6 +6,8 @@ markers:
     port_toggle: tests which toggle ports
     disable_loganalyzer: make to disable automatic loganalyzer
     broadcom: test specific to Broadcom platform
+    pretest: tests are run before feature/regression test cases to prepare the DUT/environment.
+    posttest: tests are run after feature/regression test cases to cleanup the DUT/environment and/or collect diagnostics.
     sanity_check: override the default sanity check settings
     topology: specify which topology testcase can be executed on: (t0, t1, ptf, etc)
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -95,12 +95,14 @@ function setup_test_options()
     fi
 
     if [[ x"${OMIT_FILE_LOG}" == x"True" ]]; then
-        UTIL_LOGGING_OPTIONS=""
+        PRET_LOGGING_OPTIONS=""
+        POST_LOGGING_OPTIONS=""
         TEST_LOGGING_OPTIONS=""
     else
         mkdir -p ${LOG_PATH}
 
-        UTIL_LOGGING_OPTIONS="--junit-xml=${LOG_PATH}/util.xml --log-file=${LOG_PATH}/util.log"
+        PRET_LOGGING_OPTIONS="--junit-xml=${LOG_PATH}/pretest.xml --log-file=${LOG_PATH}/pretest.log"
+        POST_LOGGING_OPTIONS="--junit-xml=${LOG_PATH}/posttest.xml --log-file=${LOG_PATH}/posttest.log"
         TEST_LOGGING_OPTIONS="--junit-xml=${LOG_PATH}/tr.xml --log-file=${LOG_PATH}/test.log"
     fi
     UTIL_TOPOLOGY_OPTIONS="--topology util"
@@ -132,7 +134,8 @@ function run_debug_tests()
     echo "TESTBED_FILE:          ${TESTBED_FILE}"
     echo "TEST_LOGGING_OPTIONS:  ${TEST_LOGGING_OPTIONS}"
     echo "TEST_TOPOLOGY_OPTIONS: ${TEST_TOPOLOGY_OPTIONS}"
-    echo "UTIL_LOGGING_OPTIONS:  ${UTIL_LOGGING_OPTIONS}"
+    echo "PRET_LOGGING_OPTIONS:  ${PRET_LOGGING_OPTIONS}"
+    echo "POST_LOGGING_OPTIONS:  ${POST_LOGGING_OPTIONS}"
     echo "UTIL_TOPOLOGY_OPTIONS: ${UTIL_TOPOLOGY_OPTIONS}"
 
     echo "PYTEST_COMMON_OPTS:    ${PYTEST_COMMON_OPTS}"
@@ -141,27 +144,26 @@ function run_debug_tests()
 function prepare_dut()
 {
     echo "=== Preparing DUT for subsequent tests ==="
-    py.test ${PYTEST_COMMON_OPTS} ${UTIL_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
+    py.test ${PYTEST_COMMON_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m pretest
 
     # Give some delay for the newly announced routes to propagate.
     sleep 120
 }
 
+function cleanup_dut()
+{
+    echo "=== Cleaning up DUT after tests ==="
+    py.test ${PYTEST_COMMON_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m posttest
+}
+
 function run_group_tests()
 {
-    if [[ x"${BYPASS_UTIL}" == x"False" ]]; then
-        prepare_dut
-    fi
     echo "=== Running tests in groups ==="
     py.test ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} ${TEST_CASES}
 }
 
 function run_individual_tests()
 {
-    if [[ x"${BYPASS_UTIL}" == x"False" ]]; then
-        prepare_dut
-    fi
-
     SKIP_SCRIPTS="${SKIP_SCRIPTS} test_announce_routes.py test_nbr_health.py"
 
     ignores=$(python -c "print '|'.join('''$SKIP_FOLDERS'''.split())")
@@ -258,4 +260,12 @@ done
 validate_parameters
 setup_test_options
 
+if [[ x"${BYPASS_UTIL}" == x"False" ]]; then
+    prepare_dut
+fi
+
 run_${TEST_METHOD}_tests
+
+if [[ x"${BYPASS_UTIL}" == x"False" ]]; then
+    cleanup_dut
+fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -264,8 +264,11 @@ if [[ x"${BYPASS_UTIL}" == x"False" ]]; then
     prepare_dut
 fi
 
-run_${TEST_METHOD}_tests
+RC=0
+run_${TEST_METHOD}_tests || RC=$?
 
 if [[ x"${BYPASS_UTIL}" == x"False" ]]; then
     cleanup_dut
 fi
+
+exit ${RC}

--- a/tests/test_announce_routes.py
+++ b/tests/test_announce_routes.py
@@ -1,6 +1,7 @@
 import pytest
 
 pytestmark = [
+    pytest.mark.pretest,
     pytest.mark.topology('util') #special marker
 ]
 

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -6,6 +6,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
+    pytest.mark.pretest,
     pytest.mark.topology('util') #special marker
 ]
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Reduce the chattiness of the util test group output.

#### How did you do it?

- util test group split to pre-test group and post-test group.
- pre-test group is responsible for gettign DUT ready for test.
- post-test group is responsible for cleaning up DUT after tests.
- remove addon-ops to give perference to run_test.sh.
- make sure the RC is set per feature/regression tests.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Execute test with run_test.sh. Observed the pretest and post test output.