### PR TITLE
[run_test.sh] add maxfail option and improve help information

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,20 +5,21 @@ function show_help_and_exit()
     echo "Usage ${SCRIPT} [options]"
     echo "    options with (*) must be provided"
     echo "    -h -?          : get this help"
-    echo "    -c             : specify test cases to execute (default: none, executed all matched)"
-    echo "    -d             : specify DUT name (*)"
-    echo "    -e             : specify extra parameter(s) (default: none)"
-    echo "    -f             : specify testbed file (default testbed.csv)"
-    echo "    -i             : specify inventory name"
-    echo "    -k             : specify file log level: error|warning|info|debug (default debug)"
-    echo "    -l             : specify cli log level: error|warning|info|debug (default warning)"
-    echo "    -m             : specify test method group|individual|debug (default group)"
-    echo "    -n             : specify testbed name (*)"
+    echo "    -c <testcases> : specify test cases to execute (default: none, executed all matched)"
+    echo "    -d <dut name>  : specify DUT name (*)"
+    echo "    -e <paramters> : specify extra parameter(s) (default: none)"
+    echo "    -f <tb file>   : specify testbed file (default testbed.csv)"
+    echo "    -i <inventory> : specify inventory name"
+    echo "    -k <log level> : specify file log level: error|warning|info|debug (default debug)"
+    echo "    -l <log level> : specify cli log level: error|warning|info|debug (default warning)"
+    echo "    -m <method>    : specify test method group|individual|debug (default group)"
+    echo "    -n <testbed>   : specify testbed name (*)"
     echo "    -o             : omit the file logs"
-    echo "    -p             : specify log path (default: logs)"
+    echo "    -p <path>      : specify log path (default: logs)"
+    echo "    -q <n>         : test will stop after <n> failures (default: not stop on failure)"
     echo "    -r             : retain individual file log for suceeded tests (default: remove)"
-    echo "    -s             : specify list of scripts to skip (default: none)"
-    echo "    -t             : specify toplogy: t0|t1|any|combo like t0,any (*)"
+    echo "    -s <tests>     : specify list of tests to skip (default: none)"
+    echo "    -t <topology>  : specify toplogy: t0|t1|any|combo like t0,any (*)"
     echo "    -u             : bypass util group"
     echo "    -x             : print commands and their arguments as they are executed"
 
@@ -69,6 +70,7 @@ function setup_environment()
     TESTBED_FILE="${BASE_PATH}/ansible/testbed.csv"
     TEST_CASES=""
     TEST_METHOD='group'
+    TEST_MAX_FAIL=0
 
     export ANSIBLE_CONFIG=${BASE_PATH}/ansible
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
@@ -113,6 +115,12 @@ function setup_test_options()
     else
         TEST_TOPOLOGY_OPTIONS="--topology ${TOPOLOGY}"
     fi
+
+    PYTEST_UTIL_OPTS=${PYTEST_COMMON_OPTS}
+    # Max failure only applicable to the test session. Not the preparation and cleanup session.
+    if [[ ${TEST_MAX_FAIL} != 0 ]]; then
+        PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --maxfail=${TEST_MAX_FAIL}"
+    fi
 }
 
 function run_debug_tests()
@@ -136,6 +144,7 @@ function run_debug_tests()
     echo "SKIP_SCRIPTS:          ${SKIP_SCRIPTS}"
     echo "SKIP_FOLDERS:          ${SKIP_FOLDERS}"
     echo "TEST_CASES:            ${TEST_CASES}"
+    echo "TEST_MAX_FAIL:         ${TEST_MAX_FAIL}"
     echo "TEST_METHOD:           ${TEST_METHOD}"
     echo "TESTBED_FILE:          ${TESTBED_FILE}"
     echo "TEST_LOGGING_OPTIONS:  ${TEST_LOGGING_OPTIONS}"
