### PR TITLE
Set test module name in payload of packets injected by ptfadapter

### DIFF
--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -11,35 +11,41 @@ DEFAULT_DEVICE_NUM = 0
 ETH_PFX = 'eth'
 
 
-# Below code is to override the 'send' function in the ptf.testutils module. Purpose of this change is to insert
-# code for updating the packet pattern before send it out. Generally we want to make the payload part of injected
-# packet to have string of current test module and case name. While inspecting the captured packets, it is easier
-# to fiture out which packets are injected by which test case.
-def _send(test, port_id, pkt, count=1):
-    update_payload = getattr(test, "update_payload", None)
-    if update_payload and callable(update_payload):
-        pkt = test.update_payload(pkt)
-
-    return ptf.testutils.send_packet(test, port_id, pkt, count=count)
-setattr(ptf.testutils, "send", _send)
+def pytest_addoption(parser):
+    parser.addoption("--keep_payload", action="store_true", default=False,
+                     help="Keep the original packet payload, do not update payload to default pattern")
 
 
-# Below code is to override the 'dp_poll' function in the ptf.testutils module. This function is called by all
-# the other functions for receiving packets in the ptf.testutils module. Purpose of this overriding is to update
-# the payload of received packet using the same method to match the updated injected packets.
-def _dp_poll(test, device_number=0, port_number=None, timeout=-1, exp_pkt=None):
-    update_payload = getattr(test, "update_payload", None)
-    if update_payload and callable(update_payload):
-        exp_pkt = test.update_payload(exp_pkt)
+def override_ptf_functions():
+    # Below code is to override the 'send' function in the ptf.testutils module. Purpose of this change is to insert
+    # code for updating the packet pattern before send it out. Generally we want to make the payload part of injected
+    # packet to have string of current test module and case name. While inspecting the captured packets, it is easier
+    # to fiture out which packets are injected by which test case.
+    def _send(test, port_id, pkt, count=1):
+        update_payload = getattr(test, "update_payload", None)
+        if update_payload and callable(update_payload):
+            pkt = test.update_payload(pkt)
 
-    result = test.dataplane.poll(
-        device_number=device_number, port_number=port_number,
-        timeout=timeout, exp_pkt=exp_pkt, filters=ptf.testutils.FILTERS
-    )
-    if isinstance(result, test.dataplane.PollSuccess):
-        test.at_receive(result.packet, device_number=result.device, port_number=result.port)
-    return result
-setattr(ptf.testutils, "dp_poll", _dp_poll)
+        return ptf.testutils.send_packet(test, port_id, pkt, count=count)
+    setattr(ptf.testutils, "send", _send)
+
+
+    # Below code is to override the 'dp_poll' function in the ptf.testutils module. This function is called by all
+    # the other functions for receiving packets in the ptf.testutils module. Purpose of this overriding is to update
+    # the payload of received packet using the same method to match the updated injected packets.
+    def _dp_poll(test, device_number=0, port_number=None, timeout=-1, exp_pkt=None):
+        update_payload = getattr(test, "update_payload", None)
+        if update_payload and callable(update_payload):
+            exp_pkt = test.update_payload(exp_pkt)
+
+        result = test.dataplane.poll(
+            device_number=device_number, port_number=port_number,
+            timeout=timeout, exp_pkt=exp_pkt, filters=ptf.testutils.FILTERS
+        )
+        if isinstance(result, test.dataplane.PollSuccess):
+            test.at_receive(result.packet, device_number=result.device, port_number=result.port)
+        return result
+    setattr(ptf.testutils, "dp_poll", _dp_poll)
 
 
 def get_ifaces(netdev_output):
