### PR TITLE
[drop counters] Skip test cases requiring explicit fanout support

### DIFF
--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -22,8 +22,10 @@
 l2_l3:
     - "x86_64-dell.*"
     - "x86_64-arista.*"
+    - "x86_64-cel_seastone.*"
 
 acl_l2:
     - "x86_64-mlnx"
     - "x86_64-dell.*"
     - "x86_64-arista.*"
+    - "x86_64-cel_seastone.*"

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -1,10 +1,12 @@
+import logging
+import os
+import importlib
+import netaddr
 import pytest
+
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
-import logging
-import netaddr
-import importlib
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"
@@ -222,6 +224,9 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, duthost, setup, fanouthost, p
     """
     @summary: Create a packet with equal SMAC and DMAC.
     """
+    if not fanouthost:
+        pytest.skip("Test case requires explicit fanout support")
+
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["dst_mac"], pkt_fields["ipv4_dst"], pkt_fields["ipv4_src"])
     src_mac = ports_info["dst_mac"]
 
@@ -256,6 +261,9 @@ def test_multicast_smac_drop(do_test, ptfadapter, duthost, setup, fanouthost, pk
     """
     @summary: Create a packet with multicast SMAC.
     """
+    if not fanouthost:
+        pytest.skip("Test case requires explicit fanout support")
+
     multicast_smac = "01:00:5e:00:01:02"
     src_mac = multicast_smac
 

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -1,30 +1,23 @@
-import pytest
-import ptf.testutils as testutils
-import ptf.mask as mask
-import ptf.packet as packet
 import logging
-import importlib
-import pprint
-import random
-import time
-import yaml
-import re
 import os
-import json
-import netaddr
+import re
+import time
+import pytest
+import yaml
+
+import ptf.packet as packet
+import ptf.testutils as testutils
+
 from tests.common.utilities import wait_until
-from drop_packets import *
+from drop_packets import *  # FIXME
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology("any")
 ]
 
 logger = logging.getLogger(__name__)
 
 PKT_NUMBER = 1000
-
-# Discard key from 'portstat -j' CLI command output
-
 
 # CLI commands to obtain drop counters
 GET_L2_COUNTERS = "portstat -j"
@@ -291,6 +284,9 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthost, setup, fanouthost, pkt
         01:80:C2:00:00:05 - reserved for future standardization
         01:80:C2:00:00:08 - provider Bridge group address
     """
+    if not fanouthost:
+        pytest.skip("Test case requires explicit fanout support")
+
     reserved_mac_addr = ["01:80:C2:00:00:05", "01:80:C2:00:00:08"]
     for reserved_dmac in reserved_mac_addr:
         dst_mac = reserved_dmac


### PR DESCRIPTION
- Update SKU list for combined counters
- Skip L2 tests that require fanout support

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: [drop counters] Various drop counter test improvements

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There are some test cases that require explicit fanout support to run properly, so I added a skip for those if `fanout` is not initialized.

There were also some unused imports, so I cleaned those up as well.

#### How did you verify/test it?
Ran tests locally, verified that there was no regression + the L2 test cases were skipped if `fanouthost` was not initialized.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
