### PR TITLE
Revert creds access method for advance_reboot and wr_arp testcase

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -170,7 +170,7 @@ class TestWrArp:
         ptfhost.script('./scripts/remove_ip.sh')
 
     @pytest.fixture(scope='class', autouse=True)
-    def prepareSshKeys(self, duthost, ptfhost, creds):
+    def prepareSshKeys(self, duthost, ptfhost):
         '''
             Prepares testbed ssh keys by generating ssh key on ptf host and adding this key to known_hosts on duthost
             This class-scope fixture runs once before test start
@@ -182,7 +182,11 @@ class TestWrArp:
             Returns:
                 None
         '''
-        prepareTestbedSshKeys(duthost, ptfhost, creds['sonicadmin_user'])
+        hostVars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+        invetory = hostVars['inventory_file'].split('/')[-1]
+        secrets = duthost.host.options['variable_manager']._hostvars[duthost.hostname]['secret_group_vars']
+
+        prepareTestbedSshKeys(duthost, ptfhost, secrets[invetory]['sonicadmin_user'])
 
     def testWrArp(self, request, duthost, ptfhost):
         '''

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -25,7 +25,7 @@ class AdvancedReboot:
     inboot/preboot list. The class transfers number of configuration files to the dut/ptf in preparation for reboot test.
     Test cases can trigger test start utilizing runRebootTestcase API.
     '''
-    def __init__(self, request, duthost, ptfhost, localhost, testbed, creds, **kwargs):
+    def __init__(self, request, duthost, ptfhost, localhost, testbed, **kwargs):
         '''
         Class constructor.
         @param request: pytest request object
@@ -44,7 +44,6 @@ class AdvancedReboot:
         self.ptfhost = ptfhost
         self.localhost = localhost
         self.testbed = testbed
-        self.creds = creds
         self.enableContinuousIO = False # default value may get overwritten by value in kwargs
         self.__dict__.update(kwargs)
         self.__extractTestParam()
@@ -123,8 +122,11 @@ class AdvancedReboot:
         self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
         self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
 
-        self.rebootData['dut_username'] = self.creds['sonicadmin_user']
-        self.rebootData['dut_password'] = self.creds['sonicadmin_password']
+        hostVars = self.duthost.host.options['variable_manager']._hostvars[self.duthost.hostname]
+        invetory = hostVars['inventory_file'].split('/')[-1]
+        secrets = hostVars['secret_group_vars']
+        self.rebootData['dut_username'] = secrets[invetory]['sonicadmin_user']
+        self.rebootData['dut_password'] = secrets[invetory]['sonicadmin_password']
 
         # Change network of the dest IP addresses (used by VM servers) to be different from Vlan network
         prefixLen = self.mgFacts['minigraph_vlan_interfaces'][0]['prefixlen'] - 3
@@ -481,7 +483,7 @@ class AdvancedReboot:
             self.__restorePrevImage()
 
 @pytest.fixture
-def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed, creds):
+def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed):
     '''
     Pytest test fixture that provides access to AdvancedReboot test fixture
         @param request: pytest request object
@@ -497,7 +499,7 @@ def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed, creds):
         API that returns instances of AdvancedReboot class
         '''
         assert len(instances) == 0, "Only one instance of reboot data is allowed"
-        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, creds, **kwargs)
+        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, **kwargs)
         instances.append(advancedReboot)
         return advancedReboot
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Regression post https://github.com/Azure/sonic-mgmt/pull/1885
Fix advanced_reboot script error during starting remote command on ptf.
Fixes # (issue)
Advanced_reboot fails to start a remote command on the ptf host.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The `creds` fixture incorrectly fetches `sonicadmin_user` and `sonicadmin_password` as:
`"{{ secret_group_vars['"'"'str'"'"']['"'"'sonicadmin_user'"'"'] }}"`
`"{{ secret_group_vars['"'"'str'"'"']['"'"'sonicadmin_password'"'"'] }}"`

The reason for this error is `creds` fixture pulls the information from the `yml` files and above dicts are not rendered.


#### How did you do it?
Reverted the change added by https://github.com/Azure/sonic-mgmt/pull/1885

More work to be soon added for ptf_runner warning and error handling.

#### How did you verify/test it?
Tested warm_reboot testcase and the IO thread on the PTF starts successfully.

