### PR TITLE
[qos] Add qos params for Th 50G 300m

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -404,6 +404,54 @@ qos_params:
                 pkts_num_trig_ingr_drp: 7063
                 pkts_num_fill_egr_min: 8
                 cell_size: 208
+        50000_300m:
+            pkts_num_leak_out: 23
+            xoff_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7225
+            xoff_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7225
+            hdrm_pool_size:
+                dscps: [3, 4]
+                ecn: 1
+                pgs: [3, 4]
+                src_port_ids: [1, 2, 3, 4]
+                dst_port_id: 5
+                pgs_num: 8
+                pkts_num_trig_pfc: 1458
+                pkts_num_hdrm_full: 682
+                pkts_num_hdrm_partial: 267
+            wm_pg_headroom:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7225
+                cell_size: 208
+            wm_q_shared_lossless:
+                dscp: 3
+                ecn: 1
+                queue: 3
+                pkts_num_fill_min: 8
+                pkts_num_trig_ingr_drp: 7225
+                cell_size: 208
+            wm_buf_pool_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                queue: 3
+                pkts_num_fill_ingr_min: 6
+                pkts_num_trig_pfc: 6542
+                pkts_num_trig_ingr_drp: 7225
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
         100000_300m:
             pkts_num_leak_out: 36
             xoff_1:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### What is the motivation for this PR?
Failure seen in nightly runs due to qos params missing for 50G 300m

#### How did you verify/test it?
Tested on Th with pg profile having 50G 300m