### PR TITLE
[warm-reboot test] Update warm-reboot test to support kvm image

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -126,6 +126,7 @@ class ReloadTest(BaseTest):
         self.sad_handle = None
         self.process_id = str(os.getpid())
         self.test_params = testutils.test_params_get()
+        self.check_param('kvm_test', False, required = False)
         self.check_param('verbose', False, required=False)
         self.check_param('dut_username', '', required=True)
         self.check_param('dut_password', '', required=True)
@@ -155,7 +156,6 @@ class ReloadTest(BaseTest):
         self.check_param('vnet', False, required = False)
         self.check_param('vnet_pkts', None, required = False)
         self.check_param('target_version', '', required = False)
-        self.check_param('kvm_test', True, required = False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':
@@ -493,12 +493,12 @@ class ReloadTest(BaseTest):
         self.default_ip_range = self.test_params['default_ip_range']
 
         self.limit = datetime.timedelta(seconds=self.test_params['reboot_limit_in_seconds'])
+        self.kvm_test = self.test_params['kvm_test']
         self.reboot_type = self.test_params['reboot_type']
         if self.reboot_type not in ['fast-reboot', 'warm-reboot', 'warm-reboot -f']:
             raise ValueError('Not supported reboot_type %s' % self.reboot_type)
         self.dut_mac = self.test_params['dut_mac']
 
-        self.kvm_test = self.test_params['kvm_test']
         if self.kvm_test:
             self.log("This test is for KVM platform")
 
@@ -757,8 +757,6 @@ class ReloadTest(BaseTest):
         self.reboot_start = None
         self.no_routing_start = None
         self.no_routing_stop = None
-        self.no_control_start = None
-        self.no_control_stop = None
         self.no_cp_replies = None
         self.upper_replies = []
         self.routing_always = False
@@ -795,8 +793,9 @@ class ReloadTest(BaseTest):
             self.do_inboot_oper()
         self.reboot_start = datetime.datetime.now()
         self.log("Dut reboots: reboot start %s" % str(self.reboot_start))
-        self.no_control_start = self.cpu_state.get_state_time('down')
-        self.log("control plane down starts %s" % str(self.no_control_start))
+        if self.kvm_test:
+            self.no_control_start = self.cpu_state.get_state_time('down')
+            self.log("control plane down starts %s" % str(self.no_control_start))
 
     def handle_fast_reboot_health_check(self):
         if not self.kvm_test: # The data plane is expected to go down with control plane in KVM tests
@@ -851,11 +850,6 @@ class ReloadTest(BaseTest):
 
         self.save_sniffed_packets()
 
-        self.log("Wait until control plane up")
-        async_cpu_up = self.pool.apply_async(self.wait_until_cpu_port_up)
-        self.no_control_stop = self.cpu_state.get_state_time('up')
-        self.log("Control plane down stops %s" % str(self.no_control_stop))
-
         examine_start = datetime.datetime.now()
         self.log("Packet flow examine started %s after the reboot" % str(examine_start - self.reboot_start))
         self.examine_flow()
@@ -870,29 +864,27 @@ class ReloadTest(BaseTest):
             self.no_routing_start = self.reboot_start
             self.no_routing_stop  = self.reboot_start
 
-    def handle_warm_reboot_health_check_kvm(self):
+    def handle_advanced_reboot_health_check_kvm(self):
         self.log("Wait until data plane stops")
         async_forward_stop = self.pool.apply_async(self.check_forwarding_stop)
 
         self.log("Wait until control plane up")
         async_cpu_up = self.pool.apply_async(self.wait_until_cpu_port_up)
-        self.no_control_stop = self.cpu_state.get_state_time('up')
-        self.log("Control plane down stops %s" % str(self.no_control_stop))
+
+        try:
+            self.no_routing_start, _ = async_forward_stop.get(timeout=self.task_timeout)
+            self.log("Data plane was stopped, Waiting until it's up. Stop time: %s" % str(self.no_routing_start))
+        except TimeoutError:
+            self.log("Data plane never stop")
 
         try:
             async_cpu_up.get(timeout=self.task_timeout)
+            self.no_control_stop = self.cpu_state.get_state_time('up')
+            self.log("Control plane down stops %s" % str(self.no_control_stop))
         except TimeoutError as e:
             self.log("DUT hasn't bootup in %d seconds" % self.task_timeout)
             self.fails['dut'].add("DUT hasn't booted up in %d seconds" % self.task_timeout)
             raise
-
-        try:
-            self.no_routing_start, self.upper_replies = async_forward_stop.get(timeout=self.task_timeout)
-            self.log("Data plane was stopped, Waiting until it's up. Stop time: %s" % str(self.no_routing_start))
-        except TimeoutError:
-            self.log("Data plane never stop")
-            self.routing_always = True
-            self.upper_replies = [self.nr_vl_pkts]
 
         if self.no_routing_start is not None:
             self.no_routing_stop, _ = self.timeout(self.check_forwarding_resume,
@@ -923,16 +915,11 @@ class ReloadTest(BaseTest):
         self.log("Data plane works again. Start time: %s" % str(self.no_routing_stop))
         self.log("")
 
-        if self.reboot_type == 'fast-reboot':
-            self.no_cp_replies = self.extract_no_cpu_replies(self.upper_replies)
-
         if self.no_routing_stop - self.no_routing_start > self.limit:
             self.fails['dut'].add("Longest downtime period must be less then %s seconds. It was %s" \
                     % (self.test_params['reboot_limit_in_seconds'], str(self.no_routing_stop - self.no_routing_start)))
         if self.no_routing_stop - self.reboot_start > datetime.timedelta(seconds=self.test_params['graceful_limit']):
             self.fails['dut'].add("%s cycle must be less than graceful limit %s seconds" % (self.reboot_type, self.test_params['graceful_limit']))
-        if self.reboot_type == 'fast-reboot' and self.no_cp_replies < 0.95 * self.nr_vl_pkts:
-            self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (self.no_cp_replies, self.nr_vl_pkts))
 
         if 'warm-reboot' in self.reboot_type:
             if self.total_disrupt_time > self.limit.total_seconds():
@@ -950,6 +937,11 @@ class ReloadTest(BaseTest):
             else:
                 # verify there are no interface flaps after warm boot
                 self.neigh_lag_status_check()
+
+        if self.reboot_type == 'fast-reboot' and not self.kvm_test:
+            self.no_cp_replies = self.extract_no_cpu_replies(self.upper_replies)
+            if self.no_cp_replies < 0.95 * self.nr_vl_pkts:
+                self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (self.no_cp_replies, self.nr_vl_pkts))
 
     def handle_post_reboot_test_reports(self):
         # Stop watching DUT
