### PR TITLE
[VRF] Add duthost fixture parameter to TestVrfLoopbackIntf setup

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -709,7 +709,7 @@ class TestVrfLoopbackIntf():
     announce_prefix = '10.10.10.0/26'
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_vrf_loopback(self, ptfhost, cfg_facts, tbinfo):
+    def setup_vrf_loopback(self, duthost, ptfhost, cfg_facts, tbinfo):
         # -------- Setup ----------
         lb0_ip_facts = get_intf_ips('Loopback0', cfg_facts)
         vlan1000_ip_facts = get_intf_ips('Vlan1000', cfg_facts)


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
https://github.com/Azure/sonic-mgmt/pull/2369 make use of duthost in TestVrfLoopbackIntf setup while there is no such fixture parameter in the setup function, adding the parameter.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
```
____________________________________________ ERROR at setup of TestVrfLoopbackIntf.test_ping_vrf1_loopback ____________________________________________

self = <test_vrf.TestVrfLoopbackIntf instance at 0x7f07aa150cf8>, ptfhost = <tests.common.devices.PTFHost object at 0x7f07af3c7790>
cfg_facts = {...}

    @pytest.fixture(scope="class", autouse=True)
    def setup_vrf_loopback(self, ptfhost, cfg_facts, tbinfo):
        # -------- Setup ----------
        lb0_ip_facts = get_intf_ips('Loopback0', cfg_facts)
        vlan1000_ip_facts = get_intf_ips('Vlan1000', cfg_facts)
        lb2_ip_facts = get_intf_ips('Loopback2', cfg_facts)
        vlan2000_ip_facts = get_intf_ips('Vlan2000', cfg_facts)
    
        self.c_vars['lb0_ip_facts'] = lb0_ip_facts
        self.c_vars['lb2_ip_facts'] = lb2_ip_facts
        self.c_vars['vlan1000_ip_facts'] = vlan1000_ip_facts
        self.c_vars['vlan2000_ip_facts'] = vlan2000_ip_facts
    
        # deploy routes to loopback
        for ver, ips in lb0_ip_facts.iteritems():
            for vlan_ip in vlan1000_ip_facts[ver]:
                nexthop = vlan_ip.ip
                break
            for ip in ips:
                ptfhost.shell("ip netns exec {} ip route add {} nexthop via {} ".format(g_vars['vlan_peer_vrf2ns_map']['Vrf1'], ip, nexthop))
    
        for ver, ips in lb2_ip_facts.iteritems():
            for vlan_ip in vlan2000_ip_facts[ver]:
                nexthop = vlan_ip.ip
                break
            for ip in ips:
                ptfhost.shell("ip netns exec {} ip route add {} nexthop via {} ".format(g_vars['vlan_peer_vrf2ns_map']['Vrf2'], ip, nexthop))
    
>       duthost.shell("sysctl -w net.ipv6.ip_nonlocal_bind=1")
E       NameError: global name 'duthost' is not defined

vrf/test_vrf.py:739: NameError
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
the bug introduced in #2369 pr
#### How did you do it?
just added the lacking parameter
#### How did you verify/test it?
did a run of the test
#### Any platform specific information?
none
#### Supported testbed topology if it's a new test case?
n/a
### Documentation 
n/a
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
