### PR TITLE
[dhcp-relay] Tests With Random Source Port And Unicast MAC Packets

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -143,6 +143,9 @@ class DHCPTest(DataplaneBaseTest):
         self.client_ip = incrementIpAddress(self.relay_iface_ip, 1) 
         self.client_subnet = self.test_params['relay_iface_netmask']
 
+        self.dest_mac_address = self.test_params['dest_mac_address']
+        self.client_udp_src_port = self.test_params['client_udp_src_port']
+
 
     def tearDown(self):
         DataplaneBaseTest.tearDown(self)
@@ -153,8 +156,13 @@ class DHCPTest(DataplaneBaseTest):
     
     """
 
-    def create_dhcp_discover_packet(self):
-        return testutils.dhcp_discover_packet(eth_client=self.client_mac, set_broadcast_bit=True)
+    def create_dhcp_discover_packet(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
+        discover_packet = testutils.dhcp_discover_packet(eth_client=self.client_mac, set_broadcast_bit=True)
+
+        discover_packet[scapy.Ether].dst = dst_mac
+        discover_packet[scapy.IP].sport = src_port
+
+        return discover_packet
 
     def create_dhcp_discover_relayed_packet(self):
         my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
@@ -255,11 +263,18 @@ class DHCPTest(DataplaneBaseTest):
         pkt = ether / ip / udp / bootp
         return pkt
 
-    def create_dhcp_request_packet(self):
-        return testutils.dhcp_request_packet(eth_client=self.client_mac,
-                    ip_server=self.server_ip,
-                    ip_requested=self.client_ip,
-                    set_broadcast_bit=True)
+    def create_dhcp_request_packet(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
+        request_packet = testutils.dhcp_request_packet(
+            eth_client=self.client_mac,
+            ip_server=self.server_ip,
+            ip_requested=self.client_ip,
+            set_broadcast_bit=True
+        )
+
+        request_packet[scapy.Ether].dst = dst_mac
+        request_packet[scapy.IP].sport = src_port
+
+        return request_packet
 
     def create_dhcp_request_relayed_packet(self):
         my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
@@ -363,9 +378,9 @@ class DHCPTest(DataplaneBaseTest):
     """
 
     # Simulate client coming on VLAN and broadcasting a DHCPDISCOVER message
