### PR TITLE
[multi_passwd_ssh] Enable for group sonic

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -1,4 +1,5 @@
 ansible_ssh_user: admin
+ansible_connection: multi_passwd_ssh
 
 sonic_version: "v2"
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -76,6 +76,7 @@ function setup_environment()
 
     export ANSIBLE_CONFIG=${BASE_PATH}/ansible
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
+    export ANSIBLE_CONNECTION_PLUGINS=${BASE_PATH}/ansible/plugins/connection
 }
 
 function setup_test_options()


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make `multi_passwd_ssh` connection plugin the default for group `sonic`.

#### How did you do it?

#### How did you verify/test it?
```
/run_tests.sh -i veos_vtb -d vlab-01 -n vms-kvm-t0 -f vtestbed.csv -k debug -l warning -m individual -q 1 -a False -e --disable_loganalyzer -c dhcp_relay/test_dhcp_relay.py
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
