### PR TITLE
Pdu and Console connection info in connection graph

### DIFF
--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -80,6 +80,8 @@ class LabGraph(object):
         csv_file.close()
  
     def read_consolelinks(self):
+        if not os.path.exists(self.conscsv):
+            return
         csv_file = open(self.conscsv)
         csv_cons = csv.DictReader(csv_file)
         conslinks_root = etree.SubElement(self.csgroot, 'ConsoleLinksInfo')
@@ -92,6 +94,8 @@ class LabGraph(object):
         csv_file.close()
 
     def read_pdulinks(self):
+        if not os.path.exists(self.pducsv):
+            return
         csv_file = open(self.pducsv)
         csv_pdus = csv.DictReader(csv_file)
         pduslinks_root = etree.SubElement(self.pcgroot, 'PowerControlLinksInfo')
@@ -148,17 +152,30 @@ class LabGraph(object):
         result = etree.tostring(root, pretty_print=True)
         onexml.write(result)
 
+def get_file_names(args):
+    if not args.inventory:
+        device, links, console, pdu = args.device, args.links, args.console, args.pdu
+    else:
+        device = 'sonic_{}_devices.csv'.format(args.inventory)
+        links = 'sonic_{}_links.csv'.format(args.inventory)
+        console = 'sonic_{}_console_links.csv'.format(args.inventory)
+        pdu = 'sonic_{}_pdu_links.csv'.format(args.inventory)
+
+    return device, links, console, pdu
+
 def main():
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--device", help="device file", default=DEFAULT_DEVICECSV)
-    parser.add_argument("-l", "--links", help="link file", default=DEFAULT_LINKCSV)
-    parser.add_argument("-c", "--console", help="console connection file", default=DEFAULT_CONSOLECSV)
-    parser.add_argument("-p", "--pdu", help="pdu connection file", default=DEFAULT_PDUCSV)
+    parser.add_argument("-d", "--device", help="device file [deprecate warning: use -i instead]", default=DEFAULT_DEVICECSV)
+    parser.add_argument("-l", "--links", help="link file [deprecate warning: use -i instead]", default=DEFAULT_LINKCSV)
+    parser.add_argument("-c", "--console", help="console connection file [deprecate warning: use -i instead]", default=DEFAULT_CONSOLECSV)
+    parser.add_argument("-p", "--pdu", help="pdu connection file [deprecate warning: use -i instead]", default=DEFAULT_PDUCSV)
+    parser.add_argument("-i", "--inventory", help="specify inventory namei to generate device/link/console/pdu file names, default none", default=None)
     parser.add_argument("-o", "--output", help="output xml file", required=True)
     args = parser.parse_args()
 
-    mygraph = LabGraph(args.device, args.links, args.console, args.pdu, args.output)
+    device, links, console, pdu = get_file_names(args)
+    mygraph = LabGraph(device, links, console, pdu, args.output)
 
     mygraph.read_devices()
     mygraph.read_links()

--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -42,70 +42,66 @@ class LabGraph(object):
 
 
     def read_devices(self):
-        csv_dev = open(self.devcsv)
-        csv_devices = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_dev))
-        devices_root = etree.SubElement(self.pngroot, 'Devices')
-        pdus_root = etree.SubElement(self.pcgroot, 'DevicesPowerControlInfo')
-        cons_root = etree.SubElement(self.csgroot, 'DevicesConsoleInfo')
-        for row in csv_devices:
-            attrs = {}
-            self.devices.append(row)
-            devtype=row['Type'].lower()
-            if 'pdu' in devtype:
-                for  key in row:
-                    attrs[key]=row[key].decode('utf-8')
-                etree.SubElement(pdus_root, 'DevicePowerControlInfo', attrs)
-            elif 'consoleserver' in devtype:
-                for  key in row:
-                    attrs[key]=row[key].decode('utf-8')
-                etree.SubElement(cons_root, 'DeviceConsoleInfo', attrs)
-            else:
-                for  key in row:
-                    if key.lower() != 'managementip' and key.lower() !='protocol':
+        with open(self.devcsv) as csv_dev:
+            csv_devices = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_dev))
+            devices_root = etree.SubElement(self.pngroot, 'Devices')
+            pdus_root = etree.SubElement(self.pcgroot, 'DevicesPowerControlInfo')
+            cons_root = etree.SubElement(self.csgroot, 'DevicesConsoleInfo')
+            for row in csv_devices:
+                attrs = {}
+                self.devices.append(row)
+                devtype=row['Type'].lower()
+                if 'pdu' in devtype:
+                    for  key in row:
                         attrs[key]=row[key].decode('utf-8')
