### PR TITLE
[Platform API][Chassis][Module] Remove tests for deprecated, redundant get_serial_number() methods

### DIFF
--- a/tests/common/helpers/platform_api/chassis.py
+++ b/tests/common/helpers/platform_api/chassis.py
@@ -52,10 +52,6 @@ def get_base_mac(conn):
     return chassis_api(conn, 'get_base_mac')
 
 
-def get_serial_number(conn):
-    return chassis_api(conn, 'get_serial_number')
-
-
 def get_system_eeprom_info(conn):
     return chassis_api(conn, 'get_system_eeprom_info')
 

--- a/tests/common/helpers/platform_api/module.py
+++ b/tests/common/helpers/platform_api/module.py
@@ -54,10 +54,6 @@ def get_base_mac(conn, mod_idx):
     return module_api(conn, mod_idx, 'get_base_mac')
 
 
-def get_serial_number(conn, mod_idx):
-    return module_api(conn, mod_idx, 'get_serial_number')
-
-
 def get_system_eeprom_info(conn, mod_idx):
     return module_api(conn, mod_idx, 'get_system_eeprom_info')
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -146,19 +146,6 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
         self.compare_value_with_device_facts('base_mac', base_mac, False)
 
-    def test_get_serial_number(self, duthost, localhost, platform_api_conn):
-        # Ensure the serial number is sane
-        # Note: It appears that when retrieving some variable-length fields,
-        # the value is padded with trailing '\x00' bytes because the field
-        # length is longer than the actual value, so we strip those bytes
-        # here before comparing. We may want to change the EEPROM parsing
-        # logic to ensure that trailing '\x00' bytes are removed when retreiving
-        # a variable-length value.
-        serial = chassis.get_serial_number(platform_api_conn).rstrip('\x00')
-        pytest_assert(serial is not None, "Failed to retrieve serial number")
-        pytest_assert(re.match(REGEX_SERIAL_NUMBER, serial), "Serial number appears to be incorrect")
-        self.compare_value_with_device_facts('serial', serial)
-
     def test_get_system_eeprom_info(self, duthost, localhost, platform_api_conn):
         ''' Test that we can retrieve sane system EEPROM info from the DUT via the platform API
         '''

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -107,7 +107,7 @@ class TestModuleApi(PlatformApiTestBase):
 
         for i in range(self.num_modules):
             serial = module.get_serial(platform_api_conn, i)
-            if self.expect(serial is not None, "Unable to retrieve module {} serial number".format(i)):
+            if self.expect(serial is not None, "Module {}: Failed to retrieve serial number".format(i)):
                 self.expect(isinstance(serial, STRING_TYPE), "Module {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
@@ -136,25 +136,6 @@ class TestModuleApi(PlatformApiTestBase):
             if not self.expect(base_mac is not None, "Module {}: Failed to retrieve base MAC address".format(i)):
                 continue
             self.expect(re.match(REGEX_MAC_ADDRESS, base_mac), "Module {}: Base MAC address appears to be incorrect".format(i))
-        self.assert_expectations()
-
-    def test_get_serial_number(self, duthost, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
-
-        # Ensure the serial number of each module is sane
-        # Note: It appears that when retrieving some variable-length fields,
-        # the value is padded with trailing '\x00' bytes because the field
-        # length is longer than the actual value, so we strip those bytes
-        # here before comparing. We may want to change the EEPROM parsing
-        # logic to ensure that trailing '\x00' bytes are removed when retreiving
-        # a variable-length value.
-        # TODO: Add expected serial number of each module to inventory file and compare against it
-        for i in range(self.num_modules):
-            serial = module.get_serial_number(platform_api_conn, i).rstrip('\x00')
-            if not self.expect(serial is not None, "Module {}: Failed to retrieve serial number".format(i)):
-                continue
-            self.expect(re.match(REGEX_SERIAL_NUMBER, serial), "Module {}: Serial number appears to be incorrect".format(i))
         self.assert_expectations()
 
     def test_get_system_eeprom_info(self, duthost, localhost, platform_api_conn):


### PR DESCRIPTION
### Description of PR

Summary:

No longer test deprecated `get_serial_number()` methods of Chassis and Module classes

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

The `get_serial_number()` methods are redundant and are being removed in https://github.com/Azure/sonic-platform-common/pull/130

#### How did you do it?

With the backspace key ;)

#### How did you verify/test it?

Ensure all remaining tests run correctly, and that the remaining "get_serial()" methods still get tested.

#### Any platform specific information?

No
