### PR TITLE
Explicitly skip test_ser for unmatched asic_type

### DIFF
--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -46,4 +46,4 @@ def test_ser(duthost):
         logger.info('Test complete with %s: ' % rc)
 
     else:
-        logger.info('Skipping SER test for asic_type: %s' % asic_type)
+        pytest.skip('Skipping SER test for asic_type: %s' % asic_type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The Broadcom specific test_ser.py script just logs a message and exit when `asic_type` is not `broadcom`. When this test script is executed on other platforms, the script will be marked as `passed`. This doesn't make sense.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When the Broadcom platform specific test script `test_ser.py` is executed on other platforms, the script will be marked as `passed`. This does not make sense.

#### How did you do it?
Explicitly skip the Broadcom specific tests on other platforms.

#### How did you verify/test it?
Test run the script on non Broadcom platforms, the test is marked as `skipped`.

#### Any platform specific information?
The updated script is Broadcom platform specific.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
