### PR TITLE
Configure VMs in parallel for test_bgp_gr_helper

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 import logging
+import json
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.parallel import parallel_run
 
 logger = logging.getLogger(__name__)
 
@@ -24,18 +27,49 @@ def setup_bgp_graceful_restart(duthost, nbrhosts):
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
 
-    for k, nbr in nbrhosts.items():
-        logger.info("enable graceful restart on neighbor {}".format(k))
-        logger.info("bgp asn {}".format(nbr['conf']['bgp']['asn']))
-        nbr['host'].eos_config(lines=["graceful-restart restart-time 300"], \
-                               parents=["router bgp {}".format(nbr['conf']['bgp']['asn'])])
-        nbr['host'].eos_config(lines=["graceful-restart"], \
-                               parents=["router bgp {}".format(nbr['conf']['bgp']['asn']), "address-family ipv4"])
-        nbr['host'].eos_config(lines=["graceful-restart"], \
-                               parents=["router bgp {}".format(nbr['conf']['bgp']['asn']), "address-family ipv6"])
+    def configure_nbr_gr(node=None, results=None):
+        """Target function will be used by multiprocessing for configuring VM hosts.
 
-    # change graceful restart option will clear the bgp session.
-    # so, let's wait for all bgp sessions to be up
+        Args:
+            node (object, optional): A value item of the dict type fixture 'nbrhosts'. Defaults to None.
+            results (Proxy to shared dict, optional): An instance of multiprocessing.Manager().dict(). Proxy to a dict
+                shared by all processes for returning execution results. Defaults to None.
+        """
+        if node is None or results is None:
+            logger.error('Missing kwarg "node" or "results"')
+            return
+
+        node_results = []
+        logger.info('enable graceful restart on neighbor host {}'.format(node['host'].hostname))
+        logger.info('bgp asn {}'.format(node['conf']['bgp']['asn']))
+        node_results.append(node['host'].eos_config(
+                lines=['graceful-restart restart-time 300'], \
+                parents=['router bgp {}'.format(node['conf']['bgp']['asn'])], \
+                module_ignore_errors=True)
+            )
+        node_results.append(node['host'].eos_config(
+                lines=['graceful-restart'], \
+                parents=['router bgp {}'.format(node['conf']['bgp']['asn']), 'address-family ipv4'], \
+                module_ignore_errors=True)
+            )
+        node_results.append(node['host'].eos_config(
+                lines=['graceful-restart'], \
+                parents=['router bgp {}'.format(node['conf']['bgp']['asn']), 'address-family ipv6'], \
+                module_ignore_errors=True)
+            )
+        results[node['host'].hostname] = node_results
+
+    results = parallel_run(configure_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
+
+    failed_results = {}
+    for node_name, node_results in results.items():
+        failed_node_results = [res for res in node_results if res['failed']]
+        if len(failed_node_results) > 0:
+            failed_results[node_name] = failed_node_results
+    if failed_results:
+        logger.error('failed_results => {}'.format(json.dumps(failed_results, indent=2)))
+        pt_assert(False, 'Some processes for configuring nbr hosts returned failed results')
+
     logger.info("bgp neighbors: {}".format(bgp_neighbors.keys()))
     if not wait_until(300, 10, duthost.check_bgp_session_state, bgp_neighbors.keys()):
         pytest.fail("not all bgp sessions are up after enable graceful restart")
@@ -45,14 +79,44 @@ def setup_bgp_graceful_restart(duthost, nbrhosts):
 
     yield
 
-    for k, nbr in nbrhosts.items():
+    def restore_nbr_gr(node=None, results=None):
+        """Target function will be used by multiprocessing for restoring configuration for the VM hosts.
+
+        Args:
+            node (object, optional): A value item of the dict type fixture 'nbrhosts'. Defaults to None.
+            results (Proxy to shared dict, optional): An instance of multiprocessing.Manager().dict(). Proxy to a dict
+                shared by all processes for returning execution results. Defaults to None.
+        """
+        if node is None or results is None:
+            logger.error('Missing kwarg "node" or "results"')
+            return
+
         # start bgpd if not started
-        nbr['host'].start_bgpd()
-        logger.info("disable graceful restart on neighbor {}".format(k))
-        nbr['host'].eos_config(lines=["no graceful-restart"], \
-                               parents=["router bgp {}".format(nbr['conf']['bgp']['asn']), "address-family ipv4"])
-        nbr['host'].eos_config(lines=["no graceful-restart"], \
-                               parents=["router bgp {}".format(nbr['conf']['bgp']['asn']), "address-family ipv6"])
+        node_results = []
+        node['host'].start_bgpd()
+        logger.info('disable graceful restart on neighbor {}'.format(k))
+        node_results.append(node['host'].eos_config(
+                lines=['no graceful-restart'], \
+                parents=['router bgp {}'.format(node['conf']['bgp']['asn']), 'address-family ipv4'], \
+                module_ignore_errors=True)
+            )
+        node_results.append(node['host'].eos_config(
+                lines=['no graceful-restart'], \
+                parents=['router bgp {}'.format(node['conf']['bgp']['asn']), 'address-family ipv6'], \
+                module_ignore_errors=True)
+            )
+        results[node['host'].hostname] = node_results
+
+    results = parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
+
+    failed_results = {}
+    for node_name, node_results in results.items():
+        failed_node_results = [res for res in node_results if res['failed']]
+        if len(failed_node_results) > 0:
+            failed_results[node_name] = failed_node_results
+    if failed_results:
+        logger.error('failed_results => {}'.format(json.dumps(failed_results, indent=2)))
+        pt_assert(False, 'Some processes for restoring nbr hosts returned failed results')
 
     if not wait_until(300, 10, duthost.check_bgp_session_state, bgp_neighbors.keys()):
         pytest.fail("not all bgp sessions are up after disable graceful restart")

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -799,7 +799,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         if stat in bgp_facts['bgp_statistics']:
             ret = bgp_facts['bgp_statistics'][stat]
         return ret;
-        
+
     def check_bgp_statistic(self, stat, value):
         val = self.get_bgp_statistic(stat)
         return val == value
@@ -844,8 +844,8 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         @param neighbor_ip: bgp neighbor IP
         """
         nbinfo = self.get_bgp_neighbor_info(neighbor_ip)
-        if nbinfo['bgpState'].lower() == "Active".lower():
-            if nbinfo['bgpStateIs'].lower() == "passiveNSF".lower():
+        if 'bgpState' in nbinfo and nbinfo['bgpState'].lower() == "Active".lower():
+            if 'bgpStateIs' in nbinfo and nbinfo['bgpStateIs'].lower() == "passiveNSF".lower():
                 return True
         return False
 

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -68,7 +68,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None):
         for p in running_processes:
             try:
                 os.kill(p.pid, signal.SIGKILL)
-            except:
+            except OSError:
                 pass
 
         pt_assert(False, \

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -1,0 +1,79 @@
+import datetime
+import logging
+import os
+import signal
+from multiprocessing import Process, Manager
+from tests.common.helpers.assertions import pytest_assert as pt_assert
+
+logger = logging.getLogger(__name__)
+
+
+def parallel_run(target, args, kwargs, nodes, timeout=None):
+    """Run target function on nodes in parallel
+
+    Args:
+        target (function): The target function to be executed in parallel.
+        args (list of tuple): List of arguments for the target function.
+        kwargs (dict): Keyword arguments for the target function. It will be extended with two keys: 'node' and
+            'results'. The 'node' key will hold an item of the nodes list. The 'result' key will hold an instance of
+            multiprocessing.Manager().dict(). It is a proxy of the shared dict that will be used by each process for
+            returning execution results.
+        nodes (list of nodes): List of nodes to be used by the target function
+        timeout (int or float, optional): Total time allowed for the spawned multiple processes to run. Defaults to
+            None. When timeout is specified, this function will wait at most 'timeout' seconds for the processes to
+            run. When time is up, this function will try to terminate or even kill all the processes.
+
+    Raises:
+        flag.: In case any of the spawned process cannot be terminated, fail the test.
+
+    Returns:
+        dict: An instance of multiprocessing.Manager().dict(). It is a proxy to the shared dict that is used by all the
+            spawned processes.
+    """
+    workers = []
+    results = Manager().dict()
+    start_time = datetime.datetime.now()
+    for node in nodes:
+        kwargs['node'] = node
+        kwargs['results'] = results
+        worker = Process(target=target, args=args, kwargs=kwargs)
+        worker.start()
+        logger.debug('Started process {} running target "{}"'.format(worker.pid, target.__name__))
+        workers.append(worker)
+
+    for worker in workers:
+        logger.debug('Wait for process "{}" to complete, timeout={}'.format(worker.pid, timeout))
+        worker.join(timeout)
+        logger.debug('Process "{}" completed'.format(worker.pid))
+
+        # If execution time of processes exceeds timeout, need to force terminate them all.
+        if timeout is not None:
+            if (datetime.datetime.now() - start_time).seconds > timeout:
+                logger.error('Process execution time exceeds {} seconds.'.format(str(timeout)))
+                break
+
+    # Force terminate spawned processes
+    for worker in workers:
+        if worker.is_alive():
+            logger.error('Process {} is still alive, try to force terminate it.'.format(worker.pid))
+            worker.terminate()
+
+    end_time = datetime.datetime.now()
+    delta_time = end_time - start_time
+
+    # Some processes cannot be terminated. Try to kill them and raise flag.
+    running_processes = [worker for worker in workers if worker.is_alive()]
+    if len(running_processes) > 0:
+        logger.error('Found processes still running: {}. Try to kill them.'.format(str(running_processes)))
+        for p in running_processes:
+            try:
+                os.kill(p.pid, signal.SIGKILL)
+            except:
+                pass
+
+        pt_assert(False, \
+            'Processes running target "{}" could not be terminated. Tried killing them. But please check'.format(target.__name__))
+
+    logger.info('Completed running processes for target "{}" in {} seconds'.format(target.__name__, str(delta_time)))
+
+    return results


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add a helper function to run a function in parallel for multiple nodes. Update the test_bgp_gr_helper test to use this new function to configure VM nodes in parallel.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_bgp_gr_helper.py script needs to configure each of the VM nodes one by one.
For topologies like t1 and t1-lag, it takes a long time to do that. This change

#### How did you do it?
* Added a helper function to run the configuration tasks in parallel using the python
  multiprocessing library.
* Updated the setup code for test_bgp_gr_helper to configure the VMs in parallel.

Without this change, the test_bgp_gr_helper.py script needs over 900 seconds to run
on t1-lag topology. With this change, testing time is decreased to around 200 seconds

#### How did you verify/test it?
Test run test_bgp_gr_helper using topologies t0 and t1-lag.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