@@ -992,7 +984,8 @@ class ReloadTest(BaseTest):
 
         if self.no_routing_stop:
             self.log("Longest downtime period was %s" % str(self.no_routing_stop - self.no_routing_start))
-            self.log("Control plane downtime period was %s" % str(self.no_control_stop - self.no_control_start))
+            if self.kvm_test:
+                self.log("Control plane downtime period was %s" % str(self.no_control_stop - self.no_control_start))
             reboot_time = "0:00:00" if self.routing_always else str(self.no_routing_stop - self.reboot_start)
             self.log("Reboot time was %s" % reboot_time)
             self.log("Expected downtime is less then %s" % self.limit)
@@ -1042,10 +1035,14 @@ class ReloadTest(BaseTest):
             thr.start()
 
             self.wait_until_reboot()
-            if self.reboot_type == 'fast-reboot':
-                self.handle_fast_reboot_health_check()
-            if 'warm-reboot' in self.reboot_type:
-                self.handle_warm_reboot_health_check()
+            if self.kvm_test:
+                self.handle_advanced_reboot_health_check_kvm()
+            else:
+                if self.reboot_type == 'fast-reboot':
+                    self.handle_fast_reboot_health_check()
+                if 'warm-reboot' in self.reboot_type:
+                    self.handle_warm_reboot_health_check()
+
             self.handle_post_reboot_health_check()
 
             # Check sonic version after reboot

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -943,6 +943,10 @@ class ReloadTest(BaseTest):
             if self.no_cp_replies < 0.95 * self.nr_vl_pkts:
                 self.fails['dut'].add("Dataplane didn't route to all servers, when control-plane was down: %d vs %d" % (self.no_cp_replies, self.nr_vl_pkts))
 
