### PR TITLE
Render some username and password in creds fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import getpass
 import pytest
 import csv
 import yaml
+import jinja2
 import ipaddr as ipaddress
 
 from collections import defaultdict
@@ -359,6 +360,13 @@ def creds(duthost):
                 creds.update(v)
             else:
                 logging.info("skip empty var file {}".format(f))
+
+    cred_vars = ["sonicadmin_user", "sonicadmin_password"]
+    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+    for cred_var in cred_vars:
+        if cred_var in creds:
+            creds[cred_var] = jinja2.Template(creds[cred_var]).render(**hostvars)
+
     return creds
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Some username and password retrieved using the creds fixture
may have reference to other variables. If the username and
password are not consumed by ansible, they would not be
rendered. This fix renders some of the username and password
in the creds fixture.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The ptf testing in advanced reboot failed because the dut_username and dut_password contain un-rendered variables.
This PR is to fix the issue.
The test_wr_arp.py also need to be fixed.

#### How did you do it?
Render the sonicadmin_user and sonicadmin_password variables using Jinja2 template and gathered vars of the duthost in the creds fixture.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
