### PR TITLE
[Platform API][SFP] Compare applicable data against values from platform.json

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -118,9 +118,9 @@ class TestSfpApi(PlatformApiTestBase):
         expected_value = None
 
         if self.chassis_facts:
-            expeceted_sfps = self.chassis_facts.get("sfps")
-            if expeceted_sfps:
-                expected_value = expeceted_sfps[sfp_idx].get(key)
+            expected_sfps = self.chassis_facts.get("sfps")
+            if expected_sfps:
+                expected_value = expected_sfps[sfp_idx].get(key)
 
         if not expected_value:
             logger.warning("Unable to get expected value for '{}' from platform.json file for SFP {}".format(key, sfp_idx))

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -27,6 +27,15 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(scope="class")
+def gather_facts(request, duthost):
+    # Get platform facts from platform.json file
+    request.cls.chassis_facts = duthost.facts.get("chassis")
+    if not request.cls.chassis_facts:
+        logger.warning("Unable to get chassis_facts from platform.json, test results will not be comprehensive")
+
+
+@pytest.mark.usefixtures("gather_facts")
 class TestSfpApi(PlatformApiTestBase):
     """
     This class contains test cases intended to verify the functionality and
@@ -85,15 +94,9 @@ class TestSfpApi(PlatformApiTestBase):
         'txpowerlowalarm'
     ]
 
+    chassis_facts = None
+    duthost_vars = None
     num_sfps = None
-
-    def is_xcvr_optical(self, xcvr_info_dict):
-        """Returns True if transceiver is optical, False if copper (DAC)"""
-        spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
-        compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code")
-        if compliance_code == "40GBASE-CR4":
-            return False
-        return True
 
     # This fixture would probably be better scoped at the class level, but
     # it relies on the platform_api_conn fixture, which is scoped at the function
@@ -106,6 +109,34 @@ class TestSfpApi(PlatformApiTestBase):
             except:
                 pytest.fail("num_sfps is not an integer")
 
+
+    #
+    # Helper functions
+    #
+
+    def compare_value_with_platform_facts(self, key, value, sfp_idx):
+        expected_value = None
+
+        if self.chassis_facts:
+            expeceted_sfps = self.chassis_facts.get("sfps")
+            if expeceted_sfps:
+                expected_value = expeceted_sfps[sfp_idx].get(key)
+
+        if not expected_value:
+            logger.warning("Unable to get expected value for '{}' from platform.json file for SFP {}".format(key, sfp_idx))
+            return
+
+        self.expect(value == expected_value,
+                      "'{}' value is incorrect. Got '{}', expected '{}' for SFP {}".format(key, value, expected_value, sfp_idx))
+
+    def is_xcvr_optical(self, xcvr_info_dict):
+        """Returns True if transceiver is optical, False if copper (DAC)"""
+        spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
+        compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code")
+        if compliance_code == "40GBASE-CR4":
+            return False
+        return True
+
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -115,6 +146,7 @@ class TestSfpApi(PlatformApiTestBase):
             name = sfp.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve transceiver {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Transceiver {} name appears incorrect".format(i))
+                compare_value_with_platform_facts(self, 'name', name, i)
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):


### PR DESCRIPTION
Summary:

For SFP tests where known facts are available in the platform.json file, compare actual values against those facts

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To improve the quality of the SFP platform API test

#### How did you do it?

For SFP tests where known facts are available in the platform.json file, compare actual values against those facts 

#### How did you verify/test it?

Run SFP tests on a device with a populated platform.json present

#### Any platform specific information?

Platform must have a populated platform.json present

