### PR TITLE
[test_vrf][pytest] Terminate all processes with 'exabgp' in the command line

### DIFF
--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -842,8 +842,8 @@ class TestVrfLoopbackIntf():
         # deploy start script
         ptfhost.template(src="vrf/bgp_speaker/start.j2", dest="%s/%s" % (exabgp_dir, 'start.sh'), mode="u+rwx")
 
-        # kill exabgp if any
-        ptfhost.shell("pkill exabgp || true")
+        # Send SIGTERM to exabgp processes if any
+        ptfhost.shell("pkill -f exabgp || true")
 
         # start exabgp instance
         ptfhost.shell("bash %s/start.sh" % exabgp_dir)
@@ -864,8 +864,8 @@ class TestVrfLoopbackIntf():
         for (vrf, vlan_peer_port), ips in g_vars['vlan_peer_ips'].iteritems():
             duthost.shell("vtysh -c 'configure terminal' -c 'no ip route {} {} vrf {}'".format(peer_range, ips['ipv4'][0], vrf))
 
-        # kill exabgp
-        ptfhost.shell("pkill exabgp || true")
+        # Send SIGTERM to exabgp processes if any
+        ptfhost.shell("pkill -f exabgp || true")
 
         # del speaker ips from ptf ports
         for vrf, vlan_peer_port in g_vars['vlan_peer_ips']:


### PR DESCRIPTION
The test_vrf PyTest is using the same mechanism the old Ansible Playbook version of the BGP speaker test used to control exabgp, thus it requires the same patch I added here: https://github.com/Azure/sonic-mgmt/pull/1908.

It appears that there is now a PyTest fixture for exabgp which is used by the PyTest version of the BGP speaker test. Maybe that should be used here instead?

Add `-f` flag to pkill so that it will send the signal to processes where "exabgp" appears anywhere in the command line. Without this flag, it only sends the signal to processes where "exabgp" is the actual file being executed, thus leaving two `sh exabgp/start.sh` processes running. This change ensures all "exabgp" processes as well as the `sh exabgp/start.sh` processes are stopped.

Also update comment to be more precise about what signal is being sent, in case we need to be more forceful in the future, we could send SIGKILL instead.