### PR TITLE
[library/action_sync.py]: This module will make sure that actions such as add-topo, deploy-mg and remove-topo are in sync with current topo.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -189,6 +189,13 @@
       become: true
 
   - block:
+      - name: call action sync
+        action_sync: action="deploy-mg" topo={{ testbed_name }} dut={{ dut }} server={{ server }}
+        connection: local
+        register: action_sync_result
+
+      - debug: msg="{{ action_sync_result }}"
+
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true

--- a/ansible/library/action_sync.py
+++ b/ansible/library/action_sync.py
@@ -1,0 +1,261 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+from ansible.module_utils.basic import *
+from datetime import datetime
+
+import shelve
+
+DOCUMENTATION = '''
+---
+module: action_sync
+version_added:
+author: Praveen Chaudhary (pchaudhary@linkedin.com)
+
+description:
+    - this module will store below DB with information about topology,
+    dut and server.
+    - DB format: {
+        current_topo: {
+            topo_name: "<topo_topo_name>",
+            "deploy-mg": "<True\False>",
+            "dut": <dut>,
+            "server: <server>
+        },
+        actions : {
+            success: [
+                "add-topo <topo_topo_name> <dut> <server>",
+                "deploy-mg <topo_topo_name> <dut> <server>",
+                "run_test <test-topo_name> <topo_topo_name> <dut> <server>",
+            ],
+            failures: [
+                "deploy-mg <topo_topo_name> <dut> <server>",
+                "run_test <topo_topo_name> <dut> <server>",
+                "run_test <test-topo_name> <topo_topo_name> <dut> <server>",
+            ]
+        }
+    }
+    - to start with current_topo will be None, or will not exist, or DB will
+    not exist. All 3 will be treated as current_topo == None.
+
+    - if action is add_topo, makes sure current_topo is None. Else fail. Fill
+    new information with current_topo['deploy-mg'] is False.
+
+    - if action is deploy-mg, makes sure current_topo['topo_name'] == topo. Match
+    dut and server too. Set current_topo['topo_name'] == True.
+
+    - run_test: Make Sure, deploy-mg it True.
+    - remove-topo: makes sure current_topo['topo_name'] == topo. Match
+    dut and server too. Assign current_topo == None.
+    - For each action, store it in either action['success'] or action['failures'].
+
+    Note:
+    - deploy-mg may not be necessary always after add topo, for that we can add
+    avoid deploy-mg parameter later or keep deploy-mg == True in DB.
+    - add-topo can be issues on same topo again.
+'''
+
+EXAMPLES = '''
+ - topo_name: test action sync
+    action_sync: action={{ action }} topo={{ topo_name }} dut = {{ dut }}
+        server = {{ server }} test_name={{ test_name}}
+    connection: local
+    register: action_sync
+'''
+
+MaxLogLen = 5
+
+class ActionSync(object):
+    def __init__(self):
+        self.module = AnsibleModule(
+            argument_spec=dict(
+              action=dict(required=True, type='str'),
+              topo =dict(required=True, type='str'),
+              dut=dict(required=True, type='str'),
+              server=dict(required=True, type='str'),
+              test_name=dict(required=False, type='str'),
+            ),
+            supports_check_mode=True)
+
+        self.action = self.module.params['action']
+        self.topo = self.module.params['topo']
+        self.dut = self.module.params['dut']
+        self.server = self.module.params['server']
+        self.test_name = self.module.params.get('test_name')
+
+        # class variables
+        self.file = "actionDb"
+
+        # DB & Results
+        self.db = self.readDbFile()
+
+        return
+
+    def run(self):
+        """
+            Main method of the class
+
+        """
+        try :
+            # init DB, If Not Created.
+            if len(self.db) == 0:
+                self.initDB()
+
+            if self.action == "add-topo":
+                self.processAddTopo()
+            elif self.action == "deploy-mg":
+                self.processDeploMg()
+            elif self.action == "run-tests":
+                self.processRunTests()
+            elif self.action == "remove-topo":
+                self.processRemoveTopo()
+            else:
+                raise Exception("Wrong Action:{}".format(self.action))
+
+            self.facts   =  {'action_sync': dict(self.db)}
+            self.db.close()
+            self.module.exit_json(ansible_facts=self.facts)
+        except Exception as e:
+            self.facts   =  {'action_sync': dict(self.db)}
+            self.db.close()
+            self.module.fail_json(msg="{}".format(e), ansible_facts=self.facts)
+
+        return
+
+    def processAddTopo(self):
+
+        d = self.db['current_topo']
+
+        '''
+            if None add this topo, or same topo is loaded already.
+            Later is needed if add-topo failed at later stages.
+        '''
+        if d is None or (d['topo_name'] == self.topo and d['dut'] == self.dut and \
+            d['server'] == self.server):
+
+            d = dict()
+            d['topo_name'] = self.topo
+            d['deploy-mg'] = False
+            d['dut'] = self.dut
+            d['server'] = self.server
+            self.db['current_topo'] = d
+            self.logSuccess()
+        else:
+            self.logFailure()
+            raise Exception("{} failed".format(self.action))
+        return
+
+    def processDeploMg(self):
+
+        d = self.db['current_topo']
+
+        '''
+            Deploy Mg if same setup and topo is added.
+        '''
+        if d is None or d['topo_name'] != self.topo or d['dut'] != self.dut or \
+            d['server'] != self.server:
+
+            self.logFailure()
+            raise Exception("{} failed".format(self.action))
+        else:
+            d['deploy-mg'] = True
+            self.db['current_topo'] = d
+            self.logSuccess()
+
+        return
+
+    def processRemoveTopo(self):
+
+        d = self.db['current_topo']
+
+        '''
+            Remove Topo if same setup and topo is added.
+        '''
+        if d is None or d['topo_name'] != self.topo or d['dut'] != self.dut or \
+            d['server'] != self.server:
+
+            self.logFailure()
+            raise Exception("{} failed".format(self.action))
+        else:
+            self.db['current_topo'] = None
+            self.logSuccess()
+
+        return
+
+    def processRunTests(self):
+
+        d = self.db['current_topo']
+
+        if self.test_name is None:
+            self.logFailure()
+            raise Exception("No test_name Provided")
+
+        # if None add this topo
+        if d is None or d['topo_name'] != self.topo or d['dut'] != self.dut or \
+            d['server'] != self.server:
+
+            self.logFailure()
+            raise Exception("{} failed".format(self.action))
+        else:
+            self.logSuccess()
+
+
+    def logSuccess(self):
+
+        log = "{}: {} topo={} dut={} server={}".format(datetime.now(), \
+            self.action, self.topo, self.dut, self.server)
+        if self.action == "run-tests" and self.test_name is not None:
+            log = log + " test=" + self.test_name
+
+        d = self.db['actions']
+
+        if len(d['success']) == MaxLogLen:
+            d['success'].pop(0)
+
+        d['success'].append(log)
+        self.db['actions'] = d
+
+        self.logFailure(logAs='SUCC')
+        return
+
+    def logFailure(self, logAs='FAIL'):
+
+        log = "{}: -{}- {} topo={} dut={} server={}".format(datetime.now(), \
+            logAs, self.action, self.topo, self.dut, self.server)
+        if self.action == "run-tests" and self.test_name is not None:
+            log = log + " test=" + self.test_name
+
+        d = self.db['actions']
+
+        if len(d['all']) == 2*MaxLogLen:
+            d['all'].pop(0)
+
+        d['all'].append(log)
+        self.db['actions'] = d
+
+        return
+
+    def initDB(self):
+        self.db['current_topo'] = None
+        self.db['actions'] = {
+            'success': [],
+            'all': []
+        }
+
+        return
+
+    def readDbFile(self):
+        """
+            Function to read shelve DB file
+            TODO: Take lock.
+        """
+        return shelve.open(self.file)
+
+def main():
+    actionSync = ActionSync()
+    actionSync.run()
+
+    return
+
+if __name__ == "__main__":
+    main()

