### PR TITLE
[pytest]: add remove_ip.sh and arp_responder.py to ptfhost_utils

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from tests.ptf_runner import ptf_runner
 
@@ -155,19 +156,6 @@ class TestWrArp:
             result = duthost.shell(cmd='ip route delete {0}/32 {1}'.format(ptfIp, gwIp), module_ignore_errors=True)
             assert result["rc"] == 0 or "No such process" in result["stderr"], \
                 "Failed to delete route with error '{0}'".format(result["stderr"])
-
-    @pytest.fixture(scope='class', autouse=True)
-    def removePtfhostIp(self, ptfhost):
-        '''
-            Removes IP assigned to eth<n> inerface of PTF host. This class-scope fixture runs once before test start
-
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-
-            Returns:
-                None
-        '''
-        ptfhost.script('./scripts/remove_ip.sh')
 
     @pytest.fixture(scope='class', autouse=True)
     def prepareSshKeys(self, duthost, ptfhost, creds):

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -6,6 +6,7 @@ import requests
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_tcp_connection
 
@@ -50,8 +51,6 @@ def common_setup_teardown(duthost, ptfhost, localhost):
 
     ptfip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     logging.info("ptfip=%s" % ptfip)
-
-    ptfhost.script("./scripts/remove_ip.sh")
 
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     interface_facts = duthost.interface_facts()['ansible_facts']
@@ -125,8 +124,6 @@ def common_setup_teardown(duthost, ptfhost, localhost):
 
     for ip in vlan_ips:
         duthost.command("ip route flush %s/32" % ip.ip, module_ignore_errors=True)
-
-    ptfhost.script("./scripts/remove_ip.sh")
 
     logging.info("########### Done teardown for bgp speaker testing ###########")
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -5,10 +5,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 ROOT_DIR = "/root"
+OPT_DIR = "/opt"
+SCRIPTS_SRC_DIR = "scripts/"
 ACS_TESTS = "acstests"
 PTF_TESTS = "ptftests"
 SAI_TESTS = "saitests"
+ARP_RESPONDER_PY = "arp_responder.py"
 CHANGE_MAC_ADDRESS_SCRIPT = "scripts/change_mac.sh"
+REMOVE_IP_ADDRESS_SCRIPT = "scripts/remove_ip.sh"
 
 @pytest.fixture(scope="session", autouse=True)
 def copy_acstests_directory(ptfhost):
@@ -80,3 +84,39 @@ def change_mac_addresses(ptfhost):
     """
     logger.info("Change interface MAC addresses on ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.script(CHANGE_MAC_ADDRESS_SCRIPT)
+
+@pytest.fixture(scope="session", autouse=True)
+def remove_ip_addresses(ptfhost):
+    """
+        Remove existing IP addresses on PTF host.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+        Returns:
+            None
+    """
+    logger.info("Remove existing IPs on ptfhost '{0}'".format(ptfhost.hostname))
+    ptfhost.script(REMOVE_IP_ADDRESS_SCRIPT)
+
+    yield
+
+    logger.info("Remove IPs to restore ptfhost '{0}'".format(ptfhost.hostname))
+    ptfhost.script(REMOVE_IP_ADDRESS_SCRIPT)
+    
+@pytest.fixture(scope="session", autouse=True)
+def copy_arp_responder_py(ptfhost):
+    """
+        Copy arp_responder to PTF container.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+        Returns:
+            None
+    """
+    logger.info("Copy arp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
+    ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, ARP_RESPONDER_PY), dest=OPT_DIR)
+
+    yield
+
+    logger.info("Delete arp_responder.py from ptfhost '{0}'".format(ptfhost.hostname))
+    ptfhost.file(path=os.path.join(OPT_DIR, ARP_RESPONDER_PY), state="absent")

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -9,6 +9,7 @@ from ansible.plugins.filter.core import to_bool
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 from tests.common.plugins.fib import generate_routes
 
@@ -110,8 +111,6 @@ def gen_fib_info(ptfhost, testbed, cfg_facts):
 
 
 def prepare_ptf(ptfhost, testbed, cfg_facts):
-    logger.info("Remove IP on PTF container")
-    ptfhost.script("./scripts/remove_ip.sh")
 
     gen_fib_info(ptfhost, testbed, cfg_facts)
 

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -22,6 +22,7 @@ import configurable_drop_counters as cdc
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import fanout_switch_port_lookup
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # lgtm[py/unused-import]
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -203,7 +204,6 @@ def arp_responder(ptfhost, testbed_params):
     ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
 
     logging.info("Copying ARP responder to PTF container")
-    ptfhost.copy(src="scripts/arp_responder.py", dest="/opt")
 
     logging.info("Copying ARP responder config file")
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": "-e"})

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -8,6 +8,7 @@ import logging
 import pprint
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 
 pytestmark = [
     pytest.mark.topology('t0')
@@ -172,8 +173,6 @@ def test_fdb(ansible_adhoc, testbed, ptfadapter, duthost, ptfhost, pkt_type):
     host_facts  = duthost.setup()['ansible_facts']
     conf_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
-    # remove existing IPs from PTF host
-    ptfhost.script('scripts/remove_ip.sh')
     # reinitialize data plane due to above changes on PTF interfaces
     ptfadapter.reinit()
 

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -4,6 +4,7 @@ from ipaddress import ip_address
 import logging
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 
 TOPO_LIST = {'t0', 't1', 't1-lag'}
 PORTS_TOPO = {'t1'}
@@ -16,12 +17,6 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def prepare_ptf(ptfhost):
-    # remove existing IPs from ptf host
-    ptfhost.script('scripts/remove_ip.sh')
 
 
 def lag_facts(dut, mg_facts):

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -5,6 +5,7 @@ import json
 import re
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 from tests.common import reboot
 from tests.common  import config_reload
@@ -73,7 +74,6 @@ def setup_ptf(ptfhost, collector_ports):
     extra_vars = {'arp_responder_args' : '--conf /tmp/sflow_arpresponder.conf'}
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
     ptfhost.template(src="../ansible/roles/test/templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
-    ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py", dest="/opt")
     ptfhost.shell('supervisorctl reread')
     ptfhost.shell('supervisorctl update')
     for i in range(len(collector_ports)):

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -12,6 +12,7 @@ import logging
 import pprint
 
 from tests.common.errors import RunAnsibleModuleFail
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # lgtm[py/unused-import]
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +148,6 @@ def setup_vlan(ptfadapter, duthost, ptfhost, vlan_ports_list, vlan_intfs_list, c
                     ))
 
         logger.info("Copy arp_responder to ptfhost")
-        ptfhost.copy(src='scripts/arp_responder.py', dest='/opt')
 
         setUpArpResponder(vlan_ports_list, ptfhost)
 

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -8,6 +8,8 @@ from netaddr import IPAddress
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
@@ -27,11 +29,8 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts):
     @param mg_facts: Minigraph facts
     @param dut_facts: Host facts of DUT
     """
-    logger.info("Remove IP")
-    ptfhost.script("./scripts/remove_ip.sh")
 
     logger.info("Prepare arp_responder")
-    ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py", dest="/opt")
 
     arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
     ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="--conf /tmp/vxlan_arpresponder.conf"),


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
- create new fixtures to copy remove_ip.sh and arp_responder.py to PTF container
- change existing tests to use these fixtures

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make the use of pytest fixtures more consistent across tests
#### How did you do it?
Create fixtures for running `remove_ip.sh` and copying `arp_responder.py` on PTF host
#### How did you verify/test it?
Running the changed tests gives the same results with and without the new fixtures.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
