### PR TITLE
[copp] Remove extra parameter in copp test

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -105,7 +105,7 @@ def copp_testbed(duthost, ptfhost, testbed, request):
     _teardown_testbed(duthost, ptfhost, test_params)
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(self, duthost, loganalyzer):
+def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     """
         Ignore expected failures logs during test execution.
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Removes an extra parameter in the copp test that can cause the test to err out.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The copp tests can fail because the `ignore_expected_loganalyzer_exceptions` isn't part of a class.

#### How did you do it?
Remove `self`.

#### How did you verify/test it?
Re-run tests locally.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
