### PR TITLE
[Platform API][pytest]Fan_drawer class basic platform api tests

### DIFF
--- a/tests/common/helpers/platform_api/fan_drawer.py
+++ b/tests/common/helpers/platform_api/fan_drawer.py
@@ -1,0 +1,61 @@
+""" This module provides interface to interact with the fan_drawer of the DUT
+    via platform API remotely """
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def fan_drawer_api(conn, index, name, args=None):
+    if args is None:
+        args = []
+    conn.request('POST', '/platform/chassis/fan_drawer/{}/{}'.format(index, name), json.dumps({'args': args}))
+    resp = conn.getresponse()
+    res = json.loads(resp.read())['res']
+    logger.info('Executing fan_drawer API: "{}", index: {}, arguments: "{}", result: "{}"'.format(name, index, args, res))
+    return res
+
+#
+# Methods inherited from DeviceBase class
+#
+
+
+def get_name(conn, index):
+    return fan_drawer_api(conn, index, 'get_name')
+
+
+def get_presence(conn, index):
+    return fan_drawer_api(conn, index, 'get_presence')
+
+
+def get_model(conn, index):
+    return fan_drawer_api(conn, index, 'get_model')
+
+
+def get_serial(conn, index):
+    return fan_drawer_api(conn, index, 'get_serial')
+
+
+def get_status(conn, index):
+    return fan_drawer_api(conn, index, 'get_status')
+
+#
+# Methods defined in fan_drawerBase class
+#
+
+
+def get_num_fans(conn, index):
+    return fan_drawer_api(conn, index, 'get_num_fans')
+
+
+def get_all_fans(conn, index):
+    return fan_drawer_api(conn, index, 'get_all_fans')
+
+
+def set_status_led(conn, index, color):
+    return fan_drawer_api(conn, index, 'set_status_led', [color])
+
+
+def get_status_led(conn, index):
+    return fan_drawer_api(conn, index, 'get_status_led')

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -1,0 +1,134 @@
+import logging
+import random
+import re
+import time
+
+import pytest
+import yaml
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.platform_api import chassis, fan_drawer
+
+from platform_api_test_base import PlatformApiTestBase
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
+]
+
+STATUS_LED_COLOR_GREEN = "green"
+STATUS_LED_COLOR_AMBER = "amber"
+STATUS_LED_COLOR_RED = "red"
+STATUS_LED_COLOR_OFF = "off"
+
+
+class TestFan_drawer_DrawerApi(PlatformApiTestBase):
+
+    num_fan_drawers = None
+
+    # This fixture would probably be better scoped at the class level, but
+    # it relies on the platform_api_conn fixture, which is scoped at the function
+    # level, so we must do the same here to prevent a scope mismatch.
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, platform_api_conn):
+        if self.num_fan_drawers is None:
+            try:
+                self.num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
+            except:
+                pytest.fail("num_fan_drawers is not an integer")
+
+    #
+    # Functions to test methods inherited from DeviceBase class
+    #
+    def test_get_name(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+            name = fan_drawer.get_name(platform_api_conn, i)
+
+            if self.expect(name is not None, "Unable to retrieve Fan_drawer {} name".format(i)):
+                self.expect(isinstance(name, str), "Fan_drawer {} name appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    def test_get_presence(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+            presence = fan_drawer.get_presence(platform_api_conn, i)
+
+            if self.expect(presence is not None, "Unable to retrieve fan_drawer {} presence".format(i)):
+                if self.expect(isinstance(presence, bool), "Fan_drawer {} presence appears incorrect".format(i)):
+                    self.expect(presence is True, "Fan_drawer {} is not present".format(i))
+
+        self.assert_expectations()
+
+    def test_get_model(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+            model = fan_drawer.get_model(platform_api_conn, i)
+
+            if self.expect(model is not None, "Unable to retrieve fan_drawer {} model".format(i)):
+                self.expect(isinstance(model, str), "Fan_drawer {} model appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    def test_get_serial(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+            serial = fan_drawer.get_serial(platform_api_conn, i)
+
+            if self.expect(serial is not None, "Unable to retrieve fan_drawer {} serial number".format(i)):
+                self.expect(isinstance(serial, str), "Fan_drawer {} serial number appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    def test_get_status(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+            status = fan_drawer.get_status(platform_api_conn, i)
+
+            if self.expect(status is not None, "Unable to retrieve fan_drawer {} status".format(i)):
+                self.expect(isinstance(status, bool), "Fan_drawer {} status appears incorrect".format(i))
+
+        self.assert_expectations()
+
+    #
+    # Functions to test methods defined in Fan_drawerBase class
+    #
+    def test_get_num_fan(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+
+            num_fans = fan_drawer.get_num_fans(platform_api_conn, i)
+            if self.expect(num_fans is not None, "Unable to retrieve fan_drawer {} number of fans".format(i)):
+                self.expect(isinstance(num_fans, int), "fan drawer {} number of fans appear to be incorrect".format(i))
+        self.assert_expectations()
+
+    def test_get_all_fans(self, duthost, localhost, platform_api_conn):
+        for i in range(self.num_fan_drawers):
+
+            fans_list = fan_drawer.get_all_fans(platform_api_conn, i)
+            if self.expect(fans_list is not None, "Unable to retrieve fan_drawer {} all fans".format(i)):
+                self.expect(isinstance(fans_list, list), "fan drawer {} list of fans appear to be incorrect".format(i))
+        self.assert_expectations()
+
+    def test_set_fan_drawers_led(self, duthost, localhost, platform_api_conn):
+        LED_COLOR_LIST = [
+            "off",
+            "red",
+            "amber",
+            "green",
+        ]
+
+        for i in range(self.num_fan_drawers):
+            for color in LED_COLOR_LIST:
+
+                result = fan_drawer.set_status_led(platform_api_conn, i, color)
+                if self.expect(result is not None, "Failed to perform set_status_led"):
+                    self.expect(result is True, "Failed to set status_led for fan_drawer {} to {}".format(i, color))
+
+                color_actual = fan_drawer.get_status_led(platform_api_conn, i)
+
+                if self.expect(color_actual is not None, "Failed to retrieve status_led"):
+                    if self.expect(isinstance(color_actual, str), "Status LED color appears incorrect"):
+                        self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {} for fan_drawer {})".format(
+                            color, color_actual, i))
+
+        self.assert_expectations()

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -14,7 +14,6 @@ from platform_api_test_base import PlatformApiTestBase
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -92,7 +92,7 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
     #
     # Functions to test methods defined in Fan_drawerBase class
     #
-    def test_get_num_fan(self, duthost, localhost, platform_api_conn):
+    def test_get_num_fans(self, duthost, localhost, platform_api_conn):
         for i in range(self.num_fan_drawers):
 
             num_fans = fan_drawer.get_num_fans(platform_api_conn, i)


### PR DESCRIPTION
Add a basic test suite for the Fan_drawer class of the new platform API,
utilizing the platform API HTTP server, including the following functions:

```
test_get_name
test_get_presence
test_get_model
test_get_serial
test_get_status
test_get_num_fans
test_get_all_fans
test_set_fan_drawers_led
```

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
