### PR TITLE
[Mellanox] QoS test enhancement for more-than-64-ports systems support . Avoid hard coded value usage

### DIFF
--- a/tests/qos/files/mellanox/packets_aging.py
+++ b/tests/qos/files/mellanox/packets_aging.py
@@ -28,10 +28,23 @@ if (rc != SX_STATUS_SUCCESS):
     print >> sys.stderr, "Failed to open api handle.\nPlease check that SDK is running."
     sys.exit(errno.EACCES)
 
-# Get list of ports
-port_attributes_list = new_sx_port_attributes_t_arr(128)
+# Get number of ports
+port_attributes_list = new_sx_port_attributes_t_arr(0)
 port_cnt_p = new_uint32_t_p()
-uint32_t_p_assign(port_cnt_p, 128)
+uint32_t_p_assign(port_cnt_p, 0)
+
+rc = sx_api_port_device_get(handle, 1 , 0, port_attributes_list,  port_cnt_p)
+if (rc != SX_STATUS_SUCCESS):
+    print >> sys.stderr, "An error returned by sx_api_port_device_get."
+    sys.exit()
+port_cnt = uint32_t_p_value(port_cnt_p)
+
+print >> sys.stderr, "Got port count {}".format(port_cnt)
+
+# Get list of ports
+port_attributes_list = new_sx_port_attributes_t_arr(port_cnt)
+port_cnt_p = new_uint32_t_p()
+uint32_t_p_assign(port_cnt_p, port_cnt)
 
 rc = sx_api_port_device_get(handle, 1 , 0, port_attributes_list,  port_cnt_p)
 if (rc != SX_STATUS_SUCCESS):

--- a/tests/qos/files/mellanox/packets_aging.py
+++ b/tests/qos/files/mellanox/packets_aging.py
@@ -29,9 +29,9 @@ if (rc != SX_STATUS_SUCCESS):
     sys.exit(errno.EACCES)
 
 # Get list of ports
-port_attributes_list = new_sx_port_attributes_t_arr(64)
+port_attributes_list = new_sx_port_attributes_t_arr(128)
 port_cnt_p = new_uint32_t_p()
-uint32_t_p_assign(port_cnt_p, 64)
+uint32_t_p_assign(port_cnt_p, 128)
 
 rc = sx_api_port_device_get(handle, 1 , 0, port_attributes_list,  port_cnt_p)
 if (rc != SX_STATUS_SUCCESS):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Many test cases of QoS depend on closing the egress port to create congestion. There are some timers inside the ASIC controlling the lifetime of packets. These timers need to be adjusted as well otherwise the packets can be dropped due to timeout. Some timers are per-port, which means we need to fetch all ports to set them.
The original logic of fetching port assumes the maximum number of ports is 64, which is not true any longer on some new switches with more than 64 ports. As a result, the timer is set for only the first 64 ports, thus failing the test.
In this PR the logic has been updated to fetching the port count first and then fetching each port.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