--- a/ansible/library/action_sync.py
+++ b/ansible/library/action_sync.py
@@ -28,7 +28,7 @@ description:
                 "deploy-mg <topo_topo_name> <dut> <server>",
                 "run_test <test-topo_name> <topo_topo_name> <dut> <server>",
             ],
-            failures: [
+            all: [
                 "deploy-mg <topo_topo_name> <dut> <server>",
                 "run_test <topo_topo_name> <dut> <server>",
                 "run_test <test-topo_name> <topo_topo_name> <dut> <server>",
@@ -47,7 +47,7 @@ description:
     - run_test: Make Sure, deploy-mg it True.
     - remove-topo: makes sure current_topo['topo_name'] == topo. Match
     dut and server too. Assign current_topo == None.
-    - For each action, store it in either action['success'] or action['failures'].
+    - For each action, store it in either action['success'] or action['all'].
 
     Note:
     - deploy-mg may not be necessary always after add topo, for that we can add
@@ -63,7 +63,7 @@ EXAMPLES = '''
     register: action_sync
 '''
 
-MaxLogLen = 5
+MaxLogLen = 25
 
 class ActionSync(object):
     def __init__(self):
@@ -198,7 +198,6 @@ class ActionSync(object):
             raise Exception("{} failed".format(self.action))
         else:
             self.logSuccess()
-
 
     def logSuccess(self):
 

--- a/ansible/test_sonic.yml
+++ b/ansible/test_sonic.yml
@@ -14,6 +14,14 @@
 
 
 - hosts: sonic
+  pre_tasks:
+  - name: call action sync
+    action_sync: action="run-tests" topo={{ testbed_name }} dut={{ inventory_hostname }}  server={{ server }} test_name={{ testcase_name }}
+    connection: local
+    register: action_sync_result
+
+  - debug: msg="{{ action_sync_result }}"
+
   roles:
     - { role: test, scope: 'sonic' }
   force_handlers: true

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -70,6 +70,21 @@
     fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"
     when: ptf_imagename is not defined
 
+  - name: Check that variable topo_name is defined
+    fail: msg="Define topo_name"
+    when: topo_name is not defined
+
+  - name: Check that variable server is defined
+    fail: msg="Define server"
+    when: server is not defined
+
+  - name: call action sync
+    action_sync: action="add-topo" topo={{ topo_name }} dut={{ dut_name }} server={{ server }}
+    connection: local
+    register: action_sync_result
+
+  - debug: msg="{{ action_sync_result }}"
+
   - name: Load topo variables
     include_vars: "vars/topo_{{ topo }}.yml"
 

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -47,6 +47,21 @@
     fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"
     when: ptf_imagename is not defined
 
+  - name: Check that variable topo_name is defined
+    fail: msg="Define topo_name"
+    when: topo_name is not defined
+
+  - name: Check that variable server is defined
+    fail: msg="Define server"
+    when: server is not defined
+
+  - name: call test action sync
+    action_sync: action="remove-topo" topo={{ topo_name }} dut={{ dut_name }} server={{ server }}
+    connection: local
+    register: action_sync_result
+
+  - debug: msg="{{ action_sync_result }}"
+
   - name: Load topo variables
     include_vars: "vars/topo_{{ topo }}.yml"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

[library/action_sync.py]: This module will make sure that actions such as add-topo, deploy-mg and remove-topo are in sync with current topo.

    Changes:
    -- New ansible module to make sure add-topo, deploy-mg and remove-topo are in sync.
    -- related changes in other playbooks.

    How I did:
    -- Use shelve to store a DB in a file.
    -- DB will have info about current topo, dut and server.
    -- This will make sure, a topo is removed before adding new one.
    -- Also deploy-mg, remove-topo will be allowed only for currently loaded topo.

Note: I did it for add-topo, deploy-mg and remove-topo , but can be extended for renumber etc.

    Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
    How I did:
    -- Use shelve to store a DB in a file.
    -- DB will have info about current topo, dut and server.
    -- This will make sure, a topo is removed before adding new one.
    -- Also deploy-mg, remove-topo will be allowed only for currently loaded topo.

#### What is the motivation for this PR?
Today from same sonic-mgmt docker, 2 users may end up running 2 separate add-topo commands which may messed up the Setup. Ideally deploy-mg, remove-topo should be allowed only for currently loaded topo. And add-topo must be allowed only after removing current-topo.
With this PR I use a shelve DB, which makes sure actions are in sync. Also it stored last executed commands.

#### How did you do it?
    How I did:
    -- Use shelve to store a DB in a file.
    -- DB will have info about current topo, dut and server.
    -- This will make sure, a topo is removed before adding new one.
    -- Also deploy-mg, remove-topo will be allowed only for currently loaded topo.

#### How did you verify/test it?
Testing is recorded in a video, But below I copied 

Steps:
1.) $ ./testbed-cli.sh add-topo vms-celdx10-t1-16 ~/.password -e ptf_imagetag=202006 -vvv

2.) $ ./testbed-cli.sh add-topo vms-celdx10-t1-8 ~/.password -e ptf_imagetag=202006 -vvv

