### PR TITLE
[reporting] Add testbed and timestamp to JUnit test reports

### DIFF
--- a/test_reporting/tests/files/sample_archive/tr_1.xml
+++ b/test_reporting/tests/files/sample_archive/tr_1.xml
@@ -2,7 +2,8 @@
 <testsuite errors="0" failures="0" name="pytest" skipped="1" tests="2" time="109.472">
     <properties>
         <property name="topology" value="t0"/>
-        <property name="markers" value=""/>
+        <property name="timestamp" value="2020-09-14 18:24:19.675190" />
+        <property name="testbed" value="vms-kvm-t0" />
         <property name="host" value="vlab-01"/>
         <property name="asic" value="vs"/>
         <property name="platform" value="x86_64-kvm_x86_64-r0"/>

--- a/test_reporting/tests/files/sample_archive/tr_2.xml
+++ b/test_reporting/tests/files/sample_archive/tr_2.xml
@@ -2,7 +2,8 @@
 <testsuite errors="1" failures="1" name="pytest" skipped="0" tests="2" time="104.582">
     <properties>
         <property name="topology" value="t0"/>
-        <property name="markers" value=""/>
+        <property name="timestamp" value="2020-09-14 18:25:17.233592"/>
+        <property name="testbed" value="vms-kvm-t0" />
         <property name="host" value="vlab-01"/>
         <property name="asic" value="vs"/>
         <property name="platform" value="x86_64-kvm_x86_64-r0"/>

--- a/test_reporting/tests/files/sample_tr.xml
+++ b/test_reporting/tests/files/sample_tr.xml
@@ -2,7 +2,8 @@
 <testsuite errors="1" failures="1" name="pytest" skipped="1" tests="4" time="214.054">
     <properties>
         <property name="topology" value="t0"/>
-        <property name="markers" value=""/>
+        <property name="timestamp" value="2020-09-14 18:24:19.675190" />
+        <property name="testbed" value="vms-kvm-t0" />
         <property name="host" value="vlab-01"/>
         <property name="asic" value="vs"/>
         <property name="platform" value="x86_64-kvm_x86_64-r0"/>

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -11,7 +11,8 @@ VALID_TEST_RESULT = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite errors="1" failures="1" name="pytest" skipped="1" tests="4" time="214.054">
     <properties>
         <property name="topology" value="t0"/>
-        <property name="markers" value=""/>
+        <property name="timestamp" value="2020-09-14 18:24:19.675190" />
+        <property name="testbed" value="vms-kvm-t0" />
         <property name="host" value="vlab-01"/>
         <property name="asic" value="vs"/>
         <property name="platform" value="x86_64-kvm_x86_64-r0"/>
@@ -82,6 +83,8 @@ EXPECTED_JSON_OUTPUT = {
     "test_metadata": {
         "asic": "vs",
         "host": "vlab-01",
+        "timestamp": "2020-09-14 18:24:19.675190",
+        "testbed": "vms-kvm-t0",
         "hwsku": "Force10-S6000",
         "os_version": "master.449-9c22d19b",
         "platform": "x86_64-kvm_x86_64-r0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import jinja2
 import ipaddr as ipaddress
 
 from collections import defaultdict
+from datetime import datetime
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.devices import SonicHost, Localhost
 from tests.common.devices import PTFHost, EosHost, FanoutHost
@@ -403,27 +404,19 @@ def collect_techsupport(request, duthost):
 
         logging.info("########### Collected tech support for test {} ###########".format(testname))
 
-__report_metadata_added = False
-
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def tag_test_report(request, pytestconfig, testbed, duthost, record_testsuite_property):
     if not request.config.getoption("--junit-xml"):
         return
 
-    # NOTE: This is a gnarly hack to deal with the fact that we only want to add this
-    # metadata to the test report once per session. Since the duthost fixture has
-    # module scope we can't give this fixture session scope.
-    global __report_metadata_added
-    if not __report_metadata_added:
-        # Test run information
-        record_testsuite_property("topology", testbed['topo']['name'])
-        record_testsuite_property("markers", pytestconfig.getoption("-m"))
+    # Test run information
+    record_testsuite_property("topology", testbed["topo"]["name"])
+    record_testsuite_property("testbed", testbed["conf-name"])
+    record_testsuite_property("timestamp", datetime.utcnow())
 
-        # Device information
-        record_testsuite_property("host", duthost.hostname)
-        record_testsuite_property("asic", duthost.facts["asic_type"])
-        record_testsuite_property("platform", duthost.facts["platform"])
-        record_testsuite_property("hwsku", duthost.facts["hwsku"])
-        record_testsuite_property("os_version", duthost.os_version)
-
-        __report_metadata_added = True
+    # Device information
+    record_testsuite_property("host", duthost.hostname)
+    record_testsuite_property("asic", duthost.facts["asic_type"])
+    record_testsuite_property("platform", duthost.facts["platform"])
+    record_testsuite_property("hwsku", duthost.facts["hwsku"])
+    record_testsuite_property("os_version", duthost.os_version)


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [reporting] Add testbed and timestamp to JUnit test reports

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
It is helpful to know when a test was run and what testbed was used to run the tests when viewing test reports.

#### How did you do it?
Added two metadata fields to the XML output. I also updated the JSON parser to accommodate these two new fields.

#### How did you verify/test it?
Updated the pytest cases and ran a few test cases with the new conftest on a physical DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
