### PR TITLE
[pre-test] prepare DUT to run tests when option --deep_clean is provided

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,12 @@ def pytest_addoption(parser):
     parser.addoption("--allow_recover", action="store_true", default=False,
                      help="Allow recovery attempt in sanity check in case of failure")
 
+    ########################
+    #   pre-test options   #
+    ########################
+    parser.addoption("--deep_clean", action="store_true", default=False,
+                     help="Deep clean DUT before tests (remove old logs, cores, dumps)")
+
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):

--- a/tests/test_cleanup_dut.py
+++ b/tests/test_cleanup_dut.py
@@ -8,7 +8,7 @@ pytestmark = [
     pytest.mark.topology('util')
 ]
 
-def test_prepare_dut(duthost, request):
+def test_cleanup_dut(duthost, request):
     deep_clean = request.config.getoption("--deep_clean")
     if deep_clean:
         logger.info("Deep cleaning DUT {}".format(duthost.hostname))

--- a/tests/test_prepare_dut.py
+++ b/tests/test_prepare_dut.py
@@ -1,0 +1,20 @@
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.pretest,
+    pytest.mark.topology('util') #special marker
+]
+
+def test_prepare_dut(duthost, request):
+    deep_clean = request.config.getoption("--deep_clean")
+    if deep_clean:
+        logger.info("Deep cleaning DUT {}".format(duthost.hostname))
+        # Remove old log files.
+        duthost.shell("sudo find /var/log/ -name '*.gz' | xargs sudo rm -f", executable="/bin/bash")
+        # Remove old core files.
+        duthost.shell("sudo rm -f /var/core/*", executable="/bin/bash")
+        # Remove old core files.
+        duthost.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")

--- a/tests/test_prepare_dut.py
+++ b/tests/test_prepare_dut.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.pretest,
-    pytest.mark.topology('util') #special marker
+    pytest.mark.topology('util')
 ]
 
 def test_prepare_dut(duthost, request):
@@ -16,5 +16,5 @@ def test_prepare_dut(duthost, request):
         duthost.shell("sudo find /var/log/ -name '*.gz' | xargs sudo rm -f", executable="/bin/bash")
         # Remove old core files.
         duthost.shell("sudo rm -f /var/core/*", executable="/bin/bash")
-        # Remove old core files.
+        # Remove old dump files.
         duthost.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Some testbed has small hard drive. When old cores/dumps are not cleaned up periodically, these files would clog up the hard drive and making next fail due to lack of disk space.

Also keep very old logs could add noise to investigation. Ideally, old test failures should be captured by dumps and stored away by test framework (Jenkins). Then new test can start without ancient history.

For the time being, default behavior is not changed, still not doing any cleaning up.

#### How did you do it?

Clean up DUT old information.

- Remove old logs
- Remove old cores
- Remove old dumps

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
3 tests: (1) deep cleaning, something is there to be cleaned. (2) deep cleaning, nothing to be cleaned. (3), no cleaning.

yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-7260cx3-acs-2 -n vms7-t0-7260-2  -s "test_vrf.py test_vrf_attr.py test_mgmtvrf.py copp/test_copp.py platform_tests/test_cont_warm_reboot.py" -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veo -u -m group -p /tmp/logs-01 -t util -c test_prepare_dut.py -e "--skip_sanity --deep_clean"
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_prepare_dut.py::test_prepare_dut 
------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------
03:06:44 WARNING test_prepare_dut.py:test_prepare_dut:14: Deep cleaning DUT str-7260cx3-acs-2
PASSED                                                                                                                                                                             [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
========================================================================= 1 passed, 2 warnings in 14.11 seconds ==========================================================================
INFO:tests.conftest:==================== test_prepare_dut.py::test_prepare_dut teardown done ====================
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-7260cx3-acs-2 -n vms7-t0-7260-2  -s "test_vrf.py test_vrf_attr.py test_mgmtvrf.py copp/test_copp.py platform_tests/test_cont_warm_reboot.py" -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veo -u -m group -p /tmp/logs-01 -t util -c test_prepare_dut.py -e "--skip_sanity --deep_clean"
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_prepare_dut.py::test_prepare_dut 
------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------
03:07:03 WARNING test_prepare_dut.py:test_prepare_dut:14: Deep cleaning DUT str-7260cx3-acs-2
PASSED                                                                                                                                                                             [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
========================================================================= 1 passed, 2 warnings in 13.86 seconds ==========================================================================
INFO:tests.conftest:==================== test_prepare_dut.py::test_prepare_dut teardown done ====================
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-7260cx3-acs-2 -n vms7-t0-7260-2  -s "test_vrf.py test_vrf_attr.py test_mgmtvrf.py copp/test_copp.py platform_tests/test_cont_warm_reboot.py" -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veo -u -m group -p /tmp/logs-01 -t util -c test_prepare_dut.py -e "--skip_sanity"             
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_prepare_dut.py::test_prepare_dut PASSED                                                                                                                                       [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
========================================================================= 1 passed, 2 warnings in 12.60 seconds ==========================================================================
