### PR TITLE
[pytest/test_arpall.py]Use general config reload api to avoid sanity check fail

### DIFF
--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -52,7 +52,7 @@ def common_setup_teardown(duthost, ptfhost):
         yield duthost, ptfhost, int_facts, intf1, intf2, intf1_indice, intf2_indice
     finally:
         # Recover DUT interface IP address
-        config_reload(duthost, config_source='minigraph', wait=120)
+        config_reload(duthost, config_source='config_db', wait=120)
 
 def test_arp_unicast_reply(common_setup_teardown):
     duthost, ptfhost, int_facts, intf1, intf2, intf1_indice, intf2_indice = common_setup_teardown

--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
+from tests.common import config_reload
 
 pytestmark = [
     pytest.mark.topology('t1')
@@ -51,7 +52,7 @@ def common_setup_teardown(duthost, ptfhost):
         yield duthost, ptfhost, int_facts, intf1, intf2, intf1_indice, intf2_indice
     finally:
         # Recover DUT interface IP address
-        duthost.shell("sudo config reload -y &>/dev/null", executable="/bin/bash")
+        config_reload(duthost, config_source='minigraph', wait=120)
 
 def test_arp_unicast_reply(common_setup_teardown):
     duthost, ptfhost, int_facts, intf1, intf2, intf1_indice, intf2_indice = common_setup_teardown


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes sanity check fail that test exit without confirm DUT has not fully reloaded

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fixes sanity check fail that test exit without confirm DUT has not fully reloaded

#### How did you do it?
Use existing config reload API which will wait a while after reload config

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
