### PR TITLE
Refactor: rename the 'testbed' fixture to 'tbinfo'

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -47,11 +47,11 @@ LOG_EXPECT_ACL_RULE_REMOVE_RE = '.*Successfully deleted ACL rule.*'
 
 
 @pytest.fixture(scope='module')
-def setup(duthost, testbed, ptfadapter):
+def setup(duthost, tbinfo, ptfadapter):
     """
-    setup fixture gathers all test required information from DUT facts and testbed
+    setup fixture gathers all test required information from DUT facts and tbinfo
     :param duthost: DUT host object
-    :param testbed: Testbed object
+    :param tbinfo: fixture provides information about testbed
     :return: dictionary with all test required information
     """
 
@@ -62,7 +62,7 @@ def setup(duthost, testbed, ptfadapter):
     port_channels = []
     acl_table_ports = []
 
-    if testbed['topo']['name'] not in ('t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet'):
+    if tbinfo['topo']['name'] not in ('t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet'):
         pytest.skip('Unsupported topology')
 
     # gather ansible facts
@@ -82,10 +82,10 @@ def setup(duthost, testbed, ptfadapter):
     port_channels = mg_facts['minigraph_portchannels']
 
     # get the list of port to be combined to ACL tables
-    if testbed['topo']['name'] in ('t1', 't1-lag'):
+    if tbinfo['topo']['name'] in ('t1', 't1-lag'):
         acl_table_ports += tor_ports
 
-    if testbed['topo']['name'] in ('t1-lag', 't1-64-lag', 't1-64-lag-clet'):
+    if tbinfo['topo']['name'] in ('t1-lag', 't1-64-lag', 't1-64-lag-clet'):
         acl_table_ports += port_channels
     else:
         acl_table_ports += spine_ports

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart, testbed):
+def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_restart, tbinfo):
     """
     Verify that DUT routes are preserved when peer performed graceful restart
     """
@@ -63,7 +63,7 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
     bgp_nbr = bgp_neighbors[str(bgp_nbr_ipv4)]
     nbr_hostname = bgp_nbr['name']
     nbrhost = nbrhosts[nbr_hostname]['host']
-    topo = testbed['topo']['properties']['configuration_properties']
+    topo = tbinfo['topo']['properties']['configuration_properties']
     exabgp_ips = [topo['common']['nhipv4'], topo['common']['nhipv6']]
     exabgp_sessions = ['exabgp_v4', 'exabgp_v6']
     pytest_assert(nbrhost.check_bgp_session_state(exabgp_ips, exabgp_sessions), \

--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -8,19 +8,19 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-def get_t2_neigh(testbed):
+def get_t2_neigh(tbinfo):
     dut_t2_neigh = []
-    for vm in testbed['topo']['properties']['topology']['VMs'].keys():
+    for vm in tbinfo['topo']['properties']['topology']['VMs'].keys():
         if 'T2' in vm:
             dut_t2_neigh.append(vm)
     return  dut_t2_neigh
 
-def get_t0_neigh(testbed, topo_config):
+def get_t0_neigh(tbinfo, topo_config):
     """
     get all t0 router names which has vips defined
     """
     dut_t0_neigh = []
-    for vm in testbed['topo']['properties']['topology']['VMs'].keys():
+    for vm in tbinfo['topo']['properties']['topology']['VMs'].keys():
         if 'T0' in vm:
             if topo_config[vm].has_key('vips'):
                 dut_t0_neigh.append(vm)
@@ -49,7 +49,7 @@ def get_vips_prefix_paths(dut_t0_neigh, vips_prefix, topo_config):
             vips_asn.append(topo_config[neigh]['vips']['ipv4']['asn'])
     return vips_t0, vips_asn
 
-def get_bgp_v4_neighbors_from_minigraph(duthost, testbed):
+def get_bgp_v4_neighbors_from_minigraph(duthost, tbinfo):
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 
     # Find all V4 bgp neighbors from minigraph
@@ -60,20 +60,20 @@ def get_bgp_v4_neighbors_from_minigraph(duthost, testbed):
         bgp_v4nei[item['name']] = item['addr']
     return bgp_v4nei
 
-def test_bgp_multipath_relax(testbed, duthost):
+def test_bgp_multipath_relax(tbinfo, duthost):
 
-    logger.info("Starting test_bgp_multipath_relax on topology {}".format(testbed['topo']['name']))
-    topo_config = testbed['topo']['properties']['configuration']
+    logger.info("Starting test_bgp_multipath_relax on topology {}".format(tbinfo['topo']['name']))
+    topo_config = tbinfo['topo']['properties']['configuration']
 
-    bgp_v4nei = get_bgp_v4_neighbors_from_minigraph(duthost, testbed)
+    bgp_v4nei = get_bgp_v4_neighbors_from_minigraph(duthost, tbinfo)
 
     logger.info("bgp_v4nei {}".format(bgp_v4nei))
 
     # get all t0 routers name which has vips defined
-    dut_t0_neigh = get_t0_neigh(testbed, topo_config)
+    dut_t0_neigh = get_t0_neigh(tbinfo, topo_config)
 
     # get t2 neighbors
-    dut_t2_neigh = get_t2_neigh(testbed)
+    dut_t2_neigh = get_t2_neigh(tbinfo)
 
     if not dut_t0_neigh:
         pytest.fail("Didn't find multipath t0's")

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -179,7 +179,7 @@ def test_bgp_speaker_bgp_sessions(common_setup_teardown, duthost, ptfhost, colle
     assert str(speaker_ips[2].ip) in bgp_facts["bgp_neighbors"], "No bgp session with PTF"
 
 
-def bgp_speaker_announce_routes_common(common_setup_teardown, testbed, duthost, ptfhost, ipv4, ipv6, mtu, family, prefix, nexthop_ips):
+def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6, mtu, family, prefix, nexthop_ips):
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """
@@ -227,7 +227,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, testbed, duthost, 
                 "ptftests",
                 "fib_test.FibTest",
                 platform_dir="ptftests",
-                params={"testbed_type": testbed['topo']['name'],
+                params={"testbed_type": tbinfo['topo']['name'],
                         "router_mac": interface_facts['ansible_interface_facts']['Ethernet0']['macaddress'],
                         "fib_info": "/root/bgp_speaker_route_%s.txt" % family,
                         "ipv4": ipv4,
@@ -245,18 +245,18 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, testbed, duthost, 
 
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, False, 1514)])
-def test_bgp_speaker_announce_routes(common_setup_teardown, testbed, duthost, ptfhost, ipv4, ipv6, mtu, collect_techsupport):
+def test_bgp_speaker_announce_routes(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6, mtu, collect_techsupport):
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """
     nexthops = common_setup_teardown[3]
-    bgp_speaker_announce_routes_common(common_setup_teardown, testbed, duthost, ptfhost, ipv4, ipv6, mtu, "v4", "10.10.10.0/26", nexthops)
+    bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6, mtu, "v4", "10.10.10.0/26", nexthops)
 
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(False, True, 1514)])
-def test_bgp_speaker_announce_routes_v6(common_setup_teardown, testbed, duthost, ptfhost, ipv4, ipv6, mtu, collect_techsupport):
+def test_bgp_speaker_announce_routes_v6(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6, mtu, collect_techsupport):
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """
     nexthops = common_setup_teardown[4]
-    bgp_speaker_announce_routes_common(common_setup_teardown, testbed, duthost, ptfhost, ipv4, ipv6, mtu, "v6", "fc00:10::/64", nexthops)
+    bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6, mtu, "v6", "fc00:10::/64", nexthops)

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -25,14 +25,14 @@ class AdvancedReboot:
     inboot/preboot list. The class transfers number of configuration files to the dut/ptf in preparation for reboot test.
     Test cases can trigger test start utilizing runRebootTestcase API.
     '''
-    def __init__(self, request, duthost, ptfhost, localhost, testbed, creds, **kwargs):
+    def __init__(self, request, duthost, ptfhost, localhost, tbinfo, creds, **kwargs):
         '''
         Class constructor.
         @param request: pytest request object
         @param duthost: AnsibleHost instance of DUT
         @param ptfhost: PTFHost for interacting with PTF through ansible
         @param localhost: Localhost for interacting with localhost through ansible
-        @param testbed: fixture provides information about testbed
+        @param tbinfo: fixture provides information about testbed
         @param kwargs: extra parameters including reboot type
         '''
         assert 'rebootType' in kwargs and kwargs['rebootType'] in ['fast-reboot', 'warm-reboot'], (
@@ -43,7 +43,7 @@ class AdvancedReboot:
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.localhost = localhost
-        self.testbed = testbed
+        self.tbinfo = tbinfo
         self.creds = creds
         self.moduleIgnoreErrors = False
         self.__dict__.update(kwargs)
@@ -100,7 +100,7 @@ class AdvancedReboot:
         '''
         Accessor method for testbed's topology name
         '''
-        return self.testbed['topo']['name']
+        return self.tbinfo['topo']['name']
 
     def __buildTestbedData(self):
         '''
@@ -143,8 +143,8 @@ class AdvancedReboot:
         '''
         if self.inbootList is not None:
             self.rebootData['nexthop_ips'] = [
-                self.testbed['topo']['properties']['configuration_properties']['common']['nhipv4'],
-                self.testbed['topo']['properties']['configuration_properties']['common']['nhipv6'],
+                self.tbinfo['topo']['properties']['configuration_properties']['common']['nhipv4'],
+                self.tbinfo['topo']['properties']['configuration_properties']['common']['nhipv6'],
             ]
         else:
             self.rebootData['nexthop_ips'] = None
@@ -497,14 +497,14 @@ class AdvancedReboot:
             self.__restorePrevImage()
 
 @pytest.fixture
-def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed, creds):
+def get_advanced_reboot(request, duthost, ptfhost, localhost, tbinfo, creds):
     '''
     Pytest test fixture that provides access to AdvancedReboot test fixture
         @param request: pytest request object
         @param duthost: AnsibleHost instance of DUT
         @param ptfhost: PTFHost for interacting with PTF through ansible
         @param localhost: Localhost for interacting with localhost through ansible
-        @param testbed: fixture provides information about testbed
+        @param tbinfo: fixture provides information about testbed
     '''
     instances = []
 
@@ -513,7 +513,7 @@ def get_advanced_reboot(request, duthost, ptfhost, localhost, testbed, creds):
         API that returns instances of AdvancedReboot class
         '''
         assert len(instances) == 0, "Only one instance of reboot data is allowed"
-        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, creds, **kwargs)
+        advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, tbinfo, creds, **kwargs)
         instances.append(advancedReboot)
         return advancedReboot
 

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -167,7 +167,7 @@ def enable_pfc_asym(setup, duthost):
             assert setup["pfc_bitmask"]["pfc_mask"] == int(duthost.command(get_asym_pfc.format(port=p_oid, sai_attr=sai_default_asym_pfc))["stdout"])
 
 @pytest.fixture(scope="module")
-def setup(testbed, duthost, ptfhost, ansible_facts, minigraph_facts, request):
+def setup(tbinfo, duthost, ptfhost, ansible_facts, minigraph_facts, request):
     """
     Fixture performs initial steps which is required for test case execution.
     Also it compose data which is used as input parameters for PTF test cases, and PFC - RX and TX masks which is used in test case logic.
