### PR TITLE
[ptf_runner] Add timeout option for ptf test run

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -2,7 +2,7 @@ import pipes
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
-               socket_recv_size=None, log_file=None, device_sockets=[]):
+               socket_recv_size=None, log_file=None, device_sockets=[], timeout=0):
 
     cmd = "ptf --test-dir {} {}".format(testdir, testname)
 
@@ -33,5 +33,8 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
 
     if device_sockets:
         cmd += " ".join(map(" --device-socket {}".format, device_sockets))
+
+    if timeout:
+        cmd += " --test-case-timeout {}".format(int(timeout))
 
     host.shell(cmd, chdir="/root")


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Provide a testcase timeout option in ptf runner

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Passed the timeout option set to 120 in one of the scripts using ptf runner. Included a sleep of 600s in the testcase. The ptf runner timed out after 120s

E                    Failed: run module shell failed, Ansible Results =>
E                    {
E                        "changed": true, 
E                        "cmd": "ptf --test-dir ptftests pfc_wd.PfcWdTest --platform-dir ptftests --platform remote -t 'port_type='\"'\"'vlan'\"'\"';port_src=0;ip_dst=u'\"'\"'192.168.0.2'\"'\"';router_mac=u'\"'\"'74:83:ef:0a:c9:5c'\"'\"';wd_action='\"'\"'dontcare'\"'\"';pkt_count=100;port_dst='\"'\"'[55]'\"'\"';queue_index=4' --relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.2020-08-10-20:07:05.log --test-case-timeout 120", 
E                        "delta": "0:02:02.285100", 
E                        "end": "2020-08-10 18:57:49.258519", 
E                        "invocation": {
E                            "module_args": {
E                                "_raw_params": "ptf --test-dir ptftests pfc_wd.PfcWdTest --platform-dir ptftests --platform remote -t 'port_type='\"'\"'vlan'\"'\"';port_src=0;ip_dst=u'\"'\"'192.168.0.2'\"'\"';router_mac=u'\"'\"'74:83:ef:0a:c9:5c'\"'\"';wd_action='\"'\"'dontcare'\"'\"';pkt_count=100;port_dst='\"'\"'[55]'\"'\"';queue_index=4' --relax --debug info --log-file /tmp/pfc_wd.PfcWdTest.2020-08-10-20:07:05.log --test-case-timeout 120", 
E                                "_uses_shell": true, 
E                                "argv": null, 
E                                "chdir": "/root", 
E                                "creates": null, 
E                                "executable": null, 
E                                "removes": null, 
E                                "stdin": null, 
E                                "stdin_add_newline": true, 
E                                "strip_empty_ends": true, 
E                                "warn": true
E                            }
E                        }, 
E                        "msg": "non-zero return code", 
E                        "rc": 1, 
E                        "start": "2020-08-10 18:55:46.973419", 
E                        "stderr": "WARNING: No route found for IPv6 destination :: (no default route?)\npfc_wd.PfcWdTest ... ERROR\n\n======================================================================\nERROR: pfc_wd.PfcWdTest\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"ptftests/pfc_wd.py\", line 38, in runTest\n    time.sleep(600)\n  File \"/usr/lib/python2.7/dist-packages/ptf/ptfutils.py\", line 102, in raise_timeout\n    raise Timeout.TimeoutError()\nTimeoutError\n\n----------------------------------------------------------------------\nRan 1 test in 120.001s\n\nFAILED (errors=1)", 
E                        "stderr_lines": [
E                            "WARNING: No route found for IPv6 destination :: (no default route?)", 
E                            "pfc_wd.PfcWdTest ... ERROR", 
E                            "", 
E                            "======================================================================", 
E                            "ERROR: pfc_wd.PfcWdTest", 
E                            "----------------------------------------------------------------------", 
E                            "Traceback (most recent call last):", 
E                            "  File \"ptftests/pfc_wd.py\", line 38, in runTest", 
E                            "    time.sleep(600)", 
E                            "  File \"/usr/lib/python2.7/dist-packages/ptf/ptfutils.py\", line 102, in raise_timeout", 
E                            "    raise Timeout.TimeoutError()", 
E                            "TimeoutError", 
E                            "", 
E                            "----------------------------------------------------------------------", 
E                            "Ran 1 test in 120.001s", 
E                            "", 
E                            "FAILED (errors=1)"
E                        ], 
E                        "stdout": "", 
E                        "stdout_lines": []
E                    }