If fails due to prev topo:
```
                    "2020-09-29 18:26:18.426128: -SUCC- add-topo topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2",
                    "2020-09-29 18:30:12.101652: -SUCC- run-tests topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2 test=bgp_facts"
,
                    "2020-09-29 18:30:41.133856: -SUCC- run-tests topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2 test=bgp_fact",
                    "2020-09-29 22:04:59.211082: -FAIL- add-topo topo=vms-celdx10-t1-8 dut=falco-open19-flex server=server_2"
                ],
                "success": [
                    "2020-09-29 17:09:04.402483: run-tests topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2 test=bgp_facts",
                    "2020-09-29 17:11:13.223194: remove-topo topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2",
                    "2020-09-29 18:26:18.425939: add-topo topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2",
                    "2020-09-29 18:30:12.101459: run-tests topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2 test=bgp_facts",
                    "2020-09-29 18:30:41.133659: run-tests topo=vms-celdx10-t1-16 dut=falco-test-dut04 server=server_2 test=bgp_fact"
                ]
            },
            "current_topo": {
                "deploy-mg": false,
                "dut": "falco-test-dut04",
                "server": "server_2",
                "topo_name": "vms-celdx10-t1-16"
            }
```
./testbed-cli.sh deploy-mg vms-celdx10-t0-8 lab ~/.password
FAIL
```
                    "2020-09-29 22:04:59.211082: -FAIL- deploy-mg topo=vms-celdx10-t1-8 dut=falco-open19-flex server=server_2"
                ],
                "success": [ .... ]
            },
            "current_topo": {
                "deploy-mg": false,
                "dut": "falco-test-dut04",
                "server": "server_2",
                "topo_name": "vms-celdx10-t1-16"
            }
```


3.) ./testbed-cli.sh deploy-mg vms-celdx10-t0-16 lab ~/.password

PASS
```
            "current_topo": {
                "deploy-mg": true,
                "dut": "falco-test-dut04",
                "server": "server_2",
                "topo_name": "vms-celdx10-t1-16"
            }

```

4.) ./testbed-cli.sh run-tests vms-celdx10-t0-16 lab bgp_facts
PASS
5.) ./testbed-cli.sh remove-topo vms-celdx10-t1-8 ~/.password -vvv


               "2020-09-29 22:09:47.984047: -FAIL- remove-topo topo=vms-celdx10-t1-8 dut=falco-open19-flex server=server_2"
                ],
                "success": [.....]
            },
            "current_topo": {
                "deploy-mg": false,
                "dut": "falco-test-dut04",
                "server": "server_2",
                "topo_name": "vms-celdx10-t1-16"
            }
```
6.) ./testbed-cli.sh remove-topo vms-celdx10-t1-16 ~/.password -vvv
PASS

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
