### PR TITLE
[Platform API][pytest]Api tests for thermal class

### DIFF
--- a/tests/common/helpers/platform_api/thermal.py
+++ b/tests/common/helpers/platform_api/thermal.py
@@ -1,0 +1,73 @@
+""" This module provides interface to interact with the thermal of the DUT
+    via platform API remotely """
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def thermal_api(conn, index, name, args=None):
+    if args is None:
+        args = []
+    conn.request('POST', '/platform/chassis/thermal/{}/{}'.format(index, name), json.dumps({'args': args}))
+    resp = conn.getresponse()
+    res = json.loads(resp.read())['res']
+    logger.info('Executing thermal API: "{}", index: {}, arguments: "{}", result: "{}"'.format(name, index, args, res))
+    return res
+
+#
+# Methods inherited from DeviceBase class
+#
+
+
+def get_name(conn, index):
+    return thermal_api(conn, index, 'get_name')
+
+
+def get_presence(conn, index):
+    return thermal_api(conn, index, 'get_presence')
+
+
+def get_model(conn, index):
+    return thermal_api(conn, index, 'get_model')
+
+
+def get_serial(conn, index):
+    return thermal_api(conn, index, 'get_serial')
+
+
+def get_status(conn, index):
+    return thermal_api(conn, index, 'get_status')
+
+#
+# Methods defined in thermalBase class
+#
+
+
+def get_temperature(conn, index):
+    return thermal_api(conn, index, 'get_temperature')
+
+
+def get_high_threshold(conn, index):
+    return thermal_api(conn, index, 'get_high_threshold')
+
+
+def get_low_threshold(conn, index):
+    return thermal_api(conn, index, 'get_low_threshold')
+
+
+def set_high_threshold(conn, index, temperature):
+    return thermal_api(conn, index, 'set_high_threshold', [temperature])
+
+
+def set_low_threshold(conn, index, temperature):
+    return thermal_api(conn, index, 'set_low_threshold', [temperature])
+
+
+def get_high_critical_threshold(conn, index):
+    return thermal_api(conn, index, 'get_high_critical_threshold')
+
+
+def get_low_critical_threshold(conn, index):
+    return thermal_api(conn, index, 'get_low_critical_threshold')

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -14,7 +14,6 @@ from platform_api_test_base import PlatformApiTestBase
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]
@@ -42,7 +41,6 @@ class TestFanApi(PlatformApiTestBase):
         if self.num_fans is None:
             try:
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
-                logger.error("vaibhav got num_fans {}".format(self.num_fans))
             except:
                 pytest.fail("num_fans is not an integer")
 

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -14,7 +14,6 @@ from platform_api_test_base import PlatformApiTestBase
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -1,0 +1,175 @@
+import logging
+import random
+import re
+import time
+
+import pytest
+import yaml
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.platform_api import chassis, thermal
+
+from platform_api_test_base import PlatformApiTestBase
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
+]
+
+
+class TestThermalApi(PlatformApiTestBase):
+
+    num_thermals = None
+
+    # This fixture would probably be better scoped at the class level, but
+    # it relies on the platform_api_conn fixture, which is scoped at the function
+    # level, so we must do the same here to prevent a scope mismatch.
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, platform_api_conn):
+        if self.num_thermals is None:
+            try:
+                self.num_thermals = int(chassis.get_num_thermals(platform_api_conn))
+            except:
+                pytest.fail("num_thermals is not an integer")
+
+    #
+    # Functions to test methods inherited from DeviceBase class
+    #
+    def test_get_name(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_thermals):
+            name = thermal.get_name(platform_api_conn, i)
+
+            if self.expect(name is not None, "Unable to retrieve Thermal {} name".format(i)):
+                self.expect(isinstance(name, str), "Thermal {} name appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    def test_get_presence(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_thermals):
+            presence = thermal.get_presence(platform_api_conn, i)
+
+            if self.expect(presence is not None, "Unable to retrieve thermal {} presence".format(i)):
+                if self.expect(isinstance(presence, bool), "Thermal {} presence appears incorrect".format(i)):
+                    self.expect(presence is True, "Thermal {} is not present".format(i))
+
+        self.assert_expectations()
+
+    def test_get_model(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_thermals):
+            model = thermal.get_model(platform_api_conn, i)
+
+            if self.expect(model is not None, "Unable to retrieve thermal {} model".format(i)):
+                self.expect(isinstance(model, str), "Thermal {} model appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    def test_get_serial(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_thermals):
+            serial = thermal.get_serial(platform_api_conn, i)
+
+            if self.expect(serial is not None, "Unable to retrieve thermal {} serial number".format(i)):
+                self.expect(isinstance(serial, str), "Thermal {} serial number appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    def test_get_status(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_thermals):
+            status = thermal.get_status(platform_api_conn, i)
+
+            if self.expect(status is not None, "Unable to retrieve thermal {} status".format(i)):
+                self.expect(isinstance(status, bool), "Thermal {} status appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    #
+    # Functions to test methods defined in ThermalBase class
+    #
+
+    def test_get_temperature(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_thermals):
+            temperature = thermal.get_temperature(platform_api_conn, i)
+
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} temperature".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} temperature appears incorrect".format(i)):
+                    self.expect(temperature > 0 and temperature <= 100,
+                                "Thermal {} temperature {} reading is not within range".format(i, temperature))
+        self.assert_expectations()
+
+    def test_get_low_threshold(self, duthost, localhost, platform_api_conn):
+        # Ensure the thermal low threshold temperature is sane
+        for i in range(self.num_thermals):
+            temperature = thermal.get_low_threshold(platform_api_conn, i)
+
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} low threshold".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} low threshold appears incorrect".format(i)):
+                    self.expect(temperature > 0 and temperature <= 100,
+                                "Thermal {} low threshold {} reading is not within range".format(i, temperature))
+        self.assert_expectations()
+
+    def test_get_high_threshold(self, duthost, localhost, platform_api_conn):
+        # Ensure the thermal high threshold temperature is sane
+        for i in range(self.num_thermals):
+            temperature = thermal.get_high_threshold(platform_api_conn, i)
+
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} high threshold".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} high threshold appears incorrect".format(i)):
+                    self.expect(temperature > 0 and temperature <= 100,
+                                "Thermal {} high threshold {} reading is not within range".format(i, temperature))
+        self.assert_expectations()
+
+    def test_get_low_critical_threshold(self, duthost, localhost, platform_api_conn):
+        # Ensure the thermal low critical threshold temperature is sane
+        for i in range(self.num_thermals):
+            temperature = thermal.get_low_critical_threshold(platform_api_conn, i)
+
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} low critical threshold".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} low threshold appears incorrect".format(i)):
+                    self.expect(temperature > 0 and temperature <= 110,
+                                "Thermal {} low critical threshold {} reading is not within range".format(i, temperature))
+        self.assert_expectations()
+
+    def test_get_high_critical_threshold(self, duthost, localhost, platform_api_conn):
+        # Ensure the thermal high threshold temperature is sane
+        for i in range(self.num_thermals):
+            temperature = thermal.get_high_critical_threshold(platform_api_conn, i)
+
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} high critical threshold".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} high threshold appears incorrect".format(i)):
+                    self.expect(temperature > 0 and temperature <= 110,
+                                "Thermal {} high critical threshold {} reading is not within range".format(i, temperature))
+        self.assert_expectations()
+
+    def test_set_low_threshold(self, duthost, localhost, platform_api_conn):
+        # Ensure the thermal temperature is sane
+        for i in range(self.num_thermals):
+            low_temperature = 20
+            result = thermal.set_low_threshold(platform_api_conn, i, low_temperature)
+            if self.expect(result is not None, "Failed to perform set_low_threshold"):
+                self.expect(result is True, "Failed to set set_low_threshold for thermal {} to {}".format(i, low_temperature))
+
+            temperature = thermal.get_low_threshold(platform_api_conn, i)
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} low threshold".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} low threshold appears incorrect".format(i)):
+                    self.expect(temperature == 20,
+                                "Thermal {} low threshold {} is not matching the set value {}".format(i, temperature, low_temperature))
+
+        self.assert_expectations()
+
+    def test_set_high_threshold(self, duthost, localhost, platform_api_conn):
+        # Ensure the thermal temperature is sane
+        for i in range(self.num_thermals):
+            high_temperature = 80
+            result = thermal.set_high_threshold(platform_api_conn, i, high_temperature)
+            if self.expect(result is not None, "Failed to perform set_high_threshold"):
+                self.expect(result is True, "Failed to set set_high_threshold for thermal {} to {}".format(i, high_temperature))
+
+            temperature = thermal.get_high_threshold(platform_api_conn, i)
+            if self.expect(temperature is not None, "Unable to retrieve Thermal {} high threshold".format(i)):
+                if self.expect(isinstance(temperature, float), "Thermal {} high threshold appears incorrect".format(i)):
+                    self.expect(temperature == 80,
+                                "Thermal {} high threshold {} is not matching the set value {}".format(i, temperature, high_temperature))
+        self.assert_expectations()


### PR DESCRIPTION
Add a basic test suite for the THERMAL class of the new
platform API, utilizing the platform API HTTP server,
including the following functions:
```
test_get_name
test_get_presence
test_get_model
test_get_serial
test_get_status
test_get_temperature
test_get_low_threshold
test_get_high_threshold
test_get_low_critical_threshold
test_get_high_critical_threshold
test_set_low_threshold
test_set_high_threshold
```
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
