### PR TITLE
[test_route_perf] Fix test_route_perf.

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -1,42 +1,89 @@
 import pytest
 import json
+import logging
 from datetime import datetime
 from tests.common.utilities import wait_until
+from tests.common import config_reload
 
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')
 ]
 
+logger = logging.getLogger(__name__)
+
 ROUTE_TABLE_NAME = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
+    """
+        Ignore expected failures logs during test execution.
+
+        The route_checker script will compare routes in APP_DB and ASIC_DB, and an ERROR will be
+        recorded if mismatch. The testcase will add 10,000 routes to APP_DB, and route_checker may
+        detect mismatch during this period. So a new pattern is added to ignore possible error logs.
+
+        Args:
+            duthost: DUT fixture
+            loganalyzer: Loganalyzer utility fixture
+    """
+    ignoreRegex = [
+        ".*ERR route_check.py:.*",
+        ".*ERR.* \'routeCheck\' status failed.*"
+    ]
+    if loganalyzer:
+        # Skip if loganalyzer is disabled
+        loganalyzer.ignore_regex.extend(ignoreRegex)
+
+@pytest.fixture(params=[4, 6])
+def ip_versions(request):
+    """
+    Parameterized fixture for IP versions.
+    """
+    yield request.param
+
+@pytest.fixture(scope='function', autouse=True)
+def reload_dut(duthost, request):
+    yield
+    if request.node.rep_call.failed:
+        #Issue a config_reload to clear statically added route table and ip addr
+        logging.info("Reloading config..")
+        config_reload(duthost)
 
 def prepare_dut(duthost, intf_neighs):
     for intf_neigh in intf_neighs:
         # Set up interface
         duthost.shell('sudo config interface ip add {} {}'.format(intf_neigh['interface'], intf_neigh['ip']))
-        
         # Set up neighbor
-        duthost.shell('sudo ip neigh add {} lladdr {} dev {}'.format(intf_neigh['neighbor'], intf_neigh['mac'], intf_neigh['interface']))
+        duthost.shell('sudo ip neigh replace {} lladdr {} dev {}'.format(intf_neigh['neighbor'], intf_neigh['mac'], intf_neigh['interface']))
 
 def cleanup_dut(duthost, intf_neighs):
     for intf_neigh in intf_neighs:
         # Delete neighbor
         duthost.shell('sudo ip neigh del {} dev {}'.format(intf_neigh['neighbor'], intf_neigh['interface']))
-
         # remove interface
         duthost.shell('sudo config interface ip remove {} {}'.format(intf_neigh['interface'], intf_neigh['ip']))
 
-def generate_intf_neigh(num_neigh):
+def generate_intf_neigh(num_neigh, ip_version):
     # Generate interfaces and neighbors
     intf_neighs = []
     str_intf_nexthop = {'ifname':'', 'nexthop':''}
     for idx_neigh in range(num_neigh):
-        intf_neigh = {
-            'interface' : 'Ethernet%d' % (idx_neigh * 4 + 4),
-            'ip' : '10.%d.0.1/24' % (idx_neigh + 1),
-            'neighbor' : '10.%d.0.2' % (idx_neigh + 1),
-            'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
-        }
+        if ip_version == 4:
+            intf_neigh = {
+                'interface' : 'Ethernet%d' % (idx_neigh * 4 + 4),
+                'ip' : '10.%d.0.1/24' % (idx_neigh + 1),
+                'neighbor' : '10.%d.0.2' % (idx_neigh + 1),
+                'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
+            }
+        else:
+            intf_neigh = {
+                'interface' : 'Ethernet%d' % (idx_neigh * 4),
+                'ip' : '%x::1/64' % (0x2000 + idx_neigh),
+                'neighbor' : '%x::2' % (0x2000 + idx_neigh),
+                'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
+            }
+
         intf_neighs.append(intf_neigh)
         if idx_neigh == 0:
             str_intf_nexthop['ifname'] += intf_neigh['interface']
@@ -44,30 +91,9 @@ def generate_intf_neigh(num_neigh):
         else:
             str_intf_nexthop['ifname'] += ',' + intf_neigh['interface']
             str_intf_nexthop['nexthop'] += ',' + intf_neigh['neighbor']
-    
+
     return intf_neighs, str_intf_nexthop
 
