### PR TITLE
Fix pfcwd error setting poll interval

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -80,6 +80,10 @@ def setup_pfc_test(duthost, ptfhost, conn_graph_facts):
     else:
         setup_info['vlan'] = None
 
+    # stop pfcwd
+    logger.info("--- Stopping Pfcwd ---")
+    duthost.command("pfcwd stop")
+
     # set poll interval
     duthost.command("pfcwd interval {}".format(setup_info['pfc_timers']['pfc_wd_poll_time']))
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fixes the error seen in test_pfc_config.py run on T1
"stderr": "unable to use polling interval = 400ms, value is bigger than one of the configured detection time values, please choose a smaller polling_interval", 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran the test with the change and it passed

platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/nejo/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 8 items                                                                                                                                                                                                                       

pfcwd/test_pfc_config.py ........                                                                                                                                                                                                 [100%]

====================================================================================================== 8 passed in 129.54 seconds =======================================================================================================
