### PR TITLE
Add 'mgmt_ip' property to non-localhost ansible hosts

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -49,6 +49,7 @@ class AnsibleHostBase(object):
             self.host = ansible_adhoc(connection='local', host_pattern=hostname)[hostname]
         else:
             self.host = ansible_adhoc(become=True, *args, **kwargs)[hostname]
+            self.mgmt_ip = self.host.options["inventory_manager"].get_host(hostname).vars["ansible_host"]
         self.hostname = hostname
 
     def __getattr__(self, module_name):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In many test scripts, we need to get the management IP address of a host,
for example PTF IP, DUT management IP, etc. This PR added a 'mgmt_ip'
property to the AnsibleHostBase class. Please be noted that the 'mgmt_ip'
property is not available on 'localhost'.

#### How did you do it?
Added a 'mgmt_ip' property to the AnsibleHostBase class. This property is not available on 'localhost'.

#### How did you verify/test it?
Prepared a test script like below:
```
import logging
import pytest
import json

logger = logging.getLogger(__name__)


def test_case1(duthost):
    logger.info("duthost.mgmt_ip={}".format(duthost.mgmt_ip))
    logger.info("duthost.facts={}".format(json.dumps(duthost.facts)))

def test_case2(ptfhost):
    logger.info("ptfhost.mgmt_ip={}".format(ptfhost.mgmt_ip))

def test_case3(nbrhosts):
    for nbrhost in nbrhosts:
        vm = nbrhosts[nbrhost]["host"]
        logger.info("{}.mgmt_ip={}".format(vm.hostname, vm.mgmt_ip))
```
Log of running the above script:
```
johnar@4c1f7b289839:~/code/sonic-mgmt/tests$ pytest --inventory veos_vtb --host-pattern vlab-01  --testbed vms-kvm-t0 --testbed_file vtestbed.csv --showlocals --show-capture no --assert plain --log-cli-level info test_pr.py --skip_sanity --disable_loganalyzer
=========================================================================================================== test session starts ===========================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini
plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2
collected 3 items                                                                                                                                                                                                                         

test_pr.py::test_case1 
------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------
10:55:08 INFO __init__.py:set_default:14: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
10:55:08 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
10:55:12 INFO conftest.py:creds:334: dut vlab-01 belongs to groups [u'lab', u'sonic', 'fanout']
10:55:12 INFO conftest.py:creds:346: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
10:55:12 INFO conftest.py:creds:346: skip empty var file ../ansible/group_vars/all/env.yml
10:55:13 INFO __init__.py:sanity_check:45: Start pre-test sanity check
10:55:13 INFO __init__.py:sanity_check:89: Sanity check settings: skip_sanity=True, check_items=set(['services', 'bgp', 'interfaces', 'processes', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False
10:55:13 INFO __init__.py:sanity_check:92: Skip sanity check according to command line argument or configuration of test script.
10:55:13 INFO __init__.py:loganalyzer:15: Log analyzer is disabled
-------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------
10:55:13 INFO test_pr.py:test_case1:9: duthost.mgmt_ip=10.250.0.101
10:55:13 INFO test_pr.py:test_case1:10: duthost.facts={"platform": "x86_64-kvm_x86_64-r0", "hwsku": "Force10-S6000", "asic_type": "vs", "num_asic": 1}
PASSED                                                                                                                                                                                                                              [ 33%]
test_pr.py::test_case2 
------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------
10:55:13 INFO __init__.py:set_default:14: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
10:55:13 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
10:55:13 INFO __init__.py:loganalyzer:15: Log analyzer is disabled
-------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------
10:55:13 INFO test_pr.py:test_case2:13: ptfhost.mgmt_ip=10.250.0.102
PASSED                                                                                                                                                                                                                              [ 66%]
test_pr.py::test_case3 
------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------
10:55:13 INFO __init__.py:set_default:14: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
10:55:13 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
10:55:13 INFO __init__.py:loganalyzer:15: Log analyzer is disabled
-------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------
10:55:13 INFO test_pr.py:test_case3:18: VM0103.mgmt_ip=10.250.0.54
10:55:13 INFO test_pr.py:test_case3:18: VM0102.mgmt_ip=10.250.0.53
10:55:13 INFO test_pr.py:test_case3:18: VM0101.mgmt_ip=10.250.0.52
10:55:13 INFO test_pr.py:test_case3:18: VM0100.mgmt_ip=10.250.0.51
PASSED                                                                                                                                                                                                                              [100%]

======================================================================================================== 3 passed in 5.69 seconds =========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
