### PR TITLE
[copp] Fix COPP test failures and make clean-up more robust

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -202,3 +202,8 @@ def restore_default_syncd(dut):
 
     _LOGGER.info("swss has been restarted, waiting 60 seconds to initialize...")
     time.sleep(60)
+
+    # Remove the RPC image from the DUT
+    docker_rpc_image = docker_syncd_name + "-rpc"
+    registry = load_docker_registry_info(dut)
+    dut.command("docker rmi {}/{}:{}".format(registry.host, docker_rpc_image, sonic_version))

--- a/tests/copp/conftest.py
+++ b/tests/copp/conftest.py
@@ -24,8 +24,9 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--swap_syncd",
-        action="store_true",
-        default=False,
-        help="Install syncd RPC image for this test case"
+        "--copp_swap_syncd",
+        action="store",
+        type=bool,
+        default=True,
+        help="Swap syncd container with syncd-rpc container",
     )

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -58,10 +58,11 @@ def configure_ptf(ptf, nn_target_port):
             nn_target_port (int): The port to run NN agent on.
     """
 
+    ptf.script(cmd=_REMOVE_IP_SCRIPT)
     ptf.script(cmd=_ADD_IP_SCRIPT)
 
     facts = {"nn_target_port": nn_target_port}
-    ptf.host.options['variable_manager'].extra_vars.update(facts)
+    ptf.host.options["variable_manager"].extra_vars.update(facts)
     ptf.template(src=_PTF_NN_TEMPLATE, dest=_PTF_NN_DEST)
 
     ptf.supervisorctl(name="ptf_nn_agent", state="restarted")
@@ -77,7 +78,7 @@ def restore_ptf(ptf):
     ptf.script(cmd=_REMOVE_IP_SCRIPT)
 
     facts = {"nn_target_port": DEFAULT_NN_TARGET_PORT}
-    ptf.host.options['variable_manager'].extra_vars.update(facts)
+    ptf.host.options["variable_manager"].extra_vars.update(facts)
 
     ptf.template(src=_PTF_NN_TEMPLATE, dest=_PTF_NN_DEST)
 
@@ -98,7 +99,7 @@ def configure_syncd(dut, nn_target_port):
 
     facts = {"nn_target_port": nn_target_port,
              "nn_target_interface": _map_port_number_to_interface(dut, nn_target_port)}
-    dut.host.options['variable_manager'].extra_vars.update(facts)
+    dut.host.options["variable_manager"].extra_vars.update(facts)
 
     dut.template(src=_SYNCD_NN_TEMPLATE, dest=_SYNCD_NN_DEST)
     dut.command("docker cp {} syncd:/etc/supervisor/conf.d/".format(_SYNCD_NN_DEST))

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -22,30 +22,34 @@
         --pkt_tx_count <n> (int): How many packets to send during each individual test case.
             Default is 100000.
 
-        --swap_syncd: Used to install the RPC syncd image before running the tests. Default
-            is disabled.
+        --copp_swap_syncd: Used to install the RPC syncd image before running the tests. Default
+            is enabled.
 """
 
+import logging
 import time
 import pytest
 from collections import namedtuple
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.copp import copp_utils
 from tests.ptf_runner import ptf_runner
 from tests.common.system_utils import docker
-from tests.common.broadcom_data import is_broadcom_device
+
+# Module-level fixtures
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
 pytestmark = [
-    pytest.mark.topology('t1')
+    pytest.mark.disable_loganalyzer,  # TODO: Figure out how to *only* ignore LLDP log messages.
+    pytest.mark.topology("t1")
 ]
 
 _COPPTestParameters = namedtuple("_COPPTestParameters",
                                  ["nn_target_port",
                                   "pkt_tx_count",
                                   "swap_syncd",
-                                  "topo"])
+                                  "topo",
+                                  "bgp_graph"])
 _SUPPORTED_TOPOS = ["ptf32", "ptf64", "t1", "t1-lag"]
 _TEST_RATE_LIMIT = 600
 
@@ -65,15 +69,6 @@ class TestCOPP(object):
             Checks that the policer enforces the rate limit for protocols
             that have a set rate limit.
         """
-
-        if protocol == "ARP" \
-                and is_broadcom_device(duthost) \
-                and "201811" not in duthost.os_version:
-            pytest.xfail("ARP policy disabled on BRCM devices due to SAI bug")
-
-        if protocol in ["IP2ME", "SNMP", "SSH"] and _copp_testbed.topo == "t1-lag":
-            pytest.xfail("Packets not received due to faulty DIP, see #1171")
-
         _copp_runner(duthost,
                      ptfhost,
                      protocol,
@@ -91,10 +86,6 @@ class TestCOPP(object):
             Checks that the policer does not enforce a rate limit for protocols
             that do not have any set rate limit.
         """
