### PR TITLE
[Platform API][Fans][Pytest] Align file and class naming

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -44,7 +44,7 @@ def gather_facts(request, duthost):
 
 
 @pytest.mark.usefixtures("gather_facts")
-class TestFanApi(PlatformApiTestBase):
+class TestChassisFans(PlatformApiTestBase):
 
     num_fans = None
     chassis_facts = None

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -44,7 +44,7 @@ def gather_facts(request, duthost):
 
 
 @pytest.mark.usefixtures("gather_facts")
-class TestFanDrawerFansApi(PlatformApiTestBase):
+class TestFanDrawerFans(PlatformApiTestBase):
 
     num_fan_drawers = None
     chassis_facts = None

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -44,7 +44,7 @@ def gather_facts(request, duthost):
 
 
 @pytest.mark.usefixtures("gather_facts")
-class TestFanDrawerFansApi(PlatformApiTestBase):
+class TestPsuFans(PlatformApiTestBase):
 
     num_psus = None
     chassis_facts = None


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To align naming conventions

#### How did you do it?

Rename "test_fan.py" to "test_chassis_fans.py", update class names to align with file names, correcting a typo in test_psu_fans.py in the process.

#### How did you verify/test it?

Run the test cases in the affected test files

#### Any platform specific information?

No

