### PR TITLE
[bgp_speaker(ipv6)] Fix bug in test_bgp_speaker_announce_routes_v6

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -98,9 +98,8 @@ def common_setup_teardown(duthost, ptfhost, localhost):
     logging.info("setup ip/routes in ptf")
     for i in [0, 1, 2]:
         ptfhost.shell("ip -6 addr add %s dev eth%d:%d" % (nexthops_ipv6[i], vlan_ports[0], i))
-    # Set ipv6 nexthop addresses on the ptf interfaces
-    duthost.command("ip -6 route flush %s" % vlan_ipv6_prefix)
-    duthost.command("ip -6 route add %s dev %s" % (vlan_ipv6_prefix, vlan_if_name))
+
+    # Issue a ping command to populate entry for next_hop
     for nh in nexthops_ipv6:
         duthost.shell("ping6 %s -c 3" % nh.ip)
 
@@ -156,15 +155,12 @@ def common_setup_teardown(duthost, ptfhost, localhost):
         ptfhost.exabgp(name="bgps%d" % i, state="absent")
     logging.info("exabgp stopped")
 
-    for nh in nexthops_ipv6:
-        duthost.command("ip -6 route flush %s/64" % nh.ip)
-    logging.info("Flushed ipv6 nexthop routes from dut")
-
     for ip in vlan_ips:
         duthost.command("ip route flush %s/32" % ip.ip, module_ignore_errors=True)
 
     duthost.command("sonic-clear arp")
     duthost.command("sonic-clear fdb all")
+    duthost.command("ip -6 neigh flush all")
 
     logging.info("########### Done teardown for bgp speaker testing ###########")
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to remove unnecessary add/remove of static router for ipv6 next_hop, and a cleanup of ipv6 neighbor is also added.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Recent PR #2127 add a ping to populate entry for ipv6 nexthop. 
At the same PR, following code is added to add static router for nexthop.
https://github.com/Azure/sonic-mgmt/blob/cc08f76f5be5dea033cf069f0ca0b3b6b84aab8c/tests/bgp/test_bgp_speaker.py#L102-L103
However, there should be static router for these addresses, which are missing on my DUT.
After checking the code, I found that following code removes the static router at teardown,  which should be a bug.
https://github.com/Azure/sonic-mgmt/blob/cc08f76f5be5dea033cf069f0ca0b3b6b84aab8c/tests/bgp/test_bgp_speaker.py#L159-L160
As a fix, this PR remove these unnecessary lines.
#### How did you do it?
Remove unnecessary add/remove of static router for ipv6 next_hop, and add a cleanup of ipv6 neighbor.
#### How did you verify/test it?
Verified on Arista-7260.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-1 --module-path ../ansible/library/ --testbed vms7-t0-7260-1 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util bgp/test_bgp_speaker.py::test_bgp_speaker_announce_routes_v6
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 1 item                                                                                                                                                                                      

bgp/test_bgp_speaker.py::test_bgp_speaker_announce_routes_v6[False-True-1514] PASSED                                                                                                            [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 129.61 seconds ======================================================================================
```
And after test, the route still exists:
```
root@str-7260cx3-acs-1:~# ip -6 route show match fc02:1000::2
fc02:1000::/64 dev Vlan1000 proto kernel metric 256  pref medium
default via fc00::22 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref medium
default via fc00::26 dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
default via fc00::2a dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
default via fc00::2e dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.