### PR TITLE
Stabilize the NTP test

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -11,15 +11,18 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+
 @pytest.fixture(scope="module")
 def setup_ntp(ptfhost, duthost, creds):
     """setup ntp client and server"""
-    if creds.get('proxy_env'):
-        # If testbed is behaind proxy then force ntpd inside ptf use local time
-        ptfhost.lineinfile(path="/etc/ntp.conf", line="server 127.127.1.0 prefer")
 
-    # enable ntp server
-    ntp_en_res = ptfhost.service(name="ntp", state="started")
+    ptfhost.lineinfile(path="/etc/ntp.conf", line="server 127.127.1.0 prefer")
+
+    # restart ntp server
+    ntp_en_res = ptfhost.service(name="ntp", state="restarted")
+
+    pytest_assert(wait_until(120, 5, check_ntp_status, ptfhost), \
+        "NTP server was not started in PTF container {}; NTP service start result {}".format(ptfhost.hostname, ntp_en_res))
 
     # setup ntp on dut to sync with ntp server
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -27,19 +30,17 @@ def setup_ntp(ptfhost, duthost, creds):
     for ntp_server in ntp_servers:
         duthost.command("config ntp del %s" % ntp_server)
 
-    ptfip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
-    duthost.command("config ntp add %s" % ptfip)
-    pytest_assert(wait_until(120, 5, check_ntp_status, ptfhost), \
-        "NTP server was not started in PTF container {}; NTP service start result {}".format(ptfhost.hostname, ntp_en_res))
+    duthost.command("config ntp add %s" % ptfhost.mgmt_ip)
 
     yield
 
     # stop ntp server
     ptfhost.service(name="ntp", state="stopped")
     # reset ntp client configuration
-    duthost.command("config ntp del %s" % ptfip)
+    duthost.command("config ntp del %s" % ptfhost.mgmt_ip)
     for ntp_server in ntp_servers:
         duthost.command("config ntp add %s" % ntp_server)
+
 
 def check_ntp_status(host):
     res = host.command("ntpstat", module_ignore_errors=True)
@@ -47,8 +48,9 @@ def check_ntp_status(host):
        return False
     return True
 
+
 def test_ntp(duthost, setup_ntp):
-    """ verify the LLDP message on DUT """
+    """ Verify that DUT is synchronized with configured NTP server """
 
     duthost.service(name='ntp', state='stopped')
     duthost.command("ntpd -gq")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Stabilize the NTP test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Script test_ntp.py is failing and caused sonic-mgmt PR testing failed. 

#### How did you do it?
This change is to stabilize the ntp test to ensure that the NTP server on PTF is always restarted to take the configuration change in setup.

There are multiple issues in the script:
* Configuration `ptfhost.lineinfile(path="/etc/ntp.conf", line="server 127.127.1.0 prefer")` is not always added.
* Code `ptfhost.service(name="ntp", state="started")` will not restart the NTP service if NTP service is already running on PTF. Consequently, the updated configuration may not always in effect. Then run `ntpstate` on PTF will always fail.

This commit ensures that the configuration is always added and the NTP service on PTF is always restarted to take the latest configuration change.

#### How did you verify/test it?
Test run the test_ntp.py script using vsimage.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
