### PR TITLE
Add asic marker to cases for mellanox

### DIFF
--- a/tests/platform_tests/mellanox/test_check_sfp_presence.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_presence.py
@@ -9,6 +9,7 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 
 pytestmark = [
+    pytest.mark.asic('mellanox'),
     pytest.mark.topology('any')
 ]
 

--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -13,6 +13,7 @@ from tests.common.mellanox_data import SPC3_HWSKUS
 from check_hw_mgmt_service import check_hw_management_service
 
 pytestmark = [
+    pytest.mark.asic('mellanox'),
     pytest.mark.topology('any')
 ]
 

--- a/tests/platform_tests/mellanox/test_check_sysfs.py
+++ b/tests/platform_tests/mellanox/test_check_sysfs.py
@@ -9,6 +9,7 @@ import pytest
 from check_sysfs import check_sysfs
 
 pytestmark = [
+    pytest.mark.asic('mellanox'),
     pytest.mark.topology('any')
 ]
 

--- a/tests/platform_tests/mellanox/test_hw_management_service.py
+++ b/tests/platform_tests/mellanox/test_hw_management_service.py
@@ -8,6 +8,7 @@ import pytest
 from check_hw_mgmt_service import check_hw_management_service
 
 pytestmark = [
+    pytest.mark.asic('mellanox'),
     pytest.mark.topology('any')
 ]
 

--- a/tests/platform_tests/mellanox/test_thermal_control.py
+++ b/tests/platform_tests/mellanox/test_thermal_control.py
@@ -10,6 +10,7 @@ from tests.platform_tests.thermal_control_test_helper import *
 from mellanox_thermal_control_test_helper import MockerHelper, AbnormalFanMocker
 
 pytestmark = [
+    pytest.mark.asic('mellanox'),
     pytest.mark.topology('any')
 ]
 


### PR DESCRIPTION
Currently there is no asic marker for cases under platform_tests/mellanox so that we are not able to skip them.
This PR will add asic marker to these cases.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
**Add asic marker to cases for mellanox**
    Currently there is no asic marker for cases under platform_tests/mellanox so that we are not able to skip them.
    This PR will add asic marker to these cases.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to add ASIC marker to test cases under platform_tests/mellanox so that we can skip them on other platforms.
#### How did you do it?
Add ASIC marker to each test cases under platform_tests/mellanox.
#### How did you verify/test it?
Verify it on Arista-7260 with broadcom ASIC.
```
py.test --inventory ../ansible/str --testbed tb --testbed_file ../ansible/testbed.csv --log-cli-level warn --log-file-level debug --showlocals --assert plain --show-capture no -rav --allow_recover --topology t0,any platform_tests/mellanox --allow_recover --showlocals --assert plain -rav --module-path ../ansible/library/ --collect_techsupport False --asic broadcom
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 7 items                                                                                                                                                                                     

platform_tests/mellanox/test_check_sfp_presence.py::test_check_sfp_presence SKIPPED                                                                                                             [ 14%]
platform_tests/mellanox/test_check_sfp_using_ethtool.py::test_check_sfp_using_ethtool SKIPPED                                                                                                   [ 28%]
platform_tests/mellanox/test_check_sysfs.py::test_check_hw_mgmt_sysfs SKIPPED                                                                                                                   [ 42%]
platform_tests/mellanox/test_check_sysfs.py::test_hw_mgmt_sysfs_mapped_to_pmon SKIPPED                                                                                                          [ 57%]
platform_tests/mellanox/test_hw_management_service.py::test_hw_management_service_status SKIPPED                                                                                                [ 71%]
platform_tests/mellanox/test_thermal_control.py::test_dynamic_minimum_table SKIPPED                                                                                                             [ 85%]
platform_tests/mellanox/test_thermal_control.py::test_set_psu_fan_speed SKIPPED                                                                                                                 [100%]

----------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/platform_tests/mellanox.xml ------------------------------------------------------
======================================================================================= short test summary info =======================================================================================
SKIPPED [7] /data/sonic-mgmt/tests/common/plugins/custom_markers/__init__.py:86: test requires asic in ['mellanox']
====================================================================================== 7 skipped in 0.06 seconds ======================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.