### PR TITLE
Fixed 'test_drop_counters' test suite

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -188,7 +188,7 @@ def base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_du
     # Clear SONiC counters
     duthost.command("sonic-clear counters")
     duthost.command("sonic-clear rifcounters")
-    send_packets(pkt, duthost, ptfadapter, ports_info["ptf_tx_port_id"])
+    send_packets(pkt, duthost, ptfadapter, ports_info["ptf_tx_port_id"], PKT_NUMBER)
     if discard_group == "L2":
         verify_drop_counters(duthost, ports_info["dut_iface"], GET_L2_COUNTERS, L2_COL_KEY)
         ensure_no_l3_drops(duthost)


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Fix drop counter tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To fix drop counter tests, as in recent changes it was missed a number of sending packets as parameter for 'send_packets' function, which causes test cases to fail.

#### How did you do it?

#### How did you verify/test it?
Verified on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
