### PR TITLE
[sanity check] Skip bgp check for particular topology

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -41,7 +41,7 @@ def _update_check_items(old_items, new_items, supported_items):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def sanity_check(localhost, duthost, request, fanouthosts):
+def sanity_check(localhost, duthost, request, fanouthosts, testbed):
     logger.info("Start pre-test sanity check")
 
     skip_sanity = False
@@ -80,6 +80,10 @@ def sanity_check(localhost, duthost, request, fanouthosts):
     if items:
         items_array=str(items).split(',')
         check_items = _update_check_items(check_items, items_array, constants.SUPPORTED_CHECK_ITEMS)
+
+    # ignore BGP check for particular topology type
+    if testbed['topo']['type'] == 'ptf' and 'bgp' in check_items:
+        check_items.remove('bgp')
 
     logger.info("Sanity check settings: skip_sanity=%s, check_items=%s, allow_recover=%s, recover_method=%s, post_check=%s" % \
         (skip_sanity, check_items, allow_recover, recover_method, post_check))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
There are topologies that don't have BGP sessions. The PR is to skip bgp check for those topologies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

There are topologies that don't have BGP sessions. The PR is to skip bgp check for those topologies.

#### How did you do it?

For particular topologies, remove bgp from the check items.

#### How did you verify/test it?

Run a basic regression test case

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
