### PR TITLE
[test_vnet] Add asic marker 'mellanox' so that the cases don't run on other platform

### DIFF
--- a/tests/vxlan/test_vnet_route_leak.py
+++ b/tests/vxlan/test_vnet_route_leak.py
@@ -11,7 +11,8 @@ from vnet_utils import cleanup_vnet_routes, cleanup_dut_vnets, cleanup_vxlan_tun
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology("t0"),
+    pytest.mark.asic("mellanox")
 ]
 
 BGP_WAIT_TIMEOUT = 240

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology("t0"),
-    pytest.mark.sanity_check(post_check=True)
+    pytest.mark.sanity_check(post_check=True),
+    pytest.mark.asic("mellanox")
 ]
 
 def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Test cases test_vnet_route_leak and test_vnet_vxlan only run on mellanox platform. This PR add an asic marker 'mellanox' on module level, and these cases will be skipped on non-mellonax platform after PR #2221 is merged.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Skip test_vnet_route_leak and test_vnet_vxlan on non-mellanox platform.
#### How did you do it?
Add an asic marker 'mellanox' on module level.
#### How did you verify/test it?
Verified on Arista 7260 (broadcom platform), and the cases are skipped
```
collected 4 items                                                                                                                                                                                     

vxlan/test_vnet_route_leak.py::test_vnet_route_leak SKIPPED                                                                                                                                     [ 25%]
vxlan/test_vnet_vxlan.py::test_vnet_vxlan[Disabled] SKIPPED                                                                                                                                     [ 50%]
vxlan/test_vnet_vxlan.py::test_vnet_vxlan[Enabled] SKIPPED                                                                                                                                      [ 75%]
vxlan/test_vnet_vxlan.py::test_vnet_vxlan[Cleanup] SKIPPED                                                                                                                                      [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 4 skipped in 39.44 seconds ======================================================================================
```
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No