### PR TITLE
[sanity-check]: Fix UnboundLocalError when post-check fails

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -134,7 +134,7 @@ def sanity_check(localhost, duthost, request, fanouthosts, tbinfo):
     logger.info("!!!!!!!!!!!!!!!! Post-test sanity check results: !!!!!!!!!!!!!!!!\n%s" % \
                 json.dumps(post_check_results, indent=4))
     if any([result["failed"] for result in post_check_results]):
-        failed_items = json.dumps([result for result in new_check_results if result["failed"]], indent=4)
+        failed_items = json.dumps([result for result in post_check_results if result["failed"]], indent=4)
         logger.error("Failed check items:\n{}".format(failed_items))
         pytest.fail("Post-test sanity check failed with failed items:\n{}".format(failed_items))
         return


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Dump the correct check results variable when the post-test sanity check fails.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When dumping failed post check items to stack trace, code would previously reference pre-test check results by mistake.
#### How did you do it?
Use the correct variable name 🤦‍♂️
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