-def generate_intf_neigh_ipv6(num_neigh):
-    # Generate interfaces and neighbors
-    intf_neighs = []
-    str_intf_nexthop = {'ifname':'', 'nexthop':''}
-    for idx_neigh in range(num_neigh):
-        intf_neigh = {
-            'interface' : 'Ethernet%d' % (idx_neigh * 4),
-            'ip' : '%x::1/64' % (0x2000 + idx_neigh),
-            'neighbor' : '%x::2' % (0x2000 + idx_neigh),
-            'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
-        }
-        intf_neighs.append(intf_neigh)
-        if idx_neigh == 0:
-            str_intf_nexthop['ifname'] += intf_neigh['interface']
-            str_intf_nexthop['nexthop'] += intf_neigh['neighbor']
-        else:
-            str_intf_nexthop['ifname'] += ',' + intf_neigh['interface']
-            str_intf_nexthop['nexthop'] += ',' + intf_neigh['neighbor']
-    
-    return intf_neighs, str_intf_nexthop
-         
 def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
     route_data = []
     for prefix in prefixes:
@@ -83,6 +109,12 @@ def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
     # Copy json file to DUT
     duthost.copy(content=json.dumps(route_data, indent=4), dest=dir)
 
+def count_routes(host):
+    num = host.shell(
+        'sonic-db-cli ASIC_DB eval "return #redis.call(\'keys\', \'{}*\')" 0'.format(ROUTE_TABLE_NAME),
+        module_ignore_errors=True)['stdout']
+    return int(num)
+
 def exec_routes(duthost, prefixes, str_intf_nexthop, op):
     # Create a tempfile for routes
     route_file_dir = duthost.shell('mktemp')['stdout']
@@ -91,8 +123,8 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
     generate_route_file(duthost, prefixes, str_intf_nexthop, route_file_dir, op)
 
     # Check the number of routes in ASIC_DB
-    start_num_route = int(duthost.shell('sonic-db-cli ASIC_DB eval "return #redis.call(\'keys\', \'{}*\')" 0'.format(ROUTE_TABLE_NAME))['stdout'])
-    
+    start_num_route = count_routes(duthost)
+
     # Calculate timeout as a function of the number of routes
     route_timeout = max(len(prefixes) / 500, 1) # Allow at least 1 second even when there is a limited number of routes
 
@@ -106,13 +138,16 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
     start_time = datetime.now()
 
     # Apply routes with swssconfig
-    duthost.shell('docker exec -i swss swssconfig /dev/stdin < {}'.format(route_file_dir))
+    result = duthost.shell('docker exec -i swss swssconfig /dev/stdin < {}'.format(route_file_dir),
+                           module_ignore_errors=True)
+    if result['rc'] != 0:
+        pytest.fail('Failed to apply route configuration file: {}'.format(result['stderr']))
 
     # Wait until the routes set/del applys to ASIC_DB
     def _check_num_routes(expected_num_routes):
         # Check the number of routes in ASIC_DB
-        num_routes = int(duthost.shell('sonic-db-cli ASIC_DB eval "return #redis.call(\'keys\', \'{}*\')" 0'.format(ROUTE_TABLE_NAME))['stdout'])
-        return num_routes == expected_num_routes
+        return count_routes(duthost) == expected_num_routes
+
     if not wait_until(route_timeout, 0.5, _check_num_routes, expected_num_routes):
         pytest.fail('failed to add routes within time limit')
 
@@ -135,52 +170,32 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
     # Retuen time used for set/del routes
     return (end_time - start_time).total_seconds()
 
-def test_perf_add_remove_routes(duthost, request):
+def test_perf_add_remove_routes(duthost, request, ip_versions):
     # Number of routes for test
     num_routes = request.config.getoption("--num_routes")
 
     # Generate interfaces and neighbors
-    intf_neighs, str_intf_nexthop = generate_intf_neigh(8)
+    NUM_NEIGHS = 8
+    intf_neighs, str_intf_nexthop = generate_intf_neigh(NUM_NEIGHS, ip_versions)
 
     # Generate ip prefixes of routes
-    prefixes = ['%d.%d.%d.%d/%d' % (101 + int(idx_route / 256 ** 2), int(idx_route / 256) % 256, idx_route % 256, 0, 24)
-                for idx_route in range(num_routes)]
+    if (ip_versions == 4):
+        prefixes = ['%d.%d.%d.%d/%d' % (101 + int(idx_route / 256 ** 2), int(idx_route / 256) % 256, idx_route % 256, 0, 24)
+                    for idx_route in range(num_routes)]
+    else:
+        prefixes = ['%x:%x:%x::/%d' % (0x3000 + int(idx_route / 65536), idx_route % 65536, 1, 64)
+                    for idx_route in range(num_routes)]
+    try:
+        # Set up interface and interface for routes
+        prepare_dut(duthost, intf_neighs)
 
-    # Set up interface and interface for routes
-    prepare_dut(duthost, intf_neighs)
+        # Add routes
+        time_set = exec_routes(duthost, prefixes, str_intf_nexthop, 'SET')
+        logger.info('Time to set %d ipv%d routes is %.2f seconds.' % (num_routes, ip_versions, time_set))
 
