### PR TITLE
Add performance test for set/delete routes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,7 @@ def pytest_addoption(parser):
                      help="The autorestart of containers will be disabled by default. \
                          Set this option to skip fixture disable_container_autorestart")
 
+
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,19 +135,9 @@ def pytest_addoption(parser):
     ########################
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
-<<<<<<< HEAD
     parser.addoption("--skip_fixture_disable_container_autorestart", action="store_true", default=False,
                      help="The autorestart of containers will be disabled by default. \
                          Set this option to skip fixture disable_container_autorestart")
-=======
-
-    ###############################
-    #   test_route_perf options   #
-    ###############################
-    parser.addoption("--num_routes", action="store", default=10000, type=int,
-                     help="Number of routes for add/delete")
-
->>>>>>> Address review comments
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,9 +135,19 @@ def pytest_addoption(parser):
     ########################
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
+<<<<<<< HEAD
     parser.addoption("--skip_fixture_disable_container_autorestart", action="store_true", default=False,
                      help="The autorestart of containers will be disabled by default. \
                          Set this option to skip fixture disable_container_autorestart")
+=======
+
+    ###############################
+    #   test_route_perf options   #
+    ###############################
+    parser.addoption("--num_routes", action="store", default=10000, type=int,
+                     help="Number of routes for add/delete")
+
+>>>>>>> Address review comments
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):

