### PR TITLE
[dir_bcast] Skip the prefix if not an IPv4 prefix

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -72,6 +72,8 @@ class BcastTest(BaseTest):
             for line in f.readlines():
                 entry = line.split(' ', 1)
                 prefix = ip_network(unicode(entry[0]))
+                if prefix.version != 4:
+                    continue
                 self._vlan_dict[prefix] = [int(i) for i in entry[1].split()]
 
     #---------------------------------------------------------------------
@@ -116,7 +118,7 @@ class BcastTest(BaseTest):
         logging.info("Sending packet from port " + str(src_port) + " to " + ip_dst)
 
         pkt_count = count_matched_packets_all_ports(self, masked_exp_pkt, dst_port_list)
-        ''' 
+        '''
         Check if broadcast packet is received on all member ports of vlan
         '''
         logging.info("Received " + str(pkt_count) + " broadcast packets, expecting " + str(len(dst_port_list)))
@@ -159,7 +161,7 @@ class BcastTest(BaseTest):
         logging.info("Sending BOOTP packet from port " + str(src_port) + " to " + ip_dst)
 
         pkt_count = count_matched_packets_all_ports(self, masked_exp_pkt, dst_port_list)
-        ''' 
+        '''
         Check if broadcast BOOTP packet is received on all member ports of vlan
         '''
         logging.info("Received " + str(pkt_count) + " broadcast BOOTP packets, expecting " + str(len(dst_port_list)))


### PR DESCRIPTION
There is no broadcast for v6.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
