### PR TITLE
[fast-reboot]: Increase packet timeout to handle ARP flooding

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -109,6 +109,7 @@ class StateMachine():
 
 class ReloadTest(BaseTest):
     TIMEOUT = 0.5
+    PKT_TOUT = 1
     VLAN_BASE_MAC_PATTERN = '72060001{:04}'
     LAG_BASE_MAC_PATTERN = '5c010203{:04}'
     SOCKET_RECV_BUFFER_SIZE = 10 * 1024 * 1024
@@ -284,6 +285,7 @@ class ReloadTest(BaseTest):
             if verbose and self.test_params['verbose'] or not verbose:
                 print "%s : %s" % (current_time, message)
             self.log_fp.write("%s : %s\n" % (current_time, message))
+            self.log_fp.flush()
 
     def timeout(self, func, seconds, message):
         async_res = self.pool.apply_async(func)
@@ -1500,7 +1502,7 @@ class ReloadTest(BaseTest):
         for i in xrange(self.nr_pc_pkts):
             testutils.send_packet(self, self.from_server_src_port, self.from_vlan_packet)
 
-        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.from_vlan_exp_packet, self.from_server_dst_ports, timeout=self.TIMEOUT)
+        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.from_vlan_exp_packet, self.from_server_dst_ports, timeout=self.PKT_TOUT)
 
         self.log("Send %5d Received %5d servers->t1" % (self.nr_pc_pkts, total_rcv_pkt_cnt), True)
 
@@ -1510,7 +1512,7 @@ class ReloadTest(BaseTest):
         for entry in self.from_t1:
             testutils.send_packet(self, *entry)
 
-        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.from_t1_exp_packet, self.vlan_ports, timeout=self.TIMEOUT)
+        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.from_t1_exp_packet, self.vlan_ports, timeout=self.PKT_TOUT)
 
         self.log("Send %5d Received %5d t1->servers" % (self.nr_vl_pkts, total_rcv_pkt_cnt), True)
 
@@ -1520,7 +1522,7 @@ class ReloadTest(BaseTest):
         for i in xrange(self.ping_dut_pkts):
             testutils.send_packet(self, self.random_port(self.vlan_ports), self.ping_dut_packet)
 
-        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.ping_dut_exp_packet, self.vlan_ports, timeout=self.TIMEOUT)
+        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.ping_dut_exp_packet, self.vlan_ports, timeout=self.PKT_TOUT)
 
         self.log("Send %5d Received %5d ping DUT" % (self.ping_dut_pkts, total_rcv_pkt_cnt), True)
 
@@ -1529,6 +1531,6 @@ class ReloadTest(BaseTest):
     def arpPing(self):
         for i in xrange(self.arp_ping_pkts):
             testutils.send_packet(self, self.arp_src_port, self.arp_ping)
-        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.arp_resp, [self.arp_src_port], timeout=self.TIMEOUT)
+        total_rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, self.arp_resp, [self.arp_src_port], timeout=self.PKT_TOUT)
         self.log("Send %5d Received %5d arp ping" % (self.arp_ping_pkts, total_rcv_pkt_cnt), True)
         return total_rcv_pkt_cnt


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

**Summary:**
The motivation of this PR is to stabilize fast-reboot test in case kernel starts simultaneous multiple neighbor entries refresh.
Since PTF can't handle such amount of packets, the DUT watcher thread reports drops right after reboot is started which fails the test with the next error:

**Ansible log:**
```
ok: [sonic-t0] => { 
    "out.stdout_lines": [ 
        "WARNING: No route found for IPv6 destination :: (no default route?)", 
        "advanced-reboot.ReloadTest ... FAIL", 
        "", 
        "======================================================================", 
        "FAIL: advanced-reboot.ReloadTest", 
        "----------------------------------------------------------------------", 
        "Traceback (most recent call last):", 
        "  File \"ptftests/advanced-reboot.py\", line 964, in runTest", 
        "    self.assertTrue(is_good, errors)", 
        "AssertionError: ", 
        "", 
        "Something went wrong. Please check output below:", 
        "", 
        "FAILED:dut:Data plane stopped working", 
        "FAILED:dut:Data plane has a forwarding problem after CPU went down", 
        "", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 60.673s", 
        "", 
        "FAILED (failures=1)", 
        "No handlers could be found for logger \"dataplane\"" 
    ] 
}
```