--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -1,0 +1,5 @@
+# Pytest configuration used by the route tests.
+def pytest_addoption(parser):
+    # Add options to pytest that are used by route tests
+    parser.addoption("--num_routes", action="store", default=10000, type=int,
+                     help="Number of routes for add/delete")

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -1,0 +1,142 @@
+import pytest
+import ipaddress
+import json
+import logging
+import time
+from datetime import datetime
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+ROUTE_JSON = 'route.json'
+NEIGH_JSON = 'neigh.json'
+ROUTE_TIMEOUT = 20 # Time limit for applying route changes
+ROUTE_TABLE_NAME = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
+
+def prepare_dut(duthost):
+    # Set up interface
+    duthost.shell('sudo sonic-cfggen -a \'{\"INTERFACE\":{\"Ethernet72\":{\"NULL\":\"NULL\"}}}\' --write-to-db')
+    duthost.shell('sudo sonic-cfggen -a \'{\"INTERFACE\":{\"Ethernet72|10.1.0.54/31\":{\"NULL\":\"NULL\"}}}\' --write-to-db')
+    
+    # Set up neighbor
+    neighbor = [{
+        'NEIGH_TABLE:Ethernet72:10.1.0.37': {
+            'neigh': '55:54:00:ad:48:98',
+            'family': 'IPv4'
+        },
+        'OP': 'SET'
+    }]
+    duthost.copy(content=json.dumps(neighbor, indent=4), dest=NEIGH_JSON)
+    duthost.shell('docker cp {} swss:/'.format(NEIGH_JSON))
+    duthost.shell('docker exec -i swss swssconfig /{}'.format(NEIGH_JSON))
+
+    time.sleep(5)
+
+def cleanup_dut(duthost):
+    # Delete neighbor
+    neighbor = [{
+        'NEIGH_TABLE:Ethernet72:10.1.0.37': {
+            'neigh': '55:54:00:ad:48:98',
+            'family': 'IPv4'
+        },
+        'OP': 'SET'
+    }]
+    duthost.copy(content=json.dumps(neighbor, indent=4), dest='NEIGH_JSON')
+    duthost.shell('docker cp {} swss:/'.format(NEIGH_JSON))
+    duthost.shell('docker exec -i swss swssconfig /{}'.format(NEIGH_JSON))
+
+    # remove files
+    duthost.shell('rm {}'.format(ROUTE_JSON))
+    duthost.shell('rm {}'.format(NEIGH_JSON))
+    duthost.shell('docker exec -i swss rm {}'.format(ROUTE_JSON))
+    duthost.shell('docker exec -i swss rm {}'.format(NEIGH_JSON))
+
+    time.sleep(5)
+
+def generate_route_file(duthost, prefixes, op):
+    route_data = []
+    for prefix in prefixes:
+        key = 'ROUTE_TABLE:' + prefix
+        route = {}
+        route['ifname'] = 'Ethernet72'
+        route['nexthop'] = '10.1.0.37'
+        route_command = {}
+        route_command[key] = route
+        route_command['OP'] = op
+        route_data.append(route_command)
+
+    # Copy json file to DUT
+    duthost.copy(content=json.dumps(route_data, indent=4), dest=ROUTE_JSON)
+
+def exec_routes(duthost, num_routes, op):
+    # generate ip prefixes of routes
+    prefixes = ['%d.%d.%d.%d/%d' % (101 + int(idx_route / 256 ** 2), int(idx_route / 256) % 256, idx_route % 256, 0, 24)
+                for idx_route in range(num_routes)]
+
+    # Generate json file for routes
+    generate_route_file(duthost, prefixes, op)
+
+    def _check_num_routes(expected_num_routes):
+        # Check the number of routes in ASIC_DB
+        num_routes = int(duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\' | wc -l'.format(ROUTE_TABLE_NAME))['stdout'])
+        return num_routes == expected_num_routes
+
+    # Copy route file to swss container
+    duthost.shell('docker cp {} swss:/'.format(ROUTE_JSON))
+    
+    # Check the number of routes in ASIC_DB
+    start_num_route = int(duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\' | wc -l'.format(ROUTE_TABLE_NAME))['stdout'])
+    
+    # Calculate expected number of route and record start time
+    if op == 'SET':
+        expected_num_routes = start_num_route + num_routes
+    elif op == 'DEL':
+        expected_num_routes = start_num_route - num_routes
+    else:
+        pytest.fail('Operation {} not supported'.format(op))
+    start_time = datetime.now()
+
+    # Apply routes with swssconfig
+    duthost.shell('docker exec -i swss swssconfig /{}'.format(ROUTE_JSON))
+
+    # Wait until the routes set/del applys to ASIC_DB
+    if not wait_until(ROUTE_TIMEOUT, 0.1, _check_num_routes, expected_num_routes):
+        pytest.fail('failed to add routes within time limit')
+
+    # Record time when all routes show up in ASIC_DB
+    end_time = datetime.now()
+
+    # Check route entries are correct
+    asic_route_lines = duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\''.format(ROUTE_TABLE_NAME))['stdout_lines']
+    asic_prefixes = []
+    for line in asic_route_lines:
+        json_obj = line[len(ROUTE_TABLE_NAME) + 1 : ]
+        asic_prefixes.append(json.loads(json_obj)['dest'])
+    if op == 'SET':
+        assert all(prefix in asic_prefixes for prefix in prefixes)
+    elif op == 'DEL':
+        assert all(prefix not in asic_prefixes for prefix in prefixes)
+    else:
+        pytest.fail('Operation {} not supported'.format(op))
+
+    # Retuen time used for set/del routes
+    return (end_time - start_time).total_seconds()
+
+def test_perf_add_remove_routes(duthost):
+    # Number of routes for test
+    num_routes = 10000
+
+    # Set up interface and interface for routes
+    prepare_dut(duthost)
+
+    # Add routes
+    time_set = exec_routes(duthost, num_routes, 'SET')
+    print("Time to set %d routes is %.2f seconds. " % (num_routes, time_set))
+
+    # Remove routes
+    time_del = exec_routes(duthost, num_routes, 'DEL')
+    print("Time to del %d routes is %.2f seconds. " % (num_routes, time_del))
+
+    # Cleanup DUT
+    cleanup_dut(duthost)

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -40,7 +40,7 @@ def cleanup_dut(duthost):
             'neigh': '55:54:00:ad:48:98',
             'family': 'IPv4'
         },
-        'OP': 'SET'
+        'OP': 'DEL'
     }]
     duthost.copy(content=json.dumps(neighbor, indent=4), dest='NEIGH_JSON')
     duthost.shell('docker cp {} swss:/'.format(NEIGH_JSON))

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -76,17 +76,17 @@ def exec_routes(duthost, num_routes, op):
         # Check the number of routes in ASIC_DB
         num_routes = int(duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\' | wc -l'.format(ROUTE_TABLE_NAME))['stdout'])
         return num_routes == expected_num_routes