@@ -150,7 +159,7 @@ function run_debug_tests()
 function prepare_dut()
 {
     echo "=== Preparing DUT for subsequent tests ==="
-    py.test ${PYTEST_COMMON_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m pretest
+    py.test ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m pretest
 
     # Give some delay for the newly announced routes to propagate.
     sleep 120
@@ -159,7 +168,7 @@ function prepare_dut()
 function cleanup_dut()
 {
     echo "=== Cleaning up DUT after tests ==="
-    py.test ${PYTEST_COMMON_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m posttest
+    py.test ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m posttest
 }
 
 function run_group_tests()
@@ -205,6 +214,9 @@ function run_individual_tests()
             fi
         else
             EXIT_CODE=1
+            if [[ ${TEST_MAX_FAIL} != 0 ]]; then
+                return ${EXIT_CODE}
+            fi
         fi
 
     done
@@ -214,7 +226,7 @@ function run_individual_tests()
 
 setup_environment
 
-while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:ux" opt; do
+while getopts "h?c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -251,6 +263,9 @@ while getopts "h?c:d:e:f:i:k:l:m:n:op:rs:t:ux" opt; do
             ;;
         p )
             LOG_PATH=${OPTARG}
+            ;;
+        q )
+            TEST_MAX_FAIL=${OPTARG}
             ;;
         r )
             RETAIN_SUCCESS_LOG="True"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,7 +5,7 @@ function show_help_and_exit()
     echo "Usage ${SCRIPT} [options]"
     echo "    options with (*) must be provided"
     echo "    -h -?          : get this help"
-    echo "    -a <True|False>: specify specify if autu-recover is allowed (default: True)"
+    echo "    -a <True|False>: specify if autu-recover is allowed (default: True)"
     echo "    -c <testcases> : specify test cases to execute (default: none, executed all matched)"
     echo "    -d <dut name>  : specify DUT name (*)"
     echo "    -e <parameters>: specify extra parameter(s) (default: none)"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -232,7 +232,7 @@ function run_individual_tests()
 
 setup_environment
 
-while getopts "h?c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
+while getopts "h?a:c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,13 +5,14 @@ function show_help_and_exit()
     echo "Usage ${SCRIPT} [options]"
     echo "    options with (*) must be provided"
     echo "    -h -?          : get this help"
+    echo "    -a <True|False>: specify specify if autu-recover is allowed (default: True)"
     echo "    -c <testcases> : specify test cases to execute (default: none, executed all matched)"
     echo "    -d <dut name>  : specify DUT name (*)"
-    echo "    -e <paramters> : specify extra parameter(s) (default: none)"
+    echo "    -e <parameters>: specify extra parameter(s) (default: none)"
     echo "    -f <tb file>   : specify testbed file (default testbed.csv)"
     echo "    -i <inventory> : specify inventory name"
-    echo "    -k <log level> : specify file log level: error|warning|info|debug (default debug)"
-    echo "    -l <log level> : specify cli log level: error|warning|info|debug (default warning)"
+    echo "    -k <file log>  : specify file log level: error|warning|info|debug (default debug)"
+    echo "    -l <cli log>   : specify cli log level: error|warning|info|debug (default warning)"
     echo "    -m <method>    : specify test method group|individual|debug (default group)"
     echo "    -n <testbed>   : specify testbed name (*)"
     echo "    -o             : omit the file logs"
@@ -58,6 +59,7 @@ function setup_environment()
     BASE_PATH=$(dirname ${SCRIPT_PATH})
     LOG_PATH="logs"
 
+    AUTO_RECOVER="True"
     BYPASS_UTIL="False"
     CLI_LOG_LEVEL='warning'
     EXTRA_PARAMETERS=""
@@ -84,11 +86,14 @@ function setup_test_options()
                       --testbed_file ${TESTBED_FILE} \
                       --log-cli-level ${CLI_LOG_LEVEL} \
                       --log-file-level ${FILE_LOG_LEVEL} \
-                      --allow_recover \
                       --showlocals \
                       --assert plain \
                       --show-capture no \
                       -rav"
+
+    if [[ x"${AUTO_RECOVER}" == x"True" ]]; then
+        PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --allow_recover"
+    fi
 
     for skip in ${SKIP_SCRIPTS} ${SKIP_FOLDERS}; do
         PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --ignore=${skip}"
