### PR TITLE
Add a generic method for running and parsing output of show commands

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -799,10 +799,14 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             logging.error('Possibly bad command output, exception: {}'.format(repr(e)))
             return result
 
+        headers = []
+        for (left, right) in positions:
+            headers.append(header_line[left:right].strip().lower())
+
         for content_line in content_lines:
             item = {}
-            for (left, right) in positions:
-                k = header_line[left:right].strip().lower()
+            for idx, (left, right) in enumerate(positions):
+                k = headers[idx]
                 v = content_line[left:right].strip()
                 item[k] = v
             result.append(item)

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -750,6 +750,135 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             feature_status[r[0]] = r[1]
         return feature_status, True
 
+    def _parse_column_positions(self, sep_line, sep_char='-'):
+        """Parse the position of each columns in the command output
+
+        Args:
+            sep_line: The output line separating actual data and column headers
+            sep_char: The character used in separation line. Defaults to '-'.
+
+        Returns:
+            Returns a list. Each item is a tuple with two elements. The first element is start position of a column. The
+            second element is the end position of the column.
+        """
+        prev = ' ',
+        positions = []
+        for pos, char in enumerate(sep_line + ' '):
+            if char == sep_char:
+                if char != prev:
+                    left = pos
+            else:
+                if char != prev:
+                    right = pos
+                    positions.append((left, right))
+            prev = char
+        return positions
+
+
+    def _parse_show(self, output_lines):
+
+        result = []
+
+        sep_line_pattern = re.compile(r"^( *-+ *)+$")
+        sep_line_found = False
+        for idx, line in enumerate(output_lines):
+            if sep_line_pattern.match(line):
+                sep_line_found = True
+                header_line = output_lines[idx-1]
+                sep_line = output_lines[idx]
+                content_lines = output_lines[idx+1:]
+                break
+
+        if not sep_line_found:
+            logging.error('Failed to find separation line in the show command output')
+            return result
+
+        try:
+            positions = self._parse_column_positions(sep_line)
+        except Exception as e:
+            logging.error('Possibly bad command output, exception: {}'.format(repr(e)))
+            return result
+
+        for content_line in content_lines:
+            item = {}
+            for (left, right) in positions:
+                k = header_line[left:right].strip().lower()
+                v = content_line[left:right].strip()
+                item[k] = v
+            result.append(item)
+
+        return result
+
+    def show_and_parse(self, show_cmd, **kwargs):
+        """Run a show command and parse the output using a generic pattern.
+
+        This method can adapt to the column changes as long as the output format follows the pattern of
+        'show interface status'.
+
+        The key is to have a line of headers. Then a separation line with '-' under each column header. Both header and
+        column content are within the width of '-' chars for that column.
+
+        For example, part of the output of command 'show interface status':
+
+        admin@str-msn2700-02:~$ show interface status
+              Interface            Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin             Type    Asym PFC
+        ---------------  ---------------  -------  -----  -----  -------  ---------------  ------  -------  ---------------  ----------
+              Ethernet0          0,1,2,3      40G   9100    N/A     etp1  PortChannel0002      up       up   QSFP+ or later         off
+              Ethernet4          4,5,6,7      40G   9100    N/A     etp2  PortChannel0002      up       up   QSFP+ or later         off
+              Ethernet8        8,9,10,11      40G   9100    N/A     etp3  PortChannel0005      up       up   QSFP+ or later         off
+        ...
+
+        The parsed example will be like:
+            [{
+                "oper": "up",
+                "lanes": "0,1,2,3",
+                "fec": "N/A",
+                "asym pfc": "off",
+                "admin": "up",
+                "type": "QSFP+ or later",
+                "vlan": "PortChannel0002",
+                "mtu": "9100",
+                "alias": "etp1",
+                "interface": "Ethernet0",
+                "speed": "40G"
+              },
+              {
+                "oper": "up",
+                "lanes": "4,5,6,7",
+                "fec": "N/A",
+                "asym pfc": "off",
+                "admin": "up",                                                                                                                                                                                                                             "type": "QSFP+ or later",                                                                                                                                                                                                                  "vlan": "PortChannel0002",                                                                                                                                                                                                                 "mtu": "9100",                                                                                                                                                                                                                             "alias": "etp2",
+                "interface": "Ethernet4",
+                "speed": "40G"
+              },
+              {
+                "oper": "up",
+                "lanes": "8,9,10,11",
+                "fec": "N/A",
+                "asym pfc": "off",
+                "admin": "up",
+                "type": "QSFP+ or later",
+                "vlan": "PortChannel0005",
+                "mtu": "9100",
+                "alias": "etp3",
+                "interface": "Ethernet8",
+                "speed": "40G"
+              },
+              ...
+            ]
+
+        Args:
+            show_cmd: The show command that will be executed.
+
+        Returns:
+            Return the parsed output of the show command in a list of dictionary. Each list item is a dictionary,
+            corresponding to one content line under the header in the output. Keys of the dictionary are the column
+            headers in lowercase.
+        """
+        output = self.shell(show_cmd, **kwargs)["stdout_lines"]
+        return self._parse_show(output)
+
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The output format of some `show` commands may be update. Columns could be added or removed. This caused trouble with the functions for parsing the output of such commands.

