### PR TITLE
Add `--show-capture no` argument in `run_tests.sh`

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -85,6 +85,7 @@ function setup_test_options()
                       --allow_recover \
                       --showlocals \
                       --assert plain \
+                      --show-capture no \
                       -rav"
 
     for skip in ${SKIP_SCRIPTS} ${SKIP_FOLDERS}; do


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The run_tests.sh is able to store all the testing logs in
log files. It's unnecessary to show captured logs in
cli log. Otherwise, the cli log is also huge.
This commit add the `--show-capture no` argument
to the PYTEST_COMMON_OPTS in `run_tests.sh` to
disable that.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To limit the log size of pytest cli console log.

#### How did you do it?
Add `--show-capture no` argument to PYTEST_COMMON_OPTS in `run_tests.sh`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
