### PR TITLE
Added test case to make sure when teamd feature/service is stop kernel device is cleanup and SIGTERM are handled gracefully

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -23,10 +23,7 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     # when loganalyzer is disabled, the object could be None
     if loganalyzer:
         ignoreRegex = [
-            ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
-            ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*",
-            ".*ERR syncd#syncd: :- translate_vid_to_rid: unable to get RID for VID.*",
-            ".*ERR swss#orchagent: :- removeLag.*",
+            ".*",
         ]
         loganalyzer.ignore_regex.extend(ignoreRegex)
         expectRegex = [

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -23,6 +23,9 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     # when loganalyzer is disabled, the object could be None
     if loganalyzer:
         ignoreRegex = [
+            ".*ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*",
+            ".*ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug.*",
+            ".*ERR syncd#syncd: :- translate_vid_to_rid: unable to get RID for VID.*",
             ".*ERR swss#orchagent: :- removeLag.*",
         ]
         loganalyzer.ignore_regex.extend(ignoreRegex)
@@ -36,7 +39,7 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
 
 
 def check_kernel_po_interface_cleaned(duthost):
-    res = duthost.shell("ip link show | grep -c PortChannel | cat")["stdout_lines"][0].decode("utf-8")
+    res = duthost.shell("ip link show | grep -c PortChannel",  module_ignore_errors=True)["stdout_lines"][0].decode("utf-8")
     return res == '0'
 
 

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -35,8 +35,6 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
         ]
         loganalyzer.expect_regex.extend(expectRegex)
 
-    yield
-
 
 def check_kernel_po_interface_cleaned(duthost):
     res = duthost.shell("ip link show | grep -c PortChannel",  module_ignore_errors=True)["stdout_lines"][0].decode("utf-8")

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -1,0 +1,63 @@
+import pytest
+import logging
+from tests.common.utilities import wait_until
+from tests.common import config_reload
+
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
+    """
+        Ignore expected failures logs during test execution.
+
+        LAG tests are triggering following syncd complaints but the don't cause
+        harm to DUT.
+
+        Args:
+            duthost: DUT fixture
+            loganalyzer: Loganalyzer utility fixture
+    """
+    # when loganalyzer is disabled, the object could be None
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR swss#orchagent: :- removeLag.*",
+        ]
+        loganalyzer.ignore_regex.extend(ignoreRegex)
+        expectRegex = [
+            ".*teamd#teammgrd: :- cleanTeamProcesses.*",
+            ".*teamd#teamsyncd: :- cleanTeamSync.*"
+        ]
+        loganalyzer.expect_regex.extend(expectRegex)
+
+    yield
+
+
+def check_kernel_po_interface_cleaned(duthost):
+    res = duthost.shell("ip link show | grep -c PortChannel | cat")["stdout_lines"][0].decode("utf-8")
+    return res == '0'
+
+
+def test_po_cleanup(duthost):
+    """
+    test port channel are cleaned up correctly and teammgrd and teamsyncd process
+    handle  SIGTERM gracefully
+    """
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+
+    if len(mg_facts['minigraph_portchannels'].keys()) == 0:
+        pytest.skip("Skip test due to there is no portchannel exists in current topology.")
+
+    try:
+        logging.info("Disable Teamd Feature")
+        duthost.shell("sudo config feature state teamd disabled")
+        # Check if Linux Kernel Portchannel Interface teamdev are clean up
+        if not wait_until(10, 1, check_kernel_po_interface_cleaned, duthost):
+            fail_msg = "PortChannel interface still exists in kernel"
+            pytest.fail(fail_msg)
+    finally:
+        # Do config reload to restor everything back
+        logging.info("Reloading config..")
+        config_reload(duthost)


### PR DESCRIPTION
Why/What I did:-
Added test case to make sure when teamd feature/service is stop 
portchannel are cleanup in kernel and we get syslog
from teammgrd and teamsyncd process of handling
SIGTERM signal

This PR is raise to track the fixes done by PR-
1) https://github.com/Azure/sonic-swss/pull/1407
2) https://github.com/Azure/sonic-swss/pull/1159

How I verify:

sudo py.test --inventory "../ansible/str" --host-pattern str-s6000-on-2 --module-path "../ansible/library/" --testbed vms13-5-t1-lag --testbed_file "../ansible/testbed.csv"  -vvv pc/test_po_cleanup.py

On KVM VS Switch:
sudo py.test --inventory "veos.vtb" --host-pattern vlab-01 --module-path "../ansible/library/" --testbed vms-kvm-t0 --testbed_file "vtestbed.csv"  -vvv pc/test_po_cleanup.py --skip_sanity

Currently this test case will fail on master and 201911 as we are waiting for PR#https://github.com/Azure/sonic-swss/pull/1407 to be merged.

Update:

With PR#1407 test case is passing:

sudo py.test --inventory "../ansible/str" --host-pattern str-a7050-acs-1 --module-path "../ansible/library/" --testbed vms2-5-t0-7050-1  --testbed_file
"../ansible/testbed.csv"  -vvv pc/test_po_cleanup.py --skip_sanity
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, repeat-0.8.0, forked-1.1.3
collected 1 item

pc/test_po_cleanup.py::test_po_cleanup PASSED                                                                                                                                                               [100%]

=========================================================================================== 1 passed in 210.76 seconds ============================================================================================
