### PR TITLE
[Mellanox] Align sensors labels for human readable output for MSN3420

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2956,3 +2956,195 @@ sensors_checks:
         side: left
         skip_list:
         - ym2851-i2c-9-58
+
+  x86_64-mlnx_msn3420-r0:
+    alarms:
+      fan:
+      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_alarm
+      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_fault
+
+      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_alarm
+      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_fault
+
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 1/fan1_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 2/fan2_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 1/fan3_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 2/fan4_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 1/fan5_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 2/fan6_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 1/fan7_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 2/fan8_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-5 Tach 1/fan9_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-5 Tach 2/fan10_fault
+      power:
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 VCORE 0.8V Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 VCORE 0.8V Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 COMEX 1.2V Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 COMEX 1.2V Rail (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 VCORE 0.8V Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 VCORE 0.8V Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 COMEX 1.2V Rail Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 COMEX 1.2V Rail Curr (out)/curr4_crit_alarm
+
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 1.8V Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 1.8V Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 1.8V Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 1.8V Rail Curr (out)/curr3_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in1)/in1_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in2)/in2_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail (out)/in4_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail (out)/in4_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in2)/in2_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
+
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_max_alarm
+
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in2_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_max_alarm
+      temp:
+      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - mlxsw-i2c-2-48/front panel 001/temp2_fault
+      - mlxsw-i2c-2-48/front panel 002/temp3_fault
+      - mlxsw-i2c-2-48/front panel 003/temp4_fault
+      - mlxsw-i2c-2-48/front panel 004/temp5_fault
+      - mlxsw-i2c-2-48/front panel 005/temp6_fault
+      - mlxsw-i2c-2-48/front panel 006/temp7_fault
+      - mlxsw-i2c-2-48/front panel 007/temp8_fault
+      - mlxsw-i2c-2-48/front panel 008/temp9_fault
+      - mlxsw-i2c-2-48/front panel 009/temp10_fault
+      - mlxsw-i2c-2-48/front panel 010/temp11_fault
+      - mlxsw-i2c-2-48/front panel 011/temp12_fault
+      - mlxsw-i2c-2-48/front panel 012/temp13_fault
+      - mlxsw-i2c-2-48/front panel 013/temp14_fault
+      - mlxsw-i2c-2-48/front panel 014/temp15_fault
+      - mlxsw-i2c-2-48/front panel 015/temp16_fault
+      - mlxsw-i2c-2-48/front panel 016/temp17_fault
+      - mlxsw-i2c-2-48/front panel 017/temp18_fault
+      - mlxsw-i2c-2-48/front panel 018/temp19_fault
+      - mlxsw-i2c-2-48/front panel 019/temp20_fault
+      - mlxsw-i2c-2-48/front panel 020/temp21_fault
+      - mlxsw-i2c-2-48/front panel 021/temp22_fault
+      - mlxsw-i2c-2-48/front panel 022/temp23_fault
+      - mlxsw-i2c-2-48/front panel 023/temp24_fault
+      - mlxsw-i2c-2-48/front panel 024/temp25_fault
+      - mlxsw-i2c-2-48/front panel 025/temp26_fault
+      - mlxsw-i2c-2-48/front panel 026/temp27_fault
+      - mlxsw-i2c-2-48/front panel 027/temp28_fault
+      - mlxsw-i2c-2-48/front panel 028/temp29_fault
+      - mlxsw-i2c-2-48/front panel 029/temp30_fault
+      - mlxsw-i2c-2-48/front panel 030/temp31_fault
+      - mlxsw-i2c-2-48/front panel 031/temp32_fault
+      - mlxsw-i2c-2-48/front panel 032/temp33_fault
+      - mlxsw-i2c-2-48/front panel 033/temp34_fault
+      - mlxsw-i2c-2-48/front panel 034/temp35_fault
+      - mlxsw-i2c-2-48/front panel 035/temp36_fault
+      - mlxsw-i2c-2-48/front panel 036/temp37_fault
+      - mlxsw-i2c-2-48/front panel 037/temp38_fault
+      - mlxsw-i2c-2-48/front panel 038/temp39_fault
+      - mlxsw-i2c-2-48/front panel 039/temp40_fault
+      - mlxsw-i2c-2-48/front panel 040/temp41_fault
+      - mlxsw-i2c-2-48/front panel 041/temp42_fault
+      - mlxsw-i2c-2-48/front panel 042/temp43_fault
+      - mlxsw-i2c-2-48/front panel 043/temp44_fault
+      - mlxsw-i2c-2-48/front panel 044/temp45_fault
+      - mlxsw-i2c-2-48/front panel 045/temp46_fault
+      - mlxsw-i2c-2-48/front panel 046/temp47_fault
+      - mlxsw-i2c-2-48/front panel 047/temp48_fault
+      - mlxsw-i2c-2-48/front panel 048/temp49_fault
+      - mlxsw-i2c-2-48/front panel 049/temp50_fault
+      - mlxsw-i2c-2-48/front panel 050/temp51_fault
+      - mlxsw-i2c-2-48/front panel 051/temp52_fault
+      - mlxsw-i2c-2-48/front panel 052/temp53_fault
+      - mlxsw-i2c-2-48/front panel 053/temp54_fault
+      - mlxsw-i2c-2-48/front panel 054/temp55_fault
+      - mlxsw-i2c-2-48/front panel 055/temp56_fault
+      - mlxsw-i2c-2-48/front panel 056/temp57_fault
+      - mlxsw-i2c-2-48/front panel 057/temp58_fault
+      - mlxsw-i2c-2-48/front panel 058/temp59_fault
+      - mlxsw-i2c-2-48/front panel 059/temp60_fault
+      - mlxsw-i2c-2-48/front panel 060/temp61_fault
+
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-64/PMIC-2 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 Temp 1/temp1_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_max_alarm
+
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_max_alarm
+    compares:
+      power: []
+      temp:
+      - - coretemp-isa-0000/Physical id 0/temp1_input
+        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_max
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_max
+
+      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
+
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+
+      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
+        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}
+    


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Align sensors labels for human readable output for MSN3420.

#### How did you do it?
Modify 'sku-sensors-data.yml' file with correct labels from 'sonic-buildimage' repo.

#### How did you verify/test it?
Run sensors test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
