### PR TITLE
[copp_test] Make copp CT working with copp config generated on swss start

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -4,12 +4,14 @@
     Todo:
         Refactor ptfadapter so it can be leveraged in these test cases.
 """
+import os
 
 DEFAULT_NN_TARGET_PORT = 3
 
 _REMOVE_IP_SCRIPT = "scripts/remove_ip.sh"
 _ADD_IP_SCRIPT = "scripts/add_ip.sh"
 _UPDATE_COPP_SCRIPT = "copp/scripts/update_copp_config.py"
+_COPP_GEN_ENABLE_SCRIPT = "copp/scripts/copp_gen_enable.sh"
 
 _BASE_COPP_CONFIG = "/tmp/00-copp.config.json"
 _SWSS_COPP_CONFIG = "swss:/etc/swss/config.d/00-copp.config.json"
@@ -37,6 +39,18 @@ def limit_policer(dut, pps_limit):
     dut.script(cmd="{} {} {} {}".format(_UPDATE_COPP_SCRIPT, pps_limit,
                                         _BASE_COPP_CONFIG, _TEMP_COPP_CONFIG))
     dut.command("docker cp {} {}".format(_TEMP_COPP_CONFIG, _SWSS_COPP_CONFIG))
+    # Comment out copp config generation in start.sh
+    copp_gen_script_text = '#!/bin/bash\n' + \
+                    'docker exec -ti swss bash -c ' + \
+                    '\"sed -i \'s+sonic-cfggen -d -t /usr/share/sonic/templates/copp.json.j2+' + \
+                    '#sonic-cfggen -d -t /usr/share/sonic/templates/copp.json.j2+g\' /usr/bin/start.sh\"'
+       
+    with open(_COPP_GEN_ENABLE_SCRIPT, 'w') as f:
+        f.write(copp_gen_script_text)
+
+    dut.script(cmd="{}".format(_COPP_GEN_ENABLE_SCRIPT))
+    os.system("rm {}".format(_COPP_GEN_ENABLE_SCRIPT))
+
 
 def restore_policer(dut):
     """
@@ -47,6 +61,19 @@ def restore_policer(dut):
 
             The SWSS container must be restarted for the config change to take effect.
     """
+    # Uncomment copp config generation in start.sh
+    copp_gen_script_text = '#!/bin/bash\n' + \
+                    'docker exec -ti swss bash -c ' + \
+                    '\"sed -i \'s+#sonic-cfggen -d -t /usr/share/sonic/templates/copp.json.j2+' + \
+                    'sonic-cfggen -d -t /usr/share/sonic/templates/copp.json.j2+g\' /usr/bin/start.sh\"'
+       
+    with open(_COPP_GEN_ENABLE_SCRIPT, 'w') as f:
+        f.write(copp_gen_script_text)
+
+    dut.script(cmd="{}".format(_COPP_GEN_ENABLE_SCRIPT))
+    os.system("rm {}".format(_COPP_GEN_ENABLE_SCRIPT))
+
+    # Copy old configf back for backward compatibility on older SONiC images
     dut.command("docker cp {} {}".format(_BASE_COPP_CONFIG, _SWSS_COPP_CONFIG))
 
 def configure_ptf(ptf, nn_target_port):

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -4,7 +4,6 @@
     Todo:
         Refactor ptfadapter so it can be leveraged in these test cases.
 """
-import os
 
 DEFAULT_NN_TARGET_PORT = 3
 

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -43,9 +43,7 @@ def limit_policer(dut, pps_limit):
 
     # As copp config is regenerated each time swss starts need to replace the template with
     # config updated above. But before doing that need store the original template in a temporary file
-    # for restore after test. Also if there is no such a template on older SONiC images let's create it 
-    # with "touch" command for backward compatibility.
-    dut.command("docker exec -d swss touch {}".format(_COPP_TEMPLATE_PATH))
+    # for restore after test.
     dut.command("docker cp {} {}".format(_SWSS_COPP_TEMPLATE, _TEMP_COPP_TEMPLATE))
     dut.command("docker cp {} {}".format(_TEMP_COPP_CONFIG, _SWSS_COPP_TEMPLATE))
 
