### PR TITLE
[ansible]: parse json output for frr in bgp_route module

### DIFF
--- a/ansible/library/bgp_route.py
+++ b/ansible/library/bgp_route.py
@@ -367,7 +367,7 @@ def main():
         command = "docker exec -i bgp vtysh -c 'show version'"
         rc, out, err = module.run_command(command)
         if rc != 0:
-            err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rt, out, err)
+            err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rc, out, err)
             module.fail_json(msg=err_message)
             return
         if "FRRouting" in out:
@@ -381,7 +381,7 @@ def main():
                 command = "docker exec -i bgp vtysh -c 'show ipv6 bgp {} {}'".format(str(prefix), use_json)
             rc, out, err = module.run_command(command)
             if rc != 0:
-                err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rt, out, err)
+                err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rc, out, err)
                 module.fail_json(msg=err_message)
                 return
             if is_frr:
@@ -396,7 +396,7 @@ def main():
                 command = "docker exec -i bgp vtysh -c 'show ipv6 bgp neighbor {] {} {}'".format(str(neighbor), str(direction), use_json)
             rc, out, err = module.run_command(command)
             if rc !=  0:
-                err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rt, out, err)
+                err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rc, out, err)
                 module.fail_json(msg=err_message)
                 return
             if is_frr:

--- a/ansible/library/bgp_route.py
+++ b/ansible/library/bgp_route.py
@@ -142,6 +142,7 @@ SAMPLE_COMMAND_DATA = '''
 
 
 ### TODO: Not fully tested ipv6 route entries parsing option, need continue working on ipv6 specific commands###
+import json
 
 class BgpRoutes(object):
     '''
@@ -157,12 +158,29 @@ class BgpRoutes(object):
     def get_facts(self):
         return self.facts
 
+    def parse_bgp_route_adv_json(self, cmd_result):
+        '''
+        parse BGP routing facts of neighbor advertised routes in json format
+        '''
+
+        self.facts['bgp_route_neiadv']['neighbor'] = self.neighbor
+
+        res = json.loads(cmd_result)
+
+        for k, rt in res['advertisedRoutes'].items():
+            entry = dict()
+            entry['nexthop'] = rt['nextHop']
+            entry['origin']  = rt['bgpOriginCode']
+            entry['weigh']   = rt['weight']
+            entry['aspath']  = rt['asPath'].split()
+            self.facts['bgp_route_neiadv']["{}/{}".format(rt['addrPrefix'], rt['prefixLen'])] = entry
+
     def parse_bgp_route_adv(self, cmd_result):
         '''
         parse BGP routing facts of neighbor advertised routes
         '''
         self.facts['bgp_route_neiadv']['neighbor'] = self.neighbor
-        ### so far parsing prefix, nexthop and aspath, origin and weight 
+        ### so far parsing prefix, nexthop and aspath, origin and weight
         header = 'Metric LocPrf Weight Path'
         result_lines = cmd_result.split('\n')
         table_start = False
@@ -199,6 +217,26 @@ class BgpRoutes(object):
                     entry['weight'] = weight
                 self.facts['bgp_route_neiadv'][prefix] = entry
 
