### PR TITLE
[pfcwd] Filter rx ports out of test ports

### DIFF
--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -225,10 +225,20 @@ def select_test_ports(test_ports):
         selected_ports (dict): random port info or set of ports matching seed
     """
     selected_ports = dict()
+    rx_ports = set()
     seed = int(datetime.datetime.today().day)
-    for key, value in test_ports.items():
-        if (int(value['test_port_id']) % 15) == (seed % 15):
-            selected_ports.update({key:value})
+    for port, port_info in test_ports.items():
+        rx_port = port_info["rx_port"]
+        if isinstance(rx_port, (list, tuple)):
+            rx_ports.update(rx_port)
+        else:
+            rx_ports.add(rx_port)
+        if (int(port_info['test_port_id']) % 15) == (seed % 15):
+            selected_ports[port] = port_info
+
+    # filter out selected ports that also act as rx ports
+    selected_ports = {p: pi for p, pi in selected_ports.items()
+                      if p not in rx_port}
 
     if not selected_ports:
         random_port = test_ports.keys()[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

If port `A` is used as test port and rx port for port `B`, and the test
conducts `storm_restore_path` over port `B` prior to port `A`. The
traffic verification for port `B` will fail because it uses port `A` as
rx port, which is currently in stormed state.

So filter out those ports that act as rx port out of selected test
ports.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If a port is used as the rx port, it cannot be used as a test port in `pfcwd` tests since it might be in stormed state, and the traffic verification will fail.

#### How did you do it?
Remove all ports as rx ports from test ports.

#### How did you verify/test it?

#### Any platform specific information?
Test over Arista7260, it is more likely to reproduce with DUT that has more ports.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
