### PR TITLE
Use topology marker to run lldp pytest on supported topology.

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -4,14 +4,9 @@ import pytest
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t0', 't1'),
     pytest.mark.device_type('vs')
 ]
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_check_topo(tbinfo):
-    if tbinfo['topo']['type'] == 'ptf':
-        pytest.skip('Unsupported topology')
 
 def test_lldp(duthost, localhost, collect_techsupport):
     """ verify the LLDP message on DUT """

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,14 +1,9 @@
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('t0', 't1'),
     pytest.mark.device_type('vs')
 ]
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_check_topo(tbinfo):
-    if tbinfo['topo']['type'] == 'ptf':
-        pytest.skip('Unsupported topology')
 
 @pytest.mark.bsl
 def test_snmp_lldp(duthost, localhost, creds):


### PR DESCRIPTION
Signed-off-by: Emma Lin <emma_lin@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use topology marker to run lldp pytest on supported topology.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Use new marker 'topology' to replace the function 'setup_check_topo()'.

#### How did you do it?
Use topology marker to run lldp pytest on supported topology.

#### How did you verify/test it?
Verify that it shall skip lldp tests when topology is ptf.
```
johnar@fa6c7e01f5ce:~/sonic-mgmt/tests$ cd ~/sonic-mgmt/tests/ && py.test "lldp/test_lldp.py" --host-pattern=2-6_ptf32 --topology=ptf --module-path ../ansible/library/ --testbed_file=testbed.csv --inventory=lab --testbed=2-6_ptf32 --log-level=INFO --show-capture=stdout --duration=0 -v -o log_cli=true -o log_cli_level=WARN
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.4.0-87-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /var/johnar/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, repeat-0.8.0, metadata-1.10.0, xdist-1.28.0, html-1.22.1, forked-1.3.0
collected 2 items

lldp/test_lldp.py::test_lldp SKIPPED                                                                             [ 50%]
lldp/test_lldp.py::test_lldp_neighbor SKIPPED                                                                    [100%]

================================================ slowest test durations ================================================

(0.00 durations hidden.  Use -vv to show these durations.)
============================================== 2 skipped in 0.02 seconds ===============================================
```
```
johnar@fa6c7e01f5ce:~/sonic-mgmt/tests$ cd ~/sonic-mgmt/tests/ && py.test "snmp/test_snmp_lldp.py" --host-pattern=2-6_ptf32 --topology=ptf --module-path ../ansible/library/ --testbed_file=testbed.csv --inventory=lab --testbed=2-6_ptf32 --log-level=INFO --show-capture=stdout --duration=0 -v -o log_cli=true -o log_cli_level=WARN
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.4.0-87-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /var/johnar/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, repeat-0.8.0, metadata-1.10.0, xdist-1.28.0, html-1.22.1, forked-1.3.0
collected 1 item

snmp/test_snmp_lldp.py::test_snmp_lldp SKIPPED                                                                   [100%]

================================================ slowest test durations ================================================

(0.00 durations hidden.  Use -vv to show these durations.)
============================================== 1 skipped in 0.02 seconds ===============================================
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.