@@ -133,6 +138,7 @@ function run_debug_tests()
 
     echo "ANSIBLE_CONFIG:        ${ANSIBLE_CONFIG}"
     echo "ANSIBLE_LIBRARY:       ${ANSIBLE_LIBRARY}"
+    echo "AUTO_RECOVER:          ${AUTO_RECOVER}"
     echo "BYPASS_UTIL:           ${BYPASS_UTIL}"
     echo "CLI_LOG_LEVEL:         ${CLI_LOG_LEVEL}"
     echo "EXTRA_PARAMETERS:      ${EXTRA_PARAMETERS}"
@@ -230,6 +236,9 @@ while getopts "h?c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
+            ;;
+        a )
+            AUTO_RECOVER=${OPTARG}
             ;;
         c )
             TEST_CASES="${TEST_CASES} ${OPTARG}"


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR test behavior changed after switching over to use run_tests.sh. It is no longer stop at first failure and causing longer run time for failed tests.

#### How did you do it?
- Allow setting maxfail for the test.
- Allow disabling auto recovery
- With individual method, if maxfail is set, any failure in a test
  module will cause test to end.
- Explicit about options with parameter.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
Don't specify -q 1 option:

yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos -u -m group -p /tmp/logs-01 -c copp/test_copp.py
=== Running tests in groups ===

copp/test_copp.py::TestCOPP::test_policer[ARP] 
------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------
19:53:09 WARNING recover.py:recover:92: Try to recover str-dx010-acs-1 using method adaptive
19:53:09 WARNING recover.py:adaptive_recover:80: Restoring {'check_item': 'processes', 'failed': True, 'services_status': {'lldp': True, 'bgp': True, 'pmon': True, 'database': True, 'teamd': True, 'swss': False, 'syncd': True, 'snmp': True}, 'processes_status': {'lldp': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'lldp-syncd', u'lldpd', u'lldpmgrd']}, 'pmon': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'psud', u'xcvrd']}, 'database': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'redis']}, 'snmp': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'snmp-subagent', u'snmpd']}, 'bgp': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'bgpcfgd', u'bgpd', u'fpmsyncd', u'staticd', u'zebra']}, 'teamd': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'teammgrd', u'teamsyncd']}, 'syncd': {'status': True, 'exited_critical_process': [], 'running_critical_process': [u'syncd']}, 'swss': {'status': False, 'exited_critical_process': [u'orchagent'], 'running_critical_process': [u'buffermgrd', u'intfmgrd', u'nbrmgrd', u'neighsyncd', u'portmgrd', u'portsyncd', u'vlanmgrd', u'vrfmgrd', u'vxlanmgrd']}}} with proposed action: config_reload, final action: config_reload
Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
FAILED                                                                                                                                                                             [ 11%]
copp/test_copp.py::TestCOPP::test_policer[IP2ME] PASSED                                                                                                                            [ 22%]
copp/test_copp.py::TestCOPP::test_policer[SNMP] PASSED                                                                                                                             [ 33%]
copp/test_copp.py::TestCOPP::test_policer[SSH] PASSED                                                                                                                              [ 44%]
copp/test_copp.py::TestCOPP::test_no_policer[BGP] PASSED                                                                                                                           [ 55%]
copp/test_copp.py::TestCOPP::test_no_policer[DHCP] PASSED                                                                                                                          [ 66%]
copp/test_copp.py::TestCOPP::test_no_policer[LACP] PASSED                                                                                                                          [ 77%]
copp/test_copp.py::TestCOPP::test_no_policer[LLDP] PASSED                                                                                                                          [ 88%]
copp/test_copp.py::TestCOPP::test_no_policer[UDLD] PASSED                                                                                                                          [100%]

======================================================================================== FAILURES ========================================================================================
=================================================================== 1 failed, 8 passed, 3 warnings in 1154.50 seconds ====================================================================


Specify -q 1 option:
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos -u -m group -p /tmp/logs-01 -c copp/test_copp.py -e -x                           
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 9 items                                                                                                                                                                        

copp/test_copp.py::TestCOPP::test_policer[ARP] Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
FAILED                                                                                                                              [ 11%]
======================================================================================== FAILURES ========================================================================================
========================================================================= 1 failed, 3 warnings in 453.74 seconds =========================================================================

