### PR TITLE
[copp] Skip adding loganalyzer regex when loganalyzer is disabled

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -138,9 +138,8 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
         ".*ERR monit.*'lldp_syncd' process is not running",
         ".*snmp#snmp-subagent.*",
     ]
-    loganalyzer.ignore_regex.extend(ignoreRegex)
-
-    yield
+    if loganalyzer:  # Skip if loganalyzer is disabled
+        loganalyzer.ignore_regex.extend(ignoreRegex)
 
 def _copp_runner(dut, ptf, protocol, test_params, dut_type):
     """


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip adding loganalyzer regex when loganalyzer is disabled

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If the `--disable_loganalyzer` option is passed in then the loganalyzer fixture will not exist, causing this test to crash. So, we should check if it exists first.

#### How did you do it?
Added an `if loganalyzer` check.

#### How did you verify/test it?
Ran the tests with `--disable_loganalzyer`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
