### PR TITLE
[test_crm] Fix exception in test_crm_fdb_entry

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -112,7 +112,7 @@ def generate_fdb_config(duthost, entry_num, vlan_id, iface, op, dest):
     entry_key_template = "FDB_TABLE:Vlan{vid}:{mac}"
 
     for mac_address in generate_mac(entry_num):
-        fdb_entry_json = {entry_key_template.format(vid=vlan_id, mac=mac_address): 
+        fdb_entry_json = {entry_key_template.format(vid=vlan_id, mac=mac_address):
             {"port": iface, "type": "dynamic"},
             "OP": op
         }
@@ -837,6 +837,8 @@ def test_crm_fdb_entry(duthost, testbed):
 
     used_percent = get_used_percent(new_crm_stats_fdb_entry_used, new_crm_stats_fdb_entry_available)
     if used_percent < 1:
+        # Clear pre-set fdb entry
+        duthost.command("fdbclear")
         # Preconfiguration needed for used percentage verification
         fdb_entries_num = get_entries_num(new_crm_stats_fdb_entry_used, new_crm_stats_fdb_entry_available)
         # Generate FDB json file with 'fdb_entries_num' entries and apply it on DUT


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Test case test_crm_fdb_entry build FDB entry by applying fdb config to swss. And two different config files will be applied to swss at some cases. However, the config file applied later will result in a incomplete FDB table is the previous entry is not clear. This commit fix the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix the exception in test_crm_fdb_entry.
#### How did you do it?
Use **fdbclear** to do a cleanup between two applying fdb configs.
#### How did you verify/test it?
Verified on Arista 7260
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-1 --module-path ../ansible/library/ --testbed vms7-t0-7260-1 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util crm/test_crm.py::test_crm_fdb_entry
========================================================================================= test session starts =========================================================================================
collected 1 item                                                                                                                                                                                      

crm/test_crm.py::test_crm_fdb_entry PASSED                                                                                                                                                      [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 197.32 seconds ======================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.