### PR TITLE
Add new regex matches to support MONIT logging innew images

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -136,7 +136,10 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     """
     ignoreRegex = [
         ".*ERR monit.*'lldpd_monitor' process is not running",
+        ".*ERR monit.* 'lldp\|lldpd_monitor' status failed.*-- 'lldpd:' is not running.",
+
         ".*ERR monit.*'lldp_syncd' process is not running",
+        ".*ERR monit.*'lldp\|lldp_syncd' status failed.*'python2 -m lldp_syncd' is not running.",
         ".*snmp#snmp-subagent.*",
     ]
     if loganalyzer:  # Skip if loganalyzer is disabled

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -466,10 +466,21 @@ class QosSaiBase:
         if loganalyzer:
             ignoreRegex = [
                 ".*ERR monit.*'lldpd_monitor' process is not running",
+                ".*ERR monit.* 'lldp\|lldpd_monitor' status failed.*-- 'lldpd:' is not running.",
+
                 ".*ERR monit.*'lldp_syncd' process is not running",
+                ".*ERR monit.* 'lldp\|lldp_syncd' status failed.*-- 'python2 -m lldp_syncd' is not running.",
+
                 ".*ERR monit.*'bgpd' process is not running",
+                ".*ERR monit.* 'bgp\|bgpd' status failed.*-- '/usr/lib/frr/bgpd' is not running.",
+
                 ".*ERR monit.*'bgpcfgd' process is not running",
-                ".*ERR syncd#syncd:.*brcm_sai_set_switch_attribute:.*updating switch mac addr failed.*"
+                ".*ERR monit.* 'bgp\|bgpcfgd' status failed.*-- '/usr/bin/python /usr/local/bin/bgpcfgd' is not running.",
+
+                ".*ERR syncd#syncd:.*brcm_sai_set_switch_attribute:.*updating switch mac addr failed.*",
+
+                ".*ERR monit.*'bgp\|bgpmon' status failed.*'/usr/bin/python /usr/local/bin/bgpmon' is not running",
+                ".*ERR monit.*bgp\|fpmsyncd.*status failed.*NoSuchProcess process no longer exists.*",
             ]
             loganalyzer.ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Updated regex match lists to support new `MONIT` logging format 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`Monit` warning/err message format has changed. This has caused the existing regex ignore match strings to become obsolete for new images. New regex strings are added here to support testing new images.

#### How did you do it?
Updated `ignoreRegex` list for qos_sai and copp testcases.

#### How did you verify/test it?
With old list of  `ignoreRegex`, the testcase fails:
```

qos/test_qos_sai.py::TestQosSai::testParameter PASSED                                                                                                                                                                 [  5%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] PASSED                                                                                                                                                [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] ERROR                                                                                                                                                 [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_2] PASSED                                                                                                                                                [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_1] PASSED                                                                                                                                                  [ 22%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_1] ERROR                                                                                                                                                   [ 22%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_2] PASSED                                                                                                                                                  [ 27%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_2] ERROR                                                                                                                                                   [ 27%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize PASSED                                                                                                                                                    [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize ERROR                                                                                                                                                     [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[wm_buf_pool_lossless] SKIPPED                                                                                                                          [ 38%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[wm_buf_pool_lossy] SKIPPED                                                                                                                             [ 44%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue PASSED                                                                                                                                                          [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping PASSED                                                                                                                                                    [ 55%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping ERROR                                                                                                                                                     [ 55%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr PASSED                                                                                                                                                                [ 61%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossless] PASSED                                                                                                                            [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossless] ERROR                                                                                                                             [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossy] PASSED                                                                                                                               [ 72%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossy] ERROR                                                                                                                                [ 72%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark PASSED                                                                                                                                                 [ 77%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark ERROR                                                                                                                                                  [ 77%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossless] PASSED                                                                                                                              [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossless] ERROR                                                                                                                               [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossy] PASSED                                                                                                                                 [ 88%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossy] ERROR                                                                                                                                  [ 88%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping SKIPPED                                                                                                                                                    [ 94%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange PASSED                                                                                                                                                    [100%]


common/plugins/loganalyzer/loganalyzer.py:85: LogAnalyzerError
================================================================================================== short test summary info ==================================================================================================
SKIPPED [2] /var/src/6100-5/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:208: Buffer Pool watermark test is disabled
SKIPPED [1] /var/src/6100-5/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:501: DSCP to PG mapping test disabled
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:37:39': ["Oct 20 18:37:44.325056 str-dx010-acs-5 ERR monit[557]: 'lldp|lldpd_moni...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_1] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:39:56': ["Oct 20 18:39:45.726438 str-dx010-acs-5 ERR monit[557]: 'lldp|lldpd_monito...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_2] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:41:15': ["Oct 20 18:40:46.303142 str-dx010-acs-5 ERR monit[557]: 'lldp|lldpd_monito...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:43:07': ["Oct 20 18:41:46.928118 str-dx010-acs-5 ERR monit[557]: 'lldp|lldpd_monitor'...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:44:58': ["Oct 20 18:44:48.724415 str-dx010-acs-5 ERR monit[557]: 'lldp|lldpd_monitor'...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossless] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:47:03': ["Oct 20 18:45:49.324536 str-dx010-acs-5 ERR monit[55...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossy] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:48:45': ["Oct 20 18:47:50.616420 str-dx010-acs-5 ERR monit[557]:...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:50:28': ["Oct 20 18:49:51.940461 str-dx010-acs-5 ERR monit[557]: 'lldp|lldpd_monit...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossless] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:52:11': ["Oct 20 18:50:52.540502 str-dx010-acs-5 ERR monit[557]...
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossy] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-10-20-18:53:53': ["Oct 20 18:52:53.676470 str-dx010-acs-5 ERR monit[557]: '...
===================================================================================== 15 passed, 3 skipped, 10 error in 1688.74 seconds =====================================================================================
```

With new regex, the test has started passing again:
```
qos/test_qos_sai.py::TestQosSai::testParameter PASSED                                                                                                                                                                 [  5%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] PASSED                                                                                                                                                [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_2] PASSED                                                                                                                                                [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_1] PASSED                                                                                                                                                  [ 22%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_2] PASSED                                                                                                                                                  [ 27%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize PASSED                                                                                                                                                    [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[wm_buf_pool_lossless] SKIPPED                                                                                                                          [ 38%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[wm_buf_pool_lossy] SKIPPED                                                                                                                             [ 44%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue PASSED                                                                                                                                                          [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping PASSED                                                                                                                                                    [ 55%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr PASSED                                                                                                                                                                [ 61%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossless] PASSED                                                                                                                            [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossy] PASSED                                                                                                                               [ 72%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark PASSED                                                                                                                                                 [ 77%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossless] PASSED                                                                                                                              [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossy] PASSED                                                                                                                                 [ 88%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping SKIPPED                                                                                                                                                    [ 94%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange PASSED                                                                                                                                                    [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
