### PR TITLE
[copp] Fix recent COPP test failures

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -158,8 +158,7 @@ def swap_syncd(dut):
               "{}/{}".format(registry.host, docker_rpc_image),
               sonic_version)
 
-    dut.command("systemctl reset-failed swss")
-    dut.command("systemctl start swss")
+    dut.command("config reload -y")
 
     _LOGGER.info("swss has been restarted, waiting 60 seconds to initialize...")
     time.sleep(60)
@@ -197,8 +196,7 @@ def restore_default_syncd(dut):
               docker_syncd_name,
               sonic_version)
 
-    dut.command("systemctl reset-failed swss")
-    dut.command("systemctl start swss")
+    dut.command("config reload -y")
 
     _LOGGER.info("swss has been restarted, waiting 60 seconds to initialize...")
     time.sleep(60)

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -8,6 +8,7 @@ import os
 import time
 import yaml
 
+from tests.common import config_reload
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 
@@ -158,10 +159,9 @@ def swap_syncd(dut):
               "{}/{}".format(registry.host, docker_rpc_image),
               sonic_version)
 
-    dut.command("config reload -y")
+    _LOGGER.info("Reloading config and restarting swss...")
+    config_reload(dut)
 
-    _LOGGER.info("swss has been restarted, waiting 60 seconds to initialize...")
-    time.sleep(60)
 
 def restore_default_syncd(dut):
     """
@@ -196,10 +196,8 @@ def restore_default_syncd(dut):
               docker_syncd_name,
               sonic_version)
 
-    dut.command("config reload -y")
-
-    _LOGGER.info("swss has been restarted, waiting 60 seconds to initialize...")
-    time.sleep(60)
+    _LOGGER.info("Reloading config and restarting swss...")
+    config_reload(dut)
 
     # Remove the RPC image from the DUT
     docker_rpc_image = docker_syncd_name + "-rpc"

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -5,7 +5,6 @@
 import collections
 import logging
 import os
-import time
 import yaml
 
 from tests.common import config_reload

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -225,6 +225,5 @@ def _restart_swss(dut):
 
     # The failure counter may be incremented by other test cases, so we clear it
     # first to avoid crashing the testbed.
-    dut.command("systemctl reset-failed swss")
-    dut.command("systemctl restart swss")
+    dut.command("config reload -y")
     time.sleep(60)

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -201,7 +201,7 @@ def _setup_testbed(dut, ptf, test_params):
     else:
         # NOTE: Even if the rpc syncd image is already installed, we need to restart
         # SWSS for the COPP changes to take effect.
-        logging.info("Restart SWSS...")
+        logging.info("Reloading config and restarting swss...")
         config_reload(dut)
 
     logging.info("Configure syncd RPC for testing")
@@ -222,7 +222,7 @@ def _teardown_testbed(dut, ptf, test_params):
         logging.info("Restore default syncd docker...")
         docker.restore_default_syncd(dut)
     else:
-        logging.info("Restart SWSS...")
+        logging.info("Reloading config and restarting swss...")
         config_reload(dut)
 
     logging.info("Restore LLDP")

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -33,6 +33,7 @@ from collections import namedtuple
 
 from tests.copp import copp_utils
 from tests.ptf_runner import ptf_runner
+from tests.common import config_reload
 from tests.common.system_utils import docker
 
 # Module-level fixtures
@@ -202,7 +203,7 @@ def _setup_testbed(dut, ptf, test_params):
         # NOTE: Even if the rpc syncd image is already installed, we need to restart
         # SWSS for the COPP changes to take effect.
         logging.info("Restart SWSS...")
-        _restart_swss(dut)
+        config_reload(dut)
 
     logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port)
@@ -223,18 +224,8 @@ def _teardown_testbed(dut, ptf, test_params):
         docker.restore_default_syncd(dut)
     else:
         logging.info("Restart SWSS...")
-        _restart_swss(dut)
+        config_reload(dut)
 
     logging.info("Restore LLDP")
     dut.command("docker exec lldp supervisorctl start lldpd")
     dut.command("docker exec lldp supervisorctl start lldp-syncd")
-
-def _restart_swss(dut):
-    """
-        Restarts SWSS and waits for the system to stabilize.
-    """
-
-    # The failure counter may be incremented by other test cases, so we clear it
-    # first to avoid crashing the testbed.
-    dut.command("config reload -y")
-    time.sleep(60)

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -27,7 +27,6 @@
 """
 
 import logging
-import time
 import pytest
 from collections import namedtuple
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -85,6 +85,17 @@ class TestCOPP(object):
             Checks that the policer does not enforce a rate limit for protocols
             that do not have any set rate limit.
         """
+        # FIXME: The DHCP COPP Policy was removed from T1 in a recent change, so no
+        # packets will be trapped to CPU. So, we should have two cases:
+        #
+        # 1. Verify that NO DHCP packets are trapped to CPU on T1, and
+        # 2. Verify that DHCP packets ARE trapped to CPU on T0
+        #
+        # Because COPP doesn't run on T0 yet and the ptf script does not support "no
+        # packets received", we expect the test to fail for the time being.
+        if protocol == "DHCP":
+            pytest.mark.xfail("DHCP COPP Policy has been removed from T1 config")
+
         _copp_runner(duthost,
                      ptfhost,
                      protocol,


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fix recent COPP test failures due to swss restart and T1 behavioral changes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The COPP tests can occasionally trigger crashes and inconsistent behavior in orchagent. This is because `restart swss` does not provide strong guarantees for the ordering that services are restarted in. To mitigate this risk, we can use `config reload` as this ensures that services will be restarted in the proper order.

In addition, there was a recent behavioral change for T1 devices that causes DHCP packets to not be trapped to CPU. As a result, this case is now expected to fail.

#### How did you do it?
- Swap `restart swss` for `config reload`
- Mark DHCP as xfail

#### How did you verify/test it?
Ran locally x3 and the tests passed. Orchagent did not crash during or after the test run.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
