### PR TITLE
[minigraph] generate minigraph for DUT doesn't have IPv6 address specified

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -32,9 +32,17 @@
           <Name>V6HostIP</Name>
           <AttachTo>eth0</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+{% if ansible_hostv6 is defined %}
             <b:IPPrefix>{{ ansible_hostv6 }}/64</b:IPPrefix>
+{% else %}
+            <b:IPPrefix>FC00:2::32/64</b:IPPrefix>
+{% endif %}
           </a:Prefix>
+{% if ansible_hostv6 is defined %}
           <a:PrefixStr>{{ ansible_hostv6 }}/64</a:PrefixStr>
+{% else %}
+          <a:PrefixStr>FC00:2::32/64</a:PrefixStr>
+{% endif %}
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Generating minigraph for DUT doesn't have ansible_hostv6 defined would fail.

#### How did you do it?
Generate default IPv6 address when not specified (old behavior).

#### How did you verify/test it?
Deploy minigraph to a DUT that doesn't have ansible_hostv6 specified.