### PR TITLE
[pfcwd] Add option to fake PFC storm and adapt tests

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -24,6 +24,8 @@ def pytest_addoption(parser):
                      help='Warm reboot needs to be enabled or not')
     parser.addoption('--restore-time', action='store', type=int, default=3000,
                      help='PFC WD storm restore interval')
+    parser.addoption('--fake-storm', action='store', type=bool, default=True,
+                     help='Fake storm for most ports instead of using pfc gen')
 
 @pytest.fixture(scope="module")
 def setup_pfc_test(duthost, ptfhost, conn_graph_facts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Added a knob which when enabled will fake a PFC storm instead of relying on PFC storm from the fanout switch which sometimes is flaky and causing test failures. The functional and warm boot test are changed to make use of this knob if needed.
If 'fake-storm' knob is enabled, out of the selected ports, the first port will still be stormed by the actual PFC storm from the fanout and the rest of the ports will use fake storm.
If 'fake-storm' knob is disabled, all ports will rely on the PFC storm from the fanout.
By default, this knob is turned on.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Verified the flow works as mentioned in the description when 'fake-storm' is enabled and disabled
With the 'fake-storm' enabled, ran the pfcwd function and warm boot test and they passed