### PR TITLE
Remove the route add/del in pfcwd

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -55,9 +55,6 @@ def setup_pfc_test(duthost, ptfhost, conn_graph_facts):
         vlan_ips = duthost.get_ip_in_range(num=1, prefix="{}/{}".format(vlan_addr, vlan_prefix), exclude_ips=[vlan_addr])['ansible_facts']['generated_ips']
         vlan_nw = vlan_ips[0].split('/')[0]
 
-        duthost.shell("ip route flush {}/32".format(vlan_nw))
-        duthost.shell("ip route add {}/32 dev {}".format(vlan_nw, vlan_dev))
-
     # build the port list for the test
     tp_handle = TrafficPorts(mg_facts, neighbors, vlan_nw)
     test_ports = tp_handle.build_port_list()


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Temporary workaround to avoid the following orchagent crash on broadcom platforms
Jul 29 22:20:53.110980 str-7260cx3-acs-7 ERR syncd#syncd: [none] brcm_sai_remove_route_entry:672 L3 route delete failed with error Entry not found (0xfffffff9).
Jul 29 22:20:53.110980 str-7260cx3-acs-7 ERR syncd#syncd: :- processEvent: failed to execute api: remove, key: SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"192.168.0.2/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000044"}, status: SAI_STATUS_ITEM_NOT_FOUND
Jul 29 22:20:53.110980 str-7260cx3-acs-7 ERR syncd#syncd: :- syncd_main: Runtime error: :- processEvent: failed to execute api: remove, key: SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"192.168.0.2/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000044"}, status: SAI_STATUS_ITEM_NOT_FOUND
Jul 29 22:20:53.110980 str-7260cx3-acs-7 NOTICE syncd#syncd: :- notify_OA_about_syncd_exception: sending switch_shutdown_request notification to OA
Jul 29 22:20:53.111217 str-7260cx3-acs-7 NOTICE syncd#syncd: :- notify_OA_about_syncd_exception: notification send successfull
Jul 29 22:20:53.111453 str-7260cx3-acs-7 NOTICE swss#orchagent: :- handle_switch_shutdown_request: switch shutdown request
Jul 29 22:20:53.114306 str-7260cx3-acs-7 INFO swss#supervisord: orchagent terminate called after throwing an instance of 'std::invalid_argument'
Jul 29 22:20:53.114306 str-7260cx3-acs-7 INFO swss#supervisord: orchagent   what():  parse error - unexpected end of input
Jul 29 22:20:56.951479 str-7260cx3-acs-7 INFO swss#supervisord 2020-07-29 22:20:53,521 INFO exited: orchagent (terminated by SIGABRT (core dumped); not expected)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Ran all pfcwd tests with the change and they work as expected.