### PR TITLE
[upgrade_path]Bug fix in test_upgrade_path

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -970,7 +970,7 @@ class ReloadTest(BaseTest):
         self.assertTrue(is_good, errors)
 
     def runTest(self):
-        self.pre_reboot_test_setup()        
+        self.pre_reboot_test_setup()
         try:
             self.log("Check that device is alive and pinging")
             self.fails['dut'].add("DUT is not ready for test")
@@ -989,6 +989,8 @@ class ReloadTest(BaseTest):
                 self.handle_warm_reboot_health_check()
             self.handle_post_reboot_health_check()
 
+            # Check sonic version after reboot
+            self.check_sonic_version_after_reboot()
         except Exception as e:
             self.fails['dut'].add(e)
         finally:
@@ -1019,10 +1021,8 @@ class ReloadTest(BaseTest):
                 current_version = str(stdout[0]).replace('\n', '')
             self.log("Current={} Target={}".format(current_version, target_version))
             if current_version != target_version:
-                self.fails['dut'].add("Sonic upgrade failed. Target={} Current={}".format(\
+                raise Exception("Sonic upgrade failed. Target={} Current={}".format(\
                     target_version, current_version))
-                return False
-        return True
 
     def extract_no_cpu_replies(self, arr):
       """
@@ -1047,9 +1047,6 @@ class ReloadTest(BaseTest):
         if stderr != []:
             self.log("stderr from %s: %s" % (self.reboot_type, str(stderr)))
         self.log("return code from %s: %s" % (self.reboot_type, str(return_code)))
-        # Check sonic version after reboot
-        if not self.check_sonic_version_after_reboot():
-            thread.interrupt_main()
 
         # Note: a timeout reboot in ssh session will return a 255 code
         if return_code not in [0, 255]:
@@ -1323,6 +1320,7 @@ class ReloadTest(BaseTest):
         return self.asic_state.get_state_time(state), self.get_asic_vlan_reachability()
 
     def ping_data_plane(self, light_probe=True):
+        self.dataplane.flush()
         replies_from_servers = self.pingFromServers()
         if replies_from_servers > 0 or not light_probe:
             replies_from_upper = self.pingFromUpperTier()
@@ -1354,7 +1352,7 @@ class ReloadTest(BaseTest):
                     up_time = datetime.datetime.now()
                 up_secs = (datetime.datetime.now() - up_time).total_seconds()
                 if up_secs > dut_stabilize_secs:
-                    break;
+                    break
             else:
                 # reset up_time
                 up_time = None

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -45,7 +45,7 @@ class Interface(object):
             self.socket.close()
 
     def bind(self):
-        self.socket = scapy2.conf.L2listen(iface=self.iface)
+        self.socket = scapy2.conf.L2listen(iface=self.iface, filter='arp')
 
     def handler(self):
         return self.socket


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

**This PR updates test_upgrade_path**

1. Fix bug in check_sonic_version_after_reboot
2. Refactor code in test_upgrade_path
3. Add a filter for arp_responder
4. Disable sanitycheck and LogAnalyzer for upgrade_path
5. Use creds to retrieve sonic user and password 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix bugs in test_upgrade_path
#### How did you do it?
1. Update advanced-reboot.py

   -  Move check_sonic_version_after_reboot to the end of test because the **reboot** command will cause SSH timeout, as a result, the check will failed.
   -  The test log shows that queue in dataplane is filled. So this PR add a before sending TCP packets, and increase queue size to 10000

2. Add a filter for ARP in arp_responder to reduce CPU usage
3. Disable sanitycheck because a cold reboot is performed at the beginning of test, which probably recovers DUT from bad state
4. Disable LogAnalyzer because unexpected system log during reboot may lead to test error
5. Use creds to retrieve sonic user and password

#### How did you verify/test it?
Verified on Arista 7260. Upgrade from 20181130.51 to 20181130.83, and restore to 20191130.49 at the end of test.
```
collected 1 item                                                                                                                                                                                      

upgrade_path/test_upgrade_path.py::test_upgrade_path ^@^@^@PASSED                                                                                                                                     [100%]^@

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 1414.72 seconds =====================================================================================
```
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No