### PR TITLE
[pytest]: Make DUT name optional for `run_tests.sh`

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,7 +7,7 @@ function show_help_and_exit()
     echo "    -h -?          : get this help"
     echo "    -a <True|False>: specify if autu-recover is allowed (default: True)"
     echo "    -c <testcases> : specify test cases to execute (default: none, executed all matched)"
-    echo "    -d <dut name>  : specify DUT name (*)"
+    echo "    -d <dut name>  : specify DUT name (default: DUT name associated with testbed in testbed file)"
     echo "    -e <parameters>: specify extra parameter(s) (default: none)"
     echo "    -f <tb file>   : specify testbed file (default testbed.csv)"
     echo "    -i <inventory> : specify inventory name"
@@ -25,6 +25,14 @@ function show_help_and_exit()
     echo "    -x             : print commands and their arguments as they are executed"
 
     exit $1
+}
+
+function get_dut_from_testbed_file() {
+    if [[ -z ${DUT_NAME} ]]; then
+        LINE=`cat $TESTBED_FILE | grep "^$TESTBED_NAME"`
+        IFS=',' read -ra ARRAY <<< "$LINE"
+        DUT_NAME=${ARRAY[9]}
+    fi
 }
 
 function validate_parameters()
@@ -294,6 +302,8 @@ while getopts "h?a:c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
             ;;
     esac
 done
+
+get_dut_from_testbed_file
 
 if [[ x"${TEST_METHOD}" != x"debug" ]]; then
     validate_parameters


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
* Automatically look up associated DUT from the testbed file if no DUT
name is provided to `run_tests.sh`
* Make `-d` argument optional

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For nearly all cases, tests run with a given testbed should also be run with the DUT associated with that testbed in the testbed file.

#### How did you do it?
Lookup the given testbed name in the testbed file and retrieve the associated DUT name

#### How did you verify/test it?
* Run a test without passing the DUT name, only the testbed name. Verify that the test is able to pass normally.
* Run a test passing the DUT name and testbed name. Verify that the test is able to pass normally. (Ensures backwards compatibility for any automated jobs that currently use the `-d` parameter)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
