### PR TITLE
[BGP] Add clear arp to fix ping error in test_bgp_speaker

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -125,6 +125,12 @@ class TestWrArp:
         ptfhost.shell('supervisorctl reread && supervisorctl update')
 
     @pytest.fixture(scope='class', autouse=True)
+    def clean_dut(self, duthost):
+        yield
+        logger.info("Clear ARP cache on DUT")
+        duthost.command('sonic-clear arp')
+
+    @pytest.fixture(scope='class', autouse=True)
     def setupRouteToPtfhost(self, duthost, ptfhost):
         '''
             Sets routes up on DUT to PTF host. This class-scope fixture runs once before test start

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -112,6 +112,8 @@ def common_setup_teardown(duthost, ptfhost, localhost):
     ptfhost.shell("ip route flush %s/%d" % (lo_addr, lo_addr_prefixlen))
     ptfhost.shell("ip route add %s/%d via %s" % (lo_addr, lo_addr_prefixlen, vlan_addr))
 
+    logging.info("clear ARP cache on DUT")
+    duthost.command("sonic-clear arp")
     for ip in vlan_ips:
         duthost.command("ip route flush %s/32" % ip.ip)
         # The ping here is workaround for known issue:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
**This commit is to fix the exception when pinging from DUT in test_bgp_speaker.**
```
E               "stdout": "PING 192.168.0.3 (192.168.0.3) 56(84) bytes of data.\n\n--- 192.168.0.3 ping statistics ---\n3 packets transmitted, 0 received, 100% packet loss, time 2034ms", 
E               "stdout_lines": [
E                   "PING 192.168.0.3 (192.168.0.3) 56(84) bytes of data.", 
E                   "", 
E                   "--- 192.168.0.3 ping statistics ---", 
E                   "3 packets transmitted, 0 received, 100% packet loss, time 2034ms"
E               ]
```
The ping command in test_bgp_speaker return error code when running on Jenkins. This is because the test_wr_arp leave ARP table on DUT, which causes some ip address unreachable. This commit add clear after test_wr_arp and before test_bgp_speaker
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ping failure in test_bgp_speaker when running on Jenkins.
#### How did you do it?
1. Add **sonic-clear arp** after test_wr_arp to clear ARP cache, in case that the ARP table has lasting effect on other cases;
2. Add **sonic-clear arp** before test_bgp_speaker to make itself more robust.
#### How did you verify/test it?
1.Run test_wr_arp and test_bgp_speaker_bgp_sessions, and both cases passed.
2.Run **show arp** on DUT to confirm ARP table is cleared.
```
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 1 item                                                                                                                                                                                      

arp/test_wr_arp.py::TestWrArp::testWrArp ^@PASSED                                                                                                                                                 [100%]
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 1 item                                                                                                                                                                                      

bgp/test_bgp_speaker.py::test_bgp_speaker_bgp_sessions PASSED                                                                                                                                   [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A