### PR TITLE
Updated sensors test for  x86_64-arista_7170_64c platform due to updates in coretemp module

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2687,7 +2687,7 @@ sensors_checks:
       - dps1900-i2c-7-58/vout1/in2_crit_alarm
       - dps1900-i2c-7-58/vout1/in2_lcrit_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/P[a-z]* id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - dps1900-i2c-6-58/PSU1 primary hotspot temp/temp1_alarm
@@ -2718,8 +2718,8 @@ sensors_checks:
       - - dps1900-i2c-7-58/iout1/curr2_input
         - dps1900-i2c-7-58/iout1/curr2_max
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/P[a-z]* id 0/temp1_input
+        - coretemp-isa-0000/P[a-z]* id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input

--- a/ansible/library/sensors_facts.py
+++ b/ansible/library/sensors_facts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+import re
 import subprocess
 from ansible.module_utils.basic import *
 
@@ -151,14 +151,19 @@ class SensorsModule(object):
         '''
         keys = path.split('/')
 
-        cur_value = self.raw
+        cur_values = self.raw
+        res = None
         for key in keys:
-            if key in cur_value:
-                cur_value = cur_value[key]
-            else:
+            pattern = re.compile(key)
+            for cur_value in cur_values.keys():
+                res = re.match(pattern, cur_value)
+                if res is not None:
+                    cur_values = cur_values[res.group()]
+                    break
+            if res is None:
                 return None
 
-        return cur_value
+        return cur_values
 
     def check_alarms(self):
         '''


### PR DESCRIPTION
Signed-off-by: Nazar Tkachuk <nazarx.tkachuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test sensors is failed on x86_64-arista_7170_64c platform with error `Path coretemp-isa-0000/Physical id 0/temp1_crit_alarm is not exist`. This issue is observed on SONiC master.
The root cause of failure: command `sensors` returns `Package id 0` instead of `Physical id 0` as it was on SONiC 201911.
Today SONiC master is based on kernel `4.19` which contains `coretemps` module updates (see https://github.com/torvalds/linux/commit/712668460594294d74c13f2a023398a597fbe95f).
Based on these updates in `coretemps` module output is correct(means `Package id 0`)



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix test `sensors`  for  x86_64-arista_7170_64c platform

#### How did you do it?
Updated approach for getting sensors date with regex to support backward compatibility (SONiC master and SONiC 201911)

#### How did you verify/test it?
Run `sensors` tests on x86_64-arista_7170_64c platform with latest SONiC master and SONiC 201911

#### Any platform specific information?
Fixed and verified only for  x86_64-arista_7170_64c platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
