### PR TITLE
[docker-setup]: Remove requirement for PyYAML to pull from registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Options with (*) are required
                       |   1. The local image named \"docker-sonic-mgmt\"
                       |   2. The local image named \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\"
                       |   3. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\"
-                      |      Note: to use option 3, your system must have Python3 with the PyYAML package installed
 
 -d <directory>        : specify directory inside container to bind mount to sonic-mgmt root (default "/var/src/")
 ```

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -2,9 +2,6 @@
 
 DOCKER_SONIC_MGMT="docker-sonic-mgmt"
 DOCKER_REGISTRY="sonicdev-microsoft.azurecr.io:443/"
-VAR_FILE="ansible/vars/docker_registry.yml"
-USER_KEY="docker_registry_username"
-PASS_KEY="docker_registry_password"
 
 function show_help_and_exit() {
     echo "Usage $0 [options]"
@@ -19,7 +16,6 @@ function show_help_and_exit() {
     echo "                      |   1. The local image named \"docker-sonic-mgmt\""
     echo "                      |   2. The local image named \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\""
     echo "                      |   3. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\""
-    echo "                      |      Note: to use option 3, your system must have Python3 with the PyYAML package installed"
     echo ""
     echo "-d <directory>        : specify directory inside container to bind mount to sonic-mgmt root (default \"/var/src/\")"
     exit $1
@@ -90,18 +86,8 @@ function validate_parameters() {
             IMAGE_ID=$DOCKER_SONIC_MGMT
         elif docker images --format "{{.Repository}}" | grep -q "^${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}$"; then
             IMAGE_ID=${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}
-        elif python3 -c "import yaml" 2> /dev/null ; then
-            echo "Pulling image from registry"
-            DOCKER_USER=`python3 -c "import yaml;print(yaml.load(open(\"$VAR_FILE\").read())[\"$USER_KEY\"])"`
-            DOCKER_PASS=`python3 -c "import yaml;print(yaml.load(open(\"$VAR_FILE\").read())[\"$PASS_KEY\"])"`
-        
-            if docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY > /dev/null 2> /dev/null; then
-                docker pull ${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}
-                IMAGE_ID=${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}  
-            else
-                echo "Problem logging into container registry, check credentials in $VAR_FILE"
-                exit 1
-            fi
+        elif echo "Pulling image from registry" && docker pull ${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}; then 
+            IMAGE_ID=${DOCKER_REGISTRY}${DOCKER_SONIC_MGMT}  
         else
             echo "Unable to find a usable default image, please specify one manually"
             show_help_and_exit 1


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

* Since the SONiC container registry now has anonymous read access enabled, reading the registry credentials with PyYAML is no longer required

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Previously, the SONiC container registry did not allow anonymous read access so the container setup script depended on PyYAML to read the registry credentials from `ansible/vars/docker_registry.yml` in order to run `docker login` before pulling the image. However, anonymous read has now been enabled for the registry, eliminating this dependency.

#### How did you do it?
Remove all Python commands and references to YAML.

#### How did you verify/test it?
Manually remove all docker-sonic-mgmt images from my machine and confirm that all three default images can be used to create a container.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
