### PR TITLE
PR contain changes in arpall.yml and swap_syncd.yml 

### DIFF
--- a/ansible/roles/test/tasks/arpall.yml
+++ b/ansible/roles/test/tasks/arpall.yml
@@ -30,7 +30,7 @@
       with_dict: minigraph_portchannels
 
     - name: move interface {{ intf1 }} out of {{ po1 }}
-      shell: teamdctl {{ po1 }} port remove {{ intf1 }}
+      shell: config portchannel member del {{ po1 }} {{ intf1 }}
       become: yes
       when: po1 is defined
 
@@ -46,7 +46,7 @@
       with_dict: minigraph_portchannels
 
     - name: move {{ intf2 }} out of {{ po2 }}
-      shell: teamdctl {{ po2 }} port remove {{ intf2 }}
+      shell: config portchannel member del {{ po2 }} {{ intf2 }}
       become: yes
       when: po2 is defined
 

--- a/ansible/swap_syncd.yml
+++ b/ansible/swap_syncd.yml
@@ -47,14 +47,14 @@
       become: true
       sysctl:
         name: "net.core.rmem_max"
-        value: 509430500
+        value: 609430500
         sysctl_set: yes
 
     - name: Set sysctl SENDBUF parameter for tests
       become: true
       sysctl:
         name: "net.core.wmem_max"
-        value: 509430500
+        value: 609430500
         sysctl_set: yes
 
     - name: Gather SONiC base image version


### PR DESCRIPTION
Following changes are being done via this PR:

a) Instead of teamdctl to add/remove port-channel member
   we should use config port-channel command. Reason being show interface
   status does not get updated as teamdctl bypass config db. Same change is is master already.
More information present here PR:https://github.com/Azure/sonic-utilities/pull/1026

b) One of change done by me as part of PR# https://github.com/Azure/sonic-mgmt/pull/1893 
was not complete as I forgot to update Buffer size in swap_syncd.yml. Fixed now.


