### PR TITLE
[vnet_vxlan][wr_arp] Fix test fail bonding_masters

### DIFF
--- a/ansible/roles/test/files/ptftests/vnet_vxlan.py
+++ b/ansible/roles/test/files/ptftests/vnet_vxlan.py
@@ -53,8 +53,9 @@ class VNET(BaseTest):
     def readMacs(self):
         addrs = {}
         for intf in os.listdir('/sys/class/net'):
-            with open('/sys/class/net/%s/address' % intf) as fp:
-                addrs[intf] = fp.read().strip()
+            if os.path.isdir('/sys/class/net/%s' % intf):
+                with open('/sys/class/net/%s/address' % intf) as fp:
+                    addrs[intf] = fp.read().strip()
 
         return addrs
 

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -113,8 +113,9 @@ class ArpTest(BaseTest):
     def readMacs(self):
         addrs = {}
         for intf in os.listdir('/sys/class/net'):
-            with open('/sys/class/net/%s/address' % intf) as fp:
-                addrs[intf] = fp.read().strip()
+            if os.path.isdir('/sys/class/net/%s' % intf):
+                with open('/sys/class/net/%s/address' % intf) as fp:
+                    addrs[intf] = fp.read().strip()
 
         return addrs
 


### PR DESCRIPTION
Signed-off-by: Olha Oliynyk <olhax.oliynyk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
**The PR fixes vnet_vxlan and wr_arp test cases error on bonding_master file.**
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Test case vnet_vxlan fails when test tries to take address with opening the file bonding_masters.
The error occurs: Not a directory
``` "Traceback (most recent call last):", [0m
[0;32m        "  File \"ptftests/vnet_vxlan.py\", line 265, in setUp", [0m
[0;32m        "    self.ptf_mac_addrs = self.readMacs()", [0m
[0;32m        "  File \"ptftests/vnet_vxlan.py\", line 56, in readMacs", [0m
[0;32m        "    with open('/sys/class/net/%s/address' % intf) as fp:", [0m
[0;32m        "IOError: [Errno 20] Not a directory: '/sys/class/net/bonding_masters/address'"
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [] Bug fix
-->

- [+ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Added verification is it a the directory before opening a dir.
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
SONiC:
	SONiC Software Version: SONiC.HEAD.761-dirty-20200903.072206
	Build commit: dd908c2e
	Build date: Thu Sep  3 07:29:57 UTC 2020

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