@@ -60,8 +58,6 @@ def restore_policer(dut):
     """
     # Restore the copp template in swss 
     dut.command("docker cp {} {}".format(_TEMP_COPP_TEMPLATE, _SWSS_COPP_TEMPLATE))
-    # Restore copp config for backward compatibility on older SONiC images
-    dut.command("docker cp {} {}".format(_BASE_COPP_CONFIG, _SWSS_COPP_CONFIG))
 
 def configure_ptf(ptf, nn_target_port):
     """

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -28,6 +28,7 @@
 
 import logging
 import pytest
+import json
 from collections import namedtuple
 
 from tests.copp import copp_utils
@@ -51,7 +52,7 @@ _COPPTestParameters = namedtuple("_COPPTestParameters",
                                   "bgp_graph"])
 _SUPPORTED_PTF_TOPOS = ["ptf32", "ptf64"]
 _SUPPORTED_T1_TOPOS = ["t1", "t1-lag"]
-_T1_NO_COPP_PROTOCOL = ["DHCP"]
+_NO_TOR_EXCLUDE_PROTOCOL = ["DHCP"]
 _TEST_RATE_LIMIT = 600
 
 class TestCOPP(object):
@@ -80,17 +81,32 @@ class TestCOPP(object):
                                           "LACP",
                                           "LLDP",
                                           "UDLD"])
-    def test_no_policer(self, protocol, duthost, ptfhost, copp_testbed):
+    def test_no_policer(self, protocol, duthost, ptfhost, copp_testbed, dut_type):
         """
             Validates that non-rate-limited COPP groups work as expected.
 
             Checks that the policer does not enforce a rate limit for protocols
             that do not have any set rate limit.
         """
+        if protocol in _NO_TOR_EXCLUDE_PROTOCOL and dut_type != "ToRRouter":
+            pytest.skip("{} not supported on {}.".format(protocol, dut_type))
+
         _copp_runner(duthost,
-                     ptfhost,
-                     protocol,
-                     copp_testbed)
+                    ptfhost,
+                    protocol,
+                    copp_testbed)
+
+@pytest.fixture(scope="class")
+def dut_type(duthost):
+    cfg_facts = json.loads(duthost.shell("sonic-cfggen -d --print-data")['stdout'])  # return config db contents(running-config)
+    dut_type = None
+
+    if "DEVICE_METADATA" in cfg_facts:
+        if "localhost" in cfg_facts["DEVICE_METADATA"]:
+            if "type" in cfg_facts["DEVICE_METADATA"]["localhost"]:
+                dut_type = cfg_facts["DEVICE_METADATA"]["localhost"]["type"]
+
+    return dut_type
 
 @pytest.fixture(scope="class")
 def copp_testbed(duthost, creds, ptfhost, testbed, request):
@@ -147,8 +163,7 @@ def _copp_runner(dut, ptf, protocol, test_params):
     ptf_runner(host=ptf,
                testdir="ptftests",
                # Special Handling for DHCP if we are using T1 Topo
-               testname="copp_tests.{}Test".format((protocol+"TopoT1")
-                         if test_params.topo in _SUPPORTED_T1_TOPOS and protocol in _T1_NO_COPP_PROTOCOL else protocol),
+               testname="copp_tests.{}Test".format(protocol),
                platform="nn",
                qlen=100000,
                params=params,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -64,7 +64,7 @@ class TestCOPP(object):
                                           "IP2ME",
                                           "SNMP",
                                           "SSH"])
-    def test_policer(self, protocol, duthost, ptfhost, copp_testbed):
+    def test_policer(self, protocol, duthost, ptfhost, copp_testbed, dut_type):
         """
             Validates that rate-limited COPP groups work as expected.
 
@@ -74,7 +74,8 @@ class TestCOPP(object):
         _copp_runner(duthost,
                      ptfhost,
                      protocol,
-                     copp_testbed)
+                     copp_testbed,
+                     dut_type)
 
     @pytest.mark.parametrize("protocol", ["BGP",
                                           "DHCP",


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR
Fix copp CT in order to make it working with the copp config regenerated each time swss starts.

Summary:
Fixes # (issue)

### Type of change

- [ *] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
copp CT fails on the latest SONiC 201911 release image due to copp config is regenerated each time swss starts which makes the config changed by the testcase overwritten by the one from the template.

#### How did you do it?
1. Comment out copp config generation in /usr/bin/start.sh of swss container and restore it back after testing is finished
1. Skip DHCP test not only for T1 topology but depending on the DUT type as on ptf32 topology the DUT has "LeafRouter" type as well

#### How did you verify/test it?
Ran copp Ct on ptf32 toplogy on 201911 release

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
