### PR TITLE
[QoS]: Add 40000_40 qos parameters for td2.

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -228,6 +228,44 @@ qos_params:
                 pkts_num_trig_ingr_drp: 5164
                 pkts_num_fill_egr_min: 0
                 cell_size: 208
+        40000_40m:
+            pkts_num_leak_out: 48
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 0
+                pkts_num_trig_ingr_drp: 5164
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 4898
+                pkts_num_trig_ingr_drp: 5164
+                pkts_num_fill_egr_min: 0
+                cell_size: 208
         xon_1:
             dscp: 3
             ecn: 1


### PR DESCRIPTION
Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
qos test on fails on TD2 platfrom, as qos parameters are missing.

#### How did you do it?
Add 40000_40 parameter for td2 platform.

#### How did you verify/test it?
qos test is successful after this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
