### PR TITLE
[201811][bgp_speaker] Ignore errors upon terminating exabgp processes

### DIFF
--- a/ansible/roles/test/tasks/bgp_speaker.yml
+++ b/ansible/roles/test/tasks/bgp_speaker.yml
@@ -129,7 +129,7 @@
       delegate_to: "{{ptf_host}}"
 
     - name: Kill exabgp instances if existing
-      shell: pkill exabgp
+      shell: pkill -f exabgp
       delegate_to: "{{ptf_host}}"
       ignore_errors: yes
 
@@ -204,6 +204,7 @@
     - name: Send SIGTERM to exabgp instances
       shell: pkill -f exabgp
       delegate_to: "{{ptf_host}}"
+      ignore_errors: yes
 
     - name: Flush vlan ips route
       command: ip route flush {{item.split('/')[0]}}/32


### PR DESCRIPTION
- Ignore errors upon terminating exabgp processes
- Also add `-f` flag to another `pkill` call