-                etree.SubElement(devices_root, 'Device', attrs)
-        csv_dev.close()
+                    etree.SubElement(pdus_root, 'DevicePowerControlInfo', attrs)
+                elif 'consoleserver' in devtype:
+                    for  key in row:
+                        attrs[key]=row[key].decode('utf-8')
+                    etree.SubElement(cons_root, 'DeviceConsoleInfo', attrs)
+                else:
+                    for  key in row:
+                        if key.lower() != 'managementip' and key.lower() !='protocol':
+                            attrs[key]=row[key].decode('utf-8')
+                    etree.SubElement(devices_root, 'Device', attrs)
  
     def read_links(self):
-        csv_file = open(self.linkcsv)
-        csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
-        links_root = etree.SubElement(self.pngroot, 'DeviceInterfaceLinks')
-        for link in csv_links:
-            attrs = {}
-            for key in link:
-                if key.lower() != 'vlanid' and key.lower() != 'vlanmode':
-                    attrs[key]=link[key].decode('utf-8')
-            etree.SubElement(links_root, 'DeviceInterfaceLink', attrs)
-            self.links.append(link)
-        csv_file.close()
+        with open(self.linkcsv) as csv_file:
+            csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
+            links_root = etree.SubElement(self.pngroot, 'DeviceInterfaceLinks')
+            for link in csv_links:
+                attrs = {}
+                for key in link:
+                    if key.lower() != 'vlanid' and key.lower() != 'vlanmode':
+                        attrs[key]=link[key].decode('utf-8')
+                etree.SubElement(links_root, 'DeviceInterfaceLink', attrs)
+                self.links.append(link)
  
     def read_consolelinks(self):
         if not os.path.exists(self.conscsv):
             return
-        csv_file = open(self.conscsv)
-        csv_cons = csv.DictReader(csv_file)
-        conslinks_root = etree.SubElement(self.csgroot, 'ConsoleLinksInfo')
-        for cons in csv_cons:
-            attrs = {}
-            for key in cons:
-                attrs[key]=cons[key].decode('utf-8')
-            etree.SubElement(conslinks_root, 'ConsoleLinkInfo', attrs)
-            self.consoles.append(cons)
-        csv_file.close()
+        with open(self.conscsv) as csv_file:
+            csv_cons = csv.DictReader(csv_file)
+            conslinks_root = etree.SubElement(self.csgroot, 'ConsoleLinksInfo')
+            for cons in csv_cons:
+                attrs = {}
+                for key in cons:
+                    attrs[key]=cons[key].decode('utf-8')
+                etree.SubElement(conslinks_root, 'ConsoleLinkInfo', attrs)
+                self.consoles.append(cons)
 
     def read_pdulinks(self):
         if not os.path.exists(self.pducsv):
             return
-        csv_file = open(self.pducsv)
-        csv_pdus = csv.DictReader(csv_file)
-        pduslinks_root = etree.SubElement(self.pcgroot, 'PowerControlLinksInfo')
-        for pdu_link in csv_pdus:
-            attrs = {}
-            for key in pdu_link:
-                attrs[key]=pdu_link[key].decode('utf-8')
-            etree.SubElement(pduslinks_root, 'PowerControlLinkInfo', attrs)
-            self.pdus.append(pdu_link)
-        csv_file.close()
+        with open(self.pducsv) as csv_file:
+            csv_pdus = csv.DictReader(csv_file)
+            pduslinks_root = etree.SubElement(self.pcgroot, 'PowerControlLinksInfo')
+            for pdu_link in csv_pdus:
+                attrs = {}
+                for key in pdu_link:
+                    attrs[key]=pdu_link[key].decode('utf-8')
+                etree.SubElement(pduslinks_root, 'PowerControlLinkInfo', attrs)
+                self.pdus.append(pdu_link)
 
     def generate_dpg(self):
         for dev in self.devices:

