### PR TITLE
[conn graph] add support for multiple graph files

### DIFF
--- a/ansible/files/empty_graph.xml
+++ b/ansible/files/empty_graph.xml
@@ -1,0 +1,7 @@
+<LabConnectionGraph>
+  <PhysicalNetworkGraphDeclaration>
+    <Devices/>
+    <DeviceInterfaceLinks/>
+  </PhysicalNetworkGraphDeclaration>
+  <DataPlaneGraph/>
+</LabConnectionGraph>

--- a/ansible/files/graph_files.yml
+++ b/ansible/files/graph_files.yml
@@ -1,0 +1,7 @@
+---
+    # Public graph files
+    - lab_connection_graph.xml
+    - example_ixia_connection_graph.xml
+
+
+    # Private graph files

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -233,7 +233,7 @@ class Parse_Lab_Graph():
 
 
 LAB_CONNECTION_GRAPH_FILE = 'graph_files.yml'
-EMPTY_GRAPH_FILE = 'empty_graph.yml'
+EMPTY_GRAPH_FILE = 'empty_graph.xml'
 LAB_GRAPHFILE_PATH = 'files/'
 
 """

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -81,11 +81,7 @@ class Parse_Lab_Graph():
     """
 
     def __init__(self, xmlfile):
-        if xmlfile:
-            self.root = ET.parse(xmlfile)
-        else:
-            # create an empty tree
-            self.root = ET.element('root')
+        self.root = ET.parse(xmlfile)
         self.devices = {}
         self.vlanport = {}
         self.vlanrange = {}
@@ -237,6 +233,7 @@ class Parse_Lab_Graph():
 
 
 LAB_CONNECTION_GRAPH_FILE = 'graph_files.yml'
+EMPTY_GRAPH_FILE = 'empty_graph.yml'
 LAB_GRAPHFILE_PATH = 'files/'
 
 """
@@ -256,8 +253,12 @@ def find_graph(hostnames, anchor):
         if anchor and lab_graph.contains_hosts(anchor):
             return lab_graph
 
-    # Fallback to return an empty connection graph
-    lab_graph = Parse_Lab_Graph(None)
+    # Fallback to return an empty connection graph, this is
+    # needed to bridge the kvm test needs. The KVM test needs
+    # A graph file, which used to be whatever hardcoded file.
+    # Here we provide one empty file for the purpose.
+    lab_graph = Parse_Lab_Graph(LAB_GRAPHFILE_PATH + EMPTY_GRAPH_FILE)
+    lab_graph.parse_graph()
     return lab_graph
 
 def main():

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -238,7 +238,7 @@ LAB_GRAPHFILE_PATH = 'files/'
 """
     Find a graph file contains all devices in testbed.
 """
-def find_graph(hostnames):
+def find_graph(hostnames, anchor):
     filename = LAB_GRAPHFILE_PATH + LAB_CONNECTION_GRAPH_FILE
     with open(filename) as fd:
         file_list = yaml.load(fd)
@@ -247,7 +247,9 @@ def find_graph(hostnames):
         filename = LAB_GRAPHFILE_PATH + fn
         lab_graph = Parse_Lab_Graph(filename)
         lab_graph.parse_graph()
-        if lab_graph.contains_hosts(hostnames):
+        if hostnames and lab_graph.contains_hosts(hostnames):
+            return lab_graph
+        if anchor and lab_graph.contains_hosts(anchor):
             return lab_graph
 
     return None
@@ -258,6 +260,7 @@ def main():
             host=dict(required=False),
             hosts=dict(required=False, type='list'),
             filename=dict(required=False),
+            anchor=dict(required=False, type='list'),
         ),
         mutually_exclusive=[['host', 'hosts']],
         supports_check_mode=True
@@ -265,6 +268,7 @@ def main():
     m_args = module.params
 
     hostnames = m_args['hosts']
+    anchor = m_args['anchor']
     if not hostnames:
         hostnames = [m_args['host']]
     try:
@@ -273,7 +277,7 @@ def main():
             lab_graph = Parse_Lab_Graph(filename)
             lab_graph.parse_graph()
         else:
-            lab_graph = find_graph(hostnames)
+            lab_graph = find_graph(hostnames, anchor)
 
         device_info = []
         device_conn = []

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -81,7 +81,11 @@ class Parse_Lab_Graph():
     """
 
     def __init__(self, xmlfile):
-        self.root = ET.parse(xmlfile)
+        if xmlfile:
+            self.root = ET.parse(xmlfile)
+        else:
+            # create an empty tree
+            self.root = ET.element('root')
         self.devices = {}
         self.vlanport = {}
         self.vlanrange = {}
@@ -252,7 +256,9 @@ def find_graph(hostnames, anchor):
         if anchor and lab_graph.contains_hosts(anchor):
             return lab_graph
 
-    return None
+    # Fallback to return an empty connection graph
+    lab_graph = Parse_Lab_Graph(None)
+    return lab_graph
 
 def main():
     module = AnsibleModule(

--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -7,6 +7,8 @@
 - set_fact: dut="{{ leaf_name }}"
   when: deploy_leaf
 
+- debug: msg="Configuring fanout switch for {{ dut }}"
+
 - name: Gathering connection facts about the DUTs or leaffanout device
   conn_graph_facts:
     host: "{{ dut if ',' not in dut else omit }}"
@@ -17,6 +19,7 @@
 
 - name: Gathering connection facts about the lab
   conn_graph_facts:
+    anchor: "{{ dut.split(',') | list }}"
   delegate_to: localhost
   tags: always
   register: lab


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Before this change add-topo/remove-topo can only work with one inventory / graph file hard coded in conn_graph_facts.py. It is very inconvenient when deploying from a different inventory is needed.

#### How did you do it?
Put all graph files into a yaml list. When a testbed is requesting graph, parse all files in the list and find the graph file contains all duts of the testbed.

When getting the whole graph, provide dut list as anchor to match the right graph file.

For KVM test: if none of the graph file matches, fall back to an empty graph file so that the test won't fail at deployment stage. KVM test generally doesn't need graph otherwise. And for physical DUT, this empty graph file will cause other failure to stop deployment.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
add-topo/remove-topo from different inventories.