### PR TITLE
[everflow] Improve Everflow v6 tests

### DIFF
--- a/tests/everflow/templates/acl_rule_v6.json.j2
+++ b/tests/everflow/templates/acl_rule_v6.json.j2
@@ -340,12 +340,6 @@
                                         "source-ip-address": "ffbe:0225:7c6b:a982:d48b:230e:f271:000c/128",
                                         "destination-ip-address": "ffbe:0225:7c6b:a982:d48b:230e:f271:000d/128"
                                     }
-                                },
-                                "transport": {
-                                    "config": {
-                                        "source-port": "12002",
-                                        "destination-port": "12003"
-                                    }
                                 }
                             },
                             "19": {
@@ -462,6 +456,28 @@
                                     "config": {
                                         "source-port": "12012",
                                         "destination-port": "12013"
+                                    }
+                                }
+                            },
+                            "24": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 24
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "ffbe:0225:7c6b:a982:d48b:230e:f271:001c/128",
+                                        "destination-ip-address": "ffbe:0225:7c6b:a982:d48b:230e:f271:001d/128"
+                                    }
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "12002",
+                                        "destination-port": "12003"
                                     }
                                 }
                             }

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -269,9 +269,20 @@ class EverflowIPv6Tests(BaseEverflowTest):
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d",
-            sport=12002,
-            dport=12003
+            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d"
+        )
+
+        self._send_and_check_mirror_packets(setup_info,
+                                            setup_mirror_session,
+                                            ptfadapter,
+                                            duthost,
+                                            test_packet)
+
+        test_packet = self._base_udp_packet(
+            ptfadapter,
+            setup_info,
+            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
+            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d"
         )
 
         self._send_and_check_mirror_packets(setup_info,
@@ -285,24 +296,39 @@ class EverflowIPv6Tests(BaseEverflowTest):
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
             dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d",
-            sport=12002,
-            dport=12003
-        )
-
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
-
-        test_packet = self._base_udp_packet(
-            ptfadapter,
-            setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d",
-            sport=12002,
-            dport=12003,
             next_header=0xAB
+        )
+
+        self._send_and_check_mirror_packets(setup_info,
+                                            setup_mirror_session,
+                                            ptfadapter,
+                                            duthost,
+                                            test_packet)
+
+    def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthost):
+        """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
+        test_packet = self._base_tcp_packet(
+            ptfadapter,
+            setup_info,
+            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001c",
+            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001d",
+            sport=12002,
+            dport=12003
+        )
+
+        self._send_and_check_mirror_packets(setup_info,
+                                            setup_mirror_session,
+                                            ptfadapter,
+                                            duthost,
+                                            test_packet)
+
+        test_packet = self._base_udp_packet(
+            ptfadapter,
+            setup_info,
+            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001c",
+            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001d",
+            sport=12002,
+            dport=12003
         )
 
         self._send_and_check_mirror_packets(setup_info,
@@ -313,29 +339,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
-        test_packet = self._base_tcp_packet(
-            ptfadapter,
-            setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000e",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000f",
-            dscp=16,
-            sport=12004,
-            dport=12005,
-            flags=0x12,
-            next_header=0x7F
-        )
+        pass
 
-        # NOTE: We're keeping this test + its associated ACL rule here for now since tbh
-        # it mostly just exists to see if the ASIC will panic if it sees proto=UDP +
-        # TCP flags in the same ACL rule. Will take another look at the payload comparison
-        # logic later.
-        pytest.xfail("Invalid comparison logic")
-
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        # NOTE: This type of rule won't really function since you need a TCP packet to have TCP flags.
+        # However, we have still included such a rule in the acl.json file to validate that the SAI
+        # will not crash if such a rule is installed. If this does happen, we expect the whole test
+        # suite + loganaylzer + the sanity check to fail.
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match packets with a Source IPv6 Subnet."""


### PR DESCRIPTION
- Add separate test cases for matching any IP protocol v. transport protocols
- Clarify invalid TCP test case

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fixed some inconsistencies in the Everflow v6 test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There were a few logical issues in the v6 test cases:
- The existing `any_protocol` test case does not make since as the made-up protocol `0xAB` does not have any concept of "source port" or "dest port", so it does not make sense for the ASIC to match this packet.
- This issue also exists for the `invalid_tcp_rule`. Since a UDP packet can't have TCP flags, it doesn't make sense for this rule to actually match any packets.

#### How did you do it?
I broke the `any_protocol` test down into two test cases:
- One removes the port qualifiers and purely checks that src ip and dst ip are matched regardless of the NEXT_HEADER field.
- The other includes port qualifiers and verifies that both TCP and UDP are matched if no NEXT_HEADER is specified.

I made the `invalid_tcp_rule` purely a configuration test case (e.g. as long as the ASIC does not crash when we install the rule, the test is considered "passed").

#### How did you verify/test it?
Ran the tests on my DUT:
```
daall@00c187053803:/var/src/Networking-acs-sonic-mgmt/tests$ pytest everflow/test_everflow_ipv6.py --testbed=vms1-8 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-msn2700-06 --module-path=../ansible/library -v --skip_sanity                     
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/src/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 20 items                                                                                                                                                                                                 

everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring PASSED                                                                                                                      [  5%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring PASSED                                                                                                                      [ 10%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring PASSED                                                                                                                   [ 15%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring PASSED                                                                                                                   [ 20%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring PASSED                                                                                                                   [ 25%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring PASSED                                                                                                             [ 30%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring PASSED                                                                                                             [ 35%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring PASSED                                                                                                                     [ 40%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring PASSED                                                                                                                          [ 45%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring PASSED                                                                                                                      [ 50%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring PASSED                                                                                                                  [ 55%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring PASSED                                                                                                               [ 60%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring PASSED                                                                                                               [ 65%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol PASSED                                                                                                                            [ 70%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol PASSED                                                                                                                  [ 75%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule PASSED                                                                                                                        [ 80%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet PASSED                                                                                                                           [ 85%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet PASSED                                                                                                                             [ 90%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets PASSED                                                                                                                            [ 95%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets PASSED                                                                                                                           [100%]

=========================================================================================== 20 passed in 166.58 seconds ============================================================================================
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
