### PR TITLE
Continuous warm reboot test parameters changes

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -131,7 +131,7 @@ class ReloadTest(BaseTest):
         self.check_param('dut_hostname', '', required=True)
         self.check_param('reboot_limit_in_seconds', 30, required=False)
         self.check_param('reboot_type', 'fast-reboot', required=False)
-        self.check_param('graceful_limit', 180, required=False)
+        self.check_param('graceful_limit', 240, required=False)
         self.check_param('portchannel_ports_file', '', required=True)
         self.check_param('vlan_ports_file', '', required=True)
         self.check_param('ports_file', '', required=True)

--- a/tests/platform_tests/args/cont_warm_reboot_args.py
+++ b/tests/platform_tests/args/cont_warm_reboot_args.py
@@ -6,7 +6,7 @@ def add_cont_warm_reboot_args(parser):
         "--continuous_reboot_count",
         action="store",
         type=int,
-        default=5,
+        default=3,
         help="Number of iterations of warm-reboot",
     )
 

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -353,6 +353,8 @@ class ContinuousReboot:
         with open(report_file, "w") as report_file:
             json.dump(test_report, report_file, indent=4)
 
+        pytest_assert(self.test_failures == 0, "Continuous reboot test failed {}/{} times".\
+            format(self.test_failures, self.reboot_count))
 
     def wait_until_uptime(self):
         logging.info("Wait until DUT uptime reaches {}s".format(self.continuous_reboot_delay))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach

#### What is the motivation for this PR?
False positive failures due to existing grafeul time for warm-reboot set to 180s whereas it ideal value is 240s.
Failures in iterations do not stop the test (mark fail and continue) - this leads to missed opportunity to debug the issue on the failed-state in DUT.

#### How did you do it?
Added changes to stop the test when a failure is seen.
Increased warmreboot graceful time from 3 to 4 minutes.

#### How did you verify/test it?
Tested more than 100 iterations on a T0 device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
