### PR TITLE
Fix get_ip_route_info()

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -21,11 +21,11 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
     po = config_facts.get('PORTCHANNEL', {})
     dev_nbr = config_facts.get('DEVICE_NEIGHBOR', {})
 
-    rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_address(u'0.0.0.0'))
+    rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_network(u'0.0.0.0/0'))
     if len(rtinfo_v4['nexthops']) == 0:
         pytest.skip("there is no next hop for v4 default route")
 
-    rtinfo_v6 = duthost.get_ip_route_info(ipaddress.ip_address(u'::'))
+    rtinfo_v6 = duthost.get_ip_route_info(ipaddress.ip_network(u'::/0'))
     if len(rtinfo_v6['nexthops']) == 0:
         pytest.skip("there is no next hop for v6 default route")
 
@@ -74,11 +74,11 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
             "neighbor {} does not enter NSF state".format(bgp_nbr_ipv6))
 
     # confirm ip route still there
-    rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_address(u'0.0.0.0'))
+    rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_network(u'0.0.0.0/0'))
     pytest_assert(ipaddress.ip_address(bgp_nbr_ipv4) in [ nh[0] for nh in rtinfo_v4['nexthops'] ], \
         "cannot find nexthop {} in the new default route nexthops. {}".format(bgp_nbr_ipv4, rtinfo_v4))
 
-    rtinfo_v6 = duthost.get_ip_route_info(ipaddress.ip_address(u'::'))
+    rtinfo_v6 = duthost.get_ip_route_info(ipaddress.ip_network(u'::/0'))
     pytest_assert(ipaddress.ip_address(bgp_nbr_ipv6) in [ nh[0] for nh in rtinfo_v6['nexthops'] ], \
         "cannot find nexthop {} in the new default route nexthops. {}".format(bgp_nbr_ipv6, rtinfo_v6))
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -545,27 +545,65 @@ class SonicHost(AnsibleHostBase):
         Please beware: if dstip is an ip network, you will receive all ECMP nexthops
         But if dstip is an ip address, only one nexthop will be returned, the one which is going to be used to send a packet to the destination.
 
-        Debian stretch.
-
         Exanples:
-        get_ip_route_info(ipaddress.ip_address(unicode("192.168.8.0")))
-        returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
+----------------
+get_ip_route_info(ipaddress.ip_address(unicode("192.168.8.0")))
+returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
 
-        get_ip_route_info(ipaddress.ip_network(unicode("192.168.8.0/25")))
-        returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
+raw data sonic 20191130
+192.168.8.0 via 10.0.0.13 dev PortChannel0004 src 10.1.0.32
+    cache
 
-        get_ip_route_info(ipaddress.ip_address(unicode("20c0:a818::")))
-        returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
+----------------
+get_ip_route_info(ipaddress.ip_network(unicode("192.168.8.0/25")))
+returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
 
-        get_ip_route_info(ipaddress.ip_network(unicode("20c0:a818::/64")))
-        returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
+raw data sonic 20191130
+192.168.8.0/25 proto 186 src 10.1.0.32 metric 20
+        nexthop via 10.0.0.1  dev PortChannel0001 weight 1
+        nexthop via 10.0.0.5  dev PortChannel0002 weight 1
+        nexthop via 10.0.0.9  dev PortChannel0003 weight 1
+        nexthop via 10.0.0.13  dev PortChannel0004 weight 1
 
-        get_ip_route_info(ipaddress.ip_network(unicode("0.0.0.0/0")))
-        returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
+----------------
+get_ip_route_info(ipaddress.ip_address(unicode("20c0:a818::")))
+returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
 
-        get_ip_route_info(ipaddress.ip_network(unicode("::/0")))
-        returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
+raw data sonic 20191130
+20c0:a818:: from :: via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
 
+----------------
+get_ip_route_info(ipaddress.ip_network(unicode("20c0:a818::/64")))
+returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
+
+raw data sonic 20191130
+20c0:a818::/64 via fc00::2 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
+20c0:a818::/64 via fc00::a dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
+20c0:a818::/64 via fc00::12 dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
+20c0:a818::/64 via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
+
+----------------
+get_ip_route_info(ipaddress.ip_network(unicode("0.0.0.0/0")))
+returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
+
+raw data sonic 20191130
+default proto 186 src 10.1.0.32 metric 20
+        nexthop via 10.0.0.1  dev PortChannel0001 weight 1
+        nexthop via 10.0.0.5  dev PortChannel0002 weight 1
+        nexthop via 10.0.0.9  dev PortChannel0003 weight 1
+        nexthop via 10.0.0.13  dev PortChannel0004 weight 1
+
+----------------
+get_ip_route_info(ipaddress.ip_network(unicode("::/0")))
+returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
+
+raw data sonic 20191130
+default via fc00::2 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
+default via fc00::a dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
+default via fc00::12 dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
+default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
+
+----------------
         """
 
         rtinfo = {'set_src': None, 'nexthops': [] }

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -615,12 +615,12 @@ class SonicHost(AnsibleHostBase):
         @param ipv6: check ipv6 default
         """
         if ipv4:
