### PR TITLE
[Platform API][Chassis] Ignore case when comparing base MAC address

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -86,7 +86,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if 'base_mac' in duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars:
             expected_base_mac = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['base_mac']
-            pytest_assert(base_mac == expected_base_mac, "Base MAC address is incorrect")
+            pytest_assert(base_mac.lower() == expected_base_mac.lower(), "Base MAC address is incorrect")
         else:
             logger.warning('Inventory file does not contain base MAC address for {}'.format(duthost.hostname))
 


### PR DESCRIPTION
### Description of PR

Summary:
Perfrom a case-insensitive comparison of base MAC address

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This will allow for either uppercase or lowercase alpha hex chars in the base MAC address specified in the inventory file

#### How did you do it?
Add `.lower()` to both strings in comparison

#### How did you verify/test it?
Ran against both matching and no-matching cases

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
N/A
