### PR TITLE
[reporting] Improve accuracy of generated JSON report

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -196,16 +196,14 @@ def validate_junit_xml_archive(directory_name):
 
 
 def _validate_junit_xml(root):
-    tests, skipped = _validate_test_summary(root)
-    if tests != skipped:
-        _validate_test_metadata(root)
+    _validate_test_summary(root)
+    _validate_test_metadata(root)
     _validate_test_cases(root)
 
     return root
 
 
 def _validate_test_summary(root):
-    tests, skipped = 0, 0
     if root.tag != TESTSUITE_TAG:
         raise JUnitXMLValidationError(f"{TESTSUITE_TAG} tag not found on root element")
 
@@ -222,19 +220,12 @@ def _validate_test_summary(root):
                 f'"{root.get(xml_field)}"'
             ) from e
 
-        if xml_field == "tests":
-            tests = int(root.get(xml_field))
-        elif xml_field == "skipped":
-            skipped = int(root.get(xml_field))
-
-    return tests, skipped
-
 
 def _validate_test_metadata(root):
     properties_element = root.find("properties")
 
     if not properties_element:
-        raise JUnitXMLValidationError(f"metadata element <{METADATA_TAG}> not found")
+        return
 
     seen_properties = []
     for prop in properties_element.iterfind(METADATA_PROPERTY_TAG):

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -324,7 +324,7 @@ def _extract_test_summary(test_cases):
     for _, cases in test_cases.items():
         for case in cases:
             test_result_summary["tests"] += 1
-            test_result_summary["failures"] += case["result"] == "failure"
+            test_result_summary["failures"] += case["result"] == "failure" or case["result"] == "error"
             test_result_summary["skipped"] += case["result"] == "skipped"
             test_result_summary["errors"] += case["error"]
             test_result_summary["time"] += float(case["time"])

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -310,11 +310,12 @@ def parse_test_result(roots):
     test_result_json = defaultdict(dict)
 
     for root in roots:
-        test_result_json["test_summary"] = _update_test_summary(test_result_json["test_summary"],
-                                                                _parse_test_summary(root))
         test_result_json["test_metadata"] = _update_test_metadata(test_result_json["test_metadata"],
                                                                   _parse_test_metadata(root))
-        test_result_json["test_cases"] = _update_test_cases(test_result_json["test_cases"], _parse_test_cases(root))
+        test_cases = _parse_test_cases(root)
+        test_result_json["test_cases"] = _update_test_cases(test_result_json["test_cases"], test_cases)
+        test_result_json["test_summary"] = _update_test_summary(test_result_json["test_summary"],
+                                                                _extract_test_summary(test_cases))
 
     return test_result_json
 
@@ -324,6 +325,20 @@ def _parse_test_summary(root):
     for attribute, _ in REQUIRED_TESTSUITE_ATTRIBUTES:
         test_result_summary[attribute] = root.get(attribute)
 
+    return test_result_summary
+
+
+def _extract_test_summary(test_cases):
+    test_result_summary = defaultdict(int)
+    for _, cases in test_cases.items():
+        for case in cases:
+            test_result_summary["tests"] += 1
+            test_result_summary["failures"] += case["result"] == "failure"
+            test_result_summary["skipped"] += case["result"] == "skipped"
+            test_result_summary["errors"] += case["error"]
+            test_result_summary["time"] += float(case["time"])
+
+    test_result_summary = {k: str(v) for k, v in test_result_summary.items()}
     return test_result_summary
 
 
@@ -359,16 +374,22 @@ def _parse_test_cases(root):
         error = test_case.find("error")
         skipped = test_case.find("skipped")
 
-        # NOTE: Errors can occur during a failed, skipped, or succesful test run, so we capture those
-        # first for consistency.
-        if error is not None:
-            result["result"] = "error"
-        elif failure is not None:
+        # NOTE: "error" is unique in that it can occur alongside a succesful, failed, or skipped test result.
+        # Because of this, we track errors separately so that the error can be correlated with the stage it
+        # occurred.
+        #
+        # If there is *only* an error tag we note that as well, as this indicates that the framework
+        # errored out during setup or teardown.
+        if failure is not None:
             result["result"] = "failure"
         elif skipped is not None:
             result["result"] = "skipped"
+        elif error is not None:
+            result["result"] = "error"
         else:
             result["result"] = "success"
+
+        result["error"] = error is not None
 
         return feature, result
 
@@ -381,7 +402,7 @@ def _parse_test_cases(root):
 
 def _update_test_summary(current, update):
     if not current:
