### PR TITLE
Fix test_watchdog.py import issues

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -3,8 +3,8 @@ import time
 import logging
 import yaml
 import pytest
-from common.helpers.platform_api import watchdog
-from common.helpers.assertions import pytest_assert
+from tests.common.helpers.platform_api import watchdog
+from tests.common.helpers.assertions import pytest_assert
 from platform_api_test_base import PlatformApiTestBase
 
 pytestmark = [


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

After PR #1864 is merged, `from common.xx import yy` is
no longer supported. Probably this PR was created/tested
before PR#1864 was merged. This commit is to fix the
`from common.xx import yy` issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix the import issue in test_watchdog.py.

#### How did you do it?
Change the imports to:
```
from tests.common.helpers.platform_api import watchdog
from tests.common.helpers.assertions import pytest_assert
```

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
