### PR TITLE
[pytest] Fix unicode error in pfcwd

### DIFF
--- a/ansible/roles/test/files/ptftests/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/pfc_wd.py
@@ -53,7 +53,10 @@ class PfcWdTest(BaseTest):
                 dport = random.randint(0, 65535)
                 ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
                 ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
-                while ip_src == ipaddress.IPv4Address(unicode(self.ip_dst,'utf-8')) or ip_src.is_multicast or ip_src.is_private or ip_src.is_global or ip_src.is_reserved:
+                if not isinstance(self.ip_dst, unicode):
+                    self.ip_dst = unicode(self.ip_dst, 'utf-8')
+                ip_dst = ipaddress.IPv4Address(self.ip_dst)
+                while ip_src == ip_dst or ip_src.is_multicast or ip_src.is_private or ip_src.is_global or ip_src.is_reserved:
                     ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
                     ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fixes the unicode error seen in pytest runs when selected port type is a 'portchannel'
E                        "stderr_lines": [
E                            "WARNING: No route found for IPv6 destination :: (no default route?)", 
E                            "pfc_wd.PfcWdTest ... ERROR", 
E                            "", 
E                            "======================================================================", 
E                            "ERROR: pfc_wd.PfcWdTest", 
E                            "----------------------------------------------------------------------", 
E                            "Traceback (most recent call last):", 
E                            "  File \"ptftests/pfc_wd.py\", line 56, in runTest", 
E                            "    while ip_src == ipaddress.IPv4Address(unicode(self.ip_dst,'utf-8')) or ip_src.is_multicast or ip_src.is_private or ip_src.is_global or ip_src.is_reserved:", 
E                            "TypeError: decoding Unicode is not supported", 
E                            "", 
E                            "----------------------------------------------------------------------", 
E                            "Ran 1 test in 0.003s", 
E                            "", 
E                            "FAILED (errors=1)"
E                        ], 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
set pfcwd seed to 0 which will pick up a portchannel interface for the test on the setup I validated.
Ran the test without the changes which resulted in the error above
Ran pytest and the ansible test with the fix and they passed