### PR TITLE
[docker-setup]: Fix docker group membership check

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -76,6 +76,12 @@ function start_and_config_container() {
 
 
 function validate_parameters() {
+    if ! `id -Gn $USER | grep -q '\bdocker\b'`; then
+        echo "User $USER is not in the docker group"
+        echo "Please add $USER to the docker group before proceeding"
+        exit 1
+    fi
+
     if [[ -z ${CONTAINER_NAME} ]]; then
         echo "Container name not set"
         show_help_and_exit 1
@@ -99,12 +105,6 @@ function validate_parameters() {
     if [[ -z ${LINK_DIR} ]]; then
         LINK_DIR="/var/src"
         echo "Using default bind mount directory $LINK_DIR"
-    fi
-
-    if [[ ! `id -Gn $USER | grep '\bdocker\b'` ]]; then
-        echo "User $USER is not in the docker group"
-        echo "Please add $USER to the docker group before proceeding"
-        exit 1
     fi
 }
 

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -76,9 +76,9 @@ function start_and_config_container() {
 
 
 function validate_parameters() {
-    if ! `id -Gn $USER | grep -q '\bdocker\b'`; then
-        echo "User $USER is not in the docker group"
-        echo "Please add $USER to the docker group before proceeding"
+    if ! docker ps > /dev/null 2> /dev/null; then
+        echo "Unable to access Docker daemon"
+        echo "Hint: make sure $USER is a member of the docker group"
         exit 1
     fi
 

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -76,7 +76,7 @@ function start_and_config_container() {
 
 
 function validate_parameters() {
-    if ! docker ps > /dev/null 2> /dev/null; then
+    if ! docker info > /dev/null 2> /dev/null; then
         echo "Unable to access Docker daemon"
         echo "Hint: make sure $USER is a member of the docker group"
         exit 1


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fix the check that the user is a member of the docker group. Also moves the membership check to before any docker commands are run.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Prevent docker commands from running without first validating that user is a member of the docker group. It is possible for a user to have docker permissions without explicitly being in the docker group (show by `id -Gn <user>` or `groups <user>`). The previous approach grepped the output of `id -Gn` for the docker group, which is not always reliable.

#### How did you do it?
Instead of searching the output of `id -Gn`, check if user is able to run `docker info` successfully. Successful execution indicates the user has docker privileges, failure means the use does not have docker privileges. 
#### How did you verify/test it?
Remove user from docker group and run script - ensure that script exits early with correct error message about group membership.
Re-add user to docker group and run script - ensure that script completes successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
