### PR TITLE
[device] simplify AnsibleHostBase constructor parameter handling

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -29,21 +29,11 @@ class AnsibleHostBase(object):
     on the host.
     """
 
-    def __init__(self, ansible_adhoc, hostname, connection=None, become_user=None):
+    def __init__(self, ansible_adhoc, hostname, *args, **kwargs):
         if hostname == 'localhost':
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
         else:
-            if connection is None:
-                if become_user is None:
-                    self.host = ansible_adhoc(become=True)[hostname]
-                else:
-                    self.host = ansible_adhoc(become=True, become_user=become_user)[hostname]
-            else:
-                logging.debug("connection {} for {}".format(connection, hostname))
-                if become_user is None:
-                    self.host = ansible_adhoc(become=True, connection=connection)[hostname]
-                else:
-                    self.host = ansible_adhoc(become=True, connection=connection, become_user=become_user)[hostname]
+            self.host = ansible_adhoc(become=True, *args, **kwargs)[hostname]
         self.hostname = hostname
 
     def __getattr__(self, module_name):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
AnsibleHostBase handles connection and become_user with a complicated if else structure. If we want pass another parameter to ansible_adhoc, it would be exploding.

#### How did you do it?
Let ansible_adhoc class handles the parameter list.

#### How did you verify/test it?
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos -u -p /tmp/logs-01 -c iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_counter[default]
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_counter[default] PASSED                                                                        [100%]

