### PR TITLE
[conn_graph] improve graph facts collector

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -345,7 +345,7 @@ def main():
 
         # flatten the lists for single host
         if m_args['hosts'] is None:
-            results = {k: v[0] for k, v in results.items()}
+            results = {k: v[0] if isinstance(v, list) else v for k, v in results.items()}
 
         module.exit_json(ansible_facts=results)
     except (IOError, OSError):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Nightly test are all failing due to regression in conn_graph_facts.py.

#### How did you do it?
- Collect first element of list.
- Collect full variable for non-list variables.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test on physical DUT. Without fix:

        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module conn_graph_facts failed, Ansible Results =>
E           {
E               "changed": false, 
E               "failed": true, 
E               "invocation": {
E                   "module_args": {
E                       "anchor": null, 
E                       "filename": "/var/src/sonic-mgmt/tests/common/fixtures/../../../ansible/files/starlab_connection_graph.xml", 
E                       "filepath": null, 
E                       "host": "str-dx010-acs-1", 
E                       "hosts": null
E                   }
E               }, 
E               "msg": "Traceback (most recent call last):\n  File \"/tmp/ansible_conn_graph_facts_payload_PAqL5h/__main__.py\", line 348, in main\n    results = {k: v[0] for k, v in results.items()}\n  File \"/tmp/ansible_conn_graph_facts_payload_PAqL5h/__main__.py\", line 348, in <dictcomp>\n    results = {k: v[0] for k, v in results.items()}\nKeyError: 0\n"
E           }

With the fix, test passes.