### PR TITLE
[copp] ignore snmp error messages during COPP tests

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -119,6 +119,7 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     ignoreRegex = [
         ".*ERR monit.*'lldpd_monitor' process is not running",
         ".*ERR monit.*'lldp_syncd' process is not running",
+        ".*snmp#snmp-subagent.*",
     ]
     loganalyzer.ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
COPP test is replacing syncd docker during test, which requires config reload. And that in turn triggers some snmp-subagent error message and failing the test but doesn't affect system health.

#### How did you do it?
Ignore these snmp subagent messages.

#### How did you verify/test it?

Before fix:
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

copp/test_copp.py::TestCOPP::test_no_policer[BGP] PASSED                                                                                                                           [100%]
copp/test_copp.py::TestCOPP::test_no_policer[BGP] ERROR                                                                                                                            [100%]

========================================================================================= ERRORS =========================================================================================
___________________________________________________________________ ERROR at teardown of TestCOPP.test_no_policer[BGP] ___________________________________________________________________

duthost = <tests.common.devices.SonicHost object at 0x7f78eb98d3d0>, request = <SubRequest 'loganalyzer' for <Function test_no_policer[BGP]>>

    @pytest.fixture(autouse=True)
    def loganalyzer(duthost, request):
        if request.config.getoption("--disable_loganalyzer") or "disable_loganalyzer" in request.keywords:
            logging.info("Log analyzer is disabled")
            yield
            return
        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
        logging.info("Add start marker into DUT syslog")
        marker = loganalyzer.init()
        logging.info("Load config and analyze log")
        # Read existed common regular expressions located with legacy loganalyzer module
        loganalyzer.load_common_config()
    
        yield loganalyzer
    
>       loganalyzer.analyze(marker)

duthost    = <tests.common.devices.SonicHost object at 0x7f78eb98d3d0>
loganalyzer = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f78e90dbf80>
marker     = 'test_no_policer[BGP].2020-07-23-19:58:42'
request    = <SubRequest 'loganalyzer' for <Function test_no_policer[BGP]>>

common/plugins/loganalyzer/__init__.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common/plugins/loganalyzer/loganalyzer.py:254: in analyze
    self._verify_log(analyzer_summary)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f78e90dbf80>
result = {'expect_messages': {'/tmp/syslog.2020-07-23-19:59:52': []}, 'match_files': {'/tmp/syslog.2020-07-23-19:59:52': {'expe...neType' object is not subscriptable\n"]}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 2}, ...}

    def _verify_log(self, result):
        """
        Verify that total match and expected missing match equals to zero or raise exception otherwise.
        Verify that expected_match is not equal to zero when there is configured expected regexp in self.expect_regex list
        """
        if not result:
            raise LogAnalyzerError("Log analyzer failed - no result.")
        if result["total"]["match"] != 0 or result["total"]["expected_missing_match"] != 0:
>           raise LogAnalyzerError(result)
E           LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-07-23-19:59:52': ['Jul 23 19:59:06.608271 str-dx010-acs-1 ERR snmp#snmp-subagent message repeated 9 times: [ [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 40, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 115, in reinit_data#012    self.loc_chassis_data[b\'lldp_loc_sys_cap_supported\'] = parse_sys_capability(self.loc_chassis_data[b\'lldp_loc_sys_cap_supported\'])#012TypeError: \'NoneType\' object is not subscriptable]\n', 'Jul 23 19:59:10.627549 str-dx010-acs-1 ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 40, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 115, in reinit_data#012    self.loc_chassis_data[b\'lldp_loc_sys_cap_supported\'] = parse_sys_capability(self.loc_chassis_data[b\'lldp_loc_sys_cap_supported\'])#012TypeError: \'NoneType\' object is not subscriptable\n']}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 2}, 'match_files': {'/tmp/syslog.2020-07-23-19:59:52': {'expected_match': 0, 'match': 2}}, 'expect_messages': {'/tmp/syslog.2020-07-23-19:59:52': []}, 'unused_expected_regexp': []}

result     = {'expect_messages': {'/tmp/syslog.2020-07-23-19:59:52': []}, 'match_files': {'/tmp/syslog.2020-07-23-19:59:52': {'expe...neType' object is not subscriptable\n"]}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 2}, ...}
self       = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f78e90dbf80>

common/plugins/loganalyzer/loganalyzer.py:85: LogAnalyzerError
==================================================================================== warnings summary ====================================================================================


After fix:
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

copp/test_copp.py::TestCOPP::test_no_policer[BGP] PASSED                                                                                                                           [100%]

==================================================================================== warnings summary ====================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/stepwise
    self.warn("could not create cache path {path}", path=path)

/usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127
  /usr/local/lib/python2.7/dist-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: could not create cache path /var/src/sonic-mgmt/tests/.pytest_cache/v/cache/nodeids
    self.warn("could not create cache path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
