### PR TITLE
[root_fanout_connect.yml] Avoid registering skipped status

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -7,19 +7,13 @@
 - set_fact: dut="{{ leaf_name }}"
   when: deploy_leaf
 
-- name: Gathering connection facts about the DUT or leaffanout device
-  conn_graph_facts: host={{ dut }}
-  delegate_to: localhost
-  tags: always
-  register: devinfo
-  when: dut.split(',')|length == 1
-
 - name: Gathering connection facts about the DUTs or leaffanout device
-  conn_graph_facts: hosts={{ dut.split(',') }}
+  conn_graph_facts:
+    host: "{{ dut if ',' not in dut else omit }}"
+    hosts: "{{ dut.split(',') if ',' in dut else omit }}"
   delegate_to: localhost
   tags: always
   register: devinfo
-  when: dut.split(',')|length > 1
 
 - name: Gathering connection facts about the lab
   conn_graph_facts:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Note if either call to module `conn_graph_facts` is skipped, the
variable `devinfo` is still registered with a skipped status. Fixing
this with `omit` to omit module parameter, either `host` or `hosts`, to
achieve dynamic call behavior.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Thanks to @wangxin for pointing out this issue, that for a skipped task, `register` statement still saves variable.

#### How did you do it?

#### How did you verify/test it?
```
#  ansible-playbook fanout_connect.yml -i veos --limit "server_16" --vault-password-file="password.txt" -e "dut=lab-msn2700-test-1,lab-msn2700-test-2,lab-a7060-test-1,lab-a7060-test-2"
```
OR
```
#  ansible-playbook fanout_connect.yml -i veos --limit "server_16" --vault-password-file="password.txt" -e "dut=lab-msn2700-test-1"
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
