### PR TITLE
[lag update] add log analysis exception

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -24,6 +24,7 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
         ignoreRegex = [
             ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
             ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*",
+            ".*ERR syncd#syncd: :- translate_vid_to_rid: unable to get RID for VID.*",
         ]
         loganalyzer.ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
test_po_update encountered this failure.

Jul 31 10:59:24.114655 str-dx010-acs-1 NOTICE swss#orchagent: :- removeRouterIntfs: Router interface is still referenced
Jul 31 10:59:24.115036 str-dx010-acs-1 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop 10.0.0.9 on PortChannel999
Jul 31 10:59:24.115036 str-dx010-acs-1 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor 52:54:00:6e:6e:99 on PortChannel999
Jul 31 10:59:24.118737 str-dx010-acs-1 NOTICE swss#orchagent: :- removeRouterIntfs: Remove router interface for port PortChannel999
**Jul 31 10:59:24.143035 str-dx010-acs-1 ERR syncd#syncd: :- translate_vid_to_rid: unable to get RID for VID: 0x60000000009fa
Jul 31 10:59:24.143188 str-dx010-acs-1 WARNING syncd#syncd: :- processFlexCounterEvent: port VID oid:0x60000000009fa, was not found (probably port was removed/splitted) and will remove from counters now**


#### How did you do it?
When removing lag members, flex counter query could temporarily unable to find the object.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

