### PR TITLE
Add an option in run_tests.sh to run tests in the input order and make kvm tests running in input order

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -36,7 +36,8 @@ PYTEST_CLI_COMMON_OPTS="\
 -m individual \
 -q 1 \
 -a False \
--e --disable_loganalyzer"
+-e --disable_loganalyzer \
+-O"
 
 cd $SONIC_MGMT_DIR/tests
 rm -rf logs

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -257,7 +257,7 @@ function run_individual_tests()
 
 setup_environment
 
-while getopts "h?a:c:d:e:f:i:k:l:m:n:op:Os:q:rs:t:ux" opt; do
+while getopts "h?a:c:d:e:f:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,6 +16,7 @@ function show_help_and_exit()
     echo "    -m <method>    : specify test method group|individual|debug (default group)"
     echo "    -n <testbed>   : specify testbed name (*)"
     echo "    -o             : omit the file logs"
+    echo "    -O             : run tests in input order rather than alphabetical order"
     echo "    -p <path>      : specify log path (default: logs)"
     echo "    -q <n>         : test will stop after <n> failures (default: not stop on failure)"
     echo "    -r             : retain individual file log for suceeded tests (default: remove)"
@@ -79,6 +80,7 @@ function setup_environment()
     SKIP_FOLDERS="ptftests acstests saitests scripts"
     TESTBED_FILE="${BASE_PATH}/ansible/testbed.csv"
     TEST_CASES=""
+    TEST_INPUT_ORDER="False"
     TEST_METHOD='group'
     TEST_MAX_FAIL=0
 
@@ -107,7 +109,11 @@ function setup_test_options()
         done
     fi
     # Ignore the scripts specified in $SKIP_SCRIPTS
-    TEST_CASES=$(python -c "print '\n'.join([testcase for testcase in list('''$all_scripts'''.split()) if testcase not in set('''$SKIP_SCRIPTS'''.split())])")
+    if [[ x"${TEST_INPUT_ORDER}" == x"True" ]]; then
+        TEST_CASES=$(python -c "print '\n'.join([testcase for testcase in list('''$all_scripts'''.split()) if testcase not in set('''$SKIP_SCRIPTS'''.split())])")
+    else
+        TEST_CASES=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
+    fi
 
     PYTEST_COMMON_OPTS="--inventory ${INVENTORY} \
                       --host-pattern ${DUT_NAME} \
@@ -179,6 +185,7 @@ function run_debug_tests()
     echo "SKIP_SCRIPTS:          ${SKIP_SCRIPTS}"
     echo "SKIP_FOLDERS:          ${SKIP_FOLDERS}"
     echo "TEST_CASES:            ${TEST_CASES}"
+    echo "TEST_INPUT_ORDER:      ${TEST_INPUT_ORDER}"
     echo "TEST_MAX_FAIL:         ${TEST_MAX_FAIL}"
     echo "TEST_METHOD:           ${TEST_METHOD}"
     echo "TESTBED_FILE:          ${TESTBED_FILE}"
@@ -250,7 +257,7 @@ function run_individual_tests()
 
 setup_environment
 
-while getopts "h?a:c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
+while getopts "h?a:c:d:e:f:i:k:l:m:n:op:Os:q:rs:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -287,6 +294,9 @@ while getopts "h?a:c:d:e:f:i:k:l:m:n:op:q:rs:t:ux" opt; do
             ;;
         o )
             OMIT_FILE_LOG="True"
+            ;;
+        O )
+            TEST_INPUT_ORDER="True"
             ;;
         p )
             LOG_PATH=${OPTARG}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -107,7 +107,7 @@ function setup_test_options()
         done
     fi
     # Ignore the scripts specified in $SKIP_SCRIPTS
-    TEST_CASES=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
+    TEST_CASES=$(python -c "print '\n'.join([testcase for testcase in list('''$all_scripts'''.split()) if testcase not in set('''$SKIP_SCRIPTS'''.split())])")
 
     PYTEST_COMMON_OPTS="--inventory ${INVENTORY} \
                       --host-pattern ${DUT_NAME} \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add an option in run_tests.sh to run tests in the input order and make kvm tests running in input order
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently, run_tests.sh sort tests in alphabetical order. Running in the input order may provide more freedom in organizing test cases. Adding running in input order as an option in run_tests.sh.

#### How did you do it?
Add an option in run_tests.sh to run tests in the input order rather than alphabetical order. And make kvm tests running in input order.

#### How did you verify/test it?
Verified by running tests locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