-    if not wait_until(ROUTE_TIMEOUT, 0.1, _check_num_routes, expected_num_routes):
+    if not wait_until(ROUTE_TIMEOUT, 0.5, _check_num_routes, expected_num_routes):
         pytest.fail('failed to add routes within time limit')
 
     # Record time when all routes show up in ASIC_DB
     end_time = datetime.now()
 
     # Check route entries are correct
-    asic_route_lines = duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\''.format(ROUTE_TABLE_NAME))['stdout_lines']
+    asic_route_keys = duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\''.format(ROUTE_TABLE_NAME))['stdout_lines']
     asic_prefixes = []
-    for line in asic_route_lines:
-        json_obj = line[len(ROUTE_TABLE_NAME) + 1 : ]
+    for key in asic_route_keys:
+        json_obj = key[len(ROUTE_TABLE_NAME) + 1 : ]
         asic_prefixes.append(json.loads(json_obj)['dest'])
     if op == 'SET':
         assert all(prefix in asic_prefixes for prefix in prefixes)

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -1,11 +1,12 @@
 import pytest
 import json
-import logging
 from datetime import datetime
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
-logger = logging.getLogger(__name__)
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
 
 ROUTE_JSON = 'route.json'
 ROUTE_TIMEOUT = 20 # Time limit for applying route changes

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -53,11 +53,6 @@ def exec_routes(duthost, num_routes, op):
     # Generate json file for routes
     generate_route_file(duthost, prefixes, op)
 
-    def _check_num_routes(expected_num_routes):
-        # Check the number of routes in ASIC_DB
-        num_routes = int(duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\' | wc -l'.format(ROUTE_TABLE_NAME))['stdout'])
-        return num_routes == expected_num_routes
-
     # Copy route file to swss container
     duthost.shell('docker cp {} swss:/'.format(ROUTE_JSON))
     
@@ -77,6 +72,10 @@ def exec_routes(duthost, num_routes, op):
     duthost.shell('docker exec -i swss swssconfig /{}'.format(ROUTE_JSON))
 
     # Wait until the routes set/del applys to ASIC_DB
+    def _check_num_routes(expected_num_routes):
+        # Check the number of routes in ASIC_DB
+        num_routes = int(duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\' | wc -l'.format(ROUTE_TABLE_NAME))['stdout'])
+        return num_routes == expected_num_routes
     if not wait_until(ROUTE_TIMEOUT, 0.1, _check_num_routes, expected_num_routes):
         pytest.fail('failed to add routes within time limit')
 
@@ -108,11 +107,11 @@ def test_perf_add_remove_routes(duthost):
 
     # Add routes
     time_set = exec_routes(duthost, num_routes, 'SET')
-    print("Time to set %d routes is %.2f seconds. " % (num_routes, time_set))
+    print('Time to set %d routes is %.2f seconds.' % (num_routes, time_set))
 
     # Remove routes
     time_del = exec_routes(duthost, num_routes, 'DEL')
