### PR TITLE
[test_ntp] Increase NTP sync wait time

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -53,4 +53,5 @@ def test_ntp(duthost, setup_ntp):
     duthost.service(name='ntp', state='stopped')
     duthost.command("ntpd -gq")
     duthost.service(name='ntp', state='restarted')
-    pytest_assert(wait_until(300, 5, check_ntp_status, duthost), "NTP not in sync")
+    pytest_assert(wait_until(720, 10, check_ntp_status, duthost),
+                  "NTP not in sync")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

300s might be limited for DUT to sync with ptf, increased to 720s.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test failed because DUT cannot sync with NTP server(`ptf`).

#### How did you do it?
Increase wait time for sync.

#### How did you verify/test it?
run testcase `ntp/test_ntp.py`.

#### Any platform specific information?
Arista 7260
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
