### PR TITLE
[MgmtVrf] Using "ip vrf exec" or cgexec based on linux version

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -7,6 +7,7 @@ from tests.common import reboot
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
+from pkg_resources import parse_version
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -89,7 +90,11 @@ def execute_dut_command(duthost, command, mvrf=True, ignore_errors=False):
     result = {}
     prefix = ""
     if mvrf:
-        prefix = "sudo cgexec -g l3mdev:mgmt "
+        dut_kernel = duthost.setup()['ansible_facts']['ansible_kernel'].split('-')
+        if parse_version(dut_kernel[0]) > parse_version("4.9.0"):
+            prefix = "sudo ip vrf exec mgmt "
+        else:
+            prefix = "sudo cgexec -g l3mdev:mgmt "
     result = duthost.command(prefix + command, module_ignore_errors=ignore_errors)
     return result
 


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Kernel 4.19 remove l3mdev-cgroup, mgmt vrf makes relevant changes to Buster, using "ip vrf exec" or cgexec based on linux version
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
