### PR TITLE
[Platform API][Chassis] Compare applicable data against values from platform.json

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -57,45 +57,45 @@ class TestChassisApi(PlatformApiTestBase):
     chassis_truth = None
     duthost_vars = None
 
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(scope="function", autouse=True)
     def setup(self, duthost):
         # Get platform truths from platform.json file
-        chassis_truth = duthost.facts.get("chassis")
-        if not chassis_truth:
+        self.chassis_truth = duthost.facts.get("chassis")
+        if not self.chassis_truth:
             logger.warning("Unable to get chassis_truth from platform.json, test results will not be comprehensive")
 
         # Get host vars from inventory file
-        duthost_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+        self.duthost_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
 
     #
     # Helper functions
     #
 
-    def compare_value_with_platform_facts(self, name, value):
+    def compare_value_with_platform_facts(self, key, value):
         expected_value = None
 
         if self.chassis_truth:
-            expected_value = self.chassis_truth.get(name)
+            expected_value = self.chassis_truth.get(key)
 
         if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from platform.json file".format(name))
+            logger.warning("Unable to get expected value for '{}' from platform.json file".format(key))
             return
 
         pytest_assert(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}'".format(name, value, expected_value))
+                      "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
 
-    def compare_value_with_device_facts(self, name, value):
+    def compare_value_with_device_facts(self, key, value):
         expected_value = None
 
         if self.duthost_vars:
-            expected_value = self.duthost_vars.get(name)
+            expected_value = self.duthost_vars.get(key)
 
         if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from inventory file".format(name))
+            logger.warning("Unable to get expected value for '{}' from inventory file".format(key))
             return
 
         pytest_assert(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}'".format(name, value, expected_value))
+                      "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
 
     #
     # Functions to test methods inherited from DeviceBase class

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -16,6 +16,17 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
+
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
 REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9]+$'
 
@@ -58,7 +69,7 @@ class TestChassisApi(PlatformApiTestBase):
     def test_get_name(self, duthost, localhost, platform_api_conn):
         name = chassis.get_name(platform_api_conn)
         pytest_assert(name is not None, "Unable to retrieve chassis name")
-        pytest_assert(isinstance(name, str), "Chassis name appears incorrect")
+        pytest_assert(isinstance(name, STRING_TYPE), "Chassis name appears incorrect")
 
         if self.chassis_truth:
             expected_name = self.chassis_truth.get('name')
@@ -75,7 +86,7 @@ class TestChassisApi(PlatformApiTestBase):
     def test_get_model(self, duthost, localhost, platform_api_conn):
         model = chassis.get_model(platform_api_conn)
         pytest_assert(model is not None, "Unable to retrieve chassis model")
-        pytest_assert(isinstance(model, str), "Chassis model appears incorrect")
+        pytest_assert(isinstance(model, STRING_TYPE), "Chassis model appears incorrect")
 
         if self.chassis_truth:
             expected_model = self.chassis_truth.get('model')
@@ -85,7 +96,7 @@ class TestChassisApi(PlatformApiTestBase):
     def test_get_serial(self, duthost, localhost, platform_api_conn):
         serial = chassis.get_serial(platform_api_conn)
         pytest_assert(serial is not None, "Unable to retrieve chassis serial number")
-        pytest_assert(isinstance(serial, str), "Chassis serial number appears incorrect")
+        pytest_assert(isinstance(serial, STRING_TYPE), "Chassis serial number appears incorrect")
 
         if 'serial' in duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars:
             expected_serial = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['serial']
@@ -371,7 +382,7 @@ class TestChassisApi(PlatformApiTestBase):
 
             color_actual = chassis.get_status_led(platform_api_conn)
             if self.expect(color_actual is not None, "Failed to retrieve status_led"):
