### PR TITLE
[Multi-asic]: Fix function to get number of npus to parse updated asic.conf file

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -8,7 +8,7 @@ pytestmark = [
 def test_bgp_facts(duthost):
     """compare the bgp facts between observed states and target state"""
 
-    npus = duthost.num_npus()
+    npus = duthost.num_asics()
     bgp_facts = duthost.bgp_facts()['ansible_facts']
     mg_facts  = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -8,7 +8,6 @@ pytestmark = [
 def test_bgp_facts(duthost):
     """compare the bgp facts between observed states and target state"""
 
-    npus = duthost.num_asics()
     bgp_facts = duthost.bgp_facts()['ansible_facts']
     mg_facts  = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 


### PR DESCRIPTION

Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Function to get number of asics on a platform does not return the correct number of asics because the asic.conf file format was modified.
Function to generate the multi-instance service names running on multi-asic platform fails.
#### How did you do it?
- Fix the function to get the number of asics by parsing asic.conf, update the function to parse the file and get number of asics against "NUM_ASIC" keyword.
- Fix the function to generate the multi-instance service names.
- Remove usage of num_npu in bgp_facts test case as it is not used currently.

#### How did you verify/test it?
Ran any multi-asic compatible test case(SNMP) on multi-asic platform, test runs successfully.
Single-asic platform - No change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