-    print("Time to del %d routes is %.2f seconds. " % (num_routes, time_del))
+    print('Time to del %d routes is %.2f seconds.' % (num_routes, time_del))
 
     # Cleanup DUT
     cleanup_dut(duthost)

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -10,27 +10,71 @@ pytestmark = [
 
 ROUTE_TABLE_NAME = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
 
-def prepare_dut(duthost):
-    # Set up interface
-    duthost.shell('sudo config interface ip add Ethernet72 10.1.0.54/31')
+def prepare_dut(duthost, intf_neighs):
+    for intf_neigh in intf_neighs:
+        # Set up interface
+        duthost.shell('sudo config interface ip add {} {}'.format(intf_neigh['interface'], intf_neigh['ip']))
+        
+        # Set up neighbor
+        duthost.shell('sudo ip neigh add {} lladdr {} dev {}'.format(intf_neigh['neighbor'], intf_neigh['mac'], intf_neigh['interface']))
+
+def cleanup_dut(duthost, intf_neighs):
+    for intf_neigh in intf_neighs:
+        # Delete neighbor
+        duthost.shell('sudo ip neigh del {} dev {}'.format(intf_neigh['neighbor'], intf_neigh['interface']))
+
+        # remove interface
+        duthost.shell('sudo config interface ip remove {} {}'.format(intf_neigh['interface'], intf_neigh['ip']))
+
+def generate_intf_neigh(num_neigh):
+    # Generate interfaces and neighbors
+    intf_neighs = []
+    str_intf_nexthop = {'ifname':'', 'nexthop':''}
+    for idx_neigh in range(num_neigh):
+        intf_neigh = {
+            'interface' : 'Ethernet%d' % (idx_neigh * 4 + 4),
+            'ip' : '10.%d.0.1/24' % (idx_neigh + 1),
+            'neighbor' : '10.%d.0.2' % (idx_neigh + 1),
+            'mac' : '55:54:00:ad:48:%0.2x' % idx_neigh
+        }
+        intf_neighs.append(intf_neigh)
+        if idx_neigh == 0:
+            str_intf_nexthop['ifname'] += intf_neigh['interface']
+            str_intf_nexthop['nexthop'] += intf_neigh['neighbor']
+        else:
+            str_intf_nexthop['ifname'] += ',' + intf_neigh['interface']
+            str_intf_nexthop['nexthop'] += ',' + intf_neigh['neighbor']
     
-    # Set up neighbor
-    duthost.shell('sudo ip neigh add 10.10.10.37 lladdr 55:54:00:ad:48:98 dev Ethernet72')
+    return intf_neighs, str_intf_nexthop
 
-def cleanup_dut(duthost):
-    # Delete neighbor
-    duthost.shell('sudo ip neigh del 10.10.10.37 dev Ethernet72')
-
-    # remove interface
-    duthost.shell('sudo config interface ip remove Ethernet72 10.1.0.54/31')
-
-def generate_route_file(duthost, prefixes, dir, op):
+def generate_intf_neigh_ipv6(num_neigh):
+    # Generate interfaces and neighbors
+    intf_neighs = []
+    str_intf_nexthop = {'ifname':'', 'nexthop':''}
+    for idx_neigh in range(num_neigh):
+        intf_neigh = {
+            'interface' : 'Ethernet%d' % (idx_neigh * 4),
+            'ip' : '%x::1/64' % (0x2000 + idx_neigh),
+            'neighbor' : '%x::2' % (0x2000 + idx_neigh),
+            'mac' : '55:54:00:ad:48:%0.2x' % idx_neigh
+        }
+        intf_neighs.append(intf_neigh)
+        if idx_neigh == 0:
+            str_intf_nexthop['ifname'] += intf_neigh['interface']
+            str_intf_nexthop['nexthop'] += intf_neigh['neighbor']
+        else:
+            str_intf_nexthop['ifname'] += ',' + intf_neigh['interface']
+            str_intf_nexthop['nexthop'] += ',' + intf_neigh['neighbor']
+    
+    return intf_neighs, str_intf_nexthop
+         
+def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
     route_data = []
     for prefix in prefixes:
         key = 'ROUTE_TABLE:' + prefix
         route = {}
-        route['ifname'] = 'Ethernet72'
-        route['nexthop'] = '10.10.10.37'
+        route['ifname'] = str_intf_nexthop['ifname']
+        route['nexthop'] = str_intf_nexthop['nexthop']
         route_command = {}
         route_command[key] = route
         route_command['OP'] = op
@@ -39,28 +83,24 @@ def generate_route_file(duthost, prefixes, dir, op):
     # Copy json file to DUT
     duthost.copy(content=json.dumps(route_data, indent=4), dest=dir)
 
-def exec_routes(duthost, num_routes, op):
-    # generate ip prefixes of routes
-    prefixes = ['%d.%d.%d.%d/%d' % (101 + int(idx_route / 256 ** 2), int(idx_route / 256) % 256, idx_route % 256, 0, 24)
-                for idx_route in range(num_routes)]
-
+def exec_routes(duthost, prefixes, str_intf_nexthop, op):
     # Create a tempfile for routes
     route_file_dir = duthost.shell('mktemp')['stdout']
 
     # Generate json file for routes
-    generate_route_file(duthost, prefixes, route_file_dir, op)
+    generate_route_file(duthost, prefixes, str_intf_nexthop, route_file_dir, op)
 
     # Check the number of routes in ASIC_DB
     start_num_route = int(duthost.shell('sonic-db-cli ASIC_DB keys \'{}*\' | wc -l'.format(ROUTE_TABLE_NAME))['stdout'])
     
     # Calculate timeout as a function of the number of routes
-    route_timeout = max(num_routes / 500, 1) # Allow at least 1 second even when there is a limited number of routes
+    route_timeout = max(len(prefixes) / 500, 1) # Allow at least 1 second even when there is a limited number of routes
 
     # Calculate expected number of route and record start time
     if op == 'SET':
-        expected_num_routes = start_num_route + num_routes
+        expected_num_routes = start_num_route + len(prefixes)
     elif op == 'DEL':
-        expected_num_routes = start_num_route - num_routes
+        expected_num_routes = start_num_route - len(prefixes)
     else:
         pytest.fail('Operation {} not supported'.format(op))
     start_time = datetime.now()
@@ -99,16 +139,48 @@ def test_perf_add_remove_routes(duthost, request):
     # Number of routes for test
     num_routes = request.config.getoption("--num_routes")
 
+    # Generate interfaces and neighbors
+    intf_neighs, str_intf_nexthop = generate_intf_neigh(8)
+
+    # Generate ip prefixes of routes
+    prefixes = ['%d.%d.%d.%d/%d' % (101 + int(idx_route / 256 ** 2), int(idx_route / 256) % 256, idx_route % 256, 0, 24)
+                for idx_route in range(num_routes)]
+
     # Set up interface and interface for routes
-    prepare_dut(duthost)
+    prepare_dut(duthost, intf_neighs)
 
     # Add routes
-    time_set = exec_routes(duthost, num_routes, 'SET')
-    print('Time to set %d routes is %.2f seconds.' % (num_routes, time_set))
+    time_set = exec_routes(duthost, prefixes, str_intf_nexthop, 'SET')
+    print('Time to set %d ipv4 routes is %.2f seconds.' % (num_routes, time_set))
 
     # Remove routes
-    time_del = exec_routes(duthost, num_routes, 'DEL')
-    print('Time to del %d routes is %.2f seconds.' % (num_routes, time_del))
+    time_del = exec_routes(duthost, prefixes, str_intf_nexthop, 'DEL')
+    print('Time to del %d ipv4 routes is %.2f seconds.' % (num_routes, time_del))
 
     # Cleanup DUT
-    cleanup_dut(duthost)
+    cleanup_dut(duthost, intf_neighs)
+
+def test_perf_add_remove_routes_ipv6(duthost, request):
+    # Number of routes for test
+    num_routes = request.config.getoption("--num_routes")
+
+    # Generate interfaces and neighbors
+    intf_neighs, str_intf_nexthop = generate_intf_neigh_ipv6(8)
+
+    # Generate ip prefixes of routes
+    prefixes = ['%x:%x:%x::/%d' % (0x3000 + int(idx_route / 65536), idx_route % 65536, 1, 64)
+                for idx_route in range(num_routes)]
+
+    # Set up interface and interface for routes
+    prepare_dut(duthost, intf_neighs)
+
+    # Add routes
+    time_set = exec_routes(duthost, prefixes, str_intf_nexthop, 'SET')
+    print('Time to set %d ipv6 routes is %.2f seconds.' % (num_routes, time_set))
+
+    # Remove routes
+    time_del = exec_routes(duthost, prefixes, str_intf_nexthop, 'DEL')
+    print('Time to del %d ipv6 routes is %.2f seconds.' % (num_routes, time_del))
+
+    # Cleanup DUT
+    cleanup_dut(duthost, intf_neighs)

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -35,7 +35,7 @@ def generate_intf_neigh(num_neigh):
             'interface' : 'Ethernet%d' % (idx_neigh * 4 + 4),
             'ip' : '10.%d.0.1/24' % (idx_neigh + 1),
             'neighbor' : '10.%d.0.2' % (idx_neigh + 1),
-            'mac' : '55:54:00:ad:48:%0.2x' % idx_neigh
+            'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
         }
         intf_neighs.append(intf_neigh)
         if idx_neigh == 0:
