### PR TITLE
[broadcom ser] make a backup sshd_config and restore it after test

### DIFF
--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -28,8 +28,8 @@ def disable_ssh_timout(dut):
     @param dut: Ansible host DUT
     '''
     logger.info('Disabling ssh time out on dut: %s' % dut.hostname)
-    dut.command("sudo sed -i 's/^ClientAliveInterval/#&/' /etc/ssh/sshd_config")
-    dut.command("sudo sed -i 's/^ClientAliveCountMax/#&/' /etc/ssh/sshd_config")
+    dut.command("sudo cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak")
+    dut.command("sudo sed -i -e 's/^ClientAliveInterval/#&/' -e 's/^ClientAliveCountMax/#&/' /etc/ssh/sshd_config")
 
     dut.command("sudo systemctl restart ssh")
     time.sleep(5)
@@ -41,8 +41,7 @@ def enable_ssh_timout(dut):
     @param dut: Ansible host DUT
     '''
     logger.info('Enabling ssh time out on dut: %s' % dut.hostname)
-    dut.command("sudo sed -i '/^#ClientAliveInterval/s/^#//' /etc/ssh/sshd_config")
-    dut.command("sudo sed -i '/^#ClientAliveCountMax/s/^#//' /etc/ssh/sshd_config")
+    dut.command("sudo cp /etc/ssh/sshd_config.bak /etc/ssh/sshd_config")
 
     dut.command("sudo systemctl restart ssh")
     time.sleep(5)

--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -41,7 +41,7 @@ def enable_ssh_timout(dut):
     @param dut: Ansible host DUT
     '''
     logger.info('Enabling ssh time out on dut: %s' % dut.hostname)
-    dut.command("sudo cp /etc/ssh/sshd_config.bak /etc/ssh/sshd_config")
+    dut.command("sudo mv /etc/ssh/sshd_config.bak /etc/ssh/sshd_config")
 
     dut.command("sudo systemctl restart ssh")
     time.sleep(5)


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ssh timeout stopped happening after nightly test.

#### How did you do it?
The sshd_config file contains commented out ClientAliveInterval and ClientAliveCountMax with contradicting values than the ones we want to use.

While commentted out the active ones does the job of disabling ssh timeout. Uncomment them will also uncomment the originally commented out ones which seems take precedence and disabled the ssh timeout inadvertently.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

