### PR TITLE
Fix the issue of configuring wrong VMs while add-topo

### DIFF
--- a/ansible/roles/eos/tasks/main.yml
+++ b/ansible/roles/eos/tasks/main.yml
@@ -11,7 +11,7 @@
   set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
 
 - name: Extract VM names from the inventory
-  set_fact: VM_list={{ groups[current_server] | filter_by_prefix('VM') }}
+  set_fact: VM_list={{ groups[current_server] | filter_by_prefix('VM') | sort }}
 
 - name: Get VM host name
   set_fact: VM_host={{ groups[current_server] | difference(VM_list) }}

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -113,7 +113,7 @@
           set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
 
         - name: Extract VM names from the inventory
-          set_fact: VM_hosts={{ groups[current_server] | filter_by_prefix('VM') }}
+          set_fact: VM_hosts={{ groups[current_server] | filter_by_prefix('VM') | sort }}
 
         - name: Generate vm list of target VMs
           set_fact: VM_targets={{ VM_hosts | filter_vm_targets(topology['VMs'], VM_base) }}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Probably the issue was introduced after converted the inventory file
to yaml format. While running `testbed-cli.sh add-topo`, one of the
step is to get the target list of VMs to be configured. We get this target
 list by applying a `filter_vm_targets` filter against the list of VMs
 belonging to the current test server. Originally the list of VMs is sorted.
 Probably because of the recent inventory file format change, now the
 list is unsorted. Then the target list of VMs to be configured could be
 wrong.

#### How did you do it?
 The fix:
 * Sort the list of VMs belonging to current server before applying the
   `filter_vm_targets` filter.

#### How did you verify/test it?
Test run `testbed-cli.sh remove-topo` and `testbed-cli.sh add-topo`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
