### PR TITLE
[loganalyzer] Forcely-rotate logs before adding marker

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -15,6 +15,10 @@ def loganalyzer(duthost, request):
         logging.info("Log analyzer is disabled")
         yield
         return
+    # Force rotate logs
+    duthost.shell(
+        "/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1"
+        )
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
     logging.info("Add start marker into DUT syslog")
     marker = loganalyzer.init()


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Forcely rotates logs before adding `LogAnalyzer` markers.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For 7060 devices, the `/var/log` is limited to `128` MB, which might be filled up. In this situation, `LogAnalyzer` will fail to add a starting marker to `syslog`, which will make the `extract_log` module fail. 

#### How did you do it?
Try to free up space before each call to `LogAnalyzer`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
