### PR TITLE
[kvm] Re-enable test_po_update for KVM test

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -57,6 +57,7 @@ dhcp_relay/test_dhcp_relay.py \
 lldp/test_lldp.py \
 ntp/test_ntp.py \
 pc/test_po_cleanup.py \
+pc/test_po_update.py \
 route/test_default_route.py \
 snmp/test_snmp_cpu.py \
 snmp/test_snmp_interfaces.py \
@@ -67,9 +68,6 @@ syslog/test_syslog.py \
 tacacs/test_rw_user.py \
 tacacs/test_ro_user.py \
 telemetry/test_telemetry.py"
-
-# FIXME: This test has been disabled and needs to be fixed and put back in:
-# pc/test_po_update.py
 
 pushd $SONIC_MGMT_DIR/tests
 ./run_tests.sh $PYTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [kvm] Re-enable test_po_update for KVM test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We previously disabled po_update for KVM because it was flaky. This flakiness was addressed in https://github.com/Azure/sonic-swss/pull/1462 so we can re-enable it.

#### How did you do it?
Added the test to the run list.

#### How did you verify/test it?
Re-ran test locally multiple times.

#### Any platform specific information?
KVM

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
