### PR TITLE
[everflow] Migrate Everflow v4 tests to use ptfadapter

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1,9 +1,16 @@
 """Utilities for testing the Everflow feature in SONiC."""
-
-import pytest
+import logging
+import random
 import ipaddr
+import binascii
+import pytest
+
+import ptf.testutils as testutils
+import ptf.packet as packet
 
 from abc import abstractmethod
+from ptf.mask import Mask
+from tests.common.helpers.assertions import pytest_assert
 
 
 @pytest.fixture(scope="module")
@@ -25,8 +32,6 @@ def setup_info(duthost, testbed):
 
     tor_ports = []
     spine_ports = []
-    # TODO: I don't think this is actually used anywhere but I'll save this for another PR.
-    port_channels = []
 
     # Gather test facts
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
@@ -40,9 +45,6 @@ def setup_info(duthost, testbed):
             tor_ports.append(dut_port)
         elif "T2" in neigh["name"]:
             spine_ports.append(dut_port)
-
-    # Get the list of port channels
-    port_channels = mg_facts["minigraph_portchannels"]
 
     switch_capabilities = switch_capability_facts["switch_capabilities"]["switch"]
 
@@ -68,11 +70,10 @@ def setup_info(duthost, testbed):
     #
     # TODO: Add a namedtuple to make the groupings more explicit
     def get_port_info(in_port_list, out_port_list, out_port_ptf_id_list, out_port_lag_name):
-        ptf_port_id = ""
         out_port_exclude_list = []
-
         for port in in_port_list:
             if port not in out_port_list and port not in out_port_exclude_list and len(out_port_list) < 4:
+                ptf_port_id = ""
                 ptf_port_id += (str(mg_facts["minigraph_port_indices"][port]))
                 out_port_list.append(port)
                 out_port_lag_name.append("Not Applicable")
@@ -87,7 +88,6 @@ def setup_info(duthost, testbed):
                             out_port_exclude_list.append(lag_member)
 
                 out_port_ptf_id_list.append(ptf_port_id)
-                ptf_port_id = ""
 
     tor_dest_ports = []
     tor_dest_ports_ptf_id = []
@@ -108,7 +108,6 @@ def setup_info(duthost, testbed):
         "router_mac": host_facts["ansible_Ethernet0"]["macaddress"],
         "tor_ports": tor_ports,
         "spine_ports": spine_ports,
-        "port_channels": port_channels,
         "test_mirror_v4": test_mirror_v4,
         "test_mirror_v6": test_mirror_v6,
         "ingress": {
@@ -216,6 +215,8 @@ class BaseEverflowTest(object):
     mirror and ACL stage for the tests.
     """
 
+    OUTER_HEADER_SIZE = 38
+
     @pytest.fixture(scope="class")
     def setup_mirror_session(self, duthost):
         """
@@ -226,7 +227,6 @@ class BaseEverflowTest(object):
 
         Yields:
             dict: Information about the mirror session configuration.
-
         """
         session_info = self._mirror_session_info("test_session_1", duthost.facts["asic_type"])
 
@@ -252,7 +252,6 @@ class BaseEverflowTest(object):
 
         Yields:
             dict: Information about the mirror session configuration.
-
         """
 
         # Create a policer that allows 100 packets/sec through
@@ -284,7 +283,6 @@ class BaseEverflowTest(object):
             duthost: DUT fixture
             setup_info: Fixture with info about the testbed setup
             setup_mirror_session: Fixtue with info about the mirror session
-
         """
         pass
 
@@ -303,9 +301,95 @@ class BaseEverflowTest(object):
         Get the ACL stage for this set of test cases.
 
         Used to parametrize test cases based on the ACL stage.
-
         """
         pass
+
+    def send_and_check_mirror_packets(self,
+                                      setup,
+                                      mirror_session,
+                                      ptfadapter,
+                                      duthost,
+                                      mirror_packet,
+                                      src_port=None,
+                                      dest_ports=None,
+                                      expect_recv=True):
+        expected_mirror_packet = self._get_expected_mirror_packet(mirror_session,
+                                                                  setup,
+                                                                  duthost,
+                                                                  mirror_packet)
+
+        if not src_port:
+            src_port = self._get_random_src_port(setup)
+
+        if not dest_ports:
+            dest_ports = [self._get_monitor_port(setup, mirror_session, duthost)]
+
+        ptfadapter.dataplane.flush()
+        testutils.send(ptfadapter, src_port, mirror_packet)
+
+        if expect_recv:
+            _, received_packet = testutils.verify_packet_any_port(
+                ptfadapter,
+                expected_mirror_packet,
+                ports=dest_ports
+            )
+
+            logging.info("received: %s", packet.Ether(received_packet).summary())
+
+            inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet))
+            logging.info("inner_packet: %s", inner_packet.summary())
+            logging.info("expected_packet: %s", mirror_packet.summary())
+            pytest_assert(Mask(inner_packet).pkt_match(mirror_packet), "Mirror payload does not match received packet")
+        else:
+            testutils.verify_no_packet_any(ptfadapter, expected_mirror_packet, dest_ports)
+
+    def _get_expected_mirror_packet(self, mirror_session, setup, duthost, mirror_packet):
+        payload = mirror_packet.copy()
+
+        # Add vendor specific padding to the packet
+        if duthost.facts["asic_type"] in ["mellanox"]:
+            payload = binascii.unhexlify("0" * 44) + str(payload)
+
+        if duthost.facts["asic_type"] in ["barefoot"]:
+            payload = binascii.unhexlify("0" * 24) + str(payload)
+
+        # If the mirroring type is egress, we expect the TTL to drop by 1
+        expected_ttl = int(mirror_session["session_ttl"]) - (self.mirror_type == "egress")
+
+        expected_packet = testutils.simple_gre_packet(
+            eth_src=setup["router_mac"],
+            ip_src=mirror_session["session_src_ip"],
+            ip_dst=mirror_session["session_dst_ip"],
+            ip_dscp=int(mirror_session["session_dscp"]),
+            ip_id=0,
+            ip_ttl=expected_ttl,
+            inner_frame=payload
+        )
+
+        expected_packet["GRE"].proto = mirror_session["session_gre"]
+
+        expected_packet = Mask(expected_packet)
+        expected_packet.set_do_not_care_scapy(packet.Ether, "dst")
+        expected_packet.set_do_not_care_scapy(packet.IP, "ihl")
+        expected_packet.set_do_not_care_scapy(packet.IP, "len")
+        expected_packet.set_do_not_care_scapy(packet.IP, "flags")
+        expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
+
+        # The fanout switch may modify this value en route to the PTF so we should ignore it, even
+        # though the session does have a DSCP specified.
+        expected_packet.set_do_not_care_scapy(packet.IP, "tos")
+
+        # Mask off the payload (we check it later)
+        expected_packet.set_do_not_care(self.OUTER_HEADER_SIZE * 8, len(payload) * 8)
+
+        return expected_packet
+
+    def _extract_mirror_payload(self, encapsulated_packet, payload_size):
+        pytest_assert(len(encapsulated_packet) >= self.OUTER_HEADER_SIZE,
+                      "Incomplete packet, expected at least {} header bytes".format(self.OUTER_HEADER_SIZE))
+
+        inner_frame = encapsulated_packet[-payload_size:]
+        return packet.Ether(inner_frame)
 
     def _mirror_session_info(self, session_name, asic_type):
         session_src_ip = "1.1.1.1"
