### PR TITLE
[pytest] Move qos ptf_portmap arg to the global conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,9 @@ def pytest_addoption(parser):
     parser.addoption("--vrf_capacity", action="store", default=None, type=int, help="vrf capacity of dut (4-1000)")
     parser.addoption("--vrf_test_count", action="store", default=None, type=int, help="number of vrf to be tested (1-997)")
 
+    # qos_sai options
+    parser.addoption("--ptf_portmap", action="store", default=None, type=str, help="PTF port index to DUT port alias map")
+
     ############################
     # pfc_asym options         #
     ############################

--- a/tests/qos/args/qos_sai_args.py
+++ b/tests/qos/args/qos_sai_args.py
@@ -13,14 +13,6 @@ def add_qos_sai_args(parser):
     qos_group = parser.getgroup("QoS test suite options")
 
     qos_group.addoption(
-        "--ptf_portmap",
-        action="store",
-        type=str,
-        default=None,
-        help="PTF port index to DUT port alias map",
-    )
-
-    qos_group.addoption(
         "--disable_test",
         action="store",
         type=bool,


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Ptf portmap argument needs to be moved to global conftest.py. Without this change, due to the delayed discovery of args specified under a feature folder, using run_test.sh to run the entire test suite for nightly runs, need to add an additional check to verify if the current test script being run is 'qos_sai' and pass this parameter.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran 1 of the qos sai testcases after moving the arg to global conftest and it passed.
Ran a pfcwd test passing this arg and no errors seen
