### PR TITLE
[test_warm_reboot_multi_sad_inboot] Fix error in get_bgp_route_cnt

### DIFF
--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -320,9 +320,9 @@ class SadOper(SadPath):
     def get_bgp_route_cnt(self, is_up=True, v4=True):
         # extract the neigh ip and current number of routes
         if v4:
-            cmd = 'show ip bgp summary | sed \'1,/Neighbor/d;/^$/,$d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
+            cmd = 'show ip bgp summary | sed \'1,/Neighbor/d;/^$/,$di;/^-/d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
         else:
-            cmd = 'show ipv6 bgp summary | sed \'1,/Neighbor/d;/^$/,$d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
+            cmd = 'show ipv6 bgp summary | sed \'1,/Neighbor/d;/^$/,$d/^-/d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
 
         stdout, stderr, return_code = self.dut_connection.execCommand(cmd)
         if return_code != 0:

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -320,9 +320,9 @@ class SadOper(SadPath):
     def get_bgp_route_cnt(self, is_up=True, v4=True):
         # extract the neigh ip and current number of routes
         if v4:
-            cmd = 'show ip bgp summary | sed \'1,/Neighbor/d;/^$/,$di;/^-/d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
+            cmd = 'show ip bgp summary | sed \'1,/Neighbor/d;/^$/,$d;/^-/d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
         else:
-            cmd = 'show ipv6 bgp summary | sed \'1,/Neighbor/d;/^$/,$d/^-/d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
+            cmd = 'show ipv6 bgp summary | sed \'1,/Neighbor/d;/^$/,$d;/^-/d\' | sed \'s/\s\s*/ /g\' | cut -d\' \' -f 1,10'
 
         stdout, stderr, return_code = self.dut_connection.execCommand(cmd)
         if return_code != 0:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -385,7 +385,9 @@ class AdvancedReboot:
 
     def runRebootTest(self):
         # Run advanced-reboot.ReloadTest for item in preboot/inboot list
+        count = 0
         for rebootOper in self.rebootData['sadList']:
+            count += 1
             try:
                 result = self.__runPtfRunner(rebootOper)
             finally:
@@ -394,7 +396,7 @@ class AdvancedReboot:
                 self.__clearArpAndFdbTables()
             if not result:
                 return result
-            if len(self.rebootData['sadList']) > 1:
+            if len(self.rebootData['sadList']) > 1 and count != len(self.rebootData['sadList']):
                 time.sleep(TIME_BETWEEN_SUCCESSIVE_TEST_OPER)
         return result
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test case ```test_warm_reboot_multi_sad_inboot```.
The output of ```show ip bgp summary``` has a line with only ```---```
```
Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.33      4  4200064600       3210       4523         0      0       0  00:05:47             6400  ARISTA01T1
10.0.0.35      4  4200064600       3210       4523         0      0       0  00:05:47             6400  ARISTA02T1
10.0.0.37      4  4200064600       3210       4523         0      0       0  00:05:47             6400  ARISTA03T1
10.0.0.39      4  4200064600       3210       4523         0      0       0  00:05:47             6400  ARISTA04T1
```
However, the method ```get_bgp_route_cnt``` in ```sad_path.py``` failed to filter it out.
This commit address the issue.
Besides, this PR cancel the wait for last reboot operation, which will save 420 seconds. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix test case ```test_warm_reboot_multi_sad_inboot```.
#### How did you do it?
Update the script used to parse the output of ```show ip bgp sum```.
#### How did you verify/test it?
Verified on Arista-7260.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad_inboot
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 1 item                                                                                                                                                                                      

platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad_inboot ^@^@^@^@PASSED                                                                                                                [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 1381.94 seconds =====================================================================================
bingwang@df9bc4cdf9b3:/data/Networking-acs-sonic-mgmt$ 
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.