### PR TITLE
[docker-setup]: Always mount repository parent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tools for managing, configuring and monitoring SONiC
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3933/badge)](https://bestpractices.coreinfrastructure.org/projects/3933)
 
 # Docker Container Setup
-Use the `setup-container.sh` script to automatically create and configure your sonic-mgmt Docker container. This script should be run directly from the root of the sonic-mgmt repo. You should also run this script as the user that will be using the created container.
+Use the `setup-container.sh` script to automatically create and configure your sonic-mgmt Docker container. You should run this script as the user that will be using the created container.
 
 ```
 Usage ./setup-container.sh [options]

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -23,8 +23,10 @@ function show_help_and_exit() {
 
 function start_and_config_container() {
     echo "Creating container $CONTAINER_NAME"
-    CURRENT_DIR=`pwd`/..
-    docker run --name $CONTAINER_NAME -v $CURRENT_DIR:$LINK_DIR -d -t $IMAGE_ID bash > /dev/null
+    SCRIPT_DIR=`dirname $0`
+    cd $SCRIPT_DIR
+    PARENT_DIR=`pwd`/..
+    docker run --name $CONTAINER_NAME -v $PARENT_DIR:$LINK_DIR -d -t $IMAGE_ID bash > /dev/null
 
     if [[ "$?" != 0 ]]; then
         echo "Container creation failed, exiting"


### PR DESCRIPTION


Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
* Change docker setup script working directory to the repository root, which ensures the directory mounted inside the container is always the parent directory of the repository

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Allow users to run the script from any directory on their system while still consistently mounting the sonic-mgmt repository parent directory inside the created container

#### How did you do it?
Use `dirname` to obtain the script's location on disk and `cd` to navigate to it.

#### How did you verify/test it?
Ran the script from several directories that were not the repository root and ensure that the directory mounted inside the created container was the same for all cases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
