### PR TITLE
Change pytest CLI arguments position for discovering subfolder conftest.py

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -35,6 +35,10 @@ Hosting pytest test infrastructure and test cases
     * execute link flap test case.
     * when specifying test cast list, no need to specify topology with -t.
 
+### Run scripts under a folder ###
+* ./run_tests.sh -d <dut_name> -n <testbed_name> -u -c "snmp/test_*.py" -s "snmp/test_snmp_cpu.py"
+    * execute all the scripts under `snmp`, skip script `snmp/test_snmp_cpu.py`.
+    * the test scripts pattern **MUST** be double quoted, otherwise there would be problem of running correct scripts.
 
 ### Run a list of test cases ###
 * ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c "platform_tests/test_link_flap.py platform_tests/test_reboot.py::test_cold_reboot"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -81,6 +81,27 @@ function setup_environment()
 
 function setup_test_options()
 {
+    # If a test script is explicitly specified in pytest command line, then use `--ignore` to ignore it will not work
+    # Below logic is to ensure that SKIP_FOLDERS and SKIP_SCRIPTS take precedence over the specified TEST_CASES.
+    # If a test script is in both ${TEST_CASES} and ${SKIP_SCRIPTS}, the script will not be executed. This design is
+    # for the scenario of specifying test scripts using pattern like `subfolder/test_*.py`. The pattern will be
+    # expanded to matched test scripts by bash. Among the expanded scripts, we may want to skip a few. Then we can
+    # explicitly specify the script to be skipped.
+    SKIP_SCRIPTS="${SKIP_SCRIPTS} test_announce_routes.py test_nbr_health.py"
+    ignores=$(python -c "print '|'.join('''$SKIP_FOLDERS'''.split())")
+    if [[ -z ${TEST_CASES} ]]; then
+        # When TEST_CASES is not specified, find all the possible scripts, ignore the scripts under $SKIP_FOLDERS
+        all_scripts=$(find ./ -name 'test_*.py' | sed s:^./:: | grep -vE "^(${ignores})")
+    else
+        # When TEST_CASES is specified, ignore the scripts under $SKIP_FOLDERS
+        all_scripts=""
+        for test_script in ${TEST_CASES}; do
+            all_scripts="${all_scripts} $(echo ${test_script} | sed s:^./:: | grep -vE "^(${ignores})")"
+        done
+    fi
+    # Ignore the scripts specified in $SKIP_SCRIPTS
+    TEST_CASES=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
+
     PYTEST_COMMON_OPTS="--inventory ${INVENTORY} \
                       --host-pattern ${DUT_NAME} \
                       --testbed ${TESTBED_NAME} \
@@ -181,26 +202,15 @@ function cleanup_dut()
 function run_group_tests()
 {
     echo "=== Running tests in groups ==="
-    pytest ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} ${TEST_CASES}
+    pytest ${TEST_CASES} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
 }
 
 function run_individual_tests()
 {
-    if [[ -n ${TEST_CASES} ]] ;then
-        test_scripts=${TEST_CASES}
-    else
-        SKIP_SCRIPTS="${SKIP_SCRIPTS} test_announce_routes.py test_nbr_health.py"
-
-        ignores=$(python -c "print '|'.join('''$SKIP_FOLDERS'''.split())")
-
-        all_scripts=$(find ./ -name 'test_*.py' | sed s:^./:: | grep -vE "^(${SKIP_FOLDERS})")
-        test_scripts=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
-    fi
-
     EXIT_CODE=0
 
     echo "=== Running tests individually ==="
-    for test_script in ${test_scripts}; do
+    for test_script in ${TEST_CASES}; do
         if [[ x"${OMIT_FILE_LOG}" != x"True" ]]; then
             test_dir=$(dirname ${test_script})
             script_name=$(basename ${test_script})
@@ -211,7 +221,7 @@ function run_individual_tests()
             TEST_LOGGING_OPTIONS="--log-file ${LOG_PATH}/${test_dir}/${test_name}.log --junitxml=${LOG_PATH}/${test_dir}/${test_name}.xml"
         fi
 
-        pytest ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${test_script} ${EXTRA_PARAMETERS}
+        pytest ${test_script} ${PYTEST_COMMON_OPTS} ${TEST_LOGGING_OPTIONS} ${TEST_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS}
         ret_code=$?
 
         # If test passed, no need to keep its log.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If test script is specified after pytest command line options defined in any conftest.py, then the conftest.py defined in subfolder may not be discovered and loaded by pytest. This could lead to `unrecognized argument` issue.

#### How did you do it?
Update the pytest CLI arguments position in the run_tests.sh script to ensure
that conftest.py defined in subfolders can be discovered by pytest to avoid
"unrecognized argument" issue.

For more details, please refer to https://github.com/Azure/sonic-mgmt/blob/master/tests/README.md

#### How did you verify/test it?
Run the script using individual and group mode.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