--- a/ansible/files/lab_connection_graph.xml
+++ b/ansible/files/lab_connection_graph.xml
@@ -90,4 +90,30 @@
       <InterfaceVlan mode="Trunk" portname="Ethernet30" vlanids="1681-1712"/>
     </DevicesL2Info>
   </DataPlaneGraph>
+  <ConsoleGraphDeclaration>
+    <DevicesConsoleInfo>
+      <DeviceConsoleInfo Hostname="console-1" HwSku="Cisco" ManagementIp="192.168.10.1" Protocol="ssh" Type="ConsoleServer"/>
+    </DevicesConsoleInfo>
+    <ConsoleLinksInfo>
+      <ConsoleLinkInfo EndDevice="str-msn2700-01" StartDevice="console-1" StartPort="10"/>
+      <ConsoleLinkInfo EndDevice="str-7260-10" StartDevice="console-1" StartPort="11"/>
+      <ConsoleLinkInfo EndDevice="str-7260-11" StartDevice="console-1" StartPort="12"/>
+    </ConsoleLinksInfo>
+  </ConsoleGraphDeclaration>
+  <PowerControlGraphDeclaration>
+    <DevicesPowerControlInfo>
+      <DevicePowerControlInfo Hostname="pdu-1" HwSku="Apc" ManagementIp="192.168.9.2" Protocol="snmp" Type="Pdu"/>
+      <DevicePowerControlInfo Hostname="pdu-2" HwSku="Sentry" ManagementIp="192.168.9.3" Protocol="snmp" Type="Pdu"/>
+    </DevicesPowerControlInfo>
+    <PowerControlLinksInfo>
+      <PowerControlLinkInfo EndDevice="str-msn2700-01" EndPort="PSU1" StartDevice="pdu-1" StartPort="1"/>
+      <PowerControlLinkInfo EndDevice="str-msn2700-01" EndPort="PSU2" StartDevice="pdu-1" StartPort="3"/>
+      <PowerControlLinkInfo EndDevice="str-7260-10" EndPort="PSU1" StartDevice="pdu-1" StartPort="2"/>
+      <PowerControlLinkInfo EndDevice="str-7260-10" EndPort="PSU2" StartDevice="pdu-1" StartPort="4"/>
+      <PowerControlLinkInfo EndDevice="str-7260-11" EndPort="PSU1" StartDevice="pdu-2" StartPort="1"/>
+      <PowerControlLinkInfo EndDevice="str-7260-11" EndPort="PSU2" StartDevice="pdu-2" StartPort="3"/>
+      <PowerControlLinkInfo EndDevice="str-acs-serv-01" EndPort="PSU1" StartDevice="pdu-2" StartPort="2"/>
+      <PowerControlLinkInfo EndDevice="str-acs-serv-01" EndPort="PSU2" StartDevice="pdu-2" StartPort="4"/>
+    </PowerControlLinksInfo>
+  </PowerControlGraphDeclaration>
 </LabConnectionGraph>

--- a/ansible/files/sonic_lab_console_links.csv
+++ b/ansible/files/sonic_lab_console_links.csv
@@ -1,0 +1,4 @@
+StartDevice,StartPort,EndDevice
+console-1,10,str-msn2700-01
+console-1,11,str-7260-10
+console-1,12,str-7260-11

--- a/ansible/files/sonic_lab_devices.csv
+++ b/ansible/files/sonic_lab_devices.csv
@@ -1,5 +1,8 @@
-Hostname,ManagementIp,HwSku,Type
-str-msn2700-01,10.251.0.188/23,Mellanox-2700,DevSonic
-str-7260-10,10.251.0.13/23,Arista-7260QX-64,FanoutLeaf
-str-7260-11,10.251.0.234/23,Arista-7260QX-64,FanoutRoot
-str-acs-serv-01,10.251.0.245/23,TestServ,Server
+Hostname,ManagementIp,HwSku,Type,Protocol
+str-msn2700-01,10.251.0.188/23,Mellanox-2700,DevSonic,
+str-7260-10,10.251.0.13/23,Arista-7260QX-64,FanoutLeaf,
+str-7260-11,10.251.0.234/23,Arista-7260QX-64,FanoutRoot,
+str-acs-serv-01,10.251.0.245/23,TestServ,Server,
+pdu-1,192.168.9.2,Apc,Pdu,snmp
+pdu-2,192.168.9.3,Sentry,Pdu,snmp
+console-1,192.168.10.1,Cisco,ConsoleServer,ssh

