### PR TITLE
Use paramiko for ssh connection in test_wr_arp

### DIFF
--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -1,5 +1,6 @@
 import paramiko
 import logging
+import socket
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,13 @@ class DeviceConnection:
             logger.error('SSH Authentiaction failure with message: %s' % authenticationException)
         except BadHostKeyException as badHostKeyException:
             logger.error('SSH Authentiaction failure with message: %s' % badHostKeyException)
+        except socket.timeout as e:
+            # The ssh session will timeout in case of a successful reboot
+            logger.error('Caught exception socket.timeout: {}, {}, {}'.format(repr(e), str(e), type(e)))
+            retValue = 255
+        except Exception as e:
+            logger.error('Exception caught: {}, {}, type: {}'.format(repr(e), str(e), type(e)))
+            logger.error(sys.exc_info())
         finally:
             client.close()
 

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -23,8 +23,6 @@ from ptf.base_tests import BaseTest
 from ptf import config
 import ptf.dataplane as dataplane
 import ptf.testutils as testutils
-import paramiko
-from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
 from device_connection import DeviceConnection
 
 

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -6,13 +6,13 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
-from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
 from tests.ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.disable_loganalyzer
 ]
 
 # Globals
@@ -159,22 +159,7 @@ class TestWrArp:
             assert result["rc"] == 0 or "No such process" in result["stderr"], \
                 "Failed to delete route with error '{0}'".format(result["stderr"])
 
-    @pytest.fixture(scope='class', autouse=True)
-    def prepareSshKeys(self, duthost, ptfhost, creds):
-        '''
-            Prepares testbed ssh keys by generating ssh key on ptf host and adding this key to known_hosts on duthost
-            This class-scope fixture runs once before test start
-
-            Args:
-                duthost (AnsibleHost): Device Under Test (DUT)
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-
-            Returns:
-                None
-        '''
-        prepareTestbedSshKeys(duthost, ptfhost, creds['sonicadmin_user'])
-
-    def testWrArp(self, request, duthost, ptfhost):
+    def testWrArp(self, request, duthost, ptfhost, creds):
         '''
             Control Plane Assistant test for Warm-Reboot.
 
@@ -206,6 +191,8 @@ class TestWrArp:
             params={
                 'ferret_ip' : ptfIp,
                 'dut_ssh' : dutIp,
+                'dut_username': creds['sonicadmin_user'],
+                'dut_password': creds['sonicadmin_password'],
                 'config_file' : VXLAN_CONFIG_FILE,
                 'how_long' : testDuration,
             },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test_wr_arp.py test failed for two reasons:
1. After reboot, the ptf ssh key on dut host is lost. Executing remote command on dut from ptf failed.
2. This test script needs to do warm reboot on dut and would cause some error messages in syslog. The test will fail when loganalyzer is enabled.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_wr_arp script put ssh key of ptfhost on dut to have password less
ssh connection. Then the ptfhost can execute command remote on dut
through this ssh connection. The problem is that the ssh key saved in
~/.ssh/authorized_keys on dut host may not persist after warm reboot.
It would also be a problem when secure boot feature is introduced. This
PR updated the test_wr_arp script to use paramiko for ssh connection
and remote command execution between ptfhost and dut.

#### How did you do it?
* Update the ptf test script to use paramiko for SSH connection with dut
* Disabled loganalyzer because test_wr_arp need to do warm-reboot on dut

#### How did you verify/test it?
Test run the test_wr_arp.py script on latest 201911 image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