+        if self.kvm_test and (self.no_control_stop - self.no_control_start) > datetime.timedelta(seconds=self.test_params['graceful_limit']):
+            self.fails['dut'].add("Control plane downtime period must be less then %s seconds. It was %s" \
+                    % (self.test_params['graceful_limit'], str(self.no_control_stop - self.no_control_start)))
+
     def handle_post_reboot_test_reports(self):
         # Stop watching DUT
         self.watching = False

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -798,11 +798,10 @@ class ReloadTest(BaseTest):
             self.log("control plane down starts %s" % str(self.no_control_start))
 
     def handle_fast_reboot_health_check(self):
-        if not self.kvm_test: # The data plane is expected to go down with control plane in KVM tests
-            self.log("Check that device is still forwarding data plane traffic")
-            self.fails['dut'].add("Data plane has a forwarding problem after CPU went down")
-            self.check_alive()
-            self.fails['dut'].clear()
+        self.log("Check that device is still forwarding data plane traffic")
+        self.fails['dut'].add("Data plane has a forwarding problem after CPU went down")
+        self.check_alive()
+        self.fails['dut'].clear()
 
         self.log("Wait until control plane up")
         port_up_signal = multiprocessing.Event()

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -885,6 +885,7 @@ class ReloadTest(BaseTest):
             self.fails['dut'].add("DUT hasn't booted up in %d seconds" % self.task_timeout)
             raise
 
