### PR TITLE
[Mellanox] Fix issue: should not format %d to a string variable

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -20,14 +20,14 @@ def check_sysfs(dut):
     logging.info("Check broken symbolinks")
     broken_symbolinks = sysfs_facts['symbolink_info']['broken_links']
     assert len(broken_symbolinks) == 0, \
-        "Found some broken symbolinks: %s" % str(broken_symbolinks)
+        "Found some broken symbolinks: {}".format(str(broken_symbolinks))
 
     logging.info("Check ASIC related sysfs")
     try:
         asic_temp = float(sysfs_facts['asic_info']['temp']) / 1000
-        assert 0 < asic_temp < 105, "Abnormal ASIC temperature: %s" % sysfs_facts['asic_info']['temp']
+        assert 0 < asic_temp < 105, "Abnormal ASIC temperature: {}".format(sysfs_facts['asic_info']['temp'])
     except Exception as e:
-        assert False, "Bad content in /var/run/hw-management/thermal/asic: %s" % repr(e)
+        assert False, "Bad content in /var/run/hw-management/thermal/asic: {}".format(repr(e))
 
     logging.info("Check fan related sysfs")
     for fan_id, fan_info in sysfs_facts['fan_info'].items():
@@ -49,8 +49,9 @@ def check_sysfs(dut):
         cpu_pack_temp = float(sysfs_facts['cpu_pack_info']['temp']) / 1000
         cpu_pack_max_temp = float(sysfs_facts['cpu_pack_info']['max_temp']) / 1000
         cpu_pack_crit_temp = float(sysfs_facts['cpu_pack_info']['crit_temp']) / 1000
-        assert cpu_pack_max_temp <= cpu_pack_crit_temp, "Bad CPU pack max temp or critical temp, %s, %s " \
-                                                        % (str(cpu_pack_max_temp), str(cpu_pack_crit_temp))
+        assert cpu_pack_max_temp <= cpu_pack_crit_temp, "Bad CPU pack max temp or critical temp, {}, {} ".format(
+                                                    str(cpu_pack_max_temp), 
+                                                    str(cpu_pack_crit_temp))
         if cpu_pack_temp >= cpu_pack_crit_temp:
             cpu_temp_high_counter += 1
         cpu_temp_list.append(cpu_pack_temp)
@@ -60,8 +61,10 @@ def check_sysfs(dut):
         cpu_core_temp = float(cpu_info["temp"]) / 1000
         cpu_core_max_temp = float(cpu_info["max_temp"]) / 1000
         cpu_core_crit_temp = float(cpu_info["crit_temp"]) / 1000
-        assert cpu_core_max_temp <= cpu_core_crit_temp, "Bad CPU core%d max temp or critical temp, %s, %s " \
-                                                        % (core_id, str(cpu_core_max_temp), str(cpu_core_crit_temp))
+        assert cpu_core_max_temp <= cpu_core_crit_temp, "Bad CPU core{} max temp or critical temp, {}, {} ".format(
+                                                    core_id, 
+                                                    str(cpu_core_max_temp), 
+                                                    str(cpu_core_crit_temp))
         if cpu_core_temp >= cpu_core_crit_temp:
             cpu_temp_high_counter += 1
         cpu_temp_list.append(cpu_core_temp)
@@ -75,23 +78,24 @@ def check_sysfs(dut):
     logging.info("Check PSU related sysfs")
     if platform_data["psus"]["hot_swappable"]:
         for psu_id, psu_info in sysfs_facts['psu_info'].items():
+            psu_id = int(psu_id)
             psu_status = int(psu_info["status"])
             if not psu_status:
-                logging.info("PSU %d doesn't exist, skipped" % psu_id)
+                logging.info("PSU {} doesn't exist, skipped".format(psu_id))
                 continue
 
             psu_pwr_status = int(psu_info["pwr_status"])
             if not psu_pwr_status:
-                logging.info("PSU %d isn't power on, skipped" % psu_id)
+                logging.info("PSU {} isn't power on, skipped".format(psu_id))
                 continue
 
             psu_temp = float(psu_info["temp"]) / 1000
             psu_max_temp = float(psu_info["max_temp"]) / 1000
-            assert psu_temp < psu_max_temp, "PSU%d overheated, temp: %s" % (psu_id, str(psu_temp))
+            assert psu_temp < psu_max_temp, "PSU{} overheated, temp: {}".format(psu_id, str(psu_temp))
             assert psu_info["max_temp_alarm"] == '0', "PSU{} temp alarm set".format(psu_id)
             try:
                 psu_fan_speed = int(psu_info["fan_speed"])
-                assert psu_fan_speed > 1000, "Bad fan speed: %s" % str(psu_fan_speed)
+                assert psu_fan_speed > 1000, "Bad fan speed: {}".format(str(psu_fan_speed))
             except Exception as e:
                 assert "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(psu_info["fan_speed"],
                                                                                          psu_id, e)
