### PR TITLE
[qos] Add timeout for qos sai ptf run

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -290,6 +290,8 @@ class QosSaiBase:
                 "--disable-nvgre",
                 "--log-file",
                 "/tmp/{0}.log".format(testCase),
+                "--test-case-timeout",
+                "600"
             ],
             chdir = "/root",
         )["rc"] == 0, "Failed when running test '{0}'".format(testCase)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Add a timeout of 600s for the ptf run

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In one of the nightly runs, the device had gone into a bad state while one of the qos sai tests was executing. The test remained in hung state till the device was recovered. Providing this timeout option should force the test to quit within 600s (which I believe is long enough for the test to finish normal execution) and continue with the rest of the cases.

#### How did you verify/test it?
Tested with the timeout set to 180s

E               "end": "2020-08-10 17:42:30.757390", 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": null, 
E                       "_uses_shell": true, 
E                       "argv": [
E                           "ptf", 
E                           "--test-dir", 
E                           "saitests", 
E                           "sai_qos_tests.HdrmPoolSizeTest", 
E                           "--platform-dir", 
E                           "ptftests", 
E                           "--platform", 
E                           "remote", 
E                           "-t", 
E                           "dst_port_2_ip='192.168.0.9';dst_port_3_ip='192.168.0.11';src_port_id=8;dst_port_ip='192.168.0.8';ecn=1;pkts_num_hdrm_full=520;pkts_num_hdrm_partial=47;sonic_asic_type=u'broadcom';src_port_ip='192.168.0.10';pgs=[3, 4];dst_port_2_id=7;src_port_ids=[6, 7, 8, 9, 10, 38, 39, 40, 41, 42];dst_port_id=6;port_map_file='/root/66_interface_to_front_map.ini';dst_port_3_id=9;pkts_num_trig_pfc=1490;dscps=[3, 4];router_mac='';server=u'10.64.246.78';pgs_num=19;testbed_type='t0-64';pkts_num_leak_out=0;src_port_ips=['192.168.0.8', '192.168.0.9', '192.168.0.10', '192.168.0.11', '192.168.0.12', '192.168.0.40', '192.168.0.41', '192.168.0.42', '192.168.0.43', '192.168.0.44']", 
E                           "--disable-ipv6", 
E                           "--disable-vxlan", 
E                           "--disable-geneve", 
E                           "--disable-erspan", 
E                           "--disable-mpls", 
E                           "--disable-nvgre", 
E                           "--log-file", 
E                           "/tmp/sai_qos_tests.HdrmPoolSizeTest.log", 
E                           "--test-case-timeout", 
E                           "180"
E                       ], 
E                       "chdir": "/root", 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2020-08-10 17:39:29.443738", 
E               "stderr": "sai_qos_tests.HdrmPoolSizeTest ... ['192.168.0.8', '192.168.0.9', '192.168.0.10', '192.168.0.11', '192.168.0.12', '192.168.0.40', '192.168.0.41', '192.168.0.42', '192.168.0.43', '192.168.0.44']\npkts num: leak_out: 0, trig_pfc: 1490, hdrm_full: 520, hdrm_partial: 47\n[(0, 3, 5), (0, 4, 6), (1, 3, 5), (1, 4, 6), (2, 3, 5), (2, 4, 6), (3, 3, 5), (3, 4, 6), (4, 3, 5), (4, 4, 6), (5, 3, 5), (5, 4, 6), (6, 3, 5), (6, 4, 6), (7, 3, 5), (7, 4, 6), (8, 3, 5), (8, 4, 6), (9, 3, 5), (9, 4, 6)]\nhere\nERROR\n\n======================================================================\nERROR: sai_qos_tests.HdrmPoolSizeTest\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"saitests/sai_qos_tests.py\", line 877, in runTest\n    time.sleep(600)\n  File \"/usr/lib/python2.7/dist-packages/ptf/ptfutils.py\", line 102, in raise_timeout\n    raise Timeout.TimeoutError()\nTimeoutError\n\n----------------------------------------------------------------------\nRan 1 test in 180.002s\n\nFAILED (errors=1)", 
E               "stderr_lines": [
E                   "sai_qos_tests.HdrmPoolSizeTest ... ['192.168.0.8', '192.168.0.9', '192.168.0.10', '192.168.0.11', '192.168.0.12', '192.168.0.40', '192.168.0.41', '192.168.0.42', '192.168.0.43', '192.168.0.44']", 
E                   "pkts num: leak_out: 0, trig_pfc: 1490, hdrm_full: 520, hdrm_partial: 47", 
E                   "[(0, 3, 5), (0, 4, 6), (1, 3, 5), (1, 4, 6), (2, 3, 5), (2, 4, 6), (3, 3, 5), (3, 4, 6), (4, 3, 5), (4, 4, 6), (5, 3, 5), (5, 4, 6), (6, 3, 5), (6, 4, 6), (7, 3, 5), (7, 4, 6), (8, 3, 5), (8, 4, 6), (9, 3, 5), (9, 4, 6)]", 
E                   "here", 
E                   "ERROR", 
E                   "", 
E                   "======================================================================", 
E                   "ERROR: sai_qos_tests.HdrmPoolSizeTest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"saitests/sai_qos_tests.py\", line 877, in runTest", 
E                   "    time.sleep(600)", 
E                   "  File \"/usr/lib/python2.7/dist-packages/ptf/ptfutils.py\", line 102, in raise_timeout", 
E                   "    raise Timeout.TimeoutError()", 
E                   "TimeoutError", 
E                   "", 
E                   "----------------------------------------------------------------------", 
E                   "Ran 1 test in 180.002s", 
E                   "", 
E                   "FAILED (errors=1)"
E               ], 
E               "stdout": "", 
E               "stdout_lines": []
E           }