@@ -334,3 +418,24 @@ class BaseEverflowTest(object):
             "session_gre": session_gre,
             "session_prefixes": session_prefixes
         }
+
+    def _get_random_src_port(self, setup):
+        return setup["port_index_map"][random.choice(setup["port_index_map"].keys())]
+
+    def _get_monitor_port(self, setup, mirror_session, duthost):
+        mirror_output = duthost.command("show mirror_session")
+        logging.info("mirror session configuration: %s", mirror_output["stdout"])
+
+        pytest_assert(mirror_session["session_name"] in mirror_output["stdout"],
+                      "Test mirror session {} not found".format(mirror_session["session_name"]))
+
+        pytest_assert(len(mirror_output["stdout_lines"]) == 3,
+                      "Unexpected number of mirror sesssions:\n{}".format(mirror_output["stdout"]))
+
+        monitor_intf = mirror_output["stdout_lines"][2].split()[-1:][0]
+
+        pytest_assert(monitor_intf in setup["port_index_map"],
+                      "Invalid monitor port:\n{}".format(mirror_output["stdout"]))
+        logging.info("selected monitor interface %s (port=%s)", monitor_intf, setup["port_index_map"][monitor_intf])
+
+        return setup["port_index_map"][monitor_intf]

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -1,14 +1,7 @@
 """Test cases to support the Everflow IPv6 Mirroring feature in SONiC."""
-import binascii
-import logging
-import random
 import pytest
 import ptf.testutils as testutils
 
-from ptf.mask import Mask
-import ptf.packet as packet
-
-from tests.common.helpers.assertions import pytest_assert
 from everflow_test_utilities import BaseEverflowTest
 
 # Module-level fixtures
@@ -33,109 +26,107 @@ class EverflowIPv6Tests(BaseEverflowTest):
     DEFAULT_SRC_IP = "ffbe:0225:7c6b:a982:d48b:230e:f271:0000"
     DEFAULT_DST_IP = "ffbe:0225:7c6b:a982:d48b:230e:f271:0001"
 
