### PR TITLE
[po_update] ignore a couple syncd complaints

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -7,6 +7,26 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
+    """
+        Ignore expected failures logs during test execution.
+
+        LAG tests are triggering following syncd complaints but the don't cause
+        harm to DUT.
+
+        Args:
+            duthost: DUT fixture
+            loganalyzer: Loganalyzer utility fixture
+    """
+    ignoreRegex = [
+        ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
+        ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*",
+    ]
+    loganalyzer.ignore_regex.extend(ignoreRegex)
+
+    yield
+
 def test_po_update(duthost):
     """
     test port channel add/deletion as well ip address configuration

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -19,11 +19,13 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
             duthost: DUT fixture
             loganalyzer: Loganalyzer utility fixture
     """
-    ignoreRegex = [
-        ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
-        ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*",
-    ]
-    loganalyzer.ignore_regex.extend(ignoreRegex)
+    # when loganalyzer is disabled, the object could be None
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
+            ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*",
+        ]
+        loganalyzer.ignore_regex.extend(ignoreRegex)
 
     yield
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
po_update test is failing due to a couple syncd complaints that didn't otherwise hurt system health.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Before change:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f0e05344b48>
result = {'expect_messages': {'/tmp/syslog.2020-07-23-21:31:05': []}, 'match_files': {'/tmp/syslog.2020-07-23-21:31:05': {'expe...since it contain invalid OIDs, bug?\n']}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 2}, ...}

    def _verify_log(self, result):
        """
        Verify that total match and expected missing match equals to zero or raise exception otherwise.
        Verify that expected_match is not equal to zero when there is configured expected regexp in self.expect_regex list
        """
        if not result:
            raise LogAnalyzerError("Log analyzer failed - no result.")
        if result["total"]["match"] != 0 or result["total"]["expected_missing_match"] != 0:
>           raise LogAnalyzerError(result)
E           LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-07-23-21:31:05': ['Jul 23 21:29:34.193597 str-dx010-acs-1 ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB\n', 'Jul 23 21:29:34.193597 str-dx010-acs-1 ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug?\n']}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 2}, 'match_files': {'/tmp/syslog.2020-07-23-21:31:05': {'expected_match': 0, 'match': 2}}, 'expect_messages': {'/tmp/syslog.2020-07-23-21:31:05': []}, 'unused_expected_regexp': []}

result     = {'expect_messages': {'/tmp/syslog.2020-07-23-21:31:05': []}, 'match_files': {'/tmp/syslog.2020-07-23-21:31:05': {'expe...since it contain invalid OIDs, bug?\n']}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 2}, ...}
self       = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f0e05344b48>

common/plugins/loganalyzer/loganalyzer.py:85: LogAnalyzerError

After change:
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 2 items                                                                                                                                                                        

pc/test_lag_2.py::test_lag PASSED                                                                                                                                                  [ 50%]
pc/test_po_update.py::test_po_update PASSED                                                                                                                                        [100%]
