### PR TITLE
[Platform API][Thermal] Compare applicable data against values from platform.json

### DIFF
--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -32,14 +32,12 @@ pytestmark = [
 def gather_facts(request, duthost):
     # Get platform facts from platform.json file
     request.cls.chassis_facts = duthost.facts.get("chassis")
-    if not request.cls.chassis_facts:
-        logger.warning("Unable to get chassis_facts from platform.json, test results will not be comprehensive")
-
 
 @pytest.mark.usefixtures("gather_facts")
 class TestThermalApi(PlatformApiTestBase):
 
     num_thermals = None
+    chassis_facts = None
 
     # This fixture would probably be better scoped at the class level, but
     # it relies on the platform_api_conn fixture, which is scoped at the function
@@ -65,14 +63,10 @@ class TestThermalApi(PlatformApiTestBase):
             if expected_thermals:
                 expected_value = expected_thermals[thermal_idx].get(key)
 
-
-        if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from platform.json file for thermal {}".format(key, thermal_idx))
-            return
-
-        self.expect(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}' for thermal {}".format(key, value, expected_value, thermal_idx))
-
+        if self.expect(expected_value is not None,
+                       "Unable to get expected value for '{}' from platform.json file for thermal {}".format(key, thermal_idx)):
+            self.expect(value == expected_value,
+                          "'{}' value is incorrect. Got '{}', expected '{}' for thermal {}".format(key, value, expected_value, thermal_idx))
 
     #
     # Functions to test methods inherited from DeviceBase class

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -77,7 +77,7 @@ class TestThermalApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Thermal {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Thermal {} name appears incorrect".format(i))
-                compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts(self, 'name', name, i)
 
         self.assert_expectations()
 
@@ -141,7 +141,6 @@ class TestThermalApi(PlatformApiTestBase):
                 if self.expect(isinstance(low_threshold, float), "Thermal {} low threshold appears incorrect".format(i)):
                     self.expect(low_threshold > 0 and low_threshold <= 100,
                                 "Thermal {} low threshold {} reading is not within range".format(i, low_threshold))
-                    self.compare_value_with_platform_facts('low_threshold', low_threshold, i)
         self.assert_expectations()
 
     def test_get_high_threshold(self, duthost, localhost, platform_api_conn):
@@ -153,7 +152,6 @@ class TestThermalApi(PlatformApiTestBase):
                 if self.expect(isinstance(high_threshold, float), "Thermal {} high threshold appears incorrect".format(i)):
                     self.expect(high_threshold > 0 and high_threshold <= 100,
                                 "Thermal {} high threshold {} reading is not within range".format(i, high_threshold))
-                    self.compare_value_with_platform_facts('high_threshold', high_threshold, i)
         self.assert_expectations()
 
     def test_get_low_critical_threshold(self, duthost, localhost, platform_api_conn):
@@ -165,7 +163,6 @@ class TestThermalApi(PlatformApiTestBase):
                 if self.expect(isinstance(low_critical_threshold, float), "Thermal {} low threshold appears incorrect".format(i)):
                     self.expect(low_critical_threshold > 0 and low_critical_threshold <= 110,
                                 "Thermal {} low critical threshold {} reading is not within range".format(i, low_critical_threshold))
-                    self.compare_value_with_platform_facts('low_critical_threshold', low_critical_threshold, i)
         self.assert_expectations()
 
     def test_get_high_critical_threshold(self, duthost, localhost, platform_api_conn):
@@ -177,7 +174,6 @@ class TestThermalApi(PlatformApiTestBase):
                 if self.expect(isinstance(high_critical_threshold, float), "Thermal {} high threshold appears incorrect".format(i)):
                     self.expect(high_critical_threshold > 0 and high_critical_threshold <= 110,
                                 "Thermal {} high critical threshold {} reading is not within range".format(i, high_critical_threshold))
-                    self.compare_value_with_platform_facts('high_critical_threshold', high_critical_threshold, i)
         self.assert_expectations()
 
     def test_set_low_threshold(self, duthost, localhost, platform_api_conn):


### PR DESCRIPTION
Summary:

For thermal tests where known truths are available in the platform.json file, compare actual values against those truths
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To improve the quality of the Thermal platform API test

#### How did you do it?

For thermal tests where known truths are available in the platform.json file, compare actual values against those truths

#### How did you verify/test it?

Run Thermal tests on a device with a populated platform.json present

#### Any platform specific information?

Platform must have a populated platform.json present

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