-            rtinfo_v4 = self.get_ip_route_info(ipaddress.ip_address(u'0.0.0.0'))
+            rtinfo_v4 = self.get_ip_route_info(ipaddress.ip_network(u'0.0.0.0/0'))
             if len(rtinfo_v4['nexthops']) == 0:
                 return False
 
         if ipv6:
-            rtinfo_v6 = self.get_ip_route_info(ipaddress.ip_address(u'::'))
+            rtinfo_v6 = self.get_ip_route_info(ipaddress.ip_network(u'::/0'))
             if len(rtinfo_v6['nexthops']) == 0:
                 return False
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -550,59 +550,53 @@ class SonicHost(AnsibleHostBase):
 get_ip_route_info(ipaddress.ip_address(unicode("192.168.8.0")))
 returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
 
-raw data sonic 20191130
+raw data
 192.168.8.0 via 10.0.0.13 dev PortChannel0004 src 10.1.0.32
     cache
-
 ----------------
 get_ip_route_info(ipaddress.ip_network(unicode("192.168.8.0/25")))
 returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
 
-raw data sonic 20191130
+raw data
 192.168.8.0/25 proto 186 src 10.1.0.32 metric 20
         nexthop via 10.0.0.1  dev PortChannel0001 weight 1
         nexthop via 10.0.0.5  dev PortChannel0002 weight 1
         nexthop via 10.0.0.9  dev PortChannel0003 weight 1
         nexthop via 10.0.0.13  dev PortChannel0004 weight 1
-
 ----------------
 get_ip_route_info(ipaddress.ip_address(unicode("20c0:a818::")))
 returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
 
-raw data sonic 20191130
+raw data
 20c0:a818:: from :: via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
-
 ----------------
 get_ip_route_info(ipaddress.ip_network(unicode("20c0:a818::/64")))
 returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
 
-raw data sonic 20191130
+raw data
 20c0:a818::/64 via fc00::2 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
 20c0:a818::/64 via fc00::a dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
 20c0:a818::/64 via fc00::12 dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
 20c0:a818::/64 via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
-
 ----------------
 get_ip_route_info(ipaddress.ip_network(unicode("0.0.0.0/0")))
 returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
 
-raw data sonic 20191130
+raw data
 default proto 186 src 10.1.0.32 metric 20
         nexthop via 10.0.0.1  dev PortChannel0001 weight 1
         nexthop via 10.0.0.5  dev PortChannel0002 weight 1
         nexthop via 10.0.0.9  dev PortChannel0003 weight 1
         nexthop via 10.0.0.13  dev PortChannel0004 weight 1
-
 ----------------
 get_ip_route_info(ipaddress.ip_network(unicode("::/0")))
 returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
 
-raw data sonic 20191130
+raw data
 default via fc00::2 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
 default via fc00::a dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
 default via fc00::12 dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
 default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
-
 ----------------
         """
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -574,27 +574,27 @@ default via fc00::7e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         """
 
         if dstip.version == 4:
-            rt = self.command("ip route list match {}".format(dstip))['stdout_lines']
+            rt = self.command("ip route list exact {}".format(dstip))['stdout_lines']
         else:
-            rt = self.command("ip -6 route list match {}".format(dstip))['stdout_lines']
+            rt = self.command("ip -6 route list exact {}".format(dstip))['stdout_lines']
 
         logging.info("route raw info for {}: {}".format(dstip, rt))
 
         rtinfo = {'set_src': None, 'nexthops': [] }
 
         # parse set_src
-        m = re.match(r"^default proto (bgp|186) src (\S+)", rt[0])
-        m1 = re.match(r"^default via (\S+) dev (\S+) proto 186 src (\S+)", rt[0])
+        m = re.match(r"^(default|\S+) proto (bgp|186) src (\S+)", rt[0])
+        m1 = re.match(r"^(default|\S+) via (\S+) dev (\S+) proto 186 src (\S+)", rt[0])
         if m:
-            rtinfo['set_src'] = ipaddress.ip_address(m.group(2))
+            rtinfo['set_src'] = ipaddress.ip_address(unicode(m.group(3)))
         elif m1:
-            rtinfo['set_src'] = ipaddress.ip_address(m1.group(3))
+            rtinfo['set_src'] = ipaddress.ip_address(unicode(m1.group(4)))
 
         # parse nexthops
         for l in rt:
