### PR TITLE
Fix conn_graph_facts issues of `anchor` and `filename` options

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -17,8 +17,28 @@ Description:
     Retrive lab fanout switches physical and vlan connections
     add to Ansible facts
 options:
-    host:  [fanout switch name|Server name|Sonic Switch Name]
-    requred: True
+    host:
+        [fanout switch name|Server name|Sonic Switch Name]
+        requred: False
+    hosts:
+        List of hosts. Applicable for multi-DUT and single-DUT setup. The host option for single DUT setup is kept
+        for backward compatibility.
+        required: False
+    anchor:
+        List of hosts. When no host and hosts is provided, the anchor option must be specified with list of hosts.
+        This option is to supply the relevant list of hosts for looking up the connection graph xml file which has
+        all the supplied hosts. The whole graph will be returned when this option is used. This is for configuring
+        the root fanout switch.
+        required: False
+    filepath:
+        Path of the connection graph xml file. Override the default path for looking up connection graph xml file.
+        required: False
+    filename:
+        Name of the connection graph xml file. Override the behavior of looking up connection graph xml file. When
+        this option is specified, always use the specified connection graph xml file.
+        required: False
+
+    Mutually exclusive options: host, hosts, anchor
 
 Ansible_facts:
     device_info: The device(host) type and hwsku
@@ -273,7 +293,7 @@ def main():
             filepath=dict(required=False),
             anchor=dict(required=False, type='list'),
         ),
-        mutually_exclusive=[['host', 'hosts']],
+        mutually_exclusive=[['host', 'hosts', 'anchor']],
         supports_check_mode=True
     )
     m_args = module.params
@@ -291,14 +311,14 @@ def main():
             LAB_GRAPHFILE_PATH = m_args['filepath']
 
         if m_args['filename']:
-            filename = m_args['filename']
+            filename = os.path.join(LAB_GRAPHFILE_PATH, m_args['filename'])
             lab_graph = Parse_Lab_Graph(filename)
             lab_graph.parse_graph()
         else:
             # When calling passed in anchor instead of hostnames,
             # the caller is asking to return the whole graph. This
             # is needed when configuring the root fanout switch.
-            target = hostnames if hostnames else anchor
+            target = anchor if anchor else hostnames
             lab_graph = find_graph(target)
 
         device_info = []

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -19,7 +19,7 @@ Description:
 options:
     host:
         [fanout switch name|Server name|Sonic Switch Name]
-        requred: False
+        required: False
     hosts:
         List of hosts. Applicable for multi-DUT and single-DUT setup. The host option for single DUT setup is kept
         for backward compatibility.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix the conn_graph_facts issues introduced in recent changes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The recent changes for conn_graph_facts introduced two issues:

* `anchor` option issue
When use `anchor` to get the whole connection graph facts for configuring root
fanout switch, the `host` and `hosts` options are not given. So the `hostnames`
variable will have value [None] which will not be evaluated to False. Then the
`target` variable will take the value of `hostnames`, i.e. [None]. Eventually the empty
graph file will be used.

* `filename` option issue
When the `filename` argument is specified, need to open the specified file under
path LAB_GRAPHFILE_PATH.

#### How did you do it?
* Fix the issue of parsing wrong connection graph file when the `anchor` option is used.
* Fix the issue of unable to find connection graph file when the `filename` option is used.
* Set host, hosts and anchor mutually exclusive.
* Update the documentation.

#### How did you verify/test it?
Prepared a temporary ansible playbook to call the conn_graph_facts module with different option combinations, including negative combinations.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
