### PR TITLE
Fix the false alarm of checking reboot result

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -114,7 +114,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
                              timeout=timeout,
                              module_ignore_errors=True)
 
-    if 'failed' in res or ('msg' in res and 'Timeout' in res['msg']):
+    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
         if reboot_res.ready():
             logger.error('reboot result: {}'.format(reboot_res.get()))
         raise Exception('DUT did not shutdown')
@@ -131,7 +131,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
                              delay=delay,
                              timeout=timeout,
                              module_ignore_errors=True)
-    if 'failed' in res or ('msg' in res and 'Timeout' in res['msg']):
+    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
         raise Exception('DUT did not startup')
 
     logger.info('ssh has started up')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
After PR "https://github.com/Azure/sonic-mgmt/pull/2063 Fix the issue of no 'failed' field in failed ansible module result "
is merged, the ansible module result will no longer have the 'failed' field filtered out. We now can count on the 'is_failed'
property of ansible module result to tell if it is failed or not. However, just assert that the result is failed if the 'failed' field
is in the result dict is not safe now. It's because the 'failed' field may have value 'false'. The reboot function in reboot.py
may raise false alarm "DUT was not shutdown".

#### How did you do it?

The fix:
* Explicitly check the 'is_failed' property of localhost.wait_for result to determine whether the DUT is down or up as expected.

#### How did you verify/test it?
Test run a simple script calling the reboot function defined in tests/common/reboot.py.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
