### PR TITLE
[syslog] Add wait_until to syslog test to stabilize kvm runners

### DIFF
--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -1,62 +1,66 @@
-import time
 import logging
 import pytest
+
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology("any")
 ]
 
+
 @pytest.fixture(scope="module")
-def config_syslog_srv(ptfhost):
-    logger.info( "Configuring the syslog server")
+def config_syslog_srv(ptfhost, duthost):
+    logger.info("Configuring the syslog server")
 
-    # add the imudp configuration if not present
-    ptfhost.shell('sed -ni \'/module/!p;$a module(load="imudp")\' /etc/rsyslog.conf')
-    ptfhost.shell('sed -i \'/input(type/!p;$a input(type="imudp" port="514")\' /etc/rsyslog.conf')
+    # Add the imudp configuration if not present
+    ptfhost.shell("sed -ni '/module/!p;$a module(load=\"imudp\")' /etc/rsyslog.conf")
+    ptfhost.shell("sed -i '/input(type/!p;$a input(type=\"imudp\" port=\"514\")' /etc/rsyslog.conf")
 
-    #Remove local /var/log/syslog   
+    # Remove local /var/log/syslog
     ptfhost.shell("rm -rf /var/log/syslog")
 
-    #restart Syslog Daemon 
+    # Restart Syslog Daemon
     ptfhost.shell("service rsyslog restart")
 
-    #Wait a little bit for service to start
-    time.sleep(30)
+    # Wait a little bit for service to start
+    def _is_syslog_running():
+        result = duthost.shell("service rsyslog status | grep \"active (running)\"")["stdout_lines"]
+        return len(result) > 0
+
+    wait_until(30, 3, _is_syslog_running)
 
     yield
 
+
 @pytest.fixture(scope="module")
 def config_dut(testbed, duthost):
-    logger.info( "Configuring the DUT")
-    local_syslog_srv_ip = testbed['ptf_ip']
-    logger.info("test_syslog_srv_ip {}".format(local_syslog_srv_ip))
-    
-    #Add Rsyslog destination for testing
+    logger.info("Configuring the DUT")
+    local_syslog_srv_ip = testbed["ptf_ip"]
+    logger.info("test_syslog_srv_ip %s", local_syslog_srv_ip)
+
+    # Add Rsyslog destination for testing
     duthost.shell("sudo config syslog add {}".format(local_syslog_srv_ip))
 
     yield
 
-    #remove the syslog configuration
+    # Remove the syslog configuration
     duthost.shell("sudo config syslog del {}".format(local_syslog_srv_ip))
 
+
 def test_syslog(duthost, ptfhost, config_dut, config_syslog_srv):
-    logger.info( "Starting syslog tests")
+    logger.info("Starting syslog tests")
     test_message = "Basic Test Message"
-    
-    #generate a syslog from the DUT
-    duthost.shell(" logger --priority INFO {}".format(test_message))
 
-    #Check syslog messages for the test message
-    result = ptfhost.shell("grep {} /var/log/syslog | grep \"{}\" | grep -v ansible".format(duthost.hostname, test_message))['stdout_lines']
-    pytest_assert(len(result) > 0, "Test syslog not seen on the server")
+    # Generate a syslog from the DUT
+    duthost.shell("logger --priority INFO {}".format(test_message))
 
+    # Check syslog messages for the test message
+    def _check_syslog():
+        result = ptfhost.shell("grep {} /var/log/syslog | grep \"{}\" | grep -v ansible"
+                               .format(duthost.hostname, test_message))["stdout_lines"]
+        return len(result) > 0
 
-    
-
-
-    
-
-
+    pytest_assert(wait_until(10, 1, _check_syslog), "Test syslog not seen on the server after 10s")


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Add `wait_until` to syslog test to even out instabilities running the test in a virtual PR environment.
Fixes #1998

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We noticed that the syslog test occasionally fails the PR tests, but rarely ever on physical switches. We think the discrepancy is because the shared kvm environment that the PR tests is quite a bit noisier and slower than the physical test environment, so we may need to wait longer for the syslog to populate.

#### How did you do it?
I used `wait_until` to poll for the syslog message rather than checking immediately after the log message is written.

In addition, I also added a `wait_until` to the test initialization to speed things along when the syslog service restarts in <30s.

I also fixed the `pep8` warnings that popped up in my dev environment.

#### How did you verify/test it?
Ran the test locally on my virtual switch and on a physical DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