@@ -56,7 +56,7 @@ def generate_intf_neigh_ipv6(num_neigh):
             'interface' : 'Ethernet%d' % (idx_neigh * 4),
             'ip' : '%x::1/64' % (0x2000 + idx_neigh),
             'neighbor' : '%x::2' % (0x2000 + idx_neigh),
-            'mac' : '55:54:00:ad:48:%0.2x' % idx_neigh
+            'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
         }
         intf_neighs.append(intf_neigh)
         if idx_neigh == 0:

--- a/tests/vxlan/__init__.py
+++ b/tests/vxlan/__init__.py
@@ -9,61 +9,6 @@ from vnet_constants import *
 
 logger = logging.getLogger(__name__)
 
-def pytest_addoption(parser):
-    """
-    Adds pytest options that are used by VxLAN tests
-    """
-
-    parser.addoption(
-        "--num_vnet",
-        action="store",
-        default=8,
-        type=int,
-        help="number of VNETs for VNET VxLAN test"
-    )
-
-    parser.addoption(
-        "--num_routes",
-        action="store",
-        default=16000,
-        type=int,
-        help="number of routes for VNET VxLAN test"
-    )
-
-    parser.addoption(
-        "--num_endpoints",
-        action="store",
-        default=4000,
-        type=int,
-        help="number of endpoints for VNET VxLAN"
-    )
-
-    parser.addoption(
-        "--num_intf_per_vnet",
-        action="store",
-        default=1,
-        type=int,
-        help="number of VLAN interfaces per VNET"
-    )
-
-    parser.addoption(
-        "--ipv6_vxlan_test",
-        action="store_true",
-        help="Use IPV6 for VxLAN test"
-    )
-
-    parser.addoption(
-        "--skip_cleanup",
-        action="store_true",
-        help="Do not cleanup after VNET VxLAN test"
-    )
-
-    parser.addoption(
-        "--skip_apply_config",
-        action="store_true",
-        help="Apply new configurations on DUT"
-    )
-
 @pytest.fixture(scope="module")
 def scaled_vnet_params(request):
     """

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -1,0 +1,54 @@
+def pytest_addoption(parser):
+    """
+    Adds pytest options that are used by VxLAN tests
+    """
+
+    parser.addoption(
+        "--num_vnet",
+        action="store",
+        default=8,
+        type=int,
+        help="number of VNETs for VNET VxLAN test"
+    )
+
+    parser.addoption(
+        "--num_routes",
+        action="store",
+        default=16000,
+        type=int,
+        help="number of routes for VNET VxLAN test"
+    )
+
+    parser.addoption(
+        "--num_endpoints",
+        action="store",
+        default=4000,
+        type=int,
+        help="number of endpoints for VNET VxLAN"
+    )
+
+    parser.addoption(
+        "--num_intf_per_vnet",
+        action="store",
+        default=1,
+        type=int,
+        help="number of VLAN interfaces per VNET"
+    )
+
+    parser.addoption(
+        "--ipv6_vxlan_test",
+        action="store_true",
+        help="Use IPV6 for VxLAN test"
+    )
+
+    parser.addoption(
+        "--skip_cleanup",
+        action="store_true",
+        help="Do not cleanup after VNET VxLAN test"
+    )
+
+    parser.addoption(
+        "--skip_apply_config",
+        action="store_true",
+        help="Apply new configurations on DUT"
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a performance test for setting and deleting routes
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The goal of this PR is to add a test case to quantify the performance of set/delete routes and make sure the operation could finish within the time limit.

#### How did you do it?
Set or delete multiple (10k level) routes with `swssconfig` and record the time for the routes to show up in ASIC_DB.

#### How did you verify/test it?
Verified by running the test locally with a virtual switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Any.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
