### PR TITLE
[interface util] use "show interface description" instead

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -9,8 +9,8 @@ from transceiver_utils import all_transceivers_detected
 
 def parse_intf_status(lines):
     """
-    @summary: Parse the output of command "intfutil description".
-    @param lines: The output lines of command "intfutil description".
+    @summary: Parse the output of command "show interface description".
+    @param lines: The output lines of command "show interface description".
     @return: Return a dictionary like:
         {
             "Ethernet0": {
@@ -38,9 +38,9 @@ def check_interface_status(dut, interfaces):
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     @param interfaces: List of interfaces that need to be checked.
     """
-    logging.info("Check interface status using cmd 'intfutil'")
+    logging.info("Check interface status using cmd 'show interface'")
     mg_ports = dut.minigraph_facts(host=dut.hostname)["ansible_facts"]["minigraph_ports"]
-    output = dut.command("intfutil description")
+    output = dut.command("show interface description")
     intf_status = parse_intf_status(output["stdout_lines"][2:])
     check_intf_presence_command = 'show interface transceiver presence {}'
     for intf in interfaces:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
A few tests start to fail with latest 201911 image because 'intfutil description' start to fail due to lack of name space parameter.

#### How did you do it?
intfutil syntax was changed recently and caused a few tests depending on this commad to fail.

Change the test to use higher level command "show interface status" instead.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
With the fix:
platform_tests/test_reload_config.py::test_reload_configuration PASSED                                                                                                             [100%]

Without the fix:
22:32:14 ERROR utilities.py:wait_until:39: Exception caught while checking check_interface_information: run module command failed, Ansible Results =>
{
    "changed": true, 
    "cmd": [
        "intfutil", 
        "description"
    ], 
    "delta": "0:00:00.441985", 
    "end": "2020-09-14 22:32:14.081311", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "_raw_params": "intfutil description", 
            "_uses_shell": false, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "stdin_add_newline": true, 
            "strip_empty_ends": true, 
            "warn": true
        }
    }, 
    "msg": "non-zero return code", 
    "rc": 2, 
    "start": "2020-09-14 22:32:13.639326", 
    "stderr": "usage: intfutil [-h] [-c COMMAND] [-i INTERFACE] [-d DISPLAY] [-n NAMESPACE]\nintfutil: error: unrecognized arguments: description", 
    "stderr_lines": [
        "usage: intfutil [-h] [-c COMMAND] [-i INTERFACE] [-d DISPLAY] [-n NAMESPACE]", 
        "intfutil: error: unrecognized arguments: description"
    ], 
    "stdout": "", 
    "stdout_lines": []
}

