### PR TITLE
[ser] address broadcom SER test issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,32 +199,6 @@ def testbed(request):
     return tbinfo.testbed_topo[tbname]
 
 
-def disable_ssh_timout(dut):
-    '''
-    @summary disable ssh session on target dut
-    @param dut: Ansible host DUT
-    '''
-    logger.info('Disabling ssh time out on dut: %s' % dut.hostname)
-    dut.command("sudo sed -i 's/^ClientAliveInterval/#&/' /etc/ssh/sshd_config")
-    dut.command("sudo sed -i 's/^ClientAliveCountMax/#&/' /etc/ssh/sshd_config")
-
-    dut.command("sudo systemctl restart ssh")
-    time.sleep(5)
-
-
-def enable_ssh_timout(dut):
-    '''
-    @summary: enable ssh session on target dut
-    @param dut: Ansible host DUT
-    '''
-    logger.info('Enabling ssh time out on dut: %s' % dut.hostname)
-    dut.command("sudo sed -i '/^#ClientAliveInterval/s/^#//' /etc/ssh/sshd_config")
-    dut.command("sudo sed -i '/^#ClientAliveCountMax/s/^#//' /etc/ssh/sshd_config")
-
-    dut.command("sudo systemctl restart ssh")
-    time.sleep(5)
-
-
 @pytest.fixture(name="duthosts", scope="session")
 def fixture_duthosts(ansible_adhoc, testbed):
     """
@@ -246,20 +220,14 @@ def duthost(duthosts, request):
     @param duthosts: fixture to get DUT hosts
     @param request: request parameters for duthost test fixture
     '''
-    stop_ssh_timeout = getattr(request.session, "pause_ssh_timeout", None)
     dut_index = getattr(request.session, "dut_index", 0)
     assert dut_index < len(duthosts), \
         "DUT index '{0}' is out of bound '{1}'".format(dut_index,
                                                        len(duthosts))
 
     duthost = duthosts[dut_index]
-    if stop_ssh_timeout is not None:
-        disable_ssh_timout(duthost)
 
-    yield duthost
-
-    if stop_ssh_timeout is not None:
-        enable_ssh_timout(duthost)
+    return duthost
 
 @pytest.fixture(scope="module", autouse=True)
 def reset_critical_services_list(duthost):


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Broadcom SER test has been failing with host unreachable error. Which doesn't make sense because the step prior to running the test is to copy the test file to DUT.

#### How did you do it?
- When using command() instead of shell(), we got host unreachable error.
- With shell() we got pass in seconds, which means that the test didn't run.
- With specifying executable, the test actually runs.
- Add cleanup code since this test has capability of leaving DUT in bad state.
- Move ssh timeout disabling/enabling code to ser test since currently, this is the only test needs it.
- Reboot to forcefully reset connection.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test_ser.py
