### PR TITLE
Fix accessing instance attribute in AdvancedReboot

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -122,8 +122,8 @@ class AdvancedReboot:
         self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
         self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
 
-        self.rebootData['dut_username'] = creds['sonicadmin_user']
-        self.rebootData['dut_password'] = creds['sonicadmin_password']
+        self.rebootData['dut_username'] = self.creds['sonicadmin_user']
+        self.rebootData['dut_password'] = self.creds['sonicadmin_password']
 
         # Change network of the dest IP addresses (used by VM servers) to be different from Vlan network
         prefixLen = self.mgFacts['minigraph_vlan_interfaces'][0]['prefixlen'] - 3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

### Fixes: Error in the tests using AdvancedReboot script
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Bug during accessing instance attribute in one of the methods of AdvancedReboot class.

#### How did you do it?
Use `self` to access the instance attribute `creds` to obtain the credentials.
#### How did you verify/test it?
Tested `platform_tests/test_advanced_reboot.py::test_fast_reboot` on T0 device and the test passed successfully.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Snippet of the error that is being fixed:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.common.fixtures.advanced_reboot.AdvancedReboot instance at 0x7f6119dea3f8>

    def __buildTestbedData(self):
        '''
        Build testbed data that are needed by ptf advanced-reboot.ReloadTest class
        '''
        hostFacts = self.duthost.setup()['ansible_facts']
    
        self.mgFacts = self.duthost.minigraph_facts(host=self.duthost.hostname)['ansible_facts']
    
        self.rebootData['arista_vms'] = [
            attr['mgmt_addr'] for dev, attr in self.mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
        ]
    
        self.hostMaxLen = len(self.rebootData['arista_vms']) - 1
        self.lagMemberCnt = len(self.mgFacts['minigraph_portchannels'].values()[0]['members'])
        self.vlanMaxCnt = len(self.mgFacts['minigraph_vlans'].values()[0]['members']) - 1
    
        self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
        self.rebootData['dut_mac'] = hostFacts['ansible_Ethernet0']['macaddress']
        self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
        self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
    
>       self.rebootData['dut_username'] = creds['sonicadmin_user']
E       NameError: global name 'creds' is not defined

common/fixtures/advanced_reboot.py:125: NameError
========================== 1 failed in 63.12 seconds ===========================
```