### PR TITLE
[run_tests] improve run_tests.sh's usability

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -65,7 +65,7 @@ function setup_environment()
     OMIT_FILE_LOG="False"
     RETAIN_SUCCESS_LOG="False"
     SKIP_SCRIPTS=""
-    SKIP_FOLDERS="ptftests acstests saitests"
+    SKIP_FOLDERS="ptftests acstests saitests scripts"
     TESTBED_FILE="${BASE_PATH}/ansible/testbed.csv"
     TEST_CASES=""
     TEST_METHOD='group'
@@ -220,13 +220,13 @@ while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:ux" opt; do
             show_help_and_exit 0
             ;;
         c )
-            TEST_CASES=${OPTARG}
+            TEST_CASES="${TEST_CASES} ${OPTARG}"
             ;;
         d )
             DUT_NAME=${OPTARG}
             ;;
         e )
-            EXTRA_PARAMETERS=${OPTARG}
+            EXTRA_PARAMETERS="${EXTRA_PARAMETERS} ${OPTARG}"
             ;;
         f )
             TESTBED_FILE=${OPTARG}
@@ -256,7 +256,7 @@ while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:ux" opt; do
             RETAIN_SUCCESS_LOG="True"
             ;;
         s )
-            SKIP_SCRIPTS=${OPTARG}
+            SKIP_SCRIPTS="${SKIP_SCRIPTS} ${OPTARG}"
             ;;
         t )
             TOPOLOGY=${OPTARG}


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Making run_tests.sh more user friendly.

#### How did you do it?
- Skip folder scripts, this folder contains helper scripts. Not intended to hold test cases.
- Allow issue -c -e -s multiple times, so user could issue each value (pair) with an option.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos -u -p /tmp/logs-01 -m debug -c test_a -c test_b -s test_c -s test_d -e param_1 -e "param2 2" 
=== Show test settings ===
SCRIPT:                ./run_tests.sh
FULL_PATH:             /var/src/sonic-mgmt/tests/run_tests.sh
SCRIPT_PATH:           /var/src/sonic-mgmt/tests
BASE_PATH:             /var/src/sonic-mgmt
ANSIBLE_CONFIG:        /var/src/sonic-mgmt/ansible
ANSIBLE_LIBRARY:       /var/src/sonic-mgmt/ansible/library/
BYPASS_UTIL:           True
CLI_LOG_LEVEL:         warning
EXTRA_PARAMETERS:       param_1 param2 2
FILE_LOG_LEVEL:        debug
INVENTORY:             /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos
LOG_PATH:              /tmp/logs-01
OMIT_FILE_LOG:         False
RETAIN_SUCCESS_LOG:    False
SKIP_SCRIPTS:           test_c test_d
SKIP_FOLDERS:          ptftests acstests saitests scripts
TEST_CASES:             test_a test_b
TEST_METHOD:           debug
TESTBED_FILE:          /var/src/sonic-mgmt/ansible/testbed.csv
TEST_LOGGING_OPTIONS:  --junit-xml=/tmp/logs-01/tr.xml --log-file=/tmp/logs-01/test.log
TEST_TOPOLOGY_OPTIONS: 
PRET_LOGGING_OPTIONS:  --junit-xml=/tmp/logs-01/pretest.xml --log-file=/tmp/logs-01/pretest.log
POST_LOGGING_OPTIONS:  --junit-xml=/tmp/logs-01/posttest.xml --log-file=/tmp/logs-01/posttest.log
UTIL_TOPOLOGY_OPTIONS: --topology util
PYTEST_COMMON_OPTS:    --inventory /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos                       --host-pattern str-dx010-acs-1                       --testbed vms3-t1-dx010-1                       --testbed_file /var/src/sonic-mgmt/ansible/testbed.csv                       --log-cli-level warning                       --log-file-level debug                       --allow_recover                       --showlocals                       --assert plain                       --show-capture no                       -rav --ignore=test_c --ignore=test_d --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts