### PR TITLE
[pfcwd] Fix the failure to start pfc_gen.py

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -174,9 +174,9 @@ class PFCStorm(object):
             with open(self.extra_vars['template_path']) as tmpl_fd:
                 tmpl = Template(tmpl_fd.read())
                 cmds = tmpl.render(**self.extra_vars).splitlines()
-            for cmd in (_.strip() for _ in cmds):
-                if cmd:
-                    self.peer_device.shell(cmd, module_ignore_errors=True)
+            cmds = (_.strip() for _ in cmds)
+            cmd = "; ".join(_ for _ in cmds if _)
+            self.peer_device.shell(cmd, module_ignore_errors=True)
         else:
             # TODO: replace this playbook execution with Mellanox
             # onyx_config/onyx_command modules


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Joining the commands together before running them with `shell` module.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For `SONiC` fanout, it fails to start `pfc_gen.py` because it fails to find `pfc_gen.py` since it is a relative path in the command and there are two `ssh` sessions to run `cd` and `pfc_gen.py` commands.

#### How did you do it?

#### How did you verify/test it?
```
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions PASSED                                           [100%]
pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore PASSED                    [100%]
pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy PASSED                          [100%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[no_storm] PASSED                                     [100%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[storm] PASSED                                        [100%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm] PASSED                                  [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
