### PR TITLE
[autorestart] Move disable_container_autorestart fixtures to pre_test and post_test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,37 +429,4 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
     record_testsuite_property("hwsku", duthost.facts["hwsku"])
     record_testsuite_property("os_version", duthost.os_version)
 
-@pytest.fixture(scope="module", autouse=True)
-def disable_container_autorestart(duthost, request):
-    command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
-    if command_output['rc'] != 0:
-        logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
-        logging.info("Skipping disable_container_autorestart fixture")
-        yield
-        return
-    skip = False
-    for m in request.node.iter_markers():
-        if m.name == "enable_container_autorestart":
-            skip = True
-            break
-    if skip:
-        yield
-        return
-    container_autorestart_states = duthost.get_container_autorestart_states()
-    # Disable autorestart for all containers
-    logging.info("Disable container autorestart")
-    cmd_disable = "config feature autorestart {} disabled"
-    cmds_disable = []
-    for name, state in container_autorestart_states.items():
-        if state == "enabled":
-            cmds_disable.append(cmd_disable.format(name))
-    duthost.shell_cmds(cmds=cmds_disable)
-    yield
-    # Recover autorestart states
-    logging.info("Recover container autorestart")
-    cmd_enable = "config feature autorestart {} enabled"
-    cmds_enable = []
-    for name, state in container_autorestart_states.items():
-        if state == "enabled":
-            cmds_enable.append(cmd_enable.format(name))
-    duthost.shell_cmds(cmds=cmds_enable)
+

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -34,12 +34,6 @@ def test_collect_techsupport(duthost):
     assert True
 
 def test_restore_container_autorestart(duthost):
-    command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
-    if command_output['rc'] != 0:
-        logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
-        logging.info("Skipping disable_container_autorestart")
-        return
-
     state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)
     if not os.path.exists(state_file_name):
         return

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -33,11 +33,11 @@ def test_collect_techsupport(duthost):
 
     assert True
 
-def test_restore_container_autorestart(duthost, request):
+def test_restore_container_autorestart(duthost):
     command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
     if command_output['rc'] != 0:
         logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
-        logging.info("Skipping disable_container_autorestart fixture")
+        logging.info("Skipping disable_container_autorestart")
         return
 
     state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -1,6 +1,8 @@
 import pytest
 import logging
 import os.path
+import os
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -30,3 +32,31 @@ def test_collect_techsupport(duthost):
         duthost.fetch(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
 
     assert True
+
+def test_restore_container_autorestart(duthost, request):
+    command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
+    if command_output['rc'] != 0:
+        logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
+        logging.info("Skipping disable_container_autorestart fixture")
+        return
+
+    state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)
+    if not os.path.exists(state_file_name):
+        return
+    stored_autorestart_states = {}
+    with open(state_file_name, "r") as f:
+        stored_autorestart_states = json.load(f)
+    container_autorestart_states = duthost.get_container_autorestart_states()
+    # Recover autorestart states
+    logging.info("Recover container autorestart")
+    cmd_enable = "config feature autorestart {} enabled"
+    cmds_enable = []
+    for name, state in container_autorestart_states.items():
+        if state == "disabled" \
+                and stored_autorestart_states.has_key(name) \
+                and stored_autorestart_states[name] == "enabled":
+            cmds_enable.append(cmd_enable.format(name))
+    # Write into config_db
+    cmds_enable.append("config save -y")
+    duthost.shell_cmds(cmds=cmds_enable)
+    os.remove(state_file_name)

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +23,27 @@ def test_cleanup_testbed(duthost, request, ptfhost):
     # Cleanup rsyslog configuration file that might have damaged by test_syslog.py
     if ptfhost:
         ptfhost.shell("if [[ -f /etc/rsyslog.conf ]]; then mv /etc/rsyslog.conf /etc/rsyslog.conf.orig; uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")
