### PR TITLE
[drop counters] Shut link from fanout side for test_egress_drop_on_down_link

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -3,10 +3,14 @@ import os
 import importlib
 import netaddr
 import pytest
+import time
 
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.device_utils import fanout_switch_port_lookup
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"
@@ -142,40 +146,36 @@ def setup(duthost, tbinfo):
 
 
 @pytest.fixture
-def rif_port_down(duthost, setup, loganalyzer):
-    """ Disable RIF interface and return neighbor IP address attached to this interface """
+def rif_port_down(duthost, setup, fanouthosts):
+    """Shut RIF interface and return neighbor IP address attached to this interface.
+
+    The RIF member is shut from the fanout side so that the ARP entry remains in
+    place on the DUT."""
     wait_after_ports_up = 30
 
     if not setup["rif_members"]:
         pytest.skip("RIF interface is absent")
     rif_member_iface = setup["rif_members"].keys()[0]
 
-    try:
-        vm_name = setup["mg_facts"]["minigraph_neighbors"][rif_member_iface]["name"]
-    except KeyError as err:
-        pytest.fail("Didn't found RIF interface in 'minigraph_neighbors'. {}".format(str(err)))
+    vm_name = setup["mg_facts"]["minigraph_neighbors"][rif_member_iface].get("name", None)
+    pytest_assert(vm_name, 'Neighbor not found for RIF member "{}"'.format(rif_member_iface))
 
     ip_dst = None
     for item in setup["mg_facts"]["minigraph_bgp"]:
-        if item["name"] == vm_name:
-            if netaddr.valid_ipv4(item["addr"]):
-                ip_dst = item["addr"]
-                break
-    else:
-        pytest.fail("Unable to find neighbor in 'minigraph_bgp' list")
+        if item["name"] == vm_name and netaddr.valid_ipv4(item["addr"]):
+            ip_dst = item["addr"]
+            break
+    pytest_assert(ip_dst, 'Unable to find IP address for neighbor "{}"'.format(vm_name))
 
-    loganalyzer.expect_regex = [LOG_EXPECT_PORT_ADMIN_DOWN_RE.format(rif_member_iface)]
-    with loganalyzer as analyzer:
-        duthost.command("config interface shutdown {}".format(rif_member_iface))
+    fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, rif_member_iface)
 
+    fanout_neighbor.shutdown(fanout_intf)
     time.sleep(1)
 
     yield ip_dst
 
-    loganalyzer.expect_regex = [LOG_EXPECT_PORT_ADMIN_UP_RE.format(rif_member_iface)]
-    with loganalyzer as analyzer:
-        duthost.command("config interface startup {}".format(rif_member_iface))
-        time.sleep(wait_after_ports_up)
+    fanout_neighbor.no_shutdown(fanout_intf)
+    time.sleep(wait_after_ports_up)
 
 
 @pytest.fixture(params=["port_channel_members", "vlan_members", "rif_members"])


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [drop counters] Shut link from fanout side for test_egress_drop_on_down_link

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_egress_drop_on_down_link test case was not passing reliably for us. We figured out that this is because the test is shutting the neighbor link from the DUT side. When this happens, the ARP entry for that interface is cleared, so the packets destined for the neighbor IP hit the default route rather than the bad ARP entry, so the packets are not dropped.

#### How did you do it?
Use the `fanout_switch_port_lookup` utility to get the corresponding fanout interface and shut that port down instead. This leaves the ARP entry intact and triggers the desired drops.

#### How did you verify/test it?
Ran test locally, it now passes reliably.
```
drop_packets/test_drop_counters.py::test_egress_drop_on_down_link[rif_members]
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
23:40:49 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
23:40:49 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
23:40:50 INFO __init__.py:loganalyzer:32: Add start marker into DUT syslog
23:40:51 INFO __init__.py:loganalyzer:34: Load config and analyze log
23:40:57 INFO devices.py:shutdown:1098: Shut interface [Ethernet57/1]
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
23:41:00 INFO drop_packets.py:log_pkt_params:206: Selected TX interface on DUT - Ethernet104
23:41:00 INFO drop_packets.py:log_pkt_params:207: Packet DST MAC - 00:e0:ec:c2:ae:74
23:41:00 INFO drop_packets.py:log_pkt_params:208: Packet SRC MAC - 1a:7c:31:5c:5a:1a
23:41:00 INFO drop_packets.py:log_pkt_params:209: Packet IP DST - 10.0.0.49
23:41:00 INFO drop_packets.py:log_pkt_params:210: Packet IP SRC - 1.1.1.1
PASSED                                                                                                                                                                                                       [100%]
------------------------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------------------------
23:41:17 INFO devices.py:no_shutdown:1105: No shut interface [Ethernet57/1]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
