### PR TITLE
[dhcp-relay] DHCP Packet forwarding Test

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -17,10 +17,8 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 class DhcpPktFwdBase:
-    """
-    Base class for DHCP packet forwarding test. The test ensure that DHCP packets are going through T1 device.
-    """
-    LEASE_TIME = 86400
+    """Base class for DHCP packet forwarding test. The test ensure that DHCP packets are going through T1 device."""
+    LEASE_TIME_SEC = 86400
     DHCP_PKT_BOOTP_MIN_LEN = 300
     DHCP_CLIENT = {
         "mac": "00:11:22:33:44:55",
@@ -48,7 +46,7 @@ class DhcpPktFwdBase:
             testPort(str): port name used for test
 
         Returns:
-            lags(list): list of port indeces (if any) if LAG which has testPort as a member
+            lags(list): list of port indices (if any) if LAG which has testPort as a member
             peerIp(str): BGP peer IP
         """
         peerIp = None
@@ -96,7 +94,7 @@ class DhcpPktFwdBase:
     @pytest.fixture(scope="class")
     def dutPorts(self, duthost, testbed):
         """
-        Buils list of DUT ports and classify them as Upstream/Downstream ports.
+        Build list of DUT ports and classify them as Upstream/Downstream ports.
 
         Args:
             duthost(Ansible Fixture): instance of SonicHost class of DUT
@@ -105,7 +103,7 @@ class DhcpPktFwdBase:
         Returns:
             dict: contains downstream/upstream ports information
         """
-        if testbed["topo"]["name"] not in ("t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"):
+        if "t1" not in testbed["topo"]["name"]:
             pytest.skip("Unsupported topology")
 
         downstreamPorts = []
@@ -212,7 +210,7 @@ class DhcpPktFwdBase:
             port_dst=self.DHCP_SERVER["port"],
             ip_gateway=self.DHCP_RELAY["ip"],
             netmask_client=self.DHCP_CLIENT["subnet"],
-            dhcp_lease=self.LEASE_TIME,
+            dhcp_lease=self.LEASE_TIME_SEC,
             padding_bytes=0,
             set_broadcast_bit=True
         )
@@ -281,15 +279,13 @@ class DhcpPktFwdBase:
             port_dst=self.DHCP_SERVER["port"],
             ip_gateway=self.DHCP_RELAY["ip"],
             netmask_client=self.DHCP_CLIENT["subnet"],
-            dhcp_lease=self.LEASE_TIME,
+            dhcp_lease=self.LEASE_TIME_SEC,
             padding_bytes=0,
             set_broadcast_bit=True
         )
 
 class TestDhcpPktFwd(DhcpPktFwdBase):
-    """
-    DHCP Packet forward test class
-    """
+    """DHCP Packet forward test class"""
     @pytest.mark.parametrize("pktInfo", [
         {"txDir": "downstream", "rxDir": "upstream", "pktGen": DhcpPktFwdBase.createDhcpDiscoverRelayedPacket},
         {"txDir": "upstream", "rxDir": "downstream", "pktGen": DhcpPktFwdBase.createDhcpOfferPacket},

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -1,0 +1,329 @@
+import logging
+import random
+import ipaddr
+import ipaddress
+import pytest
+
+import ptf.testutils as testutils
+import ptf.packet as scapy
+
+from ptf.mask import Mask
+from socket import INADDR_ANY
+
+pytestmark = [
+    pytest.mark.topology("t1")
+]
+
+logger = logging.getLogger(__name__)
+
+class DhcpPktFwdBase:
+    """
+    Base class for DHCP packet forwarding test. The test ensure that DHCP packets are going through T1 device.
+    """
+    LEASE_TIME = 86400
+    DHCP_PKT_BOOTP_MIN_LEN = 300
+    DHCP_CLIENT = {
+        "mac": "00:11:22:33:44:55",
+        "ip": "10.10.10.1",
+        "subnet": "255.255.255.0",
+        "port": 68,
+    }
+    DHCP_RELAY = {
+        "mac": "22:33:44:55:00:11",
+        "ip": "20.20.20.1",
+        "loopback": "10.0.0.33",
+    }
+    DHCP_SERVER = {
+        "mac": "44:55:00:11:22:33",
+        "ip": "30.30.30.30",
+        "port": 67,
+    }
+
+    def __getPortLagsAndPeerIp(self, duthost, testPort):
+        """
+        Retreives all port lag members for a given testPort
+
+        Args:
+            duthost(Ansible Fixture): instance of SonicHost class of DUT
+            testPort(str): port name used for test
+
+        Returns:
+            lags(list): list of port indeces (if any) if LAG which has testPort as a member
+            peerIp(str): BGP peer IP
+        """
+        peerIp = None
+        mgFacts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+        for peer in mgFacts["minigraph_bgp"]:
+            if peer["name"] == mgFacts["minigraph_neighbors"][testPort]["name"] and \
+               ipaddr.IPAddress(peer["addr"]).version == 4:
+                peerIp = peer["addr"]
+                break
+
+        lags = [mgFacts["minigraph_port_indices"][testPort]]
+        for portchannelConfig in mgFacts["minigraph_portchannels"].values():
+            if testPort in portchannelConfig["members"]:
+                for lag in portchannelConfig["members"]:
+                    if testPort != lag:
+                        lags.append(mgFacts["minigraph_port_indices"][lag])
+                break
+
+        return lags, peerIp
+
+    def __updateRoute(self, duthost, ip, peerIp, op=""):
+        """
+        Update route to add/remove for a given IP <ip> towards BGP peer
+
+         Args:
+            duthost(Ansible Fixture): instance of SonicHost class of DUT
+            ip(str): IP to add/remove route for
+            peerIp(str): BGP peer IP
+            op(str): operation add/remove to be performed, default add
+
+        Returns:
+            None
+        """
+        logger.info("{0} route to '{1}' via '{2}'".format(
+            "Deleting" if "no" == op else "Adding",
+            ip,
+            peerIp
+        ))
+        duthost.shell("vtysh -c \"configure terminal\" -c \"{} ip route {} {}\"".format(
+            op,
+            ipaddress.ip_interface(unicode(ip + "/24")).network,
+            peerIp
+        ))
+
+    @pytest.fixture(scope="class")
+    def dutPorts(self, duthost, testbed):
+        """
+        Buils list of DUT ports and classify them as Upstream/Downstream ports.
+
+        Args:
+            duthost(Ansible Fixture): instance of SonicHost class of DUT
+            testbed(Ansible Fixture): testbed information
+
+        Returns:
+            dict: contains downstream/upstream ports information
+        """
+        if testbed["topo"]["name"] not in ("t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"):
+            pytest.skip("Unsupported topology")
+
+        downstreamPorts = []
+        upstreamPorts = []
+
+        mgFacts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+
+        for dutPort, neigh in mgFacts["minigraph_neighbors"].items():
+            if "T0" in neigh["name"]:
+                downstreamPorts.append(dutPort)
+            elif "T2" in neigh["name"]:
+                upstreamPorts.append(dutPort)
+
+        yield {"upstreamPorts": upstreamPorts, "downstreamPorts": downstreamPorts}
+
+    @pytest.fixture(scope="class")
+    def testPorts(self, duthost, dutPorts):
+        """
+        Select one upstream and one downstream ports for DHCP packet forwarding test
+
+        Args:
+            duthost(Ansible Fixture): instance of SonicHost class of DUT
+            dutPorts(Ansible Fixture, dict): contains downstream/upstream ports information
+
+        Returns:
+            dict: contains downstream/upstream port (or LAG members) information used for test
+        """
+        downstreamLags, downstreamPeerIp = self.__getPortLagsAndPeerIp(
+            duthost,
+            random.choice(dutPorts["downstreamPorts"])
+        )
+        upstreamLags, upstreamPeerIp = self.__getPortLagsAndPeerIp(
+            duthost,
+            random.choice(dutPorts["upstreamPorts"])
+        )
+
+        self.__updateRoute(duthost, self.DHCP_SERVER["ip"], upstreamPeerIp)
+        self.__updateRoute(duthost, self.DHCP_RELAY["ip"], downstreamPeerIp)
+
+        yield {"upstream": upstreamLags, "downstream": downstreamLags}
+
+        self.__updateRoute(duthost, self.DHCP_SERVER["ip"], upstreamPeerIp, "no")
+        self.__updateRoute(duthost, self.DHCP_RELAY["ip"], downstreamPeerIp, "no")
+
+    @classmethod
+    def createDhcpDiscoverRelayedPacket(self, dutMac):
+        """
+        Helper function that creates DHCP Discover packet destined to DUT
+
+        Args:
+            dutMac(str): MAC address of DUT
+
+        Returns:
+            packet: DHCP Discover packet
+        """
+        ether = scapy.Ether(dst=dutMac, src=self.DHCP_RELAY["mac"], type=0x0800)
+        ip = scapy.IP(src=self.DHCP_RELAY["loopback"], dst=self.DHCP_SERVER["ip"], len=328, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_SERVER["port"], dport=self.DHCP_CLIENT["port"], len=308)
+        bootp = scapy.BOOTP(
+            op=1,
+            htype=1,
+            hlen=6,
+            hops=1,
+            xid=0,
+            secs=0,
+            flags=0x8000,
+            ciaddr=str(INADDR_ANY),
+            yiaddr=str(INADDR_ANY),
+            siaddr=str(INADDR_ANY),
+            giaddr=self.DHCP_RELAY["ip"],
+            chaddr=''.join([chr(int(octet, 16)) for octet in self.DHCP_CLIENT["mac"].split(':')])
+        )
+        bootp /= scapy.DHCP(options=[
+            ("message-type", "discover"),
+            ("end")
+        ])
+
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        if pad_bytes > 0:
+            bootp /= scapy.PADDING("\x00" * pad_bytes)
+
+        pkt = ether / ip / udp / bootp
+
+        return pkt
+
+    @classmethod
+    def createDhcpOfferPacket(self, dutMac):
+        """
+        Helper function that creates DHCP Offer packet destined to DUT
+
+        Args:
+            dutMac(str): MAC address of DUT
+
+        Returns:
+            packet: DHCP Offer packet
+        """
+        return testutils.dhcp_offer_packet(
+            eth_dst=dutMac,
+            eth_server=self.DHCP_RELAY["mac"],
+            eth_client=self.DHCP_CLIENT["mac"],
+            ip_server=self.DHCP_SERVER["ip"],
+            ip_dst=self.DHCP_RELAY["ip"],
+            ip_offered=self.DHCP_CLIENT["ip"],
+            port_dst=self.DHCP_SERVER["port"],
+            ip_gateway=self.DHCP_RELAY["ip"],
+            netmask_client=self.DHCP_CLIENT["subnet"],
+            dhcp_lease=self.LEASE_TIME,
+            padding_bytes=0,
+            set_broadcast_bit=True
+        )
+
+    @classmethod
+    def createDhcpRequestRelayedPacket(self, dutMac):
+        """
+        Helper function that creates DHCP Request packet destined to DUT
+
+        Args:
+            dutMac(str): MAC address of DUT
+
+        Returns:
+            packet: DHCP Request packet
+        """
+        ether = scapy.Ether(dst=dutMac, src=self.DHCP_RELAY["mac"], type=0x0800)
+        ip = scapy.IP(src=self.DHCP_RELAY["loopback"], dst=self.DHCP_SERVER["ip"], len=336, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_CLIENT["port"], dport=self.DHCP_SERVER["port"], len=316)
+        bootp = scapy.BOOTP(
+            op=1,
+            htype=1,
+            hlen=6,
+            hops=1,
+            xid=0,
+            secs=0,
+            flags=0x8000,
+            ciaddr=str(INADDR_ANY),
+            yiaddr=str(INADDR_ANY),
+            siaddr=str(INADDR_ANY),
+            giaddr=self.DHCP_RELAY["ip"],
+            chaddr=''.join([chr(int(octet, 16)) for octet in self.DHCP_CLIENT["mac"].split(':')])
+        )
+        bootp /= scapy.DHCP(options=[
+            ("message-type", "request"),
+            ("requested_addr", self.DHCP_CLIENT["ip"]),
+            ("server_id", self.DHCP_SERVER["ip"]),
+            ("end")
+        ])
+
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        if pad_bytes > 0:
+            bootp /= scapy.PADDING("\x00" * pad_bytes)
+
+        pkt = ether / ip / udp / bootp
+
+        return pkt
+
+    @classmethod
+    def createDhcpAckPacket(self, dutMac):
+        """
+        Helper function that creates DHCP Discover ACK destined to DUT
+
+        Args:
+            dutMac(str): MAC address of DUT
+
+        Returns:
+            packet: DHCP ACK packet
+        """
+        return testutils.dhcp_ack_packet(
+            eth_dst=dutMac,
+            eth_server=self.DHCP_RELAY["mac"],
+            eth_client=self.DHCP_CLIENT["mac"],
+            ip_server=self.DHCP_SERVER["ip"],
+            ip_dst=self.DHCP_RELAY["ip"],
+            ip_offered=self.DHCP_CLIENT["ip"],
+            port_dst=self.DHCP_SERVER["port"],
+            ip_gateway=self.DHCP_RELAY["ip"],
+            netmask_client=self.DHCP_CLIENT["subnet"],
+            dhcp_lease=self.LEASE_TIME,
+            padding_bytes=0,
+            set_broadcast_bit=True
+        )
+
+class TestDhcpPktFwd(DhcpPktFwdBase):
+    """
+    DHCP Packet forward test class
+    """
+    @pytest.mark.parametrize("pktInfo", [
+        {"txDir": "downstream", "rxDir": "upstream", "pktGen": DhcpPktFwdBase.createDhcpDiscoverRelayedPacket},
+        {"txDir": "upstream", "rxDir": "downstream", "pktGen": DhcpPktFwdBase.createDhcpOfferPacket},
+        {"txDir": "downstream", "rxDir": "upstream", "pktGen": DhcpPktFwdBase.createDhcpRequestRelayedPacket},
+        {"txDir": "upstream", "rxDir": "downstream", "pktGen": DhcpPktFwdBase.createDhcpAckPacket},
+    ])
+    def testDhcpPacketForwarding(self, duthost, testPorts, ptfadapter, pktInfo):
+        """
+        Validates that DHCP Discover/Offer/Request/Ack (DORA) packets are forwarded through T1 devices
+
+         Args:
+            duthost(Ansible Fixture): instance of SonicHost class of DUT
+            testPorts(Ansible Fixture, dict): contains downstream/upstream test ports information
+            ptfadapter(Ansible Fixture): instance of PTF Adapter
+            pktInfo(Pytest Params<dict>): test parameters containing information on which ports used for
+                                          sending/receiving DHCP packet and
+                                          DHCP packet to send
+        """
+        ptfadapter.dataplane.flush()
+
+        dhcpPacket = pktInfo["pktGen"](duthost.facts["router_mac"])
+        testutils.send(ptfadapter, random.choice(testPorts[pktInfo["txDir"]]), dhcpPacket)
+
+        # Update fields of the forwarded packet
+        dhcpPacket[scapy.Ether].src = duthost.facts["router_mac"]
+        dhcpPacket[scapy.IP].ttl = dhcpPacket[scapy.IP].ttl - 1
+
+        expectedDhcpPacket = Mask(dhcpPacket)
+        expectedDhcpPacket.set_do_not_care_scapy(scapy.Ether, "dst")
+        expectedDhcpPacket.set_do_not_care_scapy(scapy.IP, "chksum")
+
+        _, receivedPacket = testutils.verify_packet_any_port(
+            ptfadapter,
+            expectedDhcpPacket,
+            ports=testPorts[pktInfo["rxDir"]]
+        )
+        logger.info("Received packet: %s", scapy.Ether(receivedPacket).summary())


### PR DESCRIPTION
### Description of PR

New test case that ensures DHCP packets flow through T1 devices.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Repair item as DHCP packet were being droppped on TI by CACL rules

#### How did you do it?
New test case

#### How did you verify/test it?
```
taahme@8f31950b4410:/var/host-acs-mgmt-repo/tests$ pytest dhcp_relay/test_dhcp_pkt_fwd.py --testbed=vms7-t1-s6100 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6100-acs-5 --module-path=../ansible/library --disable_loganalyzer --skip_sanity
================================================================================================================================================== test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/host-acs-mgmt-repo/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 4 items                                                                                                                                                                                                                                                                                                        

dhcp_relay/test_dhcp_pkt_fwd.py ....                                                                                                                                                                                                                                                                               [100%]

=============================================================================================================================================== 4 passed in 19.54 seconds ================================================================================================================================================
```
#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
T1 topologies

### Documentation 
