### PR TITLE
[fib, T0-64, T0-64-32, templates] Updated announced routes for T0-64 …

### DIFF
--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -164,7 +164,7 @@ configuration_properties:
     swrole: leaf
     spine_asn: 65534
     leaf_asn_start: 4200064600
-    tor_asn_start: 4200065100
+    tor_asn_start: 4200065500
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
 

--- a/ansible/vars/topo_t0-64-32.yml
+++ b/ansible/vars/topo_t0-64-32.yml
@@ -83,8 +83,8 @@ configuration_properties:
     leaf_asn_start: 64802
     tor_asn_start: 64601
     failure_rate: 0
-    nhipv4: 10.10.246.100
-    nhipv6: FC0A::C9
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
 
 configuration:
   ARISTA01T1:

--- a/ansible/vars/topo_t0-64.yml
+++ b/ansible/vars/topo_t0-64.yml
@@ -136,8 +136,8 @@ configuration_properties:
     leaf_asn_start: 64802
     tor_asn_start: 64601
     failure_rate: 0
-    nhipv4: 10.10.246.100
-    nhipv6: FC0A::C9
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
 
 configuration:
   ARISTA01T1:

--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -103,14 +103,10 @@ def fib_t0(ptfhost, testbed, localhost, topology=None):
     max_tor_subnet_number = 16
     tor_subnet_size = 128
 
-    # TODO: spine_asn, leaf_asn_start and tor_asn_start should come from the topology file
-    spine_asn = 65534
-    if topology == 't0-116':
-        leaf_asn_start = 4200064600
-        tor_asn_start = 4200065500
-    else:
-        leaf_asn_start = 64600
-        tor_asn_start = 65500
+    common_config_topo = testbed['topo']['properties']['configuration_properties']['common']
+    spine_asn = common_config_topo.get("spine_asn", 65534)
+    leaf_asn_start = common_config_topo.get("leaf_asn_start", 64600)
+    tor_asn_start = common_config_topo.get("tor_asn_start", 65500)
 
     topo = testbed['topo']['properties']
     ptf_hostname = testbed['ptf']


### PR DESCRIPTION
…and T0-64-32

Signed-off-by: Nazar Tkachuk <nazarx.tkachuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Testbed deployment for T0-64 and T0-64-32 topologies did not perform correctly after PR https://github.com/Azure/sonic-mgmt/pull/2008 where static routes were removed.

#### How did you do it?
Updated templates for  T0-64 and T0-64-32.
Removed  hardcoded ASN assumption from fib route announcement

#### How did you verify/test it?
Run few tests on T0-64 and T0-64-32

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
