### PR TITLE
[pytest] Loganalyzer - improved adding end marker

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -180,8 +180,6 @@ class LogAnalyzer:
         marker = marker.replace(' ', '_')
         self.ansible_loganalyzer.run_id = marker
 
-        # Add end marker into DUT syslog
-        self._add_end_marker(marker)
         if not self.start_marker:
             start_string = 'start-LogAnalyzer-{}'.format(marker)
         else:
@@ -205,6 +203,9 @@ class LogAnalyzer:
                     continue
             else:
                 logging.error("Logrotate from previous task was not finished during 60 seconds")
+
+            # Add end marker into DUT syslog
+            self._add_end_marker(marker)
 
             # On DUT extract syslog files from /var/log/ and create one file by location - /tmp/syslog
             self.ansible_host.extract_log(directory='/var/log', file_prefix='syslog', start_string=start_string, target_filename=self.extracted_syslog)


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Improved adding end marker
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To add loganalyzer end marker just before extracting logs, so more logged messages will be catched by loganalyzer.
Issues with this was observed during debugging "drop_packets/test_drop_counters.py"

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
