### PR TITLE
Disable LogAnalyzer in advanced reboot test

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -4,6 +4,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
I found that most errors in test_advanced_reboot is caused by LogAnalyzer, because there are probably various ERR/WARNING during system going down and reboot, which are expected and can be explained. The list of log is pasted below. Rather than adding many patterns to cover them, I prefer to disable LogAnalyzer for these tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To remove test error in cases related to warm-reboot and fast-reboot caused by LogAnalyzer.
#### How did you do it?
LogAnalyzer is disabled for these cases.
#### How did you verify/test it?
I verify it on Arista-7260.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
### ERR/WARNING logs got from warm-reboot and fast-reboot
```
fast-reboot
Aug  5 07:19:27.747209 str-7260cx3-acs-7 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: Failed to talk with quagga socket. Reconnect later...: [Errno 32] Broken pipe.
Aug  5 07:19:29.140723 str-7260cx3-acs-7 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: Uncaught exception in sonic_ax_impl.main#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/main.py", line 72, in main#012    event_loop.run_until_complete(agent.run_in_event_loop())#012  File "/usr/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete#012    return future.result()#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/agent.py", line 49, in run_in_event_loop#012    await asyncio.wait_for(background_task, BACKGROUND_WAIT_TIMEOUT, loop=self.loop)#012  File "/usr/lib/python3.6/asyncio/tasks.py", line 352, in wait_for#012    return fut.result()#012AttributeError: \'_asyncio.Task\' object has no attribute \'send\'
Aug  5 07:19:50.704375 str-7260cx3-acs-7 ERR monit[604]: 'syncd' process is not running
Aug  5 07:19:50.712892 str-7260cx3-acs-7 ERR monit[604]: 'dsserve' process is not running
Aug  5 07:19:50.719324 str-7260cx3-acs-7 ERR monit[604]: 'orchagent' process is not running
Aug  5 07:19:50.725383 str-7260cx3-acs-7 ERR monit[604]: 'portsyncd' process is not running
Aug  5 07:19:50.730799 str-7260cx3-acs-7 ERR monit[604]: 'neighsyncd' process is not running
Aug  5 07:19:50.735835 str-7260cx3-acs-7 ERR monit[604]: 'vrfmgrd' process is not running
Aug  5 07:19:50.740998 str-7260cx3-acs-7 ERR monit[604]: 'vlanmgrd' process is not running
Aug  5 07:19:50.745769 str-7260cx3-acs-7 ERR monit[604]: 'intfmgrd' process is not running
Aug  5 07:19:50.750543 str-7260cx3-acs-7 ERR monit[604]: 'portmgrd' process is not running
Aug  5 07:19:50.755334 str-7260cx3-acs-7 ERR monit[604]: 'buffermgrd' process is not running
Aug  5 07:19:50.759901 str-7260cx3-acs-7 ERR monit[604]: 'nbrmgrd' process is not running
Aug  5 07:19:50.764395 str-7260cx3-acs-7 ERR monit[604]: 'vxlanmgrd' process is not running
Aug  5 07:19:50.768827 str-7260cx3-acs-7 ERR monit[604]: 'snmpd' process is not running
Aug  5 07:19:50.773161 str-7260cx3-acs-7 ERR monit[604]: 'snmp_subagent' process is not running
Aug  5 07:19:50.777446 str-7260cx3-acs-7 ERR monit[604]: 'lldpd_monitor' process is not running
Aug  5 07:19:50.781552 str-7260cx3-acs-7 ERR monit[604]: 'lldp_syncd' process is not running
Aug  5 07:19:50.785743 str-7260cx3-acs-7 ERR monit[604]: 'lldpmgrd' process is not running
Aug  5 07:19:50.789749 str-7260cx3-acs-7 ERR monit[604]: 'redis_server' process is not running
Aug  5 07:19:50.793783 str-7260cx3-acs-7 ERR monit[604]: 'zebra' process is not running
Aug  5 07:19:50.797706 str-7260cx3-acs-7 ERR monit[604]: 'fpmsyncd' process is not running
Aug  5 07:19:50.801656 str-7260cx3-acs-7 ERR monit[604]: 'bgpd' process is not running
Aug  5 07:19:50.805406 str-7260cx3-acs-7 ERR monit[604]: 'staticd' process is not running
Aug  5 07:19:50.809274 str-7260cx3-acs-7 ERR monit[604]: 'bgpcfgd' process is not running
Aug  5 07:19:50.812958 str-7260cx3-acs-7 ERR monit[604]: 'acms' process is not running
Aug  5 07:19:50.816659 str-7260cx3-acs-7 ERR monit[604]: 'dSMS_endpoint_modifier' process is not running
Aug  5 07:19:50.820275 str-7260cx3-acs-7 ERR monit[604]: 'cert_converter' process is not running
Aug  5 07:20:00.128815 str-7260cx3-acs-7 ERR kernel: [    1.481055] tpm tpm0: [Firmware Bug]: TPM interrupt not working, polling instead
Aug  5 07:20:00.129276 str-7260cx3-acs-7 INFO kernel: [    5.787934] EDAC MC0: Giving out device to module sbridge_edac.c controller Broadwell Socket#0: DEV 0000:ff:12.0 (INTERRUPT)
Aug  5 07:20:00.129541 str-7260cx3-acs-7 INFO systemd[1]: Starting Kernel crash dump capture service...
Aug  5 07:20:00.129680 str-7260cx3-acs-7 ERR mcelog: warning: 32 bytes ignored in each record
Aug  5 07:20:00.129684 str-7260cx3-acs-7 ERR mcelog: consider an update
Aug  5 07:20:00.130887 str-7260cx3-acs-7 ERR liblogging-stdlog: omfwd: error 101 sending via udp: Network is unreachable [v8.24.0 try http://www.rsyslog.com/e/2354 ]
Aug  5 07:20:00.161563 str-7260cx3-acs-7 INFO kdump-tools[505]: Starting kdump-tools: no crashkernel= parameter in the kernel cmdline ... failed!
Aug  5 07:20:00.287915 str-7260cx3-acs-7 INFO systemd[1]: Started Kernel crash dump capture service.
Aug  5 07:20:00.963165 str-7260cx3-acs-7 NOTICE kernel: [    6.911679] audit: type=1400 audit(1596612000.955:3): apparmor="DENIED" operation="open" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" name="sbin" pid=576 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
Aug  5 07:20:08.230632 str-7260cx3-acs-7 ERR hostcfgd: 'sudo systemctl enable telemetry.service' failed. RC: 1, output: None
Aug  5 07:20:08.265181 str-7260cx3-acs-7 ERR hostcfgd: 'sudo systemctl start telemetry.service' failed. RC: 5, output: None
Aug  5 07:20:08.771056 str-7260cx3-acs-7 ERR liblogging-stdlog: omfwd: error 101 sending via udp: Network is unreachable [v8.24.0 try http://www.rsyslog.com/e/2354 ]
Aug  5 07:20:24.480921 str-7260cx3-acs-7 ERR syncd#syncd: [none] driverEgressMemoryUpdate:1395 Error getting cosq for port 1
Aug  5 07:20:24.481362 str-7260cx3-acs-7 ERR syncd#syncd: message repeated 15 times: [ [none] driverEgressMemoryUpdate:1395 Error getting cosq for port 1]
Aug  5 07:20:24.481448 str-7260cx3-acs-7 ERR syncd#syncd: [none] driverEgressMemoryUpdate:1395 Error getting cosq for port 2
.....
Aug  5 07:20:24.860670 str-7260cx3-acs-7 ERR lldp#lldpmgrd: Port 'Ethernet192' not found in PORT_TABLE table in App DB
Aug  5 07:20:24.860997 str-7260cx3-acs-7 ERR lldp#lldpmgrd: Port 'Ethernet80' not found in PORT_TABLE table in App DB
...
Aug  5 07:20:25.310998 str-7260cx3-acs-7 WARNING syncd#syncd: :- saiDiscover: skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID
Aug  5 07:20:25.946701 str-7260cx3-acs-7 ERR swss#intfmgrd: :- exec: /sbin/ip link show type dummy | grep -o 'Loopback[^:]*': Success
Aug  5 07:20:25.973055 str-7260cx3-acs-7 ERR syncd#syncd: [none] _brcm_sai_port_wred_stats_get:5022 Hardware failure -4 in getting WRED stat 69 for port 8
Aug  5 07:20:25.973118 str-7260cx3-acs-7 ERR syncd#syncd: [none] brcm_sai_get_port_stats:2064 port wred stats get failed with error Table empty (0xfffffffb).
Aug  5 07:20:29.239164 str-7260cx3-acs-7 NOTICE kernel: [   35.187822] audit: type=1400 audit(1596612029.233:8): apparmor="DENIED" operation="open" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" name="sbin" pid=3674 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
Aug  5 07:20:29.377780 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet256. No PG profile configured for speed 10000 and cable length 5m
Aug  5 07:20:29.377780 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doTask: Failed to process invalid entry, drop it

warm-reboot
Aug  5 08:03:16.756961 str-7260cx3-acs-7 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: Failed to talk with quagga socket. Reconnect later...: [Errno 32] Broken pipe.
Aug  5 08:03:17.086402 str-7260cx3-acs-7 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: Uncaught exception in sonic_ax_impl.main#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/main.py", line 72, in main#012    event_loop.run_until_complete(agent.run_in_event_loop())#012  File "/usr/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete#012    return future.result()#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/agent.py", line 49, in run_in_event_loop#012    await asyncio.wait_for(background_task, BACKGROUND_WAIT_TIMEOUT, loop=self.loop)#012  File "/usr/lib/python3.6/asyncio/tasks.py", line 352, in wait_for#012    return fut.result()#012AttributeError: \'_asyncio.Task\' object has no attribute \'send\'
Aug  5 08:03:48.824618 str-7260cx3-acs-7 ERR kernel: [    0.908821] tpm tpm0: [Firmware Bug]: TPM interrupt not working, polling instead
Aug  5 08:03:48.825115 str-7260cx3-acs-7 INFO kernel: [    5.077281] EDAC MC0: Giving out device to module sbridge_edac.c controller Broadwell Socket#0: DEV 0000:ff:12.0 (INTERRUPT)
Aug  5 08:03:48.838908 str-7260cx3-acs-7 ERR liblogging-stdlog: omfwd: error 101 sending via udp: Network is unreachable [v8.24.0 try http://www.rsyslog.com/e/2354 ]
Aug  5 08:03:48.846220 str-7260cx3-acs-7 INFO systemd[1]: Starting Kernel crash dump capture service...
Aug  5 08:03:49.015946 str-7260cx3-acs-7 ERR mcelog: warning: 32 bytes ignored in each record
Aug  5 08:03:49.016433 str-7260cx3-acs-7 ERR mcelog: consider an update
Aug  5 08:03:49.032480 str-7260cx3-acs-7 INFO kdump-tools[485]: Starting kdump-tools: no crashkernel= parameter in the kernel cmdline ... failed!
Aug  5 08:03:49.160161 str-7260cx3-acs-7 INFO systemd[1]: Started Kernel crash dump capture service.
Aug  5 08:03:49.891171 str-7260cx3-acs-7 NOTICE kernel: [    6.268163] audit: type=1400 audit(1596614629.883:3): apparmor="DENIED" operation="open" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" name="sbin" pid=555 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
Aug  5 08:03:58.617285 str-7260cx3-acs-7 ERR liblogging-stdlog: omfwd: error 101 sending via udp: Network is unreachable [v8.24.0 try http://www.rsyslog.com/e/2354 ]
Aug  5 08:03:58.967490 str-7260cx3-acs-7 ERR hostcfgd: 'sudo systemctl enable telemetry.service' failed. RC: 1, output: None
Aug  5 08:03:58.979188 str-7260cx3-acs-7 ERR hostcfgd: 'sudo systemctl start telemetry.service' failed. RC: 5, output: None
Aug  5 08:04:13.863343 str-7260cx3-acs-7 WARNING syncd#syncd: :- saiDiscover: skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID
Aug  5 08:04:14.586457 str-7260cx3-acs-7 ERR swss#vlanmgrd: :- exec: /sbin/ip link show Bridge 2&gt;/dev/null: Success
Aug  5 08:04:15.161748 str-7260cx3-acs-7 ERR syncd#syncd: [none] _brcm_sai_port_wred_stats_get:5022 Hardware failure -4 in getting WRED stat 69 for port 8
Aug  5 08:04:15.161748 str-7260cx3-acs-7 ERR syncd#syncd: [none] brcm_sai_get_port_stats:2064 port wred stats get failed with error Table empty (0xfffffffb).
Aug  5 08:04:18.515152 str-7260cx3-acs-7 NOTICE kernel: [   34.888906] audit: type=1400 audit(1596614658.511:8): apparmor="DENIED" operation="open" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" name="sbin" pid=4518 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
Aug  5 08:04:18.541462 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet260. No PG profile configured for speed 10000 and cable length 300m
Aug  5 08:04:18.541462 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doTask: Failed to process invalid entry, drop it
```