### PR TITLE
[framework]Update hook to ensure check_dut_asic_type runs before any other module-level fixtures

### DIFF
--- a/tests/common/plugins/custom_fixtures/__init__.py
+++ b/tests/common/plugins/custom_fixtures/__init__.py
@@ -6,5 +6,11 @@ def pytest_collection_modifyitems(items):
     for item in items:
         asic_marks = [mark for mark in item.iter_markers(name="asic")]
         if asic_marks:
-            item.fixturenames.append("check_dut_asic_type")
+            for pos, name in enumerate(item.fixturenames):
+                try:
+                    if item._fixtureinfo.name2fixturedefs[name][0].scope == 'module':
+                        break
+                except:
+                    pos = len(item.fixturenames)
+            item.fixturenames.insert(pos, "check_dut_asic_type")
 

--- a/tests/common/plugins/custom_fixtures/__init__.py
+++ b/tests/common/plugins/custom_fixtures/__init__.py
@@ -6,6 +6,9 @@ def pytest_collection_modifyitems(items):
     for item in items:
         asic_marks = [mark for mark in item.iter_markers(name="asic")]
         if asic_marks:
+            if 'check_dut_asic_type' in item.fixturenames:
+                # Already added
+                return
             for pos, name in enumerate(item.fixturenames):
                 if item._fixtureinfo.name2fixturedefs[name][0].scope == 'module':
                     break

--- a/tests/common/plugins/custom_fixtures/__init__.py
+++ b/tests/common/plugins/custom_fixtures/__init__.py
@@ -7,11 +7,8 @@ def pytest_collection_modifyitems(items):
         asic_marks = [mark for mark in item.iter_markers(name="asic")]
         if asic_marks:
             for pos, name in enumerate(item.fixturenames):
-                try:
-                    if item._fixtureinfo.name2fixturedefs[name][0].scope == 'module':
-                        break
-                except:
-                    pos = len(item.fixturenames)
+                if item._fixtureinfo.name2fixturedefs[name][0].scope == 'module':
+                    break
             else:
                 pos = len(item.fixturenames)
             item.fixturenames.insert(pos, "check_dut_asic_type")

--- a/tests/common/plugins/custom_fixtures/__init__.py
+++ b/tests/common/plugins/custom_fixtures/__init__.py
@@ -12,5 +12,7 @@ def pytest_collection_modifyitems(items):
                         break
                 except:
                     pos = len(item.fixturenames)
+            else:
+                pos = len(item.fixturenames)
             item.fixturenames.insert(pos, "check_dut_asic_type")
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fixture check_dut_asic_type is set to function level, as a result, it always runs after all module-level and function-level fixtures in default settings of pytest. 
However, some module or function level fixtures are unnecessary to run if the case is to be skipped, such as
https://github.com/Azure/sonic-mgmt/blob/438cc1f56672c1ff0036bedf4a69a8b156c81efe/tests/platform_tests/broadcom/test_ser.py#L50-L56
and
https://github.com/Azure/sonic-mgmt/blob/438cc1f56672c1ff0036bedf4a69a8b156c81efe/tests/vxlan/test_vnet_route_leak.py#L37-L58
These fixtures are either time consuming or leave the DUT in unstable status.
This commit update the hook for custom fixture to ensure check_dut_asic_type runs before any other module-level and function-level fixtures . 
#### How did you do it?
Update **pytest_collection_modifyitems** hook. The check_dut_asic_type fixture is inserted into fixturelist before all module-level fixture, so that those fixtures behind it no longer runs if the case is to be skipped.
#### How did you verify/test it?
I verified it with a sample script
```
  import pytest
  import logging

  pytestmark = [
      pytest.mark.topology('any'),
      pytest.mark.asic('mellanox')
  ]

  @pytest.fixture(scope="module", autouse=True)
  def fixture_for_module():
      logging.warn("module level fixture")

  class TestClass:
      def test_class_1(self):
          pass
      def test_class_2(self):
          pass

  def test_should_skip(fixture_for_module):
      pass

  @pytest.mark.asic('broadcom')
  def test_rewrite_marker():
      pass

  @pytest.mark.asic()
  def test_should_run():
      pass
```
And the fixture and hook work as expected.
```
collected 5 items

platform_tests/demo/test_asic.py::TestClass::test_class_1 SKIPPED                                                                                                                               [ 20%]
platform_tests/demo/test_asic.py::TestClass::test_class_2 SKIPPED                                                                                                                               [ 40%]
platform_tests/demo/test_asic.py::test_should_skip SKIPPED                                                                                                                                      [ 60%]
platform_tests/demo/test_asic.py::test_rewrite_marker
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
15:10:14 WARNING test_asic.py:fixture_for_module:11: module level fixture
PASSED                                                                                                                                                                                          [ 80%]
platform_tests/demo/test_asic.py::test_should_run PASSED                                                                                                                                        [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
================================================================================= 2 passed, 3 skipped in 7.74 seconds =================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No