### PR TITLE
[crm] Fix test_crm teardown

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -21,7 +21,7 @@ def pytest_runtest_teardown(item, nextitem):
     restore_cmd = "bash -c \"sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_threshold_type percentage \
     && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_high_threshold {high} \
     && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_low_threshold {low}\""
-    if not item.rep_call.skipped:
+    if item.rep_setup.passed and not item.rep_call.skipped:
         # Restore CRM threshods
         if crm_threshold_name:
             crm_thresholds = item.funcargs["crm_thresholds"]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
If fixtures failed during setup, there will no `rep_call` attribute for
`item`. Checking the setup's success first to guarantee this.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If `sanity_check` fails before `test_crm` related test cases, there will be an error complaining there is no `rep_call` attribute for `Item` object.

#### How did you do it?
Check if `setup` passes before fetching `rep_call`.
#### How did you verify/test it?
* before
```
________________________________________________________________________ ERROR at setup of test_acl_entry _________________________________________________________________________

localhost = <tests.common.devices.Localhost object at 0x7f7159465310>, duthost = <tests.common.devices.SonicHost object at 0x7f715f6f09d0>
request = <SubRequest 'sanity_check' for <Function test_acl_entry>>
fanouthosts = {u'str-7060cx-32s-16': { os: 'eos', hostname: 'str-7060cx-32s-16', device_type: 'FanoutLeaf' }, u'str-7060cx-32s-17': { os: 'eos', hostname: 'str-7060cx-32s-17', device_type: 'FanoutLeaf' }}
testbed = {'comment': 'prsunny', 'conf-name': 'vms6-t0-7060', 'duts': ['str-a7060cx-acs-1'], 'group-name': 'vms6-4', ...}

    @pytest.fixture(scope="module", autouse=True)
    def sanity_check(localhost, duthost, request, fanouthosts, testbed):
        logger.info("Start pre-test sanity check")
>       pytest.fail("Out of no reason")
E       Failed: Out of no reason

common/plugins/sanity_check/__init__.py:46: Failed
_______________________________________________________________________ ERROR at teardown of test_acl_entry _______________________________________________________________________

item = <Function test_acl_entry>, nextitem = None

    def pytest_runtest_teardown(item, nextitem):
        """ called after ``pytest_runtest_call``.

        :arg nextitem: the scheduled-to-be-next test item (None if no further
                       test item is scheduled).  This argument can be used to
                       perform exact teardowns, i.e. calling just enough finalizers
                       so that nextitem only needs to call setup-functions.
        """
        failures = []
        crm_threshold_name = RESTORE_CMDS.get("crm_threshold_name")
        restore_cmd = "bash -c \"sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_threshold_type percentage \
        && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_high_threshold {high} \
        && sonic-db-cli CONFIG_DB hset 'CRM|Config' {threshold_name}_low_threshold {low}\""
>       if not item.rep_call.skipped:
E       AttributeError: 'Function' object has no attribute 'rep_call'

crm/conftest.py:24: AttributeError
============================================================================= 2 error in 8.23 seconds =============================================================================
``` 
* after
```
________________________________________________________________________ ERROR at setup of test_acl_entry _________________________________________________________________________

localhost = <tests.common.devices.Localhost object at 0x7fa803bd9cd0>, duthost = <tests.common.devices.SonicHost object at 0x7fa809e1a9d0>
request = <SubRequest 'sanity_check' for <Function test_acl_entry>>
fanouthosts = {u'str-7060cx-32s-16': { os: 'eos', hostname: 'str-7060cx-32s-16', device_type: 'FanoutLeaf' }, u'str-7060cx-32s-17': { os: 'eos', hostname: 'str-7060cx-32s-17', device_type: 'FanoutLeaf' }}
testbed = {'comment': 'prsunny', 'conf-name': 'vms6-t0-7060', 'duts': ['str-a7060cx-acs-1'], 'group-name': 'vms6-4', ...}

    @pytest.fixture(scope="module", autouse=True)
    def sanity_check(localhost, duthost, request, fanouthosts, testbed):
        logger.info("Start pre-test sanity check")
>       pytest.fail("Out of no reason")
E       Failed: Out of no reason

common/plugins/sanity_check/__init__.py:46: Failed
============================================================================= 1 error in 9.47 seconds =============================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
