### PR TITLE
[qos] Dynamically generate the PTF to interface mapping 

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -4,6 +4,7 @@ import pytest
 import re
 import yaml
 
+from natsort import natsorted
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from tests.common.system_utils import docker
 
@@ -558,7 +559,7 @@ class QosSaiBase:
         }
 
     @pytest.fixture(scope='class')
-    def ptfPortMapFile(self, request, duthost, ptfhost):
+    def ptfPortMapFile(self, duthost, ptfhost):
         """
             Prepare and copys port map file to PTF host
 
@@ -570,16 +571,15 @@ class QosSaiBase:
             Returns:
                 filename (str): returns the filename copied to PTF host
         """
-        portMapFile = request.config.getoption("--ptf_portmap")
-        if not portMapFile:
-            portMapFile = self.DEFAULT_PORT_INDEX_TO_ALIAS_MAP_FILE
-            mgFacts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
-            with open(portMapFile, 'w') as file:
-                file.write("# ptf host interface @ switch front port name\n")
-                file.writelines(
-                    map(
-                        lambda (port, index): "{0}@{1}\n".format(index, port),
-                        mgFacts["minigraph_port_indices"].items()
+        intfInfo = duthost.show_interface(command = "status")['ansible_facts']['int_status']
+        portList = natsorted([port for port in intfInfo if port.startswith('Ethernet') and intfInfo[port]['speed'] != '10G'])
+        portMapFile = self.DEFAULT_PORT_INDEX_TO_ALIAS_MAP_FILE
+        with open(portMapFile, 'w') as file:
+            file.write("# ptf host interface @ switch front port name\n")
+            file.writelines(
+                map(
+                     lambda (index, port): "{0}@{1}\n".format(index, port),
+                     enumerate(portList)
                     )
                 )
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Generate the ptf_portmap file dynamically from the 'show interface status' output. We no longer need to keep static files with mappings defined for different sku's. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Tested the changes on one of the DUTs and ensured that the mapping generated is the same as the one currently defined in the mapping file