### PR TITLE
[vnet-vxlan]: Enable post-test sanity check

### DIFF
--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -14,7 +14,8 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses, change_mac_
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology("t0"),
+    pytest.mark.sanity_check(post_check=True)
 ]
 
 def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enables post-test sanity check for VNET VxLAN pytest

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test needs to be run with log analyzer disabled, so device health/status needs to be verified after test
#### How did you do it?
Add pytest marker to enable post-test sanity check
#### How did you verify/test it?
Run test and check logs for result of post-test check
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
