### PR TITLE
[test_crm] Disable route_checker for test_crm_route

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -36,3 +36,35 @@ def backup_and_restore_config_db_module(duthost):
     # TODO: Use the neater "yield from _function" syntax when we move to python3
     for func in _backup_and_restore_config_db(duthost):
         yield func
+
+
+def _disable_route_checker(duthost):
+    """
+        Some test cases will add static routes for test, which may trigger route_checker
+        to report error. This function is to disable route_checker before test, and recover it
+        after test.
+
+        Args:
+            duthost: DUT fixture
+    """
+    duthost.command('monit stop routeCheck')
+    yield
+    duthost.command('monit start routeCheck')
+
+
+@pytest.fixture
+def disable_route_checker(duthost):
+    """
+    Wrapper for _disable_route_checker, function level
+    """
+    for func in _disable_route_checker(duthost):
+        yield func
+
+
+@pytest.fixture(scope='module')
+def disable_route_checker_module(duthost):
+    """
+    Wrapper for _disable_route_checker, module level
+    """
+    for func in _disable_route_checker(duthost):
+        yield func

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -47,9 +47,9 @@ def _disable_route_checker(duthost):
         Args:
             duthost: DUT fixture
     """
-    duthost.command('monit stop routeCheck')
+    duthost.command('monit stop routeCheck', module_ignore_errors=True)
     yield
-    duthost.command('monit start routeCheck')
+    duthost.command('monit start routeCheck', module_ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -853,6 +853,7 @@ def test_crm_fdb_entry(duthost, tbinfo):
     if used_percent < 1:
         # Clear pre-set fdb entry
         duthost.command("fdbclear")
+        time.sleep(5)
         # Preconfiguration needed for used percentage verification
         fdb_entries_num = get_entries_num(new_crm_stats_fdb_entry_used, new_crm_stats_fdb_entry_available)
         # Generate FDB json file with 'fdb_entries_num' entries and apply it on DUT

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -12,6 +12,7 @@ from jinja2 import Template
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.assertions import pytest_assert
 from collections import OrderedDict
+from tests.common.fixtures.duthost_utils import disable_route_checker
 
 
 pytestmark = [
@@ -341,7 +342,7 @@ def get_entries_num(used, available):
     """ Get number of entries needed to be created that 'used' counter reached one percent """
     return ((used + available) / 100) + 1
 
-
+@pytest.mark.usefixtures('disable_route_checker')
 @pytest.mark.parametrize("ip_ver,route_add_cmd,route_del_cmd", [("4", "ip route add 2.2.2.0/24 via {}",
                                                                 "ip route del 2.2.2.0/24 via {}"),
                                                                 ("6", "ip -6 route add 2001::/126 via {}",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test case ```test_crm_route``` will add static route by ```ip route add```. There will be a small time gap between the routes inserted into APP_DB and ASIC_DB, as a result, the ```route_checker``` may detect this mismatch and  report an ERROR in syslog.
```
Oct 23 08:20:58.741773 str-dx010-acs-5 ERR route_check.py:  results: { {#012    "Unaccounted_ROUTE_ENTRY_TABLE_entries": [#012        "2.2.2.0/24"#012    ]#012} }\n', 'Oct 23 08:20:58.742569 str-dx010-acs-5 ERR route_check.py:  Failed. Look at reported mismatches above
Oct 23 08:21:53.693138 str-dx010-acs-5 ERR monit[556]: \'routeCheck\' status failed (255) -- results: { {#012    "Unaccounted_ROUTE_ENTRY_TABLE_entries": [#012        "2.2.2.0/24"#012    ]#012} }#012 Failed. Look at reported mismatches above
```
This PR will address the issue by disabling ```route_checker``` temporarily.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix issue caused by route_checker.
 
#### How did you do it?
Add a fixture to disable route_checker before test, and recover it after test.

#### How did you verify/test it?
Verified on DX010.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util crm/test_crm.py::test_crm_route
/usr/local/lib/python2.7/dist-packages/cryptography/__init__.py:39: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  CryptographyDeprecationWarning,
========================================================================================= test session starts =========================================================================================
collected 2 items                                                                                                                                                                                     

crm/test_crm.py::test_crm_route[ipv4] PASSED                                                                                                                                                    [ 50%]
crm/test_crm.py::test_crm_route[ipv6] PASSED                                                                                                                                                    [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 2 passed in 172.81 seconds ======================================================================================
```
And ```routeCheck``` is disabled before test, and reactived after test.
```
admin@str-dx010-acs-4:~$ sudo monit status routeCheck
Monit 5.20.0 uptime: 9h 49m

Program 'routeCheck'
  status                       Not monitored
  monitoring status            Not monitored
  monitoring mode              active
  on reboot                    start
  data collected               Tue, 27 Oct 2020 08:29:59
```
```
admin@str-dx010-acs-4:~$ sudo monit status routeCheck
Monit 5.20.0 uptime: 10h 5m

Program 'routeCheck'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              0
  last output                  -
  data collected               Tue, 27 Oct 2020 08:45:21
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A