### PR TITLE
Add AnsibleHost.mgmt_ip and SonicHost.facts['router_mac']

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -31,7 +31,7 @@ class AnsibleHostBase(object):
 
     def __init__(self, ansible_adhoc, hostname, connection=None, become_user=None):
         if hostname == 'localhost':
-            self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
+            self.host = ansible_adhoc(connection='smart', host_pattern=hostname)[hostname]
             self.mgmt_ip = self.host.setup(gather_subset="!all,!min,network")[hostname]["ansible_facts"]["ansible_default_ipv4"]["address"]
         else:
             if connection is None:

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -32,7 +32,7 @@ class AnsibleHostBase(object):
     def __init__(self, ansible_adhoc, hostname, connection=None, become_user=None):
         if hostname == 'localhost':
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
-            self.mgmt_ip = self.host.setup(gather_subset="!all,!min,network")[hostname]["ansible_facts"]["ansible_all_ipv4_addresses"][0]
+            self.mgmt_ip = self.host.setup(gather_subset="!all,!min,network")[hostname]["ansible_facts"]["ansible_default_ipv4"]["address"]
         else:
             if connection is None:
                 if become_user is None:

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -32,6 +32,7 @@ class AnsibleHostBase(object):
     def __init__(self, ansible_adhoc, hostname, connection=None, become_user=None):
         if hostname == 'localhost':
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
+            self.mgmt_ip = self.host.setup(gather_subset="!all,!min,network")[hostname]["ansible_facts"]["ansible_all_ipv4_addresses"][0]
         else:
             if connection is None:
                 if become_user is None:
@@ -44,6 +45,7 @@ class AnsibleHostBase(object):
                     self.host = ansible_adhoc(become=True, connection=connection)[hostname]
                 else:
                     self.host = ansible_adhoc(become=True, connection=connection, become_user=become_user)[hostname]
+            self.mgmt_ip = self.host.options["inventory_manager"].get_host(hostname).vars["ansible_host"]
         self.hostname = hostname
 
     def __getattr__(self, module_name):
@@ -136,7 +138,8 @@ class SonicHost(AnsibleHostBase):
                 "platform": "x86_64-arista_7050_qx32s",
                 "hwsku": "Arista-7050-QX-32S",
                 "asic_type": "broadcom",
