### PR TITLE
[acl] Reinit ptfadapter before running ACL tests

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -47,7 +47,7 @@ LOG_EXPECT_ACL_RULE_REMOVE_RE = '.*Successfully deleted ACL rule.*'
 
 
 @pytest.fixture(scope='module')
-def setup(duthost, testbed):
+def setup(duthost, testbed, ptfadapter):
     """
     setup fixture gathers all test required information from DUT facts and testbed
     :param duthost: DUT host object
@@ -113,6 +113,14 @@ def setup(duthost, testbed):
     }
 
     logger.info('setup variables {}'.format(pprint.pformat(setup_information)))
+
+    # FIXME: There seems to be some issue with the initial setup of the ptfadapter, causing some of the
+    # TestBasicAcl tests to fail because the forwarded packets are not being collected. This is an
+    # attempt to mitigate that issue while we continue to investigate the root cause.
+    #
+    # Ref: GitHub Issue #2032
+    logger.info("setting up the ptfadapter")
+    ptfadapter.reinit()
 
     yield setup_information
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Reinit ptfadapter before running ACL tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We're still seeing the issues from #2032 crop up in our nightly tests. This seems to affect TestBasicAcl, but not any of the successive test classes, so we're trying to add a hard reset at the beginning to try to mitigate the problem while we keep looking into the root cause of the ptfadapter failure.

#### How did you do it?
Added a `reinit` call to the ACL test setup.

#### How did you verify/test it?
Ran the tests locally with the extra code and they pass.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
