### PR TITLE
Added missing import of advanced reboot fixture

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from .args.advanced_reboot_args import add_advanced_reboot_args
 from .args.cont_warm_reboot_args import add_cont_warm_reboot_args
 from .args.normal_reboot_args import add_normal_reboot_args


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Bug fix - missing advanced_reboot_fixture
Fixes # (issue) Test setup errors seen in reboot tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR https://github.com/Azure/sonic-mgmt/pull/2121 removed the import which includes the fixture for `platform_tests` module.
Most of the reboot tests which make use of `get_advanced_reboot` fixture are now failing.

Error seen on reboot tests:
```
test_setup_failure:

tests/platform_tests/test_advanced_reboot.py, line 11
  @pytest.mark.usefixtures('get_advanced_reboot')
  def test_fast_reboot(request, get_advanced_reboot):
E       fixture 'get_advanced_reboot' not found
>       available fixtures: __pytest_repeat_step_number, ansible_adhoc, ansible_facts, ansible_module, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, change_mac_addresses, collect_techsupport, config_logging, conn_graph_facts, copy_ptftests_directory, creds, doctest_namespace, duthost, duthosts, enhance_inventory, eos, fanouthosts, fib, localhost, loganalyzer, metadata, monkeypatch, nbrhosts, pdu, psu_controller, ptfadapter, ptfhost, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, reset_critical_services_list, sanity_check, skip_on_simx, tag_test_report, test_tacacs, test_tacacs_v6, testbed, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, worker_id
>       use 'pytest --fixtures [testpath]' for help on them.
```
#### How did you do it?
By adding the removed import back, tests are no more throwing the `Fixture not found` error.

#### How did you verify/test it?
Manually executed the Pytest on a T0 topology, and the error is not seen.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
