### PR TITLE
[ansible] Add revert_syncd task to automate cleaning up after swap_syncd

### DIFF
--- a/ansible/revert_syncd.yml
+++ b/ansible/revert_syncd.yml
@@ -1,0 +1,68 @@
+# Revert docker-syncd back to docker-syncd for oneimage deployed switch
+# A temporary solution during period that sonic_docker is not ready for oneimage
+# Example usage:
+#   ansible-playbook revert_syncd.yml -i str --vault-password-file ~/password.txt --limit devicename
+
+- hosts: all
+  gather_facts: no
+  vars_files:
+    - vars/docker_registry.yml
+  tasks:
+
+    - name: Gathering minigraph facts about the device
+      minigraph_facts: host={{ inventory_hostname }}
+      tags: always
+
+    - name: Set sonic_hwsku fact
+      set_fact:
+        sonic_hwsku: "{{minigraph_hwsku}}"
+      tags: always
+
+    - name: Set sonic_asic_type fact
+      set_fact:
+        sonic_asic_type: broadcom
+        docker_rpc_image_name: docker-syncd-brcm-rpc
+        docker_syncd_name: docker-syncd-brcm
+      when: sonic_hwsku in broadcom_hwskus
+      tags: always
+
+    - name: Set sonic_asic_type fact
+      set_fact:
+        sonic_asic_type: mellanox
+        docker_rpc_image_name: docker-syncd-mlnx-rpc
+        docker_syncd_name: docker-syncd-mlnx
+      when: sonic_hwsku in mellanox_hwskus
+      tags: always
+
+    - name: Stop swss service
+      become: true
+      command: systemctl stop swss
+
+    - name: Delete syncd docker
+      become: true
+      shell: docker rm syncd
+      ignore_errors: yes
+
+    - name: Gather SONiC base image version
+      shell: sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version
+      register: result
+      changed_when: false
+
+    - name: Set base image verison variable
+      set_fact:
+        sonic_image_version: "{{ result.stdout }}"
+
+    - name: Tag default image as syncd
+      shell: docker tag {{docker_syncd_name}}:{{sonic_image_version}} {{docker_syncd_name}}
+
+    - name: Delete the rpc image
+      become: true
+      shell: docker rmi {{docker_registry_host}}/{{docker_rpc_image_name}}:{{sonic_image_version}}
+      ignore_errors: yes
+
+    - name: Start swss service
+      become: true
+      command: systemctl start swss
+
+    - name: Wait for the initialization process
+      pause: seconds=60


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Adds a corresponding task for `swap_syncd` that puts the syncd container back to normal.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Right now, if you do a `swap_syncd` it's sort of a pain to put the image back to normal. This automates the steps needed to get everything cleaned up.

#### How did you do it?
I created an ansible playbook that pretty much does the inverse of `swap_syncd`.

#### How did you verify/test it?
1. Perform a `swap_syncd`.
2. Verify that the RPC syncd docker is running and the docker image is installed.
3. Perform a `revert_syncd`.
4. Verify that the original syncd docker is running and the RPC image has been removed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