-    OUTER_HEADER_SIZE = 38
-
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on Source IPv6 addresses."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0002"
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on Destination IPv6 addresses."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0003"
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on the Next Header field."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, next_header=0x7E)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, next_header=0x7E)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on the L4 Source Port."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, sport=9000)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, sport=9000)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on the L4 Destination Port."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, dport=9001)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, dport=9001)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on a range of L4 Source Ports."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, sport=10200)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, sport=10200)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on a range of L4 Destination Ports."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, dport=10700)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, dport=10700)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on TCP Flags."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, flags=0x1B)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, flags=0x1B)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match on DSCP."""
-        test_packet = self._base_tcp_packet(ptfadapter, setup_info, dscp=37)
+        test_packet = self._base_tcpv6_packet(ptfadapter, setup_info, dscp=37)
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0004",
@@ -144,13 +135,13 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=11700
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0005",
@@ -159,15 +150,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=11200
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match a SYN -> SYN-ACK pattern."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0006",
@@ -175,13 +166,13 @@ class EverflowIPv6Tests(BaseEverflowTest):
             flags=0x2
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0007",
@@ -189,15 +180,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             flags=0x12
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match a TCP handshake between a client and server."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0008",
@@ -207,13 +198,13 @@ class EverflowIPv6Tests(BaseEverflowTest):
             flags=0x2
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0009",
@@ -223,15 +214,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             flags=0x12
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match UDP traffic between a client and server application."""
-        test_packet = self._base_udp_packet(
+        test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000a",
@@ -241,13 +232,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=514
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
-
-        test_packet = self._base_udp_packet(
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
+        test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000b",
@@ -257,41 +247,41 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12001
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
             dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d"
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-        test_packet = self._base_udp_packet(
+        test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
             dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d"
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-        test_packet = self._base_udp_packet(
+        test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
@@ -299,15 +289,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             next_header=0xAB
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001c",
@@ -316,13 +306,13 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12003
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-        test_packet = self._base_udp_packet(
+        test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001c",
@@ -331,11 +321,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12003
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
@@ -348,7 +338,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match packets with a Source IPv6 Subnet."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:b000:0000:0000:0000:0010",
@@ -357,15 +347,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12007
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match packets with a Destination IPv6 Subnet."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0010",
@@ -374,15 +364,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12009
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match packets with both source and destination subnets."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:c000:0000:0000:0000:0010",
@@ -391,15 +381,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12011
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, duthost):
         """Verify that we can match packets with non-standard subnet sizes."""
-        test_packet = self._base_tcp_packet(
+        test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
             src_ip="ffbe:0225:7c6b:e000:0000:0000:0000:0010",
@@ -408,107 +398,22 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dport=12013
         )
 
-        self._send_and_check_mirror_packets(setup_info,
-                                            setup_mirror_session,
-                                            ptfadapter,
-                                            duthost,
-                                            test_packet)
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           duthost,
+                                           test_packet)
 
-    def _send_and_check_mirror_packets(self, setup, mirror_session, ptfadapter, duthost, mirror_packet):
-        expected_mirror_packet = self._get_expected_mirror_packet(mirror_session, setup, duthost, mirror_packet)
-
-        ptfadapter.dataplane.flush()
-        testutils.send(ptfadapter, self._get_src_port(setup), mirror_packet)
-        _, received_packet = testutils.verify_packet_any_port(
-            ptfadapter,
-            expected_mirror_packet,
-            ports=[self._get_monitor_port(setup, mirror_session, duthost)]
-        )
-
-        logging.info("received: %s", packet.Ether(received_packet).summary())
-
-        inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet))
-        logging.info("inner_packet: %s", inner_packet.summary())
-        logging.info("expected_packet: %s", mirror_packet.summary())
-        pytest_assert(Mask(inner_packet).pkt_match(mirror_packet), "Mirror payload does not match received packet")
-
-    def _get_src_port(self, setup):
-        return setup["port_index_map"][random.choice(setup["port_index_map"].keys())]
-
-    # TODO: This could probably be refactored into a common utility method later.
-    def _get_monitor_port(self, setup, mirror_session, duthost):
-        mirror_output = duthost.command("show mirror_session")
-        logging.info("mirror session configuration: %s", mirror_output["stdout"])
-
-        pytest_assert(mirror_session["session_name"] in mirror_output["stdout"],
-                      "Test mirror session {} not found".format(mirror_session["session_name"]))
-
-        pytest_assert(len(mirror_output["stdout_lines"]) == 3,
-                      "Unexpected number of mirror sesssions:\n{}".format(mirror_output["stdout"]))
-
-        monitor_intf = mirror_output["stdout_lines"][2].split()[-1:][0]
-
-        pytest_assert(monitor_intf in setup["port_index_map"],
-                      "Invalid monitor port:\n{}".format(mirror_output["stdout"]))
-        logging.info("selected monitor interface %s (port=%s)", monitor_intf, setup["port_index_map"][monitor_intf])
-
-        return setup["port_index_map"][monitor_intf]
-
-    def _get_expected_mirror_packet(self, mirror_session, setup, duthost, mirror_packet):
-        payload = mirror_packet.copy()
-
-        # Add vendor specific padding to the packet
-        if duthost.facts["asic_type"] in ["mellanox"]:
-            payload = binascii.unhexlify("0" * 44) + str(payload)
-
-        if duthost.facts["asic_type"] in ["barefoot"]:
-            payload = binascii.unhexlify("0" * 24) + str(payload)
-
-        expected_packet = testutils.simple_gre_packet(
-            eth_src=setup["router_mac"],
-            ip_src=mirror_session["session_src_ip"],
-            ip_dst=mirror_session["session_dst_ip"],
-            ip_dscp=int(mirror_session["session_dscp"]),
-            ip_id=0,
-            ip_ttl=int(mirror_session["session_ttl"]),
-            inner_frame=payload
-        )
-
-        expected_packet["GRE"].proto = mirror_session["session_gre"]
-
-        expected_packet = Mask(expected_packet)
-        expected_packet.set_do_not_care_scapy(packet.Ether, "dst")
-        expected_packet.set_do_not_care_scapy(packet.IP, "ihl")
-        expected_packet.set_do_not_care_scapy(packet.IP, "len")
-        expected_packet.set_do_not_care_scapy(packet.IP, "flags")
-        expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
-
-        # The fanout switch may modify this value en route to the PTF so we should ignore it, even
-        # though the session does have a DSCP specified.
-        expected_packet.set_do_not_care_scapy(packet.IP, "tos")
-
-        # Mask off the payload (we check it later)
-        expected_packet.set_do_not_care(self.OUTER_HEADER_SIZE * 8, len(payload) * 8)
-
-        return expected_packet
-
-    def _extract_mirror_payload(self, encapsulated_packet, payload_size):
-        pytest_assert(len(encapsulated_packet) >= self.OUTER_HEADER_SIZE,
-                      "Incomplete packet, expected at least {} header bytes".format(self.OUTER_HEADER_SIZE))
-
-        inner_frame = encapsulated_packet[-payload_size:]
-        return packet.Ether(inner_frame)
-
-    def _base_tcp_packet(self,
-                         ptfadapter,
-                         setup,
-                         src_ip=DEFAULT_SRC_IP,
-                         dst_ip=DEFAULT_DST_IP,
-                         next_header=None,
-                         dscp=None,
-                         sport=2020,
-                         dport=8080,
-                         flags=0x10):
+    def _base_tcpv6_packet(self,
+                           ptfadapter,
+                           setup,
+                           src_ip=DEFAULT_SRC_IP,
+                           dst_ip=DEFAULT_DST_IP,
+                           next_header=None,
+                           dscp=None,
+                           sport=2020,
+                           dport=8080,
+                           flags=0x10):
         pkt = testutils.simple_tcpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup["router_mac"],
@@ -526,15 +431,15 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
         return pkt
 
-    def _base_udp_packet(self,
-                         ptfadapter,
-                         setup,
-                         src_ip=DEFAULT_SRC_IP,
-                         dst_ip=DEFAULT_DST_IP,
-                         next_header=None,
-                         dscp=None,
-                         sport=2020,
-                         dport=8080):
+    def _base_udpv6_packet(self,
+                           ptfadapter,
+                           setup,
+                           src_ip=DEFAULT_SRC_IP,
+                           dst_ip=DEFAULT_DST_IP,
+                           next_header=None,
+                           dscp=None,
+                           sport=2020,
+                           dport=8080):
         pkt = testutils.simple_udpv6_packet(
             eth_src=ptfadapter.dataplane.get_mac(0, 0),
             eth_dst=setup["router_mac"],

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -638,5 +638,5 @@ class TestEverflowV4EgressAclEgressMirror(EverflowIPv4Tests):
     def acl_stage(self):
         return "egress"
 
-    def  mirror_type(self):
+    def mirror_type(self):
         return "egress"

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1,8 +1,10 @@
 """Test cases to support the Everflow Mirroring feature in SONiC."""
-
+import logging
 import os
 import time
 import pytest
+
+import ptf.testutils as testutils
 import everflow_test_utilities as everflow_utils
 
 from tests.ptf_runner import ptf_runner
@@ -13,30 +15,29 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory   # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 from everflow_test_utilities import setup_info                            # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
-BASE_DIR = os.path.dirname(os.path.realpath(__file__))
-DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))
-FILES_DIR = os.path.join(BASE_DIR, 'files')
-TEMPLATE_DIR = os.path.join(BASE_DIR, 'templates')
-
-EVERFLOW_TABLE_RULE_CREATE_TEMPLATE = 'acl_rule_persistent.json.j2'
-EVERFLOW_TABLE_RULE_CREATE_FILE = 'acl_rule_persistent.json'
-EVERFLOW_TABLE_RULE_DELETE_FILE = 'acl_rule_persistent-del.json'
-DUT_RUN_DIR = '/home/admin/everflow_tests'
-
 pytestmark = [
-    pytest.mark.topology('t1')
+    pytest.mark.topology("t1")
 ]
 
