### PR TITLE
[qos] Skip loganalyzer update when disabled and expand loganalyzer ignore list

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -462,13 +462,15 @@ class QosSaiBase:
             Returns:
                 None
         """
-        ignoreRegex = [
-            ".*ERR monit.*'lldpd_monitor' process is not running",
-            ".*ERR monit.*'lldp_syncd' process is not running",
-            ".*ERR monit.*'bgpd' process is not running",
-            ".*ERR monit.*'bgpcfgd' process is not running",
-        ]
-        loganalyzer.ignore_regex.extend(ignoreRegex)
+        if loganalyzer:
+            ignoreRegex = [
+                ".*ERR monit.*'lldpd_monitor' process is not running",
+                ".*ERR monit.*'lldp_syncd' process is not running",
+                ".*ERR monit.*'bgpd' process is not running",
+                ".*ERR monit.*'bgpcfgd' process is not running",
+                ".*ERR syncd#syncd:.*brcm_sai_set_switch_attribute:.*updating switch mac addr failed.*"
+            ]
+            loganalyzer.ignore_regex.extend(ignoreRegex)
 
         yield
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update the loganalyzer ignore list only if the loganalyzer object is present
Expand the loganalyzer ignore list to skip 'syncd' error seen while calling switch_init 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)
