### PR TITLE
Fix issues of test_platform_info

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -869,17 +869,17 @@ class AbnormalFanMocker(SingleFanMocker):
     def check_result(self, actual_data):
         """
         Check actual data with mocked data.
-        :param actual_data: A dictionary contains actual command line data. Key of the dictionary is FAN name. Value
-                            of the dictionary is a list of field values for a line of FAN data.
+        :param actual_data: A list of dictionary contains actual command line data.
+
         :return: True if a match line is found.
         """
-        for name, fields in actual_data.items():
-            if name == self.fan_data.name:
+        for fan in actual_data:
+            if fan['fan'] == self.fan_data.name:
                 try:
                     actual_color = self.fan_drawer_data.get_status_led()
-                    assert actual_color == self.expect_led_color, 'FAN {} color is {}, expect: {}'.format(name,
-                                                                                                        actual_color,
-                                                                                                        self.expect_led_color)
+                    assert actual_color == self.expect_led_color, 'FAN {} color is {}, expect: {}'.format(fan['fan'],
+                                                                                                          actual_color,
+                                                                                                          self.expect_led_color)
                 except SysfsNotExistError as e:
                     logging.info('LED check only support on SPC2 and SPC3: {}'.format(e))
                 return

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -91,7 +91,7 @@ def psu_test_setup_teardown(duthost):
     logging.info("Starting psu test teardown")
     sensord_running_status, sensord_pid = check_sensord_status(duthost)
     if not sensord_running_status:
-        ans_host.command("docker exec pmon supervisorctl restart lm-sensors")
+        duthost.command("docker exec pmon supervisorctl restart lm-sensors")
         time.sleep(3)
         sensord_running_status, sensord_pid = check_sensord_status(duthost)
         if sensord_running_status:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix multiple issues of `tests/platform_tests/test_platform_info.py`.

Changes:
1. Update `ans_host` to `duthost`.
2. Import mellanox_thermal_control_test_helper to register mockers for Mellanox platform
3. Update the methods checking platform fan and temperature to support both master and 201911

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There are couple of issues in test_platform_info.py and its dependent scripts.
1. In `test_platform_info.py`, line 94 is still using deprecated `ans_host`. The issue was not exposed because it is in a branch that is rarely hit.
2. In PR #1864, a line for importing the mellanox_thermal_control_test_helper.py module was removed. This caused some mockers for Mellanox platform are not registered. Consequently some test cases in test_platform_info are always skipped.
3. The code for checking platform fan and temperature is not able to handle the command output difference between master and 201911 branch.

#### How did you do it?
1. Update `ans_host` to `duthost`.
2. Import mellanox_thermal_control_test_helper to register mockers for Mellanox platform.
3. Update the methods checking platform fan and temperature to support both master and 201911.

#### How did you verify/test it?
Test run the `test_platform_info.py` script on SONiC.20191130.44. Only one case `test_thermal_control_fan_status` failed because expected log is not found. This is another problem. All the other cases related with the changes are passed.

#### Any platform specific information?
Mellanox platform specific change.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