-#partial_ptf_runner is a pytest fixture that takes all the necessary arguments to run
-#each everflow ptf test cases and calling the main function ptf_runner which will then
-#combine all the arguments and form ptf command to run via ptfhost.shell().
-#some of the arguments are fix for each everflow test cases and are define here and
-#arguments specific to each everflow testcases are passed in each test via partial_ptf_runner
-#Argumnents are passed in dictionary format via kwargs within each test case.
+TEMPLATE_DIR = "everflow/templates"
+EVERFLOW_TABLE_RULE_CREATE_TEMPLATE = "acl_rule_persistent.json.j2"
+
+DUT_RUN_DIR = "/home/admin/everflow_tests"
+EVERFLOW_TABLE_RULE_CREATE_FILE = "acl_rule_persistent.json"
+EVERFLOW_TABLE_RULE_DELETE_FILE = "acl_rule_persistent-del.json"
 
 @pytest.fixture
 def partial_ptf_runner(request, duthost, ptfhost):
+    """
+    Fixture to run each Everflow PTF test case via ptf_runner.
+
+    Takes all the necessary arguments to run the test case and returns a handle to the caller
+    to execute the ptf_runner.
+    """
     def _partial_ptf_runner(setup_info, session_info, acl_stage, mirror_type,  expect_receive = True, test_name = None, **kwargs):
+        # Some of the arguments are fixed for each Everflow test case and defined here.
+        # Arguments specific to each Everflow test case are passed in by each test via _partial_ptf_runner.
+        # Arguments are passed in dictionary format via kwargs within each test case.
         params = {
                   'hwsku' :  duthost.facts['hwsku'],
                   'asic_type' :  duthost.facts['asic_type'],
@@ -49,6 +50,7 @@ def partial_ptf_runner(request, duthost, ptfhost):
                   'mirror_stage' : mirror_type,
                   'expect_received' : expect_receive }
         params.update(kwargs)
