### PR TITLE
[conn_graph_facts] Add 'device_vlan_map_list' after flatten

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -326,7 +326,6 @@ def main():
         device_port_vlans = []
         device_vlan_range = []
         device_vlan_list = []
-        device_vlan_map_list = {}
         for hostname in hostnames:
             dev = lab_graph.get_host_device_info(hostname)
             if dev is None:
@@ -338,7 +337,6 @@ def main():
             if host_vlan:
                 device_vlan_range.append(host_vlan["VlanRange"])
                 device_vlan_list.append(host_vlan["VlanList"])
-                device_vlan_map_list[hostname] = host_vlan["VlanList"]
             device_port_vlans.append(lab_graph.get_host_port_vlans(hostname))
         results = {k: v for k, v in locals().items()
                    if (k.startswith("device_") and v)}
@@ -346,7 +344,8 @@ def main():
         # flatten the lists for single host
         if m_args['hosts'] is None:
             results = {k: v[0] for k, v in results.items()}
-
+        results["device_vlan_map_list"] = dict(zip(hostnames,
+                                                   device_vlan_list))
         module.exit_json(ansible_facts=results)
     except (IOError, OSError):
         module.fail_json(msg="Can not find lab graph file under {}".format(LAB_GRAPHFILE_PATH))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Currently, flatten list for single hosts will error because
`device_vlan_map_list` is a dictionary.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For single host, `conn_graph_facts` current fail when try to flatten `device_vlan_map_list`, which is a dictionary.

#### How did you do it?
Add `device_vlan_map_list` to the result of `conn_graph_facts` after flattenning the list.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
