### PR TITLE
[pytest] Fixed ACL test in test_drop_counters.py test suite

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -89,6 +89,7 @@ def acl_setup(duthost, loganalyzer):
         duthost.command("config acl update full {}".format(dut_clear_conf_file_path))
         logger.info("Removing {}".format(dut_tmp_dir))
         duthost.command("rm -rf {}".format(dut_tmp_dir))
+        time.sleep(ACL_COUNTERS_UPDATE_INTERVAL)
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fixed ACL drop counter test case
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To fix loganalyzer failure which occurs when "Successfully deleted ACL rule" message appears after loganalyzer end marker.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