+        # Wait until data plane up if it stopped
         if self.no_routing_start is not None:
             self.no_routing_stop, _ = self.timeout(self.check_forwarding_resume,
                     self.task_timeout,

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1,6 +1,6 @@
 #
-#ptf --test-dir ptftests fast-reboot --qlen=1000 --platform remote -t 'verbose=True;dut_username="admin";dut_hostname="10.0.0.243";reboot_limit_in_seconds=30;portchannel_ports_file="/tmp/portchannel_interfaces.json";vlan_ports_file="/tmp/vlan_interfaces.json";ports_file="/tmp/ports.json";dut_mac="4c:76:25:f5:48:80";default_ip_range="192.168.0.0/16";vlan_ip_range="172.0.0.0/22";arista_vms="[\"10.0.0.200\",\"10.0.0.201\",\"10.0.0.202\",\"10.0.0.203\"]"' --platform-dir ptftests --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
-#
+# ptf --test-dir ptftests fast-reboot --qlen=1000 --platform remote -t 'verbose=True;dut_username="admin";dut_hostname="10.0.0.243";reboot_limit_in_seconds=30;portchannel_ports_file="/tmp/portchannel_interfaces.json";vlan_ports_file="/tmp/vlan_interfaces.json";ports_file="/tmp/ports.json";dut_mac="4c:76:25:f5:48:80";default_ip_range="192.168.0.0/16";vlan_ip_range="172.0.0.0/22";arista_vms="[\"10.0.0.200\",\"10.0.0.201\",\"10.0.0.202\",\"10.0.0.203\"]"' --platform-dir ptftests --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
+# This test also support basic warm/fast-reboot function check by adding test parameter 'kvm_test=True'
 #
 # This test checks that DUT is able to make FastReboot procedure
 #

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1473,8 +1473,9 @@ class ReloadTest(BaseTest):
             if state == 'up':
                 if not uptime:
                     uptime = self.asic_state.get_state_time(state)
-            elif uptime:
-                raise Exception("Data plane stopped working")
+            else:
+                if uptime:
+                    raise Exception("Data plane stopped working")
             time.sleep(2)
 
         # wait, until FDB entries are populated

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -956,8 +956,8 @@ class ReloadTest(BaseTest):
         for _, q in self.ssh_jobs:
             q.put('quit')
 
-        def wait_for_ssh_threads():
-            while any(thr.is_alive() for thr, _ in self.ssh_jobs):
+        def wait_for_ssh_threads(signal):
+            while any(thr.is_alive() for thr, _ in self.ssh_jobs) and not signal.is_set():
                 time.sleep(self.TIMEOUT)
 
             for thr, _ in self.ssh_jobs:

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -126,7 +126,7 @@ class ReloadTest(BaseTest):
         self.sad_handle = None
         self.process_id = str(os.getpid())
         self.test_params = testutils.test_params_get()
-        self.check_param('kvm_test', False, required = False)
+        self.check_param('kvm_test', False, required=False)
         self.check_param('verbose', False, required=False)
         self.check_param('dut_username', '', required=True)
         self.check_param('dut_password', '', required=True)
@@ -147,15 +147,15 @@ class ReloadTest(BaseTest):
         self.check_param('min_bgp_gr_timeout', 15, required=False)
         self.check_param('warm_up_timeout_secs', 300, required=False)
         self.check_param('dut_stabilize_secs', 30, required=False)
-        self.check_param('preboot_files', None, required = False)
-        self.check_param('preboot_oper', None, required = False) # preboot sad path to inject before warm-reboot
-        self.check_param('inboot_oper', None, required = False) # sad path to inject during warm-reboot
-        self.check_param('nexthop_ips', [], required = False) # nexthops for the routes that will be added during warm-reboot
-        self.check_param('allow_vlan_flooding', False, required = False)
-        self.check_param('sniff_time_incr', 60, required = False)
-        self.check_param('vnet', False, required = False)
-        self.check_param('vnet_pkts', None, required = False)
-        self.check_param('target_version', '', required = False)
+        self.check_param('preboot_files', None, required=False)
+        self.check_param('preboot_oper', None, required=False) # preboot sad path to inject before warm-reboot
+        self.check_param('inboot_oper', None, required=False) # sad path to inject during warm-reboot
+        self.check_param('nexthop_ips', [], required=False) # nexthops for the routes that will be added during warm-reboot
+        self.check_param('allow_vlan_flooding', False, required=False)
+        self.check_param('sniff_time_incr', 60, required=False)
+        self.check_param('vnet', False, required=False)
+        self.check_param('vnet_pkts', None, required=False)
+        self.check_param('target_version', '', required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -872,8 +872,8 @@ class ReloadTest(BaseTest):
         for _, q in self.ssh_jobs:
             q.put('quit')
 
-        def wait_for_ssh_threads():
-            while any(thr.is_alive() for thr, _ in self.ssh_jobs):
+        def wait_for_ssh_threads(signal):
+            while any(thr.is_alive() for thr, _ in self.ssh_jobs) and not signal.is_set():
                 time.sleep(self.TIMEOUT)
 
             for thr, _ in self.ssh_jobs:
@@ -890,7 +890,7 @@ class ReloadTest(BaseTest):
         if self.no_routing_stop - self.reboot_start > datetime.timedelta(seconds=self.test_params['graceful_limit']):
             self.fails['dut'].add("%s cycle must be less than graceful limit %s seconds" % (self.reboot_type, self.test_params['graceful_limit']))
 
-        if self.reboot_type == 'warm-reboot':
+        if 'warm-reboot' in self.reboot_type:
             if self.total_disrupt_time > self.limit.total_seconds():
                 self.fails['dut'].add("Total downtime period must be less then %s seconds. It was %s" \
                     % (str(self.limit), str(self.total_disrupt_time)))

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -39,13 +39,11 @@ class AdvancedReboot:
             "Please set rebootType var."
         )
 
-        if duthost.facts['asic_type'] == 'vs':
+        if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
             self.kvmTest = True
-            # skip testcase if it is not marked as kvm compatible
-            # TODO: A better way could be selecting kvm testcases with the vs device type marker
-            #       Remove this check once the vs testcases are selected using the marker
-            if 'kvmCompatible' not in kwargs or kwargs['kvmCompatible'] != True:
-                pytest.skip("Testcase not supported for kvm")
+            device_marks = [arg for mark in request.node.iter_markers(name='device_type') for arg in mark.args]
+            if 'vs' not in device_marks:
+                pytest.skip('Testcase not supported for kvm')
         else:
             self.kvmTest = False
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -42,6 +42,8 @@ class AdvancedReboot:
         if duthost.facts['asic_type'] == 'vs':
             self.kvmTest = True
             # skip testcase if it is not marked as kvm compatible
+            # TODO: A better way could be selecting kvm testcases with the vs device type marker
+            #       Remove this check once the vs testcases are selected using the marker
             if 'kvmCompatible' not in kwargs or kwargs['kvmCompatible'] != True:
                 pytest.skip("Testcase not supported for kvm")
         else:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -83,7 +83,7 @@ class AdvancedReboot:
         self.postRebootCheckScript = self.request.config.getoption("--post_reboot_check_script")
 
         # Set default reboot limit if it is not given
-        if self.rebootLimit == None:
+        if self.rebootLimit is None:
             if self.kvmTest:
                 self.rebootLimit = 150 # Default reboot limit for kvm
             else:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -40,9 +40,11 @@ class AdvancedReboot:
         )
 
         if duthost.facts['asic_type'] == 'vs':
