### PR TITLE
change timeouts on changes involving bgp to allow for convergence

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -681,6 +681,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         """
         ret = None
+        bgp_facts = self.bgp_facts()['ansible_facts']
         if stat in bgp_facts['bgp_statistics']:
             ret = bgp_facts['bgp_statistics'][stat]
         return ret;

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -687,7 +687,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         
     def check_bgp_statistic(self, stat, value):
         val = get_bgp_statistic(stat)
-        return val == value:
+        return val == value
 
     def get_bgp_neighbors(self):
         """

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -671,6 +671,24 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         return nbinfo[str(neighbor_ip)]
 
+    def get_bgp_statistic(self, stat):
+        """
+        Get the named bgp statistic
+
+        Args: stat - name of statistic
+
+        Returns: statistic value or None if not found
+
+        """
+        ret = None
+        if stat in bgp_facts['bgp_statistics']:
+            ret = bgp_facts['bgp_statistics'][stat]
+        return ret;
+        
+    def check_bgp_statistic(self, stat, value):
+        val = get_bgp_statistic(stat)
+        return val == value:
+
     def get_bgp_neighbors(self):
         """
         Get a diction of BGP neighbor states

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -682,12 +682,12 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         """
         ret = None
         bgp_facts = self.bgp_facts()['ansible_facts']
-        if stat in bgp_facts['bgp_statistics']:
-            ret = bgp_facts['bgp_statistics'][stat]
+        if stat in self.bgp_facts['bgp_statistics']:
+            ret = self.bgp_facts['bgp_statistics'][stat]
         return ret;
         
     def check_bgp_statistic(self, stat, value):
