### PR TITLE
[vm_set]: ensure ansible user in libvirt group

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -97,8 +97,17 @@
 - name: Ensure {{ ansible_user }} in docker,sudo group
   user:
     name: "{{ ansible_user }}"
+    append: yes
     groups: docker,sudo
   become: yes
+
+- name: Ensure {{ ansible_user }} in libvirt group
+  user:
+    name: "{{ ansible_user }}"
+    append: yes
+    groups: libvirt
+  become: yes
+  when: host_distribution_version.stdout == "20.04"
 
 - name: Install br_netfilter kernel module
   become: yes


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ensure ansible user is in libvirt group

on ubuntu 20.04, ansible user needs to be in libvirt group to access
virsh commands

#### How did you do it?
add ansible user to be in libvirt group

#### How did you verify/test it?
run refresh-dut command and verify the ansible user is added to the libvirt group 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
