### PR TITLE
[test_vlan] Fix test_vlan 

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -2,7 +2,6 @@
 import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
-from ptf.testutils import dp_poll
 from ptf.mask import Mask
 from collections import defaultdict
 

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -2,6 +2,7 @@
 import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
+from ptf.testutils import dp_poll
 from ptf.mask import Mask
 from collections import defaultdict
 
@@ -49,7 +50,7 @@ def vlan_ports_list(cfg_facts, ptfhost):
             port = config_portchannels[po]['members'][0]
             vlan_ports_list.append({
                 'dev' : po,
-                'port_index' : config_port_indices[port],
+                'port_index' : [config_port_indices[member] for member in config_portchannels[po]['members']],
                 'pvid' : pvid_cycle.next(),
                 'permit_vlanid' : { vid : {
                     'peer_ip' : '192.168.{}.{}'.format(vid, 2 + config_port_indices.keys().index(port)),
@@ -65,7 +66,7 @@ def vlan_ports_list(cfg_facts, ptfhost):
     for port in ports[:4]:
         vlan_ports_list.append({
             'dev' : port,
-            'port_index' : config_port_indices[port],
+            'port_index' : [config_port_indices[port]],
             'pvid' : pvid_cycle.next(),
             'permit_vlanid' : { vid : {
                 'peer_ip' : '192.168.{}.{}'.format(vid, 2 + config_port_indices.keys().index(port)),
@@ -82,12 +83,12 @@ def create_vlan_interfaces(vlan_ports_list, vlan_intfs_list, duthost, ptfhost):
             if int(permit_vlanid) != vlan_port["pvid"]:
 
                 ptfhost.command("ip link add link eth{idx} name eth{idx}.{pvid} type vlan id {pvid}".format(
-                   idx=vlan_port["port_index"],
+                   idx=vlan_port["port_index"][0],
                    pvid=permit_vlanid
                 ))
 
                 ptfhost.command("ip link set eth{idx}.{pvid} up".format(
-                   idx=vlan_port["port_index"],
+                   idx=vlan_port["port_index"][0],
                    pvid=permit_vlanid
                 ))
 
@@ -186,7 +187,7 @@ def tearDown(vlan_ports_list, duthost, ptfhost, vlan_intfs_list, portchannel_int
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
                 if int(permit_vlanid) != vlan_port["pvid"]:
                     ptfhost.command("ip link delete eth{idx}.{pvid}".format(
-                    idx=vlan_port["port_index"],
+                    idx=vlan_port["port_index"][0],
                     pvid=permit_vlanid
                     ))
     except RunAnsibleModuleFail as e:
@@ -203,9 +204,9 @@ def setUpArpResponder(vlan_ports_list, ptfhost):
     for vlan_port in vlan_ports_list:
         for permit_vlanid in vlan_port["permit_vlanid"].keys():
             if int(permit_vlanid) == vlan_port["pvid"]:
-                iface = "eth{}".format(vlan_port["port_index"])
+                iface = "eth{}".format(vlan_port["port_index"][0])
             else:
-                iface = "eth{}.{}".format(vlan_port["port_index"], permit_vlanid)
+                iface = "eth{}.{}".format(vlan_port["port_index"][0], permit_vlanid)
             d[iface].append(vlan_port["permit_vlanid"][permit_vlanid]["peer_ip"])
 
     with open('/tmp/from_t1.json', 'w') as file:
@@ -226,26 +227,59 @@ def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff
                                 ip_ttl=ttl)
     return pkt
 
+def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], device_number=0, timeout=1):
+    for port in ports:
+        result = testutils.dp_poll(test, device_number=device_number, port_number=port,
+                                   timeout=timeout, exp_pkt=pkt)
+        if isinstance(result, test.dataplane.PollFailure):
+            test.fail("Expected packet was not received on device %d, port %r.\n%s"
+                    % (device_number, port, result.format()))
+
+    for port_group in portchannel_ports:
+        for port in port_group:
+            result = testutils.dp_poll(test, device_number=device_number, port_number=port,
+                                       timeout=timeout, exp_pkt=pkt)
+            if isinstance(result, test.dataplane.PollSuccess):
+                break
+        else:
+            test.fail("Expected packet was not received on device %d, ports %s.\n"
+                    % (device_number, str(port_group)))
+
 def verify_icmp_packets(ptfadapter, vlan_ports_list, vlan_port, vlan_id):
-    untagged_dst_ports = []
-    tagged_dst_ports = []
-    untagged_pkts = []
-    tagged_pkts = []
     untagged_pkt = build_icmp_packet(0)
     tagged_pkt = build_icmp_packet(vlan_id)
+    untagged_dst_ports = []
+    tagged_dst_ports = []
+    untagged_dst_pc_ports = []
+    tagged_dst_pc_ports = []
+    # vlan priority attached to packets is determined by the port, so we ignore it here
+    masked_tagged_pkt = Mask(tagged_pkt)
+    masked_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
 
+    logger.info("Verify untagged packets from ports " + str(vlan_port["port_index"][0]))
     for port in vlan_ports_list:
         if vlan_port["port_index"] == port["port_index"]:
             # Skip src port
             continue
         if port["pvid"] == vlan_id:
-            untagged_dst_ports.append(port["port_index"])
-            untagged_pkts.append(untagged_pkt)
+            if len(port["port_index"]) > 1:
+                untagged_dst_pc_ports.append(port["port_index"])
+            else:
+                untagged_dst_ports += port["port_index"]
         elif vlan_id in map(int, port["permit_vlanid"].keys()):
-            tagged_dst_ports.append(port["port_index"])
-            tagged_pkts.append(tagged_pkt)
-    logger.info("Verify untagged packets from ports " + str(untagged_dst_ports) + " tagged packets from ports " + str(tagged_dst_ports))
-    testutils.verify_each_packet_on_each_port(ptfadapter, untagged_pkts+tagged_pkts, untagged_dst_ports+tagged_dst_ports)
+            if len(port["port_index"]) > 1:
+                tagged_dst_pc_ports.append(port["port_index"])
+            else:
+                tagged_dst_ports += port["port_index"]
+
+    verify_packets_with_portchannel(test=ptfadapter,
+                                    pkt=untagged_pkt,
+                                    ports=untagged_dst_ports,
+                                    portchannel_ports=untagged_dst_pc_ports)
+    verify_packets_with_portchannel(test=ptfadapter,
+                                    pkt=masked_tagged_pkt,
+                                    ports=tagged_dst_ports,
+                                    portchannel_ports=tagged_dst_pc_ports)
 
 @pytest.mark.bsl
 def test_vlan_tc1_send_untagged(ptfadapter, vlan_ports_list):
@@ -259,9 +293,9 @@ def test_vlan_tc1_send_untagged(ptfadapter, vlan_ports_list):
 
     for vlan_port in vlan_ports_list:
         pkt = build_icmp_packet(0)
-        logger.info("Send untagged packet from {} ...".format(vlan_port["port_index"]))
+        logger.info("Send untagged packet from {} ...".format(vlan_port["port_index"][0]))
         logger.info(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
-        testutils.send(ptfadapter, vlan_port["port_index"], pkt)
+        testutils.send(ptfadapter, vlan_port["port_index"][0], pkt)
         verify_icmp_packets(ptfadapter, vlan_ports_list, vlan_port, vlan_port["pvid"])
 
 
@@ -279,9 +313,9 @@ def test_vlan_tc2_send_tagged(ptfadapter, vlan_ports_list):
     for vlan_port in vlan_ports_list:
         for permit_vlanid in map(int, vlan_port["permit_vlanid"].keys()):
             pkt = build_icmp_packet(permit_vlanid)
-            logger.info("Send tagged({}) packet from {} ...".format(permit_vlanid, vlan_port["port_index"]))
+            logger.info("Send tagged({}) packet from {} ...".format(permit_vlanid, vlan_port["port_index"][0]))
             logger.info(pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
-            testutils.send(ptfadapter, vlan_port["port_index"], pkt)
+            testutils.send(ptfadapter, vlan_port["port_index"][0], pkt)
             verify_icmp_packets(ptfadapter, vlan_ports_list, vlan_port, permit_vlanid)
 
 @pytest.mark.bsl
@@ -297,10 +331,10 @@ def test_vlan_tc3_send_invalid_vid(ptfadapter, vlan_ports_list):
     invalid_tagged_pkt = build_icmp_packet(4095)
     masked_invalid_tagged_pkt = Mask(invalid_tagged_pkt)
     masked_invalid_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
-
     for vlan_port in vlan_ports_list:
-        src_port = vlan_port["port_index"]
-        dst_ports = [port["port_index"] for port in vlan_ports_list
+        dst_ports = []
+        src_port = vlan_port["port_index"][0]
+        dst_ports += [port["port_index"] for port in vlan_ports_list
                                 if port != vlan_port ]
         logger.info("Send invalid tagged packet " + " from " + str(src_port) + "...")
         logger.info(invalid_tagged_pkt.sprintf("%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
**This PR fix two issues in test_vlan.py**
1. Add a new method to capture and check packets from involved interfaces, including portchannel. If packet is captured from any port of the portchannel, the check passes.
2. VLAN priority is ignored when matching expected packets, because the VLAN priority is determined by the port and VLAN configuration.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix test_vlan case.
#### How did you do it?
Two updates:
1. Add a new method to capture and check packets from interfaces (including portchannel);
2. VLAN priority is ignored when matching expected packets.
#### How did you verify/test it?
Verify it on Arista-7260cx3 DUT.
```
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 3 items                                                                                                                                                                                     

vlan/test_vlan.py::test_vlan_tc1_send_untagged PASSED                                                                                                                                           [ 33%]
vlan/test_vlan.py::test_vlan_tc2_send_tagged PASSED                                                                                                                                             [ 66%]
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid PASSED                                                                                                                                        [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 3 passed in 416.55 seconds =====================================================================================
```                        
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.