### PR TITLE
Fix cleanup when running ansible version for pfc_all_port_storm

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_action.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/storm_all_action.yml
@@ -27,19 +27,28 @@
 - name: Initialize loganalyzer
   include_tasks: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
 
-- name: Take action on fanout switch
-  action: apswitch template="{{storm_action_template}}"
-  args:
-    host: "{{peer_mgmt}}"
-    login: "{{peer_login}}"
-  connection: switch
+- block:
+    - name: Take action on fanout switch
+      action: apswitch template="{{storm_action_template}}"
+      args:
+        host: "{{peer_mgmt}}"
+        login: "{{peer_login}}"
+      connection: switch
 
-- name: Let PFC storm happen for a while
-  pause:
-    seconds: 5
+    - name: Let PFC storm happen for a while
+      pause:
+        seconds: 5
 
-- name: Check if logs contain message that PFC WD detected deadlock
-  include_tasks: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+    - name: Check if logs contain message that PFC WD detected deadlock
+      include_tasks: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
 
-- name: Check if logs contain message that PFC WD detected deadlock
-  include_tasks: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+    - name: Check if logs contain message that PFC WD detected deadlock
+      include_tasks: roles/test/files/tools/loganalyzer/loganalyzer_end.yml
+
+  rescue:
+    - name: Stop PFC storm on fanout switch
+      action: apswitch template="{{pfc_wd_storm_stop_template}}"
+      args:
+        host: "{{peer_mgmt}}"
+        login: "{{peer_login}}"
+      connection: switch


### PR DESCRIPTION
Why I did:
when running ansible version for pfc_all_port_storm if test case fail for pfcwd start case then cleanup of
pfc_gen.py running on Fanout switch does not happens
and switch keeps on getting PFC Frames because of which
subsequent manual run also fails.

How I fix:
Fix is to stop PFC storm on Fanout as part of failure handling using rescue

