### PR TITLE
[show_vlan_config] Fix test_show_vlan_config

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -542,6 +542,7 @@ class TestShowVlan():
         dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan member add 100 {}'.format(ifmode, v_intf))
         show_vlan = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo show vlan config | grep -w "Vlan100"'.format(ifmode))['stdout']
         logger.info('show_vlan:\n{}'.format(show_vlan))
+        dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config vlan member del 100 {}'.format(ifmode, v_intf))
 
         assert v_intf in show_vlan
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
An interface is added to Vlan100 to test. However, the test script remove Vlan100 at the end of test without removing added interface. As a result, a WARNING log is printed and causes test error. This commit address the issue.
```
 'ERR swss#orchagent: :- removeVlan:Failed to remove non-empty VLAN Vlan100'
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix test error caused by removing Vlan100 without cleanup in test_show_vlan_config.
#### How did you do it?
Add a remove for added interface before test ends.
#### How did you verify/test it?
Verified on Celestica-DX010:
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_config
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 2 items                                                                                                                                                                                     

iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_config[alias] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
PASSED                                                                                                                                                                                          [ 50%]
iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_config[default] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
PASSED                                                                                                                                                                                          [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 2 passed in 126.09 seconds ======================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.