-
-        if protocol == "BGP" and _copp_testbed.topo == "t1-lag":
-            pytest.xfail("Packets not received due to faulty DIP, see #1171")
-
         _copp_runner(duthost,
                      ptfhost,
                      protocol,
@@ -105,8 +96,7 @@ def _copp_testbed(duthost, ptfhost, testbed, request):
     """
         Pytest fixture to handle setup and cleanup for the COPP tests.
     """
-
-    test_params = _gather_test_params(testbed, request)
+    test_params = _gather_test_params(testbed, duthost, request)
 
     if test_params.topo not in _SUPPORTED_TOPOS:
         pytest.skip("Topology not supported by COPP tests")
@@ -122,7 +112,8 @@ def _copp_runner(dut, ptf, protocol, test_params):
 
     params = {"verbose": False,
               "pkt_tx_count": test_params.pkt_tx_count,
-              "target_port": test_params.nn_target_port}
+              "target_port": test_params.nn_target_port,
+              "minig_bgp": test_params.bgp_graph}
 
     dut_ip = dut.setup()["ansible_facts"]["ansible_eth0"]["ipv4"]["address"]
     device_sockets = ["0-{}@tcp://127.0.0.1:10900".format(test_params.nn_target_port),
@@ -141,41 +132,48 @@ def _copp_runner(dut, ptf, protocol, test_params):
                debug_level=None,
                device_sockets=device_sockets)
 
-def _gather_test_params(testbed, request):
+def _gather_test_params(testbed, duthost, request):
     """
         Fetches the test parameters from pytest.
     """
 
     nn_target_port = request.config.getoption("--nn_target_port")
     pkt_tx_count = request.config.getoption("--pkt_tx_count")
-    swap_syncd = request.config.getoption("--swap_syncd")
+    swap_syncd = request.config.getoption("--copp_swap_syncd")
     topo = testbed["topo"]["name"]
+    bgp_graph = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]["minigraph_bgp"]
 
     return _COPPTestParameters(nn_target_port=nn_target_port,
                                pkt_tx_count=pkt_tx_count,
                                swap_syncd=swap_syncd,
-                               topo=topo)
+                               topo=topo,
+                               bgp_graph=bgp_graph)
 
 def _setup_testbed(dut, ptf, test_params):
     """
         Sets up the testbed to run the COPP tests.
     """
 
-    # We don't want LLDP to throw off our test results, so we disable it first.
+    logging.info("Disable LLDP for COPP tests")
     dut.command("docker exec lldp supervisorctl stop lldp-syncd")
     dut.command("docker exec lldp supervisorctl stop lldpd")
 
+    logging.info("Set up the PTF for COPP tests")
     copp_utils.configure_ptf(ptf, test_params.nn_target_port)
 
+    logging.info("Update the rate limit for the COPP policer")
     copp_utils.limit_policer(dut, _TEST_RATE_LIMIT)
 
     if test_params.swap_syncd:
+        logging.info("Swap out syncd to use RPC image...")
         docker.swap_syncd(dut)
     else:
         # NOTE: Even if the rpc syncd image is already installed, we need to restart
         # SWSS for the COPP changes to take effect.
+        logging.info("Restart SWSS...")
         _restart_swss(dut)
 
+    logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port)
 
 def _teardown_testbed(dut, ptf, test_params):
@@ -183,15 +181,20 @@ def _teardown_testbed(dut, ptf, test_params):
         Tears down the testbed, returning it to its initial state.
     """
 
+    logging.info("Restore PTF post COPP test")
     copp_utils.restore_ptf(ptf)
 
+    logging.info("Restore COPP policer to default settings")
     copp_utils.restore_policer(dut)
 
     if test_params.swap_syncd:
+        logging.info("Restore default syncd docker...")
         docker.restore_default_syncd(dut)
     else:
+        logging.info("Restart SWSS...")
         _restart_swss(dut)
 
+    logging.info("Restore LLDP")
     dut.command("docker exec lldp supervisorctl start lldpd")
     dut.command("docker exec lldp supervisorctl start lldp-syncd")
 


### PR DESCRIPTION
- Add minig_bgp var introduced by 1171
- Disable loganalyzer by default for LLDP messages
- Updates default swap_syncd behavior to match qos_sai
- Remove docker images after test

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fix COPP test failures and make clean-up process more robust.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There are a few problems we found:
- The pytests do not support the fix in #1171 yet
- The default behavior for swap_syncd was different between this set of tests and qos_sai, so this set of tests wasn't running properly
- Loganalyzer flags the "LLDP down" messages as failures
- swap_syncd leaves the RPC image behind after test, which is problematic for performing upgrade tests on devices with smaller hard drives

This PR addresses all 4 of those issues, which should make the COPP tests more reliable and stable.

#### How did you do it?
I addressed each issue in turn:
- Added the `minig_bgp` variable from #1171 to the ptf runner params
- Changed swap_syncd to enable by default to match qos_sai
- Disabled loganalyzer for this set of tests (note: it would be helpful to *only* ignore LLDP error messages, as those are expected, but this will be refined in a later PR)
- Removed the RPC docker image at the end of restore_syncd

#### How did you verify/test it?
Tests pass locally, and the RPC docker image is not present on the DUT after the tests complete.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