+
         ptf_runner(host=ptfhost,
                    testdir="acstests",
                    platform_dir="ptftests",
@@ -61,212 +63,349 @@ def partial_ptf_runner(request, duthost, ptfhost):
 
 
 class EverflowIPv4Tests(BaseEverflowTest):
-    @pytest.fixture(params=['tor', 'spine'])
+    """Base class for testing the Everflow feature w/ IPv4."""
+
+    DEFAULT_SRC_IP = "20.0.0.1"
+    DEFAULT_DST_IP = "30.0.0.1"
+
+    @pytest.fixture(params=["tor", "spine"])
     def dest_port_type(self, request):
         """
-        used to parametrized test cases on dest port type
-        :param request: pytest request object
-        :return: destination port type
+        Get the dest port for this test case.
+
+        Used to parametrize test cases based on dest port type to validate forwarding behavior.
+
+        Args:
+            request: Pytest request object
+
+        Returns:
+            A destination port type in {tor, spine}.
         """
         return request.param
 
-    def test_everflow_case1(self, duthost, setup_info, setup_mirror_session, dest_port_type, partial_ptf_runner):
-        """  Test on Resolved route, unresolved route, best prefix match route creation and removal flows """
-
-        rx_port_ptf_id =  setup_info[dest_port_type] ['src_port_ptf_id']
-        tx_port = setup_info[dest_port_type]['dest_port'][0]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][0]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-        # call the function return by pytest fixture and pass arguments needed for
-        # ptf test case like src port, dest port, acl_stage, mirror_type.
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port, False)
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
-
-        tx_port = setup_info[dest_port_type]['dest_port'][1]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][1]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
-        time.sleep(3)
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
-        time.sleep(3)
-        tx_port = setup_info[dest_port_type]['dest_port'][0]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][0]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-    def test_everflow_case2(self, duthost, setup_info, setup_mirror_session, dest_port_type, partial_ptf_runner):
-        """Test case 2 - Change neighbor MAC address.
-        Verify that session destination MAC address is changed after neighbor MAC address update."""
-
-        rx_port_ptf_id =  setup_info[dest_port_type] ['src_port_ptf_id']
-        tx_port = setup_info[dest_port_type]['dest_port'][0]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][0]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        if setup_info[dest_port_type]['dest_port_lag_name'][0] != 'Not Applicable':
-            tx_port = setup_info[dest_port_type]['dest_port_lag_name'][0]
-
-
-        duthost.shell("ip neigh replace {} lladdr 00:11:22:33:44:55 nud permanent dev {}".format(peer_ip, tx_port))
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id,
-                           expected_dst_mac = '00:11:22:33:44:55')
-
-
-        duthost.shell("ip neigh del {} dev {}".format(peer_ip, tx_port))
-
-        duthost.shell("ping {} -c3".format(peer_ip))
-
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-    def test_everflow_case3(self, duthost, setup_info, setup_mirror_session, dest_port_type, partial_ptf_runner):
-        """Test case 3 -  ECMP route change (remove next hop not used by session).
-        Verify that after removal of next hop that was used by session from ECMP route session state is active."""
-
-        rx_port_ptf_id =  setup_info[dest_port_type] ['src_port_ptf_id']
-        tx_port = setup_info[dest_port_type]['dest_port'][0]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-        peer_ip0 = peer_ip
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        tx_port = setup_info[dest_port_type]['dest_port'][1]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][1]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-        peer_ip1 = peer_ip
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id + ',' + setup_info[dest_port_type]['dest_port_ptf_id'][0])
-
-        tx_port = setup_info[dest_port_type]['dest_port'][2]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][2]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(), expect_receive = False,
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = setup_info[dest_port_type]['dest_port_ptf_id'][0] + ',' + setup_info[dest_port_type]['dest_port_ptf_id'][1])
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(), expect_receive = False,
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip0)
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip1)
-
-
-    def test_everflow_case4(self, duthost, setup_info, setup_mirror_session, dest_port_type, partial_ptf_runner):
-        """Test case 4 - ECMP route change (remove next hop used by session).
-        Verify that removal of next hop that is not used by session doesn't cause DST port and MAC change."""
-
-        rx_port_ptf_id =  setup_info[dest_port_type] ['src_port_ptf_id']
-        tx_port = setup_info[dest_port_type]['dest_port'][0]
-        tx_port_ptf_id = setup_info[dest_port_type]['dest_port_ptf_id'][0]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-        peer_ip0 = peer_ip
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = tx_port_ptf_id)
-
-        tx_port = setup_info[dest_port_type]['dest_port'][1]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-        peer_ip1 = peer_ip
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        tx_port = setup_info[dest_port_type]['dest_port'][2]
-        peer_ip, peer_mac = everflow_utils.get_neighbor_info(duthost, tx_port)
-        peer_ip2 = peer_ip
-
-        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports = setup_info[dest_port_type]['dest_port_ptf_id'][0])
-
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(), expect_receive = False,
-                           src_port = rx_port_ptf_id,
-                           dst_ports =  setup_info[dest_port_type]['dest_port_ptf_id'][1] + ',' + setup_info[dest_port_type]['dest_port_ptf_id'][2])
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip0)
-
-        time.sleep(3)
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(), expect_receive = False,
-                           src_port = rx_port_ptf_id,
-                           dst_ports = setup_info[dest_port_type]['dest_port_ptf_id'][0])
-
-        partial_ptf_runner(setup_info, setup_mirror_session,self.acl_stage(), self.mirror_type(),
-                           src_port = rx_port_ptf_id,
-                           dst_ports =  setup_info[dest_port_type]['dest_port_ptf_id'][1] + ',' + setup_info[dest_port_type]['dest_port_ptf_id'][2])
-
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip1)
-        everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip2)
+    # FIXME: We use a lot of try-catch here to clean up routes, but it's a bit messy.
+    # A better solution might be to have a fixture that receives route updates and then
+    # cleans up any remaining routes at the end.
+
+    def test_everflow_basic_forwarding(self, duthost, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+        """
+        Verify basic forwarding scenarios for the Everflow feature.
+
+        Scenarios covered include:
+            - Resolved route
+            - Unresolved route
+            - LPM (longest prefix match)
+            - Route creation and removal
+        """
+        try:
+            # Add a route to the mirror session destination IP
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is sent along the route we installed
+            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Add a (better) unresolved route to the mirror session destination IP
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, resolved=False)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is still sent along the original route
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Remove the unresolved route
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+
+            # Add a better route to the mirror session destination IP
+            tx_port = setup_info[dest_port_type]["dest_port"][1]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic uses the new route
+            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Remove the better route.
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic switches back to the original route
+            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Clean up the test
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
+
+        except Exception:
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+
+            tx_port = setup_info[dest_port_type]["dest_port"][1]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+
+            raise
+
+    def test_everflow_neighbor_mac_change(self, duthost, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+        """Verify that session destination MAC address is changed after neighbor MAC address update."""
+        try:
+            # Add a route to the mirror session destination IP
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is sent along the route we installed
+            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Update the MAC on the neighbor interface for the route we installed
+            if setup_info[dest_port_type]["dest_port_lag_name"][0] != "Not Applicable":
+                tx_port = setup_info[dest_port_type]["dest_port_lag_name"][0]
+
+            duthost.shell("ip neigh replace {} lladdr 00:11:22:33:44:55 nud permanent dev {}".format(peer_ip, tx_port))
+            time.sleep(3)
+
+            # Verify that everything still works
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Clean up the test
+            duthost.shell("ip neigh del {} dev {}".format(peer_ip, tx_port))
+            duthost.shell("ping {} -c3".format(peer_ip))
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+
+        except Exception:
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+
+            raise
+
+    def test_everflow_remove_unused_ecmp_next_hop(self, duthost, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+        """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
+        try:
+            # Create two ECMP next hops
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+            time.sleep(3)
+
+            tx_port = setup_info[dest_port_type]["dest_port"][1]
+            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is sent to one of the next hops
+            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+            tx_port_ptf_ids = [
+                setup_info[dest_port_type]["dest_port_ptf_id"][0],
+                setup_info[dest_port_type]["dest_port_ptf_id"][1]
+            ]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                tx_port_ptf_ids
+            )
+
+            # Add another ECMP next hop
+            tx_port = setup_info[dest_port_type]["dest_port"][2]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is not sent to this new next hop
+            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][2]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id],
+                expect_recv=False
+            )
+
+            # Remove the extra hop
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is not sent to the deleted next hop
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id],
+                expect_recv=False
+            )
+
+            # Verify that mirrored traffic is still sent to one of the original next hops
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                tx_port_ptf_ids
+            )
+
+            # Clean up the test
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+
+        except Exception:
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)   
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+
+            raise
+
+    def test_everflow_remove_used_ecmp_next_hop(self, duthost, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+        """Verify that session is still active after removal of next hop from ECMP route that was in use."""
+        try:
+            # Add a route to the mirror session destination IP
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
+            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is sent along the route we installed
+            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Add two new ECMP next hops
+            tx_port = setup_info[dest_port_type]["dest_port"][1]
+            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+
+            tx_port = setup_info[dest_port_type]["dest_port"][2]
+            peer_ip_2, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
+            time.sleep(3)
+
+            # Verify that traffic is still sent along the original next hop
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id]
+            )
+
+            # Verify that traffic is not sent along either of the new next hops
+            tx_port_ptf_ids = [
+                setup_info[dest_port_type]["dest_port_ptf_id"][1],
+                setup_info[dest_port_type]["dest_port_ptf_id"][2]
+            ]
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                tx_port_ptf_ids,
+                expect_recv=False
+            )
+
+            # Remove the original next hop
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+            time.sleep(3)
+
+            # Verify that mirrored traffic is no longer sent along the original next hop
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                [tx_port_ptf_id],
+                expect_recv=False
+            )
+
+            # Verify that mirrored traffis is now sent along either of the new next hops
+            self._run_everflow_test_scenarios(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                duthost,
+                rx_port_ptf_id,
+                tx_port_ptf_ids
+            )
+
+            # Clean up the tests
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
+        except Exception:
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
+
+            raise
 
     def test_everflow_dscp_with_policer(self, duthost, setup_info, policer_mirror_session, dest_port_type, partial_ptf_runner):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table."""
@@ -311,122 +450,193 @@ class EverflowIPv4Tests(BaseEverflowTest):
             duthost.command("config acl remove table EVERFLOW_DSCP")
             everflow_utils.remove_route(duthost, policer_mirror_session["session_prefixes"][0], peer_ip)
 
+    def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port, tx_ports, expect_recv=True):
+        # FIXME: In the ptf_runner version of these tests, LAGs were passed down to the tests as comma-separated strings of
+        # LAG member port IDs (e.g. portchannel0001 -> "2,3"). Because the DSCP test is still using ptf_runner we will preserve
+        # this for now, but we should try to make the format a little more friendly once the DSCP test also gets converted.
+        tx_port_ids = []
+        for port in tx_ports:
+            members = port.split(',')
+            for member in members:
+                tx_port_ids.append(int(member))
+
+        pkt_dict = {
+            "(src ip)": self._base_tcp_packet(ptfadapter, setup, src_ip="20.0.0.10"),
+            "(dst ip)": self._base_tcp_packet(ptfadapter, setup, dst_ip="30.0.0.10"),
+            "(l4 src port)": self._base_tcp_packet(ptfadapter, setup, sport=0x1235),
+            "(l4 dst port)": self._base_tcp_packet(ptfadapter, setup, dport=0x1235),
+            "(ip protocol)": self._base_tcp_packet(ptfadapter, setup, ip_protocol=0x7E),
+            "(tcp flags)": self._base_tcp_packet(ptfadapter, setup, flags=0x12),
+            "(l4 src range)": self._base_tcp_packet(ptfadapter, setup, sport=4675),
+            "(l4 dst range)": self._base_tcp_packet(ptfadapter, setup, dport=4675),
+            "(dscp)": self._base_tcp_packet(ptfadapter, setup, dscp=51)
+        }
+
+        for description, pkt in pkt_dict.items():
+            logging.info("Sending packet with qualifier set %s to DUT" % description)
+            self.send_and_check_mirror_packets(
+                setup,
+                mirror_session,
+                ptfadapter,
+                duthost,
+                pkt,
+                src_port=rx_port,
+                dest_ports=tx_port_ids,
+                expect_recv=expect_recv
+            )
+
+    def _base_tcp_packet(
+        self,
+        ptfadapter,
+        setup,
+        src_ip=DEFAULT_SRC_IP,
+        dst_ip=DEFAULT_DST_IP,
+        ip_protocol=None,
+        dscp=None,
+        sport=0x1234,
+        dport=0x50,
+        flags=0x10
+    ):
+        pkt = testutils.simple_tcp_packet(
+            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_dst=setup["router_mac"],
+            ip_src=src_ip,
+            ip_dst=dst_ip,
+            ip_ttl=64,
+            tcp_sport=sport,
+            tcp_dport=dport,
+            tcp_flags=flags
+        )
+
+        # NOTE: Yes testutils has an `ip_dscp` field, no it does not work here. I don't know why either. /shrug
+        if dscp:
+            pkt["IP"].tos = dscp << 2
+
+        if ip_protocol:
+            pkt["IP"].proto = ip_protocol
+
+        return pkt
+
 
 class TestEverflowV4IngressAclIngressMirror(EverflowIPv4Tests):
-    @pytest.fixture(scope='class',  autouse = True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_acl_table(self, duthost, setup_info, setup_mirror_session):
-        if setup_info[self.acl_stage()][self.mirror_type()] == False:
-            pytest.skip("Skipping Feature not Supported {} ACL having {} Mirror".format(self.acl_stage(), self.mirror_type()))
+        if not setup_info[self.acl_stage()][self.mirror_type()]:
+            pytest.skip("Feature Not Supported: {} ACL w/ {} Mirroring"
+                        .format(self.acl_stage(), self.mirror_type()))
 
         duthost.shell("mkdir -p {}".format(DUT_RUN_DIR))
 
-        duthost.host.options['variable_manager'].extra_vars.update({'acl_table_name' : "EVERFLOW"})
-        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE), dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
-        duthost.command('acl-loader update full {} --session_name={}'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE)),setup_mirror_session['session_name']))
+        duthost.host.options["variable_manager"].extra_vars.update({"acl_table_name": "EVERFLOW"})
+        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE),
+                         dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
+
+        duthost.command("acl-loader update full {} --session_name={}"
+                        .format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE),
+                                setup_mirror_session["session_name"]))
 
         yield
 
         duthost.copy(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE), dest=DUT_RUN_DIR)
