### PR TITLE
[conftest]: Add fixture to write test module to syslog

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,9 @@ def pytest_addoption(parser):
     # qos_sai options
     parser.addoption("--ptf_portmap", action="store", default=None, type=str, help="PTF port index to DUT port alias map")
 
+    parser.addoption("--write_syslog", action="store_true", default=False, help="Write each test module to DUT syslog as it's run. Default is disabled (False)")
+
+
     ############################
     # pfc_asym options         #
     ############################
@@ -463,3 +466,13 @@ def disable_container_autorestart(duthost, request):
         if state == "enabled":
             cmds_enable.append(cmd_enable.format(name))
     duthost.shell_cmds(cmds=cmds_enable)
+
+@pytest.fixture(scope="module", autouse=True)
+def write_test_module_to_syslog(duthost, request):
+    """Write the test case name to the DUT syslog"""
+
+    write_syslog = request.config.getoption("write_syslog")
+
+    if write_syslog:
+        log_msg = "-----BEGIN TEST MODULE {}-----".format(request.node.name)
+        duthost.syslogger(msg=log_msg) 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In DUT syslogs, it's not immediately clear which logs are a result of which tests, or where the division between tests is. This can make it more difficult to debug tests that aren't passing.

#### How did you do it?
Add a fixture to write the name of each test module that is run into the DUT syslog.
Add a CLI parameter to turn this feature on (off by default)

#### How did you verify/test it?
Run some pytests with `-e --write_syslog` option and confirm that the test module name is logged.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
