### PR TITLE
[vnet] Update cleanup step for VNET test to remove VLAN configuration

### DIFF
--- a/tests/vxlan/vnet_utils.py
+++ b/tests/vxlan/vnet_utils.py
@@ -129,11 +129,19 @@ def cleanup_dut_vnets(duthost, mg_facts, vnet_config):
     """
     logger.info("Removing VNET information from DUT")
 
+    duthost.shell("sonic-clear fdb all")
+
     for intf in vnet_config['vlan_intf_list']:
         duthost.shell("redis-cli -n 4 del \"VLAN_INTERFACE|{}|{}\"".format(intf['ifname'], intf['ip']))
 
     for intf in vnet_config['vlan_intf_list']:
         duthost.shell("redis-cli -n 4 del \"VLAN_INTERFACE|{}\"".format(intf['ifname']))
+
+    for intf in vnet_config['vlan_intf_list']:
+        duthost.shell("redis-cli -n 4 del \"VLAN_MEMBER|{}|{}\"".format(intf['ifname'], intf['port']))
+
+    for intf in vnet_config['vlan_intf_list']:
+        duthost.shell("redis-cli -n 4 del \"VLAN|{}\"".format(intf['ifname']))
 
     for vnet in vnet_config['vnet_id_list']:
         duthost.shell("redis-cli -n 4 del \"VNET|{}\"".format(vnet))


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Cleanup VLAN configuration that is configured by VNET test

#### How did you do it?
Updated cleanup step for VNET test to remove VLAN configuration

#### How did you verify/test it?
- Run VNET test
- Verify test passed
- Verify all applied by VNET test configuration is removed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A