### PR TITLE
[Platform API][SFP] Remove 'skip_sanity=True' pytest marker

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -22,7 +22,6 @@ else:
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]


### PR DESCRIPTION
### Description of PR

Summary:

Remove 'skip_sanity=True' pytest marker from SFP platform API test file

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To ensure no tests skip the sanity check, which is useful for helping determine if a test has left the device in a bad state

#### How did you do it?

Remove 'skip_sanity=True' pytest marker from SFP platform API test file, which must have slipped in in a previous PR

#### How did you verify/test it?

Run the tests in the module

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