-                "num_npu": 1
+                "num_npu": 1,
+                "router_mac": "52:54:00:f0:ac:9d"
             }
         """
 
@@ -201,6 +204,7 @@ class SonicHost(AnsibleHostBase):
         facts = dict()
         facts.update(self._get_platform_info())
         facts["num_npu"] = self._get_npu_count(facts["platform"])
+        facts["router_mac"] = self._get_router_mac()
 
         logging.debug("Gathered SonicHost facts: %s" % json.dumps(facts))
         return facts
@@ -222,6 +226,9 @@ class SonicHost(AnsibleHostBase):
             return int(num_npu)
         except:
             return 1
+
+    def _get_router_mac(self):
+        return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0].decode("utf-8")
 
     def _generate_critical_services_for_multi_npu(self, services):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The IP address of AnsibleHost is frequently required in test scripts. The base mac of SONiC is usually required when the test script need to run a PTF test. It is a little bit complicated to get these information in a test script. This PR enhanced the infrastructure code for test scripts to get these information easier.

For example:
* To get IP address of PTF host, we can just get it through the ip attribute of the ptfhost fixture: `ptfhost.mgmt_ip`
* To get IP address of SONiC switch: `duthost.mgmt_ip`
* To get IP address of VMs:
```
for vm in nbrhosts.keys():
    vmhost = nbrhosts[vm]["host"]
    print vmhost.mgmt_ip
```

* To get the router MAC address of SONiC switch:
```
router_mac = duthost.facts["router_mac"]
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
* Add mgmt_ip attribute to AnsibleHost
* Add SonicHost.facts['router_mac']

#### How did you verify/test it?

Test run this example script:
```
import logging
import pytest
import json

logger = logging.getLogger(__name__)


def test_case1(duthost):
    logger.info("duthost.mgmt_ip={}".format(duthost.mgmt_ip))
    logger.info("duthost.facts={}".format(json.dumps(duthost.facts)))

def test_case2(ptfhost):
    logger.info("ptfhost.mgmt_ip={}".format(ptfhost.mgmt_ip))

def test_case3(nbrhosts):
    for nbrhost in nbrhosts:
        vm = nbrhosts[nbrhost]["host"]
        logger.info("{}.mgmt_ip={}".format(vm.hostname, vm.mgmt_ip))

def test_case4(localhost):
    logger.info("localhost.mgmt_ip={}".format(localhost.mgmt_ip))

```

```
johnar@e88ba1fda5a2:~/code/sonic-mgmt/tests$ py.test --inventory veos.vtb --host-pattern vlab-01 --user admin -vvv --show-capture stdout --testbed vms-kvm-t0 --testbed_file vtestbed.csv --log-cli-level info
 test_pr.py --skip_sanity --disable_loganalyzer
============================================================================================ test session starts =============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python                                
cachedir: .pytest_cache                                           
ansible: 2.8.7                                                                                                                 
rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini                                                                                                                                               
plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2                                                        
collected 4 items                                                                                                                                                                                            
                                                                                                                             
test_pr.py::test_case1
----------------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------------
07:15:29 INFO conftest.py:pytest_runtest_setup:355: ==================== test_pr.py::test_case1 setup ====================      
07:15:39 INFO conftest.py:creds:338: dut vlab-01 belongs to groups [u'lab', u'sonic', 'fanout']                                      
07:15:39 INFO conftest.py:creds:349: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
07:15:39 INFO conftest.py:creds:349: skip empty var file ../ansible/group_vars/all/env.yml
07:15:39 INFO __init__.py:sanity_check:45: Start pre-test sanity check          
07:15:39 INFO __init__.py:sanity_check:81: Sanity check settings: skip_sanity=True, check_items=set(['services', 'interfaces', 'processes', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_c
heck=False                                          
07:15:39 INFO __init__.py:sanity_check:84: Skip sanity check according to command line argument or configuration of test script.
07:15:39 INFO __init__.py:loganalyzer:15: Log analyzer is disabled
07:15:39 INFO conftest.py:pytest_runtest_setup:357: ==================== test_pr.py::test_case1 setup done ====================
----------------------------------------------------------------------------------------------- live log call ------------------------------------------------------------------------------------------------
07:15:39 INFO conftest.py:pytest_runtest_call:362: ==================== test_pr.py::test_case1 call ====================
07:15:39 INFO test_pr.py:test_case1:9: duthost.mgmt_ip=10.250.0.101  
07:15:39 INFO test_pr.py:test_case1:10: duthost.facts={"platform": "x86_64-kvm_x86_64-r0", "hwsku": "Force10-S6000", "router_mac": "52:54:00:f0:ac:9d", "asic_type": "vs", "num_npu": 1}
07:15:39 INFO conftest.py:pytest_runtest_call:364: ==================== test_pr.py::test_case1 call done ====================
                                            
--------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------
07:15:39 INFO conftest.py:pytest_runtest_teardown:369: ==================== test_pr.py::test_case1 teardown ====================
07:15:39 INFO conftest.py:pytest_runtest_teardown:371: ==================== test_pr.py::test_case1 teardown done ====================
                                            
----------------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------------
07:15:39 INFO conftest.py:pytest_runtest_setup:355: ==================== test_pr.py::test_case2 setup ====================
07:15:40 INFO __init__.py:loganalyzer:15: Log analyzer is disabled                                                                                                                                            
07:15:40 INFO conftest.py:pytest_runtest_setup:357: ==================== test_pr.py::test_case2 setup done ====================
----------------------------------------------------------------------------------------------- live log call ------------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_call:362: ==================== test_pr.py::test_case2 call ====================
07:15:40 INFO test_pr.py:test_case2:13: ptfhost.mgmt_ip=10.250.0.102
07:15:40 INFO conftest.py:pytest_runtest_call:364: ==================== test_pr.py::test_case2 call done ====================
                                                                                                                                                                                                             
--------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_teardown:369: ==================== test_pr.py::test_case2 teardown ====================
07:15:40 INFO conftest.py:pytest_runtest_teardown:371: ==================== test_pr.py::test_case2 teardown done ====================

----------------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_setup:355: ==================== test_pr.py::test_case3 setup ====================
07:15:40 INFO __init__.py:loganalyzer:15: Log analyzer is disabled              
07:15:40 INFO conftest.py:pytest_runtest_setup:357: ==================== test_pr.py::test_case3 setup done ====================                                                                               
----------------------------------------------------------------------------------------------- live log call ------------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_call:362: ==================== test_pr.py::test_case3 call ====================        
07:15:40 INFO test_pr.py:test_case3:18: VM0103.mgmt_ip=10.250.0.54
07:15:40 INFO test_pr.py:test_case3:18: VM0102.mgmt_ip=10.250.0.53                                                             
07:15:40 INFO test_pr.py:test_case3:18: VM0101.mgmt_ip=10.250.0.52                                                                                                                                            
07:15:40 INFO test_pr.py:test_case3:18: VM0100.mgmt_ip=10.250.0.51                                                      
07:15:40 INFO conftest.py:pytest_runtest_call:364: ==================== test_pr.py::test_case3 call done ====================
                                                                                                                                                                                        
--------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_teardown:369: ==================== test_pr.py::test_case3 teardown ====================
07:15:40 INFO conftest.py:pytest_runtest_teardown:371: ==================== test_pr.py::test_case3 teardown done ====================                                                                         
                                                                                                                                
----------------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_setup:355: ==================== test_pr.py::test_case4 setup ====================
07:15:40 INFO __init__.py:loganalyzer:15: Log analyzer is disabled                                                                                                                                            
07:15:40 INFO conftest.py:pytest_runtest_setup:357: ==================== test_pr.py::test_case4 setup done ====================
----------------------------------------------------------------------------------------------- live log call ------------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_call:362: ==================== test_pr.py::test_case4 call ====================       
07:15:40 INFO test_pr.py:test_case4:21: localhost.mgmt_ip=172.17.0.2                                                                                                                                          
07:15:40 INFO conftest.py:pytest_runtest_call:364: ==================== test_pr.py::test_case4 call done ====================
                                                                    
--------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------
07:15:40 INFO conftest.py:pytest_runtest_teardown:369: ==================== test_pr.py::test_case4 teardown ====================                                                                             
07:15:40 INFO conftest.py:pytest_runtest_teardown:371: ==================== test_pr.py::test_case4 teardown done ====================                                                                         
                                                                                                                                
                                                                                                                                                                                                              
========================== 4 passed in 11.01 seconds ===========================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
