### PR TITLE
[Platform API][SFP] Add missing 'self.' prefix on class method call

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -145,7 +145,7 @@ class TestSfpApi(PlatformApiTestBase):
             name = sfp.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve transceiver {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Transceiver {} name appears incorrect".format(i))
-                compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts(self, 'name', name, i)
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):


### PR DESCRIPTION
Summary:

Add missing 'self.' prexfix on `compare_value_with_platform_facts()` method call

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Fix a bug.

#### How did you do it?

Add missing 'self.' prexfix on `compare_value_with_platform_facts()` method call
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
