### PR TITLE
[run_tests.sh] user can specify either topology or test case list

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,10 +31,12 @@ Hosting pytest test infrastructure and test cases
 
 
 ### Run a single test case ###
-* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -t t1 -u -c platform_tests/test_link_flap.py
+* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c platform_tests/test_link_flap.py
     * execute link flap test case.
+    * when specifying test cast list, no need to specify topology with -t.
 
 
 ### Run a list of test cases ###
-* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -t t1 -u -c "platform_tests/test_link_flap.py platform_tests/test_reboot.py::test_cold_reboot"
+* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c "platform_tests/test_link_flap.py platform_tests/test_reboot.py::test_cold_reboot"
     * execute link flap test and cold reboot test case.
+    * when specifying test cast list, no need to specify topology with -t.

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -40,7 +40,7 @@ function validate_parameters()
     fi
 
     if [[ -z ${TOPOLOGY} && -z ${TEST_CASES} ]]; then
-        echo "Niether TOPOLOGY (-t) nor test case list (-c) is not set.."
+        echo "Neither TOPOLOGY (-t) nor test case list (-c) is set.."
         RET=3
     fi
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -39,8 +39,8 @@ function validate_parameters()
         RET=2
     fi
 
-    if [[ -z ${TOPOLOGY} ]]; then
-        echo "TOPOLOGY (-t) is not set.."
+    if [[ -z ${TOPOLOGY} && -z ${TEST_CASES} ]]; then
+        echo "Niether TOPOLOGY (-t) nor test case list (-c) is not set.."
         RET=3
     fi
 
@@ -108,7 +108,11 @@ function setup_test_options()
         TEST_LOGGING_OPTIONS="--junit-xml=${LOG_PATH}/tr.xml --log-file=${LOG_PATH}/test.log"
     fi
     UTIL_TOPOLOGY_OPTIONS="--topology util"
-    TEST_TOPOLOGY_OPTIONS="--topology ${TOPOLOGY}"
+    if [[ -z ${TOPOLOGY} ]]; then
+        TEST_TOPOLOGY_OPTIONS=""
+    else
+        TEST_TOPOLOGY_OPTIONS="--topology ${TOPOLOGY}"
+    fi
 }
 
 function run_debug_tests()
@@ -166,12 +170,16 @@ function run_group_tests()
 
 function run_individual_tests()
 {
-    SKIP_SCRIPTS="${SKIP_SCRIPTS} test_announce_routes.py test_nbr_health.py"
+    if [[ -n ${TEST_CASES} ]] ;then
+        test_scripts=${TEST_CASES}
+    else
+        SKIP_SCRIPTS="${SKIP_SCRIPTS} test_announce_routes.py test_nbr_health.py"
 
-    ignores=$(python -c "print '|'.join('''$SKIP_FOLDERS'''.split())")
+        ignores=$(python -c "print '|'.join('''$SKIP_FOLDERS'''.split())")
 
-    all_scripts=$(find ./ -name 'test_*.py' | sed s:^./:: | grep -vE "^(${SKIP_FOLDERS})")
-    test_scripts=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
+        all_scripts=$(find ./ -name 'test_*.py' | sed s:^./:: | grep -vE "^(${SKIP_FOLDERS})")
+        test_scripts=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
+    fi
 
     EXIT_CODE=0
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Having to specify both topology and test case list seems unnecessary.

#### How did you do it?
When test case list is specified. User doesn't have to specify topology.

#### How did you verify/test it?
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -s "test_vrf.py test_vrf_attr.py test_mgmtvrf.py copp/test_copp.py platform_tests/test_cont_warm_reboot.py" -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veo -u -m group -p /tmp/logs-01 -c test_interfaces.py 
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_interfaces.py::test_interfaces PASSED                                                                                                                                         [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
========================================================================= 1 passed, 2 warnings in 73.78 seconds ==========================================================================
INFO:tests.conftest:==================== test_interfaces.py::test_interfaces teardown done ====================
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -s "test_vrf.py test_vrf_attr.py test_mgmtvrf.py copp/test_copp.py platform_tests/test_cont_warm_reboot.py" -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veo -u -m group -p /tmp/logs-01 -c test_interfaces.py -m individual
=== Running tests individually ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

test_interfaces.py::test_interfaces PASSED                                                                                                                                         [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------ generated xml file: /tmp/logs-01/test_interfaces.xml ------------------------------------------------------------------
========================================================================= 1 passed, 2 warnings in 73.17 seconds ==========================================================================
