### PR TITLE
Fix test_populate_fdb issue cused by IPv6 address

### DIFF
--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -67,7 +67,7 @@ class PopulateFdb:
                 })
         vlan_interfaces = {}
         for vlan in mgFacts["minigraph_vlan_interfaces"]:
-            if isinstance(ipaddress.IPNetwork(vlan['addr']), ipaddress.IPv4Network):
+            if ipaddress.IPNetwork(vlan['addr']).version == 4:
                 vlan_interfaces[vlan["attachto"]] = vlan
 
         vlanConfigData = {

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import pytest
-
+import ipaddr as ipaddress
 from tests.ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
@@ -65,10 +65,14 @@ class PopulateFdb:
                     "vlan": vlan,
                     "index": mgFacts["minigraph_port_indices"][port]
                 })
+        vlan_interfaces = {}
+        for vlan in mgFacts["minigraph_vlan_interfaces"]:
+            if isinstance(ipaddress.IPNetwork(vlan['addr']), ipaddress.IPv4Network):
+                vlan_interfaces[vlan["attachto"]] = vlan
 
         vlanConfigData = {
             "vlan_ports": mgVlanPorts,
-            "vlan_interfaces": {vlan["attachto"]: vlan for vlan in mgFacts["minigraph_vlan_interfaces"]},
+            "vlan_interfaces": vlan_interfaces,
             "dut_mac": self.duthost.setup()["ansible_facts"]["ansible_Ethernet0"]["macaddress"]
         }
 


### PR DESCRIPTION
There are both ipv4 and ipv6 address for vlan on DUT. This commit fix
the issue that only IPv6 address is retrived from migigraph and write to
test config, which will lead to an exception in ptf scripts

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix test_populate_fdb
    There are both ipv4 and ipv6 address for vlan on DUT. This commit fix
    the issue that only IPv6 address is retrived from migigraph and write to
    test config, which will lead to an exception in ptf scripts
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This commit is to fix the exception in ptftests/populate_fdb.py caused by incorrect test config, which contains only IPv6 address.
An additional check is added in this PR to ensure that only IPv4 address is added.
```
E               "stderr_lines": [
E                   "WARNING: No route found for IPv6 destination :: (no default route?)", 
E                   "populate_fdb.PopulateFdb ... FAIL", 
E                   "", 
E                   "======================================================================", 
E                   "FAIL: populate_fdb.PopulateFdb", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"ptftests/populate_fdb.py\", line 176, in runTest", 
E                   "    self.__populateDutFdb()", 
E                   "  File \"ptftests/populate_fdb.py\", line 148, in __populateDutFdb", 
E                   "    vmIp = self.__prepareVmIp()", 
E                   "  File \"ptftests/populate_fdb.py\", line 123, in __prepareVmIp", 
E                   "    numDistinctIp", 
E                   "AssertionError: Vlan network '-2.99999999977' does not support the requested number of IPs '20'", 
E                   "", 
E                   "----------------------------------------------------------------------", 
E                   "Ran 1 test in 0.006s", 
E                   "", 
E                   "FAILED (failures=1)"
E               ], 
```
#### How did you do it?
An additional check is added in this PR to ensure that only IPv4 address is added.
#### How did you verify/test it?
Verified on Arista-7260
```
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 1 item                                                                                                                                                                                      

testbed_setup/test_populate_fdb.py::test_populate_fdb PASSED                                                                                                                                    [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
====================================================================================== 1 passed in 34.95 seconds ======================================================================================
```
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No