### PR TITLE
[everflow] Make monitor port parsing more robust

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -595,18 +595,16 @@ class BaseEverflowTest(object):
 
     def _get_monitor_port(self, setup, mirror_session, duthost):
         mirror_output = duthost.command("show mirror_session")
-        logging.info("mirror session configuration: %s", mirror_output["stdout"])
+        logging.info("Running mirror session configuration:\n%s", mirror_output["stdout"])
 
-        pytest_assert(mirror_session["session_name"] in mirror_output["stdout"],
-                      "Test mirror session {} not found".format(mirror_session["session_name"]))
+        matching_session = list(filter(lambda line: line.startswith(mirror_session["session_name"]),
+                                       mirror_output["stdout_lines"]))
+        pytest_assert(matching_session, "Test mirror session {} not found".format(mirror_session["session_name"]))
+        logging.info("Found mirror session:\n%s", matching_session[0])
 
-        pytest_assert(len(mirror_output["stdout_lines"]) == 3,
-                      "Unexpected number of mirror sesssions:\n{}".format(mirror_output["stdout"]))
-
-        monitor_intf = mirror_output["stdout_lines"][2].split()[-1:][0]
-
-        pytest_assert(monitor_intf in setup["port_index_map"],
+        monitor_port = matching_session[0].split()[-1]
+        pytest_assert(monitor_port in setup["port_index_map"],
                       "Invalid monitor port:\n{}".format(mirror_output["stdout"]))
-        logging.info("selected monitor interface %s (port=%s)", monitor_intf, setup["port_index_map"][monitor_intf])
+        logging.info("Selected monitor port %s (index=%s)", monitor_port, setup["port_index_map"][monitor_port])
 
-        return setup["port_index_map"][monitor_intf]
+        return setup["port_index_map"][monitor_port]


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [everflow] Make monitor port parsing more robust
Fixes #2290 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Monitor port parsing breaks in the master image b/c it now includes SPAN info as well as ERSPAN info.

#### How did you do it?
I updated the parsing to look for a specific line by the mirror session name rather than hard-coding which line to look at in the output.

#### How did you verify/test it?
Ran test against master image as well as 201911 image:
```
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[cli] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
22:02:34 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:02:34 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
22:02:35 INFO __init__.py:loganalyzer:32: Add start marker into DUT syslog
22:02:36 INFO __init__.py:loganalyzer:34: Load config and analyze log
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
22:02:38 INFO everflow_test_utilities.py:_get_monitor_port:598: Running mirror session configuration:
ERSPAN Sessions
Name            Status    SRC IP    DST IP      GRE    DSCP    TTL  Queue    Policer    Monitor Port    SRC Port    Direction
--------------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------
test_session_1  active    1.1.1.1   2.2.2.2   35006       8      1                      Ethernet0

SPAN Sessions
Name    Status    DST Port    SRC Port    Direction    Queue    Policer
------  --------  ----------  ----------  -----------  -------  ---------
22:02:38 INFO everflow_test_utilities.py:_get_monitor_port:603: Found mirror session:
test_session_1  active    1.1.1.1   2.2.2.2   35006       8      1                      Ethernet0
22:02:38 INFO everflow_test_utilities.py:_get_monitor_port:608: Selected monitor port Ethernet0 (index=0)
22:02:38 INFO everflow_test_utilities.py:send_and_check_mirror_packets:492: Received packet: Ether / IP / GRE / ERSPAN / 60:00:00:00:00:2e > 66:56:c2:00:86:dd (0x640) / Raw
22:02:38 INFO everflow_test_utilities.py:send_and_check_mirror_packets:495: Received inner packet: Ether / IPv6 / TCP ffbe:225:7c6b:e000::10:12012 > ffbe:225:7c6b:f000::10:12013 A / Raw
22:02:38 INFO everflow_test_utilities.py:send_and_check_mirror_packets:515: Expected inner packet: Ether / IPv6 / TCP ffbe:225:7c6b:e000::10:12012 > ffbe:225:7c6b:f000::10:12013 A / Raw
PASSED
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