@@ -204,7 +204,7 @@ def setup(testbed, duthost, ptfhost, ansible_facts, minigraph_facts, request):
     - Remove ARP responder
     - Restore supervisor configuration in PTF container
     """
-    if testbed['topo']['name'] != "t0":
+    if tbinfo['topo']['name'] != "t0":
         pytest.skip('Unsupported topology')
     setup_params = {
         "pfc_bitmask": {

--- a/tests/common/ixia/ixia_fixtures.py
+++ b/tests/common/ixia/ixia_fixtures.py
@@ -1,6 +1,6 @@
 """
 This module contains the necessary fixtures for running test cases with
-Ixia devices and IxNetwork. If more fixtures are required, they should be 
+Ixia devices and IxNetwork. If more fixtures are required, they should be
 included in this file.
 """
 
@@ -8,19 +8,19 @@ import pytest
 from ixnetwork_restpy import SessionAssistant
 
 @pytest.fixture(scope = "module")
-def ixia_api_serv_ip(testbed):
-    """ 
-    In an Ixia testbed, there is no PTF docker. 
-    Hence, we use ptf_ip field to store Ixia API server. 
+def ixia_api_serv_ip(tbinfo):
+    """
+    In an Ixia testbed, there is no PTF docker.
+    Hence, we use ptf_ip field to store Ixia API server.
     This fixture returns the IP address of the Ixia API server.
 
-    Args: 
-       testbed (pytest fixture): The testbed fixture.
+    Args:
+       tbinfo (pytest fixture): fixture provides information about testbed
 
     Returns:
         Ixia API server IP
     """
-    return testbed['ptf_ip']
+    return tbinfo['ptf_ip']
 
 
 @pytest.fixture(scope = "module")
@@ -30,7 +30,7 @@ def ixia_api_serv_user(duthost):
 
     Args:
         duthost (pytest fixture): The duthost fixture.
- 
+
     Returns:
         Ixia API server username.
     """
@@ -44,7 +44,7 @@ def ixia_api_serv_passwd(duthost):
 
     Args:
         duthost (pytest fixture): The duthost fixture.
- 
+
     Returns:
         Ixia API server password.
     """
@@ -58,7 +58,7 @@ def ixia_api_serv_port(duthost):
 
     Args:
         duthost (pytest fixture): The duthost fixture.
- 
+
     Returns:
         Ixia API server REST port.
     """
@@ -83,11 +83,11 @@ def ixia_api_serv_session_id(duthost):
 @pytest.fixture(scope = "module")
 def ixia_dev(duthost, fanouthosts):
     """
-    Returns the Ixia chassis IP. This fixture can return multiple IPs if 
+    Returns the Ixia chassis IP. This fixture can return multiple IPs if
     multiple Ixia chassis are present in the test topology.
 
     Args:
-        duthost (pytest fixture): The duthost fixture. 
+        duthost (pytest fixture): The duthost fixture.
         fanouthosts (pytest fixture): The fanouthosts fixture.
 
     Returns:
