### PR TITLE
[Vnet-Vxlan] Add test to cover subnet routes as tunnel routes

### DIFF
--- a/tests/vxlan/templates/vnet_config.j2
+++ b/tests/vxlan/templates/vnet_config.j2
@@ -163,6 +163,23 @@ vnet_local_routes:
         ifname: 'Vlan{{ vlan_batch[1] }}'
 {% endfor %}
 
+{# Vnet - Subnet tunnel route Configurations #}
+vnet_subnet_routes:
+{% for vlan_batch in range (vlan_id_base, vlan_id_base + max_rif)|batch(4) %}
+  - Vnet{{ vlan_batch[0]-vlan_id_base+1 }}_route_list:
+    {% set vlan_str = (vlan_batch[0]-1)|string %}
+    {% set ip_a, ip_b = vlan_str[:2]|int, (vlan_str[2:]|int)+1 %}
+      - pfx: '{{ ip_a }}.{{ ip_b }}.10.201/32'
+        end: '200.1.{{ ip_a }}.{{ ip_b }}'
+  - Vnet{{ vlan_batch[1]-vlan_id_base+1 }}_route_list:
+    {% set vlan_str = (vlan_batch[1]-1)|string %}
+    {% set ip_a, ip_b = vlan_str[:2]|int, (vlan_str[2:]|int)+1 %}
+      - pfx: '{{ ip_a }}.{{ ip_b }}.10.202/32'
+        end: '200.1.{{ ip_a }}.{{ ip_b }}'
+        vni: '12345'
+        mac: '00:00:00:00:a1:b2'
+{% endfor %}
+
 {# Vnet - Routes
  Route Pfx - A.B.C.D/32; starts 100.1.1.1/32
             (A,B derived from 100+vnet_id; C,D derived from number of routes per vnet)

--- a/tests/vxlan/templates/vnet_routes.j2
+++ b/tests/vxlan/templates/vnet_routes.j2
@@ -60,6 +60,30 @@
 {%- endfor %}
 {%- endfor %}
 
+{%- for vnet in vnet_id_list %}
+{%- for routes in vnet_subnet_routes %}
+{%- set route_list = vnet + '_route_list' %}
+{%- if routes.keys()[0] == route_list %}
+{%- for key,entries in routes.items() %}
+{%- for route in entries %}
+    {
+        "VNET_ROUTE_TUNNEL_TABLE:{{ vnet }}:{{ route.pfx }}" : {
+{%- if route.vni is defined %}
+            "vni": "{{ route.vni }}",
+{%- endif %}
+{%- if route.mac is defined %}
+            "mac_address": "{{ route.mac }}",
+{%- endif %}
+            "endpoint": "{{ route.end }}"
+        },
+        "OP": "{{ op }}"
+    },
+{%- endfor %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+
 {%- for intf in intf_list %}
 {%- set outloop = loop %}
 {%- for vnet_intf in vnet_intf_list %}

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -50,7 +50,7 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):
         "minigraph_vlan_interfaces": mg_facts["minigraph_vlan_interfaces"],
         "dut_mac": dut_facts["ansible_Ethernet0"]["macaddress"],
         "vnet_interfaces": vnet_config["vnet_intf_list"],
-        "vnet_routes": vnet_config["vnet_route_list"]+vnet_config["vnet_subnet_routes"],
+        "vnet_routes": vnet_config["vnet_route_list"] + vnet_config["vnet_subnet_routes"],
         "vnet_local_routes": vnet_config["vnet_local_routes"],
         "vnet_neighbors": vnet_config["vnet_nbr_list"],
         "vnet_peers": vnet_config["vnet_peer_list"]

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -50,7 +50,7 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):
         "minigraph_vlan_interfaces": mg_facts["minigraph_vlan_interfaces"],
         "dut_mac": dut_facts["ansible_Ethernet0"]["macaddress"],
         "vnet_interfaces": vnet_config["vnet_intf_list"],
-        "vnet_routes": vnet_config["vnet_route_list"],
+        "vnet_routes": vnet_config["vnet_route_list"]+vnet_config["vnet_subnet_routes"],
         "vnet_local_routes": vnet_config["vnet_local_routes"],
         "vnet_neighbors": vnet_config["vnet_nbr_list"],
         "vnet_peers": vnet_config["vnet_peer_list"]


### PR DESCRIPTION
Summary:


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test coverage for PR - https://github.com/Azure/sonic-swss/pull/1421

#### How did you do it?

#### How did you verify/test it?
Run vnet-vxlan test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
