### PR TITLE
[Platform API][pytest] Remove 'self' parameters from method calls

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -88,7 +88,7 @@ class TestChassisFans(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Fan {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Fan {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts('name', name, i)
 
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -85,7 +85,7 @@ class TestComponentApi(PlatformApiTestBase):
             name = component.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Component {}: Unable to retrieve name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Component {}: Name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts('name', name, i)
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -94,7 +94,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
                 if self.expect(name is not None, "Unable to retrieve fan drawer {} fan {} name".format(j, i)):
                     self.expect(isinstance(name, STRING_TYPE), "fan drawer {} fan {} name appears incorrect".format(j, i))
-                    self.compare_value_with_platform_facts(self, 'name', name, j, i)
+                    self.compare_value_with_platform_facts('name', name, j, i)
 
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -79,7 +79,7 @@ class TestPsuApi(PlatformApiTestBase):
             name = psu.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve PSU {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "PSU {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts('name', name, i)
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -94,7 +94,7 @@ class TestPsuFans(PlatformApiTestBase):
 
                 if self.expect(name is not None, "Unable to retrieve psu {} fan {} name".format(j, i)):
                     self.expect(isinstance(name, STRING_TYPE), "psu {} fan {} name appears incorrect".format(j, i))
-                    self.compare_value_with_platform_facts(self, 'name', name, j, i)
+                    self.compare_value_with_platform_facts('name', name, j, i)
 
         self.assert_expectations()
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -145,7 +145,7 @@ class TestSfpApi(PlatformApiTestBase):
             name = sfp.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve transceiver {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Transceiver {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts('name', name, i)
         self.assert_expectations()
 
     def test_get_presence(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -77,7 +77,7 @@ class TestThermalApi(PlatformApiTestBase):
 
             if self.expect(name is not None, "Unable to retrieve Thermal {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Thermal {} name appears incorrect".format(i))
-                self.compare_value_with_platform_facts(self, 'name', name, i)
+                self.compare_value_with_platform_facts('name', name, i)
 
         self.assert_expectations()
 


### PR DESCRIPTION

### Description of PR

Summary:

Class methods do not take "self" as a parameter when called. Fix copy/paste mistakes from method definitions.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To ensure the tests run properly

#### How did you do it?
Remove unnecessary 'self' parameter from method calls

#### How did you verify/test it?
Run tests against working platform
