### PR TITLE
[ser] skip broadcom ser test for now

### DIFF
--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -67,6 +67,7 @@ def test_setup_teardown(duthost, localhost):
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.broadcom
+@pytest.mark.skip(reason="Test is currently taking multiple hours to false negatively pass")
 def test_ser(duthost):
     '''
     @summary: Broadcom SER injection test use Broadcom SER injection utility to insert SER


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
While working on add completeness support to this test, I found that this test was actually failing after 2-3 hours, but because the test script ser_injector.py never returned none-zero return code. The failure had been always ignored.

#### How did you do it?
Unfortunately this test is passing as false negative. The test never returned failure code even when the test has unverified
memory addresses.

During the test, the iteration wait time was too long (20 min), and the most of the wait period didn't have any syslog hit or
miss.

There are always mynsterious SER correction addresses that are not in the test candidate address list.

Take this test out of service until these issues were figured out.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
yinxi@acs-trusty8:/var/src/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos -u -p /tmp/logs-01 -c platform_tests/broadcom/test_ser.py 
=== Running tests in groups ===
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, forked-1.1.3, repeat-0.8.0
collected 1 item                                                                                                                                                                         

platform_tests/broadcom/test_ser.py::test_ser SKIPPED                                                                                                                              [100%]
