### PR TITLE
[pytest][pfcwd] Sort detect and restore lists before validation

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -158,6 +158,8 @@ class TestPfcwdAllTimer(object):
         """
         Compare the timestamps obtained and verify the timer accuracy
         """
+        self.all_detect_time.sort()
+        self.all_restore_time.sort()
         logger.info("Verify that real detection time is not greater than configured")
         config_detect_time = self.timers['pfc_wd_detect_time'] + self.timers['pfc_wd_poll_time']
         err_msg = ("Real detection time is greater than configured: Real detect time: {} "


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR
Sort pfc detect and restore lists before validation
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Timer validation using logs time stamp is not very accurate method so sometimes the detect/restore value might be slightly bigger then required. If this happens with 10th iteration the test will fail. Here is the output of detect/restore lists (already sorted) from test run BFN Arista box:

```
(Pdb) self.all_detect_time
[326, 326, 341, 393, 439, 502, 511, 562, 567, 591, 604, 639, 651, 660, 663, 675, 714, 748, 771]
(Pdb) self.all_restore_time
[461, 461, 522, 535, 543, 585, 622, 635, 639, 670, 730, 761, 762, 765, 772, 781, 783, 798, 827]
```

In order to avoid this and check the average value the lists are sorted before check like this was done in ansible version:   https://github.com/Azure/sonic-mgmt/blob/master/ansible/roles/test/tasks/pfc_wd/functional_test/check_timer_accuracy_test.yml#L58

#### How did you do it?

#### How did you verify/test it?
Ran timer accuracy test on BFN platform 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