-        duthost.command('acl-loader update full {}'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE))))
+        duthost.command("acl-loader update full {}".format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE)))
         duthost.shell("rm -rf {}".format(DUT_RUN_DIR))
 
     def acl_stage(self):
-        return 'ingress'
+        return "ingress"
 
     def mirror_type(self):
-        return 'ingress'
+        return "ingress"
 
 
 class TestEverflowV4IngressAclEgressMirror(EverflowIPv4Tests):
-    @pytest.fixture(scope='class',  autouse = True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_acl_table(self, duthost, setup_info, setup_mirror_session):
-        if setup_info[self.acl_stage()][self.mirror_type()] == False:
-            pytest.skip("Skipping Feature not Supported {} ACL having {} Mirror".format(self.acl_stage(), self.mirror_type()))
+        if not setup_info[self.acl_stage()][self.mirror_type()]:
+            pytest.skip("Feature Not Supported: {} ACL w/ {} Mirroring"
+                        .format(self.acl_stage(), self.mirror_type()))
 
         duthost.shell("mkdir -p {}".format(DUT_RUN_DIR))
 
-        duthost.host.options['variable_manager'].extra_vars.update({'acl_table_name' : "EVERFLOW"})
-        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE), dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
-        duthost.command('acl-loader update full {} --session_name={}'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE)),setup_mirror_session['session_name']))
+        duthost.host.options["variable_manager"].extra_vars.update({"acl_table_name": "EVERFLOW"})
+        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE),
+                         dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
+
+        duthost.command("acl-loader update full {} --session_name={}"
+                        .format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE),
+                                setup_mirror_session["session_name"]))
 
         yield
 
         duthost.copy(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE), dest=DUT_RUN_DIR)
