### PR TITLE
Fix conflicting options of vxlan and route tests

### DIFF
--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -1,5 +1,8 @@
 # Pytest configuration used by the route tests.
 def pytest_addoption(parser):
     # Add options to pytest that are used by route tests
-    parser.addoption("--num_routes", action="store", default=10000, type=int,
+
+    route_group = parser.getgroup("Route test suite options")
+
+    route_group.addoption("--num_routes", action="store", default=10000, type=int,
                      help="Number of routes for add/delete")

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -3,7 +3,9 @@ def pytest_addoption(parser):
     Adds pytest options that are used by VxLAN tests
     """
 
-    parser.addoption(
+    vxlan_group = parser.getgroup("VXLAN test suite options")
+
+    vxlan_group.addoption(
         "--num_vnet",
         action="store",
         default=8,
@@ -11,7 +13,7 @@ def pytest_addoption(parser):
         help="number of VNETs for VNET VxLAN test"
     )
 
-    parser.addoption(
+    vxlan_group.addoption(
         "--num_routes",
         action="store",
         default=16000,
@@ -19,7 +21,7 @@ def pytest_addoption(parser):
         help="number of routes for VNET VxLAN test"
     )
 
-    parser.addoption(
+    vxlan_group.addoption(
         "--num_endpoints",
         action="store",
         default=4000,
@@ -27,7 +29,7 @@ def pytest_addoption(parser):
         help="number of endpoints for VNET VxLAN"
     )
 
-    parser.addoption(
+    vxlan_group.addoption(
         "--num_intf_per_vnet",
         action="store",
         default=1,
@@ -35,19 +37,19 @@ def pytest_addoption(parser):
         help="number of VLAN interfaces per VNET"
     )
 
-    parser.addoption(
+    vxlan_group.addoption(
         "--ipv6_vxlan_test",
         action="store_true",
         help="Use IPV6 for VxLAN test"
     )
 
-    parser.addoption(
+    vxlan_group.addoption(
         "--skip_cleanup",
         action="store_true",
         help="Do not cleanup after VNET VxLAN test"
     )
 
-    parser.addoption(
+    vxlan_group.addoption(
         "--skip_apply_config",
         action="store_true",
         help="Apply new configurations on DUT"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR https://github.com/Azure/sonic-mgmt/pull/2344 introduced an option
`--num_routes` which conflicts with the same option of vxlan test.

Use run_tests.sh to run nightly regression would trigger the conflicting
issue during pre-test.

```
18:56:42 + echo '=== Preparing DUT for subsequent tests ==='
18:56:42 === Preparing DUT for subsequent tests ===
18:56:42 + pytest --inventory veos_vtb --host-pattern '[vlab-03]' --testbed vms-kvm-t1-lag --testbed_file vtestbed.csv --log-cli-level warning --log-file-level debug --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --junit-xml=logs/pretest.xml --log-file=logs/pretest.log --topology util --disable_loganalyzer -m pretest
18:56:44 ============================= test session starts ==============================
18:56:44 platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.8.1, pluggy-0.13.1
18:56:44 ansible: 2.8.7
18:56:44 rootdir: /var/johnar/workspace/RunPytest/tests, inifile: pytest.ini
18:56:44 plugins: repeat-0.8.0, xdist-1.28.0, forked-1.1.3, ansible-2.2.2
18:56:45 collected 0 items / 1 errors
18:56:45 WARNING: No route found for IPv6 destination :: (no default route?)
18:56:45 DEBUG:pytest_ansible.plugin:pytest_report_header() called
18:56:45 DEBUG:pytest_ansible.plugin:pytest_collection_modifyitems() called
18:56:45 DEBUG:pytest_ansible.plugin:items: []
18:56:45 
18:56:45 ==================================== ERRORS ====================================
18:56:45 ________________________ ERROR collecting test session _________________________
18:56:45 /usr/local/lib/python2.7/dist-packages/py/_path/common.py:383: in visit
18:56:45     for x in Visitor(fil, rec, ignore, bf, sort).gen(self):
18:56:45 /usr/local/lib/python2.7/dist-packages/py/_path/common.py:425: in gen
18:56:45     if p.check(dir=1) and (rec is None or rec(p))])
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/main.py:667: in _recurse
18:56:45     ihook = self.gethookproxy(dirpath)
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/main.py:482: in gethookproxy
18:56:45     my_conftestmodules = pm._getconftestmodules(fspath)
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:424: in _getconftestmodules
18:56:45     mod = self._importconftest(conftestpath.realpath())
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:474: in _importconftest
18:56:45     self.consider_conftest(mod)
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:527: in consider_conftest
18:56:45     self.register(conftestmodule, name=conftestmodule.__file__)
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:321: in register
18:56:45     ret = super(PytestPluginManager, self).register(plugin, name)
18:56:45 /usr/local/lib/python2.7/dist-packages/pluggy/manager.py:127: in register
18:56:45     hook._maybe_apply_history(hookimpl)
18:56:45 /usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:333: in _maybe_apply_history
18:56:45     res = self._hookexec(self, [method], kwargs)
18:56:45 /usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
18:56:45     return self._inner_hookexec(hook, methods, kwargs)
18:56:45 /usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
18:56:45     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
18:56:45 vxlan/conftest.py:19: in pytest_addoption
18:56:45     help="number of routes for VNET VxLAN test"
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/config/argparsing.py:73: in addoption
18:56:45     self._anonymous.addoption(*opts, **attrs)
18:56:45 /usr/local/lib/python2.7/dist-packages/_pytest/config/argparsing.py:304: in addoption
18:56:45     raise ValueError("option names %s already added" % conflict)
18:56:45 E   ValueError: option names set(['--num_routes']) already added
18:56:45 -- generated xml file: /var/johnar/workspace/RunPytest/tests/logs/pretest.xml --
18:56:45 =========================== short test summary info ============================
18:56:45 FAILED  - ValueError: option names set(['--num_routes']) already added
18:56:45 !!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
18:56:45 =========================== 1 error in 0.42 seconds ============================
```

#### How did you do it?
The fix is to introduce option group for both vxlan and route tests to avoid conflicting.

#### How did you verify/test it?
* Use `run_tests.sh` to trigger nightly tests.
* Run pretest
* Run tests/route/test_route_perf.py
* Run tests/route/test_vnet_vxlan.py
No issue of conflicting option.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