--- a/ansible/files/sonic_lab_pdu_links.csv
+++ b/ansible/files/sonic_lab_pdu_links.csv
@@ -1,0 +1,9 @@
+StartDevice,StartPort,EndDevice,EndPort
+pdu-1,1,str-msn2700-01,PSU1
+pdu-1,3,str-msn2700-01,PSU2
+pdu-1,2,str-7260-10,PSU1
+pdu-1,4,str-7260-10,PSU2
+pdu-2,1,str-7260-11,PSU1
+pdu-2,3,str-7260-11,PSU2
+pdu-2,2,str-acs-serv-01,PSU1
+pdu-2,4,str-acs-serv-01,PSU2

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -219,9 +219,13 @@ class Parse_Lab_Graph():
                         start_dev = consolelink.attrib['StartDevice']
                         end_dev = consolelink.attrib['EndDevice']
                         if start_dev:
-                            self.consolelinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': 'ConsolePort'}
+                            if start_dev not in self.consolelinks:
+                                self.consolelinks.update({start_dev : {}})
+                            self.consolelinks[start_dev][consolelink.attrib['StartPort']] = {'peerdevice':consolelink.attrib['EndDevice'], 'peerport': 'ConsolePort'}
                         if end_dev:
-                            self.consolelinks[end_dev]['ConsolePort'] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
+                            if end_dev not in self.consolelinks:
+                                self.consolelinks.update({end_dev : {}})
+                            self.consolelinks[end_dev]['ConsolePort'] = {'peerdevice': consolelink.attrib['StartDevice'], 'peerport': consolelink.attrib['StartPort']}
 
         pdu_root = self.root.find(self.pcgtag)
         if pdu_root:

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -335,7 +335,7 @@ class Parse_Lab_Graph():
         """
         if hostname in self.devices:
             try:
-                ret = self.devices[self.consolelinks[hostname]['ConsolePort'][peerdevice]]
+                ret = self.devices[self.consolelinks[hostname]['ConsolePort']['peerdevice']]
             except KeyError:
                 ret = {}
             return ret

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -223,7 +223,7 @@ class Parse_Lab_Graph():
                         if end_dev:
                             self.consolelinks[end_dev]['ConsolePort'] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
 
-        pdu_root = devicepcgroot = self.root.find(self.pcgtag)
+        pdu_root = self.root.find(self.pcgtag)
         if pdu_root:
             devicepcgroot = pdu_root.find('DevicesPowerControlInfo')
             devicespcsg = devicepcgroot.findall('DevicePowerControlInfo')

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -190,56 +190,61 @@ class Parse_Lab_Graph():
                     self.links[start_dev][link.attrib['StartPort']] = {'peerdevice':link.attrib['EndDevice'], 'peerport': link.attrib['EndPort'], 'speed': link.attrib['BandWidth']}
                 if end_dev:
                     self.links[end_dev][link.attrib['EndPort']] = {'peerdevice': link.attrib['StartDevice'], 'peerport': link.attrib['StartPort'], 'speed': link.attrib['BandWidth']}
-        devicecsgroot = self.root.find(self.csgtag).find('DevicesConsoleInfo')
-        devicescsg = devicecsgroot.findall('DeviceConsoleInfo')
-        if devicescsg is not None:
-            for dev in devicescsg:
-                hostname = dev.attrib['Hostname']
-                if hostname is not None:
-                    deviceinfo[hostname] = {}
-                    hwsku = dev.attrib['HwSku']
-                    devtype = dev.attrib['Type']
-                    protocol = dev.attrib['Protocol']
-                    mgmt_ip = dev.attrib['ManagementIp']
-                    deviceinfo[hostname]['HwSku'] = hwsku
-                    deviceinfo[hostname]['Type'] = devtype
-                    deviceinfo[hostname]['Protocol'] = protocol
-                    deviceinfo[hostname]['ManagementIp'] = mgmt_ip
-                    self.consolelinks[hostname] = {}
-        allconsolelinks = self.root.find(self.csgtag).find('ConsoleLinksInfo').findall('ConsoleLinkInfo')
-        if allconsolelinks is not None:
-            for consolelink in allconsolelinks:
-                start_dev = consolelink.attrib['StartDevice']
-                end_dev = consolelink.attrib['EndDevice']
-                if start_dev:
-                    self.consolelinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': 'ConsolePort'}
-                if end_dev:
-                    self.consolelinks[end_dev]['ConsolePort'] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
-        devicepcgroot = self.root.find(self.pcgtag).find('DevicesPowerControlInfo')
-        devicespcsg = devicepcgroot.findall('DevicePowerControlInfo')
-        if devicespcsg is not None:
-            for dev in devicespcsg:
-                hostname = dev.attrib['Hostname']
-                if hostname is not None:
-                    deviceinfo[hostname] = {}
-                    hwsku = dev.attrib['HwSku']
-                    devtype = dev.attrib['Type']
-                    protocol = dev.attrib['Protocol']
-                    mgmt_ip = dev.attrib['ManagementIp']
-                    deviceinfo[hostname]['HwSku'] = hwsku
-                    deviceinfo[hostname]['Type'] = devtype
-                    deviceinfo[hostname]['Protocol'] = protocol
-                    deviceinfo[hostname]['ManagementIp'] = mgmt_ip
-                    self.pdulinks[hostname] = {}
-        allpdulinks = self.root.find(self.pcgtag).find('PowerControlLinksInfo').findall('PowerControlLinkInfo')
-        if allpdulinks is not None:
-            for pdulink in allpdulinks:
-                start_dev = pdulink.attrib['StartDevice']
-                end_dev = pdulink.attrib['EndDevice']
-                if start_dev:
-                    self.pdulinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': pdulink.attrib['EndPort']}
-                if end_dev:
-                    self.pdulinks[end_dev][pdulink.attrib['EndPort']] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
+        console_root = self.root.find(self.csgtag)
+        if console_root:
+            devicecsgroot = console_root.find('DevicesConsoleInfo')
+            devicescsg = devicecsgroot.findall('DeviceConsoleInfo')
+            if devicescsg is not None:
+                for dev in devicescsg:
+                    hostname = dev.attrib['Hostname']
+                    if hostname is not None:
+                        deviceinfo[hostname] = {}
+                        hwsku = dev.attrib['HwSku']
+                        devtype = dev.attrib['Type']
+                        protocol = dev.attrib['Protocol']
+                        mgmt_ip = dev.attrib['ManagementIp']
+                        deviceinfo[hostname]['HwSku'] = hwsku
+                        deviceinfo[hostname]['Type'] = devtype
+                        deviceinfo[hostname]['Protocol'] = protocol
+                        deviceinfo[hostname]['ManagementIp'] = mgmt_ip
+                        self.consolelinks[hostname] = {}
+            allconsolelinks = console_root.find('ConsoleLinksInfo').findall('ConsoleLinkInfo')
+            if allconsolelinks is not None:
+                for consolelink in allconsolelinks:
+                    start_dev = consolelink.attrib['StartDevice']
+                    end_dev = consolelink.attrib['EndDevice']
+                    if start_dev:
+                        self.consolelinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': 'ConsolePort'}
+                    if end_dev:
+                        self.consolelinks[end_dev]['ConsolePort'] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
+
+        pdu_root = devicepcgroot = self.root.find(self.pcgtag)
+        if pdu_root:
+            devicepcgroot = pdu_root.find('DevicesPowerControlInfo')
+            devicespcsg = devicepcgroot.findall('DevicePowerControlInfo')
+            if devicespcsg is not None:
+                for dev in devicespcsg:
+                    hostname = dev.attrib['Hostname']
+                    if hostname is not None:
+                        deviceinfo[hostname] = {}
+                        hwsku = dev.attrib['HwSku']
+                        devtype = dev.attrib['Type']
+                        protocol = dev.attrib['Protocol']
+                        mgmt_ip = dev.attrib['ManagementIp']
+                        deviceinfo[hostname]['HwSku'] = hwsku
+                        deviceinfo[hostname]['Type'] = devtype
+                        deviceinfo[hostname]['Protocol'] = protocol
+                        deviceinfo[hostname]['ManagementIp'] = mgmt_ip
+                        self.pdulinks[hostname] = {}
+            allpdulinks = pdu_root.find('PowerControlLinksInfo').findall('PowerControlLinkInfo')
+            if allpdulinks is not None:
+                for pdulink in allpdulinks:
+                    start_dev = pdulink.attrib['StartDevice']
+                    end_dev = pdulink.attrib['EndDevice']
+                    if start_dev:
+                        self.pdulinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': pdulink.attrib['EndPort']}
+                    if end_dev:
+                        self.pdulinks[end_dev][pdulink.attrib['EndPort']] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
         self.devices = deviceinfo
         self.vlanport = devicel2info
 
@@ -312,11 +317,15 @@ class Parse_Lab_Graph():
         return  the given hostname console info of mgmtip, protocol, hwsku and type
         """
         if hostname in self.devices:
