### PR TITLE
Update devices.py to make it compatible with latest SONiC image

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -421,7 +421,7 @@ class SonicHost(AnsibleHostBase):
         @return: dictionary of { service_name1 : state1, ... ... }
         """
         # some services are meant to have a short life span or not part of the daemons
-        exemptions = ['lm-sensors', 'start.sh', 'rsyslogd']
+        exemptions = ['lm-sensors', 'start.sh', 'rsyslogd', 'start', 'dependent-startup']
 
         daemons = self.shell('docker exec pmon supervisorctl status')['stdout_lines']
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -758,9 +758,13 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             bool: status obtained successfully (True | False)
         """
         feature_status = {}
-        command_output = self.shell('show features', module_ignore_errors=True)
-        if command_output['rc'] != 0:
-            return feature_status, False
+        command_list = ['show feature status', 'show features']
+        for cmd in command_list:
+            command_output = self.shell(cmd, module_ignore_errors=True)
+            if command_output['rc'] == 0:
+                break
+            else:
+                return feature_status, False
 
         features_stdout = command_output['stdout_lines']
         lines = features_stdout[2:]

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -763,8 +763,8 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             command_output = self.shell(cmd, module_ignore_errors=True)
             if command_output['rc'] == 0:
                 break
-            else:
-                return feature_status, False
+        else:
+            return feature_status, False
 
         features_stdout = command_output['stdout_lines']
         lines = features_stdout[2:]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
1. Recent SONiC image added dependent-startup service to docker images, and start.sh is renamed to start. These two updates cause check_pmon_daemon_status return false;
2. The latest image introduces command 'show feature status' to get feature list. This commit update the command used in get_feature_status, and keep compatible with pre versions and the same time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to update devices.py to make it compatible with latest SONiC image.
#### How did you do it?
1. Update the ignore list in check_pmon_daemon_status;
2. Update the command used in get_feature_status.
#### How did you verify/test it?
Verified on Arista-7260.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A