### PR TITLE
[test_advanced_reboot]Add a fixture to backup and restore config_db.json

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -1,0 +1,19 @@
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def backup_and_restore_config_db(duthost):
+    """
+    Some cases will shutdown interfaces or BGP in test, and the change is writen to
+    config db after warm-reboot. Therefore, we need to backup config_db.json before
+    test starts and then restore after test ends
+    """
+    CONFIG_DB = "/etc/sonic/config_db.json"
+    CONFIG_DB_BAK = "/etc/sonic/config_db.json.before_test"
+    logger.info("Backup {} to {}".format(CONFIG_DB, CONFIG_DB_BAK))
+    duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
+    yield
+    logger.info("Restore {} with {}".format(CONFIG_DB, CONFIG_DB_BAK))
+    duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -8,6 +8,19 @@ pytestmark = [
     pytest.mark.topology('t0')
 ]
 
+@pytest.fixture
+def backup_and_restore_config_db(duthost):
+    """
+    Some cases will shutdown interfaces or BGP in test, and the change is writen to
+    config db after warm-reboot. Therefore, we need to backup config_db.json before
+    test starts and then restore after test ends
+    """
+    CONFIG_DB = "/etc/sonic/config_db.json"
+    CONFIG_DB_BAK = "/etc/sonic/config_db.json.before_advanced_reboot"
+    duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
+    yield
+    duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
+
 @pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot):
     '''
@@ -30,7 +43,7 @@ def test_warm_reboot(request, get_advanced_reboot):
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     advancedReboot.runRebootTestcase()
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad(request, get_advanced_reboot):
     '''
     Warm reboot with sad path
@@ -57,7 +70,7 @@ def test_warm_reboot_sad(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_multi_sad(request, get_advanced_reboot):
     '''
     Warm reboot with multi sad path
@@ -93,7 +106,7 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
     '''
     Warm reboot with multi sad path (during boot)
@@ -114,7 +127,7 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
     '''
     Warm reboot with sad (bgp)
@@ -136,7 +149,7 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
     '''
     Warm reboot with sad path (lag member)
@@ -167,7 +180,7 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_lag(request, get_advanced_reboot):
     '''
     Warm reboot with sad path (lag)
@@ -189,7 +202,7 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
-@pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot):
     '''
     Warm reboot with sad path (vlan port)

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -2,24 +2,12 @@ import pytest
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]
-
-@pytest.fixture
-def backup_and_restore_config_db(duthost):
-    """
-    Some cases will shutdown interfaces or BGP in test, and the change is writen to
-    config db after warm-reboot. Therefore, we need to backup config_db.json before
-    test starts and then restore after test ends
-    """
-    CONFIG_DB = "/etc/sonic/config_db.json"
-    CONFIG_DB_BAK = "/etc/sonic/config_db.json.before_advanced_reboot"
-    duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
-    yield
-    duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
 
 @pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to address the issue that some interfaces are shutdown after running ```test_advanced_reboot```.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Some test cases in test_advanced_reboot.py will shutdown interfaces to do a test, and recover them at the end of test. However, the finalize-warmboot.sh will do a config save after warm-reboot, and the down status is writen into config_db.json. 
This commit add a fixture to backup config_db.json and then restore the file before test ends.

#### How did you do it?
Add a fixture to backup config_db.json before test starts and then restore the file before test ends.
#### How did you verify/test it?
Verified on Arista-7260. 
**step 1**  Run test_warm_reboot_sad_vlan_port in ```test_advanced_reboot```
**step 2** Check the backup file ```/etc/sonic/config_db.json.before_advanced_reboot``` is generated
**step 3** Check the ```config_db.json``` is restore to backuped file, and the admin status of each interface is not changed.
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.