### PR TITLE
[test reporting] Add support for combining a set of test results

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -34,7 +34,7 @@ import defusedxml.ElementTree as ET
 
 TEST_REPORT_CLIENT_VERSION = (1, 0, 0)
 
-MAXIMUM_XML_SIZE = 10e7  # 10MB
+MAXIMUM_XML_SIZE = 20e7  # 20MB
 
 # Fields found in the testsuite/root section of the JUnit XML file.
 TESTSUITE_TAG = "testsuite"

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -134,6 +134,21 @@ def validate_junit_xml_file(document_name):
 
 
 def validate_junit_xml_archive(directory_name):
+    """Validate that an XML archive contains valid JUnit XML.
+
+    Args:
+        directory_name: The name of the directory containing XML documents.
+
+    Returns:
+        A list of roots of validated XML documents.
+
+    Raises:
+        JUnitXMLValidationError: if any of the following are true:
+            - The provided directory doesn't exist
+            - The provided files exceed 10MB
+            - Any of the provided files are unparseable
+            - Any of the provided files are missing required fields
+    """
     if not os.path.exists(directory_name) or not os.path.isdir(directory_name):
         raise JUnitXMLValidationError("file not found")
 
@@ -339,16 +354,17 @@ def _parse_test_cases(root):
 
         # NOTE: "if failure" and "if error" does not work with the ETree library.
         failure = test_case.find("failure")
-        if failure is not None:
-            result["failure"] = failure.get("message")
-
         error = test_case.find("error")
-        if error is not None:
-            result["error"] = error.get("message")
-
         skipped = test_case.find("skipped")
-        if skipped is not None:
-            result["skipped"] = skipped.get("message")
+
+        if failure is not None:
+            result["result"] = "failure"
+        elif error is not None:
+            result["result"] = "error"
+        elif skipped is not None:
+            result["result"] = "skipped"
+        else:
+            result["result"] = "success"
 
         return feature, result
 

--- a/test_reporting/tests/files/sample_archive/tr_1.xml
+++ b/test_reporting/tests/files/sample_archive/tr_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<testsuite errors="1" failures="1" name="pytest" skipped="1" tests="4" time="214.054">
+<testsuite errors="0" failures="0" name="pytest" skipped="1" tests="2" time="109.472">
     <properties>
         <property name="topology" value="t0"/>
         <property name="markers" value=""/>
@@ -10,16 +10,6 @@
         <property name="os_version" value="master.449-9c22d19b"/>
     </properties>
     <testcase classname="bgp.test_bgp" file="bgp/test_bgp.py" line="161" name="test_bgp_fact" time="109.472" />
-    <testcase classname="bgp.test_bgp" file="bgp/test_bgp.py" line="248" name="test_bgp_speaker" time="46.316">
-        <failure message="test machine go brr">
-            this is definitely a stacktrace
-        </failure>
-    </testcase>
-    <testcase classname="acl.test_acl" file="acl/test_acl.py" line="257" name="test_acl" time="58.161">
-        <error message="test machine broke">
-            also a stacktrace
-        </error>
-    </testcase>
     <testcase classname="acl.test_acl" file="acl/test_acl.py" line="369" name="test_acl_2" time="0.0">
         <skipped message="test machine skipped">
             a descriptive skip message

--- a/test_reporting/tests/files/sample_archive/tr_2.xml
+++ b/test_reporting/tests/files/sample_archive/tr_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<testsuite errors="1" failures="1" name="pytest" skipped="1" tests="4" time="214.054">
+<testsuite errors="1" failures="1" name="pytest" skipped="0" tests="2" time="104.582">
     <properties>
         <property name="topology" value="t0"/>
         <property name="markers" value=""/>
@@ -9,7 +9,6 @@
         <property name="hwsku" value="Force10-S6000"/>
         <property name="os_version" value="master.449-9c22d19b"/>
     </properties>
-    <testcase classname="bgp.test_bgp" file="bgp/test_bgp.py" line="161" name="test_bgp_fact" time="109.472" />
     <testcase classname="bgp.test_bgp" file="bgp/test_bgp.py" line="248" name="test_bgp_speaker" time="46.316">
         <failure message="test machine go brr">
             this is definitely a stacktrace
@@ -19,10 +18,5 @@
         <error message="test machine broke">
             also a stacktrace
         </error>
-    </testcase>
-    <testcase classname="acl.test_acl" file="acl/test_acl.py" line="369" name="test_acl_2" time="0.0">
-        <skipped message="test machine skipped">
-            a descriptive skip message
-        </skipped>
     </testcase>
 </testsuite>

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -145,7 +145,7 @@ def test_invalid_junit_xml_missing_xml(input_string):
 
 def test_invalid_junit_xml_too_large():
     with pytest.raises(JUnitXMLValidationError, match="provided stream is too large"):
-        validate_junit_xml_stream("a" * int(10e7))
+        validate_junit_xml_stream("a" * int(20e7))
 
 
 @pytest.mark.parametrize("token,replacement", [("</", "<"), ("</properties>", "")])

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -45,7 +45,7 @@ EXPECTED_JSON_OUTPUT = {
         "acl": [
             {
                 "classname": "acl.test_acl",
-                "error": "test machine broke",
+                "result": "error",
                 "file": "acl/test_acl.py",
                 "line": "257",
                 "name": "test_acl",
@@ -56,7 +56,7 @@ EXPECTED_JSON_OUTPUT = {
                 "file": "acl/test_acl.py",
                 "line": "369",
                 "name": "test_acl_2",
-                "skipped": "test machine skipped",
+                "result": "skipped",
                 "time": "0.0"
             }
         ],
@@ -66,11 +66,12 @@ EXPECTED_JSON_OUTPUT = {
                 "file": "bgp/test_bgp.py",
                 "line": "161",
                 "name": "test_bgp_fact",
-                "time": "109.472"
+                "time": "109.472",
+                "result": "success"
             },
             {
                 "classname": "bgp.test_bgp",
-                "failure": "test machine go brr",
+                "result": "failure",
                 "file": "bgp/test_bgp.py",
                 "line": "248",
                 "name": "test_bgp_speaker",


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: [test reporting] Add support for combining a set of test results
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Running the tests in individual mode produces a huge directory of `*.xml` test result files. These need to be combined together in order to get a comprehensive view of the results for a given test run.

#### How did you do it?
I updated the parser logic to support a full directory of test results, with the following restrictions:
- The metadata should match across all files (i.e. we assume that the testbed/hwsku/version/etc. are not going to be changing throughout a single test run)
- The summary + test cases are simply combined together.

There were also some changes to the parser logic:
- Some files may not have test results (e.g. pretest + posttest) if checks are not run, so the requirement that every file must have test cases has been removed.
- Skipped messages are now included in the json output
- "Markers" is no longer required.

#### How did you verify/test it?
Added a new test case + updated the old ones w/ the latest changes. Also ran the CLI in `-d` mode against a few nightly test runs and they were combined as expected.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
