### PR TITLE
[loganalyzer] Fix exception in loganalyzer caused by force rotate logs

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -15,10 +15,14 @@ def loganalyzer(duthost, request):
         logging.info("Log analyzer is disabled")
         yield
         return
+        
     # Force rotate logs
-    duthost.shell(
-        "/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1"
-        )
+    hwsku = duthost.facts["hwsku"].lower()
+    if "arista" in hwsku and "7060" in duthost.facts["hwsku"]:
+        duthost.shell(
+            "/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1"
+            )
+
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
     logging.info("Add start marker into DUT syslog")
     marker = loganalyzer.init()

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -15,10 +15,10 @@ def loganalyzer(duthost, request):
         logging.info("Log analyzer is disabled")
         yield
         return
-        
+
     # Force rotate logs
     hwsku = duthost.facts["hwsku"].lower()
-    if "arista" in hwsku and "7060" in duthost.facts["hwsku"]:
+    if "arista" in hwsku and "7060" in hwsku:
         duthost.shell(
             "/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1"
             )


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR [#2161](https://github.com/Azure/sonic-mgmt/pull/2161) added force rotate logs to loganalyzer, which caused the issue in loganalyzer for other Arista platforms. This commit is to address this issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Loganalyzer failed on Arista platforms
#### How did you do it?
Added condition with checking hwsku.
#### How did you verify/test it?
Run test on the Arista platform.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
