### PR TITLE
[201811][bgp_speaker] Terminate all processes with 'exabgp' in the command line

### DIFF
--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -201,8 +201,8 @@
           - testbed_mtu={{ mtu|default(9114) }}
         ptf_extra_options: "--relax --debug info --log-file /tmp/bgp_speaker_test.FibTest.log --socket-recv-size 16384"
   always:
-    - name: Kill exabgp instances
-      shell: pkill exabgp
+    - name: Send SIGTERM to exabgp instances
+      shell: pkill -f exabgp
       delegate_to: "{{ptf_host}}"
 
     - name: Flush vlan ips route


### PR DESCRIPTION
Add `-f` flag to pkill so that it will send the signal to processes where "exabgp" appears anywhere in the command line. Without this flag, it only sends the signal to processes where "exabgp" is the actual file being executed, thus leaving two `sh exabgp/start.sh` processes running. This change ensures all "exabgp" processes as well as the `sh exabgp/start.sh` processes are stopped.

Also update comment to be more precise about what signal is being sent, in case we need to be more forceful in the future, we could send SIGKILL instead.