### PR TITLE
[test_feature] Fix test_show_features

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -6,15 +6,6 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def get_status_redisout(status_out):
-    """Extract status value for feature in redis
-    """
-    status_list = status_out[1:]
-    status = ""
-    for s in status_list:
-        status = s.encode('UTF-8')
-        return status
-
 # Test Functions
 def test_show_features(duthost):
     """Verify show features command output against CONFIG_DB
@@ -23,7 +14,5 @@ def test_show_features(duthost):
     pytest_assert(succeeded, "failed to obtain feature status")
     for cmd_key, cmd_value in features_dict.items():
         feature = str(cmd_key)
-        status_out = duthost.shell('/usr/bin/redis-cli -n 4 hgetall "FEATURE|{}"'.format(feature), module_ignore_errors=False)['stdout_lines']
-        redis_value = get_status_redisout(status_out)
-        status_value_expected = str(cmd_value)
-        assert str(redis_value) == status_value_expected, "'{}' is '{}' which does not match with config_db".format(cmd_key, cmd_value)
+        redis_value = duthost.shell('/usr/bin/redis-cli -n 4 hget "FEATURE|{}" "state"'.format(feature), module_ignore_errors=False)['stdout']
+        assert redis_value.lower() == cmd_value.lower(), "'{}' is '{}' which does not match with config_db".format(cmd_key, cmd_value)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -14,5 +14,5 @@ def test_show_features(duthost):
     pytest_assert(succeeded, "failed to obtain feature status")
     for cmd_key, cmd_value in features_dict.items():
         feature = str(cmd_key)
-        redis_value = duthost.shell('/usr/bin/redis-cli -n 4 hget "FEATURE|{}" "state"'.format(feature), module_ignore_errors=False)['stdout']
+        redis_value = duthost.shell('/usr/bin/redis-cli -n 4 --raw hget "FEATURE|{}" "state"'.format(feature), module_ignore_errors=False)['stdout']
         assert redis_value.lower() == cmd_value.lower(), "'{}' is '{}' which does not match with config_db".format(cmd_key, cmd_value)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -15,4 +15,4 @@ def test_show_features(duthost):
     for cmd_key, cmd_value in features_dict.items():
         feature = str(cmd_key)
         redis_value = duthost.shell('/usr/bin/redis-cli -n 4 --raw hget "FEATURE|{}" "state"'.format(feature), module_ignore_errors=False)['stdout']
-        assert redis_value.lower() == cmd_value.lower(), "'{}' is '{}' which does not match with config_db".format(cmd_key, cmd_value)
+        pytest_assert(redis_value.lower() == cmd_value.lower(), "'{}' is '{}' which does not match with config_db".format(cmd_key, cmd_value))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The code used for parsing redis output is not robust enough. As a result, the result is incorrect if the order for output of redis-cli is changed. This commit addressed the issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to address issue for parsing output of redis-cli to get feature enable status.
#### How did you do it?
Update the method to retrieve state from redis.
#### How did you verify/test it?
Verified on both Arista-7260 and Celestica-DX010
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util test_features.py
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 1 item                                                                                                                                                                                      

test_features.py::test_show_features PASSED                                                                                                                                                     [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
====================================================================================== 1 passed in 19.58 seconds ======================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.