+
+    def parse_bgp_route_prefix_json(self, cmd_result):
+        """
+        parse BGP facts for specific prefix in json format
+        """
+
+        prefix = self.prefix
+        self.facts['bgp_route'] = defaultdict(dict)
+
+        p = json.loads(cmd_result)
+
+        if not p.has_key('prefix'):
+            self.facts['bgp_route'][prefix]['found'] = False
+            return
+
+        self.facts['bgp_route'][prefix]['found'] = True
+        self.facts['bgp_route'][prefix]['aspath'] = []
+        self.facts['bgp_route'][prefix]['path_num'] = len(p['paths'])
+        for path in p['paths']:
+            self.facts['bgp_route'][prefix]['aspath'].append(path['aspath']['string'])
 
     def parse_bgp_route_prefix(self, cmd_result):
         '''
@@ -302,6 +340,9 @@ def main():
                 ),
             supports_check_mode=False
             )
+    is_frr = False
+    use_json = ""
+
     m_args = module.params
     neighbor = m_args['neighbor']
     direction = m_args['direction']
@@ -323,29 +364,45 @@ def main():
     try:
         bgproute = BgpRoutes(neighbor, direction, prefix)
 
+        command = "docker exec -i bgp vtysh -c 'show version'"
+        rc, out, err = module.run_command(command)
+        if rc != 0:
+            err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rt, out, err)
+            module.fail_json(msg=err_message)
+            return
+        if "FRRouting" in out:
+            is_frr = True
+            use_json = "json"
+
         if prefix:
             if regex_ipv4.match(prefix):
-                command = "docker exec -i bgp vtysh -c 'show ip bgp " + str(prefix) + "'"
+                command = "docker exec -i bgp vtysh -c 'show ip bgp {} {}'".format(str(prefix), use_json)
             else:
-                command = "docker exec -i bgp vtysh -c 'show ipv6 bgp " + str(prefix) +  "'"
+                command = "docker exec -i bgp vtysh -c 'show ipv6 bgp {} {}'".format(str(prefix), use_json)
             rc, out, err = module.run_command(command)
             if rc != 0:
                 err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rt, out, err)
                 module.fail_json(msg=err_message)
                 return
-            bgproute.parse_bgp_route_prefix(out)
+            if is_frr:
+                bgproute.parse_bgp_route_prefix_json(out)
+            else:
+                bgproute.parse_bgp_route_prefix(out)
 
         elif neighbor:
             if netaddr.valid_ipv4(neighbor):
-                command = "docker exec -i bgp vtysh -c 'show ip bgp neighbor " + str(neighbor) + " " + str(direction) + "'"
+                command = "docker exec -i bgp vtysh -c 'show ip bgp neighbor {} {} {}'".format(str(neighbor), str(direction), use_json)
             else:
-                command = "docker exec -i bgp vtysh -c 'show ipv6 bgp neighbor " + str(neighbor) + " " + str(direction) + "'"
+                command = "docker exec -i bgp vtysh -c 'show ipv6 bgp neighbor {] {} {}'".format(str(neighbor), str(direction), use_json)
             rc, out, err = module.run_command(command)
             if rc !=  0:
                 err_message = "command %s failed rc=%d, out=%s, err=%s" %(command, rt, out, err)
                 module.fail_json(msg=err_message)
                 return
-            bgproute.parse_bgp_route_adv(out)
+            if is_frr:
+                bgproute.parse_bgp_route_adv_json(out)
+            else:
+                bgproute.parse_bgp_route_adv(out)
 
         results = bgproute.get_facts()
         module.exit_json(ansible_facts=results)


### PR DESCRIPTION
frr support json output, it is more robust to use frr json
output directly instead of parsing the cmd line

Resolves https://github.com/Azure/sonic-buildimage/issues/5556

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
frr support json output, it is more robust to use frr json
output directly instead of parsing the cmd line

#### How did you do it?
first check if bgp stack is frr or not, if it is frr, then use the json output.

#### How did you verify/test it?
```
lgh@54edb99ee27f:/var/src/sonic-mgmt/tests$ ./run_tests.sh -i veos_vtb -d vlab-01 -n vms-kvm-t1-lag -f vtestbed.csv -k debug -l warning -m individual -q 1 -a False -e --disable_loganalyzer -u -c bgp/test_bgp_multipath_relax.py
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
================================================================================ test session starts =================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, metadata-1.10.0, html-1.22.1, repeat-0.8.0, ansible-2.2.2
collected 1 item                                                                                                                                                                     

bgp/test_bgp_multipath_relax.py::test_bgp_multipath_relax PASSED                                                                                                               [100%]

------------------------------------------------ generated xml file: /var/src/sonic-mgmt/tests/logs/bgp/test_bgp_multipath_relax.xml -------------------------------------------------
============================================================================= 1 passed in 28.78 seconds ==============================================================================
```

#### Any platform specific information?
kvm imae

#### Supported testbed topology if it's a new test case?
t1-lag

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