-            self.kvm_test = True
+            self.kvmTest = True
+            if 'kvmCompatible' not in kwargs or kwargs['kvmCompatible'] != True:
+                pytest.skip("Testcase not supported for kvm")
         else:
-            self.kvm_test = False
+            self.kvmTest = False
 
         self.request = request
         self.duthost = duthost
@@ -79,7 +81,7 @@ class AdvancedReboot:
 
         # Set default reboot limit if it is not given
         if self.rebootLimit == None:
-            if self.kvm_test:
+            if self.kvmTest:
                 self.rebootLimit = 150 # Default reboot limit for kvm
             else:
                 self.rebootLimit = 30 # Default reboot limit for physical devices
@@ -480,7 +482,7 @@ class AdvancedReboot:
                 "setup_fdb_before_test" : True,
                 "vnet" : self.vnet,
                 "vnet_pkts" : self.vnetPkts,
-                "kvm_test" : self.kvm_test,
+                "kvm_test" : self.kvmTest,
             },
             log_file=u'/tmp/advanced-reboot.ReloadTest.log',
             module_ignore_errors=self.moduleIgnoreErrors

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -483,7 +483,6 @@ class AdvancedReboot:
                 "setup_fdb_before_test" : True,
                 "vnet" : self.vnet,
                 "vnet_pkts" : self.vnetPkts,
-                "kvm_test" : self.kvmTest,
             },
             log_file=u'/tmp/advanced-reboot.ReloadTest.log',
             module_ignore_errors=self.moduleIgnoreErrors

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -39,6 +39,11 @@ class AdvancedReboot:
             "Please set rebootType var."
         )
 
+        if duthost.facts['asic_type'] == 'vs':
+            self.kvm_test = True
+        else:
+            self.kvm_test = False
+
         self.request = request
         self.duthost = duthost
         self.ptfhost = ptfhost
@@ -71,6 +76,13 @@ class AdvancedReboot:
         self.readyTimeout = self.request.config.getoption("--ready_timeout")
         self.replaceFastRebootScript = self.request.config.getoption("--replace_fast_reboot_script")
         self.postRebootCheckScript = self.request.config.getoption("--post_reboot_check_script")