Since the output of most `show` commands follow a same pattern:
* The first line shows headers of all columns
* The second line separates the header line with content lines using char '-' and whitespace.
* For each column, the header and its corresponding content fit within the width of the '-' chars for this column.

We can take advantage of this to have a generic method for parsing the outputs that follow this pattern. The parsed output can be a list of dictionaries. Each list item is a dictionary, corresponding to one content line under the header in the output. Keys of the dictionary are the column headers in lowercase.


For example, part of the output of command 'show interface status':
```
        admin@str-msn2700-02:~$ show interface status
              Interface            Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin             Type    Asym PFC
        ---------------  ---------------  -------  -----  -----  -------  ---------------  ------  -------  ---------------  ----------
              Ethernet0          0,1,2,3      40G   9100    N/A     etp1  PortChannel0002      up       up   QSFP+ or later         off
              Ethernet4          4,5,6,7      40G   9100    N/A     etp2  PortChannel0002      up       up   QSFP+ or later         off
              Ethernet8        8,9,10,11      40G   9100    N/A     etp3  PortChannel0005      up       up   QSFP+ or later         off
        ...
```

The parsed example will be like:
```
            [{
                "oper": "up",
                "lanes": "0,1,2,3",
                "fec": "N/A",
                "asym pfc": "off",
                "admin": "up",
                "type": "QSFP+ or later",
                "vlan": "PortChannel0002",
                "mtu": "9100",
                "alias": "etp1",
                "interface": "Ethernet0",
                "speed": "40G"
              },
              {
                "oper": "up",
                "lanes": "4,5,6,7",
                "fec": "N/A",
                "asym pfc": "off",
                "admin": "up",                                                                                                                                                                                                                                                             "type": "QSFP+ or later",                                                                                                                                                                                                                  "vlan": "PortChannel0002",                                                                                                                                                                                                                 "mtu": "9100",                                                                                                                                                                                                                             "alias": "etp2",
                "interface": "Ethernet4",
                "speed": "40G"
              },
              {
                "oper": "up",
                "lanes": "8,9,10,11",
                "fec": "N/A",
                "asym pfc": "off",
                "admin": "up",
                "type": "QSFP+ or later",
                "vlan": "PortChannel0005",
                "mtu": "9100",
                "alias": "etp3",
                "interface": "Ethernet8",
                "speed": "40G"
              },
              ...
            ]
```
#### How did you do it?
Added a method to SonicHost class for running and parsing the output of supplied `show` commands.

#### How did you verify/test it?
Use this method to run some show commands and check its parsed output.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
