### PR TITLE
Remove unnecessary hard coded skip scripts in run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -95,7 +95,6 @@ function setup_test_options()
     # for the scenario of specifying test scripts using pattern like `subfolder/test_*.py`. The pattern will be
     # expanded to matched test scripts by bash. Among the expanded scripts, we may want to skip a few. Then we can
     # explicitly specify the script to be skipped.
-    SKIP_SCRIPTS="${SKIP_SCRIPTS} test_announce_routes.py test_nbr_health.py"
     ignores=$(python -c "print '|'.join('''$SKIP_FOLDERS'''.split())")
     if [[ -z ${TEST_CASES} ]]; then
         # When TEST_CASES is not specified, find all the possible scripts, ignore the scripts under $SKIP_FOLDERS


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix the issue introduced in PR #2146

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Two scripts "test_announce_routes.py" and "test_nbr_health.py" are hard coded
as scripts to be skipped in run_tests.sh. This caused these two scripts are not
executed while preparing the DUT for testing.

Indeed, either "-t TOPOLOGY" or "-c TEST_CASES" must be specified in
the run_tests.sh command line arguments. When "-t TOPOLOGY" is specified,
the scripts with "utils" mark will be skipped during test execution. It's
unnecessary to specify them in the skip list. When "-c TEST_CASE" is specified,
the person running the command is responsible for the correctness of the
TEST_CASES list.

#### How did you do it?
Remove the two hard coded scripts to be skipped from the list:
* test_announce_routes.py
* test_nbr_health.py

#### How did you verify/test it?
Test run `./run_tests.sh -i veos_vtb -d vlab-01 -n vms-kvm-t0 -f vtestbed.csv -k debug -l warning -m individual -q 1 -a False -e --disable_loganalyzer -c 'test_interfaces.py bgp/test_bgp_fact.py bgp/test_bgp_gr_helper.py bgp/test_bgp_speaker.py cacl/test_cacl_application.py cacl/test_cacl_function.py dhcp_relay/test_dhcp_relay.py lldp/test_lldp.py ntp/test_ntp.py route/test_default_route.py snmp/test_snmp_cpu.py snmp/test_snmp_interfaces.py snmp/test_snmp_lldp.py snmp/test_snmp_pfc_counters.py snmp/test_snmp_queue.py syslog/test_syslog.py tacacs/test_rw_user.py tacacs/test_ro_user.py telemetry/test_telemetry.py' -p logs/1vlan`. The `test_announce_routes.py` script is executed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
