### PR TITLE
[reboot] Fail the test when SSH timeout failure is encountered

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -114,7 +114,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
                              timeout=timeout,
                              module_ignore_errors=True)
 
-    if 'failed' in res:
+    if 'failed' in res or ('msg' in res and 'Timeout' in res['msg']):
         if reboot_res.ready():
             logger.error('reboot result: {}'.format(reboot_res.get()))
         raise Exception('DUT did not shutdown')
@@ -131,7 +131,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
                              delay=delay,
                              timeout=timeout,
                              module_ignore_errors=True)
-    if 'failed' in res:
+    if 'failed' in res or ('msg' in res and 'Timeout' in res['msg']):
         raise Exception('DUT did not startup')
 
     logger.info('ssh has started up')


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
The reboot testcase currently proceeds even when SSH timeout is encountered. Fail the test if that is the case

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


#### How did you verify/test it?
Ran cold reboot, fast and warm reboot with the changes and they passed. 
For a genuine failure case, the test failed as expected

platform_tests/test_reboot.py:129: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
platform_tests/test_reboot.py:58: in reboot_and_check
    reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
common/reboot.py:122: in reboot
    logger.error('reboot result: {}'.format(reboot_res.get()))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <multiprocessing.pool.ApplyResult object at 0x7f095d7866d0>
timeout = None

    def get(self, timeout=None):
        self.wait(timeout)
        if not self._ready:
            raise TimeoutError
        if self._success:
            return self._value
        else:
>           raise self._value
E           RunAnsibleModuleFail: run module command failed, Ansible Results =>
E           {
E               "changed": true, 
E               "cmd": [
E                   "warm-reboot"
E               ], 
E               "delta": "0:00:01.282156", 
E               "end": "2020-08-11 21:56:31.082055", 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "warm-reboot", 
E                       "_uses_shell": false, 
E                       "argv": null, 
E                       "chdir": null, 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2020-08-11 21:56:29.799899", 
E               "stderr": "ASIC config may have changed: errno=1", 
E               "stderr_lines": [
E                   "ASIC config may have changed: errno=1"
E               ], 
E               "stdout": "", 
E               "stdout_lines": []
E           }

/usr/lib/python2.7/multiprocessing/pool.py:567: RunAnsibleModuleFail