### PR TITLE
Add "router_mac" to SonicHost.facts

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -142,6 +142,7 @@ class SonicHost(AnsibleHostBase):
                 "hwsku": "Arista-7050-QX-32S",
                 "asic_type": "broadcom",
                 "num_asic": 1,
+                "router_mac": "52:54:00:f0:ac:9d",
             }
         """
 
@@ -206,6 +207,7 @@ class SonicHost(AnsibleHostBase):
         facts = dict()
         facts.update(self._get_platform_info())
         facts["num_asic"] = self._get_asic_count(facts["platform"])
+        facts["router_mac"] = self._get_router_mac()
 
         logging.debug("Gathered SonicHost facts: %s" % json.dumps(facts))
         return facts
@@ -232,6 +234,8 @@ class SonicHost(AnsibleHostBase):
         except:
             return int(num_asic)
 
+    def _get_router_mac(self):
+        return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0].decode("utf-8")
 
     def _generate_critical_services_for_multi_asic(self, services):
         """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For PTF related tests, we often need to get the router MAC of the SONiC
switch and pass it to the PTF script in arguments. Many test scripts use
the 'setup' Ansible module to get the router MAC. However, the 'setup'
module gathers too much information and generats too much log. It is
a over kill to just get router MAC using the 'setup' module.

#### How did you do it?
This enhancement gets the router MAC from running config and stores
it in the SonicHost.facts property. In test script, we can get it using
code like 'duthost.facts["router_mac"]'.

#### How did you verify/test it?
Prepared a test script like below:
```
import logging
import json

logger = logging.getLogger(__name__)


def test_case1(duthost):
    logger.info("duthost.facts={}".format(json.dumps(duthost.facts)))
    logger.info("router_mac={}".format(duthost.facts["router_mac"]))

```
Log of running the above script:
```
johnar@4c1f7b289839:~/code/sonic-mgmt/tests$ pytest --inventory veos_vtb --host-pattern vlab-01  --testbed vms-kvm-t0 --testbed_file vtestbed.csv --showlocals --show-capture no --assert plain --log-cli-level info test_pr.py --skip_sanity --disable_loganalyzer
=========================================================================================================== test session starts ===========================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/johnar/code/sonic-mgmt/tests, inifile: pytest.ini
plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2
collected 1 item                                                                                                                                                                                                                          

test_pr.py::test_case1 
------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------
11:38:42 INFO __init__.py:set_default:14: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
11:38:42 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
11:38:49 INFO conftest.py:creds:334: dut vlab-01 belongs to groups [u'lab', u'sonic', 'fanout']
11:38:49 INFO conftest.py:creds:346: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
11:38:49 INFO conftest.py:creds:346: skip empty var file ../ansible/group_vars/all/env.yml
11:38:51 INFO __init__.py:sanity_check:45: Start pre-test sanity check
11:38:51 INFO __init__.py:sanity_check:89: Sanity check settings: skip_sanity=True, check_items=set(['services', 'bgp', 'interfaces', 'processes', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False
11:38:51 INFO __init__.py:sanity_check:92: Skip sanity check according to command line argument or configuration of test script.
11:38:51 INFO __init__.py:loganalyzer:15: Log analyzer is disabled
-------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------
11:38:51 INFO test_pr.py:test_case1:9: duthost.facts={"platform": "x86_64-kvm_x86_64-r0", "hwsku": "Force10-S6000", "router_mac": "52:54:00:3d:63:05", "asic_type": "vs", "num_asic": 1}
11:38:51 INFO test_pr.py:test_case1:10: router_mac=52:54:00:3d:63:05
PASSED                                                                                                                                                                                                                              [100%]

======================================================================================================== 1 passed in 8.86 seconds =========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
