### PR TITLE
[syslog] address syslog test issues

### DIFF
--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -16,26 +16,25 @@ SYSLOG_STARTUP_POLLING_INTERVAL = 3
 SYSLOG_MESSAGE_TEST_TIMEOUT = 10
 
 
-@pytest.fixture(scope="module")
-def config_syslog_srv(ptfhost, duthost):
+def config_syslog_srv(ptfhost):
     logger.info("Configuring the syslog server")
 
     # Add the imudp configuration if not present
-    ptfhost.shell("sed -ni '/module/!p;$a module(load=\"imudp\")' /etc/rsyslog.conf")
-    ptfhost.shell("sed -i '/input(type/!p;$a input(type=\"imudp\" port=\"514\")' /etc/rsyslog.conf")
+    ptfhost.shell("sed -i -e '/^input(type/d' -e '/^module/d' /etc/rsyslog.conf; sed -i -e '$amodule(load=\"imudp\")' -e '$ainput(type=\"imudp\" port=\"514\")' /etc/rsyslog.conf")
 
-    # Remove local /var/log/syslog
-    ptfhost.shell("rm -rf /var/log/syslog")
-
-    # Restart Syslog Daemon
-    ptfhost.shell("service rsyslog restart")
+    # Stop Syslog Daemon
+    logger.info("Restarting rsyslog service")
+    ptfhost.shell("service rsyslog stop && rm -rf /var/log/syslog && touch /var/log/syslog && service rsyslog restart")
 
     # Wait a little bit for service to start
+    rsyslog_running_msg="rsyslogd is running"
     def _is_syslog_running():
-        result = duthost.shell("service rsyslog status | grep \"active (running)\"")["stdout"]
-        return "active (running)" in result
+        result = ptfhost.shell("service rsyslog status | grep \"{}\"".format(rsyslog_running_msg))["stdout"]
+        return rsyslog_running_msg in result
 
+    logger.debug("Waiting for rsyslog server restarting")
     wait_until(SYSLOG_STARTUP_TIMEOUT, SYSLOG_STARTUP_POLLING_INTERVAL, _is_syslog_running)
+    logger.debug("rsyslog server restarted")
 
 
 @pytest.fixture(scope="module")
@@ -46,6 +45,7 @@ def config_dut(testbed, duthost):
 
     # Add Rsyslog destination for testing
     duthost.shell("sudo config syslog add {}".format(local_syslog_srv_ip))
+    logger.debug("Added new rsyslog server IP {}".format(local_syslog_srv_ip))
 
     yield
 
@@ -53,18 +53,22 @@ def config_dut(testbed, duthost):
     duthost.shell("sudo config syslog del {}".format(local_syslog_srv_ip))
 
 
-def test_syslog(duthost, ptfhost, config_dut, config_syslog_srv):
+def test_syslog(duthost, ptfhost, config_dut):
     logger.info("Starting syslog tests")
     test_message = "Basic Test Message"
 
+    logger.debug("Configuring rsyslog server")
+    config_syslog_srv(ptfhost)
+
+    logger.debug("Generating log message from DUT")
     # Generate a syslog from the DUT
     duthost.shell("logger --priority INFO {}".format(test_message))
 
     # Check syslog messages for the test message
     def _check_syslog():
