### PR TITLE
Specify log format for console and log file

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -12,4 +12,5 @@ markers:
     topology: specify which topology testcase can be executed on: (t0, t1, ptf, etc)
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)
 
-log_format: %(asctime)s %(levelname)s %(filename)s:%(funcName)s:%(lineno)d: %(message)s
+log_cli_format: %(asctime)s %(levelname)s %(filename)s:%(funcName)s:%(lineno)d: %(message)s
+log_file_format: %(asctime)s %(levelname)s %(filename)s:%(funcName)s:%(lineno)d: %(message)s


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #1910

The pytest.ini has 'log-format' configuration. But it is not used by log file somehow. The log messages in log file do not have timestamp. This change explicitly specify the default log format for command line log and file based log. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add timestamp to log messages in pytest log file.

#### How did you do it?
Explicitly configure `log-cli-format` and `log-file-format` in pytest.ini.

#### How did you verify/test it?
Test run a script. Configure both cli log and file based log. Verify the generated log message format.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
