### PR TITLE
[Platform API][Fan] Compare applicable data against values from platform.json

### DIFF
--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -88,19 +88,6 @@ class TestFanApi(PlatformApiTestBase):
         self.expect(value == expected_value,
                       "'{}' value is incorrect. Got '{}', expected '{}' for fan {}".format(key, value, expected_value, i))
 
-    def compare_value_with_device_facts(self, key, value):
-        expected_value = None
-
-        if self.duthost_vars:
-            expected_value = self.duthost_vars.get(key)
-
-        if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from inventory file".format(key))
-            return
-
-        self.expect(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
-
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -130,7 +117,6 @@ class TestFanApi(PlatformApiTestBase):
 
             if self.expect(model is not None, "Unable to retrieve fan {} model".format(i)):
                 self.expect(isinstance(model, STRING_TYPE), "Fan {} model appears incorrect".format(i))
-                self.compare_value_with_device_facts('model', model)
 
         self.assert_expectations()
 
@@ -140,7 +126,6 @@ class TestFanApi(PlatformApiTestBase):
 
             if self.expect(serial is not None, "Unable to retrieve fan {} serial number".format(i)):
                 self.expect(isinstance(serial, STRING_TYPE), "Fan {} serial number appears incorrect".format(i))
-                self.compare_value_with_device_facts('serial', serial)
 
         self.assert_expectations()
 
@@ -165,7 +150,6 @@ class TestFanApi(PlatformApiTestBase):
                 if self.expect(isinstance(speed, int), "Fan {} speed appears incorrect".format(i)):
                     self.expect(speed > 0 and speed <= 100,
                                 "Fan {} speed {} reading is not within range".format(i, speed))
-                    self.compare_value_with_platform_facts('speed', speed, i)
 
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -70,12 +70,9 @@ class TestFanApi(PlatformApiTestBase):
         expected_value = None
 
         if self.chassis_facts:
-            expected_fan_drawers = self.chassis_facts.get("fan_drawers")
-            if expected_fan_drawers:
-                expected_fans = expected_fan_drawers[(fan_idx)/2].get("fans")
-                if expected_fans:
-                    expected_value = expected_fans[fan_idx].get(key)
-
+            expected_fans = self.chassis_facts.get("fans")
+            if expected_fans:
+                expected_value = expected_fans[fan_idx].get(key)
 
         if not expected_value:
             logger.warning("Unable to get expected value for '{}' from platform.json file for fan {}".format(key, fan_idx))

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -63,7 +63,7 @@ class TestFanApi(PlatformApiTestBase):
         if self.chassis_facts:
             expected_fan_drawers = self.chassis_facts.get("fan_drawers")
             if expected_fan_drawers:
-                expected_fans = expected_fan_drawers[(fan_idx -1)/2].get("fans")
+                expected_fans = expected_fan_drawers[(fan_idx)/2].get("fans")
                 if expected_fans:
                     expected_value = expected_fans[fan_idx].get(key)
 

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -37,6 +37,15 @@ STATUS_LED_COLOR_AMBER = "amber"
 STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
+@pytest.fixture(scope="class")
+def gather_facts(request, duthost):
+    # Get platform facts from platform.json file
+    request.cls.chassis_facts = duthost.facts.get("chassis")
+    if not request.cls.chassis_facts:
+        logger.warning("Unable to get chassis_facts from platform.json, test results will not be comprehensive")
+
+
+@pytest.mark.usefixtures("gather_facts")
 class TestFanApi(PlatformApiTestBase):
 
     num_fans = None

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -55,7 +55,7 @@ class TestFanApi(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self , platform_api_conn):
+    def setup(self, platform_api_conn):
         if self.num_fans is None:
             try:
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -37,7 +37,6 @@ STATUS_LED_COLOR_AMBER = "amber"
 STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
-@pytest.mark.usefixtures("gather_facts")
 class TestFanApi(PlatformApiTestBase):
 
     num_fans = None
@@ -47,7 +46,7 @@ class TestFanApi(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, duthost, platform_api_conn):
+    def setup(self , platform_api_conn):
         if self.num_fans is None:
             try:
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
@@ -63,7 +62,7 @@ class TestFanApi(PlatformApiTestBase):
 
         if self.chassis_facts:
             expected_fan_drawers = self.chassis_facts.get("fan_drawers")
-            if expeceted_fan_drawers:
+            if expected_fan_drawers:
                 expected_fans = expected_fan_drawers[(fan_idx -1)/2].get("fans")
                 if expected_fans:
                     expected_value = expected_fans[fan_idx].get(key)

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -88,7 +88,7 @@ class TestFanApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Fan {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Fan {} name appears incorrect".format(i))
-                compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts(self, 'name', name, i)
 
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_fan.py
+++ b/tests/platform_tests/api/test_fan.py
@@ -75,18 +75,18 @@ class TestFanApi(PlatformApiTestBase):
     # Helper functions
     #
 
-    def compare_value_with_platform_facts(self, key, value):
+    def compare_value_with_platform_facts(self, key, value, i):
         expected_value = None
 
-        if self.fan_truth:
-            expected_value = self.fan_truth.get(key)
+        if self.fan_truth[i]:
+            expected_value = self.fan_truth[i].get(key)
 
         if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from platform.json file".format(key))
+            logger.warning("Unable to get expected value for '{}' from platform.json file for fan {}".format(key, i))
             return
 
         self.expect(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
+                      "'{}' value is incorrect. Got '{}', expected '{}' for fan {}".format(key, value, expected_value, i))
 
     def compare_value_with_device_facts(self, key, value):
         expected_value = None
@@ -110,7 +110,7 @@ class TestFanApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Fan {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Fan {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts('name', name)
+                self.compare_value_with_platform_facts('name', name, i)
 
         self.assert_expectations()
 
@@ -165,7 +165,7 @@ class TestFanApi(PlatformApiTestBase):
                 if self.expect(isinstance(speed, int), "Fan {} speed appears incorrect".format(i)):
                     self.expect(speed > 0 and speed <= 100,
                                 "Fan {} speed {} reading is not within range".format(i, speed))
-                    self.compare_value_with_platform_facts('speed', speed)
+                    self.compare_value_with_platform_facts('speed', speed, i)
 
         self.assert_expectations()
 
@@ -180,7 +180,7 @@ class TestFanApi(PlatformApiTestBase):
             direction = fan.get_direction(platform_api_conn, i)
             if self.expect(direction is not None, "Unable to retrieve Fan {} direction".format(i)):
                 self.expect(direction in FAN_DIRECTION_LIST, "Fan {} direction is not one of predefined directions".format(i))
-                self.compare_value_with_platform_facts('direction', direction)
+                self.compare_value_with_platform_facts('direction', direction, i)
 
         self.assert_expectations()
 
@@ -204,7 +204,7 @@ class TestFanApi(PlatformApiTestBase):
             if self.expect(speed_tolerance is not None, "Unable to retrieve Fan {} speed tolerance".format(i)):
                 if self.expect(isinstance(speed_tolerance, int), "Fan {} speed tolerance appears incorrect".format(i)):
                     self.expect(speed_tolerance > 0 and speed_tolerance <= 100, "Fan {} speed tolerance {} reading does not make sense".format(i, speed_tolerance))
-                    self.compare_value_with_platform_facts('tolernace', speed_tolerance)
+                    self.compare_value_with_platform_facts('tolernace', speed_tolerance, i)
 
         self.assert_expectations()
 


### PR DESCRIPTION
Summary:

For fan tests where known truths are available in the platform.json file, compare actual values against those truths
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To improve the quality of the Fan platform API test

#### How did you do it?

For fan tests where known truths are available in the platform.json file, compare actual values against those truths

#### How did you verify/test it?

Run Fan tests on a device with a populated platform.json present

#### Any platform specific information?

Platform must have a populated platform.json present

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
