### PR TITLE
[pytest/bgp_gr]: improve stability of bgp gr test

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -29,19 +29,19 @@ def setup_bgp_graceful_restart(duthost, nbrhosts):
         logger.info("bgp asn {}".format(nbr['conf']['bgp']['asn']))
         res = nbr['host'].eos_config(lines=["graceful-restart restart-time 300"], \
                                parents=["router bgp {}".format(nbr['conf']['bgp']['asn'])])
-        logger.info("abc {}".format(res))
         res = nbr['host'].eos_config(lines=["graceful-restart"], \
                                parents=["router bgp {}".format(nbr['conf']['bgp']['asn']), "address-family ipv4"])
-        logger.info("abc {}".format(res))
         res = nbr['host'].eos_config(lines=["graceful-restart"], \
                                parents=["router bgp {}".format(nbr['conf']['bgp']['asn']), "address-family ipv6"])
-        logger.info("abc {}".format(res))
 
     # change graceful restart option will clear the bgp session.
     # so, let's wait for all bgp sessions to be up
     logger.info("bgp neighbors: {}".format(bgp_neighbors.keys()))
     if not wait_until(300, 10, duthost.check_bgp_session_state, bgp_neighbors.keys()):
         pytest.fail("not all bgp sessions are up after enable graceful restart")
+
+    if not wait_until(60, 5, duthost.check_default_route):
+        pytest.fail("ipv4 or ipv6 default route not available")
 
     yield
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -595,6 +595,25 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         return rtinfo
 
+    def check_default_route(self, ipv4=True, ipv6=True):
+        """
+        @summary: return default route status
+
+        @param ipv4: check ipv4 default
+        @param ipv6: check ipv6 default
+        """
+        if ipv4:
+            rtinfo_v4 = self.get_ip_route_info(ipaddress.ip_address(u'0.0.0.0'))
+            if len(rtinfo_v4['nexthops']) == 0:
+                return False
+
+        if ipv6:
+            rtinfo_v6 = self.get_ip_route_info(ipaddress.ip_address(u'::'))
+            if len(rtinfo_v6['nexthops']) == 0:
+                return False
+
+        return True
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info


### PR DESCRIPTION
after reconfiguring bgp neighbor, wait for dut to
learn the default route before start the test

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
improve stability of bgp gr test.

it looks like the test failed because failure to obtain the default route, by looking at the log, nothing wrong here. Seems the tests
needs to wait longer to let the default route propagate to the kernel. 

https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image-pr/4915/artifact/sonic-mgmt/tests/logs/1vlan/bgp/test_bgp_gr_helper.log

#### How did you do it?
wait for default in the fixture

#### How did you verify/test it?
```
johnar@1cafe0c9f994:/data/tests$ py.test $PYTEST_COMMON_OPTS bgp/test_bgp_gr_helper.py
================================================== test session starts ===================================================
platform linux2 -- Python 2.7.12, pytest-4.6.10, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.9.9
rootdir: /data/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                         

bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved PASSED                                              [100%]
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
