### PR TITLE
Add a CLI option to skip disable_container_autorestart fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,9 @@ def pytest_addoption(parser):
     ########################
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
-
+    parser.addoption("--enable_container_autorestart", action="store_true", default=False,
+                     help="The autorestart of containers may hide errors in tests. \
+                         If still needed, enable autorestart of containers")
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):
@@ -431,6 +433,9 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
 
 @pytest.fixture(scope="module", autouse=True)
 def disable_container_autorestart(duthost, request):
+    if request.config.getoption("--enable_container_autorestart"):
+        yield
+        return
     skip = False
     for m in request.node.iter_markers():
         if m.name == "enable_container_autorestart":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,9 +135,9 @@ def pytest_addoption(parser):
     ########################
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
-    parser.addoption("--enable_container_autorestart", action="store_true", default=False,
-                     help="The autorestart of containers may hide errors in tests. \
-                         If still needed, enable autorestart of containers")
+    parser.addoption("--skip_fixture_disable_container_autorestart", action="store_true", default=False,
+                     help="The autorestart of containers will be disabled by default. \
+                         Set this option to skip fixture disable_container_autorestart")
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):
@@ -433,7 +433,7 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
 
 @pytest.fixture(scope="module", autouse=True)
 def disable_container_autorestart(duthost, request):
-    if request.config.getoption("--enable_container_autorestart"):
+    if request.config.getoption("--skip_fixture_disable_container_autorestart"):
         yield
         return
     skip = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: New CLI option to skip `disable_container_autorestart` fixture
Fixes # (issue): Test failures seen in older images which do not support `show feature autorestart` command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach

#### What is the motivation for this PR?
Some of the old images do not support command  `show feature autorestart`. After the addition of `disable_container_autorestart` (autouse=true) fixture, the tests on these old images have started failing with:

```
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {
E               "changed": true, 
E               "cmd": "show feature autorestart", 
E               "delta": "0:00:00.796420", 
E               "end": "2020-10-07 01:31:30.192988", 
E               "failed": true, 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "show feature autorestart", 
E                       "_uses_shell": true, 
E                       "argv": null, 
E                       "chdir": null, 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 2, 
E               "start": "2020-10-07 01:31:29.396568", 
E               "stderr": "Usage: show [OPTIONS] COMMAND [ARGS]...\n\nError: No such command \"feature\".", 
E               "stderr_lines": [
E                   "Usage: show [OPTIONS] COMMAND [ARGS]...", 
E                   "", 
E                   "Error: No such command \"feature\"."
E               ], 
E               "stdout": "", 
E               "stdout_lines": []
E           }

common/devices.py:91: RunAnsibleModuleFail
```
#### How did you do it?
Introduced new CLI option to skip `disable_container_autorestart` fixture logic.

#### How did you verify/test it?
Successfully executed a pytest with `--enable_container_autorestart` option.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
