### PR TITLE
updated test_bgp_fact.py to test bgpmon functionality

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -16,6 +16,9 @@ def test_bgp_facts(duthost):
         assert v['state'] == 'established'
         # Verify locat ASNs in bgp sessions
         assert v['local AS'] == mg_facts['minigraph_bgp_asn']
+        # Check bgpmon functionality by validate STATE DB contains this neighbor as well
+        state_fact = duthost.shell('sonic-db-cli STATE_DB HGET "NEIGH_STATE_TABLE|{}" "state"'.format(k), module_ignore_errors=False)['stdout_lines']
+        assert state_fact[0] == "Established"
 
     for v in mg_facts['minigraph_bgp']:
         # Compare the bgp neighbors name with minigraph bgp neigbhors name


### PR DESCRIPTION
This PR is to add test to validate the functionality of bgpmon (BGP Monitor) Daemon created by PR (https://github.com/Azure/sonic-buildimage/pull/5329) under the BGP docker. 
This PR has a dependency on (https://github.com/Azure/sonic-buildimage/pull/5329) and it should not be merged until the depended PR is merged first or else all new PRs that started to use this test changes will begin to fail since their changes would not have included the bgpmon running that this test is trying to validate.

For details on what bgpmon feature is about, please refer to PR (https://github.com/Azure/sonic-buildimage/pull/5329).
Quick summary of bgpmon: To assist gathering BGP related information periodically based on BGP activity detection to store BGP Neighbor state information into State DB.  

Dependency on the following PR:
- [Azure-sonic-buildimage] (https://github.com/Azure/sonic-buildimage/pull/5329)

Signed-off-by: Gen-Hwa Chiang <gechiang@microsoft.com>

**- What I did**

Since this test is already validating the expected BGP neighbors reaching the "established" state based on the bgpfact, for each of the expected peer we can add additional validation that its corresponding Neighbor peer state stored in STATE DB has also reached "established" state as well.  if this entry is missing or the state is not what was expected, then bgpmon functionality is in question and needs to be investigated. 

**- How I did it**

- Change bgp/test_bgp_fact.py to include the validation of expected Neighbor peer state to be present in STATE DB and has reached "Established" state.

**- How to verify it**

Ran this new testcase against a DUT or as part of a VS Image that has bgpmon running. upon successful run the following output is expected (this is sample output of running against a DUT:

```
SONIC:/var/src/Networking-acs-sonic-mgmt/tests$ sudo ./run_tests.sh -n vms12-t1-lag-1 -i ../ansible/str -f ../ansible/testbed.csv -c bgp/test_bgp_fact.py -u -l debug -e --disable_loganalyzer
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1

----------------------------------------------------------------------------------------------------------- live log sessionstart -----------------------------------------------------------------------------------------------------------
19:29:15 DEBUG plugin.py:pytest_report_header:168: pytest_report_header() called
------------------------------------------------------------------------------------------------------------ live log collection ------------------------------------------------------------------------------------------------------------
19:29:15 DEBUG plugin.py:pytest_generate_tests:123: pytest_generate_tests() called
19:29:15 DEBUG plugin.py:pytest_collection_modifyitems:173: pytest_collection_modifyitems() called
19:29:15 DEBUG plugin.py:pytest_collection_modifyitems:174: items: [<Function test_bgp_facts>]
...
19:31:32 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::2a\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:33 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::2a\" \"state\"", "end": "2020-09-18 19:31:33.464274", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:33.142881", "stderr": "", "delta": "0:00:00.321393", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::2a\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:33 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.9\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:34 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.9\" \"state\"", "end": "2020-09-18 19:31:34.461775", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:34.151904", "stderr": "", "delta": "0:00:00.309871", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.9\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:34 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.25\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:35 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.25\" \"state\"", "end": "2020-09-18 19:31:35.472989", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:35.159661", "stderr": "", "delta": "0:00:00.313328", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.25\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:35 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.5\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:36 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.5\" \"state\"", "end": "2020-09-18 19:31:36.579682", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:36.231631", "stderr": "", "delta": "0:00:00.348051", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.5\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:36 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.1\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:37 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.1\" \"state\"", "end": "2020-09-18 19:31:37.795113", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:37.419905", "stderr": "", "delta": "0:00:00.375208", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.1\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:37 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::32\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:38 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::32\" \"state\"", "end": "2020-09-18 19:31:38.832441", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:38.517520", "stderr": "", "delta": "0:00:00.314921", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::32\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:38 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::5a\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:39 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::5a\" \"state\"", "end": "2020-09-18 19:31:39.854124", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:39.549589", "stderr": "", "delta": "0:00:00.304535", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::5a\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:39 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::5e\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:40 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::5e\" \"state\"", "end": "2020-09-18 19:31:40.868556", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:40.560268", "stderr": "", "delta": "0:00:00.308288", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::5e\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:40 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::7e\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:41 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::7e\" \"state\"", "end": "2020-09-18 19:31:41.866522", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:41.563457", "stderr": "", "delta": "0:00:00.303065", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::7e\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:41 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::7a\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:42 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::7a\" \"state\"", "end": "2020-09-18 19:31:42.915470", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:42.587921", "stderr": "", "delta": "0:00:00.327549", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::7a\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:42 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::a\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:43 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::a\" \"state\"", "end": "2020-09-18 19:31:44.102750", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:43.747846", "stderr": "", "delta": "0:00:00.354904", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::a\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:43 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::46\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:44 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::46\" \"state\"", "end": "2020-09-18 19:31:45.086553", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:44.789438", "stderr": "", "delta": "0:00:00.297115", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::46\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:44 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.35\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:45 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.35\" \"state\"", "end": "2020-09-18 19:31:46.284466", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:45.916230", "stderr": "", "delta": "0:00:00.368236", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|10.0.0.35\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:45 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::42\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:47 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::42\" \"state\"", "end": "2020-09-18 19:31:47.490232", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:47.053424", "stderr": "", "delta": "0:00:00.436808", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::42\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:47 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::66\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:48 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::66\" \"state\"", "end": "2020-09-18 19:31:48.482876", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:48.179377", "stderr": "", "delta": "0:00:00.303499", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::66\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
19:31:48 DEBUG devices.py:_run:71: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell, args=["sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::62\" \"state\""], kwargs={"module_ignore_errors": false}
19:31:49 DEBUG devices.py:_run:85: /var/src/Networking-acs-sonic-mgmt/tests/bgp/test_bgp_fact.py::test_bgp_facts#21: [str-s6000-acs-8] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::62\" \"state\"", "end": "2020-09-18 19:31:49.485336", "_ansible_no_log": false, "stdout": "Established", "changed": true, "rc": 0, "start": "2020-09-18 19:31:49.182978", "stderr": "", "delta": "0:00:00.302358", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli STATE_DB HGET \"NEIGH_STATE_TABLE|fc00::62\" \"state\"", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Established"], "failed": false}
PASSED                                                                                                                                                                                                                                [100%]
------------------------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------------------------
19:42:17 INFO __init__.py:sanity_check:125: Start post-test sanity check
19:42:17 INFO __init__.py:sanity_check:128: No post-test check is required. Done post-test sanity check


--------------------------------------------------------------------------------- generated xml file: /var/src/Networking-acs-sonic-mgmt/tests/logs/tr.xml ----------------------------------------------------------------------------------
======================================================================================================== 1 passed in 151.75 seconds =========================================================================================================
SONIC:/var/src/Networking-acs-sonic-mgmt/tests$
```