### PR TITLE
[testbed]: make connect topo work for kvm testbed

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -179,6 +179,29 @@ function remove_topo
   echo Done
 }
 
+function connect_topo
+{
+  topology=$1
+  passwd=$2
+  shift
+  shift
+
+  echo "Connect to Topology '${topology}'"
+
+  read_file ${topology}
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_connect_topo.yml \
+                     --vault-password-file="${passwd}" --limit "$server" \
+                     -e topo_name="$topo_name" -e dut_name="$duts" \
+                     -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" \
+                     -e topo="$topo" -e vm_set_name="$testbed_name" \
+                     -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" $@
+
+  ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$duts" $@
+
+  echo Done
+}
+
 function renumber_topo
 {
   topology=$1
@@ -232,7 +255,6 @@ function disconnect_vms
 
   echo Done
 }
-
 
 function generate_minigraph
 {
@@ -297,15 +319,6 @@ function config_vm
   ansible-playbook -i $vmfile eos.yml --vault-password-file="$3" -l "$2" -e topo="$topo" -e VM_base="$vm_base"
 
   echo Done
-}
-
-function connect_topo
-{
-  echo "Connect to Fanout"
-
-  read_file $1
-
-  ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="$2" -e "dut=$duts"
 }
 
 vmfile=veos

--- a/ansible/testbed_connect_topo.yml
+++ b/ansible/testbed_connect_topo.yml
@@ -1,0 +1,58 @@
+- hosts: servers:&vm_host
+  gather_facts: no
+  vars_files:
+    - vars/docker_registry.yml
+  pre_tasks:
+  - name: Check for a single host
+    fail: msg="Please use -l server_X to limit this playbook to one host"
+    when: "{{ play_hosts|length }} != 1"
+
+  - name: Check that variable vm_set_name is defined
+    fail: msg="Define vm_set_name variable with -e vm_set_name=something"
+    when: vm_set_name is not defined
+
+  - name: Check that variable dut_name is defined
+    fail: msg="Define dut_name variable with -e dut_name=something"
+    when: dut_name is not defined
+
+  - name: Check that variable VM_base is defined
+    fail: msg="Define VM_base variable with -e VM_base=something"
+    when: VM_base is not defined
+
+  - name: Check that variable ptf_ip is defined
+    fail: msg="Define ptf ip variable with -e ptf_ip=something"
+    when: ptf_ip is not defined
+
+  - name: Check that variable ptf_ipv6 is defined
+    fail: msg="Define ptf ipv6 variable with -e ptf_ipv6=something"
+    when: ptf_ipv6 is not defined
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: topo is not defined
+
+  - name: Check if it is a known topology
+    fail: msg="Unknown topology {{ topo }}"
+    when: topo not in topologies
+
+  - name: Check that variable ptf_imagename is defined
+    fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"
+    when: ptf_imagename is not defined
+
+  - name: Load topo variables
+    include_vars: "vars/topo_{{ topo }}.yml"
+
+  - name: Read dut minigraph
+    conn_graph_facts:
+      host: "{{ dut_name }}"
+    delegate_to: localhost
+    when: dut_name.split(',')|length == 1
+
+  - name: Read duts minigraph
+    conn_graph_facts:
+      hosts: "{{ dut_name.split(',') }}"
+    delegate_to: localhost
+    when: dut_name.split(',')|length > 1
+
+  roles:
+    - { role: vm_set, action: 'add_topo', when external_port is not defined }


### PR DESCRIPTION
for physical testbed, this connects the DUT to the fanout
for virtual testbed, this connects the VM to the virtual
testbed

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
make connect-topo work for kvm testbed.

for physical testbed, this connects the DUT to the fanout
for virtual testbed, this connects the VM to the virtual
testbed

#### How did you do it?
merge fanout_connect.yml into connect-topo.yml

#### How did you verify/test it?
run 

    ./testbed-cli.sh -m veos.vtb -t vtestbed.csv connect-topo vms-kvm-t0 password.txt

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
