### PR TITLE
Add support of downloading and importing cEOS docker image

### DIFF
--- a/ansible/doc/README.testbed.VsSetup.md
+++ b/ansible/doc/README.testbed.VsSetup.md
@@ -20,6 +20,7 @@ $ sudo ./setup-management-network.sh
    - `vEOS-lab-4.20.15M.vmdk`
 
 ### Use cEOS image (experimental)
+#### Option 1, download and import cEOS image manually
 - Download cEOS image from [arista](https://www.arista.com/en/support/software-download) onto your testbed server
 - Import cEOS image (It will take several minutes to import, so please be patient)
 
@@ -29,6 +30,10 @@ $ docker images
 REPOSITORY                                     TAG                 IMAGE ID            CREATED             SIZE
 ceosimage                                      4.23.2F             d53c28e38448        2 hours ago         1.82GB
 ```
+#### Option 2, download and image cEOS image automatically
+Alternatively, you can host the cEOS image on a http server. Specify `vm_images_url` for downloading the image [here](https://github.com/Azure/sonic-mgmt/blob/master/ansible/group_vars/vm_host/main.yml#L2). If a saskey is required for downloading cEOS image, specify `ceosimage_saskey` in `sonic-mgmt/ansible/vars/azure_storage.yml`.
+
+If you want to skip image downloading when the cEOS image is not imported locally, set `skip_ceos_image_downloading` to `true` in `sonic-mgmt/ansible/group_vars/all/ceos.yml`. Then when cEOS image is not locally imported, the scripts will not try to download it and will fail with an error message. Please use option 1 to download and import the cEOS image manually.
 
 ## Download sonic-vs image
 
@@ -107,7 +112,7 @@ index 3e7b3c4e..edabfc40 100644
 ```
 
 - Create dummy `password.txt` under `/data/sonic-mgmt/ansible`
-  
+
   Please note: Here "password.txt" is the Ansible Vault password file name/path. Ansible allows user to use Ansible Vault to encrypt password files. By default, this shell script requires a password file. If you are not using Ansible Vault, just create a file with a dummy password and pass the filename to the command line. The file name and location is created and maintained by user.
 
 - Add user `foo`'s public key to `/home/foo/.ssh/authorized_keys` on the host

--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,3 +1,4 @@
 ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
 ceos_image_orig: ceosimage:4.23.2F
 ceos_image: ceosimage:4.23.2F-1
+skip_ceos_image_downloading: false

--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,0 +1,3 @@
+ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
+ceos_image_orig: ceosimage:4.23.2F
+ceos_image: ceosimage:4.23.2F-1

--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -10,6 +10,3 @@ sonic_default_passwords:
  - "YourPaSsWoRd"
  - "password"
 sonic_password: "password"
-
-ceos_image_orig: ceosimage:4.23.2F
-ceos_image: ceosimage:4.23.2F-1

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -13,6 +13,10 @@
   become: yes
   register: ceos_stat
 
+- name: Fail if cEOS image does not exist and downloading is not enabled
+  fail: msg="Please ensure that cEOS docker image {{ ceos_image_orig }} is imported locally in test server"
+  when: (ceos_stat.images | length == 0) and skip_ceos_image_downloading
+
 - include_vars: vars/azure_storage.yml
 
 - name: Download cEOS image
@@ -21,12 +25,12 @@
     url: "{{ vm_images_url }}/{{ ceos_image_filename }}?{{ ceosimage_saskey }}"
     dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
     timeout: 1800
-  when: ceos_stat.images | length == 0
+  when: (ceos_stat.images | length == 0) and not skip_ceos_image_downloading
 
 - name: Import cEOS image
   become: yes
   shell: "docker import {{ root_path }}/images/{{ ceos_image_filename }} {{ ceos_image_orig }}"
-  when: ceos_stat.images | length == 0
+  when: (ceos_stat.images | length == 0) and not skip_ceos_image_downloading
 
 - name: create directory for build ceos image
   become: yes

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -6,6 +6,28 @@
     fp_mtu:       "{{ fp_mtu_size }}"
     max_fp_num:   "{{ max_fp_num }}"
 
+- name: Check if cEOS image exists or not
+  docker_image_info:
+    name:
+      - "{{ ceos_image_orig }}"
+  become: yes
+  register: ceos_stat
+
+- include_vars: vars/azure_storage.yml
+
+- name: Download cEOS image
+  become: yes
+  get_url:
+    url: "{{ vm_images_url }}/{{ ceos_image_filename }}?{{ ceosimage_saskey }}"
+    dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
+    timeout: 1800
+  when: ceos_stat.images | length == 0
+
+- name: Import cEOS image
+  become: yes
+  shell: "docker import {{ root_path }}/images/{{ ceos_image_filename }} {{ ceos_image_orig }}"
+  when: ceos_stat.images | length == 0
+
 - name: create directory for build ceos image
   become: yes
   file:

--- a/ansible/vars/azure_storage.yml
+++ b/ansible/vars/azure_storage.yml
@@ -1,4 +1,4 @@
 ## saskey are treated as credential in Credscan
 vmimage_saskey: use_own_value
 cdimage_saskey: use_own_value
-
+ceosimage_saskey: use_own_value


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To deploy a testbed using cEOS, we need to manually import the cEOS docker image
on test server. It would be better if this process can be automated.

#### How did you do it?
* Added code to download the cEOS docker image and import it if it is not available.
* Moved the cEOS image related variables from `ansible/group_vars/all/creds.yml` to `ansible/group_vars/all/ceos.yml`. 
* Added a new variable `ceos_image_filename` in `ansible/group_vars/all/ceos.yml`. 

#### How did you verify/test it?
Scenario1:
* Ensure that there is no local `ceosimage` in docker.
* Try to run `testbed-cli.sh -k ceos add-topo` to deploy a cEOS based testbed.

Scenario2:
* Manually import the `ceosimage` to docker.
* Try to run `testbed-cli.sh -k ceos add-topo` to deploy a cEOS based testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