-            return  self.devices[self.consolelinks[hostname]['ConsolePort'][peerdevice]]
+            try:
+                ret = self.devices[self.consolelinks[hostname]['ConsolePort'][peerdevice]]
+            except KeyError:
+                ret = {}
+            return ret
         else:
             return self.devices
 
-    def get_host_console_links(self, hostname):
+    def get_host_console_link(self, hostname):
         """
         return  the given hostname console link info of console server and port
         """
@@ -330,7 +339,11 @@ class Parse_Lab_Graph():
         return  the given hostname pdu info of mgmtip, protocol, hwsku and type
         """
         if hostname in self.devices:
-            return  self.devices[self.pdulinks[hostname]['PSU1']['peerdevice']]
+            try:
+                ret = self.devices[self.pdulinks[hostname]['PSU1']['peerdevice']]
+            except KeyError:
+                ret = {}
+            return ret
         else:
             return self.devices
 
@@ -459,10 +472,10 @@ def main():
         device_vlan_range = {}
         device_vlan_list = {}
         device_vlan_map_list = {}
-        device_console_info = []
-        device_console_link = []
-        device_pdu_info = []
-        device_pdu_links = []
+        device_console_info = {}
+        device_console_link = {}
+        device_pdu_info = {}
+        device_pdu_links = {}
         for hostname in hostnames:
             dev = lab_graph.get_host_device_info(hostname)
             if dev is None:
@@ -497,10 +510,10 @@ def main():
                         if not found_port_for_vlan:
                             module.fail_json(msg="Did not find corresponding link for vlan %d in %s for host %s" % (a_host_vlan, port_vlans, hostname))
             device_port_vlans[hostname] = port_vlans
-            device_console_info.append(lab_graph.get_host_console_info(hostname))
-            device_console_link.append(lab_graph.get_host_console_link(hostname))
-            device_pdu_info.append(lab_graph.get_host_pdu_info(hostname))
-            device_pdu_links.append(lab_graph.get_host_pdu_links(hostname))
+            device_console_info[hostname] = lab_graph.get_host_console_info(hostname)
+            device_console_link[hostname] = lab_graph.get_host_console_link(hostname)
+            device_pdu_info[hostname] = lab_graph.get_host_pdu_info(hostname)
+            device_pdu_links[hostname] = lab_graph.get_host_pdu_links(hostname)
         results = {k: v for k, v in locals().items()
                    if (k.startswith("device_") and v)}
 

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -50,6 +50,10 @@ Ansible_facts:
     device_vlan_range: all configured vlan range for the device(host)
     device_port_vlans: detailed vlanids for each physical port and switchport mode
     server_links: each server port vlan ids
+    device_console_info: The device's console server type, mgmtip, hwsku and protocol
+    device_console_link:  The console server port connected to the device
+    device_pdu_info: The device's pdu server type, mgmtip, hwsku and protocol
+    device_pdu_links: The pdu server ports connected to the device
 
 '''
 
@@ -112,9 +116,13 @@ class Parse_Lab_Graph():
         self.vlanport = {}
         self.vlanrange = {}
         self.links = {}
+        self.consolelinks = {}
+        self.pdulinks = {}
         self.server = defaultdict(dict)
         self.pngtag = 'PhysicalNetworkGraphDeclaration'
         self.dpgtag = 'DataPlaneGraph'
+        self.pcgtag = 'PowerControlGraphDeclaration'
+        self.csgtag = 'ConsoleGraphDeclaration'
 
     def port_vlanlist(self, vlanrange):
         vlans = []
@@ -182,6 +190,56 @@ class Parse_Lab_Graph():
                     self.links[start_dev][link.attrib['StartPort']] = {'peerdevice':link.attrib['EndDevice'], 'peerport': link.attrib['EndPort'], 'speed': link.attrib['BandWidth']}
                 if end_dev:
                     self.links[end_dev][link.attrib['EndPort']] = {'peerdevice': link.attrib['StartDevice'], 'peerport': link.attrib['StartPort'], 'speed': link.attrib['BandWidth']}
+        devicecsgroot = self.root.find(self.csgtag).find('DevicesConsoleInfo')
+        devicescsg = devicecsgroot.findall('DeviceConsoleInfo')
+        if devicescsg is not None:
+            for dev in devicescsg:
+                hostname = dev.attrib['Hostname']
+                if hostname is not None:
+                    deviceinfo[hostname] = {}
+                    hwsku = dev.attrib['HwSku']
+                    devtype = dev.attrib['Type']
+                    protocol = dev.attrib['Protocol']
+                    mgmt_ip = dev.attrib['ManagementIp']
+                    deviceinfo[hostname]['HwSku'] = hwsku
+                    deviceinfo[hostname]['Type'] = devtype
+                    deviceinfo[hostname]['Protocol'] = protocol
+                    deviceinfo[hostname]['ManagementIp'] = mgmt_ip
+                    self.consolelinks[hostname] = {}
+        allconsolelinks = self.root.find(self.csgtag).find('ConsoleLinksInfo').findall('ConsoleLinkInfo')
+        if allconsolelinks is not None:
+            for consolelink in allconsolelinks:
+                start_dev = consolelink.attrib['StartDevice']
+                end_dev = consolelink.attrib['EndDevice']
+                if start_dev:
+                    self.consolelinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': 'ConsolePort'}
+                if end_dev:
+                    self.consolelinks[end_dev]['ConsolePort'] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
+        devicepcgroot = self.root.find(self.pcgtag).find('DevicesPowerControlInfo')
+        devicespcsg = devicepcgroot.findall('DevicePowerControlInfo')
+        if devicespcsg is not None:
+            for dev in devicespcsg:
+                hostname = dev.attrib['Hostname']
+                if hostname is not None:
+                    deviceinfo[hostname] = {}
+                    hwsku = dev.attrib['HwSku']
+                    devtype = dev.attrib['Type']
+                    protocol = dev.attrib['Protocol']
+                    mgmt_ip = dev.attrib['ManagementIp']
+                    deviceinfo[hostname]['HwSku'] = hwsku
+                    deviceinfo[hostname]['Type'] = devtype
+                    deviceinfo[hostname]['Protocol'] = protocol
+                    deviceinfo[hostname]['ManagementIp'] = mgmt_ip
+                    self.pdulinks[hostname] = {}
+        allpdulinks = self.root.find(self.pcgtag).find('PowerControlLinksInfo').findall('PowerControlLinkInfo')
+        if allpdulinks is not None:
+            for pdulink in allpdulinks:
+                start_dev = pdulink.attrib['StartDevice']
+                end_dev = pdulink.attrib['EndDevice']
+                if start_dev:
+                    self.pdulinks[start_dev][pdulink.attrib['StartPort']] = {'peerdevice':pdulink.attrib['EndDevice'], 'peerport': pdulink.attrib['EndPort']}
+                if end_dev:
+                    self.pdulinks[end_dev][pdulink.attrib['EndPort']] = {'peerdevice': pdulink.attrib['StartDevice'], 'peerport': pdulink.attrib['StartPort']}
         self.devices = deviceinfo
         self.vlanport = devicel2info
 
@@ -247,6 +305,43 @@ class Parse_Lab_Graph():
 
     def contains_hosts(self, hostnames):
         return set(hostnames) <= set(self.devices)
+
+
+    def get_host_console_info(self, hostname):
+        """
+        return  the given hostname console info of mgmtip, protocol, hwsku and type
+        """
+        if hostname in self.devices:
+            return  self.devices[self.consolelinks[hostname]['ConsolePort'][peerdevice]]
+        else:
+            return self.devices
+
+    def get_host_console_links(self, hostname):
+        """
+        return  the given hostname console link info of console server and port
+        """
+        if hostname in self.consolelinks:
+            return  self.consolelinks[hostname]
+        else:
+            return self.consolelinks
+
+    def get_host_pdu_info(self, hostname):
+        """
+        return  the given hostname pdu info of mgmtip, protocol, hwsku and type
+        """
+        if hostname in self.devices:
+            return  self.devices[self.pdulinks[hostname]['PSU1']['peerdevice']]
+        else:
+            return self.devices
+
+    def get_host_pdu_links(self, hostname):
+        """
+        return  the given hostname pdu links info of pdu servers and ports
+        """
+        if hostname in self.pdulinks:
+            return  self.pdulinks[hostname]
+        else:
+            return self.pdulinks
 
 
 LAB_CONNECTION_GRAPH_FILE = 'graph_files.yml'
@@ -364,6 +459,10 @@ def main():
         device_vlan_range = {}
         device_vlan_list = {}
         device_vlan_map_list = {}
+        device_console_info = []
+        device_console_link = []
+        device_pdu_info = []
+        device_pdu_links = []
         for hostname in hostnames:
             dev = lab_graph.get_host_device_info(hostname)
             if dev is None:
@@ -398,6 +497,10 @@ def main():
                         if not found_port_for_vlan:
                             module.fail_json(msg="Did not find corresponding link for vlan %d in %s for host %s" % (a_host_vlan, port_vlans, hostname))
             device_port_vlans[hostname] = port_vlans
+            device_console_info.append(lab_graph.get_host_console_info(hostname))
+            device_console_link.append(lab_graph.get_host_console_link(hostname))
+            device_pdu_info.append(lab_graph.get_host_pdu_info(hostname))
+            device_pdu_links.append(lab_graph.get_host_pdu_links(hostname))
         results = {k: v for k, v in locals().items()
                    if (k.startswith("device_") and v)}
 


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add console/PDU link to the device connection graph.

#### How did you do it?
1. Improve creategraph.py to allow specifying console connection and pdu connections.
2. Improve creategraph.py to allow specifying inventory name and generate input file names.
3. Update conn_graph_facts.py to return device PDU/console information.
4. Allow console/PDU information missing so that community members can take time to catch up.
5. Supporting DUT connects to multiple PDUs.

#### How did you verify/test it?
Tested with graph creation without specifying the console and pdu information.

Tested with instrumentation code (on graph generated before this change, and graph generated with this change but no console/pdu information, and graph with incremental console/pdu information):

```
def test_graph(conn_graph_facts):
    logger.warning('=== device_pdu_info {}'.format(json.dumps(conn_graph_facts['device_pdu_info'], indent=4)))
    logger.warning('=== device_pdu_links {}'.format(json.dumps(conn_graph_facts['device_pdu_links'], indent=4)))
    logger.warning('=== device_console_info {}'.format(json.dumps(conn_graph_facts['device_console_info'], indent=4)))
    logger.warning('=== device_console_link {}'.format(json.dumps(conn_graph_facts['device_console_link'], indent=4)))

19:44:41 WARNING test_foo.py:test_pdu:18: === device_pdu_info {
    "str-7260cx3-acs-1": {
        "PSU1": {
            "Protocol": "snmp",
            "ManagementIp": "10.3.155.107/23",
            "HwSku": "Sentry",
            "Type": "Pdu"
        },
        "PSU2": {
            "Protocol": "snmp",
            "ManagementIp": "10.3.155.107/23",
            "HwSku": "Sentry",
            "Type": "Pdu"
        }
    }
}
19:44:41 WARNING test_foo.py:test_pdu:19: === device_pdu_links {
    "str-7260cx3-acs-1": {
        "PSU1": {
            "peerdevice": "pdu-107",
            "peerport": "39"
        },
        "PSU2": {
            "peerdevice": "pdu-107",
            "peerport": "38"
        }
    }
}
17:59:28 WARNING test_foo.py:test_pdu:20: === device_console_info {
    "str-7260cx3-acs-1": {
        "Protocol": "ssh",
        "ManagementIp": "10.3.145.82",
        "HwSku": "Cisco",
        "Type": "ConsoleServer"
    }
}
17:59:28 WARNING test_foo.py:test_pdu:21: === device_console_link {
    "str-7260cx3-acs-1": {
        "ConsolePort": {
            "peerdevice": "console-82",
            "peerport": "36"
        }
    }
}
```