### PR TITLE
[Platform API] Add status LED tests to Chassis class tests

### DIFF
--- a/tests/common/helpers/platform_api/chassis.py
+++ b/tests/common/helpers/platform_api/chassis.py
@@ -152,6 +152,14 @@ def get_sfp(conn, index):
     return chassis_api(conn, 'get_sfp', [index])
 
 
+def set_status_led(conn, color):
+    return chassis_api(conn, 'set_status_led', [color])
+
+
+def get_status_led(conn):
+    return chassis_api(conn, 'get_status_led')
+
+
 def get_watchdog(conn):
     return chassis_api(conn, 'get_watchdog')
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -287,6 +287,26 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(sfp and sfp == sfp_list[i], "SFP {} is incorrect".format(i))
         self.assert_expectations()
 
+    def test_status_led(self, duthost, localhost, platform_api_conn):
+        # TODO: Get a platform-specific list of available colors for the status LED
+        LED_COLOR_LIST = [
+            "off",
+            "red",
+            "amber",
+            "green",
+        ]
+
+        for color in LED_COLOR_LIST:
+            result = chassis.set_status_led(platform_api_conn, color)
+            if self.expect(result is not None, "Failed to perform set_status_led"):
+                self.expect(result is True, "Failed to set status_led to {}".format(color))
+
+            color_actual = chassis.get_status_led(platform_api_conn)
+            if self.expect(color_actual is not None, "Failed to retrieve status_led"):
+                if self.expect(isinstance(color_actual, str), "Status LED color appears incorrect"):
+                    self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {})".format(color, color_actual))
+        self.assert_expectations()
+
     def test_get_thermal_manager(self, duthost, localhost, platform_api_conn):
         thermal_mgr = chassis.get_thermal_manager(platform_api_conn)
         pytest_assert(thermal_mgr is not None, "Failed to retrieve thermal manager")


### PR DESCRIPTION
Two new methods were recently added to the Chassis class: `set_status_led()` and `get_status_led()`. Enhancing Chassis class tests to add coverage for these.