### PR TITLE
[upgrade_path]Bug fix in test_upgrade_path

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -970,7 +970,7 @@ class ReloadTest(BaseTest):
         self.assertTrue(is_good, errors)
 
     def runTest(self):
-        self.pre_reboot_test_setup()        
+        self.pre_reboot_test_setup()
         try:
             self.log("Check that device is alive and pinging")
             self.fails['dut'].add("DUT is not ready for test")
@@ -989,6 +989,8 @@ class ReloadTest(BaseTest):
                 self.handle_warm_reboot_health_check()
             self.handle_post_reboot_health_check()
 
+            # Check sonic version after reboot
+            self.check_sonic_version_after_reboot()
         except Exception as e:
             self.fails['dut'].add(e)
         finally:
@@ -1019,10 +1021,8 @@ class ReloadTest(BaseTest):
                 current_version = str(stdout[0]).replace('\n', '')
             self.log("Current={} Target={}".format(current_version, target_version))
             if current_version != target_version:
-                self.fails['dut'].add("Sonic upgrade failed. Target={} Current={}".format(\
+                raise Exception("Sonic upgrade failed. Target={} Current={}".format(\
                     target_version, current_version))
-                return False
-        return True
 
     def extract_no_cpu_replies(self, arr):
       """
@@ -1047,9 +1047,6 @@ class ReloadTest(BaseTest):
         if stderr != []:
             self.log("stderr from %s: %s" % (self.reboot_type, str(stderr)))
         self.log("return code from %s: %s" % (self.reboot_type, str(return_code)))
-        # Check sonic version after reboot
-        if not self.check_sonic_version_after_reboot():
-            thread.interrupt_main()
 
         # Note: a timeout reboot in ssh session will return a 255 code
         if return_code not in [0, 255]:
@@ -1323,12 +1320,15 @@ class ReloadTest(BaseTest):
         return self.asic_state.get_state_time(state), self.get_asic_vlan_reachability()
 
     def ping_data_plane(self, light_probe=True):
+        self.apply_filter_all_ports("tcp dst port 5000")
+        self.dataplane.flush()
         replies_from_servers = self.pingFromServers()
         if replies_from_servers > 0 or not light_probe:
             replies_from_upper = self.pingFromUpperTier()
         else:
             replies_from_upper = 0
 
+        self.apply_filter_all_ports("")
         return replies_from_servers, replies_from_upper
 
     def wait_dut_to_warm_up(self):
@@ -1354,7 +1354,7 @@ class ReloadTest(BaseTest):
                     up_time = datetime.datetime.now()
                 up_secs = (datetime.datetime.now() - up_time).total_seconds()
                 if up_secs > dut_stabilize_secs:
-                    break;
+                    break
             else:
                 # reset up_time
                 up_time = None

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -45,7 +45,7 @@ class Interface(object):
             self.socket.close()
 
     def bind(self):
-        self.socket = scapy2.conf.L2listen(iface=self.iface)
+        self.socket = scapy2.conf.L2listen(iface=self.iface, filter='arp')
 
     def handler(self):
         return self.socket

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -94,9 +94,6 @@ def ptf_params(duthost, nbrhosts, creds):
         #TODO:Update to vm_hosts.append(value['host'].host.mgmt_ip)
         vm_hosts.append(value['host'].host.options['inventory_manager'].get_host(value['host'].hostname).vars['ansible_host'])
 
-    hostVars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
-    inventory = hostVars['inventory_file'].split('/')[-1]
-
     ptf_params = {
         "verbose": False,
         "dut_username": creds.get('sonicadmin_user'),

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -14,7 +14,9 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -10,7 +10,8 @@ from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
 from datetime import datetime
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -49,9 +50,6 @@ def cleanup(localhost, ptfhost, duthost, upgrade_path_lists):
 
 def prepare_ptf(ptfhost, duthost):
     logger.info("Preparing ptfhost")
-    ptfhost.script("./scripts/remove_ip.sh")
-    ptfhost.copy(src="../ansible/roles/test/files/helpers/arp_responder.py",
-                 dest="/opt")
 
     # Prapare vlan conf file
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
@@ -80,7 +78,7 @@ def prepare_ptf(ptfhost, duthost):
 
 
 @pytest.fixture(scope="module")
-def ptf_params(duthost, nbrhosts):
+def ptf_params(duthost, nbrhosts, creds):
 
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     lo_v6_prefix = ""
@@ -98,12 +96,11 @@ def ptf_params(duthost, nbrhosts):
 
     hostVars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
     inventory = hostVars['inventory_file'].split('/')[-1]
-    secrets = duthost.host.options['variable_manager']._hostvars[duthost.hostname]['secret_group_vars']
 
     ptf_params = {
         "verbose": False,
-        "dut_username": secrets[inventory]['sonicadmin_user'],
-        "dut_password": secrets[inventory]['sonicadmin_password'],
+        "dut_username": creds.get('sonicadmin_user'),
+        "dut_password": creds.get('sonicadmin_password'),
         "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
         "reboot_limit_in_seconds": 30,
         "reboot_type": "warm-reboot",
@@ -161,6 +158,6 @@ def test_upgrade_path(localhost, duthost, ptfhost, upgrade_path_lists, ptf_param
                        platform_dir="ptftests",
                        params=test_params,
                        platform="remote",
-                       qlen=1000,
+                       qlen=10000,
                        log_file=log_file)
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
**This PR is to fix several bug in test_upgrade_path.**
1. Fix bug in check_sonic_version_after_reboot;
2. Add filter for ping_dataplane to cut down CPU usage (99.9% -> 40%);
3. Refactor code in test_upgrade_path;
4. Use creds to retrive ssh_user and password.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix several bug in test_upgrade_path.
#### How did you do it?
Fix several bugs.
1. Fix bug in check_sonic_version_after_reboot
The original position of check_sonic_version_after_reboot is too closer to reboot, as a result, it might get a incorrect version. This commit moved it to the end of test.
2. Add filter for ping_dataplane to cut down CPU usage (99.9% -> 40%)
A filter is applied before ping_dataplane to cut down CPU usage. At the very beginning of test, flooding ARP packets are captured and analyzed by ptf, which cousume lots of CPU. The filter only allow packets on port 5000 in, and the CPU usage is cut down from 99.9% to up to 40%. At the same time, the packet queue is also increase from 1000 to 10000 because the queue is full according debug log.
3. Refactor code in test_upgrade_path
Use fixture to handle ptf scripts.
4. Use creds to retrive ssh_user and password
#### How did you verify/test it?
Verified on Arista-7260cx3
```
py.test upgrade_path/test_upgrade_path.py --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-1 --module-path ../ansible/library/ --testbed vms7-t0-7260-1 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --base_image_list=http://100.127.20.23/installer/sonic/broadcom/internal-201811/sonic-aboot-broadcom-20181130.51.swi --target_image_list=http://100.127.20.23/installer/sonic/broadcom/internal-201811/sonic-aboot-broadcom.swi --restore_to_image=http://100.127.20.23/installer/sonic/broadcom/internal-201911/sonic-aboot-broadcom.swi
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 1 item                                                                                                                                                                                      

upgrade_path/test_upgrade_path.py::test_upgrade_path ^@^@^H^@^@PASSED                                                                                                                                     [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 1507.58 seconds =====================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.
