### PR TITLE
[kvm/setup] Add script to setup VS management network

### DIFF
--- a/ansible/doc/README.testbed.VsSetup.md
+++ b/ansible/doc/README.testbed.VsSetup.md
@@ -5,16 +5,10 @@ This document describes the steps to setup the virtual switch based testbed and 
 ## Prepare testbed server
 
 - Install Ubuntu 18.04 amd64 server. To setup a T0 topology, the server needs to have 10GB free memory.
-- Install bridge utils
+- Setup internal management network:
 ```
-$ sudo apt-get install bridge-utils
-```
-- Setup internal management network.
-
-```
-$ sudo brctl addbr br1
-$ sudo ifconfig br1 10.250.0.1/24
-$ sudo ifconfig br1 up
+$ cd sonic-mgmt/ansible
+$ sudo ./setup-management-network.sh
 ```
 
 ### Use vEOS image

--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "Root privilege required"
+    exit
+fi
+
+echo "STEP 1: Checking for bridge-utils package..."
+if ! command -v brctl; then
+    echo "brctl not found, installing bridge-utils"
+    apt-get install -y bridge-utils
+fi
+echo
+
+echo "STEP 2: Checking for net-tools package..."
+if ! command -v ifconfig; then
+    echo "ifconfig not found, install net-tools"
+    apt-get install -y net-tools
+fi
+echo
+
+echo "STEP 3: Checking if bridge br1 already exists..."
+if brctl show br1; then
+    echo "br1 already exists, deleting first"
+    ifconfig br1 down
+    brctl delbr br1
+fi
+echo
+
+echo "STEP 4: Creating management bridge br1..."
+brctl addbr br1
+ifconfig br1 10.250.0.1/24
+ifconfig br1 up
+echo
+
+echo "COMPLETE. Bridge info:"
+echo
+brctl show br1
+echo
+ifconfig br1


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
I got tired of setting up the management network whenever I rebooted my dev VM so I added a script to do it in one step. :P

#### How did you do it?
Put the steps from the README into a script and added some validation checks.

#### How did you verify/test it?
```
daall@sahale ~/repo/sonic-mgmt/ansible % ./setup-management-network.sh 
Root privilege required
daall@sahale ~/repo/sonic-mgmt/ansible % sudo ./setup-management-network.sh 
STEP 1: Checking for bridge-utils package...
/usr/sbin/brctl

STEP 2: Checking for net-tools package...
/usr/sbin/ifconfig

STEP 3: Checking if bridge br1 already exists...
bridge br1 does not exist!

STEP 4: Creating management bridge br1...

COMPLETE. Bridge info:

bridge name	bridge id		STP enabled	interfaces
br1		8000.000000000000	no		

br1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.250.0.1  netmask 255.255.255.0  broadcast 10.250.0.255
        inet6 fe80::416:30ff:feba:f80e  prefixlen 64  scopeid 0x20<link>
        ether 06:16:30:ba:f8:0e  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

#### Any platform specific information?
KVM

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Updated README