### PR TITLE
[pytest] Skip testing the auto-restart feature of radv container on T1 devices

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -215,7 +215,7 @@ def test_containers_autorestart(duthost, tbinfo):
     for container_name in container_autorestart_states.keys():
         # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
         if (container_name in disabled_containers or container_name == "database"
-                or (container_name == "radv" and tbinfo["topo"]["type"] != "t1")):
+                or (container_name == "radv" and tbinfo["topo"]["type"] != "t0")):
             logger.warning("Skip testing the container '{}'".format(container_name))
             continue
 

--- a/tests/autorestart_test/test_container_autorestart.py
+++ b/tests/autorestart_test/test_container_autorestart.py
@@ -215,7 +215,7 @@ def test_containers_autorestart(duthost, tbinfo):
     for container_name in container_autorestart_states.keys():
         # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
         if (container_name in disabled_containers or container_name == "database"
-                or (container_name == "radv" and tbinfo["topo"]["name"] == "t1")):
+                or (container_name == "radv" and tbinfo["topo"]["name"] in ["t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"])):
             logger.warning("Skip testing the container '{}'".format(container_name))
             continue
 

--- a/tests/autorestart_test/test_container_autorestart.py
+++ b/tests/autorestart_test/test_container_autorestart.py
@@ -215,7 +215,7 @@ def test_containers_autorestart(duthost, tbinfo):
     for container_name in container_autorestart_states.keys():
         # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
         if (container_name in disabled_containers or container_name == "database"
-                or (container_name == "radv" and tbinfo["topo"]["name"] in ["t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"])):
+                or (container_name == "radv" and tbinfo["topo"]["type"] != "t1")):
             logger.warning("Skip testing the container '{}'".format(container_name))
             continue
 

--- a/tests/autorestart_test/test_container_autorestart.py
+++ b/tests/autorestart_test/test_container_autorestart.py
@@ -213,7 +213,7 @@ def test_containers_autorestart(duthost, tbinfo):
     disabled_containers = get_disabled_container_list(duthost)
 
     for container_name in container_autorestart_states.keys():
-        # Skip testing the database container or containers/services which are disabled
+        # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
         if (container_name in disabled_containers or container_name == "database"
                 or (container_name == "radv" and tbinfo["topo"]["name"] == "t1")):
             logger.warning("Skip testing the container '{}'".format(container_name))

--- a/tests/autorestart_test/test_container_autorestart.py
+++ b/tests/autorestart_test/test_container_autorestart.py
@@ -117,7 +117,7 @@ def kill_process_by_pid(duthost, container_name, program_name, program_pid):
 
     # Get the exit code of 'kill' command
     exit_code = kill_cmd_result["rc"]
-    if exit_code !=  0:
+    if exit_code != 0:
         pytest.fail("Failed to stop program '{}' before test".format(program_name))
 
     logger.info("Program '{}' in container '{}' was stopped successfully"
@@ -203,7 +203,7 @@ def verify_no_autorestart_with_non_critical_process(duthost, container_name, pro
     duthost.shell("docker exec {} supervisorctl start {}".format(container_name, program_name))
 
 
-def test_containers_autorestart(duthost):
+def test_containers_autorestart(duthost, tbinfo):
     """
     @summary: Test the auto-restart feature of each container against two scenarios: killing
               a non-critical process to verify the container is still running; killing each
@@ -214,7 +214,8 @@ def test_containers_autorestart(duthost):
 
     for container_name in container_autorestart_states.keys():
         # Skip testing the database container or containers/services which are disabled
-        if container_name in disabled_containers or container_name == "database":
+        if (container_name in disabled_containers or container_name == "database"
+                or (container_name == "radv" and tbinfo["topo"]["name"] == "t1")):
             logger.warning("Skip testing the container '{}'".format(container_name))
             continue
 


### PR DESCRIPTION

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Since radv container is only running on SONiC T0 devices, we will skip testing the auto-restart of it on T1 devices.

#### How did you do it?

#### How did you verify/test it?
I tested this change on a virtual testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
