### PR TITLE
[reporting] Add DB connector and report uploader script for kusto

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -65,13 +65,13 @@ class KustoConnector(ReportDBConnector):
         """
         self.db_name = db_name
 
-        ingest_cluster = os.getenv("TESTPILOT_INGEST_KUSTO_CLUSTER")
-        tenant_id = os.getenv("TESTPILOT_AAD_TENANT_ID")
-        service_id = os.getenv("TESTPILOT_AAD_CLIENT_ID")
-        service_key = os.getenv("TESTPILOT_AAD_CLIENT_KEY")
+        ingest_cluster = os.getenv("TEST_REPORT_INGEST_KUSTO_CLUSTER")
+        tenant_id = os.getenv("TEST_REPORT_AAD_TENANT_ID")
+        service_id = os.getenv("TEST_REPORT_AAD_CLIENT_ID")
+        service_key = os.getenv("TEST_REPORT_AAD_CLIENT_KEY")
 
         if not ingest_cluster or not tenant_id or not service_id or not service_key:
-            raise RuntimeError("Could not load Testpilot Kusto Credentials from environment")
+            raise RuntimeError("Could not load Kusto Credentials from environment")
 
         kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(ingest_cluster,
                                                                                     service_id,

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -1,0 +1,139 @@
+"""Wrappers and utilities for storing test reports."""
+import json
+import os
+import tempfile
+import uuid
+
+from abc import ABC, abstractmethod
+from azure.kusto.data import KustoConnectionStringBuilder
+from azure.kusto.ingest import (
+    KustoIngestClient,
+    IngestionProperties,
+    DataFormat,
+)
+from datetime import datetime
+from typing import Dict
+
+
+class ReportDBConnector(ABC):
+    """ReportDBConnector is a wrapper for a back-end data store for JUnit test reports.
+
+    The ReportDBConnector API is intentionally very high-level so that different data stores
+    with (possibly) drastically different data models can be used interchangeably.
+
+    Subclasses of ReportDBConnector should not add ANY data store/data model/schema specific
+    details into the ReportDBConnector DB API.
+    """
+
+    @abstractmethod
+    def upload_report(self, report_json: Dict, external_tracking_id: str = "") -> None:
+        """Upload a report to the back-end data store.
+
+        Args:
+            report_json: A JUnit test report in JSON format. See junit_xml_parser.
+            external_tracking_id: An identifier that a client can use to map a test report
+                to some external system of their choosing (e.g. Jenkins, Travis CI, JIRA, etc.).
+                This id does not have to be unique.
+        """
+        pass
+
+
+class KustoConnector(ReportDBConnector):
+    """KustoReportDB is a wrapper for storing test reports in Kusto/Azure Data Explorer."""
+
+    METADATA_TABLE = "TestReportMetadata"
+    SUMMARY_TABLE = "TestReportSummary"
+    RAW_CASE_TABLE = "RawTestCases"
+
+    TABLE_FORMAT_LOOKUP = {
+        METADATA_TABLE: DataFormat.JSON,
+        SUMMARY_TABLE: DataFormat.JSON,
+        RAW_CASE_TABLE: DataFormat.MULTIJSON
+    }
+
+    TABLE_MAPPING_LOOKUP = {
+        METADATA_TABLE: "FlatMetadataMappingV1",
+        SUMMARY_TABLE: "FlatSummaryMappingV1",
+        RAW_CASE_TABLE: "RawCaseMappingV1"
+    }
+
+    def __init__(self, db_name: str):
+        """Initialize a Kusto report DB connector.
+
+        Args:
+            db_name: The Kusto database to connect to.
+        """
+        self.db_name = db_name
+
+        ingest_cluster = os.getenv("TESTPILOT_INGEST_KUSTO_CLUSTER")
+        tenant_id = os.getenv("TESTPILOT_AAD_TENANT_ID")
+        service_id = os.getenv("TESTPILOT_AAD_CLIENT_ID")
+        service_key = os.getenv("TESTPILOT_AAD_CLIENT_KEY")
+
+        if not ingest_cluster or not tenant_id or not service_id or not service_key:
+            raise RuntimeError("Could not load Testpilot Kusto Credentials from environment")
+
+        kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(ingest_cluster,
+                                                                                    service_id,
+                                                                                    service_key,
+                                                                                    tenant_id)
+        self._ingestion_client = KustoIngestClient(kcsb)
+
+    def upload_report(self, report_json: Dict, external_tracking_id: str = "") -> None:
+        """Upload a report to the back-end data store.
+
+        Args:
+            report_json: A JUnit test report in JSON format. See junit_xml_parser.
+            external_tracking_id: An identifier that a client can use to map a test report
+                to some external system of their choosing (e.g. Jenkins, Travis CI, JIRA, etc.).
+                This id does not have to be unique.
+        """
+        report_guid = str(uuid.uuid4())
+
+        self._upload_metadata(report_json, external_tracking_id, report_guid)
+        self._upload_summary(report_json, report_guid)
+        self._upload_test_cases(report_json, report_guid)
+
+    def _upload_metadata(self, report_json, external_tracking_id, report_guid):
+        metadata = {
+            "id": report_guid,
+            "tracking_id": external_tracking_id,
+            "upload_time": str(datetime.utcnow())
+        }
+        metadata.update(report_json["test_metadata"])
+
+        self._ingest_data(self.METADATA_TABLE, metadata)
+
+    def _upload_summary(self, report_json, report_guid):
+        summary = {
+            "id": report_guid
+        }
+        summary.update(report_json["test_summary"])
+
+        self._ingest_data(self.SUMMARY_TABLE, summary)
+
+    def _upload_test_cases(self, report_json, report_guid):
+        test_cases = []
+        for feature, cases in report_json["test_cases"].items():
+            for case in cases:
+                case.update({
+                    "id": report_guid,
+                    "feature": feature
+                })
+                test_cases.append(case)
+        test_cases = {"cases": test_cases}
+
+        self._ingest_data(self.RAW_CASE_TABLE, test_cases)
+
+    def _ingest_data(self, table, data):
+        props = IngestionProperties(
+            database=self.db_name,
+            table=table,
+            data_format=self.TABLE_FORMAT_LOOKUP[table],
+            ingestion_mapping_reference=self.TABLE_MAPPING_LOOKUP[table]
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w+") as temp:
+            temp.write(json.dumps(data))
+            temp.seek(0)
+            self._ingestion_client.ingest_from_file(temp.name, ingestion_properties=props)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -1,0 +1,51 @@
+import argparse
+import os
+import sys
+
+from junit_xml_parser import (
+    validate_junit_xml_file,
+    validate_junit_xml_archive,
+    parse_test_result
+)
+from report_data_storage import KustoConnector
+
+
+def _run_script():
+    parser = argparse.ArgumentParser(
+        description="Upload test reports to Kusto.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+Examples:
+python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
+""",
+    )
+    parser.add_argument("path_name", metavar="path", type=str, help="A file/directory to upload.")
+    parser.add_argument("db_name", metavar="database", type=str, help="The Kusto DB to upload to.")
+    parser.add_argument(
+        "--external_id", "-e", type=str, help="An external tracking ID to append to the report.",
+    )
+
+    args = parser.parse_args()
+
+    path = args.path_name
+
+    if not os.path.exists(path):
+        print(f"{path} not found")
+        sys.exit(1)
+
+    # FIXME: This interface is actually really clunky, should just have one method and check file
+    # v. dir internally. Fix in the next PR.
+    if os.path.isfile(path):
+        roots = [validate_junit_xml_file(path)]
+    else:
+        roots = validate_junit_xml_archive(path)
+
+    test_result_json = parse_test_result(roots)
+    tracking_id = args.external_id if args.external_id else ""
+
+    kusto_db = KustoConnector(args.db_name)
+    kusto_db.upload_report(test_result_json, tracking_id)
+
+
+if __name__ == "__main__":
+    _run_script()

--- a/test_reporting/requirements.txt
+++ b/test_reporting/requirements.txt
@@ -1,2 +1,4 @@
+azure-kusto-data
+azure-kusto-ingest
 defusedxml
 pytest


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [reporting] Add DB connector and report uploader script for kusto
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We want to upload test results to a database so we can store them long-term, query them, and generate reports. To do so, we need some sort of wrapper so the upload can be automated.

#### How did you do it?
I added two things:
1. A "ReportDBConnector" abstraction. Right now there is only a Kusto implementation, but this could be implemented for other databases as well.
2. A script that uses the Kusto implementation to upload results from a directory.

#### How did you verify/test it?
Ran locally with some recent test results.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
I need to add a detailed README with information regarding the DBConnector design as well as the Kusto design/schema. This will be added in a follow-on PR.
