### PR TITLE
[vxlan_decap] Updated test with creds fixture for get user/password

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -135,14 +135,9 @@ def vxlan_status(setup, request, duthost):
         return False, request.param
 
 
-def test_vxlan_decap(setup, vxlan_status, duthost, ptfhost):
+def test_vxlan_decap(setup, vxlan_status, duthost, ptfhost, creds):
 
     vxlan_enabled, scenario = vxlan_status
-
-    hostVars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
-    inventory = hostVars['inventory_file'].split('/')[-1]
-    secrets = duthost.host.options['variable_manager']._hostvars[duthost.hostname]['secret_group_vars']
-
     logger.info("vxlan_enabled=%s, scenario=%s" % (vxlan_enabled, scenario))
     log_file = "/tmp/vxlan-decap.Vxlan.{}.{}.log".format(scenario, datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
     ptf_runner(ptfhost,
@@ -152,8 +147,8 @@ def test_vxlan_decap(setup, vxlan_status, duthost, ptfhost):
                 params={"vxlan_enabled": vxlan_enabled,
                         "config_file": '/tmp/vxlan_decap.json',
                         "count": COUNT,
-                        "sonic_admin_user": secrets[inventory]['sonicadmin_user'],
-                        "sonic_admin_password": secrets[inventory]['sonicadmin_password'],
+                        "sonic_admin_user": creds.get('sonicadmin_user'),
+                        "sonic_admin_password": creds.get('sonicadmin_password'),
                         "dut_host": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']},
                 qlen=10000,
                 log_file=log_file)


### PR DESCRIPTION
Updated test_vxlan_decap to use creds fixture when get sonicadmin_user, sonicadmin_password

Signed-off-by: Olha Oliynyk <olhax.oliynyk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ +] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test vxlan_decap failed, cannot get secret_group_vars from credentials.
#### How did you do it?
Use creds fixture to make test compatible.
#### How did you verify/test it?
Run test vxlan_decap. Test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
