### PR TITLE
[iface_namingmode] Convert iface_speed to string

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -33,6 +33,7 @@ def setup(duthost):
     if not port_speed_facts:
         all_vars = duthost.host.options['variable_manager'].get_vars()
         iface_speed = all_vars['hostvars'][duthost.hostname]['iface_speed']
+        iface_speed = str(iface_speed)
         port_speed_facts = {_: iface_speed for _ in
                             port_alias_facts['port_alias_map'].keys()}
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Convert `iface_speed` that from Ansible variables to string to align
with the return from `port_alias`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`test_config_interface_speed` failed over 7060.
#### How did you do it?

#### How did you verify/test it?
run `test_config_interface_speed` over 7060.

#### Any platform specific information?
Arista 7060.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
