### PR TITLE
Added additional teardown procedure for fdb_mac_expire test

### DIFF
--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -113,3 +113,16 @@
     - name: Clear FDB table
       shell: sonic-clear fdb all
 
+  always:
+    - name: set fdb value to default "600"
+      replace:
+        dest: switch.json
+        regexp: '"fdb_aging_time": ".*"'
+        replace: '"fdb_aging_time": "600"'
+      become: true
+
+    - name: copy current switch.json from host to docker
+      shell: docker cp switch.json swss:/etc/swss/config.d/switch.json
+
+    - name: run swssconfig switch.json command in container swss
+      shell: docker exec swss bash -c "swssconfig /etc/swss/config.d/switch.json"


### PR DESCRIPTION
Signed-off-by: Nazar Tkachuk <nazarx.tkachuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # `fdb_mac_expire` test effects another test `test_crm_fdb_entry` in regression run. Namely option `fdb_aging_time` is very small to finish `test_crm_fdb_entry` test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To fix impact on another TCs

#### How did you do it?
Added additional teardown procedure

#### How did you verify/test it?
Run test `fdb_mac_expire` and `test_crm_fdb_entry` 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
