### PR TITLE
[get_ip_route_info]: Return empty rtinfo when there is no route_entry

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -32,7 +32,13 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
     ifnames_v4 = [nh[1] for nh in rtinfo_v4['nexthops']]
     ifnames_v6 = [nh[1] for nh in rtinfo_v6['nexthops']]
 
+    logger.info("ifnames_v4: %s" % ifnames_v4)
+    logger.info("ifnames_v6: %s" % ifnames_v6)
+
     ifnames_common = [ ifname for ifname in ifnames_v4 if ifname in ifnames_v6 ]
+    if len(ifnames_common) == 0:
+        pytest.skip("No common ifnames between ifnames_v4 and ifname_v6: %s and %s" % (ifnames_v4, ifnames_v6))
+
     ifname = ifnames_common[0]
 
     # get neighbor device connected ports

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -600,6 +600,9 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
             logging.info("route raw info for {}: {}".format(dstip, rt))
 
+            if len(rt) == 0:
+                return rtinfo
+
             # parse set_src
             m = re.match(r"^(default|\S+) proto (zebra|bgp|186) src (\S+)", rt[0])
             m1 = re.match(r"^(default|\S+) via (\S+) dev (\S+) proto (zebra|bgp|186) src (\S+)", rt[0])
@@ -617,6 +620,10 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         elif isinstance(dstip, ipaddress.IPv4Address) or isinstance(dstip, ipaddress.IPv6Address):
             rt = self.command("ip route get {}".format(dstip))['stdout_lines']
             logging.info("route raw info for {}: {}".format(dstip, rt))
+
+            if len(rt) == 0:
+                return rtinfo
+
             m = re.match(".+\s+via\s+(\S+)\s+.*dev\s+(\S+)\s+.*src\s+(\S+)\s+", rt[0])
             if m:
                 nexthop_ip = ipaddress.ip_address(unicode(m.group(1)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
get_ip_route_info() fails when there was no requested entry in the routing table
 
#### How did you do it?
Check if there is empty reply on ip route request and return empty rt_info in this case

#### How did you verify/test it?
Add following code to the bottom of bgp/test_bgp_speaker.py
```
@pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(False, True, 1514)])
def test_bgp_speaker_announce_routes_v3(common_setup_teardown, testbed, duthost, ptfhost, ipv4, ipv6, mtu, collect_techsupport):
    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(unicode("0.0.0.0/0")))
    logging.info("exist rtinfo=%s" % rtinfo)

    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(unicode("123::/128")))
    logging.info("not exist rtinfo=%s" % rtinfo)
```
Run the test
```
pytest bgp/test_bgp_speaker.py --testbed=vms3-t0-s6100 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=vms3-t0-s6100 --module-path=../ansible/library --disable_loganalyzer --log-cli-level=info -k test_bgp_speaker_announce_routes_v3
```
Syslog output for the test should include:
```
14:42:08 INFO devices.py:get_ip_route_info:542: route raw info for 0.0.0.0/0: [u'default proto 186 src 10.1.0.32 metric 20 ', u'\tnexthop via 10.0.0.1  dev PortChannel0001 weight 1', u'\tnexthop via 10.0.0.5  dev PortChannel0002 weight 1', u'\tnexthop via 10.0.0.9  dev PortChannel0003 weight 1', u'\tnexthop via 10.0.0.13  dev PortChannel0004 weight 1']
14:42:08 INFO devices.py:get_ip_route_info:575: route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
14:42:08 INFO test_bgp_speaker.py:test_bgp_speaker_announce_routes_v3:305: exist rtinfo={'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
14:42:08 INFO devices.py:get_ip_route_info:542: route raw info for 123::/128: []
14:42:08 INFO test_bgp_speaker.py:test_bgp_speaker_announce_routes_v3:308: not exist rtinfo={'set_src': None, 'nexthops': []}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