-                if self.expect(isinstance(color_actual, str), "Status LED color appears incorrect"):
+                if self.expect(isinstance(color_actual, STRING_TYPE), "Status LED color appears incorrect"):
                     self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {})".format(color, color_actual))
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -232,7 +232,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_modules = len(self.chassis_truth.get('modules'))
-            pytest_assert(num_modules, expected_num_modules,
+            pytest_assert(num_modules == expected_num_modules,
                           "Number of modules ({}) does not match expected number ({})"
                           .format(num_modules, expected_num_modules))
 
@@ -254,7 +254,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_fans = len(self.chassis_truth.get('fans'))
-            pytest_assert(num_fans, expected_num_fans,
+            pytest_assert(num_fans == expected_num_fans,
                           "Number of fans ({}) does not match expected number ({})"
                           .format(num_fans, expected_num_fans))
 
@@ -276,7 +276,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_fan_drawers = len(self.chassis_truth.get('fan_drawers'))
-            pytest_assert(num_fan_drawers, expected_num_fan_drawers,
+            pytest_assert(num_fan_drawers == expected_num_fan_drawers,
                           "Number of fan drawers ({}) does not match expected number ({})"
                           .format(num_fan_drawers, expected_num_fan_drawers))
 
@@ -298,7 +298,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_psus = len(self.chassis_truth.get('psus'))
-            pytest_assert(num_psus, expected_num_psus,
+            pytest_assert(num_psus == expected_num_psus,
                           "Number of psus ({}) does not match expected number ({})"
                           .format(num_psus, expected_num_psus))
 
@@ -320,7 +320,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_thermals = len(self.chassis_truth.get('thermals'))
-            pytest_assert(num_thermals, expected_num_thermals,
+            pytest_assert(num_thermals == expected_num_thermals,
                           "Number of thermals ({}) does not match expected number ({})"
                           .format(num_thermals, expected_num_thermals))
 
@@ -342,7 +342,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_sfps = len(self.chassis_truth.get('sfps'))
-            pytest_assert(num_sfps, expected_num_sfps,
+            pytest_assert(num_sfps == expected_num_sfps,
                           "Number of sfps ({}) does not match expected number ({})"
                           .format(num_sfps, expected_num_sfps))
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -247,12 +247,6 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_modules is not an integer")
 
-        if self.chassis_truth:
-            expected_num_modules = len(self.chassis_truth.get('modules'))
-            pytest_assert(num_modules == expected_num_modules,
-                          "Number of modules ({}) does not match expected number ({})"
-                          .format(num_modules, expected_num_modules))
-
         module_list = chassis.get_all_modules(platform_api_conn)
         pytest_assert(module_list is not None, "Failed to retrieve modules")
         pytest_assert(isinstance(module_list, list) and len(module_list) == num_modules, "Modules appear to be incorrect")

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -51,21 +51,23 @@ ONIE_TLVINFO_TYPE_CODE_VENDOR_EXT = '0xFD'      # Vendor Extension
 ONIE_TLVINFO_TYPE_CODE_CRC32 = '0xFE'           # CRC-32
 
 
+@pytest.fixture(scope="class")
+def gather_facts(request, duthost):
+    # Get platform truths from platform.json file
+    request.cls.chassis_truth = duthost.facts.get("chassis")
+    if not request.cls.chassis_truth:
+        logger.warning("Unable to get chassis_truth from platform.json, test results will not be comprehensive")
+
+    # Get host vars from inventory file
+    request.cls.duthost_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+
+
+@pytest.mark.usefixtures("gather_facts")
 class TestChassisApi(PlatformApiTestBase):
     """Platform API test cases for the Chassis class"""
 
     chassis_truth = None
     duthost_vars = None
-
-    @pytest.fixture(scope="function", autouse=True)
-    def setup(self, duthost):
-        # Get platform truths from platform.json file
-        self.chassis_truth = duthost.facts.get("chassis")
-        if not self.chassis_truth:
-            logger.warning("Unable to get chassis_truth from platform.json, test results will not be comprehensive")
-
-        # Get host vars from inventory file
-        self.duthost_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
 
     #
     # Helper functions

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -210,7 +210,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         if self.chassis_truth:
             expected_num_components = len(self.chassis_truth.get('components'))
-            pytest_assert(num_components == expected_num_components
+            pytest_assert(num_components == expected_num_components,
                           "Number of components ({}) does not match expected number ({})"
                           .format(num_components, expected_num_components))
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -221,7 +221,6 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(isinstance(reboot_cause, list) and len(reboot_cause) == 2, "Reboot cause appears to be incorrect")
 
     def test_components(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of components and that the returned list is correct for this platform
         try:
             num_components = int(chassis.get_num_components(platform_api_conn))
         except:
@@ -243,7 +242,6 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_modules(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of modules and that the returned list is correct for this platform
         try:
             num_modules = int(chassis.get_num_modules(platform_api_conn))
         except:
@@ -265,7 +263,6 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_fans(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of fans and that the returned list is correct for this platform
         try:
             num_fans = int(chassis.get_num_fans(platform_api_conn))
         except:
@@ -287,7 +284,6 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_fan_drawers(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of fan drawers and that the returned list is correct for this platform
         try:
             num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
         except:
@@ -309,7 +305,6 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_psus(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of PSUs and that the returned list is correct for this platform
         try:
             num_psus = int(chassis.get_num_psus(platform_api_conn))
         except:
@@ -331,7 +326,6 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_thermals(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of thermals and that the returned list is correct for this platform
         try:
             num_thermals = int(chassis.get_num_thermals(platform_api_conn))
         except:
@@ -353,7 +347,6 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_sfps(self, duthost, localhost, platform_api_conn):
-        # TODO: Ensure the number of SFPs and that the returned list is correct for this platform
         try:
             num_sfps = int(chassis.get_num_sfps(platform_api_conn))
         except:

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -53,10 +53,10 @@ ONIE_TLVINFO_TYPE_CODE_CRC32 = '0xFE'           # CRC-32
 
 @pytest.fixture(scope="class")
 def gather_facts(request, duthost):
-    # Get platform truths from platform.json file
-    request.cls.chassis_truth = duthost.facts.get("chassis")
-    if not request.cls.chassis_truth:
-        logger.warning("Unable to get chassis_truth from platform.json, test results will not be comprehensive")
+    # Get platform facts from platform.json file
+    request.cls.chassis_facts = duthost.facts.get("chassis")
+    if not request.cls.chassis_facts:
+        logger.warning("Unable to get chassis_facts from platform.json, test results will not be comprehensive")
 
     # Get host vars from inventory file
     request.cls.duthost_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
@@ -66,7 +66,7 @@ def gather_facts(request, duthost):
 class TestChassisApi(PlatformApiTestBase):
     """Platform API test cases for the Chassis class"""
 
-    chassis_truth = None
+    chassis_facts = None
     duthost_vars = None
 
     #
@@ -76,8 +76,8 @@ class TestChassisApi(PlatformApiTestBase):
     def compare_value_with_platform_facts(self, key, value):
         expected_value = None
 
-        if self.chassis_truth:
-            expected_value = self.chassis_truth.get(key)
+        if self.chassis_facts:
+            expected_value = self.chassis_facts.get(key)
 
         if not expected_value:
             logger.warning("Unable to get expected value for '{}' from platform.json file".format(key))
@@ -226,8 +226,8 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_components is not an integer")
 
-        if self.chassis_truth:
-            expected_num_components = len(self.chassis_truth.get('components'))
+        if self.chassis_facts:
+            expected_num_components = len(self.chassis_facts.get('components'))
             pytest_assert(num_components == expected_num_components,
                           "Number of components ({}) does not match expected number ({})"
                           .format(num_components, expected_num_components))
@@ -262,8 +262,8 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_fans is not an integer")
 
-        if self.chassis_truth:
-            expected_num_fans = len(self.chassis_truth.get('fans'))
+        if self.chassis_facts:
+            expected_num_fans = len(self.chassis_facts.get('fans'))
             pytest_assert(num_fans == expected_num_fans,
                           "Number of fans ({}) does not match expected number ({})"
                           .format(num_fans, expected_num_fans))
@@ -283,8 +283,8 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_fan_drawers is not an integer")
 
-        if self.chassis_truth:
-            expected_num_fan_drawers = len(self.chassis_truth.get('fan_drawers'))
+        if self.chassis_facts:
+            expected_num_fan_drawers = len(self.chassis_facts.get('fan_drawers'))
             pytest_assert(num_fan_drawers == expected_num_fan_drawers,
                           "Number of fan drawers ({}) does not match expected number ({})"
                           .format(num_fan_drawers, expected_num_fan_drawers))
@@ -304,8 +304,8 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_psus is not an integer")
 
-        if self.chassis_truth:
-            expected_num_psus = len(self.chassis_truth.get('psus'))
+        if self.chassis_facts:
+            expected_num_psus = len(self.chassis_facts.get('psus'))
             pytest_assert(num_psus == expected_num_psus,
                           "Number of psus ({}) does not match expected number ({})"
                           .format(num_psus, expected_num_psus))
@@ -325,8 +325,8 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_thermals is not an integer")
 
-        if self.chassis_truth:
-            expected_num_thermals = len(self.chassis_truth.get('thermals'))
+        if self.chassis_facts:
+            expected_num_thermals = len(self.chassis_facts.get('thermals'))
             pytest_assert(num_thermals == expected_num_thermals,
                           "Number of thermals ({}) does not match expected number ({})"
                           .format(num_thermals, expected_num_thermals))
@@ -346,8 +346,8 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_sfps is not an integer")
 
-        if self.chassis_truth:
-            expected_num_sfps = len(self.chassis_truth.get('sfps'))
+        if self.chassis_facts:
+            expected_num_sfps = len(self.chassis_facts.get('sfps'))
             pytest_assert(num_sfps == expected_num_sfps,
                           "Number of sfps ({}) does not match expected number ({})"
                           .format(num_sfps, expected_num_sfps))

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -86,7 +86,7 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(value == expected_value,
                       "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
 
-    def compare_value_with_device_facts(self, key, value):
+    def compare_value_with_device_facts(self, key, value, case_sensitive=True):
         expected_value = None
 
         if self.duthost_vars:
@@ -96,8 +96,14 @@ class TestChassisApi(PlatformApiTestBase):
             logger.warning("Unable to get expected value for '{}' from inventory file".format(key))
             return
 
-        pytest_assert(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
+        if case_sensitive:
+            pytest_assert(value == expected_value,
+                          "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
+        else:
+            value_lower = value.lower()
+            expected_value_lower = expected_value.lower()
+            pytest_assert(value_lower == expected_value_lower,
+                          "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
 
     #
     # Functions to test methods inherited from DeviceBase class
@@ -142,7 +148,7 @@ class TestChassisApi(PlatformApiTestBase):
         base_mac = chassis.get_base_mac(platform_api_conn)
         pytest_assert(base_mac is not None, "Failed to retrieve base MAC address")
         pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
-        self.compare_value_with_device_facts('base_mac', base_mac)
+        self.compare_value_with_device_facts('base_mac', base_mac, False)
 
     def test_get_serial_number(self, duthost, localhost, platform_api_conn):
         # Ensure the serial number is sane

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -77,7 +77,7 @@ class TestChassisApi(PlatformApiTestBase):
         if self.chassis_truth:
             expected_value = self.chassis_truth.get(name)
 
-        if not self.chassis_truth or not expected_value:
+        if not expected_value:
             logger.warning("Unable to get expected value for '{}' from platform.json file".format(name))
             return
 
@@ -90,7 +90,7 @@ class TestChassisApi(PlatformApiTestBase):
         if self.duthost_vars:
             expected_value = self.duthost_vars.get(name)
 
-        if not self.duthost_vars or not expected_value:
+        if not expected_value:
             logger.warning("Unable to get expected value for '{}' from inventory file".format(name))
             return
 


### PR DESCRIPTION
Summary:

For chassis tests where known facts are available in the platform.json file, compare actual values against those facts

Also update to handle both `str` and `unicode` string types in Python 2.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To improve the quality of the Chassis platform API test

#### How did you do it?

For chassis tests where known facts are available in the platform.json file, compare actual values against those facts

#### How did you verify/test it?

Run Chassis tests on a device with a populated platform.json present

#### Any platform specific information?

Platform must have a populated platform.json present