+
+        # Set default reboot limit if it is not given
+        if self.rebootLimit == None:
+            if self.kvm_test:
+                self.rebootLimit = 150 # Default reboot limit for kvm
+            else:
+                self.rebootLimit = 30 # Default reboot limit for physical devices
 
     def getHostMaxLen(self):
         '''
@@ -468,6 +480,7 @@ class AdvancedReboot:
                 "setup_fdb_before_test" : True,
                 "vnet" : self.vnet,
                 "vnet_pkts" : self.vnetPkts,
+                "kvm_test" : self.kvm_test,
             },
             log_file=u'/tmp/advanced-reboot.ReloadTest.log',
             module_ignore_errors=self.moduleIgnoreErrors

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -41,6 +41,7 @@ class AdvancedReboot:
 
         if duthost.facts['asic_type'] == 'vs':
             self.kvmTest = True
+            # skip testcase if it is not marked as kvm compatible
             if 'kvmCompatible' not in kwargs or kwargs['kvmCompatible'] != True:
                 pytest.skip("Testcase not supported for kvm")
         else:

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -47,6 +47,7 @@ mkdir -p logs
 # TODO: Use a marker to select these tests rather than providing a hard-coded list here.
 tgname=1vlan
 tests="\
+platform_tests/test_advanced_reboot.py \
 monit/test_monit_status.py \
 test_interfaces.py \
 bgp/test_bgp_fact.py \
@@ -56,8 +57,6 @@ cacl/test_cacl_application.py \
 cacl/test_cacl_function.py \
 dhcp_relay/test_dhcp_relay.py \
 ntp/test_ntp.py \
-pc/test_po_cleanup.py \
-platform_tests/test_advanced_reboot.py \
 route/test_default_route.py \
 snmp/test_snmp_cpu.py \
 snmp/test_snmp_interfaces.py \

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -47,8 +47,8 @@ mkdir -p logs
 # TODO: Use a marker to select these tests rather than providing a hard-coded list here.
 tgname=1vlan
 tests="\
-platform_tests/test_advanced_reboot.py \
 monit/test_monit_status.py \
+platform_tests/test_advanced_reboot.py \
 test_interfaces.py \
 bgp/test_bgp_fact.py \
 bgp/test_bgp_gr_helper.py \

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -57,6 +57,7 @@ cacl/test_cacl_function.py \
 dhcp_relay/test_dhcp_relay.py \
 ntp/test_ntp.py \
 pc/test_po_cleanup.py \
+platform_tests/test_advanced_reboot.py \
 route/test_default_route.py \
 snmp/test_snmp_cpu.py \
 snmp/test_snmp_interfaces.py \

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -57,6 +57,7 @@ cacl/test_cacl_application.py \
 cacl/test_cacl_function.py \
 dhcp_relay/test_dhcp_relay.py \
 ntp/test_ntp.py \
+pc/test_po_cleanup.py \
 route/test_default_route.py \
 snmp/test_snmp_cpu.py \
 snmp/test_snmp_interfaces.py \

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -25,7 +25,6 @@ def add_advanced_reboot_args(parser):
         "--reboot_limit",
         action="store",
         type=int,
-        default=30,
         help="Reboot time limit in sec",
     )
 

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -5,6 +5,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
 
 pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -5,7 +5,6 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]
@@ -30,7 +29,7 @@ def test_warm_reboot(request, get_advanced_reboot):
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot', kvmCompatible=True)
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     advancedReboot.runRebootTestcase()
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -10,7 +10,6 @@ pytestmark = [
 ]
 
 @pytest.mark.usefixtures('get_advanced_reboot')
-@pytest.mark.device_type('vs')
 def test_fast_reboot(request, get_advanced_reboot):
     '''
     Fast reboot test case is run using advacned reboot test fixture
@@ -30,7 +29,7 @@ def test_warm_reboot(request, get_advanced_reboot):
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot', kvmCompatible=True)
     advancedReboot.runRebootTestcase()
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -10,6 +10,7 @@ pytestmark = [
 ]
 
 @pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.device_type('vs')
 def test_fast_reboot(request, get_advanced_reboot):
     '''
     Fast reboot test case is run using advacned reboot test fixture
@@ -21,6 +22,7 @@ def test_fast_reboot(request, get_advanced_reboot):
     advancedReboot.runRebootTestcase()
 
 @pytest.mark.usefixtures('get_advanced_reboot')
+@pytest.mark.device_type('vs')
 def test_warm_reboot(request, get_advanced_reboot):
     '''
     Warm reboot test case is run using advacned reboot test fixture

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -110,10 +110,9 @@ class ARPResponder(object):
         if request_ip_str not in self.ip_sets[interface.name()]:
             return
 
