### PR TITLE
[Platform API][Chassis][SFP] Fail applicable tests if unable to retrieve expected data

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -55,8 +55,6 @@ ONIE_TLVINFO_TYPE_CODE_CRC32 = '0xFE'           # CRC-32
 def gather_facts(request, duthost):
     # Get platform facts from platform.json file
     request.cls.chassis_facts = duthost.facts.get("chassis")
-    if not request.cls.chassis_facts:
-        logger.warning("Unable to get chassis_facts from platform.json, test results will not be comprehensive")
 
     # Get host vars from inventory file
     request.cls.duthost_vars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
@@ -79,9 +77,8 @@ class TestChassisApi(PlatformApiTestBase):
         if self.chassis_facts:
             expected_value = self.chassis_facts.get(key)
 
-        if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from platform.json file".format(key))
-            return
+        pytest_assert(expected_value is not None,
+                      "Unable to get expected value for '{}' from platform.json file".format(key))
 
         pytest_assert(value == expected_value,
                       "'{}' value is incorrect. Got '{}', expected '{}'".format(key, value, expected_value))
@@ -92,9 +89,8 @@ class TestChassisApi(PlatformApiTestBase):
         if self.duthost_vars:
             expected_value = self.duthost_vars.get(key)
 
-        if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from inventory file".format(key))
-            return
+        pytest_assert(expected_value is not None,
+                      "Unable to get expected value for '{}' from inventory file".format(key))
 
         if case_sensitive:
             pytest_assert(value == expected_value,

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -47,7 +47,6 @@ class TestSfpApi(PlatformApiTestBase):
 
     EXPECTED_XCVR_INFO_KEYS = [
         'type',
-        'type_abbrv_name',
         'manufacturer',
         'model',
         'hardware_rev',

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -22,6 +22,7 @@ else:
 logger = logging.getLogger(__name__)
 
 pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]
@@ -31,8 +32,6 @@ pytestmark = [
 def gather_facts(request, duthost):
     # Get platform facts from platform.json file
     request.cls.chassis_facts = duthost.facts.get("chassis")
-    if not request.cls.chassis_facts:
-        logger.warning("Unable to get chassis_facts from platform.json, test results will not be comprehensive")
 
 
 @pytest.mark.usefixtures("gather_facts")
@@ -48,19 +47,22 @@ class TestSfpApi(PlatformApiTestBase):
 
     EXPECTED_XCVR_INFO_KEYS = [
         'type',
-        'hardware_rev',
-        'serial',
+        'type_abbrv_name',
         'manufacturer',
         'model',
+        'hardware_rev',
+        'serial',
+        'vendor_oui',
+        'vendor_date',
         'connector',
         'encoding',
         'ext_identifier',
         'ext_rateselect_compliance',
+        'cable_type',
         'cable_length',
-        'nominal_bit_rate',
         'specification_compliance',
-        'vendor_date',
-        'vendor_oui'
+        'nominal_bit_rate',
+        'application_advertisement'
     ]
 
     EXPECTED_XCVR_BULK_STATUS_KEYS = [
@@ -122,12 +124,10 @@ class TestSfpApi(PlatformApiTestBase):
             if expected_sfps:
                 expected_value = expected_sfps[sfp_idx].get(key)
 
-        if not expected_value:
-            logger.warning("Unable to get expected value for '{}' from platform.json file for SFP {}".format(key, sfp_idx))
-            return
-
-        self.expect(value == expected_value,
-                      "'{}' value is incorrect. Got '{}', expected '{}' for SFP {}".format(key, value, expected_value, sfp_idx))
+        if self.expect(expected_value is not None,
+                       "Unable to get expected value for '{}' from platform.json file for SFP {}".format(key, sfp_idx)):
+            self.expect(value == expected_value,
+                          "'{}' value is incorrect. Got '{}', expected '{}' for SFP {}".format(key, value, expected_value, sfp_idx))
 
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""


### PR DESCRIPTION
For chassis and SFP tests which rely on comparing data to data retrieved from platform.json or inventory file, fail the test. The tests will _require_ factual data to compare with to validate the API call.

Also add new 'application_advertisement' field to list of expected transceiver info fields and reorganize to match order from xcvrd.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To make the test results more consistent across platforms

#### How did you do it?
Fail tests rather than log warnings

#### How did you verify/test it?
Ran against a DUT with and without platform.json and inventory data

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
