### PR TITLE
[test_vlan] Update test_vlan to fix warmRestartCheck error

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -91,8 +91,6 @@ def create_vlan_interfaces(vlan_ports_list, vlan_intfs_list, duthost, ptfhost):
                    pvid=permit_vlanid
                 ))
 
-    for vlan in vlan_intfs_list:
-        duthost.command("config interface ip add Vlan{} {}".format(vlan['vlan_id'], vlan['ip']))
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_vlan(ptfadapter, duthost, ptfhost, vlan_ports_list, vlan_intfs_list, cfg_facts):
@@ -182,6 +180,11 @@ def tearDown(vlan_ports_list, duthost, ptfhost, vlan_intfs_list, portchannel_int
 
     logger.info("Delete VLAN intf")
     try:
+        for item in vlan_ports_list:
+            for i in vlan_ports_list[0]['permit_vlanid']:
+                duthost.command('ip route flush {}'.format(
+                    item['permit_vlanid'][i]['remote_ip']))
+
         for vlan_port in vlan_ports_list:
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
                 if int(permit_vlanid) != vlan_port["pvid"]:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test case ```test_vlan``` added some static route in order to do test. 
https://github.com/Azure/sonic-mgmt/blob/457a6400e16bf018d16d0ca64e9a50a03f6ef911/tests/vlan/test_vlan.py#L143-L148
However, these staticly added routes are not cleared after test. As a result, ```warm-reboot``` will report errors because RESTARTCHECK failed.
```
root@str-7260cx3-acs-2:/var/log# warm-reboot -v
Sat Oct 10 06:43:36 UTC 2020 Pausing orchagent ...
RESTARTCHECK failed
Sat Oct 10 06:43:36 UTC 2020 warm-reboot failure (10) cleanup ...
Sat Oct 10 06:43:37 UTC 2020 Cancel warm-reboot: code (1)
```
 Logs in syslog told that these uncleared route caused ```warmRestartCheck``` failed
```
Oct 10 06:43:36.862060 str-7260cx3-acs-2 NOTICE swss#orchagent_restart_check: :- main: requested orchagent to do warm restart state check, retry count: 0
Oct 10 06:43:36.862305 str-7260cx3-acs-2 NOTICE swss#orchagent: :- doTask: RESTARTCHECK notification for orchagent
Oct 10 06:43:36.862305 str-7260cx3-acs-2 NOTICE swss#orchagent: :- doTask: orchagent|NoFreeze:false|SkipPendingTaskCheck:false
Oct 10 06:43:36.862553 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck: WarmRestart check found pending tasks:
Oct 10 06:43:36.862553 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:100.1.1.115|SET|nexthop:192.168.100.115|ifname:unknown
Oct 10 06:43:36.862577 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:100.1.1.2|SET|nexthop:192.168.100.2|ifname:unknown
Oct 10 06:43:36.862599 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:100.1.1.3|SET|nexthop:192.168.100.3|ifname:unknown
Oct 10 06:43:36.862599 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:100.1.1.4|SET|nexthop:192.168.100.4|ifname:unknown
Oct 10 06:43:36.862636 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:100.1.1.5|SET|nexthop:192.168.100.5|ifname:unknown
Oct 10 06:43:36.862687 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:100.1.1.55|SET|nexthop:192.168.100.55|ifname:unknown
Oct 10 06:43:36.862687 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:200.1.1.115|SET|nexthop:192.168.200.115|ifname:unknown
Oct 10 06:43:36.862718 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:200.1.1.2|SET|nexthop:192.168.200.2|ifname:unknown
Oct 10 06:43:36.862718 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:200.1.1.3|SET|nexthop:192.168.200.3|ifname:unknown
Oct 10 06:43:36.862718 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:200.1.1.4|SET|nexthop:192.168.200.4|ifname:unknown
Oct 10 06:43:36.862737 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:200.1.1.5|SET|nexthop:192.168.200.5|ifname:unknown
Oct 10 06:43:36.862757 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck:     ROUTE_TABLE:200.1.1.55|SET|nexthop:192.168.200.55|ifname:unknown
Oct 10 06:43:36.862757 str-7260cx3-acs-2 NOTICE swss#orchagent: :- warmRestartCheck: Restart check result: NOT_READY
```
This PR add a cleanup for static route added in test setup. 
Besides, a duplicate ```ip add``` for Vlan interface is removed.
https://github.com/Azure/sonic-mgmt/blob/457a6400e16bf018d16d0ca64e9a50a03f6ef911/tests/vlan/test_vlan.py#L94-L95
There is exactly same operation here
https://github.com/Azure/sonic-mgmt/blob/457a6400e16bf018d16d0ca64e9a50a03f6ef911/tests/vlan/test_vlan.py#L116-L118
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix warm-reboot issues caused by test_vlan. And some duplicated code is removed as well. 
#### How did you do it?
1. Add a cleanup for static route added in test setup
2. Remove duplicate 'ip add' for Vlan interface
#### How did you verify/test it?
Verified on Arista-7260. After this update, the warm-reboot completed successfully after running ```test_vlan```.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util vlan/test_vlan.py
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 3 items                                                                                                                                                                                     

vlan/test_vlan.py::test_vlan_tc1_send_untagged PASSED                                                                                                                                           [ 33%]
vlan/test_vlan.py::test_vlan_tc2_send_tagged PASSED                                                                                                                                             [ 66%]
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid PASSED                                                                                                                                        [100%]^@

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 3 passed in 464.46 seconds ======================================================================================
``` 
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.