### PR TITLE
[test_advanced_reboot] Add missing import for get_advanced_reboot

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from .args.normal_reboot_args import add_normal_reboot_args
 from .args.advanced_reboot_args import add_advanced_reboot_args
 from .args.cont_warm_reboot_args import add_cont_warm_reboot_args


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Recent PR #2239 removed import for ```get_advanced_reboot```, which caused test regression in test_advanced_reboot. 
```
E       fixture 'get_advanced_reboot' not found
>       available fixtures: __pytest_repeat_step_number, ansible_adhoc, ansible_facts, ansible_module, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, change_mac_addresses, check_dut_asic_type, collect_techsupport, config_logging, conn_graph_facts, copy_ptftests_directory, creds, disable_container_autorestart, doctest_namespace, duthost, duthosts, enhance_inventory, eos, fanouthosts, fib, localhost, loganalyzer, metadata, minigraph_facts, monkeypatch, nbrhosts, pdu, psu_controller, ptfadapter, ptfhost, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, reset_critical_services_list, sanity_check, scaled_vnet_params, skip_on_simx, tag_test_report, tbinfo, test_tacacs, test_tacacs_v6, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, vnet_config, vnet_test_params, worker_id
```
This PR is to address the issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix regression caused by #2239
#### How did you do it?
Add import for ```get_advanced_reboot```
#### How did you verify/test it?
Verified on Arista-7260
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util platform_tests/test_advanced_reboot.py::test_warm_reboot
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 1 item                                                                                                                                                                                      

platform_tests/test_advanced_reboot.py::test_warm_reboot ^@^@PASSED                                                                                                                                 [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 799.42 seconds ======================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.