### PR TITLE
Fix fanout import in test_drop_counters.py

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -37,6 +37,6 @@ def loganalyzer(duthost, request):
 
     yield loganalyzer
     # Skip LogAnalyzer if case is skipped
-    if request.node.rep_call.skipped:
+    if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped:
         return
     loganalyzer.analyze(marker)

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -42,7 +42,7 @@ def fanouthost(request, duthost, localhost):
         for file_name in os.listdir(os.path.join(os.path.dirname(__file__), "fanout")):
             # Import fanout configuration handler based on vendor name
             if "mellanox" in file_name:
-                module = importlib.import_module("fanout.{0}.{0}_fanout".format(file_name.strip(".py")))
+                module = importlib.import_module("..fanout.{0}.{0}_fanout".format(file_name.strip(".py")), __name__)
                 fanout = module.FanoutHandler(duthost, localhost)
                 break
 


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix import error in 'test_drop_counters.py' test suite
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [+] Test case(improvement)

### Approach

#### What is the motivation for this PR?
To fix import error in drop_counter tests, and improve skip reason check in loganalyzer module.

PR fixes this kind of failures:
```
drop_packets/drop_packets.py:45:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'fanout.mellanox.mellanox_fanout', package = None

    def import_module(name, package=None):
        """Import a module.

        The 'package' argument is required when performing a relative import. It
        specifies the package to use as the anchor point from which to resolve the
        relative import to an absolute import.

        """
        if name.startswith('.'):
            if not package:
                raise TypeError("relative imports require the 'package' argument")
            level = 0
            for character in name:
                if character != '.':
                    break
                level += 1
            name = _resolve_name(name[level:], package, level)
>       __import__(name)
E       ImportError: No module named fanout.mellanox.mellanox_fanout

---------------------------------------------------------------------------------------------------------------

    @pytest.fixture(autouse=True)
    def loganalyzer(duthost, request):
        if request.config.getoption("--disable_loganalyzer") or "disable_loganalyzer" in request.keywords:
            logging.info("Log analyzer is disabled")
            yield
            return

        # Force rotate logs
        try:
            duthost.shell(
                "/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1"
                )
        except RunAnsibleModuleFail as e:
            logging.warning("logrotate is failed. Command returned:\n"
                            "Stdout: {}\n"
                            "Stderr: {}\n"
                            "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))

        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
        logging.info("Add start marker into DUT syslog")
        marker = loganalyzer.init()
        logging.info("Load config and analyze log")
        # Read existed common regular expressions located with legacy loganalyzer module
        loganalyzer.load_common_config()

        yield loganalyzer
        # Skip LogAnalyzer if case is skipped
>       if request.node.rep_call.skipped:
E       AttributeError: 'Function' object has no attribute 'rep_call'

```


#### How did you do it?

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
