### PR TITLE
Advertise different IP prefixes from T0 to T1 for T1 topologies

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -95,12 +95,14 @@ def gen_fib_info(ptfhost, tbinfo, cfg_facts):
     routes_downlink_v4 = []
     routes_downlink_v6 = []
     if topo_type == "t1":
-        routes_downlink_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
-                                            0, 0, 0,
-                                            "", "", router_type="tor")
-        routes_downlink_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
-                                            0, 0, 0,
-                                            "", "", router_type="tor")
+        for tor_index in range(tor_number):
+            routes_downlink_v4.extend(generate_routes("v4", podset_number, tor_number, tor_subnet_number,
+                                      0, 0, 0,
+                                      "", "", router_type="tor", tor_index=tor_index))
+
+            routes_downlink_v6.extend(generate_routes("v6", podset_number, tor_number, tor_subnet_number,
+                                      0, 0, 0,
+                                      "", "", router_type="tor", tor_index=tor_index))
 
     for prefix, _, _ in routes_downlink_v4:
         fibs.append("{} {}".format(prefix, downlink_ports_str))

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -44,9 +44,6 @@ def setup_info(duthost, tbinfo):
         dict: Required test information
 
     """
-    # TODO: Support all T1 and T0 topos in these tests.
-    if tbinfo["topo"]["name"] not in ("t1", "t1-lag", "t1-64-lag", "t1-64-lag-clet"):
-        pytest.skip("Unsupported topology")
 
     tor_ports = []
     spine_ports = []
@@ -54,7 +51,6 @@ def setup_info(duthost, tbinfo):
     # Gather test facts
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
     switch_capability_facts = duthost.switch_capabilities_facts()["ansible_facts"]
-    host_facts = duthost.setup()["ansible_facts"]
 
     # Get the list of T0/T2 ports
     # TODO: The ACL tests do something really similar, I imagine we could refactor this bit.
@@ -122,7 +118,7 @@ def setup_info(duthost, tbinfo):
     # Also given how much info is here it probably makes sense to make a data object/named
     # tuple to help with the typing.
     setup_information = {
-        "router_mac": host_facts["ansible_Ethernet0"]["macaddress"],
+        "router_mac": duthost.facts["router_mac"],
         "tor_ports": tor_ports,
         "spine_ports": spine_ports,
         "test_mirror_v4": test_mirror_v4,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Currently for T1 type topologies, all the T0 VMs advertise same set of
routes to the T1 DUT. Generally, each T0 VM should advertise unique
set of routes to T1. This change updated the fib fixture to advertise
different prefixes from T0 to T1 for T1 topologies. Affected test scripts
were updated accordingly.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In T1 type test topology, the DUT switch is connected to both upstream T2 switches and downstream T0 switches. The T2&T1 switches are simulated by VMs.

In a typical network, each T0 switch serves a pod. The T0 switches should advertise IP prefixes of its own pod to T1 switches. In current implementation, all the T0 VMs advertise same set of IP prefixes to T1. The T1 topology is not simulating the actual network in a typical data center.

#### How did you do it?
* Update the fib fixture to advertise unique IP prefixes from T0 VMs to T1 DUT.
* Update the affected scripts.
  * decap/test_decap.py
  * everflow/everflow_test_utilities.py

The update in `everflow/everflow_test_utilities.py` is to get `route_mac` information from `duthost.facts["router_mac"]` instead of `duthost.setup()`. It looks like an unrelated change. But without this change, the `everflow/test_everflow_testbed.py` always have some cases failed. I am not sure why yet. Need more time to investigate. Include the change in this PR anyway.

#### How did you verify/test it?

Without this change, the IP routes to T0 VMs are like below:
```
192.168.0.0/25 proto bgp src 10.1.0.32 metric 20 
        nexthop via 10.0.0.33 dev Ethernet64 weight 1 
        nexthop via 10.0.0.35 dev Ethernet68 weight 1 
        nexthop via 10.0.0.37 dev Ethernet72 weight 1 
        nexthop via 10.0.0.39 dev Ethernet76 weight 1 
        nexthop via 10.0.0.41 dev Ethernet80 weight 1 
        nexthop via 10.0.0.43 dev Ethernet84 weight 1 
        nexthop via 10.0.0.45 dev Ethernet88 weight 1 
        nexthop via 10.0.0.47 dev Ethernet92 weight 1 
        nexthop via 10.0.0.49 dev Ethernet96 weight 1 
        nexthop via 10.0.0.51 dev Ethernet100 weight 1 
        nexthop via 10.0.0.53 dev Ethernet104 weight 1 
        nexthop via 10.0.0.55 dev Ethernet108 weight 1 
        nexthop via 10.0.0.57 dev Ethernet112 weight 1 
        nexthop via 10.0.0.59 dev Ethernet116 weight 1 
        nexthop via 10.0.0.61 dev Ethernet120 weight 1 
        nexthop via 10.0.0.63 dev Ethernet124 weight 1 
192.168.0.128/25 proto bgp src 10.1.0.32 metric 20 
        nexthop via 10.0.0.33 dev Ethernet64 weight 1 
        nexthop via 10.0.0.35 dev Ethernet68 weight 1 
        nexthop via 10.0.0.37 dev Ethernet72 weight 1 
        nexthop via 10.0.0.39 dev Ethernet76 weight 1 
        nexthop via 10.0.0.41 dev Ethernet80 weight 1 
        nexthop via 10.0.0.43 dev Ethernet84 weight 1 
        nexthop via 10.0.0.45 dev Ethernet88 weight 1 
        nexthop via 10.0.0.47 dev Ethernet92 weight 1 
        nexthop via 10.0.0.49 dev Ethernet96 weight 1 
        nexthop via 10.0.0.51 dev Ethernet100 weight 1 
        nexthop via 10.0.0.53 dev Ethernet104 weight 1 
        nexthop via 10.0.0.55 dev Ethernet108 weight 1 
        nexthop via 10.0.0.57 dev Ethernet112 weight 1 
        nexthop via 10.0.0.59 dev Ethernet116 weight 1 
        nexthop via 10.0.0.61 dev Ethernet120 weight 1 
        nexthop via 10.0.0.63 dev Ethernet124 weight 1 
192.168.8.0/25 proto bgp src 10.1.0.32 metric 20 
        nexthop via 10.0.0.33 dev Ethernet64 weight 1 
        nexthop via 10.0.0.35 dev Ethernet68 weight 1 
        nexthop via 10.0.0.37 dev Ethernet72 weight 1 
        nexthop via 10.0.0.39 dev Ethernet76 weight 1 
        nexthop via 10.0.0.41 dev Ethernet80 weight 1 
        nexthop via 10.0.0.43 dev Ethernet84 weight 1 
        nexthop via 10.0.0.45 dev Ethernet88 weight 1 
        nexthop via 10.0.0.47 dev Ethernet92 weight 1 
        nexthop via 10.0.0.49 dev Ethernet96 weight 1 
        nexthop via 10.0.0.51 dev Ethernet100 weight 1 
        nexthop via 10.0.0.53 dev Ethernet104 weight 1 
        nexthop via 10.0.0.55 dev Ethernet108 weight 1 
        nexthop via 10.0.0.57 dev Ethernet112 weight 1 
        nexthop via 10.0.0.59 dev Ethernet116 weight 1 
        nexthop via 10.0.0.61 dev Ethernet120 weight 1 
        nexthop via 10.0.0.63 dev Ethernet124 weight 1
...
```

With this change, the IP routes to T0 VMs are like:
```
192.168.0.0/25 via 10.0.0.33 dev Ethernet64 proto 186 src 10.1.0.32 metric 20
192.168.0.128/25 via 10.0.0.33 dev Ethernet64 proto 186 src 10.1.0.32 metric 20
192.168.8.0/25 via 10.0.0.35 dev Ethernet68 proto 186 src 10.1.0.32 metric 20
192.168.8.128/25 via 10.0.0.35 dev Ethernet68 proto 186 src 10.1.0.32 metric 20
192.168.16.0/25 via 10.0.0.37 dev Ethernet72 proto 186 src 10.1.0.32 metric 20
192.168.16.128/25 via 10.0.0.37 dev Ethernet72 proto 186 src 10.1.0.32 metric 20
192.168.24.0/25 via 10.0.0.39 dev Ethernet76 proto 186 src 10.1.0.32 metric 20
192.168.24.128/25 via 10.0.0.39 dev Ethernet76 proto 186 src 10.1.0.32 metric 20
192.168.32.0/25 via 10.0.0.41 dev Ethernet80 proto 186 src 10.1.0.32 metric 20
192.168.32.128/25 via 10.0.0.41 dev Ethernet80 proto 186 src 10.1.0.32 metric 20
192.168.40.0/25 via 10.0.0.43 dev Ethernet84 proto 186 src 10.1.0.32 metric 20
192.168.40.128/25 via 10.0.0.43 dev Ethernet84 proto 186 src 10.1.0.32 metric 20
192.168.48.0/25 via 10.0.0.45 dev Ethernet88 proto 186 src 10.1.0.32 metric 20
192.168.48.128/25 via 10.0.0.45 dev Ethernet88 proto 186 src 10.1.0.32 metric 20
192.168.56.0/25 via 10.0.0.47 dev Ethernet92 proto 186 src 10.1.0.32 metric 20
192.168.56.128/25 via 10.0.0.47 dev Ethernet92 proto 186 src 10.1.0.32 metric 20
192.168.64.0/25 via 10.0.0.49 dev Ethernet96 proto 186 src 10.1.0.32 metric 20
192.168.64.128/25 via 10.0.0.49 dev Ethernet96 proto 186 src 10.1.0.32 metric 20
192.168.72.0/25 via 10.0.0.51 dev Ethernet100 proto 186 src 10.1.0.32 metric 20
192.168.72.128/25 via 10.0.0.51 dev Ethernet100 proto 186 src 10.1.0.32 metric 20
192.168.80.0/25 via 10.0.0.53 dev Ethernet104 proto 186 src 10.1.0.32 metric 20
192.168.80.128/25 via 10.0.0.53 dev Ethernet104 proto 186 src 10.1.0.32 metric 20
192.168.88.0/25 via 10.0.0.55 dev Ethernet108 proto 186 src 10.1.0.32 metric 20
192.168.88.128/25 via 10.0.0.55 dev Ethernet108 proto 186 src 10.1.0.32 metric 20
192.168.96.0/25 via 10.0.0.57 dev Ethernet112 proto 186 src 10.1.0.32 metric 20
192.168.96.128/25 via 10.0.0.57 dev Ethernet112 proto 186 src 10.1.0.32 metric 20
192.168.104.0/25 via 10.0.0.59 dev Ethernet116 proto 186 src 10.1.0.32 metric 20
192.168.104.128/25 via 10.0.0.59 dev Ethernet116 proto 186 src 10.1.0.32 metric 20
192.168.112.0/25 via 10.0.0.61 dev Ethernet120 proto 186 src 10.1.0.32 metric 20
192.168.112.128/25 via 10.0.0.61 dev Ethernet120 proto 186 src 10.1.0.32 metric 20
192.168.120.0/25 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
192.168.120.128/25 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
```

Tested below scripts using the new t1-lag topology, all passed.
* fib/test_fib.py
* decap/test_decap.py
* ipfwd/test_dip_sip.py
* acl/test_acl.py
* everflow/test_everflow_ipv6.py
* everflow/test_everflow_testbed.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
