### PR TITLE
[iface_namingmode] Get port_speed from DUT host variables

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -29,6 +29,12 @@ def setup(duthost):
     up_ports = minigraph_facts['minigraph_ports'].keys()
     default_interfaces = port_alias_facts['port_name_map'].keys()
     minigraph_portchannels = minigraph_facts['minigraph_portchannels']
+    port_speed_facts = port_alias_facts['port_speed']
+    if not port_speed_facts:
+        all_vars = duthost.host.options['variable_manager'].get_vars()
+        iface_speed = all_vars['hostvars'][duthost.hostname]['iface_speed']
+        port_speed_facts = {_: iface_speed for _ in
+                            port_alias_facts['port_alias_map'].keys()}
 
     port_alias = list()
     port_name_map = dict()
@@ -43,7 +49,7 @@ def setup(duthost):
         port_alias.append(port_alias_new)
         port_name_map[item] = port_alias_new
         port_alias_map[port_alias_new] = item
-        port_speed[port_alias_new] = port_alias_facts['port_speed'][port_alias_old]
+        port_speed[port_alias_new] = port_speed_facts[port_alias_old]
 
         # Update port alias name in redis db
         duthost.command('redis-cli -n 4 HSET "PORT|{}" alias {}'.format(item, port_alias_new))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
`port_alias` module retrieves `port_speed` from `port_config.ini`. But
for 7060 devices, `port_config.ini` has no port speed info.
So get port speed from the host variable `iface_speed` defined in inventory.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
test `iface_namingmode`

#### Any platform specific information?
`Arista-7060CX-32S-C32`

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
