### PR TITLE
[test_watchdog.py] Change the condition for wait_for and align watchd…

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -14,18 +14,26 @@ default:
   greater_timeout: 20   # A greater timeout value that watchdog has to accept, put None if single timeout value is a watchdog limitation
   too_big_timeout: 100  # A timeout which is too big for HW watchdog, put None if there is no such limitation
 
-# Mellanox SPC-2 based systems have different hardware watchdog capabilities
-x86_64-mlnx_msn3700-r0:
+# Mellanox watchdog type 2
+x86_64-mlnx_msn.*-r0:
   default:
     greater_timeout: 100
     too_big_timeout: 300
 
-x86_64-mlnx_msn3700c-r0:
+# Mellnox watchdog type 1
+x86_64-mlnx_msn2410-r0:
   default:
-    greater_timeout: 100
-    too_big_timeout: 300
+      valid_timeout: 10
+      greater_timeout: 20
+      too_big_timeout: 100
 
+# Mellanox watchdog type 3
 x86_64-mlnx_msn3800-r0:
   default:
     greater_timeout: 100
-    too_big_timeout: 300
+    too_big_timeout: 66000
+
+x86_64-mlnx_msn2700-r0:
+  default:
+    greater_timeout: 100
+    too_big_timeout: 66000


### PR DESCRIPTION
…og parameters for Mellanox platforms

    * On some of our sonic-mgmt nodes it is observed that localhost.wait_for
      does not return 'exception' in result and does not set is_failed flag,
      thus let's not rely on that. Instead, wait_for always returns a message
      with ''Timeout waiting for ...' which can be used instead.
    * Modify watchdog test parameters per platform according to recent CPLD
      update which implements watchdog type 3

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
