### PR TITLE
Revert "[IPv6]: Add IPv6 mgmt gateway address to server"

### DIFF
--- a/ansible/host_vars/STR-ACS-SERV-01.yml
+++ b/ansible/host_vars/STR-ACS-SERV-01.yml
@@ -1,7 +1,6 @@
 mgmt_bridge: br1
 mgmt_prefixlen: 23
 mgmt_gw: 10.255.0.1
-mgmt_gw_v6: fec0::ffff:afa:1
 vm_mgmt_gw: 10.254.0.1
 external_port: p4p1
 

--- a/ansible/host_vars/STR-ACS-SERV-02.yml
+++ b/ansible/host_vars/STR-ACS-SERV-02.yml
@@ -1,5 +1,4 @@
 mgmt_bridge: br1
 mgmt_prefixlen: 23
 mgmt_gw: 10.255.0.1
-mgmt_gw_v6: fec0::ffff:afa:1
 external_port: p4p1

--- a/ansible/host_vars/STR-ACS-VSERV-01.yml
+++ b/ansible/host_vars/STR-ACS-VSERV-01.yml
@@ -1,7 +1,6 @@
 mgmt_bridge: br1
 mgmt_prefixlen: 24
 mgmt_gw: 10.250.0.1
-mgmt_gw_v6: fec0::ffff:afa:1
 vm_mgmt_gw: 10.250.0.1
 
 internal_mgmt_port: True

--- a/ansible/lab
+++ b/ansible/lab
@@ -66,7 +66,7 @@ sonic_s6000:
       ansible_hostv6: fec0::ffff:afa:9
     vlab-01:
       ansible_host: 10.250.0.101
-      ansible_hostv6: fec0::ffff:afa:a
+      ansible_hostv6: fec0::ffff:afa:1
     vlab-03:
       ansible_host: 10.250.0.105
       ansible_hostv6: fec0::ffff:afa:5

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -53,7 +53,6 @@ Parameters:
     - ptf_mgmt_ip_addr: ip address with prefixlen for the injected docker container
     - ptf_mgmt_ipv6_addr: ipv6 address with prefixlen for the injected docker container
     - ptf_mgmt_ip_gw: default gateway for the injected docker container
-    - ptf_mgmt_ipv6_gw: default ipv6 gateway for the injected docker container
     - ptf_bp_ip_addr: ipv6 address with prefixlen for the injected docker container
     - ptf_bp_ipv6_addr: ipv6 address with prefixlen for the injected docker container
     - mgmt_bridge: a bridge which is used as mgmt bridge on the host