@@ -115,9 +115,9 @@ def ixia_api_server_session(
         ixia_api_serv_user (pytest fixture): ixia_api_serv_user fixture.
         ixia_api_serv_passwd (pytest fixture): ixia_api_serv_passwd fixture.
         ixia_api_serv_port (pytest fixture): ixia_api_serv_port fixture.
-        ixia_api_serv_session_id (pytest fixture): ixia_api_serv_session_id 
+        ixia_api_serv_session_id (pytest fixture): ixia_api_serv_session_id
             fixture.
-  
+
     Returns:
         IxNetwork Session
     """
@@ -135,7 +135,7 @@ def ixia_api_server_session(
                                    RestPort=ixia_api_serv_port)
     ixNetwork = session.Ixnetwork
     ixNetwork.NewConfig()
-    
+
     yield session
 
     ixNetwork.NewConfig()

--- a/tests/common/plugins/fib.py
+++ b/tests/common/plugins/fib.py
@@ -94,8 +94,8 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
     return routes
 
 
-def fib_t0(ptfhost, testbed, localhost, topology=None):
-    logger.info("use fib_t0 to setup routes for topo {}".format(testbed['topo']['name']))
+def fib_t0(ptfhost, tbinfo, localhost, topology=None):
+    logger.info("use fib_t0 to setup routes for topo {}".format(tbinfo['topo']['name']))
 
     podset_number = 200
     tor_number = 16
@@ -103,19 +103,19 @@ def fib_t0(ptfhost, testbed, localhost, topology=None):
     max_tor_subnet_number = 16
     tor_subnet_size = 128
 
-    common_config_topo = testbed['topo']['properties']['configuration_properties']['common']
+    common_config_topo = tbinfo['topo']['properties']['configuration_properties']['common']
     spine_asn = common_config_topo.get("spine_asn", 65534)
     leaf_asn_start = common_config_topo.get("leaf_asn_start", 64600)
     tor_asn_start = common_config_topo.get("tor_asn_start", 65500)
 
-    topo = testbed['topo']['properties']
-    ptf_hostname = testbed['ptf']
+    topo = tbinfo['topo']['properties']
+    ptf_hostname = tbinfo['ptf']
     ptfip = ptfhost.host.options['inventory_manager'].get_host(ptf_hostname).vars['ansible_host']
 
     local_ip = ipaddress.IPAddress("10.10.246.254")
     local_ipv6 = ipaddress.IPAddress("fc0a::ff")
-    for k, v in testbed['topo']['properties']['configuration'].items():
-        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        vm_offset = tbinfo['topo']['properties']['topology']['VMs'][k]['vm_offset']
         peer_ip = ipaddress.IPNetwork(v['bp_interface']['ipv4'])
         peer_ipv6 = ipaddress.IPNetwork(v['bp_interface']['ipv6'])
         asn = int(v['bgp']['asn'])
@@ -140,8 +140,8 @@ def fib_t0(ptfhost, testbed, localhost, topology=None):
                        peer_asn  = asn, \
                        port = port6)
     # check if bgp http_api is ready
-    for k, v in testbed['topo']['properties']['configuration'].items():
-        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        vm_offset = tbinfo['topo']['properties']['topology']['VMs'][k]['vm_offset']
 
         port = 5000 + vm_offset
         assert wait_tcp_connection(localhost, ptfip, port)
@@ -149,8 +149,8 @@ def fib_t0(ptfhost, testbed, localhost, topology=None):
         port6 = 6000 + vm_offset
         assert wait_tcp_connection(localhost, ptfip, port6)
 
-    for k, v in testbed['topo']['properties']['configuration'].items():
-        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        vm_offset = tbinfo['topo']['properties']['topology']['VMs'][k]['vm_offset']
         port = 5000 + vm_offset
         port6 = 6000 + vm_offset
 
@@ -165,8 +165,8 @@ def fib_t0(ptfhost, testbed, localhost, topology=None):
         announce_routes(ptfip, port6, routes_v6)
 
 
-def fib_t1_lag(ptfhost, testbed, localhost):
-    logger.info("use fib_t1_lag to setup routes for topo {}".format(testbed['topo']['name']))
+def fib_t1_lag(ptfhost, tbinfo, localhost):
+    logger.info("use fib_t1_lag to setup routes for topo {}".format(tbinfo['topo']['name']))
 
     podset_number = 200
     tor_number = 16
@@ -177,15 +177,15 @@ def fib_t1_lag(ptfhost, testbed, localhost):
     leaf_asn_start  = 64600
     tor_asn_start   = 65500
 
-    topo = testbed['topo']['properties']
-    ptf_hostname = testbed['ptf']
+    topo = tbinfo['topo']['properties']
+    ptf_hostname = tbinfo['ptf']
     ptfip = ptfhost.host.options['inventory_manager'].get_host(ptf_hostname).vars['ansible_host']
 
     local_ip = ipaddress.IPAddress("10.10.246.254")
     local_ipv6 = ipaddress.IPAddress("fc0a::ff")
 
-    for k, v in testbed['topo']['properties']['configuration'].items():
-        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        vm_offset = tbinfo['topo']['properties']['topology']['VMs'][k]['vm_offset']
         peer_ip = ipaddress.IPNetwork(v['bp_interface']['ipv4'])
         peer_ipv6 = ipaddress.IPNetwork(v['bp_interface']['ipv6'])
         asn = int(v['bgp']['asn'])
@@ -210,8 +210,8 @@ def fib_t1_lag(ptfhost, testbed, localhost):
                        peer_asn  = asn, \
                        port = port6)
     # Check if bgp http_api port is ready
-    for k, v in testbed['topo']['properties']['configuration'].items():
-        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        vm_offset = tbinfo['topo']['properties']['topology']['VMs'][k]['vm_offset']
 
         port = 5000 + vm_offset
         assert wait_tcp_connection(localhost, ptfip, port)
@@ -219,9 +219,9 @@ def fib_t1_lag(ptfhost, testbed, localhost):
         port6 = 6000 + vm_offset
         assert wait_tcp_connection(localhost, ptfip, port6)
 
-    for k, v in testbed['topo']['properties']['configuration'].items():
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
 
-        vm_offset = testbed['topo']['properties']['topology']['VMs'][k]['vm_offset']
+        vm_offset = tbinfo['topo']['properties']['topology']['VMs'][k]['vm_offset']
         port = 5000 + vm_offset
         port6 = 6000 + vm_offset
 
@@ -248,12 +248,12 @@ def fib_t1_lag(ptfhost, testbed, localhost):
 
 
 @pytest.fixture(scope='module')
-def fib(ptfhost, testbed, localhost):
-    topology = testbed['topo']['name']
+def fib(ptfhost, tbinfo, localhost):
+    topology = tbinfo['topo']['name']
     logger.info("setup fib to topo {}".format(topology))
-    if testbed['topo']['type'] == "t0":
-        fib_t0(ptfhost, testbed, localhost, topology)
-    elif testbed['topo']['type'] == "t1":
-        fib_t1_lag(ptfhost, testbed, localhost)
+    if tbinfo['topo']['type'] == "t0":
+        fib_t0(ptfhost, tbinfo, localhost, topology)
+    elif tbinfo['topo']['type'] == "t1":
+        fib_t1_lag(ptfhost, tbinfo, localhost)
     else:
-        logger.error("unknonw topology {}".format(testbed['topo']['name']))
+        logger.error("unknown topology {}".format(tbinfo['topo']['name']))

--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -72,7 +72,7 @@ def get_ifaces(netdev_output):
 
 
 @pytest.fixture(scope='module')
-def ptfadapter(ptfhost, testbed, request):
+def ptfadapter(ptfhost, tbinfo, request):
     """return ptf test adapter object.
     The fixture is module scope, because usually there is not need to
     restart PTF nn agent and reinitialize data plane thread on every
@@ -105,7 +105,7 @@ def ptfadapter(ptfhost, testbed, request):
     # Force a restart of ptf_nn_agent to ensure that it is in good status.
     ptfhost.command('supervisorctl restart ptf_nn_agent')
 
-    with PtfTestAdapter(testbed['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys()) as adapter:
+    with PtfTestAdapter(tbinfo['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys()) as adapter:
         if not request.config.option.keep_payload:
             override_ptf_functions()
             node_id = request.module.__name__

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -41,7 +41,7 @@ def _update_check_items(old_items, new_items, supported_items):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def sanity_check(localhost, duthost, request, fanouthosts, testbed):
+def sanity_check(localhost, duthost, request, fanouthosts, tbinfo):
     logger.info("Start pre-test sanity check")
 
     skip_sanity = False
@@ -82,7 +82,7 @@ def sanity_check(localhost, duthost, request, fanouthosts, testbed):
         check_items = _update_check_items(check_items, items_array, constants.SUPPORTED_CHECK_ITEMS)
 
     # ignore BGP check for particular topology type
-    if testbed['topo']['type'] == 'ptf' and 'bgp' in check_items:
+    if tbinfo['topo']['type'] == 'ptf' and 'bgp' in check_items:
         check_items.remove('bgp')
 
     logger.info("Sanity check settings: skip_sanity=%s, check_items=%s, allow_recover=%s, recover_method=%s, post_check=%s" % \

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -109,11 +109,11 @@ def dut_type(duthost):
     return dut_type
 
 @pytest.fixture(scope="class")
-def copp_testbed(duthost, creds, ptfhost, testbed, request):
+def copp_testbed(duthost, creds, ptfhost, tbinfo, request):
     """
         Pytest fixture to handle setup and cleanup for the COPP tests.
     """
-    test_params = _gather_test_params(testbed, duthost, request)
+    test_params = _gather_test_params(tbinfo, duthost, request)
 
     if test_params.topo not in (_SUPPORTED_PTF_TOPOS + _SUPPORTED_T1_TOPOS):
         pytest.skip("Topology not supported by COPP tests")
@@ -171,7 +171,7 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type):
                debug_level=None,
                device_sockets=device_sockets)
 
-def _gather_test_params(testbed, duthost, request):
+def _gather_test_params(tbinfo, duthost, request):
     """
         Fetches the test parameters from pytest.
     """
@@ -179,7 +179,7 @@ def _gather_test_params(testbed, duthost, request):
     nn_target_port = request.config.getoption("--nn_target_port")
     pkt_tx_count = request.config.getoption("--pkt_tx_count")
     swap_syncd = request.config.getoption("--copp_swap_syncd")
-    topo = testbed["topo"]["name"]
+    topo = tbinfo["topo"]["name"]
     bgp_graph = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]["minigraph_bgp"]
 
     return _COPPTestParameters(nn_target_port=nn_target_port,

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -72,7 +72,7 @@ def crm_thresholds(duthost):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def crm_interface(duthost, testbed):
+def crm_interface(duthost):
     """ Return tuple of two DUT interfaces """
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -5,6 +5,9 @@ import json
 import ipaddress
 import netaddr
 import copy
+import logging
+import os
+import tempfile
 
 from jinja2 import Template
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
@@ -112,7 +115,7 @@ def generate_fdb_config(duthost, entry_num, vlan_id, iface, op, dest):
     entry_key_template = "FDB_TABLE:Vlan{vid}:{mac}"
 
     for mac_address in generate_mac(entry_num):
-        fdb_entry_json = {entry_key_template.format(vid=vlan_id, mac=mac_address): 
+        fdb_entry_json = {entry_key_template.format(vid=vlan_id, mac=mac_address):
             {"port": iface, "type": "dynamic"},
             "OP": op
         }
@@ -719,7 +722,7 @@ def test_acl_entry(duthost, collector):
 
 def test_acl_counter(duthost, collector):
     if not "acl_tbl_key" in collector:
-        pytest.skip("acl_tbl_key is not retreived")
+        pytest.skip("acl_tbl_key is not retrieved")
     acl_tbl_key = collector["acl_tbl_key"]
 
     RESTORE_CMDS["crm_threshold_name"] = "acl_counter"
@@ -784,8 +787,8 @@ def test_acl_counter(duthost, collector):
         "\"crm_stats_acl_counter_available\" counter is not equal to original value")
 
 
-def test_crm_fdb_entry(duthost, testbed):
-    if "t0" not in testbed["topo"]["name"].lower():
+def test_crm_fdb_entry(duthost, tbinfo):
+    if "t0" not in tbinfo["topo"]["name"].lower():
         pytest.skip("Unsupported topology, expected to run only on 'T0*' topology")
 
     get_fdb_stats = "redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available"

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -52,10 +52,10 @@ def get_downlink_ports(topology, topo_type):
     return downlink_ports
 
 
-def gen_fib_info(ptfhost, testbed, cfg_facts):
+def gen_fib_info(ptfhost, tbinfo, cfg_facts):
 
-    topo_type = testbed["topo"]["type"]
-    topology = testbed["topo"]["properties"]["topology"]
+    topo_type = tbinfo["topo"]["type"]
+    topology = tbinfo["topo"]["properties"]["topology"]
 
     # uplink ports
     uplink_ports_str = " ".join(get_uplink_ports(topology, topo_type))
@@ -110,13 +110,13 @@ def gen_fib_info(ptfhost, testbed, cfg_facts):
     ptfhost.copy(content="\n".join(fibs), dest="/root/fib_info.txt")
 
 
-def prepare_ptf(ptfhost, testbed, cfg_facts):
+def prepare_ptf(ptfhost, tbinfo, cfg_facts):
 
-    gen_fib_info(ptfhost, testbed, cfg_facts)
+    gen_fib_info(ptfhost, tbinfo, cfg_facts)
 
 
 @pytest.fixture(scope="module")
-def setup_teardown(request, testbed, duthost, ptfhost):
+def setup_teardown(request, tbinfo, duthost, ptfhost):
 
     # Initialize parameters
     dscp_mode = "pipe"
@@ -160,7 +160,7 @@ def setup_teardown(request, testbed, duthost, ptfhost):
     decap_conf_template = Template(open("../ansible/roles/test/templates/decap_conf.j2").read())
 
     src_ports = set()
-    topology = testbed["topo"]["properties"]["topology"]
+    topology = tbinfo["topo"]["properties"]["topology"]
     if "host_interfaces" in topology:
         src_ports.update(topology["host_interfaces"])
     if "disabled_host_interfaces" in topology:
@@ -188,7 +188,7 @@ def setup_teardown(request, testbed, duthost, ptfhost):
     duthost.shell('docker exec swss sh -c "swssconfig /decap_conf.json"')
 
     # Prepare PTFf docker
-    prepare_ptf(ptfhost, testbed, cfg_facts)
+    prepare_ptf(ptfhost, tbinfo, cfg_facts)
 
     setup_info = {
         "src_ports": ",".join([str(port) for port in src_ports]),
@@ -208,7 +208,7 @@ def setup_teardown(request, testbed, duthost, ptfhost):
     duthost.shell('docker exec swss sh -c "swssconfig /decap_conf.json"')
 
 
-def test_decap(setup_teardown, testbed, ptfhost):
+def test_decap(setup_teardown, tbinfo, ptfhost):
 
     setup_info = setup_teardown
 
@@ -217,7 +217,7 @@ def test_decap(setup_teardown, testbed, ptfhost):
                "ptftests",
                "IP_decap_test.DecapPacketTest",
                 platform_dir="ptftests",
-                params={"testbed_type": testbed['topo']['type'],
+                params={"testbed_type": tbinfo['topo']['type'],
                         "outer_ipv4": setup_info["outer_ipv4"],
                         "outer_ipv6": setup_info["outer_ipv6"],
                         "inner_ipv4": setup_info["inner_ipv4"],

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -39,7 +39,7 @@ class DhcpPktFwdBase:
 
     def __getPortLagsAndPeerIp(self, duthost, testPort):
         """
-        Retreives all port lag members for a given testPort
+        Retrieves all port lag members for a given testPort
 
         Args:
             duthost(Ansible Fixture): instance of SonicHost class of DUT
@@ -92,18 +92,18 @@ class DhcpPktFwdBase:
         ))
 
     @pytest.fixture(scope="class")
-    def dutPorts(self, duthost, testbed):
+    def dutPorts(self, duthost, tbinfo):
         """
         Build list of DUT ports and classify them as Upstream/Downstream ports.
 
         Args:
             duthost(Ansible Fixture): instance of SonicHost class of DUT
-            testbed(Ansible Fixture): testbed information
+            tbinfo(Ansible Fixture): testbed information
 
         Returns:
             dict: contains downstream/upstream ports information
         """
-        if "t1" not in testbed["topo"]["name"]:
+        if "t1" not in tbinfo["topo"]["name"]:
             pytest.skip("Unsupported topology")
 
         downstreamPorts = []

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -28,7 +28,7 @@ def ignore_expected_loganalyzer_exceptions(loganalyzer):
 
 
 @pytest.fixture(scope="module")
-def dut_dhcp_relay_data(duthost, ptfhost, testbed):
+def dut_dhcp_relay_data(duthost, ptfhost):
     """ Fixture which returns a list of dictionaries where each dictionary contains
         data necessary to test one instance of a DHCP relay agent running on the DuT.
         This fixture is scoped to the module, as the data it gathers can be used by
@@ -249,7 +249,7 @@ def test_dhcp_relay_unicast_mac(duthost, ptfhost, dut_dhcp_relay_data, validate_
 def test_dhcp_relay_random_sport(duthost, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist):
     """Test DHCP relay functionality on T0 topology with random source port (sport)
 
-       If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68). 
+       If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68).
        Verify that DHCP relay works with random high sport.
     """
     RANDOM_CLIENT_PORT = random.choice(range(1000, 65535))

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -94,7 +94,7 @@ def expected_packet_mask(pkt):
 
 
 @pytest.fixture(scope="module")
-def setup(duthost, testbed):
+def setup(duthost, tbinfo):
     """
     Setup fixture for collecting PortChannel, VLAN and RIF port members.
     @return: Dictionary with keys:
@@ -105,8 +105,8 @@ def setup(duthost, testbed):
     configured_vlans = []
     rif_members = []
 
-    if testbed["topo"]["type"] == "ptf":
-        pytest.skip("Unsupported topology {}".format(testbed["topo"]))
+    if tbinfo["topo"]["type"] == "ptf":
+        pytest.skip("Unsupported topology {}".format(tbinfo["topo"]))
 
     # Gather ansible facts
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -71,14 +71,14 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthost, mock_server
 
 
 @pytest.fixture(scope="module")
-def testbed_params(duthost, testbed):
+def testbed_params(duthost, tbinfo):
     """
     Gathers parameters about the testbed for the test cases to use.
 
     Returns: A Dictionary with the following information:
     """
-    if testbed["topo"]["type"] != "t0":
-        pytest.skip("Unsupported topology {}".format(testbed["topo"]["name"]))
+    if tbinfo["topo"]["type"] != "t0":
+        pytest.skip("Unsupported topology {}".format(tbinfo["topo"]["name"]))
 
     minigraph_facts = \
         duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -32,20 +32,20 @@ EVERFLOW_RULE_DELETE_FILE = "acl-remove.json"
 
 
 @pytest.fixture(scope="module")
-def setup_info(duthost, testbed):
+def setup_info(duthost, tbinfo):
     """
     Gather all required test information.
 
     Args:
         duthost: DUT fixture
-        testbed: testbed fixture
+        tbinfo: tbinfo fixture
 
     Returns:
         dict: Required test information
 
     """
     # TODO: Support all T1 and T0 topos in these tests.
-    if testbed["topo"]["name"] not in ("t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"):
+    if tbinfo["topo"]["name"] not in ("t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"):
         pytest.skip("Unsupported topology")
 
     tor_ports = []

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -164,7 +164,7 @@ def fdb_cleanup(duthost):
 @pytest.mark.bsl
 @pytest.mark.usefixtures('fdb_cleanup')
 @pytest.mark.parametrize("pkt_type", PKT_TYPES)
-def test_fdb(ansible_adhoc, testbed, ptfadapter, duthost, ptfhost, pkt_type):
+def test_fdb(ansible_adhoc, ptfadapter, duthost, ptfhost, pkt_type):
     """
     1. verify fdb forwarding.
     2. verify show mac command on DUT for learned mac.

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -196,7 +196,7 @@ class TestFdbMacExpire:
             self.__loadSwssConfig(duthost)
         self.__deleteTmpSwitchConfig(duthost)
 
-    def testFdbMacExpire(self, request, testbed, duthost, ptfhost):
+    def testFdbMacExpire(self, request, tbinfo, duthost, ptfhost):
         """
             TestFdbMacExpire Verifies FDb aging timer is respected
 
@@ -206,23 +206,23 @@ class TestFdbMacExpire:
 
             Args:
                 request (Fixture): pytest request object
-                testbed (Fixture, dict): Map containing testbed information
+                tbinfo (Fixture, dict): Map containing testbed information
                 duthost (AnsibleHost): Device Under Test (DUT)
                 ptfhost (AnsibleHost): Packet Test Framework (PTF)
 
             Returns:
                 None
         """
-        if "t0" not in testbed["topo"]["type"]:
+        if "t0" not in tbinfo["topo"]["type"]:
             pytest.skip(
-                "FDB MAC Expire test case is not supported on this DUT topology '{0}'".format(testbed["topo"]["type"])
+                "FDB MAC Expire test case is not supported on this DUT topology '{0}'".format(tbinfo["topo"]["type"])
             )
 
         fdbAgingTime = request.config.getoption('--fdb_aging_time')
         hostFacts = duthost.setup()['ansible_facts']
 
         testParams = {
-            "testbed_type": testbed["topo"]["name"],
+            "testbed_type": tbinfo["topo"]["name"],
             "router_mac": hostFacts['ansible_Ethernet0']['macaddress'],
             "fdb_info": self.FDB_INFO_FILE,
             "dummy_mac_prefix": self.DUMMY_MAC_PREFIX,

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -487,8 +487,8 @@ class TestShowQueue():
 class TestShowVlan():
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, testbed):
-        if testbed['topo']['type'] != 't0':
+    def setup_check_topo(self, tbinfo):
+        if tbinfo['topo']['type'] != 't0':
             pytest.skip('Unsupported topology')
 
     @pytest.fixture()
@@ -550,8 +550,8 @@ class TestShowVlan():
 class TestConfigInterface():
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, testbed):
-        if testbed['topo']['type'] != 't1':
+    def setup_check_topo(self, tbinfo):
+        if tbinfo['topo']['type'] != 't1':
             pytest.skip('Unsupported topology')
 
     @pytest.fixture(scope='class', autouse=True)
@@ -680,12 +680,12 @@ class TestConfigInterface():
 
         assert speed == native_speed
 
-def test_show_acl_table(setup, setup_config_mode, testbed):
+def test_show_acl_table(setup, setup_config_mode, tbinfo):
     """
     Checks whether 'show acl table DATAACL' lists the interface names
     as per the configured naming mode
     """
-    if testbed['topo']['type'] != 't1':
+    if tbinfo['topo']['type'] != 't1':
         pytest.skip('Unsupported topology')
 
     if not setup['physical_interfaces']:
@@ -704,12 +704,12 @@ def test_show_acl_table(setup, setup_config_mode, testbed):
             elif mode == 'default':
                 assert item in acl_table
 
-def test_show_interfaces_neighbor_expected(setup, setup_config_mode, testbed):
+def test_show_interfaces_neighbor_expected(setup, setup_config_mode, tbinfo):
     """
     Checks whether 'show interfaces neighbor expected' lists the
     interface names as per the configured naming mode
     """
-    if testbed['topo']['type'] != 't1':
+    if tbinfo['topo']['type'] != 't1':
         pytest.skip('Unsupported topology')
 
     dutHostGuest, mode, ifmode = setup_config_mode
@@ -728,8 +728,8 @@ def test_show_interfaces_neighbor_expected(setup, setup_config_mode, testbed):
 class TestNeighbors():
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, setup, testbed):
-        if testbed['topo']['type'] != 't1':
+    def setup_check_topo(self, setup, tbinfo):
+        if tbinfo['topo']['type'] != 't1':
             pytest.skip('Unsupported topology')
 
         if not setup['physical_interfaces']:
@@ -776,8 +776,8 @@ class TestNeighbors():
 class TestShowIP():
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, setup, testbed):
-        if testbed['topo']['type'] != 't1':
+    def setup_check_topo(self, setup, tbinfo):
+        if tbinfo['topo']['type'] != 't1':
             pytest.skip('Unsupported topology')
 
         if not setup['physical_interfaces']:

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -93,10 +93,10 @@ def port_facts(dut, mg_facts):
 
 
 @pytest.fixture(scope='function')
-def gather_facts(testbed, duthost):
+def gather_facts(tbinfo, duthost):
     facts = {}
 
-    topo_type = testbed['topo']['type']
+    topo_type = tbinfo['topo']['type']
     if topo_type not in ('t0', 't1'):
         pytest.skip("Unsupported topology")
 

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -8,9 +8,9 @@ pytestmark = [
     pytest.mark.topology('t0')
 ]
 
-def test_dir_bcast(duthost, ptfhost, testbed, fib):
+def test_dir_bcast(duthost, ptfhost, tbinfo, fib):
     support_testbed_types = frozenset(['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116'])
-    testbed_type = testbed['topo']['name']
+    testbed_type = tbinfo['topo']['name']
     if testbed_type not in support_testbed_types:
         pytest.skip("Not support given test bed type %s" % testbed_type)
 

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -11,9 +11,9 @@ pytestmark = [
 ]
 
 @pytest.mark.parametrize("mtu", [1514,9114])
-def test_mtu(testbed, duthost, ptfhost, mtu):
+def test_mtu(tbinfo, duthost, ptfhost, mtu):
 
-    testbed_type = testbed['topo']['name']
+    testbed_type = tbinfo['topo']['name']
     router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
 
     log_file = "/tmp/mtu_test.{}-{}.log".format(mtu,datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))

--- a/tests/ixia/test_ixia_traffic.py
+++ b/tests/ixia/test_ixia_traffic.py
@@ -1,9 +1,9 @@
 ###############################################################################
-# This test case demonstrates: 
-#   * All the fixtures required for running ixia script (please see the 
+# This test case demonstrates:
+#   * All the fixtures required for running ixia script (please see the
 #     arguments of the test function)
 #   * How Ixia chassis card/ports are addressed
-#   * How you can configure/control ixia devices, start traffic and collect 
+#   * How you can configure/control ixia devices, start traffic and collect
 #     statistics.
 #   * This simple sanity test case can be used to check if testbed setup
 #     is correct or not.
@@ -20,32 +20,32 @@ from tests.common.reboot import logger
 
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_user,\
     ixia_api_serv_passwd, ixia_api_serv_port, ixia_api_serv_session_id, \
-    ixia_api_server_session  
+    ixia_api_server_session
 
 from tests.common.ixia.ixia_helpers import  IxiaFanoutManager, configure_ports,\
     create_topology, create_ip_traffic_item, start_protocols, \
     start_traffic, stop_traffic, get_traffic_statistics, stop_protocols
 
-from tests.common.ixia.common_helpers import increment_ip_address 
+from tests.common.ixia.common_helpers import increment_ip_address
 
-def test_testbed(testbed, conn_graph_facts, duthost, fanout_graph_facts,
+def test_testbed(conn_graph_facts, duthost, fanout_graph_facts,
     ixia_api_server_session, fanouthosts):
 
     logger.info("Connection Graph Facts = %s " %(conn_graph_facts))
     logger.info("Fanout Graph facts = %s" %(fanout_graph_facts))
     logger.info("DUT hostname = %s" %(duthost.hostname))
- 
+
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)
     gateway_ip = mg_facts['ansible_facts']['minigraph_vlan_interfaces'][0]['addr']
     start_interface_ip = increment_ip_address(gateway_ip)
 
-    ixiaFanoutHostList = IxiaFanoutManager(fanout_graph_facts) 
+    ixiaFanoutHostList = IxiaFanoutManager(fanout_graph_facts)
     ixiaFanoutHostList.get_fanout_device_details(device_number = 0)
 
     session = ixia_api_server_session
 
     logger.info("Configuring ports.")
-    port_list = configure_ports(session=session, 
+    port_list = configure_ports(session=session,
                                 port_list=ixiaFanoutHostList.get_ports())
 
     logger.info("Creating topology.")
@@ -56,14 +56,14 @@ def test_testbed(testbed, conn_graph_facts, duthost, fanout_graph_facts,
                                ip_incr_step='0.0.0.1',
                                gw_start=gateway_ip,
                                gw_incr_step='0.0.0.0')
-   
+
     logger.info("Starting all protocols")
     start_protocols(session)
 
-    # Create a traffic item 
+    # Create a traffic item
     logger.info("Configuring traffic.")
     traffic_item = create_ip_traffic_item(
-        session=session, 
+        session=session,
         src_start_port=1,
         src_port_count=1,
         src_first_route_index=1,
@@ -80,10 +80,10 @@ def test_testbed(testbed, conn_graph_facts, duthost, fanout_graph_facts,
     time.sleep(5)
 
     # Fetch statistics.
-    stats = get_traffic_statistics(session=session, 
+    stats = get_traffic_statistics(session=session,
         stat_view_name='Traffic Item Statistics')
     logger.info(stats)
 
     stop_traffic(session)
-    stop_protocols(session) 
+    stop_protocols(session)
 

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -9,8 +9,8 @@ pytestmark = [
 ]
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_check_topo(testbed):
-    if testbed['topo']['type'] == 'ptf':
+def setup_check_topo(tbinfo):
+    if tbinfo['topo']['type'] == 'ptf':
         pytest.skip('Unsupported topology')
 
 def test_lldp(duthost, localhost, collect_techsupport):

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -16,7 +16,7 @@ pytestmark = [
 ]
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthost, ptfhost, testbed):
+def common_setup_teardown(duthost, ptfhost, tbinfo):
     logging.info("########### Setup for lag testing ###########")
 
     lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
@@ -31,7 +31,7 @@ def common_setup_teardown(duthost, ptfhost, testbed):
         ptfhost.copy(src=src, dest=dst)
 
     # Inlucde testbed topology configuration
-    testbed_type = testbed['topo']['name']
+    testbed_type = tbinfo['topo']['name']
 
     support_testbed_types = frozenset(['t1-lag', 't0', 't0-116'])
     if testbed_type not in support_testbed_types:

--- a/tests/pfc/test_pfc_pause_lossless.py
+++ b/tests/pfc/test_pfc_pause_lossless.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.disable_loganalyzer]
 # Data packet size in bytes.
 DATA_PKT_SIZE = 1024
 START_DELAY = 1.5
-RATE_PERCENTAGE = 50 
+RATE_PERCENTAGE = 50
 TOLERANCE_THRESHOLD = .97
 
 def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
@@ -42,8 +42,8 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
        will be received at the rx_port.
     4. No test traffic will be received at the rx_port when pause priority
        is equal to test traffic priority.
-   
-    Note: PFC pause frames should always be dropped, regardless of their 
+
+    Note: PFC pause frames should always be dropped, regardless of their
           pause priorities.
 
     Args:
@@ -86,7 +86,7 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
                                     gw_start=gw_addr,
                                     gw_incr_step='0.0.0.0')
 
-    # Assumption: Line rate percentage of background data traffic 
+    # Assumption: Line rate percentage of background data traffic
     # is equal to Line rate percentage of test data traffic.
     pytest_assert(2 * RATE_PERCENTAGE <= 100,
         "Value of RATE_PERCENTAGE should not be more than 50!")
@@ -139,7 +139,7 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
     start_traffic(session)
 
     # Wait for test and background traffic to finish.
-    time.sleep(exp_dur + start_delay + 1) 
+    time.sleep(exp_dur + start_delay + 1)
 
     # Capture traffic statistics.
     flow_statistics = get_traffic_statistics(session)
@@ -151,7 +151,7 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
         rx_frames = int(flow_stat['Rx Frames'])
         rx_bytes  = int(flow_stat['Rx Bytes'])
 
-        tolerance_ratio = rx_bytes / exp_tx_bytes  
+        tolerance_ratio = rx_bytes / exp_tx_bytes
         if 'Test' in flow_stat['Traffic Item']:
             if test_traffic_pause_expected:
                 pytest_assert(tx_frames > 0 and rx_frames == 0,
@@ -167,7 +167,7 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
 
                     logger.error("tolerance_ratio = %s" %(tolerance_ratio))
 
-                    pytest_assert(False, 
+                    pytest_assert(False,
                         "expected % of packets not received at the RX port")
 
         elif 'PFC' in flow_stat['Traffic Item']:
@@ -176,7 +176,7 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
         else:
             pytest_assert(tx_frames > 0 and tx_frames == rx_frames,
                 "Background traffic should not be impacted")
-           
+
             if ((tolerance_ratio < TOLERANCE_THRESHOLD) or
                 (tolerance_ratio > 1)) :
                 logger.error("Expected Tx/Rx = %s actual Rx = %s"
@@ -184,17 +184,16 @@ def run_pfc_exp(session, dut, tx_port, rx_port, port_bw, test_prio_list,
 
                 logger.error("tolerance_ratio = %s" %(tolerance_ratio))
 
-                pytest_assert(False, 
+                pytest_assert(False,
                     "expected % of packets not received at the RX port")
 
     stop_traffic(session)
 
 
-def test_pfc_pause_single_lossless_priority(testbed, 
-                                            conn_graph_facts, 
+def test_pfc_pause_single_lossless_priority(conn_graph_facts,
                                             lossless_prio_dscp_map,
-                                            duthost, 
-                                            ixia_dev, 
+                                            duthost,
+                                            ixia_dev,
                                             ixia_api_server_session,
                                             fanout_graph_facts):
     """
@@ -203,12 +202,12 @@ def test_pfc_pause_single_lossless_priority(testbed,
     2. Disable the PFC watchdog on the SONiC DUT.
     3. On the Ixia Tx port create two flows - a) 'Test Data Traffic' and
        b) 'Background Data traffic'.
-    4. The flow 'Test Data Traffic' can assume one of the lossless priority 
+    4. The flow 'Test Data Traffic' can assume one of the lossless priority
        values Pi.
     5. The flow 'Background Data Traffic' can assume all the priority values
        which are not in 'Test Data Traffic'. For example if the priority of
-       'Test Data Traffic' is 3, the priorities of the 'Background Data 
-       Traffic' should be 0, 1, 2, 4, 5, 6, 7.   
+       'Test Data Traffic' is 3, the priorities of the 'Background Data
+       Traffic' should be 0, 1, 2, 4, 5, 6, 7.
     6. From Rx port send pause frames on priority Pi. Such that priority of
        'Test Data Traffic' at Tx end == Pause Priority at Rx end. That is,
        send pause frames on priority Pi.
@@ -221,7 +220,7 @@ def test_pfc_pause_single_lossless_priority(testbed,
 
     Note: Test and background traffic should be started after PFC pause storm.
 
-    """ 
+    """
     port_list = list()
     fanout_devices = IxiaFanoutManager(fanout_graph_facts)
     fanout_devices.get_fanout_device_details(device_number=0)
@@ -276,11 +275,10 @@ def test_pfc_pause_single_lossless_priority(testbed,
                 clean_configuration(session=session)
 
 
-def test_pfc_pause_multi_lossless_priorities(testbed, 
-                                             conn_graph_facts, 
+def test_pfc_pause_multi_lossless_priorities(conn_graph_facts,
                                              lossless_prio_dscp_map,
-                                             duthost, 
-                                             ixia_dev, 
+                                             duthost,
+                                             ixia_dev,
                                              ixia_api_server_session,
                                              fanout_graph_facts):
     """
@@ -295,7 +293,7 @@ def test_pfc_pause_multi_lossless_priorities(testbed,
        all lossy priorities.
     6. From Rx port send pause frames on all lossless priorities. Then
        start 'Test Data Traffic' and 'Background Data Traffic'.
-    7. When pause frames are started 'Test Data Traffic' will stop; 
+    7. When pause frames are started 'Test Data Traffic' will stop;
        and when pause frames are stopped 'Test Data Traffic' will start.
     8. 'Background Data Traffic' will always flow.
     9. Repeat the steps 4 to 8 on all ports.
@@ -338,7 +336,7 @@ def test_pfc_pause_multi_lossless_priorities(testbed,
             bg_dscp_list = [x for x in range(64) if x not in test_dscp_list]
             exp_dur = 2
 
- 
+
             run_pfc_exp(session=session,
                         dut=duthost,
                         tx_port=tx_port,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -586,13 +586,13 @@ class QosSaiBase:
         yield "/root/{}".format(portMapFile.split('/')[-1])
 
     @pytest.fixture(scope='class', autouse=True)
-    def dutTestParams(self, duthost, testbed, ptfPortMapFile):
+    def dutTestParams(self, duthost, tbinfo, ptfPortMapFile):
         """
             Prepares DUT host test params
 
             Args:
                 duthost (AnsibleHost): Device Under Test (DUT)
-                testbed (Fixture, dict): Map containing testbed information
+                tbinfo (Fixture, dict): Map containing testbed information
                 ptfPortMapFile (Fxiture, str): filename residing on PTF host and contains port maps information
 
             Returns:
@@ -600,7 +600,7 @@ class QosSaiBase:
         """
         dutFacts = duthost.setup()['ansible_facts']
         mgFacts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
-        topo = testbed["topo"]["name"]
+        topo = tbinfo["topo"]["name"]
 
         yield {
             "topo": topo,
@@ -736,7 +736,7 @@ class QosSaiBase:
     def egressLossyProfile(self, request, duthost, dutConfig):
         """
             Retreives egress lossy profile
- 
+
             Args:
                 request (Fixture): pytest request object
                 duthost (AnsibleHost): Device Under Test (DUT)

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -146,7 +146,7 @@ def run_test_t0(fanouthosts,
 def run_test(fanouthosts,
              duthost,
              ptfhost,
-             testbed,
+             tbinfo,
              conn_graph_facts,
              leaf_fanouts,
              dscp,
@@ -159,7 +159,7 @@ def run_test(fanouthosts,
              max_test_intfs_count=128):
     """
     @Summary: Run a series of tests (only support T0 topology)
-    @param testbed: Testbed information
+    @param tbinfo: Testbed information
     @param conn_graph_facts: Testbed topology
     @param leaf_fanouts: Leaf fanout switches
     @param dscp: DSCP value of test data packets
@@ -173,8 +173,8 @@ def run_test(fanouthosts,
     return: Return # of iterations and # of passed iterations for each tested interface.
     """
 
-    print testbed
-    if testbed['topo']['name'].startswith('t0'):
+    print tbinfo
+    if tbinfo['topo']['name'].startswith('t0'):
         return run_test_t0(fanouthosts=fanouthosts,
                            duthost=duthost,
                            ptfhost=ptfhost,
@@ -194,14 +194,14 @@ def run_test(fanouthosts,
 def test_pfc_pause_lossless(fanouthosts,
                             duthost,
                             ptfhost,
-                            testbed,
+                            tbinfo,
                             conn_graph_facts,
                             leaf_fanouts,
                             lossless_prio_dscp_map):
 
     """
     @Summary: Test if PFC pause frames can pause a lossless priority without affecting the other priorities
-    @param testbed: Testbed information
+    @param tbinfo: Testbed information
     @param conn_graph_facts: Testbed topology
     @param lossless_prio_dscp_map: lossless priorities and their DSCP values
     """
@@ -229,7 +229,7 @@ def test_pfc_pause_lossless(fanouthosts,
                 results = run_test(fanouthosts=fanouthosts,
                                    duthost=duthost,
                                    ptfhost=ptfhost,
-                                   testbed=testbed,
+                                   tbinfo=tbinfo,
                                    conn_graph_facts=conn_graph_facts,
                                    leaf_fanouts=leaf_fanouts,
                                    dscp=dscp,
@@ -266,7 +266,7 @@ def test_pfc_pause_lossless(fanouthosts,
 def test_no_pfc(fanouthosts,
                 duthost,
                 ptfhost,
-                testbed,
+                tbinfo,
                 conn_graph_facts,
                 leaf_fanouts,
                 lossless_prio_dscp_map):
@@ -274,7 +274,7 @@ def test_no_pfc(fanouthosts,
     """
     @Summary: Test if lossless and lossy priorities can forward packets in the absence of PFC pause frames
     @param fanouthosts: Fixture for fanout hosts
-    @param testbed: Testbed information
+    @param tbinfo: Testbed information
     @param conn_graph_facts: Testbed topology
     @param lossless_prio_dscp_map: lossless priorities and their DSCP values
     """
@@ -302,7 +302,7 @@ def test_no_pfc(fanouthosts,
                 results = run_test(fanouthosts=fanouthosts,
                                    duthost=duthost,
                                    ptfhost=ptfhost,
-                                   testbed=testbed,
+                                   tbinfo=tbinfo,
                                    conn_graph_facts=conn_graph_facts,
                                    leaf_fanouts=leaf_fanouts,
                                    dscp=dscp,

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -152,9 +152,9 @@ def verify_sflow_interfaces(duthost, intf, status, sampling_rate):
 # ----------------------------------------------------------------------------------
 
 @pytest.fixture
-def partial_ptf_runner(request, ptfhost, testbed):
+def partial_ptf_runner(request, ptfhost, tbinfo):
     def _partial_ptf_runner(**kwargs):
-        params = {'testbed_type': testbed['topo']['name'],
+        params = {'testbed_type': tbinfo['topo']['name'],
                   'router_mac': var['host_facts']['ansible_Ethernet0']['macaddress'],
                   'dst_port' : var['ptf_test_indices'][2],
                   'agent_id' : var['mgmt_ip'],
@@ -172,7 +172,7 @@ def partial_ptf_runner(request, ptfhost, testbed):
 
 # ----------------------------------------------------------------------------------
 @pytest.fixture(scope='class')
-def sflowbase_config(duthost, testbed):
+def sflowbase_config(duthost):
     config_sflow(duthost,'enable')
     config_sflow_collector(duthost,'collector0','add')
     config_sflow_collector(duthost,'collector1','add')

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -136,9 +136,9 @@ def acl(duthost, acl_setup):
 # MIRRORING PART #
 
 @pytest.fixture(scope='function')
-def neighbor_ip(duthost, testbed):
+def neighbor_ip(duthost, tbinfo):
     # ptf-32 topo is not supported in mirroring
-    if testbed['topo']['name'] == 'ptf32':
+    if tbinfo['topo']['name'] == 'ptf32':
         pytest.skip('Unsupported Topology')
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     dst_ip = None
@@ -254,12 +254,11 @@ def execute_command(duthost, since):
     return stdout['rc'] == SUCCESS_CODE
 
 
-def test_techsupport(request, config, duthost, testbed):
+def test_techsupport(request, config, duthost):
     """
     test the "show techsupport" command in a loop
     :param config: fixture to configure additional setups_list on dut.
     :param duthost: DUT host
-    :param testbed: testbed
     """
     loop_range = request.config.getoption("--loop_num") or DEFAULT_LOOP_RANGE
     loop_delay = request.config.getoption("--loop_delay") or DEFAULT_LOOP_DELAY

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -6,8 +6,8 @@ pytestmark = [
 ]
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_check_topo(testbed):
-    if testbed['topo']['type'] == 'ptf':
+def setup_check_topo(tbinfo):
+    if tbinfo['topo']['type'] == 'ptf':
         pytest.skip('Unsupported topology')
 
 @pytest.mark.bsl

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -38,9 +38,9 @@ def config_syslog_srv(ptfhost):
 
 
 @pytest.fixture(scope="module")
-def config_dut(testbed, duthost):
+def config_dut(tbinfo, duthost):
     logger.info("Configuring the DUT")
-    local_syslog_srv_ip = testbed["ptf_ip"]
+    local_syslog_srv_ip = tbinfo["ptf_ip"]
     logger.info("test_syslog_srv_ip %s", local_syslog_srv_ip)
 
     # Add Rsyslog destination for testing

--- a/tests/templates/spytest_testbed.yaml.j2
+++ b/tests/templates/spytest_testbed.yaml.j2
@@ -22,7 +22,7 @@ devices:
     {% endfor %}
     ptf-01:
         device_type: TGEN
-        properties: {type: scapy, version: 1.0, ip: {{ testbed.ptf_ip }}, params: def_tg}
+        properties: {type: scapy, version: 1.0, ip: {{ tbinfo.ptf_ip }}, params: def_tg}
 
 topology:
     ptf-01:
@@ -30,7 +30,7 @@ topology:
             {% for ptf_conn in ptf_connections %}
             {{ ptf_conn.start_port }}: {{ "{" }}EndDevice: {{ ptf_conn.end_device }}, EndPort: {{ ptf_conn.end_port }}, params: def_tg_link{{ "}" }}
             {% endfor %}
-    {% for hostname in testbed.duts %}
+    {% for hostname in tbinfo.duts %}
     {% if hostname in dev_connections %}
     {{ hostname }}:
         interfaces:

--- a/tests/testbed_setup/test_gen_spy_testbed.py
+++ b/tests/testbed_setup/test_gen_spy_testbed.py
@@ -28,7 +28,7 @@ def hostvars(duthosts):
             for duthost in duthosts}
 
 
-def test_gen_spy_testbed(conn_graph_facts_multi_duts, hostvars, testbed,
+def test_gen_spy_testbed(conn_graph_facts_multi_duts, hostvars, tbinfo,
                          pytestconfig):
     """Generate spytest testbed file."""
 
@@ -40,7 +40,7 @@ def test_gen_spy_testbed(conn_graph_facts_multi_duts, hostvars, testbed,
         """Convert unicodes in obj to strings"""
         return yaml.safe_load(json.dumps(obj))
 
-    hostnames = testbed["duts"]
+    hostnames = tbinfo["duts"]
     device_conn = _to_string(conn_graph_facts_multi_duts["device_conn"])
     connections = dict(
         zip(hostnames, conn_graph_facts_multi_duts["device_conn"]))
@@ -102,7 +102,7 @@ def test_gen_spy_testbed(conn_graph_facts_multi_duts, hostvars, testbed,
         logging.warn("testbed file(%s) exists, overwrite!", testbed_file)
     testbed_stream = testbed_tmpl.stream(
         devices=devices,
-        testbed=testbed,
+        tbinfo=tbinfo,
         ptf_connections=ptf_connections,
         dev_connections=dev_connections
     )

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -53,13 +53,13 @@ class TestVrfAttrSrcMac():
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
-    def test_vrf1_neigh_with_new_router_mac(self, ptfhost, host_facts, testbed):
+    def test_vrf1_neigh_with_new_router_mac(self, ptfhost, host_facts, tbinfo):
         # send packets with new router_mac
         ptf_runner(ptfhost,
                 "ptftests",
                 "vrf_test.FwdTest",
                 platform_dir='ptftests',
-                params={'testbed_type': testbed['topo']['name'],
+                params={'testbed_type': tbinfo['topo']['name'],
                         'router_mac': self.new_vrf1_router_mac,
                         'fwd_info': "/tmp/vrf1_neigh.txt",
                         'src_ports': g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In the future, we need to support multiple dut and chassis testing.
One possible solution is to add a 'testbed' fixture represents all the
DUT nodes. When the testbed has only single DUT, the behavior
of testbed object is same as duthost. When there are multiple DUT
nodes, the testbed object can encapsulate code to handle the
complexity of dealing with multiple DUT nodes that may have
different roles. Currently the 'testbed' name is taken for providing
testbed information to test cases. We can't think of a better name
for the object that will be repensending multiple DUT nodes in a
testbed. So, this PR is to refactor the code to rename the existing
'testbed' fixture to 'tbinfo' which is more meaningful.

#### How did you do it?
Renamed the `testbed` fixture to `tbinfo`. Updated all the code using this fixture to use the new name.

#### How did you verify/test it?
Test run the affected test scripts.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
