### PR TITLE
[rsyslog] Disable rsyslog rate limit in pre_test and do a recover in post_test

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -55,22 +55,24 @@ def test_restore_container_autorestart(duthost):
     cmds_enable.append("config save -y")
     duthost.shell_cmds(cmds=cmds_enable)
     os.remove(state_file_name)
-    # Wait 30 seconds for snmp reloading
-    time.sleep(30)
+    # Wait sometime for snmp reloading
+    SNMP_RELOADING_TIME = 30
+    time.sleep(SNMP_RELOADING_TIME)
 
 def test_recover_rsyslog_rate_limit(duthost):
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
         # Something unexpected happened.
         # We don't want to fail here because it's an util
+        logging.warn("Failed to retrieve feature status")
         return
-    cmd_disable_rate_limit = r"docker exec -i {} sed -i 's/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' /etc/rsyslog.conf"
+    cmd_enable_rate_limit = r"docker exec -i {} sed -i 's/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' /etc/rsyslog.conf"
     cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"
     for feature_name, state in features_dict.items():
         if state == "disabled":
             continue
         cmds = []
-        cmds.append(cmd_disable_rate_limit.format(feature_name))
+        cmds.append(cmd_enable_rate_limit.format(feature_name))
         cmds.append(cmd_reload.format(feature_name))
         duthost.shell_cmds(cmds=cmds)
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -47,14 +47,16 @@ def test_disable_container_autorestart(duthost):
     # Write into config_db
     cmds_disable.append("config save -y")
     duthost.shell_cmds(cmds=cmds_disable)
-    # Wait 30 seconds for snmp reloading
-    time.sleep(30)
+    # Wait sometime for snmp reloading
+    SNMP_RELOADING_TIME = 30
+    time.sleep(SNMP_RELOADING_TIME)
 
 def test_disable_rsyslog_rate_limit(duthost):
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
         # Something unexpected happened.
         # We don't want to fail here because it's an util
+        logging.warn("Failed to retrieve feature status")
         return
     cmd_disable_rate_limit = r"docker exec -i {} sed -i 's/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' /etc/rsyslog.conf"
     cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is a workaround for https://github.com/Azure/sonic-buildimage/issues/5667
Syslog messages will sometimes be rate-limited for no apparent reason. The rate-limiting threshhold is set at 20k messages sent in 5 minutes, however syslog will sometimes start rate-limiting messages from orchagent when fewer than 20k messages have been logged in the past 5  minutes. 
Some ERROR or WARNING log are supressed if rsyslog begin limiting rate, and errors might not be detected. This PR add a workaround for this issue. 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to disable the rate limit of rsyslog to ensure that all logs are recorded in syslog.
#### How did you do it?
1. Add a new case ```test_disable_rsyslog_rate_limit``` in ```test_pretest.py``` to update the configuration of rsyslog to disable rate limit, and then reload the ```rsyslogd``` service  in each container;
2. Add a new case ```test_recover_rsyslog_rate_limit``` in ```test_posttest.py``` to do a recover after all tests finish.

#### How did you verify/test it?
Verified on dx010 with a sample script to generate logs running in one of containers:
```
import syslog
index = 1
while index < 100000:
    msg="Test message at INFO priority index = {}".format(index)
    index += 1
    syslog.syslog(syslog.LOG_INFO, msg)
```
Before disable rate limit, we can see a rate-limiting in syslog
```
Oct 21 05:23:40.128727 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 19995
Oct 21 05:23:40.128766 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 19996
Oct 21 05:23:40.128766 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 19997
Oct 21 05:23:40.128791 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 19998
Oct 21 05:23:40.128791 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 19999
Oct 21 05:23:40.128829 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 20000
Oct 21 05:23:40.128829 str-dx010-acs-4 INFO swss#rsyslogd: imuxsock[pid: 2210, name: python] from <str-dx010-acs-4:run.py>: begin to drop messages due to rate-limiting
```
After disable rate limit, all logs are recorded in syslog
```
Oct 21 05:20:08.373985 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 99994
Oct 21 05:20:08.374006 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 99995
Oct 21 05:20:08.374023 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 99996
Oct 21 05:20:08.374023 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 99997
Oct 21 05:20:08.374065 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 99998
Oct 21 05:20:08.374065 str-dx010-acs-4 INFO swss#run.py: Test message at INFO priority index = 99999
```
And after recover, the rate-limiting begins to work again.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.