### PR TITLE
Fix exception in fdb.py caused by IPv6 Address in vlan interfaces

### DIFF
--- a/tests/fdb/files/fdb.j2
+++ b/tests/fdb/files/fdb.j2
@@ -1,3 +1,5 @@
 {% for vlan in minigraph_vlan_interfaces %}
+{% if vlan['addr'] | ipv4 %}
 {{ vlan['subnet'] }} {% for ifname in minigraph_vlans[vlan['attachto']]['members'] %} {{ minigraph_port_indices[ifname] }} {% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PR #1982 added IPv6 address to vlan interface, which caused
regression in test_fdb_mac_expire. This commit is to address this issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR #1982 added IPv6 address to vlan interface. As a result, the config file **/root/fdb_info.txt** for test_fdb_mac_expire is misformatted, which will cause exception in fdb.py. This PR is to address this issue.
#### How did you do it?
Update the template for generating **/root/fdb_info.txt**, and only IPv4 address is included in the generated config file.  
#### How did you verify/test it?
Verify it on Arista-7260
```
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 1 item                                                                                                                                                                                      

fdb/test_fdb_mac_expire.py::TestFdbMacExpire::testFdbMacExpire 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
06:36:30 INFO __init__.py:set_default:14: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
06:36:30 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
06:36:36 INFO ptfhost_utils.py:copy_ptftests_directory:47: Copy PTF test files to PTF host 'vms7-7'
06:36:51 INFO test_fdb_mac_expire.py:copyFdbInfo:134: Copying fdb_info.txt config file to vms7-7
06:36:56 INFO __init__.py:loganalyzer:15: Log analyzer is disabled
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
06:36:59 INFO test_fdb_mac_expire.py:__runPtfTest:90: Running PTF test case 'fdb_mac_expire_test.FdbMacExpireTest' on 'vms7-7'
06:37:04 INFO test_fdb_mac_expire.py:testFdbMacExpire:236: wait for FDB aging time of '60' secs
06:38:24 INFO test_fdb_mac_expire.py:testFdbMacExpire:248: MAC table entries count: 112, after 75 sec
06:38:41 INFO test_fdb_mac_expire.py:testFdbMacExpire:248: MAC table entries count: 112, after 90 sec
06:38:57 INFO test_fdb_mac_expire.py:testFdbMacExpire:248: MAC table entries count: 0, after 105 sec
PASSED                                                                                                                                                                                          [100%]
------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------
06:39:01 INFO ptfhost_utils.py:copy_ptftests_directory:52: Delete PTF test files from PTF host 'vms7-7'


------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 151.10 seconds ======================================================================================
```
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A