### PR TITLE
[IPv6][TACACS]: Run IPv6 TACACS only when ptf docker is configured with IPv6 address

### DIFF
--- a/tests/common/plugins/tacacs.py
+++ b/tests/common/plugins/tacacs.py
@@ -56,7 +56,10 @@ def test_tacacs(ptfhost, duthost, creds):
 
 @pytest.fixture(scope="module")
 def test_tacacs_v6(ptfhost, duthost, creds):
-    tacacs_server_ip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_hostv6']
+    ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
+    if 'ansible_hostv6' not in ptfhost_vars:
+        pytest.skip("Skip IPv6 test. ptf ansible_hostv6 not configured.")
+    tacacs_server_ip = ptfhost_vars['ansible_hostv6']
     configure_tacacs(ptfhost, duthost, creds, tacacs_server_ip)
 
     yield


### PR DESCRIPTION
PTF docker is configured with IPv6 address.

Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Run IPv6 TACACS test only when ptf docker is configured with IPv6 address.

#### How did you do it?
Skip IPv6 tacacs test if ansible_hostv6 is not cofigured for the specific ptf-docker. 

#### How did you verify/test it?
Run TACACS test on testbed where ptf-docker is not configured with IPv6.
IPv4 TACACS should pass, IPv6 TACACS test case should  be skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
