### PR TITLE
[test_dhcp_relay] Ignore snmp error in LogAnalyzer

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -11,6 +11,19 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR snmp#snmp-subagent.*",
+        ]
+        loganalyzer.ignore_regex.extend(ignoreRegex)
+
+    yield
+
+
 @pytest.fixture(scope="module")
 def dut_dhcp_relay_data(duthost, ptfhost, testbed):
     """ Fixture which returns a list of dictionaries where each dictionary contains


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
To ignore the error introduce by `snmp subagent` during `test_dhcp_relay_start_with_uplinks_down`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>



Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
* log snippet
```
Jul 27 15:47:47.312560 str-7260-lab-1 ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 40, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 116, in reinit_data#012    self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'] = parse_sys_capability(self.loc_chassis_data[b'lldp_loc_sys_cap_enabled'])#012KeyError: b'lldp_loc_sys_cap_enabled'
```
#### How did you do it?
Add ignore regex to `LogAnalyzer` to ignore this type of error.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
