### PR TITLE
Fix call check_vendor_specific_psustatus error

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -91,22 +91,6 @@ def test_show_platform_syseeprom(duthost):
             pytest_assert(line in syseeprom_output, "Line '{}' was not found in output".format(line))
 
 
-# TODO: Gather expected data from a platform-specific data file instead of this method
-def check_vendor_specific_psustatus(dut, psu_status_line):
-    """
-    @summary: Vendor specific psu status check
-    """
-    if dut.facts["asic_type"] in ["mellanox"]:
-        from ..mellanox.check_sysfs import check_psu_sysfs
-
-        psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
-        psu_match = psu_line_pattern.match(psu_status_line)
-        psu_id = psu_match.group(1)
-        psu_status = psu_match.group(2)
-
-        check_psu_sysfs(dut, psu_id, psu_status)
-
-
 def test_show_platform_psustatus(duthost):
     """
     @summary: Verify output of `show platform psustatus`
@@ -118,7 +102,7 @@ def test_show_platform_psustatus(duthost):
     psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
     for line in psu_status_output_lines[2:]:
         pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output: '{}'".format(line))
-        check_vendor_specific_psustatus(duthost, line)
+        # TODO: Compare against expected platform-specific output
 
 
 def verify_show_platform_fan_output(raw_output_lines):

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -13,7 +13,6 @@ import pytest
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
 from thermal_control_test_helper import *
-from tests.platform_tests.cli.test_show_platform import check_vendor_specific_psustatus
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -115,6 +114,21 @@ def get_psu_num(dut):
         assert False, "Unable to get the number of PSUs using command '%s'" % cmd_num_psu
 
     return psu_num
+
+
+def check_vendor_specific_psustatus(dut, psu_status_line):
+    """
+    @summary: Vendor specific psu status check
+    """
+    if dut.facts["asic_type"] in ["mellanox"]:
+        from .mellanox.check_sysfs import check_psu_sysfs
+
+        psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
+        psu_match = psu_line_pattern.match(psu_status_line)
+        psu_id = psu_match.group(1)
+        psu_status = psu_match.group(2)
+
+        check_psu_sysfs(dut, psu_id, psu_status)
 
 
 def turn_all_psu_on(psu_ctrl):

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -13,6 +13,7 @@ import pytest
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
 from thermal_control_test_helper import *
+from tests.platform_tests.cli.test_show_platform import check_vendor_specific_psustatus
 
 pytestmark = [
     pytest.mark.topology('any')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Recent pr #1964 break the code file structure, results in NameError in test_platform_info.py 
```
 >               check_vendor_specific_psustatus(duthost, line)
E               NameError: global name 'check_vendor_specific_psustatus' is not defined
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix NameError: global name 'check_vendor_specific_psustatus' is not defined.
#### How did you do it?
Add  import check_vendor_specific_psustatus
#### How did you verify/test it?
Verified on Arista-7260 and pass.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
