### PR TITLE
[bgp_speaker] Cleanup ARP and MAC entries on bgp_speaker test teardown

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -164,6 +164,9 @@ def common_setup_teardown(duthost, ptfhost, localhost):
 
     for ip in vlan_ips:
         duthost.command("ip route flush %s/32" % ip.ip, module_ignore_errors=True)
+        duthost.command("arp -d %s" % ip.ip, module_ignore_errors=True)
+
+    duthost.command("sonic-clear fdb all")
 
     logging.info("########### Done teardown for bgp speaker testing ###########")
 

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -164,8 +164,8 @@ def common_setup_teardown(duthost, ptfhost, localhost):
 
     for ip in vlan_ips:
         duthost.command("ip route flush %s/32" % ip.ip, module_ignore_errors=True)
-        duthost.command("arp -d %s" % ip.ip, module_ignore_errors=True)
 
+    duthost.command("sonic-clear arp")
     duthost.command("sonic-clear fdb all")
 
     logging.info("########### Done teardown for bgp speaker testing ###########")


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR
ARP and FDB entries added during bgp_speaker execution are not cleaned up after test is finished. Clean up ARP and MAC entries on test teardown  

Summary:
Fixes # (issue)

### Type of change
- [ *] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran bgp_speaker test on BFN box.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
