### PR TITLE
Try docker login if docker registry username and password are defined

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -19,17 +19,34 @@
     container_type: "API-SERVER"
   when: ptf_imagename is defined and ptf_imagename == "docker-keysight-api-server"
 
+- name: Try to pull ptf docker image
+  docker_image:
+    name: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
+    source: pull
+    build:
+      pull: yes
+  become: yes
+  register: docker_pull_result
+  ignore_errors: yes
+
+- name: Try to login into docker registry if pull failed
+  docker_login:
+    registry_url: "{{ docker_registry_host }}"
+    username: "{{ docker_registry_username }}"
+    password: "{{ docker_registry_password }}"
+  become: yes
+  when: docker_pull_result.failed == true
 
 - name: Start Keysight API Server container
-  block: 
+  block:
     - name: default secret_group_vars if not defined
       set_fact:
         secret_group_vars:
           ixia_api_server:
             rest_port: 443
       when: >
-        secret_group_vars is not defined 
-        or secret_group_vars.ixia_api_server is not defined 
+        secret_group_vars is not defined
+        or secret_group_vars.ixia_api_server is not defined
         or secret_group_vars.ixia_api_server.rest_port is not defined
 
     - name: Pull and start Keysight API Server container
@@ -49,7 +66,7 @@
 
 
 - name: Start PTF container
-  block: 
+  block:
   - name: Create ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -19,23 +19,13 @@
     container_type: "API-SERVER"
   when: ptf_imagename is defined and ptf_imagename == "docker-keysight-api-server"
 
-- name: Try to pull ptf docker image
-  docker_image:
-    name: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
-    source: pull
-    build:
-      pull: yes
-  become: yes
-  register: docker_pull_result
-  ignore_errors: yes
-
-- name: Try to login into docker registry if pull failed
+- name: Try to login into docker registry
   docker_login:
     registry_url: "{{ docker_registry_host }}"
     username: "{{ docker_registry_username }}"
     password: "{{ docker_registry_password }}"
   become: yes
-  when: docker_pull_result.failed == true
+  when: docker_registry_username is defined and docker_registry_password is defined
 
 - name: Start Keysight API Server container
   block:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Not all docker registry have anonymous access enabled. Run `testbed-cli.sh add-topo` may fail with pull PTF docker image to create PTF container.

#### How did you do it?
This commit added code to try docker login if docker registry username and password are defined.

#### How did you verify/test it?
Logout from docker registry. Run add-topo. The scripts can automatically login to docker registry.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
