### PR TITLE
Use new shell_cmds module to enable/disable container autorestart

### DIFF
--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# This ansible module is for running multiple commands by /bin/sh on remote device.
+#
+# The ansible builtin module "command" and "shell" can run a single command on the remote device and get its output.
+# This module is to support running multiple commands in sequential and return the results of these commands. This
+# enhancement can reduce some overhead of establishing connection with the remote host when we want to run multiple
+# commands.
+#
+# Example of module output:
+# {
+#   "end": "2020-09-23 09:18:58.252273",
+#   "_ansible_no_log": false,
+#   "start": "2020-09-23 09:18:58.243835",
+#   "changed": false,
+#   "results": [
+#     {
+#       "stderr_lines": [],
+#       "stderr": "",
+#       "stdout": "admin\n",
+#       "stdout_lines": [
+#         "admin"
+#       ],
+#       "cmd": "ls /home",
+#       "rc": 0
+#     },
+#     {
+#       "stderr_lines": [],
+#       "stderr": "",
+#       "stdout": "/home/admin\n",
+#       "stdout_lines": [
+#         "/home/admin"
+#       ],
+#       "cmd": "pwd",
+#       "rc": 0
+#     }
+#   ],
+#   "cmds": [
+#     "ls /home",
+#     "pwd"
+#   ],
+#   "failed": false,
+#   "delta": "0:00:00.008438",
+#   "invocation": {
+#     "module_args": {
+#       "cmds": [
+#         "ls /home",
+#         "pwd"
+#       ]
+#     }
+#   }
+# }
+
+import datetime
+
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = r'''
+---
+module: shell_cmds
+version_added: "1.0"
+author: Xin Wang (xiwang5@microsoft.com)
+short_description: Run multiple commands on remote host.
+description:
+    - Run multiple commands by /bin/sh on remote host.
+options:
+    cmds: List of commands. Each command should be a string.
+'''
+
+EXAMPLES = r'''
+# Run multiple commands
+- name: Run multiple commands on remote host
+  shell_cmds:
+    cmds:
+        - ls /home
+        - pwd
+'''
+
+def run_cmd(module, cmd):
+
+    rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
+    result = dict(
+        cmd=cmd,
+        rc=rc,
+        stdout=out,
+        stderr=err,
+        stdout_lines=out.splitlines(),
+        stderr_lines=err.splitlines()
+    )
+    return result
+
+def main():
+
+    module = AnsibleModule(argument_spec=dict(
+            cmds=dict(type='list')
+        )
+    )
+
+    cmds = module.params['cmds']
+
+    startd = datetime.datetime.now()
+
+    results = []
+    for cmd in cmds:
+        results.append(run_cmd(module, cmd))
+
+    endd = datetime.datetime.now()
+    delta = endd - startd
+
+    output = dict(
+        cmds=cmds,
+        results=results,
+        start=str(startd),
+        end=str(endd),
+        delta=str(delta),
+        failed=any(result['rc']!=0 for result in results)
+    )
+
+    if output['failed']:
+        module.fail_json(msg='At least running one of the commands failed', **output)
+    module.exit_json(**output)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,13 +443,17 @@ def disable_container_autorestart(duthost, request):
     # Disable autorestart for all containers
     logging.info("Disable container autorestart")
     cmd_disable = "config feature autorestart {} disabled"
+    cmds_disable = []
     for name, state in container_autorestart_states.items():
         if state == "enabled":
-            duthost.command(cmd_disable.format(name))
+            cmds_disable.append(cmd_disable.format(name))
+    duthost.shell_cmds(cmds=cmds_disable)
     yield
     # Recover autorestart states
     logging.info("Recover container autorestart")
     cmd_enable = "config feature autorestart {} enabled"
+    cmds_enable = []
     for name, state in container_autorestart_states.items():
         if state == "enabled":
-            duthost.command(cmd_enable.format(name))
+            cmds_enable.append(cmd_enable.format(name))
+    duthost.shell_cmds(cmds=cmds_enable)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The ansible built-in modules like `command` only supports running single command.
The `shell` module can run multiple commands by concatenate the commands using
` && `. But the problem is that all the commands output are concatenated too. It's
hard to tell which output belongs to which command. Because of this limitation,
the fixture `disable_container_autorestart` run commands one by one to disable
or enable container autorestart for each containers. As an autoused fixture, it
caused too much unnecessary overhead.

#### How did you do it?
This commit added a new customized ansible module `shell_cmds`. It accepts
a list of commands in string and runs the commands in sequential on remote
host. Output of this module contains a list of results. One result for each
command. The `disable_container_autorestart` fixture is also updated to use
this new module. Tested on vsimage, using this new `shell_cmds` module
can reduce around 8 seconds of overhead caused by fixture
`disable_container_autorestart`

#### How did you verify/test it?
Test run any script. The `disable_container_autorestart` fixture uses the new ansible module during setup and teardown.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
