### PR TITLE
[vxlan_decap] Fix test issue on bonding_masters file

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -105,8 +105,9 @@ class Vxlan(BaseTest):
     def readMacs(self):
         addrs = {}
         for intf in os.listdir('/sys/class/net'):
-            with open('/sys/class/net/%s/address' % intf) as fp:
-                addrs[intf] = fp.read().strip()
+            if os.path.isdir('/sys/class/net/%s' % intf):
+                with open('/sys/class/net/%s/address' % intf) as fp:
+                    addrs[intf] = fp.read().strip()
 
         return addrs
 


### PR DESCRIPTION

### Description of PR
**The PR fixes vxlan_decap test case error on bonding_master file.**



Summary:
Fixes # (issue)
**Test case vxlan_decap  errors when test tries to take address with opening the file bonding_masters. 
The error occurs: Not a directory**
Test was run on SONiC:
SONiC Software Version: SONiC.HEAD.765-dirty-20200907.114217
Distribution: Debian 10.5
Kernel: 4.19.0-9-2-amd64
Build commit: 8d285b46

**Logs from testrun**:
 ` 
Traceback:  File \"ptftests/vxlan-decap.py\", line 236, in setUp
 self.ptf_mac_addrs = self.readMacs()
File \"ptftests/vxlan-decap.py\", line 108, in readMacs
with open('/sys/class/net/%s/address' % intf) as fp:
Error: [Errno 20] Not a directory: '/sys/class/net/bonding_masters/address
`
### Type of change
**Added verification if the element is a directory before opening.
This approach allows to omit file if any in /sys/class/net directory exists.**
<!--
- Fill x for your type of change.
- e.g.
- [] Bug fix
-->

- [+] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
