### PR TITLE
[pfcwd] Include regexp to ignore invalid OIDs error during loganalysis

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -24,6 +24,24 @@ def stop_pfcwd(duthost):
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
+@pytest.fixture(autouse=True)
+def ignore_loganalyzer_exceptions(duthost, loganalyzer):
+    """
+    Fixture that ignores expected failures during test execution.
+
+    Args:
+        duthost (AnsibleHost): DUT instance
+        loganalyzer (loganalyzer): Loganalyzer utility fixture
+    """
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
+            ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*"
+        ]
+        loganalyzer.ignore_regex.extend(ignoreRegex)
+
+    yield
+
 @pytest.fixture(scope='class', autouse=True)
 def pfcwd_timer_setup_restore(setup_pfc_test, fanout_graph_facts, duthost, fanouthosts):
     """


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Pfcwd timer test failed on T1 during nightly runs due the following errors seen in the loganalysis during the test teardown stage. This PR includes these regexp to ignore during loganalysis stage

g 18 10:56:49.665820 str-dx010-acs-1 ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB
Aug 18 10:56:49.665877 str-dx010-acs-1 ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug?

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