@@ -79,7 +78,6 @@ EXAMPLES = '''
     ptf_mgmt_ip_addr: "{{ ptf_ip }}"
     ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
     ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
-    ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 }}"
     ptf_bp_ip_addr: "{{ ptf_ip }}"
     ptf_bp_ipv6_addr: "{{ ptf_ip }}"
     mgmt_bridge: "{{ mgmt_bridge }}"
@@ -261,9 +259,9 @@ class VMTopology(object):
 
         return
 
-    def add_mgmt_port_to_docker(self, mgmt_bridge, mgmt_ip, mgmt_gw, mgmt_ipv6_addr=None, mgmt_gw_v6=None):
+    def add_mgmt_port_to_docker(self, mgmt_bridge, mgmt_ip, mgmt_gw, mgmt_ipv6_addr=None):
         self.add_br_if_to_docker(mgmt_bridge, PTF_MGMT_IF_TEMPLATE % self.vm_set_name, MGMT_PORT_NAME)
-        self.add_ip_to_docker_if(MGMT_PORT_NAME, mgmt_ip, mgmt_ipv6_addr=mgmt_ipv6_addr, mgmt_gw=mgmt_gw, mgmt_gw_v6=mgmt_gw_v6)
+        self.add_ip_to_docker_if(MGMT_PORT_NAME, mgmt_ip, mgmt_ipv6_addr=mgmt_ipv6_addr, mgmt_gw=mgmt_gw)
 
         return
 
@@ -293,7 +291,7 @@ class VMTopology(object):
 
         return
 
-    def add_ip_to_docker_if(self, int_if, mgmt_ip_addr, mgmt_ipv6_addr=None, mgmt_gw=None, mgmt_gw_v6=None):
+    def add_ip_to_docker_if(self, int_if, mgmt_ip_addr, mgmt_ipv6_addr=None, mgmt_gw=None):
         self.update()
         if int_if in self.cntr_ifaces:
             VMTopology.cmd("nsenter -t %s -n ip addr flush dev %s" % (self.pid, int_if))
@@ -302,8 +300,6 @@ class VMTopology(object):
                 VMTopology.cmd("nsenter -t %s -n ip -6 addr add %s dev %s" % (self.pid, mgmt_ipv6_addr, int_if))
             if mgmt_gw:
                 VMTopology.cmd("nsenter -t %s -n ip route add default via %s dev %s" % (self.pid, mgmt_gw, int_if))
-            if mgmt_ipv6_addr and mgmt_gw_v6:
-                VMTopology.cmd("nsenter -t %s -n ip -6 route add default via %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
 
         return
 
@@ -738,7 +734,6 @@ def main():
             ptf_mgmt_ip_addr=dict(required=False, type='str'),
             ptf_mgmt_ipv6_addr=dict(required=False, type='str'),
             ptf_mgmt_ip_gw=dict(required=False, type='str'),
-            ptf_mgmt_ipv6_gw=dict(required=False, type='str'),
             ptf_bp_ip_addr=dict(required=False, type='str'),
             ptf_bp_ipv6_addr=dict(required=False, type='str'),
             mgmt_bridge=dict(required=False, type='str'),
@@ -778,7 +773,6 @@ def main():
                                   'ptf_mgmt_ip_addr',
                                   'ptf_mgmt_ipv6_addr',
                                   'ptf_mgmt_ip_gw',
-                                  'ptf_mgmt_ipv6_gw',
                                   'ptf_bp_ip_addr',
                                   'ptf_bp_ipv6_addr',
                                   'mgmt_bridge',
@@ -806,10 +800,9 @@ def main():
             ptf_mgmt_ip_addr = module.params['ptf_mgmt_ip_addr']
             ptf_mgmt_ipv6_addr = module.params['ptf_mgmt_ipv6_addr']
             ptf_mgmt_ip_gw = module.params['ptf_mgmt_ip_gw']
-            ptf_mgmt_ipv6_gw = module.params['ptf_mgmt_ipv6_gw']
             mgmt_bridge = module.params['mgmt_bridge']
 
-            net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw, ptf_mgmt_ipv6_addr, ptf_mgmt_ipv6_gw)
+            net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw, ptf_mgmt_ipv6_addr)
 
             ptf_bp_ip_addr = module.params['ptf_bp_ip_addr']
             ptf_bp_ipv6_addr = module.params['ptf_bp_ipv6_addr']
@@ -864,7 +857,6 @@ def main():
                                   'ptf_mgmt_ip_addr',
                                   'ptf_mgmt_ipv6_addr',
                                   'ptf_mgmt_ip_gw',
-                                  'ptf_mgmt_ipv6_gw',
                                   'ptf_bp_ip_addr',
                                   'ptf_bp_ipv6_addr',
                                   'mgmt_bridge',
@@ -892,10 +884,9 @@ def main():
             ptf_mgmt_ip_addr = module.params['ptf_mgmt_ip_addr']
             ptf_mgmt_ipv6_addr = module.params['ptf_mgmt_ipv6_addr']
             ptf_mgmt_ip_gw = module.params['ptf_mgmt_ip_gw']
-            ptf_mgmt_ipv6_gw = module.params['ptf_mgmt_ipv6_gw']
             mgmt_bridge = module.params['mgmt_bridge']
 
-            net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw, ptf_mgmt_ipv6_addr, ptf_mgmt_ipv6_gw)
+            net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw, ptf_mgmt_ipv6_addr)
 
             ptf_bp_ip_addr = module.params['ptf_bp_ip_addr']
             ptf_bp_ipv6_addr = module.params['ptf_bp_ipv6_addr']

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -53,7 +53,6 @@
     ptf_mgmt_ip_addr: "{{ ptf_ip }}"
     ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
     ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
-    ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
     ptf_bp_ip_addr: "{{ ptf_bp_ip }}"
     ptf_bp_ipv6_addr: "{{ ptf_bp_ipv6 }}"
     mgmt_bridge: "{{ mgmt_bridge }}"

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -31,7 +31,6 @@
     ptf_mgmt_ip_addr: "{{ ptf_ip }}"
     ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
     ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
-    ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
     mgmt_bridge: "{{ mgmt_bridge }}"
     dut_fp_ports: "{{ dut_fp_ports }}"
     dut_mgmt_port: "{{ dut_mgmt_port }}"

--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -30,7 +30,6 @@ echo
 echo "STEP 4: Creating management bridge br1..."
 brctl addbr br1
 ifconfig br1 10.250.0.1/24
-ifconfig br1 inet6 add fec0::ffff:afa:1/64
 ifconfig br1 up
 echo
 

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -24,7 +24,7 @@
 # -e dut_name=str-msn2700-01 - the name of target dut
 # -e VM_base=VM0300          - the VM name which is used to as base to calculate VM name for this set
 # -e ptf_ip=10.255.0.255/23 - the ip address and prefix of ptf container mgmt interface
-# -e ptf_ipv6=fec0::ffff:afa:a/64 - the ipv6 address and prefix of ptf container mgmt interface
+# -e ptf_ipv6=fec0::ffff:afa:1/64 - the ipv6 address and prefix of ptf container mgmt interface
 # -e topo=t0                 - the name of removed topo
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 # -e vm_type=veos|ceos

--- a/ansible/testbed_refresh_dut.yml
+++ b/ansible/testbed_refresh_dut.yml
@@ -24,7 +24,7 @@
 # -e dut_name=str-msn2700-01 - the name of target dut
 # -e VM_base=VM0300          - the VM name which is used to as base to calculate VM name for this set
 # -e ptf_ip=10.255.0.255/23 - the ip address and prefix of ptf container mgmt interface
-# -e ptf_ipv6=fec0::ffff:afa:a/64 - the ipv6 address and prefix of ptf container mgmt interface
+# -e ptf_ipv6=fec0::ffff:afa:1/64 - the ipv6 address and prefix of ptf container mgmt interface
 # -e topo=t0                 - the name of removed topo
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -28,7 +28,7 @@ all:
       hosts:
         vlab-01:
           ansible_host: 10.250.0.101
-          ansible_hostv6: fec0::ffff:afa:a
+          ansible_hostv6: fec0::ffff:afa:1
           type: kvm
           hwsku: Force10-S6000
           serial_port: 9000

--- a/tests/veos_vtb
+++ b/tests/veos_vtb
@@ -33,7 +33,7 @@ all:
       hosts:
         vlab-01:
           ansible_host: 10.250.0.101
-          ansible_hostv6: fec0::ffff:afa:a
+          ansible_hostv6: fec0::ffff:afa:1
           type: kvm
           hwsku: Force10-S6000
           ansible_password: password


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#2119

We figured out that the gateway route is not being flushed when we run `refresh-dut` or `add-topo` in succession. It seems that `ip -6 flush` doesn't behave the same as `ip flush`, so we need to back this change out while we figure out the right way to flush the routes between PR runs.