### PR TITLE
[acl] Make Config DB recovery more robust

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -14,6 +14,7 @@ import ptf.packet as packet
 
 from tests.common import reboot, port_toggle
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +190,8 @@ def acl_table_config(duthost, setup, stage):
     }
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
+@pytest.mark.usefixtures("backup_and_restore_config_db")
 def acl_table(duthost, acl_table_config):
     """
     fixture to apply ACL table configuration and remove after tests
@@ -222,9 +224,6 @@ def acl_table(duthost, acl_table_config):
         with loganalyzer:
             logger.info('removing ACL table {}'.format(name))
             duthost.command('config acl remove table {}'.format(name))
-
-        # save cleaned configuration
-        duthost.command('config save -y')
 
 
 class BaseAclTest(object):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -14,7 +14,7 @@ import ptf.packet as packet
 
 from tests.common import reboot, port_toggle
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_module
 
 logger = logging.getLogger(__name__)
 
@@ -191,8 +191,7 @@ def acl_table_config(duthost, setup, stage):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.usefixtures("backup_and_restore_config_db")
-def acl_table(duthost, acl_table_config):
+def acl_table(duthost, acl_table_config, backup_and_restore_config_db_module):
     """
     fixture to apply ACL table configuration and remove after tests
     :param duthost: DUT object

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -3,17 +3,36 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-@pytest.fixture
-def backup_and_restore_config_db(duthost):
-    """
-    Some cases will shutdown interfaces or BGP in test, and the change is writen to
-    config db after warm-reboot. Therefore, we need to backup config_db.json before
-    test starts and then restore after test ends
+
+def _backup_and_restore_config_db(duthost):
+    """Back up the existing config_db.json file and restore it once the test ends.
+
+    Some cases will update the running config during the test and save the config
+    to be recovered aftet reboot. In such a case we need to backup config_db.json before
+    the test starts and then restore it after the test ends.
     """
     CONFIG_DB = "/etc/sonic/config_db.json"
     CONFIG_DB_BAK = "/etc/sonic/config_db.json.before_test"
     logger.info("Backup {} to {}".format(CONFIG_DB, CONFIG_DB_BAK))
     duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
+
     yield
+
     logger.info("Restore {} with {}".format(CONFIG_DB, CONFIG_DB_BAK))
     duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
+
+
+@pytest.fixture
+def backup_and_restore_config_db(duthost):
+    """Back up and restore config DB at the function level."""
+    # TODO: Use the neater "yield from _function" syntax when we move to python3
+    for func in _backup_and_restore_config_db(duthost):
+        yield func
+
+
+@pytest.fixture(scope="module")
+def backup_and_restore_config_db_module(duthost):
+    """Back up and restore config DB at the module level."""
+    # TODO: Use the neater "yield from _function" syntax when we move to python3
+    for func in _backup_and_restore_config_db(duthost):
+        yield func


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Make Config DB recovery more robust
Fixes #2292

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
It is possible for loganalyzer to throw an exception during table removal and never reach the `config save -y` step in the finally block. This leaves the `config_db.json` in a bad state, which can cause strange issues for downstream tests if `config reload` or a reboot are issued.

#### How did you do it?
I took advantage of the newly added `backup_and_restore` fixture to restore the `config_db.json` rather than relying on the `finally` block to work every time.

#### How did you verify/test it?
Ran the test locally, verified that the `config_db.json` was the same before and after. Going to go back and validate this works for 201911 as well as master.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
