### PR TITLE
[pytest] support for integrating platform.json static data retrieval for platform_api tests

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -275,17 +275,8 @@ class SonicHost(AnsibleHostBase):
             try:
                 out = self.command("cat {}".format(platform_file_path))
                 platform_info = json.loads(out["stdout"])
-                chassis = platform_info.get('chassis', None)
-                if chassis:
-                    result["name"] = chassis.get('name', None)
-                    result["model"] = chassis.get('model', None)
-                    result["components"] = chassis.get('components', None)
-                    result["modules"] = chassis.get('modules', None)
-                    result["fans"] = chassis.get('fans', None)
-                    result["fan_drawers"] = chassis.get('fan_drawers', None)
-                    result["psus"] = chassis.get('psus', None)
-                    result["thermals"] = chassis.get('thermals', None)
-                    result["sfps"] = chassis.get('sfps', None)
+                result["chassis"] = platform_info.get('chassis', None)
+                result["interfaces"] = platform_info.get('interfaces', None)
 
             except:
                 # if platform.json does not exist, then it's not added currently for certain platforms

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -275,12 +275,23 @@ class SonicHost(AnsibleHostBase):
             try:
                 out = self.command("cat {}".format(platform_file_path))
                 platform_info = json.loads(out["stdout"])
-                result["chassis"] = platform_info["chassis"]
+                chassis = platform_info.get('chassis', None)
+                if chassis:
+                    result["name"] = chassis.get('name', None)
+                    result["model"] = chassis.get('model', None)
+                    result["components"] = chassis.get('components', None)
+                    result["modules"] = chassis.get('modules', None)
+                    result["fans"] = chassis.get('fans', None)
+                    result["fan_drawers"] = chassis.get('fan_drawers', None)
+                    result["psus"] = chassis.get('psus', None)
+                    result["thermals"] = chassis.get('thermals', None)
+                    result["sfps"] = chassis.get('sfps', None)
+
             except:
                 # if platform.json does not exist, then it's not added currently for certain platforms
                 # eventually all the platforms should have the platform.json
