### PR TITLE
[pytest] Get critical process list for PMon container

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -404,6 +404,26 @@ class SonicHost(AnsibleHostBase):
                 succeeded = False
                 break
 
+        # For PMon container, since different daemons are enabled in different platforms, we need find common processes
+        # which are not only in the critical_processes file and also are running in that platform.
+        if succeeded and container_name == "pmon":
+            common_groups = []
+            common_processes = []
+            process_list = self.shell("docker exec {} supervisorctl status".format(container_name))
+            for process_info in process_list["stdout_lines"]:
+                process_name = process_info.split()[0].strip()
+                process_status = process_info.split()[1].strip()
+                if ":" in process_name:
+                    group_name = process_name.split(":")[0]
+                    process_name = process_name.split(":")[1]
+                    if process_status == "RUNNING" and group_name in critical_group_list:
+                        common_groups.append(process_name)
+                else:
+                    if process_status == "RUNNING" and process_name in critical_process_list:
+                        common_processes.append(process_name)
+
+            return common_groups, common_processes, succeeded
+
         return critical_group_list, critical_process_list, succeeded
 
     def critical_process_status(self, service):

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -405,10 +405,10 @@ class SonicHost(AnsibleHostBase):
                 break
 
         # For PMon container, since different daemons are enabled in different platforms, we need find common processes
-        # which are not only in the critical_processes file and also are running in that platform.
+        # which are not only in the critical_processes file and also are configured to run on that platform.
         if succeeded and container_name == "pmon":
-            common_groups = []
-            common_processes = []
+            expected_critical_group_list = []
+            expected_critical_process_list = []
             process_list = self.shell("docker exec {} supervisorctl status".format(container_name))
             for process_info in process_list["stdout_lines"]:
                 process_name = process_info.split()[0].strip()
@@ -417,12 +417,13 @@ class SonicHost(AnsibleHostBase):
                     group_name = process_name.split(":")[0]
                     process_name = process_name.split(":")[1]
                     if process_status == "RUNNING" and group_name in critical_group_list:
-                        common_groups.append(process_name)
+                        expected_critical_group_list.append(process_name)
                 else:
                     if process_status == "RUNNING" and process_name in critical_process_list:
-                        common_processes.append(process_name)
-
-            return common_groups, common_processes, succeeded
+                        expected_critical_process_list.append(process_name)
+            
+            critical_group_list = expected_critical_group_list
+            critical_process_list = expected_critical_process_list
 
         return critical_group_list, critical_process_list, succeeded
 


### PR DESCRIPTION
- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For PMon container, since different daemons are enabled in different platforms, we should find common processes which are not only in critical_processes file but also are running in that platform. I changed the logic of function 'get_critical_group_and_process_lists(...)' in devices.py such that we can correctly get the critical process list for PMon container.

#### How did you do it?

#### How did you verify/test it?
I tested the function `get_critical_and_processes_list(...)` on the virtual testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