-        return update
+        return update.copy()
 
     new_summary = {}
     for attribute, attr_type in REQUIRED_TESTSUITE_ATTRIBUTES:
@@ -393,12 +414,12 @@ def _update_test_summary(current, update):
 def _update_test_metadata(current, update):
     # Case 1: On the very first update, current will be empty since we haven't seen any results yet.
     if not current:
-        return update
+        return update.copy()
 
     # Case 2: For test cases that are 100% skipped there will be no metadata added, so we need to
     # default to current.
     if not update:
-        return current
+        return current.copy()
 
     # Case 3: For all other cases, take the earliest timestamp and default everything else to update.
     new_metadata = {}
@@ -414,11 +435,11 @@ def _update_test_metadata(current, update):
 
 def _update_test_cases(current, update):
     if not current:
-        return update
+        return update.copy()
 
     new_cases = current.copy()
     for group, cases in update.items():
-        updated_cases = cases
+        updated_cases = cases.copy()
         if group in new_cases:
             updated_cases += new_cases[group]
 

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -50,7 +50,8 @@ EXPECTED_JSON_OUTPUT = {
                 "file": "acl/test_acl.py",
                 "line": "257",
                 "name": "test_acl",
-                "time": "58.161"
+                "time": "58.161",
+                "error": True
             },
             {
                 "classname": "acl.test_acl",
@@ -58,7 +59,8 @@ EXPECTED_JSON_OUTPUT = {
                 "line": "369",
                 "name": "test_acl_2",
                 "result": "skipped",
-                "time": "0.0"
+                "time": "0.0",
+                "error": False
             }
         ],
         "bgp": [
@@ -68,7 +70,8 @@ EXPECTED_JSON_OUTPUT = {
                 "line": "161",
                 "name": "test_bgp_fact",
                 "time": "109.472",
-                "result": "success"
+                "result": "success",
+                "error": False
             },
             {
                 "classname": "bgp.test_bgp",
@@ -76,7 +79,8 @@ EXPECTED_JSON_OUTPUT = {
                 "file": "bgp/test_bgp.py",
                 "line": "248",
                 "name": "test_bgp_speaker",
-                "time": "46.316"
+                "time": "46.316",
+                "error": False
             }
         ]
     },
@@ -95,7 +99,7 @@ EXPECTED_JSON_OUTPUT = {
         "failures": "1",
         "skipped": "1",
         "tests": "4",
-        "time": "214.054"
+        "time": "213.949"
     }
 }
 

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -95,7 +95,7 @@ EXPECTED_JSON_OUTPUT = {
     },
     "test_summary": {
         "errors": "1",
-        "failures": "1",
+        "failures": "2",
         "skipped": "1",
         "tests": "4",
         "time": "213.949"

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -1,6 +1,5 @@
 """Tests for the JUnit XML parser."""
 import os
-import re
 import pytest
 
 from test_reporting.junit_xml_parser import validate_junit_xml_stream, validate_junit_xml_file

--- a/test_reporting/tests/test_junit_xml_parser.py
+++ b/test_reporting/tests/test_junit_xml_parser.py
@@ -176,12 +176,6 @@ def test_invalid_junit_xml_testsuite_errors(token, replacement, message):
         validate_junit_xml_stream(test_string)
 
 
-def test_invalid_junit_xml_no_metadata():
-    test_string = re.sub(r"<properties>[\s\S]*?</properties>", "", VALID_TEST_RESULT)
-    with pytest.raises(JUnitXMLValidationError, match="metadata element .* not found"):
-        validate_junit_xml_stream(test_string)
-
-
 @pytest.mark.parametrize(
     "token,replacement,message",
     [


### PR DESCRIPTION
- Generate summary dynamically
- Report errors as a separate field

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [reporting] Improve accuracy of generated JSON report
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR aims to solve two issues:
1. There is a bug in pytest that causes tests that pass/skip and also have an error during teardown to be counted twice in the <testsuite> tag. This causes the <testsuite>, and "test_summary" information to be inaccurate.
2. Errors can occur at several stages, and be mixed with success/failure/skipped. This granularity is currently lost when we generate the JSON reports.

#### How did you do it?
1. Generate the summary information based on the actual test cases that are present rather than the `testsuite` tag.
2. Add an "error" field so that errors can be tracked as a separate value from the pass/fail/skip result of the test.

#### How did you verify/test it?
Updated the pytest cases, and generated a few reports from nightly test results and compared them to Testanalyzer.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