+
+def test_disable_container_autorestart(duthost, request):
+    command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
+    if command_output['rc'] != 0:
+        logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
+        logging.info("Skipping disable_container_autorestart fixture")
+        return
+    container_autorestart_states = duthost.get_container_autorestart_states()
+    state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)
+    # Dump autorestart state to file
+    with open(state_file_name, "w") as f:
+        json.dump(container_autorestart_states, f)
+    # Disable autorestart for all containers
+    logging.info("Disable container autorestart")
+    cmd_disable = "config feature autorestart {} disabled"
+    cmds_disable = []
+    for name, state in container_autorestart_states.items():
+        if state == "enabled":
+            cmds_disable.append(cmd_disable.format(name))
+    # Write into config_db
+    cmds_disable.append("config save -y")
+    duthost.shell_cmds(cmds=cmds_disable)
+
+

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -24,11 +24,11 @@ def test_cleanup_testbed(duthost, request, ptfhost):
     if ptfhost:
         ptfhost.shell("if [[ -f /etc/rsyslog.conf ]]; then mv /etc/rsyslog.conf /etc/rsyslog.conf.orig; uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")
 
-def test_disable_container_autorestart(duthost, request):
+def test_disable_container_autorestart(duthost):
     command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
     if command_output['rc'] != 0:
         logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
-        logging.info("Skipping disable_container_autorestart fixture")
+        logging.info("Skipping disable_container_autorestart")
         return
     container_autorestart_states = duthost.get_container_autorestart_states()
     state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The update of autorestart feature will reload snmp container. To save unnecessary reload, the disable_container_autorestart fixture is moved to pre_test as a test case, and states are saved in /tmp path in sonic-mgnt container. All autorestart features are restored in post_test.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to improve the autouse fixture disable_container_autorestart. 
#### How did you do it?
1. The autouse fixture disable_container_autorestart is removed;
2. Add a new test case in pretest.py to disable autorestart for all containers, and save original states in /tmp path in sonic-mgnt container;
3. Add a new test case in posttest.py to restore autorestart feature for all containers;
4. config_db.json is updated after disable and restore autorestart features, so that the state will keep even after ```config reload``` or ```reboot```.

#### How did you verify/test it?
Verified on Arista-7260cx3-2.
Default states:
```
admin@str-7260cx3-acs-2:~$ show feature autorestart 
Feature     AutoRestart
----------  -------------
acms        enabled
bgp         enabled
database    disabled
dhcp_relay  enabled
lldp        enabled
pmon        enabled
radv        enabled
snmp        enabled
swss        enabled
syncd       enabled
teamd       enabled
telemetry   enabled
```
Autorestart features are disabled for all containers after running ```test_disable_container_autorestart``` and states are backed up.
```
admin@str-7260cx3-acs-2:~$ show feature autorestart 
Feature     AutoRestart
----------  -------------
acms        disabled
bgp         disabled
database    disabled
dhcp_relay  disabled
lldp        disabled
pmon        disabled
radv        disabled
snmp        disabled
swss        disabled
syncd       disabled
teamd       disabled
telemetry   disabled

bingwang@df9bc4cdf9b3:/data/Networking-acs-sonic-mgmt$ cat /tmp/autorestart_state_str-7260cx3-acs-2.json 
{"lldp": "enabled", "bgp": "enabled", "pmon": "enabled", "database": "disabled", "radv": "enabled", "telemetry": "enabled", "snmp": "enabled", "acms": "enabled", "dhcp_relay": "enabled", "teamd": "enabled", "syncd": "enabled", "swss": "enabled"}
```
Autorestart features are disabled for all containers after running ```test_restore_container_autorestart```
```
admin@str-7260cx3-acs-2:~$ show feature autorestart 
Feature     AutoRestart
----------  -------------
acms        enabled
bgp         enabled
database    disabled
dhcp_relay  enabled
lldp        enabled
pmon        enabled
radv        enabled
snmp        enabled
swss        enabled
syncd       enabled
teamd       enabled
telemetry   enabled
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.