### PR TITLE
Creds access fix for virtual testbed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,9 +282,6 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
     dev_conn = conn_graph_facts.get('device_conn', {})
     fanout_hosts = {}
     # WA for virtual testbed which has no fanout
-    admin_user = creds['fanout_admin_user']
-    admin_password = creds['fanout_admin_password']
-
     try:
         for dut_port in dev_conn.keys():
             fanout_rec = dev_conn[dut_port]
@@ -297,7 +294,8 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
                 host_vars = ansible_adhoc().options[
                     'inventory_manager'].get_host(fanout_host).vars
                 os_type = host_vars.get('os', 'eos')
-
+                admin_user = creds['fanout_admin_user']
+                admin_password = creds['fanout_admin_password']
                 # `fanout_network_user` and `fanout_network_password` are for
                 # accessing the non-shell CLI of fanout.
                 # Ansible will use this set of credentail for establishing


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix creds access error seen in virtual testbed tests
Fixes # (issue)
```
        # WA for virtual testbed which has no fanout
>       admin_user = creds['fanout_admin_user']
E       KeyError: 'fanout_admin_user'
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
An unguarded access of fanout creds is done which fails for virtual testbed.

#### What is the motivation for this PR?
Fixing a regression issue on virtual testbed.

#### How did you do it?
Fix this by moving the creds access within of try-except block.

#### How did you verify/test it?
test_bgp_fact which earlier failed is now working fine on virtual testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
