### PR TITLE
[Mellanox] Skip fan default speed check

### DIFF
--- a/tests/platform_tests/mellanox/check_hw_mgmt_service.py
+++ b/tests/platform_tests/mellanox/check_hw_mgmt_service.py
@@ -4,8 +4,6 @@ Helper function for checking the hw-management service
 import logging
 import re
 
-from tests.common.utilities import wait_until
-
 
 def check_hw_management_service(dut):
     """This function is to check the hw management service and related settings.

--- a/tests/platform_tests/mellanox/check_hw_mgmt_service.py
+++ b/tests/platform_tests/mellanox/check_hw_mgmt_service.py
@@ -7,22 +7,9 @@ import re
 from tests.common.utilities import wait_until
 
 
-def fan_speed_set_to_default(dut):
-    fan_speed_setting = dut.command("cat /var/run/hw-management/thermal/pwm1")["stdout"].strip()
-    return fan_speed_setting == "153"
-
-
-def wait_until_fan_speed_set_to_default(dut, timeout=300, interval=10):
-    wait_until(timeout, interval, fan_speed_set_to_default, dut)
-
-
 def check_hw_management_service(dut):
     """This function is to check the hw management service and related settings.
     """
-    logging.info("Check fan speed setting")
-    assert not wait_until_fan_speed_set_to_default(dut), \
-        "Fan speed is not default to 60 percent in 5 minutes. 153/255=60%"
-
     logging.info("Check service status using systemctl")
     hw_mgmt_service_state = dut.get_service_props("hw-management")
     assert hw_mgmt_service_state["ActiveState"] == "active", "The hw-management service is not active"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Mellanox no longer set default fan speed to 60% since there is thermal control running. No need to wait fan speed to reach 60%.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

It always take 5 minutes to wait for fan speed to reach 60% because fan speed will not reach that value with thermal control enabled.

#### How did you do it?

Remove the unused wait.

#### How did you verify/test it?

Manual test.

#### Any platform specific information?

All mellanox platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
