### PR TITLE
[ACL] Correct rule ID used to check ACL counter in teardown phase.

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -480,7 +480,7 @@ class BaseAclTest(object):
         testutils.send(ptfadapter, self.get_src_port(setup, direction), pkt)
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
 
-        counters_sanity_check.append(2 if direction == 'spine->tor' else 3)
+        counters_sanity_check.append(3 if direction == 'spine->tor' else 2)
 
     def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
         """ test destination IP matched packet dropped """
@@ -493,7 +493,7 @@ class BaseAclTest(object):
         testutils.send(ptfadapter, self.get_src_port(setup, direction), pkt)
         testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
 
-        counters_sanity_check.append(15 if direction == 'spine->tor' else 16)
+        counters_sanity_check.append(16 if direction == 'spine->tor' else 15)
 
     def test_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
         """ test source IP matched packet dropped """
@@ -571,7 +571,7 @@ class BaseAclTest(object):
         testutils.send(ptfadapter, self.get_src_port(setup, direction), pkt)
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
 
-        counters_sanity_check.append(5)
+        counters_sanity_check.append(9)
 
     def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
         """ test L4 source port matched packet forwarded """
@@ -610,7 +610,7 @@ class BaseAclTest(object):
         testutils.send(ptfadapter, self.get_src_port(setup, direction), pkt)
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
 
-        counters_sanity_check.append(10)
+        counters_sanity_check.append(17)
 
     def test_l4_dport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
         """ test L4 destination port range matched packet dropped """
@@ -649,7 +649,7 @@ class BaseAclTest(object):
         testutils.send(ptfadapter, self.get_src_port(setup, direction), pkt)
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
 
-        counters_sanity_check.append(5)
+        counters_sanity_check.append(19)
 
     def test_tcp_flags_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
         """ test TCP flags matched packet forwarded """


### PR DESCRIPTION
**- What I did**

Correct rule ID used to check ACL counter in teardown phase. Without the modification, counter sanity check in teardown phase will fail, because pytest check wrong ACL rule counter.

**- How I did it**

According to rules listed in `tests/acl/templates/acltb_test_rules.j2`, we verify test cases one by one and fix five following test cases:

* test_dest_ip_match_dropped
* test_dest_ip_match_forwarded
* test_l4_dport_match_forwarded
* test_l4_sport_match_dropped
* test_tcp_flags_match_dropped

**- How to verify it**

Before modification:

    ============================= test session starts ==============================
    platform linux2 -- Python 2.7.12, pytest-4.6.7, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python2
    cachedir: .pytest_cache
    ansible: 2.8.7
    rootdir: /var/sonic/sonic-mgmt/tests, inifile: pytest.ini
    plugins: ansible-2.2.2, pyfakefs-3.7.2, csv-2.0.2
    collecting ... collected 1 item

    acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ingress-spine->tor] 
    -------------------------------- live log setup --------------------------------
    ...
    ==================================== ERRORS ====================================
    _ ERROR at teardown of TestBasicAcl.test_dest_ip_match_forwarded[ingress-spine->tor] _

    self = <test_acl.TestBasicAcl object at 0x7f864e6ead50>
    duthost = <common.devices.SonicHost object at 0x7f864dcaba90>, acl_rules = None
    acl_table = {'config_file': 'tmp/acl/acl_table_DATAINGRESS.json', 'name': 'DATAINGRESS'}

        @pytest.yield_fixture(scope='class', autouse=True)
        def counters_sanity_check(self, duthost, acl_rules, acl_table):
    ...
            for rule in rule_list:
                rule = 'RULE_{}'.format(rule)
                counters_after = acl_facts_after_traffic[rule]
                counters_before = acl_facts_before_traffic[rule]
                logger.info('counters for {} before traffic:\n{}'.format(rule, pprint.pformat(counters_before)))
                logger.info('counters for {} after traffic:\n{}'.format(rule, pprint.pformat(counters_after)))
    >           assert counters_after['packets_count'] > counters_before['packets_count']
    E           assert 0 > 0
    ...
    acl/test_acl.py:349: AssertionError
    ...
    ===================== 1 passed, 1 error in 125.54 seconds ======================

After modification:

    ============================= test session starts ==============================
    platform linux2 -- Python 2.7.12, pytest-4.6.7, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python
    cachedir: .pytest_cache
    ansible: 2.8.7
    rootdir: /var/sonic/sonic-mgmt/tests, inifile: pytest.ini
    plugins: ansible-2.2.2, csv-2.0.2
    collecting ... collected 1 item

    acl/test_acl_new.py::TestBasicAcl::test_dest_ip_match_forwarded[ingress-spine->tor] 
    -------------------------------- live log call ---------------------------------
    WARNING  dataplane:dataplane.py:873 Dataplane poll with exp_pkt but no port number
    PASSED                                                                   [100%]

    ============================ slowest test durations ============================
    99.34s setup    acl/test_acl_new.py::TestBasicAcl::test_dest_ip_match_forwarded[ingress-spine->tor]
    29.57s teardown acl/test_acl_new.py::TestBasicAcl::test_dest_ip_match_forwarded[ingress-spine->tor]
    0.08s call     acl/test_acl_new.py::TestBasicAcl::test_dest_ip_match_forwarded[ingress-spine->tor]
    ========================== 1 passed in 129.05 seconds ==========================