-        val = get_bgp_statistic(stat)
+        val = self.get_bgp_statistic(stat)
         return val == value
 
     def get_bgp_neighbors(self):

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -682,8 +682,8 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         """
         ret = None
         bgp_facts = self.bgp_facts()['ansible_facts']
-        if stat in self.bgp_facts['bgp_statistics']:
-            ret = self.bgp_facts['bgp_statistics'][stat]
+        if stat in bgp_facts['bgp_statistics']:
+            ret = bgp_facts['bgp_statistics'][stat]
         return ret;
         
     def check_bgp_statistic(self, stat, value):

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -73,7 +73,6 @@ def test_po_update(duthost):
         time.sleep(30)
         int_facts = duthost.interface_facts()['ansible_facts']
         assert not int_facts['ansible_interface_facts'][portchannel]['link']
-        bgp_facts = duthost.bgp_facts()['ansible_facts']
         if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 1):
             assert duthost.get_bgp_statistic('ipv4_idle') == 1
 
@@ -95,7 +94,6 @@ def test_po_update(duthost):
         time.sleep(30)
         int_facts = duthost.interface_facts()['ansible_facts']
         assert int_facts['ansible_interface_facts'][tmp_portchannel]['link']
-        bgp_facts = duthost.bgp_facts()['ansible_facts']
         if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0):
             assert duthost.get_bgp_statistic('ipv4_idle') == 0
     finally:

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -3,6 +3,7 @@ import pytest
 import logging
 
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -74,9 +75,9 @@ def test_po_update(duthost):
 
         time.sleep(30)
         int_facts = duthost.interface_facts()['ansible_facts']
-        assert not int_facts['ansible_interface_facts'][portchannel]['link']
+        pytest_assert(not int_facts['ansible_interface_facts'][portchannel]['link'])
         if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 1):
-            assert duthost.get_bgp_statistic('ipv4_idle') == 1
+            pytest_assert(duthost.get_bgp_statistic('ipv4_idle') == 1)
 
         # Step 3: Create tmp portchannel
         duthost.shell("config portchannel add %s" % tmp_portchannel)
@@ -90,14 +91,14 @@ def test_po_update(duthost):
         # Step 5: Add portchannel ip to tmp portchannel
         duthost.shell("config interface ip add %s %s/31" % (tmp_portchannel, portchannel_ip))
         int_facts = duthost.interface_facts()['ansible_facts']
-        assert int_facts['ansible_interface_facts'][tmp_portchannel]['ipv4']['address'] == portchannel_ip
+        pytest_assert(int_facts['ansible_interface_facts'][tmp_portchannel]['ipv4']['address'] == portchannel_ip)
         add_tmp_portchannel_ip = True
 
         time.sleep(30)
         int_facts = duthost.interface_facts()['ansible_facts']
-        assert int_facts['ansible_interface_facts'][tmp_portchannel]['link']
+        pytest_assert(int_facts['ansible_interface_facts'][tmp_portchannel]['link'])
         if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0):
-            assert duthost.get_bgp_statistic('ipv4_idle') == 0
+            pytest_assert(duthost.get_bgp_statistic('ipv4_idle') == 0)
     finally:
         # Recover all states
         if add_tmp_portchannel_ip:
@@ -117,5 +118,5 @@ def test_po_update(duthost):
             for member in portchannel_members:
                 duthost.shell("config portchannel member add %s %s" % (portchannel, member))
         if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0):
-            assert duthost.get_bgp_statistic('ipv4_idle') == 0
+            pytest_assert(duthost.get_bgp_statistic('ipv4_idle') == 0)
 

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -2,6 +2,8 @@ import time
 import pytest
 import logging
 
+from tests.common.utilities import wait_until
+
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -70,7 +70,7 @@ def test_po_update(duthost):
         duthost.shell("config interface ip remove %s %s/31" % (portchannel, portchannel_ip))
         remove_portchannel_ip = True
 
-        time.sleep(30)
+        time.sleep(180)
         int_facts = duthost.interface_facts()['ansible_facts']
         assert not int_facts['ansible_interface_facts'][portchannel]['link']
         bgp_facts = duthost.bgp_facts()['ansible_facts']
@@ -91,7 +91,7 @@ def test_po_update(duthost):
         assert int_facts['ansible_interface_facts'][tmp_portchannel]['ipv4']['address'] == portchannel_ip
         add_tmp_portchannel_ip = True
 
-        time.sleep(30)
+        time.sleep(180)
         int_facts = duthost.interface_facts()['ansible_facts']
         assert int_facts['ansible_interface_facts'][tmp_portchannel]['link']
         bgp_facts = duthost.bgp_facts()['ansible_facts']
@@ -115,6 +115,6 @@ def test_po_update(duthost):
             for member in portchannel_members:
                 duthost.shell("config portchannel member add %s %s" % (portchannel, member))
 
-        time.sleep(30)
+        time.sleep(180)
         bgp_facts = duthost.bgp_facts()['ansible_facts']
         assert bgp_facts['bgp_statistics']['ipv4_idle'] == 0

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -76,8 +76,7 @@ def test_po_update(duthost):
         time.sleep(30)
         int_facts = duthost.interface_facts()['ansible_facts']
         pytest_assert(not int_facts['ansible_interface_facts'][portchannel]['link'])
-        if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 1):
-            pytest_assert(duthost.get_bgp_statistic('ipv4_idle') == 1)
+        pytest_assert(wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 1))
 
         # Step 3: Create tmp portchannel
         duthost.shell("config portchannel add %s" % tmp_portchannel)
@@ -97,8 +96,7 @@ def test_po_update(duthost):
         time.sleep(30)
         int_facts = duthost.interface_facts()['ansible_facts']
         pytest_assert(int_facts['ansible_interface_facts'][tmp_portchannel]['link'])
-        if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0):
-            pytest_assert(duthost.get_bgp_statistic('ipv4_idle') == 0)
+        pytest_assert(wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0))
     finally:
         # Recover all states
         if add_tmp_portchannel_ip:
@@ -117,6 +115,5 @@ def test_po_update(duthost):
         if remove_portchannel_members:
             for member in portchannel_members:
                 duthost.shell("config portchannel member add %s %s" % (portchannel, member))
-        if not wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0):
-            pytest_assert(duthost.get_bgp_statistic('ipv4_idle') == 0)
+        pytest_assert(wait_until(120, 10, duthost.check_bgp_statistic, 'ipv4_idle', 0))
 


### PR DESCRIPTION
[sonic-mgmt] replace 30 second sleeps around bgp changes to polling for up to 120  sec to allow time for convergence.

Signed-off-by: Syd Logan syd.logan@broadcom.com

