### PR TITLE
Add an option to configure an external TACACS server on switch

### DIFF
--- a/tests/common/plugins/tacacs.py
+++ b/tests/common/plugins/tacacs.py
@@ -54,7 +54,7 @@ def cleanup_tacacs(ptfhost, duthost, tacacs_server_ip, creds, config_tacacs_on_s
     duthost.shell("sudo config aaa authentication failthrough default")
 
 @pytest.fixture(scope="module")
-def test_tacacs(ptfhost, duthost, creds):
+def test_tacacs(request, ptfhost, duthost, creds):
     tacacs_server_ip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     config_tacacs_on_switch = request.config.getoption('--switch_tacacs_config')
 
@@ -66,7 +66,7 @@ def test_tacacs(ptfhost, duthost, creds):
 
 
 @pytest.fixture(scope="module")
-def test_tacacs_v6(ptfhost, duthost, creds):
+def test_tacacs_v6(request, ptfhost, duthost, creds):
     ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
     if 'ansible_hostv6' not in ptfhost_vars:
         pytest.skip("Skip IPv6 test. ptf ansible_hostv6 not configured.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,9 @@ def pytest_addoption(parser):
     ############################
     parser.addoption("--switch_tacacs_config", action="store", default=False, type=bool,
                     help="Boolean indicated if TACACS server configuration should be performed on switch")
+    parser.addoption("--local_username", action="store", default="ro", help="String to indicate username of what test should be added - insert ro/rw")
+    parser.addoption("--local_password", action="store", default=111111, type=int,
+                    help="A password for local username. the password needs to be different from tacacs user password")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,12 @@ def pytest_addoption(parser):
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
 
+    ############################
+    #   tacacs tests options   #
+    ############################
+    parser.addoption("--switch_tacacs_config", action="store", default=False, type=bool,
+                    help="Boolean indicated if TACACS server configuration should be performed on switch")
+
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):


### PR DESCRIPTION
Signed-off-by: Noa Or <noaor@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Adding an option to configure an external TACACS server on switch.
#### How did you do it?
The following parameters were added:
1. "--switch_tacacs_config":
If it's configured to True, the following steps will be done:
- Add the tacacs server with ip taken from creds['tacacs_servers'][0]
- Change the authtype to 'pap'
2. "--local_username": can be rw/ro. (ro by default). 
a local username will be added according to the received value. (e.g., creds['tacacs_ro_user'])
3. "--local_password": A password to add to local user. (should be different than the one configured to the tacacs username. 111111 by default.)

#### How did you verify/test it?
``` py.test --inventory ../ansible/inventory --host-pattern <host> --module-path ../ansible/library/ --testbed <host>-<topo> --testbed_file ../ansible/testbed.csv --show-capture=no --capture=no --log-cli-level info -ra --switch_tacacs_config true --local_username ro --local_password 123456 -vvvvv tacacs/test_ro_user.py```
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
