### PR TITLE
[LogAnalyzer] Skip LogAnalyzer if test case is skipped

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -27,5 +27,7 @@ def loganalyzer(duthost, request):
     loganalyzer.load_common_config()
 
     yield loganalyzer
-
+    # Skip LogAnalyzer if case is skipped
+    if request.node.rep_call.skipped:
+        return
     loganalyzer.analyze(marker)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
**Skip LogAnalyzer if test case is skipped**
Currently, LogAnalyzer still analyze log file even test case is skipped, which may result in a confusing test result. This commit fix this issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently, LogAnalyzer still analyze log file when test case is skipped, which may result in a confusing test result. 
This commit address this issue.
#### How did you do it?
Add a check before LogAnalyzer starting analyze logs. If test case is skipped, then LogAnalyzer is skipped.
#### How did you verify/test it?
Verified on Arista-7260, and confirm that LogAnalyzer is skipped.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.