@@ -100,7 +106,9 @@ def ptfadapter(ptfhost, testbed, request):
     ptfhost.command('supervisorctl restart ptf_nn_agent')
 
     with PtfTestAdapter(testbed['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys()) as adapter:
-        node_id = request.module.__name__
-        adapter.payload_pattern = node_id + " "
+        if not request.config.option.keep_payload:
+            override_ptf_functions()
+            node_id = request.module.__name__
+            adapter.payload_pattern = node_id + " "
 
         yield adapter

--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -34,7 +34,7 @@ def _dp_poll(test, device_number=0, port_number=None, timeout=-1, exp_pkt=None):
 
     result = test.dataplane.poll(
         device_number=device_number, port_number=port_number,
-        timeout=timeout, exp_pkt=exp_pkt, filters=[]
+        timeout=timeout, exp_pkt=exp_pkt, filters=ptf.testutils.FILTERS
     )
     if isinstance(result, test.dataplane.PollSuccess):
         test.at_receive(result.packet, device_number=result.device, port_number=result.port)

--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -3,10 +3,43 @@ import os
 import pytest
 
 from ptfadapter import PtfTestAdapter
+import ptf.testutils
+
 
 DEFAULT_PTF_NN_PORT = 10900
 DEFAULT_DEVICE_NUM = 0
 ETH_PFX = 'eth'
+
+
+# Below code is to override the 'send' function in the ptf.testutils module. Purpose of this change is to insert
+# code for updating the packet pattern before send it out. Generally we want to make the payload part of injected
+# packet to have string of current test module and case name. While inspecting the captured packets, it is easier
+# to fiture out which packets are injected by which test case.
+def _send(test, port_id, pkt, count=1):
+    update_payload = getattr(test, "update_payload", None)
+    if update_payload and callable(update_payload):
+        pkt = test.update_payload(pkt)
+
+    return ptf.testutils.send_packet(test, port_id, pkt, count=count)
+setattr(ptf.testutils, "send", _send)
+
+
+# Below code is to override the 'dp_poll' function in the ptf.testutils module. This function is called by all
+# the other functions for receiving packets in the ptf.testutils module. Purpose of this overriding is to update
+# the payload of received packet using the same method to match the updated injected packets.
+def _dp_poll(test, device_number=0, port_number=None, timeout=-1, exp_pkt=None):
+    update_payload = getattr(test, "update_payload", None)
+    if update_payload and callable(update_payload):
+        exp_pkt = test.update_payload(exp_pkt)
+
+    result = test.dataplane.poll(
+        device_number=device_number, port_number=port_number,
+        timeout=timeout, exp_pkt=exp_pkt, filters=[]
+    )
+    if isinstance(result, test.dataplane.PollSuccess):
+        test.at_receive(result.packet, device_number=result.device, port_number=result.port)
+    return result
+setattr(ptf.testutils, "dp_poll", _dp_poll)
 
 
 def get_ifaces(netdev_output):
@@ -33,7 +66,7 @@ def get_ifaces(netdev_output):
 
 
 @pytest.fixture(scope='module')
-def ptfadapter(ptfhost, testbed):
+def ptfadapter(ptfhost, testbed, request):
     """return ptf test adapter object.
     The fixture is module scope, because usually there is not need to
     restart PTF nn agent and reinitialize data plane thread on every
@@ -63,5 +96,11 @@ def ptfadapter(ptfhost, testbed):
     ptfhost.command('supervisorctl reread')
     ptfhost.command('supervisorctl update')
 
+    # Force a restart of ptf_nn_agent to ensure that it is in good status.
+    ptfhost.command('supervisorctl restart ptf_nn_agent')
+
     with PtfTestAdapter(testbed['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys()) as adapter:
+        node_id = request.module.__name__
+        adapter.payload_pattern = node_id + " "
+
         yield adapter

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -99,7 +99,7 @@ class PtfTestAdapter(BaseTest):
         has UDP or TCP header, then update its TCP or UDP payload.
 
         If it is a masked packet, then its 'exp_pkt' is the regular scapy packet. Update the payload of its 'exp_pkt'
-        propery.
+        properly.
 
         Args:
             pkt [scapy packet or masked packet]: The packet to be updated.
@@ -121,7 +121,7 @@ class PtfTestAdapter(BaseTest):
         """Update payload to the default_pattern if default_pattern is set.
 
         If length of the payload_pattern is longer payload, truncate payload_pattern to the length of payload.
-        Otherwise, repeat the payload_pattern to reach the leangth of payload. Keep length of updated payload same
+        Otherwise, repeat the payload_pattern to reach the length of payload. Keep length of updated payload same
         as the original payload.
 
         Args:

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -93,6 +93,20 @@ class PtfTestAdapter(BaseTest):
         self._init_ptf_dataplane(self.ptf_ip, self.ptf_nn_port, self.device_num, self.ptf_port_set, ptf_config)
 
     def update_payload(self, pkt):
+        """Update the payload of packet to the default pattern when certain conditions are met.
+
+        The packet passed in could be a regular scapy packet or a masked packet. If it is a regular scapy packet and
+        has UDP or TCP header, then update its TCP or UDP payload.
+
+        If it is a masked packet, then its 'exp_pkt' is the regular scapy packet. Update the payload of its 'exp_pkt'
+        propery.
+
+        Args:
+            pkt [scapy packet or masked packet]: The packet to be updated.
+
+        Returns:
+            [scapy packet or masked packet]: Returns the packet with payload part updated.
+        """
         if isinstance(pkt, scapy.Ether):
             for proto in (scapy.UDP, scapy.TCP):
                 if proto in pkt:
@@ -104,6 +118,18 @@ class PtfTestAdapter(BaseTest):
         return pkt
 
     def _update_payload(self, payload):
+        """Update payload to the default_pattern if default_pattern is set.
+
+        If length of the payload_pattern is longer payload, truncate payload_pattern to the length of payload.
+        Otherwise, repeat the payload_pattern to reach the leangth of payload. Keep length of updated payload same
+        as the original payload.
+
+        Args:
+            payload [string]: The payload to be updated.
+
+        Returns:
+            [string]: The updated payload.
+        """
         if self.payload_pattern:
             len_old = len(payload)
             len_new = len(self.payload_pattern)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR enhanced the ptfadapter fixture to include test module name in
the payload of injected TCP/UDP packets. Then in the captured pcap file,
it would be easier to tell which packets are injected by the test script.

#### How did you do it?
* Override the function in ptf.testutils for sending packets in the ptfadapter plugin. Intercept the packets to be sent and update its payload to repetition of test module name.
* Override the function in ptf.testutils for receiving packets in the ptfadapter plugin. Intercept the expected packet and update its payload using the same method to match the sent packets.

#### How did you verify/test it?
Test run ACL and sip_dip scripts which dependent on ptfadapter. Capture the packets and inspect the payload.
* Both ACL and sip_dip testing passed without issue.
* In captured pcap file, the packets injected by the scripts have payload set to the repetition of the test module name.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