-                logging.debug("platform.json is not available for this platform, dut facts will not contain
-                              chassis and interfaces data")
+                logging.debug("platform.json is not available for this platform."
+                              + "DUT facts will not contain complete platform information.")
                 pass
 
         return result

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -283,7 +283,6 @@ class SonicHost(AnsibleHostBase):
                 # eventually all the platforms should have the platform.json
                 logging.debug("platform.json is not available for this platform."
                               + "DUT facts will not contain complete platform information.")
-                pass
 
         return result
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -270,7 +270,7 @@ class SonicHost(AnsibleHostBase):
                 result["asic_type"] = line.split(":")[1].strip()
 
         if result["platform"]:
-            platform_file_path = os.path.join('/usr/share/sonic/device', result["platform"], 'platform.json')
+            platform_file_path = os.path.join("/usr/share/sonic/device", result["platform"], "platform.json")
 
             try:
                 out = self.command("cat {}".format(platform_file_path))

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -275,10 +275,10 @@ class SonicHost(AnsibleHostBase):
             try:
                 out = self.command("cat {}".format(platform_file_path))
                 platform_info = json.loads(out["stdout"])
-                result["chassis"] = platform_info.get('chassis', None)
-                result["interfaces"] = platform_info.get('interfaces', None)
+                for key, value in platform_info.iteritems():
+                    result[key] = value
 
-             except Exception:
+            except Exception:
                 # if platform.json does not exist, then it's not added currently for certain platforms
                 # eventually all the platforms should have the platform.json
                 logging.debug("platform.json is not available for this platform."

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -278,7 +278,7 @@ class SonicHost(AnsibleHostBase):
                 result["chassis"] = platform_info.get('chassis', None)
                 result["interfaces"] = platform_info.get('interfaces', None)
 
-            except:
+             except Exception:
                 # if platform.json does not exist, then it's not added currently for certain platforms
                 # eventually all the platforms should have the platform.json
                 logging.debug("platform.json is not available for this platform."

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -268,6 +268,19 @@ class SonicHost(AnsibleHostBase):
                 result["hwsku"] = line.split(":")[1].strip()
             elif line.startswith("ASIC:"):
                 result["asic_type"] = line.split(":")[1].strip()
+
+        if result["platform"]:
+            platform_file_path = os.path.join('/usr/share/sonic/device',result["platform"],'platform.json')
+
+            try:
+                out = self.command("cat {}".format(platform_file_path))
+                platform_info = json.loads(out["stdout"])
+                result["chassis"] = platform_info["chassis"]
+            except:
+                # if platform.json does not exist, then it's not added currently for certain platforms
+                # eventually all the platforms should have the platform.json
+                pass
+
         return result
 
     def _get_os_version(self):

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -281,7 +281,7 @@ class SonicHost(AnsibleHostBase):
             except Exception:
                 # if platform.json does not exist, then it's not added currently for certain platforms
                 # eventually all the platforms should have the platform.json
-                logging.debug("platform.json is not available for this platform."
+                logging.debug("platform.json is not available for this platform, "
                               + "DUT facts will not contain complete platform information.")
 
         return result

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -270,7 +270,7 @@ class SonicHost(AnsibleHostBase):
                 result["asic_type"] = line.split(":")[1].strip()
 
         if result["platform"]:
-            platform_file_path = os.path.join('/usr/share/sonic/device',result["platform"],'platform.json')
+            platform_file_path = os.path.join('/usr/share/sonic/device', result["platform"], 'platform.json')
 
             try:
                 out = self.command("cat {}".format(platform_file_path))
@@ -279,6 +279,8 @@ class SonicHost(AnsibleHostBase):
             except:
                 # if platform.json does not exist, then it's not added currently for certain platforms
                 # eventually all the platforms should have the platform.json
+                logging.debug("platform.json is not available for this platform, dut facts will not contain
+                              chassis and interfaces data")
                 pass
 
         return result

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -44,6 +44,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
         chassis_truth = duthost.facts.get('chassis', None)
         if chassis_truth:
             self.fan_drawer_truth = chassis_truth.get('fan_drawers', None)
+        else:
+            logger.warning("Unable to get chassis_truth from platform.json, test results will not be comprehensive")
 
     #
     # Functions to test methods inherited from DeviceBase class

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -24,7 +24,7 @@ STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
 
-class TestFan_drawer_DrawerApi(PlatformApiTestBase):
+class TestFanDrawerApi(PlatformApiTestBase):
 
     num_fan_drawers = None
     fan_drawer_truth = None
@@ -41,7 +41,9 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
             except:
                 pytest.fail("num_fan_drawers is not an integer")
 
-        self.fan_drawer_truth = duthost.facts.get('fan_drawers', None)
+        chassis_truth = duthost.facts.get('chassis', None)
+        if chassis_truth:
+            self.fan_drawer_truth = chassis_truth.get('fan_drawers', None)
 
     #
     # Functions to test methods inherited from DeviceBase class

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -34,7 +34,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn):
+    def setup(self, duthost, platform_api_conn):
         if self.num_fan_drawers is None:
             try:
                 self.num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -55,7 +55,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
             if self.expect(name is not None, "Unable to retrieve Fan_drawer {} name".format(i)):
                 self.expect(isinstance(name, str), "Fan_drawer {} name appears incorrect".format(i))
                 if self.fan_drawer_truth:
-                    self.expect(name == self.fan_drawer_truth[i]['name'], "Fan_drawer {} name does not match,  expected name {} ".format(i, self.fan_drawer_truth[i]['name']))
+                    self.expect(name == self.fan_drawer_truth[i]['name'], "Fan_drawer {} name does not match, expected name {}".format(i, self.fan_drawer_truth[i]['name']))
 
         self.assert_expectations()
 
@@ -106,7 +106,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
             if self.expect(num_fans is not None, "Unable to retrieve fan_drawer {} number of fans".format(i)):
                 self.expect(isinstance(num_fans, int), "fan drawer {} number of fans appear to be incorrect".format(i))
                 if self.fan_drawer_truth:
-                    self.expect(name == self.fan_drawer_truth[i]['num_fans'], "Fan_drawer {} num_fans does not match,  expected num_fans {} ".format(i, self.fan_drawer_truth[i]['num_fans']))
+                    self.expect(name == self.fan_drawer_truth[i]['num_fans'], "Fan_drawer {} num_fans does not match, expected num_fans {}".format(i, self.fan_drawer_truth[i]['num_fans']))
         self.assert_expectations()
 
     def test_get_all_fans(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -44,6 +44,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
         chassis_truth = duthost.facts.get('chassis', None)
         if chassis_truth:
             self.fan_drawer_truth = chassis_truth.get('fan_drawers', None)
+            if not self.fan_drawer_truth:
+                logger.warning("Unable to get fan_drawer_truth from platform.json, test results will not be comprehensive")
         else:
             logger.warning("Unable to get chassis_truth from platform.json, test results will not be comprehensive")
 

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -41,10 +41,7 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
             except:
                 pytest.fail("num_fan_drawers is not an integer")
 
-        chassis = duthost.facts.get('chassis', None)
-
-        if chassis and len(chassis['fan_drawers']) > 0 :
-            fan_drawer_truth = chassis['fan_drawers']
+        self.fan_drawer_truth = duthost.facts.get('fan_drawers', None)
 
     #
     # Functions to test methods inherited from DeviceBase class
@@ -55,8 +52,8 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Fan_drawer {} name".format(i)):
                 self.expect(isinstance(name, str), "Fan_drawer {} name appears incorrect".format(i))
-                if fan_drawer_truth:
-                    self.expect(name == fan_drawer_truth[i]['name'], "Fan_drawer {} name does not match".format(i))
+                if self.fan_drawer_truth:
+                    self.expect(name == self.fan_drawer_truth[i]['name'], "Fan_drawer {} name does not match,  expected name {} ".format(i, self.fan_drawer_truth[i]['name']))
 
         self.assert_expectations()
 
@@ -106,8 +103,8 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, i)
             if self.expect(num_fans is not None, "Unable to retrieve fan_drawer {} number of fans".format(i)):
                 self.expect(isinstance(num_fans, int), "fan drawer {} number of fans appear to be incorrect".format(i))
-                if fan_drawer_truth:
-                    self.expect(num_fans == fan_drawer_truth[i]['num_fans'], "Fan_drawer {} number of fans does not match".format(i))
+                if self.fan_drawer_truth:
+                    self.expect(name == self.fan_drawer_truth[i]['num_fans'], "Fan_drawer {} num_fans does not match,  expected num_fans {} ".format(i, self.fan_drawer_truth[i]['num_fans']))
         self.assert_expectations()
 
     def test_get_all_fans(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -27,6 +27,7 @@ STATUS_LED_COLOR_OFF = "off"
 class TestFan_drawer_DrawerApi(PlatformApiTestBase):
 
     num_fan_drawers = None
+    fan_drawer_truth = None
 
     # This fixture would probably be better scoped at the class level, but
     # it relies on the platform_api_conn fixture, which is scoped at the function
@@ -40,6 +41,11 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
             except:
                 pytest.fail("num_fan_drawers is not an integer")
 
+        chassis = duthost.facts['chassis']
+
+        if chassis and len(chassis['fan_drawers']) > 0 :
+            fan_drawer_truth = chassis['fan_drawers']
+
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -49,6 +55,8 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Fan_drawer {} name".format(i)):
                 self.expect(isinstance(name, str), "Fan_drawer {} name appears incorrect".format(i))
+                if fan_drawer_truth:
+                    self.expect(name == fan_drawer_truth[i]['name'], "Fan_drawer {} name does not match".format(i))
 
         self.assert_expectations()
 
@@ -98,6 +106,8 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, i)
             if self.expect(num_fans is not None, "Unable to retrieve fan_drawer {} number of fans".format(i)):
                 self.expect(isinstance(num_fans, int), "fan drawer {} number of fans appear to be incorrect".format(i))
+                if fan_drawer_truth:
+                    self.expect(num_fans == fan_drawer_truth[i]['num_fans'], "Fan_drawer {} number of fans does not match".format(i))
         self.assert_expectations()
 
     def test_get_all_fans(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -41,7 +41,7 @@ class TestFan_drawer_DrawerApi(PlatformApiTestBase):
             except:
                 pytest.fail("num_fan_drawers is not an integer")
 
-        chassis = duthost.facts['chassis']
+        chassis = duthost.facts.get('chassis', None)
 
         if chassis and len(chassis['fan_drawers']) > 0 :
             fan_drawer_truth = chassis['fan_drawers']


### PR DESCRIPTION
This PR adds the  support for incorporating
platform.json as a de-facto gold standard for
comparing the values returned by platform_api.
The enhancement addresses adding the
chassis and interfaces dictionary within the duthost-facts
derived from platform.json file  which in turn would be utilized
to carry out the comparison for all components of platform tests 

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
