### PR TITLE
[LogAnalyzer] Ignore "sflowmgrd process is not running" warning in LogAnalyzer for master

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -34,6 +34,14 @@ def loganalyzer(duthost, request):
     logging.info("Load config and analyze log")
     # Read existed common regular expressions located with legacy loganalyzer module
     loganalyzer.load_common_config()
+    # sflowmgrd is configed in Monit, but not included in current master branch image
+    # So a workaround is added for master branch. Once the issue is adressed, we should
+    # rm this patch
+    if "master" in duthost.os_version:
+        log_to_ignore = [
+            r".*'sflowmgrd' process is not running"
+        ]
+        loganalyzer.ignore_regex.extend(log_to_ignore)
 
     yield loganalyzer
     # Skip LogAnalyzer if case is skipped


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
sflowmgrd is configured in Monit, but not included in current master branch image. As a result, there will be a warning in syslog.
```
ERR monit[522]: 'sflowmgrd' process is not running
```
To workaroud this error temporarily, this PR add a patch to ignore the pattern for master branch.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Add a patch to ignore **'sflowmgrd' process is not running** for master branch.
#### What is the motivation for this PR?
This PR is to ignore test errors caused by **'sflowmgrd' process is not running** in syslog.
#### How did you do it?
Add a new pattern to ignore_list of LogAnalyzer.
#### How did you verify/test it?
Verified on dx010 running master branch.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.