### PR TITLE
Update paths to reflect new sonic-utilities install location, /usr/local/bin/

### DIFF
--- a/ansible/vars/configlet/t1-64-lag-clet/apply_clet.sh
+++ b/ansible/vars/configlet/t1-64-lag-clet/apply_clet.sh
@@ -2,5 +2,5 @@
 
 # Sleep to let all BGP sessions go up & running before adding a T0
 sleep 1m
-/usr/bin/configlet -j /etc/sonic/clet-to_clear.json -d
-/usr/bin/configlet -j /etc/sonic/clet-add.json -u
+configlet -j /etc/sonic/clet-to_clear.json -d
+configlet -j /etc/sonic/clet-add.json -u

--- a/tests/scripts/fast-reboot
+++ b/tests/scripts/fast-reboot
@@ -12,7 +12,7 @@ FORCE=no
 STRICT=no
 REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
-ASSISTANT_SCRIPT="/usr/bin/neighbor_advertiser"
+ASSISTANT_SCRIPT="/usr/local/bin/neighbor_advertiser"
 
 # Require 100M available on the hard drive for warm reboot temp files,
 # Size is in 1K blocks:
@@ -263,7 +263,7 @@ function reboot_pre_check()
     fi
     
     # Make sure ASIC configuration has not changed between images
-    ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
+    ASIC_CONFIG_CHECK_SCRIPT="/usr/local/bin/asic_config_check"
     ASIC_CONFIG_CHECK_SUCCESS=0
     if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
         ASIC_CONFIG_CHECK_EXIT_CODE=0
@@ -382,7 +382,7 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # into /host/fast-reboot
     mkdir -p /host/fast-reboot
     FAST_REBOOT_DUMP_RC=0
-    /usr/bin/fast-reboot-dump.py -t /host/fast-reboot || FAST_REBOOT_DUMP_RC=$?
+    /usr/local/bin/fast-reboot-dump.py -t /host/fast-reboot || FAST_REBOOT_DUMP_RC=$?
     if [[ FAST_REBOOT_DUMP_RC -ne 0 ]]; then
         error "Failed to run fast-reboot-dump.py. Exit code: $FAST_REBOOT_DUMP_RC"
         unload_kernel

--- a/tests/scripts/fast-reboot
+++ b/tests/scripts/fast-reboot
@@ -14,6 +14,13 @@ REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
 ASSISTANT_SCRIPT="/usr/local/bin/neighbor_advertiser"
 
+# To maintain backward-compatibility with 201911 branch, when sonic-utilities
+# was intalled as a Debian package, not a Python wheel.
+# TODO: Remove this check once no longer necessary
+if [[ ! -f ${ASSISTANT_SCRIPT} ]]; then
+    ASSISTANT_SCRIPT="/usr/bin/neighbor_advertiser"
+fi
+
 # Require 100M available on the hard drive for warm reboot temp files,
 # Size is in 1K blocks:
 MIN_HD_SPACE_NEEDED=100000
@@ -264,6 +271,14 @@ function reboot_pre_check()
     
     # Make sure ASIC configuration has not changed between images
     ASIC_CONFIG_CHECK_SCRIPT="/usr/local/bin/asic_config_check"
+
+    # To maintain backward-compatibility with 201911 branch, when sonic-utilities
+    # was intalled as a Debian package, not a Python wheel.
+    # TODO: Remove this check once no longer necessary
+    if [[ ! -f ${ASIC_CONFIG_CHECK_SCRIPT} ]]; then
+        ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
+    fi
+
     ASIC_CONFIG_CHECK_SUCCESS=0
     if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
         ASIC_CONFIG_CHECK_EXIT_CODE=0
@@ -382,7 +397,7 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # into /host/fast-reboot
     mkdir -p /host/fast-reboot
     FAST_REBOOT_DUMP_RC=0
-    /usr/local/bin/fast-reboot-dump.py -t /host/fast-reboot || FAST_REBOOT_DUMP_RC=$?
+    fast-reboot-dump.py -t /host/fast-reboot || FAST_REBOOT_DUMP_RC=$?
     if [[ FAST_REBOOT_DUMP_RC -ne 0 ]]; then
         error "Failed to run fast-reboot-dump.py. Exit code: $FAST_REBOOT_DUMP_RC"
         unload_kernel


### PR DESCRIPTION
As of https://github.com/Azure/sonic-buildimage/pull/5409, sonic-utilities is now being installed as a Python wheel package. As such, the installation path for scripts/entrypoints has changed from /usr/bin/ to /usr/local/bin. This PR aligns sonic-mgmt code with those changes by updating all references to sonic-utilities scripts/entrypoints to either reference the new /usr/local/bin/ location or remove absolute path entirely where applicable.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To align with new installation location for sonic-utilities scripts/entrypoints

#### How did you do it?

Update all references to sonic-utilities scripts/entrypoints to either reference the new /usr/local/bin/ location or remove absolute path entirely where applicable

#### How did you verify/test it?
Run affected tests against a device running an image built using the latest sonic-buildimage code

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