-        result = ptfhost.shell("grep {} /var/log/syslog | grep \"{}\" | grep -v ansible"
+        result = ptfhost.shell("grep {} /var/log/syslog | grep -v ansible | grep -c \"{}\""
                                .format(duthost.hostname, test_message))["stdout"]
-        return test_message in result
+        return result != "0"
 
     pytest_assert(wait_until(SYSLOG_MESSAGE_TEST_TIMEOUT, 1, _check_syslog),
                   "Test syslog message not seen on the server after {}s".format(SYSLOG_MESSAGE_TEST_TIMEOUT))

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -22,7 +22,7 @@ def config_syslog_srv(ptfhost):
     # Add the imudp configuration if not present
     ptfhost.shell("sed -i -e '/^input(type/d' -e '/^module/d' /etc/rsyslog.conf; sed -i -e '$amodule(load=\"imudp\")' -e '$ainput(type=\"imudp\" port=\"514\")' /etc/rsyslog.conf")
 
-    # Stop Syslog Daemon
+    # Restart Syslog Daemon
     logger.info("Restarting rsyslog service")
     ptfhost.shell("service rsyslog stop && rm -rf /var/log/syslog && touch /var/log/syslog && service rsyslog restart")
 
@@ -32,7 +32,7 @@ def config_syslog_srv(ptfhost):
         result = ptfhost.shell("service rsyslog status | grep \"{}\"".format(rsyslog_running_msg))["stdout"]
         return rsyslog_running_msg in result
 
-    logger.debug("Waiting for rsyslog server restarting")
+    logger.debug("Waiting for rsyslog server to restart")
     wait_until(SYSLOG_STARTUP_TIMEOUT, SYSLOG_STARTUP_POLLING_INTERVAL, _is_syslog_running)
     logger.debug("rsyslog server restarted")
 

--- a/tests/test_cleanup_testbed.py
+++ b/tests/test_cleanup_testbed.py
@@ -8,7 +8,7 @@ pytestmark = [
     pytest.mark.topology('util')
 ]
 
-def test_cleanup_dut(duthost, request):
+def test_cleanup_testbed(duthost, request, ptfhost):
     deep_clean = request.config.getoption("--deep_clean")
     if deep_clean:
         logger.info("Deep cleaning DUT {}".format(duthost.hostname))
@@ -18,3 +18,7 @@ def test_cleanup_dut(duthost, request):
         duthost.shell("sudo rm -f /var/core/*", executable="/bin/bash")
         # Remove old dump files.
         duthost.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")
+
+    # Cleanup rsyslog configuration file that might have damaged by test_syslog.py
+    if ptfhost:
+        ptfhost.shell("if [[ -f /etc/rsyslog.conf ]]; then mv /etc/rsyslog.conf /etc/rsyslog.conf.orig; uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
syslog test was stable for a while then start to fail. Investigation shows that the test duplicate contents of the /etc/rsyslog.conf on ptf host and causing more and more listening module to be created. Eventually, these many listening modules will take very long time to start, and duplicate the incoming message for so many times and cause the test to fail because grep command timeout.

#### How did you do it?
- Fix the sed command used to modify rsyslog.conf on ptf docker, the old command duplicates the contents every time it runs.  Causing multiple listening modules to be started over time. Which causes the test eventually fail.
- Make config_syslog_srv a helper funciton instead of fixture.
- Add a cleanup method to dedup the rsyslog.conf.
- Rename test_cleanup_dut to test_cleanup_testbed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?

1.  Test cleaning up code:

root@071bcd0968cd:/etc# cp rsyslog.conf.superlong rsyslog.conf 
root@071bcd0968cd:/etc# wc -l rsyslog.conf rsyslog.conf.orig 
 1426063388 rsyslog.conf
         86 rsyslog.conf.orig

test_cleanup_testbed.py::test_cleanup_testbed PASSED                                                                                                                               [100%]

root@071bcd0968cd:/etc# wc -l rsyslog.conf rsyslog.conf.orig 
         86 rsyslog.conf
 1426063388 rsyslog.conf.orig

test_cleanup_testbed.py::test_cleanup_testbed PASSED                                                                                                                               [100%]

root@071bcd0968cd:/etc# wc -l rsyslog.conf rsyslog.conf.orig 
  86 rsyslog.conf
  86 rsyslog.conf.orig

2. Test the rsyslog test fix (rsyslog.conf shrink 1 more line because there was another non consecutive duplicate line):

syslog/test_syslog.py::test_syslog PASSED                                                                                                                                          [100%]

root@071bcd0968cd:/etc# wc -l rsyslog.conf rsyslog.conf.orig 
  85 rsyslog.conf
  86 rsyslog.conf.orig

