### PR TITLE
[arp_responder] Let arp_responder send reply when there is no vlan

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -110,9 +110,10 @@ class ARPResponder(object):
         if request_ip_str not in self.ip_sets[interface.name()]:
             return
 
-        vlan_list = []
         if 'vlan' in self.ip_sets[interface.name()]:
             vlan_list = self.ip_sets[interface.name()]['vlan']
+        else:
+            vlan_list = [None]
 
         for vlan_id in vlan_list:
             arp_reply = self.generate_arp_reply(self.ip_sets[interface.name()][request_ip_str], remote_mac, request_ip, remote_ip, vlan_id)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Let arp_responder send reply when there is no vlan
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The arp_responder should send reply even if there is no vlan. This logic got changed in a recent commit https://github.com/Azure/sonic-mgmt/pull/2236

#### How did you do it?
Add a vlan_id of None when there is no vlan. As such, the arp_responder could send the proper reply.

#### How did you verify/test it?
Verified by testing locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
