### PR TITLE
wait_for DUT down/up by IP in sanity_check reboot recover

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -16,7 +16,7 @@ def reboot_dut(dut, localhost, cmd, wait_time):
 
     logger.info("Wait for DUT to go down")
     try:
-        localhost.wait_for(host=dut.hostname, port=22, state="stopped", delay=10, timeout=300)
+        localhost.wait_for(host=dut.mgmt_ip, port=22, state="stopped", delay=10, timeout=300)
     except RunAnsibleModuleFail as e:
         logger.error("DUT did not go down, exception: " + repr(e))
         if reboot_task.is_alive():
@@ -25,7 +25,7 @@ def reboot_dut(dut, localhost, cmd, wait_time):
         logger.error("reboot result %s" % str(reboot_res.get()))
         assert False, "Failed to reboot the DUT"
 
-    localhost.wait_for(host=dut.hostname, port=22, state="started", delay=10, timeout=300)
+    localhost.wait_for(host=dut.mgmt_ip, port=22, state="started", delay=10, timeout=300)
     wait(wait_time, msg="Wait {} seconds for system to be stable.".format(wait_time))
 
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If use DUT hostname in localhost.wait_for ansible module, the sonic-mgmt
docker must be able to resolve the hostname of DUT to IP address. Otherwise,
the wait_for module will fail. 

#### How did you do it?
This commit update the recover function in sanity_check to use DUT mgmt IP in localhost.wait_for module call to eliminate the hostname resolve requirement.

#### How did you verify/test it?
Temporarily update a test script to use `recover_method='reboot'`. Bring down a service and run the test script with sanity check enabled and `allow_recover=True`. With this setting, sanity check will try to reboot the DUT to recover when run this script.
Without this fix, sanity check failed with wait_for DUT down and up.
With this fix, sanity check successfully recovered DUT by reboot.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