-        duthost.command('acl-loader update full {}'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE))))
+        duthost.command("acl-loader update full {}".format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE)))
         duthost.shell("rm -rf {}".format(DUT_RUN_DIR))
 
     def acl_stage(self):
-        return 'ingress'
+        return "ingress"
 
     def mirror_type(self):
-        return 'egress'
+        return "egress"
 
 
 class TestEverflowV4EgressAclIngressMirror(EverflowIPv4Tests):
-    @pytest.fixture(scope='class',  autouse = True)
+    @pytest.fixture(scope="class", autouse=True)
     def setup_acl_table(self, duthost, setup_info, setup_mirror_session):
-        if setup_info[self.acl_stage()][self.mirror_type()] == False:
-           pytest.skip("Skipping Feature not Supported {} ACL having {} Mirror".format(self.acl_stage(), self.mirror_type()))
+        if not setup_info[self.acl_stage()][self.mirror_type()]:
+            pytest.skip("Feature Not Supported: {} ACL w/ {} Mirroring"
+                        .format(self.acl_stage(), self.mirror_type()))
 
         duthost.shell("mkdir -p {}".format(DUT_RUN_DIR))
 
-        duthost.host.options['variable_manager'].extra_vars.update({'acl_table_name' : "EVERFLOW_EGRESS"})
+        duthost.host.options["variable_manager"].extra_vars.update({"acl_table_name": "EVERFLOW_EGRESS"})
+        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE),
+                         dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
 
