### PR TITLE
[docker] Shutdown BGP before swap_syncd to force mgmt route

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -119,6 +119,7 @@ def swap_syncd(dut, creds):
     docker_syncd_name = "docker-syncd-{}".format(vendor_id)
     docker_rpc_image = docker_syncd_name + "-rpc"
 
+    dut.command("config bgp shutdown all")  # Force image download to go through mgmt network
     dut.command("systemctl stop swss")
     delete_container(dut, "syncd")
 

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -7,6 +7,8 @@ import logging
 import os
 
 from tests.common import config_reload
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 
@@ -132,6 +134,30 @@ def swap_syncd(dut, creds):
     # TODO: Getting the base image version should be a common utility
     output = dut.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
     sonic_version = output["stdout_lines"][0].strip()
+
+    def ready_for_swap():
+        syncd_status = dut.command("docker ps -f name=syncd")["stdout_lines"]
+        if len(syncd_status) > 1:
+            return False
+
+        swss_status = dut.command("docker ps -f name=swss")["stdout_lines"]
+        if len(swss_status) > 1:
+            return False
+
+        bgp_summary = dut.command("show ip bgp summary")["stdout_lines"]
+        idle_count = 0
+        expected_idle_count = 0
+        for line in bgp_summary:
+            if "Idle (Admin)" in line:
+                idle_count += 1
+
+            if "Total number of neighbors" in line:
+                tokens = line.split()
+                expected_idle_count = int(tokens[-1])
+
+        return idle_count == expected_idle_count
+
+    pytest_assert(wait_until(30, 3, ready_for_swap), "Docker and/or BGP failed to shut down")
 
     registry = load_docker_registry_info(dut, creds)
     download_image(dut, registry, docker_rpc_image, sonic_version)


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: [docker] Shutdown BGP before swap_syncd to force mgmt route
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In some setups it is possible that `docker login` attempts to go through the upstream neighbors to resolve the docker registry domain name. We want it to use the management network instead.

#### How did you do it?
The most portable/reliable way to force this route is to isolate the device from the upstream by disabling BGP during swap syncd.

#### How did you verify/test it?
Ran COPP tests locally w/ this change and everything worked as expected.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
