### PR TITLE
[test_mgmtvrf] Improve the robustness of mgmt VRF testing

### DIFF
--- a/tests/mvrf/temp_http_server.py
+++ b/tests/mvrf/temp_http_server.py
@@ -3,7 +3,7 @@ import sys
 from BaseHTTPServer import HTTPServer
 from BaseHTTPServer import BaseHTTPRequestHandler
 
-MAGIC_STRING = "MAGCI_STRING_FOR_TESTING"
+MAGIC_STRING = "MAGIC_STRING_FOR_TESTING"
 
 
 class TempHttpServer(BaseHTTPRequestHandler):

--- a/tests/mvrf/temp_http_server.py
+++ b/tests/mvrf/temp_http_server.py
@@ -1,7 +1,6 @@
 import sys
 
-from BaseHTTPServer import HTTPServer
-from BaseHTTPServer import BaseHTTPRequestHandler
+from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
 MAGIC_STRING = "MAGIC_STRING_FOR_TESTING"
 

--- a/tests/mvrf/temp_http_server.py
+++ b/tests/mvrf/temp_http_server.py
@@ -1,0 +1,28 @@
+import sys
+
+from BaseHTTPServer import HTTPServer
+from BaseHTTPServer import BaseHTTPRequestHandler
+
+MAGIC_STRING = "MAGCI_STRING_FOR_TESTING"
+
+
+class TempHttpServer(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+
+        self.wfile.write(bytes(MAGIC_STRING))
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1])
+    httpd = HTTPServer(('0.0.0.0', port), TempHttpServer)
+    httpd.timeout = 30
+
+    # Handle two requests and exit.
+    # Each handle_request() will block for httpd.timeout seconds if no request is received.
+    # This script will exit after 2 * httpd.timeout seconds in worst case that no request is received at all.
+    httpd.handle_request()  # For testing http port open
+    httpd.handle_request()  # For GET request from client

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -46,7 +46,7 @@ def setup_mvrf(duthost, testbed, localhost):
     except Exception as e:
         logger.error("Exception raised in setup, exception: {}".format(repr(e)))
         restore_config_db(duthost)
-        pytest.fail("Configure mgmt vrf failed, no test case will be executed. Teardown will not be executed either.")
+        pytest.fail("Configure mgmt vrf failed, no test case will be executed. Code after 'yield' will not be executed either.")
 
     yield
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_mgmtvrf.py script has some issues need to be fixed.
1. In teardown, command `config save` is executed on DUT after mgmt VRF configuration is removed. However, if something went wrong with removing mgmt VRF configuration, the mgmt VRF configuration will be saved to the `/etc/sonic/config_db.json` file. This could leave the system in unhealthy status and affect rest of the tests.
2. Some test cases assume that the DUT switch has Internet access. This is not always the case in lab.
3. Test case test_wget and test_curl are covering the same scenario. It's kind of duplicated.

#### How did you do it?
Changes:
* Removed test_wget. The scenario is already covered by test_curl.
* Use temporary http server on PTF for test_curl. No need for DUT to have internet access.
* Backup and restore the original config_db in reboot related tests.
* Do not run 'config save' in teardown to avoid accidentially storing mgmt vrf in config_db and affecting other tests.
* Replaced root logger with module logger for logging.
* Moved the script to mvrf subfolder.

#### How did you verify/test it?
Test run the test_mgmtvrf.py script on latest 201911 image. All cases passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
