### PR TITLE
[pfcwd] Fix AttributeError due to incorrect var name

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -138,7 +138,7 @@ class PFCStorm(object):
             "ansible_eth0_ipv4_addr": self.ip_addr,
             "peer_hwsku": self.peer_info['hwsku']
             }
-        if self.peer_device_os in self._PFC_GEN_DIR:
+        if self.peer_device.os in self._PFC_GEN_DIR:
             self.extra_vars['pfc_gen_dir'] = \
                 self._PFC_GEN_DIR[self.peer_device.os]
         if getattr(self, "pfc_storm_defer_time", None):


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix AttributeError introduced by #2244 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### What is the motivation for this PR?
if self.peer_device_os in self._PFC_GEN_DIR: E AttributeError: 'PFCStorm' object has no attribute 'peer_device_os' self = <tests.common.helpers.pfc_storm.PFCStorm object at 0x7fe9370f6710> common/helpers/pfc_storm.py:143: AttributeError

#### How did you verify/test it?
With the fix, ran one of the pfcwd tests which was failing with the above error and it passed