### PR TITLE
[pytest]: Fail WR ARP test earlier with empty DIP

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -98,7 +98,7 @@ class TestWrArp:
             sed -ne 's/0\/.*$/1/p'
             '''
         )
-        assert len(result['stderr_lines']) == 0, 'Could not obtain DIP'
+
         pytest_assert(len(result['stdout'].strip()) > 0, 'Empty DIP returned')
 
         dip = result['stdout']

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -2,6 +2,7 @@ import json
 import logging
 import pytest
 
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
@@ -98,6 +99,7 @@ class TestWrArp:
             '''
         )
         assert len(result['stderr_lines']) == 0, 'Could not obtain DIP'
+        pytest_assert(len(result['stdout'].strip()) > 0, 'Empty DIP returned')
 
         dip = result['stdout']
         logger.info('VxLan Sender {0}'.format(dip))


### PR DESCRIPTION
* Add assertion to arp/test_wr_arp.py to catch an empty DIP returned
from DUT host

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

The WR ARP test case does not fail with a clear/useful error message if it receives an empty DIP from the DUT host. 
Summary:
Fixes #1985 (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Provide clearer failure messages for the WR ARP test case
#### How did you do it?
Add an assertion to check the length of the DIP string

#### How did you verify/test it?
1. Follow steps in #1985 to reproduce the error. The test should still fail, but now with the following error message:
```
>       pytest_assert(len(result['stdout'].strip()) > 0, 'Empty DIP returned')
E       Failed: Empty DIP returned
duthost    = <tests.common.devices.SonicHost object at 
ptfhost    = <tests.common.devices.PTFHost object at 
result     = {'stderr_lines': [], u'cmd': u"ip route show type unicast |\n            sed -...chdir': None, u'stdin_add_newline': True u'stdin': None}}, 'stdout_lines': []}                                                                
self       = <tests.arp.test_wr_arp.TestWrArp instance at 0x7fc7c5827098>
arp/test_wr_arp.py:102: Failed                                                                                                                                                 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

You should be able to return your DUT to a normal state by restarting the `exabgp*` processes on the PTF host and running the `test_announce_routes.py` test case. 