**PTF log:**
```
2020-07-07 09:05:10 : Send   100 Received   100 servers->t1
2020-07-07 09:05:11 : Send   500 Received   500 t1->servers
2020-07-07 09:05:11 : Send    10 Received    10 ping DUT
2020-07-07 09:05:12 : Send     1 Received     1 arp ping
2020-07-07 09:05:12 : VLAN ARP state transition from down to up
2020-07-07 09:05:12 : Send   100 Received   100 servers->t1
2020-07-07 09:05:12 : Schedule to reboot the remote switch in 10 sec
2020-07-07 09:05:12 : Wait until Control plane is down
2020-07-07 09:05:14 : Send   500 Received   500 t1->servers
2020-07-07 09:05:14 : Send    10 Received    10 ping DUT
2020-07-07 09:05:14 : Send     1 Received     1 arp ping
2020-07-07 09:05:15 : Send   100 Received   100 servers->t1
2020-07-07 09:05:18 : Send   500 Received   500 t1->servers
2020-07-07 09:05:19 : Send    10 Received    10 ping DUT
2020-07-07 09:05:19 : Send     1 Received     0 arp ping
2020-07-07 09:05:19 : VLAN ARP state transition from up to down
2020-07-07 09:05:19 : Send   100 Received   100 servers->t1
2020-07-07 09:05:22 : Rebooting remote side
2020-07-07 09:05:23 : Send   500 Received   500 t1->servers
2020-07-07 09:05:23 : Send    10 Received    10 ping DUT
2020-07-07 09:05:24 : Send     1 Received     1 arp ping
2020-07-07 09:05:24 : VLAN ARP state transition from down to up
2020-07-07 09:05:24 : Send   100 Received   100 servers->t1
2020-07-07 09:05:29 : Send   500 Received   500 t1->servers
2020-07-07 09:05:29 : Send    10 Received     0 ping DUT
2020-07-07 09:05:29 : Control plane state transition from up to down
2020-07-07 09:05:29 : Dut reboots: reboot start 2020-07-07 09:05:29.690420
2020-07-07 09:05:29 : Check that device is still forwarding data plane traffic
2020-07-07 09:05:29 : Send     1 Received     0 arp ping
2020-07-07 09:05:29 : VLAN ARP state transition from up to down
2020-07-07 09:05:30 : Send   100 Received     0 servers->t1
2020-07-07 09:05:30 : Data plane state transition from up to down (0)
2020-07-07 09:05:30 : Send    10 Received     0 ping DUT
2020-07-07 09:05:30 : Send     1 Received     0 arp ping
2020-07-07 09:05:30 : Send   100 Received     0 servers->t1
2020-07-07 09:05:30 : Send    10 Received     0 ping DUT
2020-07-07 09:05:30 : Send     1 Received     0 arp ping
2020-07-07 09:05:31 : Send   100 Received     0 servers->t1
2020-07-07 09:05:31 : Send    10 Received     0 ping DUT
2020-07-07 09:05:31 : Send     1 Received     0 arp ping
2020-07-07 09:05:31 : ==================================================
2020-07-07 09:05:31 : Report:
2020-07-07 09:05:31 : ==================================================
2020-07-07 09:05:31 : LACP/BGP were down for (extracted from cli):
2020-07-07 09:05:31 : --------------------------------------------------
2020-07-07 09:05:31 -------------------------------------------------
2020-07-07 09:05:31 : Extracted from VM logs:
2020-07-07 09:05:31 : --------------------------------------------------
2020-07-07 09:05:31 : Summary:
2020-07-07 09:05:31 : --------------------------------------------------
2020-07-07 09:05:31 : --------------------------------------------------
2020-07-07 09:05:31 : Fails:
2020-07-07 09:05:31 : --------------------------------------------------
2020-07-07 09:05:31 : FAILED:dut:Data plane stopped working
2020-07-07 09:05:31 : FAILED:dut:Data plane has a forwarding problem after CPU went down
2020-07-07 09:05:31 : ==================================================
2020-07-07 09:05:31 : Disabling arp_responder
2020-07-07 09:05:32 : Send   100 Received   400 servers->t1
2020-07-07 09:05:33 : Send   500 Received   500 t1->servers
2020-07-07 09:05:33 : Data plane state transition from down to up (500)
2020-07-07 09:05:33 : Send    10 Received    10 ping DUT
2020-07-07 09:05:33 : Control plane state transition from down to up
2020-07-07 09:05:33 : Send     1 Received     0 arp ping
```

**Warning:** _this can be considered as a temporary solution only. Ideally we need to improve the framework to be capable to handle all the packets according to the defined topology/neighbors amount in a real time_

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
* Increased packet wait timeout to 1 sec

#### How did you verify/test it?
* Run fast-reboot test in a loop

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
* N/A
