### PR TITLE
Replace all references to 'py.test' with 'pytest'

### DIFF
--- a/ansible/roles/test/tasks/pytest_runner.yml
+++ b/ansible/roles/test/tasks/pytest_runner.yml
@@ -3,8 +3,8 @@
     msg:
       - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
       - "!!!!!! Ansible playbook for running {{ testcase_name }} is now deprecated !!!!!!"
-      - "!!!!!! This playbook is just a wrapper to run py.test in sonic-mgmt/tests !!!!!!"
-      - "!!!!!!!!!!!!!!!!!!!!!!!!!! Consider using py.test !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      - "!!!!!! This playbook is just a wrapper to run pytest in sonic-mgmt/tests  !!!!!!"
+      - "!!!!!!!!!!!!!!!!!!!!!!!!!! Consider using pytest !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
       - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 
 - fail:
@@ -15,9 +15,9 @@
     msg: Testbed is not defined
   when: testbed_name is not defined
 
-- name: set py.test command variable
+- name: set pytest command variable
   set_fact:
-    pytest_cmd: 'py.test {{ test_node }}'
+    pytest_cmd: 'pytest {{ test_node }}'
 
 - name: append filter expression if needed
   set_fact:
@@ -55,7 +55,7 @@
 
 - debug: var=pytest_cmd
 
-- name: run py.test
+- name: run pytest
   delegate_to: localhost
   shell: '{{ pytest_cmd }}'
   args:
@@ -68,5 +68,5 @@
 - debug: msg='{{ out.stdout_lines }}'
 
 - fail:
-    msg: 'py.test run failed'
+    msg: 'pytest run failed'
   when: out.rc != 0

--- a/tests/docs/pytest.org.md
+++ b/tests/docs/pytest.org.md
@@ -93,7 +93,7 @@ def test_notopo():
 Test run
 
 ```
-py.test --inventory inv --host-pattern dut-1 --module-path ../ansible/library/ --testbed tb --testbed_file tb.csv --junit-xml=tr.xml --log-cli-level warn --topology t1 test_topo
+pytest --inventory inv --host-pattern dut-1 --module-path ../ansible/library/ --testbed tb --testbed_file tb.csv --junit-xml=tr.xml --log-cli-level warn --topology t1 test_topo
  --disable_loganalyzer --topology t1 test_topo.py
 ================================= test session starts ==================================
 platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -165,7 +165,7 @@ function run_debug_tests()
 function prepare_dut()
 {
     echo "=== Preparing DUT for subsequent tests ==="
-    py.test ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m pretest
+    pytest ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m pretest
 
     # Give some delay for the newly announced routes to propagate.
     sleep 120
@@ -174,13 +174,13 @@ function prepare_dut()
 function cleanup_dut()
 {
     echo "=== Cleaning up DUT after tests ==="
-    py.test ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m posttest
+    pytest ${PYTEST_UTIL_OPTS} ${POST_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m posttest
 }
 
 function run_group_tests()
 {
     echo "=== Running tests in groups ==="
-    py.test ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} ${TEST_CASES}
+    pytest ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} ${TEST_CASES}
 }
 
 function run_individual_tests()
@@ -210,7 +210,7 @@ function run_individual_tests()
             TEST_LOGGING_OPTIONS="--log-file ${LOG_PATH}/${test_dir}/${test_name}.log --junitxml=${LOG_PATH}/${test_dir}/${test_name}.xml"
         fi
 
-        py.test ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${test_script} ${EXTRA_PARAMETERS}
+        pytest ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${test_script} ${EXTRA_PARAMETERS}
         ret_code=$?
 
         # If test passed, no need to keep its log.

--- a/tests/show_techsupport/README.md
+++ b/tests/show_techsupport/README.md
@@ -64,7 +64,7 @@ Using a parametrized fixture, for each supported configuration named in test exe
 from sonic-mgmt, docker container, tests folder:
 
 ```
-$  py.test --inventory ../ansible/inventory --host-pattern <host> --module-path ../ansible/library/
+$  pytest --inventory ../ansible/inventory --host-pattern <host> --module-path ../ansible/library/
 --testbed <host>-<topology> --testbed_file ../ansible/testbed.csv --show-capture=no --capture=no
  --log-cli-level debug -ra -vvvvv techsupport/test_techsupport.py 
  --loop_num=5 --loop_delay=8 --logs_since=3


### PR DESCRIPTION
The `pytest` command has supplanted `py.test` as the recommended entry point since pytest 3.0. Replace all references in the repo.

Refer to: https://github.com/pytest-dev/pytest/issues/1629