### PR TITLE
[Ansible] Support multiple passwords for SSH connection

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -1,0 +1,69 @@
+import imp
+import os
+
+from functools import wraps
+from ansible.errors import AnsibleAuthenticationFailure
+from ansible.plugins import connection
+
+
+# HACK: workaround to import the SSH connection plugin
+_ssh_mod = os.path.join(os.path.dirname(connection.__file__), "ssh.py")
+_ssh = imp.load_source("_ssh", _ssh_mod)
+
+# Use same options as the builtin Ansible SSH plugin
+DOCUMENTATION = _ssh.DOCUMENTATION
+# Add an option `ansible_ssh_altpassword` to represent an alternative password
+# to try if `ansible_ssh_password` is invalid
+DOCUMENTATION += """
+      altpassword:
+          description: Alternative authentication password for the C(remote_user). Can be supplied as CLI option.
+          vars:
+              - name: ansible_altpassword
+              - name: ansible_ssh_altpass
+              - name: ansible_ssh_altpassword
+""".lstrip("\n")
+
+
+def _password_retry(func):
+    """
+    Decorator to retry ssh/scp/sftp in the case of invalid password
+
+    Will retry for password in (ansible_password, ansible_altpassword):
+    """
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        password = self.get_option("password") or self._play_context.password
+        conn_passwords = [password]
+        altpassword = self.get_option("altpassword")
+        if altpassword:
+            conn_passwords.append(altpassword)
+
+        while conn_passwords:
+            conn_password = conn_passwords.pop(0)
+            # temporarily replace `password` for this trial
+            self.set_option("password", conn_password)
+            self._play_context.password = conn_password
+            try:
+                return func(self, *args, **kwargs)
+            except AnsibleAuthenticationFailure:
+                # if there is no more altpassword to try, raise
+                if not conn_passwords:
+                    raise
+            finally:
+                # reset `password` to its original state
+                self.set_option("password", password)
+                self._play_context.password = password
+            # retry here, need create a new pipe for sshpass
+            self.sshpass_pipe = os.pipe()
+    return wrapped
+
+
+class Connection(_ssh.Connection):
+
+    @_password_retry
+    def _run(self, *args, **kwargs):
+        return super(Connection, self)._run(*args, **kwargs)
+
+    @_password_retry
+    def _file_transport_command(self, *args, **kwargs):
+        return super(Connection, self)._file_transport_command(*args, **kwargs)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Add connection plugin `multi_passwd_ssh` to support specify
an alternative SSH password via setting anyone of the following
three Ansible variables:
```
ansible_altpassword
ansible_ssh_altpass
ansible_ssh_altpassword
```
With this, Ansible will try to authenticate with the password specified
by `ansible_password` first, if the authentication fails, it will switch
to `ansible_altpassword`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To test `SONiC` from different vendors with different admin passwords.

#### How did you do it?
Add decorator `_password_retry` to catch `AnsibleAuthenticationFailure` raised from Ansible SSH connection and switch
to alternative password to try.

#### How did you verify/test it?
1. Ansible
```
$ ansible -i str -m ping -e "ansible_connection='multi_passwd_ssh'" -e "ansible_password='wrongpass'" -e "ansible_ssh_altpass='correctpass'" lab-msn2700-2
lab-msn2700-2 | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "ping": "pong"
}
```
2. Pytest
```
# export ANSIBLE_LIBRARY=../ansible
# export ANSIBLE_CONNECTION_PLUGINS=../ansible/plugins/connection
# pytest --inventory ../ansible/lab --host-pattern all -vvv --show-capture stdout --testbed vms1-t0 --testbed_file ../ansible/testbed.csv --skip_sanity --log-file-level debug -vvvvv bgp/test_bgp_fact.py
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
