### PR TITLE
[drop_counter] Fix "list index out of range" Exception in random.choice in arp_responder

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -230,7 +230,7 @@ def mock_server(fanouthosts, testbed_params, arp_responder, ptfadapter, duthost)
         a server within a VLAN under a T0.
 
     """
-    server_dst_port = random.choice(testbed_params["vlan_ports"])
+    server_dst_port = random.choice(arp_responder.keys())
     server_dst_addr = random.choice(arp_responder[server_dst_port].keys())
     server_dst_intf = testbed_params["physical_port_map"][server_dst_port]
     logging.info("Creating mock server with IP %s; dut port = %s, dut intf = %s",


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix "list index out of range" exception found in nightly test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The following error is seen in nightly test:
```
   def mock_server(fanouthosts, testbed_params, arp_responder, ptfadapter, duthost):
        """
        Mock the presence of a server beneath a T0.
    
        Returns:
            A MockServer which will allow the caller to mock the behavior of
            a server within a VLAN under a T0.
    
        """
        server_dst_port = random.choice(testbed_params["vlan_ports"])
>       server_dst_addr = random.choice(arp_responder[server_dst_port].keys())

  def choice(self, seq):
        """Choose a random element from a non-empty sequence."""
>       return seq[int(self.random() * len(seq))]  # raises IndexError if seq is empty
E       IndexError: list index out of range

```
The root cause for that is the arp_responder map store 100 ports of all vlan ports, and Line 233 random select a port from all vlan ports, which may not be in the arp_responder map. As a result, an IndexError: list index out of range is raised.
#### How did you do it?
Update the way for choosing dest_port.
#### How did you verify/test it?
Verified on Arista-7260
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-1 --module-path ../ansible/library/ --testbed vms7-t0-7260-1 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util -k 'not test_fast_reboot' drop_packets/test_configurable_drop_counters.py
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.1.3, xdist-1.28.0, ansible-2.2.2, repeat-0.8.0
collected 2 items                                                                                                                                                                                     

drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED                                                                         [ 50%]
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[SWITCH_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] SKIPPED                                                                      [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
================================================================================ 1 passed, 1 skipped in 80.91 seconds =================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No