### PR TITLE
Fix spelling mistake in verify_show_platform_temperature_output

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -144,7 +144,7 @@ def verify_show_platform_temperature_output(raw_output_lines):
 
     pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output")
     if len(raw_output_lines) == 1:
-        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Thernal Not detected", "Unexpected thermal status output")
+        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Thermal Not detected", "Unexpected thermal status output")
     else:
         pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output if any thermal is detected")
         second_line = raw_output_lines[1]


### PR DESCRIPTION
There is a minor spelling mistake in verify_show_platform_temperature_output, which leads to test failure.
This PR address this issue.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
**Fix spelling mistake in verify_show_platform_temperature_output**
There is a minor spelling mistake in verify_show_platform_temperature_output, which leads to test failure.
 This PR address this issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix spelling mistake in verify_show_platform_temperature_output, which leads to test failure.
#### How did you do it?
Fix spelling mistake.
#### How did you verify/test it?
Verify this PR in Arista-7260.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.