### PR TITLE
[Platform API][pytest] Handle both 'str' and 'unicode' string types in Python 2

### DIFF
--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -9,6 +9,17 @@ from tests.common.helpers.platform_api import chassis, component
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -48,7 +59,7 @@ class TestComponentApi(PlatformApiTestBase):
         for i in range(self.num_components):
             name = component.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Component {}: Unable to retrieve name".format(i)):
-                self.expect(isinstance(name, str), "Component {}: Name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "Component {}: Name appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):
@@ -70,7 +81,7 @@ class TestComponentApi(PlatformApiTestBase):
         for i in range(self.num_components):
             model = component.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Component {}: Unable to retrieve model".format(i)):
-                self.expect(isinstance(model, str), "Component {}: Model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "Component {}: Model appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_serial(self, duthost, localhost, platform_api_conn):
@@ -80,7 +91,7 @@ class TestComponentApi(PlatformApiTestBase):
         for i in range(self.num_components):
             serial = component.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Component {}: Unable to retrieve serial number".format(i)):
-                self.expect(isinstance(serial, str), "Component {}: Serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "Component {}: Serial number appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_status(self, duthost, localhost, platform_api_conn):
@@ -105,7 +116,7 @@ class TestComponentApi(PlatformApiTestBase):
         for i in range(self.num_components):
             description = component.get_description(platform_api_conn, i)
             if self.expect(description is not None, "Component {}: Failed to retrieve description".format(i)):
-                self.expect(isinstance(description, str), "Component {}: Description appears to be incorrect".format(i))
+                self.expect(isinstance(description, STRING_TYPE), "Component {}: Description appears to be incorrect".format(i))
         self.assert_expectations()
 
     def test_get_firmware_version(self, duthost, localhost, platform_api_conn):
@@ -115,7 +126,7 @@ class TestComponentApi(PlatformApiTestBase):
         for i in range(self.num_components):
             fw_version = component.get_firmware_version(platform_api_conn, i)
             if self.expect(fw_version is not None, "Component {}: Failed to retrieve firmware version".format(i)):
-                self.expect(isinstance(fw_version, str), "Component {}: Firmware version appears to be incorrect".format(i))
+                self.expect(isinstance(fw_version, STRING_TYPE), "Component {}: Firmware version appears to be incorrect".format(i))
         self.assert_expectations()
 
     def test_get_available_firmware_version(self, duthost, localhost, platform_api_conn):
@@ -126,7 +137,7 @@ class TestComponentApi(PlatformApiTestBase):
             for image in range(image_list):
                 avail_fw_version = component.get_available_firmware_version(platform_api_conn, i, image)
                 if self.expect(avail_fw_version is not None, "Component {}: Failed to retrieve available firmware version from image {}".format(i, image)):
-                    self.expect(isinstance(avail_fw_version, str), "Component {}: Available Firmware version appears to be incorrect from image {}".format(i, image))
+                    self.expect(isinstance(avail_fw_version, STRING_TYPE), "Component {}: Available Firmware version appears to be incorrect from image {}".format(i, image))
         self.assert_expectations()
 
     def test_get_firmware_update_notification(self, duthost, localhost, platform_api_conn):
@@ -137,7 +148,7 @@ class TestComponentApi(PlatformApiTestBase):
             for image in range(image_list):
                 notif = component.get_firmware_update_notification(platform_api_conn, i, image)
                 # Can return "None" if no update required. 
-                pytest_assert(isinstance(notif, str), "Component {}: Firmware update notification appears to be incorrect from image {}".format(i, image))
+                pytest_assert(isinstance(notif, STRING_TYPE), "Component {}: Firmware update notification appears to be incorrect from image {}".format(i, image))
 
     def test_install_firmware(self, duthost, localhost, platform_api_conn):
         if self.num_components == 0:

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -11,6 +11,16 @@ from tests.common.helpers.platform_api import chassis, fan
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -52,7 +62,7 @@ class TestFanApi(PlatformApiTestBase):
             name = fan.get_name(platform_api_conn, i)
 
             if self.expect(name is not None, "Unable to retrieve Fan {} name".format(i)):
-                self.expect(isinstance(name, str), "Fan {} name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "Fan {} name appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -71,7 +81,7 @@ class TestFanApi(PlatformApiTestBase):
             model = fan.get_model(platform_api_conn, i)
 
             if self.expect(model is not None, "Unable to retrieve fan {} model".format(i)):
-                self.expect(isinstance(model, str), "Fan {} model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "Fan {} model appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -80,7 +90,7 @@ class TestFanApi(PlatformApiTestBase):
             serial = fan.get_serial(platform_api_conn, i)
 
             if self.expect(serial is not None, "Unable to retrieve fan {} serial number".format(i)):
-                self.expect(isinstance(serial, str), "Fan {} serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "Fan {} serial number appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -180,7 +190,7 @@ class TestFanApi(PlatformApiTestBase):
                 color_actual = fan.get_status_led(platform_api_conn, i)
 
                 if self.expect(color_actual is not None, "Failed to retrieve status_led"):
-                    if self.expect(isinstance(color_actual, str), "Status LED color appears incorrect"):
+                    if self.expect(isinstance(color_actual, STRING_TYPE), "Status LED color appears incorrect"):
                         self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {} for fan {})".format(
                             color, color_actual, i))
 

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -11,6 +11,16 @@ from tests.common.helpers.platform_api import chassis, fan_drawer
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -57,7 +67,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
             name = fan_drawer.get_name(platform_api_conn, i)
 
             if self.expect(name is not None, "Unable to retrieve Fan_drawer {} name".format(i)):
-                self.expect(isinstance(name, str), "Fan_drawer {} name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "Fan_drawer {} name appears incorrect".format(i))
                 if self.fan_drawer_truth:
                     self.expect(name == self.fan_drawer_truth[i]['name'], "Fan_drawer {} name does not match, expected name {}".format(i, self.fan_drawer_truth[i]['name']))
 
@@ -78,7 +88,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
             model = fan_drawer.get_model(platform_api_conn, i)
 
             if self.expect(model is not None, "Unable to retrieve fan_drawer {} model".format(i)):
-                self.expect(isinstance(model, str), "Fan_drawer {} model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "Fan_drawer {} model appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -87,7 +97,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
             serial = fan_drawer.get_serial(platform_api_conn, i)
 
             if self.expect(serial is not None, "Unable to retrieve fan_drawer {} serial number".format(i)):
-                self.expect(isinstance(serial, str), "Fan_drawer {} serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "Fan_drawer {} serial number appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -139,7 +149,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
                 color_actual = fan_drawer.get_status_led(platform_api_conn, i)
 
                 if self.expect(color_actual is not None, "Failed to retrieve status_led"):
-                    if self.expect(isinstance(color_actual, str), "Status LED color appears incorrect"):
+                    if self.expect(isinstance(color_actual, STRING_TYPE), "Status LED color appears incorrect"):
                         self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {} for fan_drawer {})".format(
                             color, color_actual, i))
 

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -8,6 +8,16 @@ from tests.common.helpers.platform_api import chassis, module
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -67,7 +77,7 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             name = module.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve module {} name".format(i)):
-                self.expect(isinstance(name, str), "Module {} name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "Module {} name appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):
@@ -88,7 +98,7 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             model = module.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve module {} model".format(i)):
-                self.expect(isinstance(model, str), "Module {} model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "Module {} model appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_serial(self, duthost, localhost, platform_api_conn):
@@ -98,7 +108,7 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             serial = module.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve module {} serial number".format(i)):
-                self.expect(isinstance(serial, str), "Module {} serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "Module {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_status(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -9,6 +9,16 @@ from tests.common.helpers.platform_api import chassis, psu
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +53,7 @@ class TestPsuApi(PlatformApiTestBase):
         for i in range(self.num_psus):
             name = psu.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve PSU {} name".format(i)):
-                self.expect(isinstance(name, str), "PSU {} name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "PSU {} name appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):
@@ -58,14 +68,14 @@ class TestPsuApi(PlatformApiTestBase):
         for i in range(self.num_psus):
             model = psu.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve PSU {} model".format(i)):
-                self.expect(isinstance(model, str), "PSU {} model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "PSU {} model appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_serial(self, duthost, localhost, platform_api_conn):
         for i in range(self.num_psus):
             serial = psu.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve PSU {} serial number".format(i)):
-                self.expect(isinstance(serial, str), "PSU {} serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_status(self, duthost, localhost, platform_api_conn):
@@ -160,7 +170,7 @@ class TestPsuApi(PlatformApiTestBase):
 
                 color_actual = psu.get_status_led(platform_api_conn, psu_id)
                 if self.expect(color_actual is not None, "Failed to retrieve status_led of PSU {}".format(psu_id)):
-                    if self.expect(isinstance(color_actual, str), "PSU {} status LED color appears incorrect".format(psu_id)):
+                    if self.expect(isinstance(color_actual, STRING_TYPE), "PSU {} status LED color appears incorrect".format(psu_id)):
                         self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {}) from PSU {}".format(color, color_actual, psu_id))
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -9,6 +9,16 @@ from tests.common.helpers.platform_api import chassis, sfp
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -104,7 +114,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in range(self.num_sfps):
             name = sfp.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve transceiver {} name".format(i)):
-                self.expect(isinstance(name, str), "Transceiver {} name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "Transceiver {} name appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):
@@ -119,14 +129,14 @@ class TestSfpApi(PlatformApiTestBase):
         for i in range(self.num_sfps):
             model = sfp.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve transceiver {} model".format(i)):
-                self.expect(isinstance(model, str), "Transceiver {} model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "Transceiver {} model appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_serial(self, duthost, localhost, platform_api_conn):
         for i in range(self.num_sfps):
             serial = sfp.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve transceiver {} serial number".format(i)):
-                self.expect(isinstance(serial, str), "Transceiver {} serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "Transceiver {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
     def test_get_status(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -11,6 +11,16 @@ from tests.common.helpers.platform_api import chassis, thermal
 
 from platform_api_test_base import PlatformApiTestBase
 
+###################################################
+# TODO: Remove this after we transition to Python 3
+import sys
+if sys.version_info.major == 3:
+    STRING_TYPE = str
+else:
+    STRING_TYPE = basestring
+# END Remove this after we transition to Python 3
+###################################################
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -43,7 +53,7 @@ class TestThermalApi(PlatformApiTestBase):
             name = thermal.get_name(platform_api_conn, i)
 
             if self.expect(name is not None, "Unable to retrieve Thermal {} name".format(i)):
-                self.expect(isinstance(name, str), "Thermal {} name appears incorrect".format(i))
+                self.expect(isinstance(name, STRING_TYPE), "Thermal {} name appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -62,7 +72,7 @@ class TestThermalApi(PlatformApiTestBase):
             model = thermal.get_model(platform_api_conn, i)
 
             if self.expect(model is not None, "Unable to retrieve thermal {} model".format(i)):
-                self.expect(isinstance(model, str), "Thermal {} model appears incorrect".format(i))
+                self.expect(isinstance(model, STRING_TYPE), "Thermal {} model appears incorrect".format(i))
 
         self.assert_expectations()
 
@@ -71,7 +81,7 @@ class TestThermalApi(PlatformApiTestBase):
             serial = thermal.get_serial(platform_api_conn, i)
 
             if self.expect(serial is not None, "Unable to retrieve thermal {} serial number".format(i)):
-                self.expect(isinstance(serial, str), "Thermal {} serial number appears incorrect".format(i))
+                self.expect(isinstance(serial, STRING_TYPE), "Thermal {} serial number appears incorrect".format(i))
 
         self.assert_expectations()
 


### PR DESCRIPTION
Summary:
Python 2 has two string types, `str` and `unicode`. Both share a `basestring` superclass. In Python 3, there is only one `str` type. This patch allows the platform API tests to consider a string type valid whether it is ASCII (`str`) or Unicode in Python 2. It also future-proofs the inevitable transition to Python 3 by checking the executing Python version.

Note that test_chassis.py is not modified here, as the change is being applied as part of https://github.com/Azure/sonic-mgmt/pull/2209

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To ensure the platform API tests properly acknowledge both `str` and `unicode` string types returned from the API.

#### How did you do it?
If Python 2, compare type to `basestring`, if Python 3, compare type to `str`.

#### How did you verify/test it?
Test that both `str` and `unicode` types are considered strings when running tests under Python 2.