### PR TITLE
[everflow] Use correct j2 filter for acl.json template

### DIFF
--- a/tests/everflow/templates/acl-erspan.json.j2
+++ b/tests/everflow/templates/acl-erspan.json.j2
@@ -19,7 +19,7 @@
                                 "{{ qset }}": {
                                     "config": {
                                         {% for qualifier, value in rule["qualifiers"][qset].items() %}
-                                        "{{ qualifier }}": {{ value|tojson }}{% if not loop.last %},{% endif %}
+                                        "{{ qualifier }}": {{ value|to_nice_json }}{% if not loop.last %},{% endif %}
                                         {% endfor %}
                                     }
                                 }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The `to_json` filter is not available in the version of J2 that our tests are using, which causes the Everflow tests to fail during setup. We need to use the more compatible `to_nice_json` filter instead.

#### How did you do it?
Update the filter.

#### How did you verify/test it?
Re-run the tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