-        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE), dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
-
-        # Remove default SONiC Everflow table (since SONiC allows only one mirror table)
-        duthost.command("config acl remove table EVERFLOW")
-
-        duthost.command("config acl add table EVERFLOW_EGRESS MIRROR --description EVERFLOW_EGRESS --stage=egress")
-        duthost.command('acl-loader update full {} --session_name={} --mirror_stage=egress'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE)),setup_mirror_session['session_name']))
+        duthost.command("config acl add table EVERFLOW_EGRESS MIRROR --stage=egress")
+        duthost.command("acl-loader update full {} --session_name={}"
+                        .format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE),
+                                setup_mirror_session["session_name"]))
 
         yield
 
         duthost.copy(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE), dest=DUT_RUN_DIR)
-        duthost.command('acl-loader update full {}'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE))))
+        duthost.command("acl-loader update full {}".format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE)))
         duthost.command("config acl remove table EVERFLOW_EGRESS")
         duthost.shell("rm -rf {}".format(DUT_RUN_DIR))
 
-        # Add default SONiC Everflow table back
-        duthost.command("config acl add table EVERFLOW MIRROR --description EVERFLOW --stage=ingress")
-
     def acl_stage(self):
-        return 'egress'
+        return "egress"
 
     def mirror_type(self):
-        return 'ingress'
+        return "ingress"
 
 
 class TestEverflowV4EgressAclEgressMirror(EverflowIPv4Tests):
-    @pytest.fixture(scope='class',  autouse = True)
+    @pytest.fixture(scope='class', autouse=True)
     def setup_acl_table(self, duthost, setup_info, setup_mirror_session):
-        if setup_info[self.acl_stage()][self.mirror_type()] == False:
-           pytest.skip("Skipping Feature not Supported {} ACL having {} Mirror".format(self.acl_stage(), self.mirror_type()))
+        if not setup_info[self.acl_stage()][self.mirror_type()]:
+            pytest.skip("Feature Not Supported: {} ACL w/ {} Mirroring"
+                        .format(self.acl_stage(), self.mirror_type()))
 
         duthost.shell("mkdir -p {}".format(DUT_RUN_DIR))
-        duthost.host.options['variable_manager'].extra_vars.update({'acl_table_name' : "EVERFLOW_EGRESS"})
 
+        duthost.host.options["variable_manager"].extra_vars.update({"acl_table_name": "EVERFLOW_EGRESS"})
+        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE),
+                         dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
 
-        duthost.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_CREATE_TEMPLATE), dest=os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE))
-
-        # Remove default SONiC Everflow table (since SONiC allows only one mirror table)
-        duthost.command("config acl remove table EVERFLOW")
-
-        duthost.command("config acl add table EVERFLOW_EGRESS MIRROR --description EVERFLOW_EGRESS --stage=egress")
-        duthost.command('acl-loader update full {} --session_name={} --mirror_stage=egress'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE)),setup_mirror_session['session_name']))
+        duthost.command("config acl add table EVERFLOW_EGRESS MIRROR --stage=egress")
+        duthost.command("acl-loader update full {} --session_name={} --mirror_stage=egress"
+                        .format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_CREATE_FILE),
+                                setup_mirror_session["session_name"]))
 
         yield
 
         duthost.copy(src=os.path.join(TEMPLATE_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE), dest=DUT_RUN_DIR)
-        duthost.command('acl-loader update full {}'.format((os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE))))
+        duthost.command("acl-loader update full {}".format(os.path.join(DUT_RUN_DIR, EVERFLOW_TABLE_RULE_DELETE_FILE)))
         duthost.command("config acl remove table EVERFLOW_EGRESS")
         duthost.shell("rm -rf {}".format(DUT_RUN_DIR))
 
-        # Add default SONiC Everflow table back
-        duthost.command("config acl add table EVERFLOW MIRROR --description EVERFLOW --stage=ingress")
-
     def acl_stage(self):
-        return 'egress'
+        return "egress"
 
     def  mirror_type(self):
-        return 'egress'
+        return "egress"


### PR DESCRIPTION
- Refactor common methods into everflow_test_utilities
- Update test cases 1-4 to use ptfadapter rather than ptf_runner

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Migrate Everflow v4 tests to use ptfadapter instead of ptf_runner.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We want to move away from using `ptf_runner` to run ptf scripts as it is harder to maintain, monitor, and debug than using the `ptfadapter` fixture.

Additionally, the new ipv6 everflow tests use `ptfadapter`, so in order to converge those test cases w/ the existing test cases we need them to share the same infrastructure.

#### How did you do it?
I replicated the contents of `everflow_tb_test.py` into the pytest script (see `_run_everflow_test_scenarios`) so that we can use `ptfadapter` to test the same logic.

Since some of this was present in the v6 tests already, I refactored a bunch of that logic out into the `utilities` class so that it can be shared between the v4 and v6 test cases.

I left the `dscp` test alone for now because there is some additional logic that needs to be implemented in the `ptfadapter` way, and this PR is already pretty huge as is.

Additionally, I fixed up whatever warnings pep8 gave me.

#### How did you verify/test it?
Ran `test_everflow_testbed` and `test_everflow_ipv6` on my DUT, all test cases passed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
