### PR TITLE
Verify generated coredump files between reboot cycles

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -256,6 +256,7 @@ class AdvancedReboot:
         Download and install new image to DUT
         '''
         if self.newSonicImage is None:
+            self.newImage = False
             return
 
         self.currentImage = self.duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
@@ -270,7 +271,12 @@ class AdvancedReboot:
         logger.info('Cleanup sonic images that is not current and/or next')
         if self.cleanupOldSonicImages:
             self.duthost.shell('sonic_installer cleanup -y')
+        if self.binaryVersion == self.currentImage:
+            logger.info("Skipping image installation: new SONiC image is installed and set to current")
+            self.newImage = False
+            return
 
+        self.newImage = True
         logger.info('Installing new SONiC image')
         self.duthost.shell('sonic_installer install -y {0}'.format(tempfile))
 

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -279,6 +279,9 @@ class ContinuousReboot:
             if "disabled" in issu_capability:
                 pytest.skip("ISSU is not supported on this DUT, skip this test case")
 
+        self.verify_no_coredumps()
+        pytest_assert(self.sub_test_result, "Continuous reboot test failed. DUT contains core files")
+
         input_data = {
             'install_list': self.image_list, # this list can be modified at runtime to enable testing different images
             'location': self.image_location,

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -100,6 +100,7 @@ class ContinuousReboot:
         # Wait until uptime reaches allowed value
         self.wait_until_uptime()
         # Perform additional post-reboot health-check
+        self.verify_no_coredumps()
         self.verify_image()
         self.check_services()
         self.check_reboot_type()
@@ -208,6 +209,12 @@ class ContinuousReboot:
             if self.advancedReboot.binaryVersion != self.current_image:
                 raise ContinuousRebootError("Image installation failed.\
                     Expected: {}. Found: {}".format(self.advancedReboot.binaryVersion, self.current_image))
+
+    @handle_test_error
+    def verify_no_coredumps(self):
+        coredumps_count = self.duthost.shell('ls /var/core/ | wc -l')['stdout']
+        if int(coredumps_count) > 0:
+            raise ContinuousRebootError("Core dumps found. Expected: 0 Found: {}".format(coredumps_count))
 
 
     def check_test_params(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Verify coredump presence between continuous reboots
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Verify if new coredumps are created between reboot iterations

#### What is the motivation for this PR?

#### How did you do it?
Added a check for any files inside `/var/core` dir. Fail the test if  files `count > 0`.

#### How did you verify/test it?
Tested on T0 testbed. Test passes when no coredumps generated, and fails when core files are generated inside `/var/core`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
