### PR TITLE
[docker]: Set default image for docker container setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ Use the `setup-container.sh` script to automatically create and configure your s
 Usage ./setup-container.sh [options]
 Options with (*) are required
 -h -?                 : get this help
+
 -n <container name>   : (*) set the name of the Docker container 
--i <image ID>         : (*) specify Docker image to use
+
+-i <image ID>         : specify Docker image to use. This can be an image ID (hashed value) or an image name.
+                      | If no value is provided, defaults to the following images in the specified order:
+                      |   1. The local image named \"docker-sonic-mgmt\"
+                      |   2. The local image named \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\"
+                      |   3. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\"
+                      |      Note: to use option 3, your system must have Python3 with the PyYAML package installed
+
 -d <directory>        : specify directory inside container to bind mount to sonic-mgmt root (default "/var/src/")
 ```
 

--- a/ansible/doc/README.testbed.VsSetup.md
+++ b/ansible/doc/README.testbed.VsSetup.md
@@ -47,6 +47,7 @@ $ mv sonic-vs.img ~/sonic-vm/images
 ## Setup sonic-mgmt docker
 
 ### Build or download *sonic-mgmt* docker image
+(Note: downloading or building the sonic-mgmt image is optional)
 
 ansible playbook in *sonic-mgmt* repo requires to setup ansible and various dependencies.
 We have built a *sonic-mgmt* docker that installs all dependencies, and you can build
@@ -73,7 +74,7 @@ Run the `setup-container.sh` in the root directory of the sonic-mgmt repository:
 
 ```
 $ cd sonic-mgmt
-$ ./setup-container.sh -n <container name> -i docker-sonic-mgmt -d /data
+$ ./setup-container.sh -n <container name> -d /data
 ```
 
 From now on, all steps are running inside the *sonic-mgmt* docker except where otherwise specified.

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -1,17 +1,32 @@
 #! /bin/bash
 
+DOCKER_SONIC_MGMT="docker-sonic-mgmt"
+DOCKER_REGISTRY="sonicdev-microsoft.azurecr.io:443/"
+VAR_FILE="ansible/vars/docker_registry.yml"
+USER_KEY="docker_registry_username"
+PASS_KEY="docker_registry_password"
+
 function show_help_and_exit() {
     echo "Usage $0 [options]"
     echo "Options with (*) are required"
+    echo ""
     echo "-h -?                 : get this help"
+    echo ""
     echo "-n <container name>   : (*) set the name of the Docker container"
-    echo "-i <image ID>         : (*) specify Docker image to use"
+    echo ""
+    echo "-i <image ID>         : specify Docker image to use. This can be an image ID (hashed value) or an image name."
+    echo "                      | If no value is provided, defaults to the following images in the specified order:"
+    echo "                      |   1. The local image named \"docker-sonic-mgmt\""
+    echo "                      |   2. The local image named \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\""
+    echo "                      |   3. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\""
+    echo "                      |      Note: to use option 3, your system must have Python3 with the PyYAML package installed"
+    echo ""
     echo "-d <directory>        : specify directory inside container to bind mount to sonic-mgmt root (default \"/var/src/\")"
     exit $1
 }
 
 function start_and_config_container() {
-    echo "Creating container"
+    echo "Creating container $CONTAINER_NAME"
     CURRENT_DIR=`pwd`/..
     docker run --name $CONTAINER_NAME -v $CURRENT_DIR:$LINK_DIR -d -t $IMAGE_ID bash > /dev/null
 
@@ -71,8 +86,28 @@ function validate_parameters() {
     fi
 
     if [[ -z ${IMAGE_ID} ]]; then
-        echo "Image ID not set"
-        show_help_and_exit 1
+        if docker images --format "{{.Repository}}" | grep -q "^${DOCKER_SONIC_MGMT}$"; then
+            IMAGE_ID=$DOCKER_SONIC_MGMT
+        elif docker images --format "{{.Repository}}" | grep -q "^${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}$"; then
+            IMAGE_ID=${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}
+        elif python3 -c "import yaml" 2> /dev/null ; then
+            echo "Pulling image from registry"
+            DOCKER_USER=`python3 -c "import yaml;print(yaml.load(open(\"$VAR_FILE\").read())[\"$USER_KEY\"])"`
+            DOCKER_PASS=`python3 -c "import yaml;print(yaml.load(open(\"$VAR_FILE\").read())[\"$PASS_KEY\"])"`
+        
+            if docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY > /dev/null 2> /dev/null; then
+                docker pull ${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}
+                IMAGE_ID=${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}  
+            else
+                echo "Problem logging into container registry, check credentials in $VAR_FILE"
+                exit 1
+            fi
+        else
+            echo "Unable to find a usable default image, please specify one manually"
+            show_help_and_exit 1
+            
+        fi
+        echo "Using default image $IMAGE_ID"
     fi
 
     if [[ -z ${LINK_DIR} ]]; then
@@ -104,6 +139,12 @@ while getopts "h?n:i:d:" opt; do
             ;;
         d )
             LINK_DIR=${OPTARG}
+            ;;
+        u )
+            DOCKER_USER=${OPTARG}
+            ;;
+        p )
+            DOCKER_PW=${OPTARG}
     esac
 done
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Sets a default docker-sonic-mgmt image as previously discussed here: https://github.com/Azure/sonic-mgmt/pull/2020#discussion_r464675492

* Use docker-sonic-mgmt for automated container setup by default or pull from SONiC container registry
* Update documentation to reflect this change
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make the container setup process as automated as possible, including picking a default sonic-mgmt image
#### How did you do it?
If no image is manually specified, attempt to use each of following images in the specified order:

1. An image on disk named "docker-sonic-mgmt"
2. An image on disk named "sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt"
3. The remote image located at "sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt" (this option currently requires Python3 with the PyYAML package installed. This requirement is necessary to read the container registry credentials from ansible/vars/docker_registry.yml and may be dropped in the future if passwordless read access can be enabled for the container registry)

#### How did you verify/test it?
Confirmed that all three default images are used in the order specified by manually removing and adding images.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->