### PR TITLE
[test_watchdog] support Mellanox 4000 platforms

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -8,6 +8,19 @@ from tests.common.helpers.platform_api import watchdog
 from tests.common.helpers.assertions import pytest_assert
 from platform_api_test_base import PlatformApiTestBase
 
+from collections import OrderedDict
+
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    class OrderedLoader(Loader):
+        pass
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)
+
 pytestmark = [
     pytest.mark.topology('any')
 ]
@@ -42,7 +55,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
         test_config = None
         with open(TEST_CONFIG_FILE) as stream:
-            test_config = yaml.safe_load(stream)
+            test_config = ordered_load(stream)
 
         config = test_config['default']
 

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -8,6 +8,9 @@
 #     [PARAMETER]: [VALUE]
 # If some parameters are not defined (None),
 # such test case will be skipped (use it when the coresponding test is trying to do something that is not supported by the platform)
+#
+# This configuration file supports matching a platform string and HWSKU string using regular expressions.
+# NOTE: more specific regular expression must be defined after less specific.
 
 default:
   valid_timeout: 10     # A valid timeout the watchdog has to accept
@@ -23,9 +26,9 @@ x86_64-mlnx_msn.*-r0:
 # Mellnox watchdog type 1
 x86_64-mlnx_msn2410-r0:
   default:
-      valid_timeout: 10
-      greater_timeout: 20
-      too_big_timeout: 100
+    valid_timeout: 10
+    greater_timeout: 20
+    too_big_timeout: 100
 
 # Mellanox watchdog type 3
 x86_64-mlnx_msn3800-r0:
@@ -37,3 +40,9 @@ x86_64-mlnx_msn2700-r0:
   default:
     greater_timeout: 100
     too_big_timeout: 66000
+
+x86_64-mlnx_msn4.*-r0:
+  default:
+    greater_timeout: 100
+    too_big_timeout: 66000
+


### PR DESCRIPTION
- Mellanox SN4*** platforms have watchdog type 3.
- Fixed an issue with overriding the the default matching platform
string in watchdog.yml. Used an ordered_laod to preserve order of
entries in watchdog.yml so that if entry for a platform is listed after
the default it won't be overwritten.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

I ran watchdog test on 2410, 2010, 3800, 4600C.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
