### PR TITLE
Improve wait_dut and prepare_ptf for the vxlan decap test

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -23,11 +23,13 @@ VNI_BASE = 336
 COUNT = 10
 
 
-def prepare_ptf(ptfhost, mg_facts, dut_facts):
-    """
-    @summary: Prepare the PTF docker container for testing
-    @param mg_facts: Minigraph facts
-    @param dut_facts: Host facts of DUT
+def prepare_ptf(ptfhost, mg_facts, duthost):
+    """Prepare arp responder configuration and store temporary vxlan decap related information to PTF docker
+
+    Args:
+        ptfhost (PTFHost): The ptfhost fixture, instance of PTFHost
+        mg_facts (dict): Collected minigraph facts
+        duthost (SonicHost): The duthost fixture, instance of SonicHost
     """
 
     logger.info("Prepare arp_responder")
@@ -47,7 +49,7 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts):
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],
         "minigraph_vlans": mg_facts["minigraph_vlans"],
         "minigraph_vlan_interfaces": mg_facts["minigraph_vlan_interfaces"],
-        "dut_mac": dut_facts["ansible_Ethernet0"]["macaddress"]
+        "dut_mac": duthost.facts["router_mac"]
     }
     ptfhost.copy(content=json.dumps(vxlan_decap, indent=2), dest="/tmp/vxlan_decap.json")
 
@@ -94,11 +96,9 @@ def setup(duthost, ptfhost):
 
     logger.info("Gather some facts")
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
-    dut_facts = duthost.setup(gather_subset="!all,!any,network", filter="ansible_Ethernet*")["ansible_facts"]
-    ptf_facts = ptfhost.setup(gather_subset="!all,!any,network")["ansible_facts"]
 
     logger.info("Prepare PTF")
-    prepare_ptf(ptfhost, mg_facts, dut_facts)
+    prepare_ptf(ptfhost, mg_facts, duthost)
 
     logger.info("Generate VxLAN config files")
     generate_vxlan_config_files(duthost, mg_facts)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Improve wait_dut and prepare_ptf for the vxlan decap test


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The logic of wait_dut in the vxlan decap PTF test script is complicated and
incorrect. There is no sleep in each iteration. The maximum loop is limited
by number of `timeout`, not by `timeout` seconds.

The route MAC is available in duthost.facts["router_mac"], there is no need to
call the setup ansible module on duthost.

The ptf_facts returned from ptfhost.setup() is not used.

#### How did you do it?
This change simplified the wait_dut function and limit the maximum loop time
to `timeout` seconds. Another change is to deprecate the call `setup` ansible
module on duthost and ptfhost. The ptf_facts returned by ptfhost.setup() is
unused and can be removed. The dut_facts returned by duthost.setup() is for
getting router MAC. There is an easier to get router MAC by
duthost.facts["router_mac"]

#### How did you verify/test it?
Test run the test_vxlan_decap script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
