### PR TITLE
[test_cont_warm_reboot] Correct fixture name for test_continuous_reboot

### DIFF
--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -42,7 +42,7 @@ def handle_test_error(health_check):
             logging.error("Health check {} failed with unknown error: {}".format(health_check.__name__, str(err)))
             self.test_report[health_check.__name__] = "Unkown error"
             self.sub_test_result = False
-            return            
+            return
         # set result to pass
         self.test_report[health_check.__name__] = True
     return _wrapper
@@ -86,7 +86,7 @@ class ContinuousReboot:
         self.fast_reboot_count = 0
         self.fast_reboot_pass = 0
         self.fast_reboot_fail = 0
-        
+
 
     def reboot_and_check(self):
         """
@@ -335,7 +335,7 @@ class ContinuousReboot:
             '/tmp/syslog',
             '/tmp/sairedis.rec',
             '/tmp/swss.rec']
-        
+
         if self.sub_test_result is True:
             test_dir = os.path.join(self.log_dir, "pass", str(self.reboot_count))
         else:
@@ -412,7 +412,7 @@ class ContinuousReboot:
             format(self.test_failures, self.reboot_count))
 
 
-def test_continuous_reboot(request, duthost, ptfhost, localhost, conn_graph_facts, testbed, creds):
+def test_continuous_reboot(request, duthost, ptfhost, localhost, conn_graph_facts, tbinfo, creds):
     """
     @summary: This test performs continuous reboot cycles on images that are provided as an input.
     Supported parameters for this test can be modified at runtime:
@@ -434,7 +434,7 @@ def test_continuous_reboot(request, duthost, ptfhost, localhost, conn_graph_fact
         Status of BGP neighbors - should be established
     """
     continuous_reboot = ContinuousReboot(request, duthost, ptfhost, localhost, conn_graph_facts)
-    continuous_reboot.start_continuous_reboot(request, duthost, ptfhost, localhost, testbed, creds)
+    continuous_reboot.start_continuous_reboot(request, duthost, ptfhost, localhost, tbinfo, creds)
     continuous_reboot.test_teardown()
 
 class ContinuousRebootError(Exception):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PR #2217 rename the 'testbed' fixture to 'tbinfo'. However, there is oneleft in test_cont_warm_reboot.py. This commit fix the issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to correct the fixture ```testbed``` to ```tbinfo``` referenced in ```test_continuous_reboot```.
#### How did you do it?
Correct the fixture ```testbed``` to ```tbinfo```.
#### How did you verify/test it?
Verified on Arista-7260.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level info --collect_techsupport=False --topology=t0,any,util platform_tests/test_cont_warm_reboot.py::test_continuous_reboot
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 1 item                                                                                                                                                                                      

platform_tests/test_cont_warm_reboot.py::test_continuous_reboot 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
==================== Start continuous reboot iteration: 1/3. Type: warm ====================
08:02:27 WARNING test_cont_warm_reboot.py:handle_image_installation:251: Continuing the test with current image
==================== End continuous reboot iteration: 1/3. Result: True ====================
==================== Start continuous reboot iteration: 2/3. Type: warm ====================
08:17:15 WARNING test_cont_warm_reboot.py:handle_image_installation:251: Continuing the test with current image
==================== End continuous reboot iteration: 2/3. Result: True ====================
==================== Start continuous reboot iteration: 3/3. Type: warm ====================
08:31:26 WARNING test_cont_warm_reboot.py:handle_image_installation:251: Continuing the test with current image
==================== End continuous reboot iteration: 3/3. Result: True ====================
PASSED                                                                                                                                                                                          [100%]
------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 2658.43 seconds =====================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.