-            m = re.search(r"(default|nexthop)\s+via\s+(\S+)\s+dev\s+(\S+)", l)
+            m = re.search(r"(default|nexthop|\S+)\s+via\s+(\S+)\s+dev\s+(\S+)", l)
             if m:
-                rtinfo['nexthops'].append((ipaddress.ip_address(m.group(2)), m.group(3)))
+                rtinfo['nexthops'].append((ipaddress.ip_address(unicode(m.group(2))), unicode(m.group(3))))
 
         logging.info("route parsed info for {}: {}".format(dstip, rtinfo))
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -89,7 +89,6 @@ def validate_dut_routes_exist(duthost, dut_dhcp_relay_data):
 
     for dhcp_server in dhcp_servers:
         rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
-        # FIXME: this test looks iconnect, because we will receive a nexthop in case we have a default route
         assert len(rtInfo["nexthops"]) > 0, "Failed to find route to DHCP server '{0}'".format(dhcp_server)
 
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -89,6 +89,7 @@ def validate_dut_routes_exist(duthost, dut_dhcp_relay_data):
 
     for dhcp_server in dhcp_servers:
         rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
+        # FIXME: this test looks iconnect, because we will receive a nexthop in case we have a default route
         assert len(rtInfo["nexthops"]) > 0, "Failed to find route to DHCP server '{0}'".format(dhcp_server)
 
 

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -34,12 +34,12 @@ def test_default_route_set_src(duthost):
     pytest_assert(lo_ipv4, "cannot find ipv4 Loopback0 address")
     pytest_assert(lo_ipv6, "cannot find ipv6 Loopback0 address")
 
-    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(u"0.0.0.0"))
+    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(u"0.0.0.0/0"))
     pytest_assert(rtinfo['set_src'], "default route do not have set src. {}".format(rtinfo))
     pytest_assert(rtinfo['set_src'] == lo_ipv4.ip, \
             "default route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv4.ip))
 
-    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(u"::"))
+    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
     pytest_assert(rtinfo['set_src'], "default v6 route do not have set src. {}".format(rtinfo))
     pytest_assert(rtinfo['set_src'] == lo_ipv6.ip, \
             "default v6 route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv6.ip))
@@ -50,7 +50,7 @@ def test_default_ipv6_route_next_hop_global_address(duthost):
 
     """
 
-    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(u"::"))
+    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
     pytest_assert(rtinfo['nexthops'] > 0, "cannot find ipv6 nexthop for default route")
     for nh in rtinfo['nexthops']:
         pytest_assert(not nh[0].is_link_local, \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To fix a bug in get_ip_route_info(). Previously it was impossible to get a routing information for a prefix, if the prefix is not a default route and if a default route is presented in the routing table. In this case you saw default route nexthop information instead of the prefix information. That was because ip route list match command returns all routes which could be used for the prefix. In our testbed we usually have default route, so default route is returned instead of the prefix route.

#### How did you do it?
1. I introduced two types of input value. For the ip_address type I use command ip route get <addr> which give me exact nexthop which is going to be used for the address. One caveat here: we will not see ECMP nexthops, only one of them. For the ip_network type I use command ip route list exact <prefix>, which will return correct route for the prefix.

#### How did you verify/test it?
I wrote a following testcase:
```
@pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(False, True, 1514)])
def test_route(common_setup, testbed, duthost, ptfhost, ipv4, ipv6, mtu, collect_techsupport):
    """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR

    """
    _ = common_setup
    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(unicode("192.168.8.0")))
    logging.info("%s" % rtinfo)

    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(unicode("192.168.8.0/25")))
    logging.info("%s" % rtinfo)

    rtinfo = duthost.get_ip_route_info(ipaddress.ip_address(unicode("20c0:a818::")))
    logging.info("%s" % rtinfo)

    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(unicode("20c0:a818::/64")))
    logging.info("%s" % rtinfo)

    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(unicode("0.0.0.0/0")))
    logging.info("%s" % rtinfo)

    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(unicode("::/0")))
    logging.info("%s" % rtinfo)




@pytest.fixture(scope="module")
def common_setup(duthost, ptfhost, localhost):
    yield 0

```

The syslog output for the testcase is:
```
test_bgp_speaker.py:test_route:413: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
test_bgp_speaker.py:test_route:416: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
test_bgp_speaker.py:test_route:419: {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
test_bgp_speaker.py:test_route:422: {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
test_bgp_speaker.py:test_route:425: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
test_bgp_speaker.py:test_route:428: {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
```

#### Any platform specific information?
Both SONiC 201811 and SONiC 201911 uses the same iproute2 version 4.9.0 from sonic-buildimage.
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