+        vlan_list = []
         if 'vlan' in self.ip_sets[interface.name()]:
             vlan_list = self.ip_sets[interface.name()]['vlan']
-        else:
-            vlan_list = [None]
 
         for vlan_id in vlan_list:
             arp_reply = self.generate_arp_reply(self.ip_sets[interface.name()][request_ip_str], remote_mac, request_ip, remote_ip, vlan_id)

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -110,9 +110,10 @@ class ARPResponder(object):
         if request_ip_str not in self.ip_sets[interface.name()]:
             return
 
-        vlan_list = []
         if 'vlan' in self.ip_sets[interface.name()]:
             vlan_list = self.ip_sets[interface.name()]['vlan']
+        else:
+            vlan_list = [None]
 
         for vlan_id in vlan_list:
             arp_reply = self.generate_arp_reply(self.ip_sets[interface.name()][request_ip_str], remote_mac, request_ip, remote_ip, vlan_id)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update warm-reboot test to support kvm image
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The motivation of this PR is to enable basic checks of the warm-reboot functionality using kvm images.

#### How did you do it?
As the data plane will go down in kvm image during warm-reboot. I changed the test logic to mainly focusing on the control plane behavior and relax data plane constraints.

A mark is added in the testcase to indicate it support kvm image and to filter out testcases not compatible for kvm test.

Example command to run the test
`pytest platform_tests/test_advanced_reboot.py --testbed=vms-kvm-t0 --inventory veos_vtb --host-pattern all --user admin -vvv --show-capture stdout --testbed_file vtestbed.csv --disable_loganalyzer --skip_sanity`
Test output
```
======================================================================= test session starts =======================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.15.0-39-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, metadata-1.10.0, repeat-0.8.0, xdist-1.28.0, forked-1.3.0, html-1.22.1
collected 9 items

platform_tests/test_advanced_reboot.py::test_fast_reboot SKIPPED                                                                                            [ 11%]
platform_tests/test_advanced_reboot.py::test_warm_reboot PASSED                                                                                             [ 22%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad SKIPPED                                                                                        [ 33%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad SKIPPED                                                                                  [ 44%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad_inboot SKIPPED                                                                           [ 55%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_bgp SKIPPED                                                                                    [ 66%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_lag_member SKIPPED                                                                             [ 77%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_lag SKIPPED                                                                                    [ 88%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_vlan_port SKIPPED                                                                              [100%]

============================================================== 1 passed, 8 skipped in 345.63 seconds ==============================================================
```
Ptftest summary
```
2020-10-22 22:57:41 : --------------------------------------------------
2020-10-22 22:57:41 : Summary:
2020-10-22 22:57:41 : --------------------------------------------------
2020-10-22 22:57:41 : Longest downtime period was 0:02:10.667073
2020-10-22 22:57:41 : Control plane downtime period was 0:01:05.868460
2020-10-22 22:57:41 : Reboot time was 0:02:13.807981
2020-10-22 22:57:41 : Expected downtime is less then 0:02:30
2020-10-22 22:57:41 : --------------------------------------------------
2020-10-22 22:57:41 : Additional info:
2020-10-22 22:57:41 : --------------------------------------------------
2020-10-22 22:57:41 : INFO:10.250.0.54:PortChannel interface state changed 1 times
2020-10-22 22:57:41 : INFO:10.250.0.51:PortChannel interface state changed 1 times
2020-10-22 22:57:41 : INFO:10.250.0.52:PortChannel interface state changed 1 times
2020-10-22 22:57:41 : INFO:10.250.0.53:PortChannel interface state changed 1 times
2020-10-22 22:57:41 : --------------------------------------------------
```


#### How did you verify/test it?
Verified by running the testcase locally on kvm

#### Any platform specific information?
This change is to enable extra support for kvm platform in warm-reboot test. It should not affect advanced reboot tests for other platforms

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
