### PR TITLE
Verify if feature autorestart is supported before disabling container autorestart

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,9 +135,7 @@ def pytest_addoption(parser):
     ########################
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
-    parser.addoption("--skip_fixture_disable_container_autorestart", action="store_true", default=False,
-                     help="The autorestart of containers will be disabled by default. \
-                         Set this option to skip fixture disable_container_autorestart")
+
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):
@@ -433,7 +431,10 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
 
 @pytest.fixture(scope="module", autouse=True)
 def disable_container_autorestart(duthost, request):
-    if request.config.getoption("--skip_fixture_disable_container_autorestart"):
+    command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
+    if command_output['rc'] != 0:
+        logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
+        logging.info("Skipping disable_container_autorestart fixture")
         yield
         return
     skip = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip fixture `disable_container_autorestart ` if `show feature autorestart` is not supported.
Fixes # (issue) Improvement.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Improvement over https://github.com/Azure/sonic-mgmt/pull/2311
Instead of asking the user to specify CLI arg to skip `disable_container_autorestart `, automatically check if `show feature autorestart` is supported in a installed image. Continue without `disable_container_autorestart` if the feature is not supported.

#### How did you do it?
If the cmd `show feature autorestart` throws an error, skip the logic present in the fixture `disable_container_autorestart`.

#### How did you verify/test it?
Tested both on images with and without `show feature autorestart` support.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
