### PR TITLE
[drop counters] Disable IGMP test for testbeds without proper fanout support

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -664,6 +664,11 @@ def test_non_routable_igmp_pkts(do_test, ptfadapter, duthost, setup, tx_dut_port
     # records=[gr_obj]).build()
     # The rest packets are build like "simple_igmp_packet" function from PTF testutils.py
 
+    # FIXME: Need some sort of configuration for EOS and SONiC fanout hosts to
+    # not drop IGMP packets before they reach the DUT
+    if not fanouthost:
+        pytest.skip("Test case requires explicit fanout support")
+
     from scapy.contrib.igmp import IGMP
     Ether = testutils.scapy.Ether
     IP = testutils.scapy.IP

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -635,7 +635,7 @@ def test_unicast_ip_incorrect_eth_dst(do_test, ptfadapter, duthost, setup, tx_du
 
 @pytest.mark.parametrize("igmp_version,msg_type", [("v1", "general_query"), ("v3", "general_query"), ("v1", "membership_report"),
 ("v2", "membership_report"), ("v3", "membership_report"), ("v2", "leave_group")])
-def test_non_routable_igmp_pkts(do_test, ptfadapter, duthost, setup, tx_dut_ports, pkt_fields, igmp_version, msg_type, ports_info):
+def test_non_routable_igmp_pkts(do_test, ptfadapter, duthost, setup, fanouthost, tx_dut_ports, pkt_fields, igmp_version, msg_type, ports_info):
     """
     @summary: Create an IGMP non-routable packets.
     """


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [drop counters] Disable IGMP test for testbeds without proper fanout support

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We notice that our root fanout switch is dropping all of the IGMP packets, so they are unable to reach the DUT at all, causing the test to fail. We need to add some sort of configuration to EOS/SONiC based fanouts so that they deliver these packets to the DUT.

#### How did you do it?
Added a check for `fanout`.

#### How did you verify/test it?
Ran the tests in the lab, saw that all the IGMP cases were skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