-    # Add routes
-    time_set = exec_routes(duthost, prefixes, str_intf_nexthop, 'SET')
-    print('Time to set %d ipv4 routes is %.2f seconds.' % (num_routes, time_set))
+        # Remove routes
+        time_del = exec_routes(duthost, prefixes, str_intf_nexthop, 'DEL')
+        logger.info('Time to del %d ipv%d routes is %.2f seconds.' % (num_routes, ip_versions, time_del))
+    finally:
+        cleanup_dut(duthost, intf_neighs)
 
-    # Remove routes
-    time_del = exec_routes(duthost, prefixes, str_intf_nexthop, 'DEL')
-    print('Time to del %d ipv4 routes is %.2f seconds.' % (num_routes, time_del))
-
-    # Cleanup DUT
-    cleanup_dut(duthost, intf_neighs)
-
-def test_perf_add_remove_routes_ipv6(duthost, request):
-    # Number of routes for test
-    num_routes = request.config.getoption("--num_routes")
-
-    # Generate interfaces and neighbors
-    intf_neighs, str_intf_nexthop = generate_intf_neigh_ipv6(8)
-
-    # Generate ip prefixes of routes
-    prefixes = ['%x:%x:%x::/%d' % (0x3000 + int(idx_route / 65536), idx_route % 65536, 1, 64)
-                for idx_route in range(num_routes)]
-
-    # Set up interface and interface for routes
-    prepare_dut(duthost, intf_neighs)
-
-    # Add routes
-    time_set = exec_routes(duthost, prefixes, str_intf_nexthop, 'SET')
-    print('Time to set %d ipv6 routes is %.2f seconds.' % (num_routes, time_set))
-
-    # Remove routes
-    time_del = exec_routes(duthost, prefixes, str_intf_nexthop, 'DEL')
-    print('Time to del %d ipv6 routes is %.2f seconds.' % (num_routes, time_del))
-
-    # Cleanup DUT
-    cleanup_dut(duthost, intf_neighs)


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2397
There are several problems in test_route_perf
1. DUT is not cleanup if error is raised before cleanup;
2. Error log reported by ```route_checker``` may cause test error, but these errors are possible and explainable ;
```
Oct 27 04:41:11.849379 str-7260cx3-acs-2 ERR route_check.py:  results: { {#012    "Unaccounted_ROUTE_ENTRY_TABLE_entries": [#012        "3000:146c:1::/64", #012        "3000:146d:1::/64", #012        "3000:146e:1::/64", #012        "3000:146f:1::/64", #012        "3000:1470:1::/64", #012        "3000:1471:1::/64", #012        "3000:1565:1::
Oct 27 04:41:11.850044 str-7260cx3-acs-2 ERR route_check.py:  Failed. Look at reported mismatches above
Oct 27 04:42:08.994134 str-7260cx3-acs-2 ERR monit[627]: 'routeCheck' status failed (255) -- results: { {#012    "Unaccounted_ROUTE_ENTRY_TABLE_entries": [#012        "3000:146c:1::/64", #012        "3000:146d:1::/64", #012        "3000:146e:1::/64", #012        "3000:146f:1::/64", #012        "3000:1470:1::/64", #012        "3000:1471:1::/64", #012        "3000:1482:1::/64", #012        "3000:1483:1::/64",
Oct 27 04:47:11.753617 str-7260cx3-acs-2 INFO monit[627]: 'routeCheck' status succeeded (0) -- no output
```
3. ```ip neigh add``` is not able to add neigh to ARP cache even ```ip neigh del``` or ```ip neigh flush``` is called.
This PR address these issues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix #2397.

#### How did you do it?
1. Use param to generate tests for ipv4/ipv6
2. Run cleanup even test failed
3. Add config reload to do a further cleanup if test failed
4. Ignore ERROR log reported by route_checker
5. Use 'ip neigh replace' in place of 'ip neigh add'

#### How did you verify/test it?
Verified on Arista-7260cx3.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util route/test_route_perf.py
/usr/local/lib/python2.7/dist-packages/cryptography/__init__.py:39: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  CryptographyDeprecationWarning,
========================================================================================= test session starts =========================================================================================
rootdir: /data/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 2 items                                                                                                                                                                                     

route/test_route_perf.py::test_perf_add_remove_routes[4] PASSED                                                                                                                                 [ 50%]
route/test_route_perf.py::test_perf_add_remove_routes[6] PASSED                                                                                                                                 [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 2 passed in 194.69 seconds ======================================================================================
```
The update is also verified on DX010-4, which is running a master branch image. The case will fail because of image issue, bug DUT is cleaned up.

 
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.