@@ -103,10 +107,10 @@ def check_sysfs(dut):
         sfp_temp_crit = float(sfp_info['crit_temp']) if sfp_info['crit_temp'] != '0' else 0
         sfp_temp_emergency = float(sfp_info['emergency_temp']) if sfp_info['emergency_temp'] != '0' else 0
         if sfp_temp_crit != 0:
-            assert sfp_temp < sfp_temp_crit, "SFP%d overheated, temp%s" % (sfp_id, str(sfp_temp))
+            assert sfp_temp < sfp_temp_crit, "SFP{} overheated, temp{}".format(sfp_id, str(sfp_temp))
             assert sfp_temp_crit < sfp_temp_emergency, "Wrong SFP critical temp or emergency temp, " \
-                                                       "critical temp: %s emergency temp: %s" \
-                                                       % (str(sfp_temp_crit), str(sfp_temp_emergency))
+                                                       "critical temp: {} emergency temp: {}".format(
+                                                           str(sfp_temp_crit), str(sfp_temp_emergency))
     logging.info("Finish checking sysfs")
 
 
@@ -114,27 +118,27 @@ def check_psu_sysfs(dut, psu_id, psu_state):
     """
     @summary: Check psu related sysfs under /var/run/hw-management/thermal against psu_state
     """
-    psu_exist = "/var/run/hw-management/thermal/psu%s_status" % psu_id
+    psu_exist = "/var/run/hw-management/thermal/psu{}_status".format(psu_id)
     if psu_state == "NOT PRESENT":
-        psu_exist_content = dut.command("cat %s" % psu_exist)
-        logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
-        assert psu_exist_content["stdout"] == "0", "CLI returns NOT PRESENT while %s contains %s" % \
-                                                   (psu_exist, psu_exist_content["stdout"])
+        psu_exist_content = dut.command("cat {}".format(psu_exist))
+        logging.info("PSU state {} file {} read {}".format(psu_state, psu_exist, psu_exist_content["stdout"]))
+        assert psu_exist_content["stdout"] == "0", "CLI returns NOT PRESENT while {} contains {}".format(
+                                                   psu_exist, psu_exist_content["stdout"])
     else:
         platform_data = get_platform_data(dut)
         hot_swappable = platform_data["psus"]["hot_swappable"]
         if hot_swappable:
-            psu_exist_content = dut.command("cat %s" % psu_exist)
-            logging.info("PSU state %s file %s read %s" % (psu_state, psu_exist, psu_exist_content["stdout"]))
-            assert psu_exist_content["stdout"] == "1", "CLI returns %s while %s contains %s" % \
-                                                       (psu_state, psu_exist, psu_exist_content["stdout"])
+            psu_exist_content = dut.command("cat {}".format(psu_exist))
+            logging.info("PSU state {} file {} read {}".format(psu_state, psu_exist, psu_exist_content["stdout"]))
+            assert psu_exist_content["stdout"] == "1", "CLI returns {} while {} contains {}".format(
+                                                       psu_state, psu_exist, psu_exist_content["stdout"])
 
-        psu_pwr_state = "/var/run/hw-management/thermal/psu%s_pwr_status" % psu_id
-        psu_pwr_state_content = dut.command("cat %s" % psu_pwr_state)
-        logging.info("PSU state %s file %s read %s" % (psu_state, psu_pwr_state, psu_pwr_state_content["stdout"]))
+        psu_pwr_state = "/var/run/hw-management/thermal/psu{}_pwr_status".format(psu_id)
+        psu_pwr_state_content = dut.command("cat {}".format(psu_pwr_state))
+        logging.info("PSU state {} file {} read {}".format(psu_state, psu_pwr_state, psu_pwr_state_content["stdout"]))
         assert (psu_pwr_state_content["stdout"] == "1" and psu_state == "OK") \
                or (psu_pwr_state_content["stdout"] == "0" and psu_state == "NOT OK"), \
-            "sysfs content %s mismatches with psu_state %s" % (psu_pwr_state_content["stdout"], psu_state)
+            "sysfs content {} mismatches with psu_state {}".format(psu_pwr_state_content["stdout"], psu_state)
 
 
 def _check_fan_speed_in_range(dut, config):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue that check_sysfs.py format %d to a string value and cause "TypeError: %d format: a number is required, not unicode". The fix is to use format() method instead of %.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fixes issue that check_sysfs.py format %d to a string value and cause "TypeError: %d format: a number is required, not unicode". 

#### How did you do it?

use format() method instead of %.

#### How did you verify/test it?

Manually run the regression case test_check_sysfs.py

#### Any platform specific information?

Mellanox platforms

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
