### PR TITLE
[vxlan-decap] Update vxlan-decap script to record DUT information in log

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -31,8 +31,6 @@ import subprocess
 import traceback
 import socket
 import struct
-from pprint import pprint
-from pprint import pformat
 from device_connection import DeviceConnection
 import re
 
@@ -91,6 +89,9 @@ class Vxlan(BaseTest):
         self.vxlan_enabled = False
         self.random_mac = '8c:01:02:03:04:05'
         self.nr = 1
+        current_time = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        log_file_name = "/tmp/vxlan_decap_test.{}.log".format(current_time)
+        self.log_fp = open(log_file_name, 'w')
 
     def cmd(self, cmds):
         process = subprocess.Popen(cmds,
@@ -101,6 +102,11 @@ class Vxlan(BaseTest):
         return_code = process.returncode
 
         return stdout, stderr, return_code
+
+    def log(self, message):
+        current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.log_fp.write("{} : {}\n".format(current_time, message))
+        self.log_fp.flush()
 
     def readMacs(self):
         addrs = {}
@@ -294,10 +300,11 @@ class Vxlan(BaseTest):
 
     def tearDown(self):
         self.cmd(["supervisorctl", "stop", "arp_responder"])
+        self.log_fp.close()
         return
 
     def warmup(self):
-        print "Warming up"
+        self.log("Warming up")
         err = ''
         trace = ''
         ret = 0
@@ -307,6 +314,7 @@ class Vxlan(BaseTest):
                 self.RegularLAGtoVLAN(test, True)
                 #wait sometime for DUT to build FDB and ARP table
                 res = self.wait_dut(test, TIMEOUT)
+                self.log_dut_status()
                 self.assertTrue(res, "DUT is not ready after {} seconds".format(TIMEOUT))
 
         except Exception as e:
@@ -314,52 +322,69 @@ class Vxlan(BaseTest):
             trace = traceback.format_exc()
             ret = -1
         if ret != 0:
-            print "The warmup failed"
-            print
-            print "Error: %s" % err
-            print
-            print trace
+            self.log("The warmup failed")
+            self.log("Error: %s" % err)
+            self.log(trace)
         else:
-            print "Warmup successful\n"
+            self.log("Warmup successful")
         sys.stdout.flush()
         if ret != 0:
             raise AssertionError("Warmup failed")
 
+    def log_dut_status(self):
+        COMMAND = 'show arp'
+        stdout, stderr, return_code = self.dut_connection.execCommand(COMMAND)
+        self.log("ARP table on DUT \n{}".format(stdout))
+
+        COMMAND = 'fdbshow'
+        stdout, stderr, return_code = self.dut_connection.execCommand(COMMAND)
+        self.log("MAC table on DUT \n{}".format(stdout))
+
+        COMMAND = 'show vxlan tunnel'
+        stdout, stderr, return_code = self.dut_connection.execCommand(COMMAND)
+        self.log("vxlan config on DUT \n{}".format(stdout))
+
     def work_test(self):
-        print "Testing"
+        self.log("Testing")
         err = ''
         trace = ''
         ret = 0
         try:
             for test in self.tests:
-                print test['name']
+                self.log(test['name'])
 
                 res_f, out_f = self.RegularLAGtoVLAN(test)
-                print "  RegularLAGtoVLAN = ", res_f
-                self.assertTrue(res_f, "RegularLAGtoVLAN test failed:\n  %s\n\ntest:\n%s" % (out_f, pformat(test)))
+                self.log("RegularLAGtoVLAN = {} {}".format(res_f, out_f))
+                if not res_f:
+                    self.log_dut_status()
+                self.assertTrue(res_f, "RegularLAGtoVLAN test failed:\n  %s\n" % (out_f))
 
                 res_t, out_t = self.RegularVLANtoLAG(test)
-                print "  RegularVLANtoLAG = ", res_t
-                self.assertTrue(res_t, "RegularVLANtoLAG test failed:\n  %s\n\ntest:\n%s" % (out_t, pformat(test)))
+                self.log("RegularVLANtoLAG = {} {}".format(res_t, out_t))
+                if not res_t:
+                    self.log_dut_status()
+                self.assertTrue(res_t, "RegularVLANtoLAG test failed:\n  %s\n" % (out_t))
 
                 res_v, out_v = self.Vxlan(test)
-                print "  Vxlan            = ", res_v
+                self.log("Vxlan = {} {}".format(res_v, out_v))
                 if self.vxlan_enabled:
-                    self.assertTrue(res_v, "VxlanTest failed:\n  %s\n\ntest:\n%s"  % (out_v, pformat(test)))
+                    if not res_v:
+                        self.log_dut_status()
+                    self.assertTrue(res_v, "VxlanTest failed:\n  %s\n"  % (out_v))
                 else:
-                    self.assertFalse(res_v, "VxlanTest: vxlan works, but it must have been disabled!\n\ntest:%s" % pformat(test))
+                    if res_v:
+                        self.log_dut_status()
+                    self.assertFalse(res_v, "VxlanTest: vxlan works, but it must have been disabled!\n")
         except AssertionError as e:
             err = str(e)
             trace = traceback.format_exc()
             ret = -1
         if ret != 0:
-            print "The test failed"
-            print
-            print "Error: %s" % err
-            print
-            print trace
+            self.log("The test failed")
+            self.log("Error: {}".format(err))
+            self.log(trace)
         else:
-            print "The test was successful"
+            self.log("The test was successful")
         sys.stdout.flush()
         if ret != 0:
             raise AssertionError(err)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR adds a log method to record DUT information for troubleshooting.
 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_vxlan_decap occasionally failed, but no log is recorded for troubleshooting. This PR adds a log method to record DUT information for troubleshooting.

#### How did you do it?
Add a log method to retrieve and record DUT state.

#### How did you verify/test it?
Verified on Celestica-DX010, and check log is recorded in PTF container.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util -k 'not test_fast_reboot' vxlan/test_vxlan_decap.py
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 3 items                                                                                                                                                                                     

vxlan/test_vxlan_decap.py::test_vxlan_decap[NoVxLAN] PASSED                                                                                                                                     [ 33%]
vxlan/test_vxlan_decap.py::test_vxlan_decap[Enabled] ^@PASSED                                                                                                                                     [ 66%]
vxlan/test_vxlan_decap.py::test_vxlan_decap[Removed] PASSED                                                                                                                                     [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 3 passed in 448.35 seconds ======================================================================================
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A.
