### PR TITLE
[pytest] Add fixture "conn_graph_facts_multi_duts"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,12 @@ import jinja2
 import ipaddr as ipaddress
 
 from collections import defaultdict
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts
-from tests.common.devices import SonicHost, Localhost, PTFHost, EosHost, FanoutHost
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts_multi_duts
+from tests.common.devices import SonicHost, Localhost
+from tests.common.devices import PTFHost, EosHost, FanoutHost
+
 
 logger = logging.getLogger(__name__)
 
@@ -221,22 +225,34 @@ def enable_ssh_timout(dut):
     time.sleep(5)
 
 
+@pytest.fixture(name="duthosts", scope="session")
+def fixture_duthosts(ansible_adhoc, testbed):
+    """
+    @summary: fixture to get DUT hosts defined in testbed.
+    @param ansible_adhoc: Fixture provided by the pytest-ansible package.
+        Source of the various device objects. It is
+        mandatory argument for the class constructors.
+    @param testbed: Ansible framework testbed information
+    """
+    return [SonicHost(ansible_adhoc, dut) for dut in testbed["duts"]]
+
+
 @pytest.fixture(scope="session")
-def duthost(ansible_adhoc, testbed, request):
+def duthost(duthosts, request):
     '''
     @summary: Shortcut fixture for getting DUT host. For a lengthy test case, test case module can
               pass a request to disable sh time out mechanis on dut in order to avoid ssh timeout.
               After test case completes, the fixture will restore ssh timeout.
-    @param ansible_adhoc: Fixture provided by the pytest-ansible package. Source of the various device objects. It is
-        mandatory argument for the class constructors.
-    @param testbed: Ansible framework testbed information
+    @param duthosts: fixture to get DUT hosts
     @param request: request parameters for duthost test fixture
     '''
     stop_ssh_timeout = getattr(request.session, "pause_ssh_timeout", None)
     dut_index = getattr(request.session, "dut_index", 0)
-    assert dut_index < len(testbed["duts"]), "DUT index '{0}' is out of bound '{1}'".format(dut_index, len(testbed["duts"]))
+    assert dut_index < len(duthosts), \
+        "DUT index '{0}' is out of bound '{1}'".format(dut_index,
+                                                       len(duthosts))
 
-    duthost = SonicHost(ansible_adhoc, testbed["duts"][dut_index])
+    duthost = duthosts[dut_index]
     if stop_ssh_timeout is not None:
         disable_ssh_timout(duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
1. Add fixture `duthosts` to return a list of dut hosts in the case of
multiple DUTs.
2. Modify fixture `duthost` to use `duthosts`.
3. Modify `get_graph_facts` to use `hostnames`, it can be either:
    * a single DUT's hostname
    * a list of DUTs' hostnames
4. Add fixture `conn_graph_facts_multi_duts` to parse connection graph
for multiple DUTs.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To generate `Spytest` testbed file, should add `conn_graph_facts_multi_duts` to parse connection graph file in this case.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
