### PR TITLE
Updated bgp_multipath_relax test due to lates updates in BGP Routing …

### DIFF
--- a/ansible/library/bgp_route.py
+++ b/ansible/library/bgp_route.py
@@ -225,6 +225,7 @@ class BgpRoutes(object):
         regex_prefix_path_p1_from = re.compile('.* from .*\([0-9a-fA-F.:]+\)')
         regex_prefix_path_p2_origin = re.compile('\s+Origin')
         regex_prefix_path_p3_timestamp = re.compile('\s+Last update:')
+        regex_prefix_path_p3_community = re.compile('\s+Community:')
         cmd_err1 = 'Unknown command'
         cmd_err2 = 'Network not in table'
 
@@ -284,6 +285,8 @@ class BgpRoutes(object):
             elif state == PREFIX_PATH_TIMESTAMP:
                 if regex_prefix_path_p3_timestamp.match(line):
                     state = PREFIX_PATHS
+                elif regex_prefix_path_p3_community.match(line):
+                    continue
                 else:
                     state = ERR
             elif state == ERR:


### PR DESCRIPTION
…facts

Signed-off-by: Nazar Tkachuk <nazarx.tkachuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # Updated bgp_multipath_relax test due to lates updates in BGP Routing facts(see below output) with new attribute `Community: 5060:12345`
```
admin@dut:~$ docker exec -i bgp vtysh -c 'show ip bgp 200.0.1.0/26'                                                                                                                                                                                                 
BGP routing table entry for 200.0.1.0/26                                                                                                                                                                                                                                     
Paths: (2 available, best #2, table default)                                                                                                                                                                                                                                 
  Advertised to non peer-group peers:                                                                                                                                                                                                                                        
  10.0.0.1 10.0.0.5 10.0.0.9 10.0.0.13 10.0.0.17 10.0.0.21 10.0.0.25 10.0.0.29 10.0.0.33 10.0.0.35 10.0.0.37 10.0.0.39 10.0.0.41 10.0.0.43 10.0.0.45 10.0.0.47 10.0.0.49 10.0.0.51 10.0.0.53 10.0.0.55 10.0.0.57 10.0.0.59 10.0.0.61 10.0.0.63                               
  64003 64700                                                                                                                                                                                                                                                                
    10.0.0.37 from 10.0.0.37 (100.1.0.19)                                                                                                                                                                                                                                    
      Origin IGP, valid, external, multipath                                                                                                                                                                                                                                 
      Community: 5060:12345                                                                                                                                                                                                                                                  
      Last update: Tue Oct 13 12:41:00 2020                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                             
  64001 64700                                                                                                                                                                                                                                                                
    10.0.0.33 from 10.0.0.33 (100.1.0.17)                                                                                                                                                                                                                                    
      Origin IGP, valid, external, multipath, best (Older Path)                                                                                                                                                                                                              
      Community: 5060:12345                                                                                                                                                                                                                                                  
      Last update: Tue Oct 13 12:41:00 2020
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make test bgp_multipath_relax  work with latest SONiC image and release SONiC image
#### How did you do it?
Added new verification step for attribute `Community`. This verification is not mandatory and should be skipped with  release SONiC image
#### How did you verify/test it?
Run bgp_multipath_relax  test with latest SONiC image and release SONiC image
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
