### PR TITLE
[Mellanox] Add retry to check fan speed sysfs

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -4,7 +4,6 @@ Helper script for checking status of sysfs.
 This script contains re-usable functions for checking status of hw-management related sysfs.
 """
 import logging
-import time
 from tests.common.utilities import wait_until
 
 
@@ -31,7 +30,6 @@ def check_sysfs(dut):
     from tests.common.mellanox_data import SWITCH_MODELS
     fan_count = SWITCH_MODELS[dut_hwsku]["fans"]["number"]
 
-    fan_speed = 0
     fan_min_speed = 0
     fan_max_speed = 0
     for fan_id in range(1, fan_count + 1):

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -5,6 +5,7 @@ This script contains re-usable functions for checking status of hw-management re
 """
 import logging
 import time
+from tests.common.utilities import wait_until
 
 
 def check_sysfs(dut):
@@ -62,18 +63,12 @@ def check_sysfs(dut):
         fan_speed_set = "/var/run/hw-management/thermal/fan{}_speed_set".format(fan_id)
         fan_speed_set_content = dut.command("cat %s" % fan_speed_set)
         fan_set_speed = int(fan_speed_set_content["stdout"])
-
+        max_tolerance_speed = ((float(fan_set_speed) / 256) * fan_max_speed) * (1 + 0.5)
+        min_tolerance_speed = ((float(fan_set_speed) / 256) * fan_max_speed) * (1 - 0.5)
         fan_speed_get = "/var/run/hw-management/thermal/fan{}_speed_get".format(fan_id)
-        try:
-            fan_speed_get_content = dut.command("cat %s" % fan_speed_get)
-            fan_speed = int(fan_speed_get_content["stdout"])
-            assert fan_min_speed < fan_speed < fan_max_speed, "Bad fan speed: %s" % str(fan_speed)
-        except Exception as e:
-            assert "Get content from %s failed, exception: %s" % (fan_speed_get, repr(e))
-
-        max_tolerance_speed = ((float(fan_set_speed)/256)*fan_max_speed)*(1 + 0.5)
-        min_tolerance_speed = ((float(fan_set_speed)/256)*fan_max_speed)*(1 - 0.5)
-        _check_fan_speed_in_tolerance(dut, fan_speed, min_tolerance_speed, max_tolerance_speed, fan_speed_get)
+        assert wait_until(30, 5, _check_fan_speed_in_range, dut, fan_min_speed, fan_max_speed,
+                          min_tolerance_speed, max_tolerance_speed, fan_speed_get), \
+            "Fan speed not in range"
 
     cpu_temp_high_counter = 0
     cpu_temp_list = []
@@ -229,24 +224,17 @@ def check_psu_sysfs(dut, psu_id, psu_state):
             "sysfs content %s mismatches with psu_state %s" % (psu_pwr_state_content["stdout"], psu_state)
 
 
-def _check_fan_speed_in_tolerance(dut, fan_speed, min_speed, max_speed, sysfs_path):
-    read_count = 6
-    read_interval = 5
-    in_range = False
-    while 1:
-        if min_speed < fan_speed < max_speed:
-            in_range = True
-            break
-
-        read_count -= 1
-        if read_count <= 0:
-            break
-
-        time.sleep(read_interval)
-        try:
-            fan_speed_get_content = dut.command("cat %s" % sysfs_path)
-            fan_speed = int(fan_speed_get_content["stdout"])
-        except Exception as e:
-            assert "Get content from %s failed, exception: %s" % (sysfs_path, repr(e))
-
-    assert in_range, "Speed %d out of tolerance speed range (%d, %d)" % (fan_speed, min_speed, max_speed)
+def _check_fan_speed_in_range(dut, min_speed, max_speed, low_threshold, high_threshold, sysfs_path):
+    try:
+        fan_speed_get_content = dut.command("cat %s" % sysfs_path)
+        fan_speed = int(fan_speed_get_content["stdout"])
+        logging.info("fan speed: {}, min_speed: {}, max_speed: {}, low_threshold: {}, high_threshold: {}".format(
+            fan_speed,
+            min_speed,
+            max_speed,
+            low_threshold,
+            high_threshold
+        ))
+        return min_speed < fan_speed < max_speed and low_threshold < fan_speed < high_threshold
+    except Exception as e:
+        assert "Get content from %s failed, exception: %s" % (sysfs_path, repr(e))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Add retry to check fan speed related sysfs

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
With thermal control enabled, fan speed changes according to temperature sensors. Thermal control may change fan speed to some expect_speed. However, fan needs a few seconds to adjust its actual_speed to expect_speed. There is chance that fan actual speed would be out of range when thermal control adjust the expect_speed and causes test cases failure. The solution is to introduce some retry to make sure the fan speed is stable and in valid range.

#### How did you do it?

Retry 6 times with intervale 5 seconds.

#### How did you verify/test it?

Manually run regression case.

#### Any platform specific information?

Mellanox platform

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