-    def client_send_discover(self):
+    def client_send_discover(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
         # Form and send DHCPDISCOVER packet
-        dhcp_discover = self.create_dhcp_discover_packet()
+        dhcp_discover = self.create_dhcp_discover_packet(dst_mac, src_port)
         testutils.send_packet(self, self.client_port_index, dhcp_discover)
 
     # Verify that the DHCP relay actually received and relayed the DHCPDISCOVER message to all of
@@ -446,8 +461,8 @@ class DHCPTest(DataplaneBaseTest):
         testutils.verify_packet(self, masked_offer, self.client_port_index)
 
     # Simulate our client sending a DHCPREQUEST message
-    def client_send_request(self):
-        dhcp_request = self.create_dhcp_request_packet()
+    def client_send_request(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
+        dhcp_request = self.create_dhcp_request_packet(dst_mac, src_port)
         testutils.send_packet(self, self.client_port_index, dhcp_request)
 
     # Verify that the DHCP relay actually received and relayed the DHCPREQUEST message to all of
@@ -522,11 +537,11 @@ class DHCPTest(DataplaneBaseTest):
         testutils.verify_packet(self, masked_ack, self.client_port_index)
 
     def runTest(self):
-        self.client_send_discover()
+        self.client_send_discover(self.dest_mac_address, self.client_udp_src_port)
         self.verify_relayed_discover()
         self.server_send_offer()
         self.verify_offer_received()
-        self.client_send_request()
+        self.client_send_request(self.dest_mac_address, self.client_udp_src_port)
         self.verify_relayed_request()
         self.server_send_ack()
         self.verify_ack_received()

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -1,5 +1,6 @@
 import ipaddress
 import pytest
+import random
 import time
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
@@ -11,6 +12,8 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+DEFAULT_DHCP_CLIENT_PORT = 68
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(loganalyzer):
@@ -124,7 +127,9 @@ def test_dhcp_relay_default(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask'])},
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": BROADCAST_MAC,
+                           "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
@@ -162,7 +167,9 @@ def test_dhcp_relay_after_link_flap(duthost, ptfhost, dut_dhcp_relay_data, valid
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask'])},
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": BROADCAST_MAC,
+                           "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
@@ -208,5 +215,59 @@ def test_dhcp_relay_start_with_uplinks_down(duthost, ptfhost, dut_dhcp_relay_dat
                            "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'][0]),
                            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask'])},
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": BROADCAST_MAC,
+                           "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT},
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+
+
+def test_dhcp_relay_unicast_mac(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
+    """Test DHCP relay functionality on T0 topology with unicast mac
+
+       Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
+    """
+    for dhcp_relay in dut_dhcp_relay_data:
+        # Run the DHCP relay test on the PTF host
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "dhcp_relay_test.DHCPTest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                           "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'][0]),
+                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": duthost.facts["router_mac"],
+                           "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT},
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+
+
+def test_dhcp_relay_synthetic_packets(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
+    """Test DHCP relay functionality on T0 topology with synthetic packet
+
+       Synthetic packets are regular packet emanating from DHCP client with non-standard client UDP port. This happens
+       if the client is SNAT'd. Verify that DHCP relay works with synthetic packets
+    """
+    SYNTHETIC_PACKET_CLIENT_PORT = random.choice(range(1000, 65535))
+    for dhcp_relay in dut_dhcp_relay_data:
+        # Run the DHCP relay test on the PTF host
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "dhcp_relay_test.DHCPTest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                           "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'][0]),
+                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": BROADCAST_MAC,
+                           "client_udp_src_port": SYNTHETIC_PACKET_CLIENT_PORT},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -246,11 +246,11 @@ def test_dhcp_relay_unicast_mac(duthost, ptfhost, dut_dhcp_relay_data, validate_
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-def test_dhcp_relay_synthetic_packets(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
-    """Test DHCP relay functionality on T0 topology with synthetic packet
+def test_dhcp_relay_random_sport(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
+    """Test DHCP relay functionality on T0 topology with random source port (sport)
 
-       Synthetic packets are regular packet emanating from DHCP client with non-standard client UDP port. This happens
-       if the client is SNAT'd. Verify that DHCP relay works with synthetic packets
+       It is possible in our network that client sends DHCP packets with non-standard client UDP src port. This happens
+       if the client is SNAT'd. Verify that DHCP relay works with random sport
     """
     SYNTHETIC_PACKET_CLIENT_PORT = random.choice(range(1000, 65535))
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -252,7 +252,7 @@ def test_dhcp_relay_random_sport(duthost, ptfhost, dut_dhcp_relay_data, validate
        It is possible in our network that client sends DHCP packets with non-standard client UDP src port. This happens
        if the client is SNAT'd. Verify that DHCP relay works with random sport
     """
-    SYNTHETIC_PACKET_CLIENT_PORT = random.choice(range(1000, 65535))
+    RANDOM_CLIENT_PORT = random.choice(range(1000, 65535))
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
         ptf_runner(ptfhost,
@@ -269,5 +269,5 @@ def test_dhcp_relay_random_sport(duthost, ptfhost, dut_dhcp_relay_data, validate
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
                            "dest_mac_address": BROADCAST_MAC,
-                           "client_udp_src_port": SYNTHETIC_PACKET_CLIENT_PORT},
+                           "client_udp_src_port": RANDOM_CLIENT_PORT},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -249,8 +249,8 @@ def test_dhcp_relay_unicast_mac(duthost, ptfhost, dut_dhcp_relay_data, validate_
 def test_dhcp_relay_random_sport(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
     """Test DHCP relay functionality on T0 topology with random source port (sport)
 
-       It is possible in our network that client sends DHCP packets with non-standard client UDP src port. This happens
-       if the client is SNAT'd. Verify that DHCP relay works with random sport
+       If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68). 
+       Verify that DHCP relay works with random high sport.
     """
     RANDOM_CLIENT_PORT = random.choice(range(1000, 65535))
     for dhcp_relay in dut_dhcp_relay_data:


### PR DESCRIPTION
### Description of PR
Summary:

Adding a couple of DHCP relay tests with; 1) unicast MAC and
2) packets with random src port.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test for special format packet that are present in Azure networks

#### How did you do it?
New tests

#### How did you verify/test it?
```
taahme@8f31950b4410:/var/host-acs-mgmt-repo/tests$ pytest dhcp_relay/test_dhcp_relay.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-14 --module-path=../ansible/library --disable_loganalyzer --skip_sanity           
================================================================================================================================================== test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/host-acs-mgmt-repo/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 5 items                                                                                                                                                                                                                                                                                                        

dhcp_relay/test_dhcp_relay.py .....                                                                                                                                                                                                                                                                                [100%]

=============================================================================================================================================== 5 passed in 233.76 seconds ===============================================================================================================================================
```
1. Unicast MAC. Ethernet from pcap:
```
Ethernet II, Src: Mellanox_a3:0a:01 (24:8a:07:a3:0a:01), Dst: Dell_16:bc:8d (f4:8e:38:16:bc:8d)
```

2. Non-conformant UDP sport. Ethernet from pcap:
```
tcpdump: listening on Vlan1000, link-type EN10MB (Ethernet), capture size 262144 bytes
16:58:08.884115 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 272)
    0.0.0.0.39561 > 255.255.255.255.67: [udp sum ok] BOOTP/DHCP, Request from 24:8a:07:a3:0a:01, length 244, Flags [Broadcast] (0x8000)
	  Client-Ethernet-Address 24:8a:07:a3:0a:01
	  Vendor-rfc1048 Extensions
	    Magic Cookie 0x63825363
	    DHCP-Message Option 53, length 1: Discover
	    END Option 255, length 0
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
