### PR TITLE
[drop_counter] Fix test failure of test_neighbor_link_down[L3_EGRESS_LINK_DOWN]

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -241,13 +241,7 @@ def mock_server(fanouthosts, testbed_params, arp_responder, ptfadapter, duthost)
     duthost.command("sonic-clear arp")
 
     # Populate FDB
-    logging.info("Populating FDB entry for mock server under VLAN")
-    src_mac = _hex_to_mac(arp_responder[server_dst_port][server_dst_addr])
-    pkt = _get_simple_ip_packet(src_mac,
-                                duthost.get_dut_iface_mac(server_dst_intf),
-                                server_dst_addr,
-                                MOCK_DEST_IP)
-    _send_packets(duthost, ptfadapter, pkt, server_dst_port, count=100)
+    logging.info("Populating FDB and ARP entry for mock server under VLAN")
     # Issue a ping to populate ARP table on DUT
     duthost.command('ping %s -c 3' % server_dst_addr, module_ignore_errors=True)
     fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, server_dst_intf)

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -297,6 +297,3 @@ def _send_packets(duthost, ptfadapter, pkt, ptf_tx_port_id,
     testutils.send(ptfadapter, ptf_tx_port_id, pkt, count=count)
     time.sleep(1)
 
-
-def _hex_to_mac(hex_mac):
-    return ':'.join(hex_mac[i:i+2] for i in range(0, len(hex_mac), 2))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
There are two minor issues causing test failure in this case:
1. The config file for arp_responder may containds duplicate ip addresses, which causes unexpected ARP table on DUT;
2. The interface is down before ARP request is sent, which causes no ARP entry for selected IP address.
This commit fix above issues.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure of test_neighbor_link_down.
#### How did you do it?
There are two minor issues causing test failure in this case as described in summary. This PR address these issues:
1. Add a check for duplication before adding ip address to config file for arp_responder;
2. Issue a ping before interface is down to populate ARP table on DUT.
#### How did you verify/test it?
Verify on Arista-7260:
```
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 2 items                                                                                                                                                                                     

drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED                                                                         [ 50%]
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[SWITCH_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] SKIPPED                                                                      [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
================================================================================ 1 passed, 1 skipped in 83.44 seconds =================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A