### PR TITLE
[minigraph]: Copy prefix_v6 into templates

### DIFF
--- a/ansible/library/vlan_config.py
+++ b/ansible/library/vlan_config.py
@@ -51,6 +51,7 @@ def main():
             vlan_configs[vlan]['id'] = vlan_param['id']
             vlan_configs[vlan]['tag'] = vlan_param['tag']
             vlan_configs[vlan]['prefix'] = vlan_param['prefix']
+            vlan_configs[vlan]['prefix_v6'] = vlan_param['prefix_v6']
             vlan_configs[vlan]['intfs'] = [port_alias[i] for i in vlan_param['intfs']]
     except Exception as e:
         module.fail_json(msg = traceback.format_exc())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The https://github.com/Azure/sonic-mgmt/pull/1982 has a bug (missed part). prefix_v6 key is not being copied to template parameters.

#### How did you do it?
Explicitly copy 'prefix_v6' to the template parameters.

#### How did you verify/test it?
```
sudo ansible-playbook  -i str -l lab -e testbed_name=vms3-t0 -e local_minigraph=true
````
Then check generated minigraph for this information
```
sudo cat /etc/sonic/minigraph.xml | less
The output should be something like this
...
        <IPInterface>
          <Name i:nil="true"/>
          <AttachTo>Vlan1000</AttachTo>
          <Prefix>fc02:1000::1/64</Prefix>
        </IPInterface>
...
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
