### PR TITLE
Fix unexpected DUT down issue in test_watchdog

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -112,7 +112,7 @@ class TestWatchdogApi(PlatformApiTestBase):
         if self.expect(remaining_time is not None, "Failed to get the remaining time of watchdog"):
             self.expect(remaining_time is -1, "Watchdog remaining_time {} seconds is wrong for disarmed state".format(remaining_time))
 
-        res = localhost.wait_for(host=duthost.hostname, port=22, state="stopped", delay=5, timeout=watchdog_timeout + TIMEOUT_DEVIATION, module_ignore_errors=True)
+        res = localhost.wait_for(host=duthost.mgmt_ip, port=22, state="stopped", delay=5, timeout=watchdog_timeout + TIMEOUT_DEVIATION, module_ignore_errors=True)
 
         self.expect('Timeout' in res.get('msg', ''), "unexpected disconnection from dut")
         self.assert_expectations()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_watchdog.py script uses DUT hostname rather than IP address
in localhost.wait_for ansible module call. The sonic-mgmt docker must
be able to resolve DUT hostname to IP. Otherwise, the wait_for module
will not work properly. The test_watchdog.py::test_arm_disarm_states
case failed with `unexpected disconnection from dut`.

#### How did you do it?
This change updated the DUT hostname to mgmt IP in the wait_for 
ansible module call in the test_watchdog.py script.

#### How did you verify/test it?
Test case test_watchdog.py::test_arm_disarm_states passed with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
