### PR TITLE
[sanity] remove disable sanity check marker in test files

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -7,7 +7,6 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
     pytest.mark.topology('any')
 ]

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 import pytest
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -12,7 +12,6 @@ from platform_api_test_base import PlatformApiTestBase
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -10,7 +10,6 @@ from tests.common.helpers.platform_api import chassis, module
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
 ]
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -12,7 +12,6 @@ from platform_api_test_base import PlatformApiTestBase
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -1,7 +1,6 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -2,7 +2,6 @@ import pytest
 import crypt
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test should not by default bypass sanity check. Bypassing sanity check could hide issues left from previous test(s).

#### How did you do it?
Enabled test module level default sanity test for all modules.

