### PR TITLE
[testbed_setup] address populate fdb test issue

### DIFF
--- a/ansible/roles/test/files/ptftests/populate_fdb.py
+++ b/ansible/roles/test/files/ptftests/populate_fdb.py
@@ -140,6 +140,10 @@ class PopulateFdb(BaseTest):
             Returns:
                 None
         """
+        if not self.configData["vlan_ports"]:
+            # No vlan port to test
+            return
+
         packet = testutils.simple_tcp_packet(
             eth_dst=self.dutMac,
             tcp_sport=self.TCP_SRC_PORT,

--- a/tests/testbed_setup/test_populate_fdb.py
+++ b/tests/testbed_setup/test_populate_fdb.py
@@ -3,7 +3,7 @@ import pytest
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('t0')
 ]
 
 def test_populate_fdb(populate_fdb):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
testbed_setup test is failing on T1 topology. The failure was an exception of divided by zero.

#### How did you do it?
- Protect against a divided by zero error in populate_fdb.py.
- test_populate_fdb.py should only run on T0 topology.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
testbed_setup/test_populate_fdb.py::test_populate_fdb PASSED                                                                                                                       [100%]
