### PR TITLE
[multi-dut] refactoring fanouthosts and conn_graph_facts to be multi-dut ready

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -244,7 +244,7 @@ class Parse_Lab_Graph():
         return the given hostname device each individual connection
         """
         if hostname in self.links:
-            return self.links[hostname]
+            return { hostname: self.links[hostname] }
         else:
             return self.links
 
@@ -322,7 +322,7 @@ def main():
             lab_graph = find_graph(target)
 
         device_info = []
-        device_conn = []
+        device_conn = {}
         device_port_vlans = []
         device_vlan_range = []
         device_vlan_list = []
@@ -332,7 +332,7 @@ def main():
             if dev is None:
                 module.fail_json(msg="cannot find info for %s" % hostname)
             device_info.append(dev)
-            device_conn.append(lab_graph.get_host_connections(hostname))
+            device_conn.update(lab_graph.get_host_connections(hostname))
             host_vlan = lab_graph.get_host_vlan(hostname)
             # for multi-DUTs, must ensure all have vlan configured.
             if host_vlan:
@@ -342,10 +342,6 @@ def main():
             device_port_vlans.append(lab_graph.get_host_port_vlans(hostname))
         results = {k: v for k, v in locals().items()
                    if (k.startswith("device_") and v)}
-
-        # flatten the lists for single host
-        if m_args['hosts'] is None:
-            results = {k: v[0] if isinstance(v, list) else v for k, v in results.items()}
 
         module.exit_json(ansible_facts=results)
     except (IOError, OSError):

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -32,23 +32,23 @@ vrf definition management
 {% set intf =  'Ethernet' + i|string + '/1'  %}
 interface {{ intf }}
 {% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
-{%     if device_conn[intf]['speed'] == "100000" %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 100gfull
    error-correction encoding reed-solomon
    no shutdown
-{%     elif device_conn[intf]['speed'] == "40000" %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+{%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
    no shutdown
-{%     elif device_conn[intf]['speed'] == "50000" %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+{%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
@@ -58,7 +58,7 @@ interface {{ intf }}
 {% set intf =  'Ethernet' + i|string + '/3'  %}
 interface {{ intf }}
 {%         if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
@@ -73,7 +73,7 @@ interface {{ intf }}
    shutdown
 {%     endif %}
 {% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[intf]['vlanids'] }}
    spanning-tree portfast

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -32,28 +32,28 @@ vrf definition management
 {% for i in range(1,65) %}
 {% set intf =  'Ethernet' + i|string + '/1'  %}
 {% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
-{%     if device_conn[intf]['speed'] == "100000" %}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
    interface {{ intf }}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 100gfull
    error-correction encoding reed-solomon
    no shutdown
-{%     elif device_conn[intf]['speed'] == "40000" %}
+{%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
    interface {{ intf }}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
    no shutdown
-{%     elif device_conn[intf]['speed'] == "10000" %}
+{%     elif device_conn[inventory_hostname][intf]['speed'] == "10000" %}
 {%          for sub in range (1,5) %}
 {%             set subintf = 'Ethernet' + i|string + '/' + sub|string %}
    interface {{ subintf }}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
@@ -61,9 +61,9 @@ vrf definition management
    no shutdown
 !
 {% endfor %}   
-{%     elif device_conn[intf]['speed'] == "50000" %}
+{%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
 interface {{ intf }}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
@@ -74,7 +74,7 @@ interface {{ intf }}
 {% set intf =  'Ethernet' + i|string + '/3'  %}
 interface {{ intf }}
 {%         if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
@@ -90,14 +90,14 @@ interface {{ intf }}
 {%     endif %}
 {% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %}
    interface {{ intf }}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[intf]['vlanids'] }}
    spanning-tree portfast
-{%       if device_conn[intf]['speed'] == "100000" %}
+{%       if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
             speed forced 100gfull
             error-correction encoding reed-solomon
-{%       elif device_conn[intf]['speed'] == "40000" %}
+{%       elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
             speed forced 40gfull
 {%       endif %}
    no shutdown

--- a/ansible/roles/fanout/templates/force10_s6100_deploy.j2
+++ b/ansible/roles/fanout/templates/force10_s6100_deploy.j2
@@ -23,14 +23,14 @@ interface {{ intf }}
  no ip address
  switchport
 {% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != 'Trunk' %}
- description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+ description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
  vlan-stack access
  no shutdown
  interface Vlan {{ device_port_vlans[intf]['vlanids'] }}
  vlan-stack compatible
  member {{ intf }}
 {% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %} 
- description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+ description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
  vlan-stack trunk 
  no shutdown
 {% for vlanid in  device_port_vlans[intf]['vlanlist']  %}

--- a/ansible/roles/fanout/templates/sonic_deploy.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy.j2
@@ -8,12 +8,12 @@
 },
 
 "PORT": {
-{% for alias in device_conn %}
+{% for alias in device_conn[inventory_hostname] %}
     "{{ alias }}": {
-{% if device_conn[alias]['speed'] == "100000" %}
+{% if device_conn[inventory_hostname][alias]['speed'] == "100000" %}
         "fec" : "rs",
 {% endif %}
-        "speed" : "{{ device_conn[alias]['speed'] }}"
+        "speed" : "{{ device_conn[inventory_hostname][alias]['speed'] }}"
     }{% if not loop.last %},{% endif %}
 {% endfor %}
 },

--- a/ansible/roles/test/tasks/check_fanout_interfaces.yml
+++ b/ansible/roles/test/tasks/check_fanout_interfaces.yml
@@ -4,7 +4,7 @@
     delegate_to: localhost
 
   - name: Fanout hostname
-    set_fact: fanout_switch={{ device_conn['Ethernet0']['peerdevice'] }}
+    set_fact: fanout_switch={{ device_conn[inventory_hostname]['Ethernet0']['peerdevice'] }}
 
   - name: Check Fanout interfaces
     local_action: shell ansible-playbook -i lab fanout.yml -l {{ fanout_switch }} --tags check_interfaces_status

--- a/ansible/roles/test/tasks/continuous_link_flap.yml
+++ b/ansible/roles/test/tasks/continuous_link_flap.yml
@@ -54,13 +54,13 @@
       delegate_to: localhost
       tags: always
 
-    - debug: msg="{{ device_conn }}"
+    - debug: msg="{{ device_conn[inventory_hostname] }}"
 
     - name: include continuous_link_flap_helper.yml
       include_tasks: continuous_link_flap/continuous_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ device_conn[inventory_hostname].keys() }}"
 
     - debug: msg="Second Iteration flap all interfaces one by one on DUT"
 
@@ -73,7 +73,7 @@
       include_tasks: continuous_link_flap/continuous_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ device_conn[inventory_hostname].keys() }}"
 
     - debug: msg="Third Iteration flap all interfaces one by one on DUT"
 
@@ -86,7 +86,7 @@
       include_tasks: continuous_link_flap/continuous_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ device_conn[inventory_hostname].keys() }}"
 
     - debug: msg="First Iteration flap all interfaces one by one on Peer Device"
 
@@ -95,16 +95,16 @@
       delegate_to: localhost
       tags: always
 
-    - debug: msg="{{ device_conn }}"
+    - debug: msg="{{ device_conn[inventory_hostname] }}"
 
     - set_fact:
-        neighbors: "{{device_conn}}"
+        neighbors: "{{device_conn[inventory_hostname]}}"
 
     - name: include continuous_peer_link_flap_helper.yml
       include_tasks: continuous_link_flap/continuous_peer_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ device_conn[inventory_hostname].keys() }}"
 
     - debug: msg="Second Iteration flap all interfaces one by one on Peer Device"
 
@@ -114,13 +114,13 @@
       tags: always
 
     - set_fact:
-        neighbors: "{{device_conn}}"
+        neighbors: "{{device_conn[inventory_hostname]}}"
 
     - name: include continuous_peer_link_flap_helper.yml
       include_tasks: continuous_link_flap/continuous_peer_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ device_conn[inventory_hostname].keys() }}"
 
     - debug: msg="Third Iteration flap all interfaces one by one on Peer Device"
 
@@ -130,13 +130,13 @@
       tags: always
 
     - set_fact:
-        neighbors: "{{device_conn}}"
+        neighbors: "{{device_conn[inventory_hostname]}}"
 
     - name: include continuous_peer_link_flap_helper.yml
       include_tasks: continuous_link_flap/continuous_peer_link_flap_helper.yml
       vars:
         interface: "{{item}}"
-      with_items: "{{ device_conn.keys() }}"
+      with_items: "{{ device_conn[inventory_hostname].keys() }}"
 
     - name: wait 60 secs so that BGP routes are relearned
       pause: seconds=60

--- a/ansible/roles/test/tasks/ecmp.yml
+++ b/ansible/roles/test/tasks/ecmp.yml
@@ -52,7 +52,7 @@
   tags: always
 
 - set_fact:
-    neighbors: "{{device_conn}}"
+    neighbors: "{{device_conn[inventory_hostname]}}"
 
 - name: Initialize an empty list to store interface names
   set_fact:
@@ -94,7 +94,7 @@
   tags: always
 
 - set_fact:
-    neighbors: "{{device_conn}}"
+    neighbors: "{{device_conn[inventory_hostname]}}"
 
 - debug: msg="iface_list {{ iface_list }}"
 
@@ -113,7 +113,7 @@
   tags: always
 
 - set_fact:
-    neighbors: "{{device_conn}}"
+    neighbors: "{{device_conn[inventory_hostname]}}"
 
 - include: ecmp/paths_up.yml
   with_items: iface_list

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -14,7 +14,7 @@
     conn_graph_facts: host={{ inventory_hostname }}
     delegate_to: localhost
 
-  - set_fact: neighbors="{{device_conn}}"
+  - set_fact: neighbors="{{device_conn[inventory_hostname]}}"
 
   - include_tasks: resume_fanout_ports.yml
     with_items: "{{ ansible_interface_link_down_ports }}"

--- a/ansible/roles/test/tasks/link_flap.yml
+++ b/ansible/roles/test/tasks/link_flap.yml
@@ -9,7 +9,7 @@
 
 - name: Set neighbor facts
   set_fact:
-    neighbors: "{{ device_conn }}"
+    neighbors: "{{ device_conn[inventory_hostname] }}"
 
 - include_tasks: link_flap/link_flap_helper.yml
-  with_items: "{{ device_conn.keys() }}"
+  with_items: "{{ device_conn[inventory_hostname].keys() }}"

--- a/ansible/roles/test/tasks/pfc_wd.yml
+++ b/ansible/roles/test/tasks/pfc_wd.yml
@@ -37,7 +37,7 @@
     ports: "{{minigraph_ports.keys() | join(' ')}}"
 
 - set_fact:
-    neighbors: "{{device_conn}}"
+    neighbors: "{{device_conn[inventory_hostname]}}"
 
 - set_fact:
     ansible_eth0_ipv4_addr: "{{ansible_eth0['ipv4']['address']}}"

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -422,7 +422,7 @@ class SonicHost(AnsibleHostBase):
                 else:
                     if process_status == "RUNNING" and process_name in critical_process_list:
                         expected_critical_process_list.append(process_name)
-            
+
             critical_group_list = expected_critical_group_list
             critical_process_list = expected_critical_process_list
 
@@ -1038,7 +1038,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         """
         output = self.shell(show_cmd, **kwargs)["stdout_lines"]
         return self._parse_show(output)
-    
+
     def get_namespace_from_asic_id(self, asic_id):
         if asic_id is DEFAULT_ASIC_ID:
             return DEFAULT_NAMESPACE
@@ -1359,6 +1359,9 @@ class FanoutHost(object):
             DUT instance in the test. As result the port mapping is
             unique from the DUT perspective. However, this function
             need update when supporting multiple DUT
+
+            host_port is a encoded string of <host name>|<port name>,
+            e.g. sample_host|Ethernet0.
         """
         self.host_to_fanout_port_map[host_port]   = fanout_port
         self.fanout_to_host_port_map[fanout_port] = host_port

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -5,21 +5,17 @@ import yaml
 
 
 @pytest.fixture(scope="module")
-def conn_graph_facts(duthost, localhost):
-    return get_graph_facts(duthost, localhost, duthost.hostname)
-
-
-@pytest.fixture(scope="module")
-def conn_graph_facts_multi_duts(duthost, duthosts, localhost):
-    return get_graph_facts(duthost, localhost,
+def conn_graph_facts(duthosts, localhost):
+    return get_graph_facts(duthosts[0], localhost,
                            [dh.hostname for dh in duthosts])
 
-  
+ 
 @pytest.fixture(scope="module")
 def fanout_graph_facts(localhost, duthost, conn_graph_facts):
     facts = dict()
-    for intf in conn_graph_facts["device_conn"]:
-        fanout = conn_graph_facts["device_conn"][intf]["peerdevice"]
+    dev_conn = conn_graph_facts.get('device_conn', {})
+    for intf, val in dev_conn[duthost.hostname].items():
+        fanout = val["peerdevice"]
         if fanout not in facts:
             facts[fanout] = get_graph_facts(duthost, localhost, fanout)
     return facts

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -23,8 +23,9 @@ ARP_RESPONDER_CONF = os.path.join(TESTS_ROOT, "templates/arp_responder.conf.j2")
 
 def get_fanout(fanout_graph_facts, setup):
     for fanout_host_name, value in fanout_graph_facts.items():
-        for fanout_inf, peer_info in value["device_conn"].items():
-            if peer_info["peerport"] == setup["ptf_test_params"]["server_ports"][0]["dut_name"]:
+        for _, ports in value["device_conn"].items():
+            for fanout_inf, peer_info in ports.items():
+                if peer_info["peerport"] == setup["ptf_test_params"]["server_ports"][0]["dut_name"]:
                 return fanout_host_name
     return None
 
@@ -106,12 +107,13 @@ def pfc_storm_runner(fanouthosts, fanout_graph_facts, pfc_storm_template, setup)
 
         def run(self):
             params["pfc_fanout_interface"] = ""
+            dev_conn = fanout_graph_facts[fanout_host_name]["device_conn"]
             if self.server_ports:
-                params["pfc_fanout_interface"] += ",".join([key for key, value in fanout_graph_facts[fanout_host_name]["device_conn"].items() if value["peerport"] in self.used_server_ports])
+                params["pfc_fanout_interface"] += ",".join([key for key, value in dev_conn[k].items() for k in dev_conn.keys() if value["peerport"] in self.used_server_ports])
             if self.non_server_port:
                 if params["pfc_fanout_interface"]:
                     params["pfc_fanout_interface"] += ","
-                params["pfc_fanout_interface"] += ",".join([key for key, value in fanout_graph_facts[fanout_host_name]["device_conn"].items() if value["peerport"] in self.used_non_server_port])
+                params["pfc_fanout_interface"] += ",".join([key for key, value in dev_conn[k].items() for k in dev_conn.keys() if value["peerport"] in self.used_non_server_port])
             fanout_host.exec_template(ansible_root=ANSIBLE_ROOT, ansible_playbook=RUN_PLAYBOOK, inventory=setup["fanout_inventory"], \
                 **params)
             time.sleep(5)

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -108,12 +108,18 @@ def pfc_storm_runner(fanouthosts, fanout_graph_facts, pfc_storm_template, setup)
         def run(self):
             params["pfc_fanout_interface"] = ""
             dev_conn = fanout_graph_facts[fanout_host_name]["device_conn"]
+            plist = []
             if self.server_ports:
-                params["pfc_fanout_interface"] += ",".join([key for key, value in dev_conn[k].items() for k in dev_conn.keys() if value["peerport"] in self.used_server_ports])
+                for _, val in dev_conn.items():
+                    p = ",".join([key for key, value in val.items() if value["peerport"] in self.used_server_ports])
+                    if p:
+                        plist.append(p)
             if self.non_server_port:
-                if params["pfc_fanout_interface"]:
-                    params["pfc_fanout_interface"] += ","
-                params["pfc_fanout_interface"] += ",".join([key for key, value in dev_conn[k].items() for k in dev_conn.keys() if value["peerport"] in self.used_non_server_port])
+                for _, val in dev_conn.items():
+                    p = ",".join([key for key, value in val.items() if value["peerport"] in self.used_non_server_port])
+                    if p:
+                        plist.append(p)
+            params["pfc_fanout_interface"] += ",".join([key for key in plist])
             fanout_host.exec_template(ansible_root=ANSIBLE_ROOT, ansible_playbook=RUN_PLAYBOOK, inventory=setup["fanout_inventory"], \
                 **params)
             time.sleep(5)

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -26,7 +26,7 @@ def get_fanout(fanout_graph_facts, setup):
         for _, ports in value["device_conn"].items():
             for fanout_inf, peer_info in ports.items():
                 if peer_info["peerport"] == setup["ptf_test_params"]["server_ports"][0]["dut_name"]:
-                return fanout_host_name
+                    return fanout_host_name
     return None
 
 

--- a/tests/common/ixia/ixia_helpers.py
+++ b/tests/common/ixia/ixia_helpers.py
@@ -115,10 +115,11 @@ class IxiaFanoutManager () :
     def __parse_fanout_connections__ (self) :
         device_conn = self.last_device_connection_details
         retval = []
-        for key in device_conn.keys() :
-            pp =  device_conn[key]['peerport']
-            string = self.ip_address + '/' + key + '/' + pp
-            retval.append(string)
+        for _, value in device_conn:        # enumerate hosts
+            for key, val in value.items():  # enumerate ports
+                pp = val['peerport']
+                string = self.ip_address + '/' + key + '/' + pp
+                retval.append(string)
         retval.sort()
         return(retval)
 

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1,8 +1,10 @@
+from tests.common.helpers.dut_ports import encode_dut_port_name
+
 """
 Helper script for fanout switch operations
 """
 
-def fanout_switch_port_lookup(fanout_switches, dut_port):
+def fanout_switch_port_lookup(fanout_switches, dut_name, dut_port):
     """
         look up the fanout switch instance and the fanout switch port
         connecting to the dut_port
@@ -10,14 +12,16 @@ def fanout_switch_port_lookup(fanout_switches, dut_port):
         Args:
             fanout_switches (list FanoutHost): list of fanout switch
                                                instances.
+            dut_name (str): the host name of the DUT
             dut_port (str): port name on the DUT
 
         Returns:
             None, None if fanout switch instance and port is not found
             FanoutHost, Portname(str) if found
     """
+    dut_host_port = encode_dut_port_name(dut_name, dut_port)
     for _, fanout in fanout_switches.items():
-        if dut_port in fanout.host_to_fanout_port_map:
-            return fanout, fanout.host_to_fanout_port_map[dut_port]
+        if dut_host_port in fanout.host_to_fanout_port_map:
+            return fanout, fanout.host_to_fanout_port_map[dut_host_port]
 
     return None, None

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -39,7 +39,7 @@ def __recover_interfaces(dut, fanouthosts, result, wait_time):
             action = 'config_reload'
             continue
 
-        fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, port)
+        fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, dut.hostname, port)
         if fanout and fanout_port:
             fanout.no_shutdown(fanout_port)
         dut.no_shutdown(port)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,42 +288,43 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
     fanout_hosts = {}
     # WA for virtual testbed which has no fanout
     try:
-        for dut_port in dev_conn.keys():
-            fanout_rec = dev_conn[dut_port]
-            fanout_host = fanout_rec['peerdevice']
-            fanout_port = fanout_rec['peerport']
+        for dut_host, value in dev_conn.items():
+            for dut_port in value.keys():
+                fanout_rec = value[dut_port]
+                fanout_host = fanout_rec['peerdevice']
+                fanout_port = fanout_rec['peerport']
 
-            if fanout_host in fanout_hosts.keys():
-                fanout = fanout_hosts[fanout_host]
-            else:
-                host_vars = ansible_adhoc().options[
-                    'inventory_manager'].get_host(fanout_host).vars
-                os_type = host_vars.get('os', 'eos')
-                admin_user = creds['fanout_admin_user']
-                admin_password = creds['fanout_admin_password']
-                # `fanout_network_user` and `fanout_network_password` are for
-                # accessing the non-shell CLI of fanout.
-                # Ansible will use this set of credentail for establishing
-                # `network_cli` connection with device when applicable.
-                network_user = creds.get('fanout_network_user', admin_user)
-                network_password = creds.get('fanout_network_password',
-                                             admin_password)
-                shell_user = creds.get('fanout_shell_user', admin_user)
-                shell_password = creds.get('fanout_shell_pass', admin_password)
-                if os_type == 'sonic':
-                    shell_user = creds['fanout_sonic_user']
-                    shell_password = creds['fanout_sonic_password']
+                if fanout_host in fanout_hosts.keys():
+                    fanout = fanout_hosts[fanout_host]
+                else:
+                    host_vars = ansible_adhoc().options[
+                        'inventory_manager'].get_host(fanout_host).vars
+                    os_type = host_vars.get('os', 'eos')
+                    admin_user = creds['fanout_admin_user']
+                    admin_password = creds['fanout_admin_password']
+                    # `fanout_network_user` and `fanout_network_password` are for
+                    # accessing the non-shell CLI of fanout.
+                    # Ansible will use this set of credentail for establishing
+                    # `network_cli` connection with device when applicable.
+                    network_user = creds.get('fanout_network_user', admin_user)
+                    network_password = creds.get('fanout_network_password',
+                                                 admin_password)
+                    shell_user = creds.get('fanout_shell_user', admin_user)
+                    shell_password = creds.get('fanout_shell_pass', admin_password)
+                    if os_type == 'sonic':
+                        shell_user = creds['fanout_sonic_user']
+                        shell_password = creds['fanout_sonic_password']
 
-                fanout = FanoutHost(ansible_adhoc,
-                                    os_type,
-                                    fanout_host,
-                                    'FanoutLeaf',
-                                    network_user,
-                                    network_password,
-                                    shell_user=shell_user,
-                                    shell_passwd=shell_password)
-                fanout_hosts[fanout_host] = fanout
-            fanout.add_port_map(dut_port, fanout_port)
+                    fanout = FanoutHost(ansible_adhoc,
+                                        os_type,
+                                        fanout_host,
+                                        'FanoutLeaf',
+                                        network_user,
+                                        network_password,
+                                        shell_user=shell_user,
+                                        shell_passwd=shell_password)
+                    fanout_hosts[fanout_host] = fanout
+                fanout.add_port_map(encode_dut_port_name(dut_host, dut_port), fanout_port)
     except:
         pass
     return fanout_hosts

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -167,7 +167,7 @@ def rif_port_down(duthost, setup, fanouthosts, loganalyzer):
             break
     pytest_assert(ip_dst, 'Unable to find IP address for neighbor "{}"'.format(vm_name))
 
-    fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, rif_member_iface)
+    fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, duthost.hostname, rif_member_iface)
 
     loganalyzer.expect_regex = [LOG_EXPECT_PORT_OPER_DOWN_RE.format(rif_member_iface)]
     with loganalyzer as _:

--- a/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
+++ b/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
@@ -21,7 +21,7 @@ class FanoutHandler(BaseFanoutHandler):
         self.ansible_localhost = localhost
 
         dut_facts = self.ansible_localhost.conn_graph_facts(host=duthost.hostname, filename=LAB_CONNECTION_GRAPH)["ansible_facts"]
-        self.fanout_host = dut_facts["device_conn"]["Ethernet0"]["peerdevice"]
+        self.fanout_host = dut_facts["device_conn"][duthost.hostname]["Ethernet0"]["peerdevice"]
         fanout_facts = self.ansible_localhost.conn_graph_facts(host=self.fanout_host, filename=LAB_CONNECTION_GRAPH)["ansible_facts"]
 
         self.fanout_trunk_port = None

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -244,7 +244,7 @@ def mock_server(fanouthosts, testbed_params, arp_responder, ptfadapter, duthost)
     logging.info("Populating FDB and ARP entry for mock server under VLAN")
     # Issue a ping to populate ARP table on DUT
     duthost.command('ping %s -c 3' % server_dst_addr, module_ignore_errors=True)
-    fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, server_dst_intf)
+    fanout_neighbor, fanout_intf = fanout_switch_port_lookup(fanouthosts, duthost.hostname, server_dst_intf)
 
     return {"server_dst_port": server_dst_port,
             "server_dst_addr": server_dst_addr,

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -48,7 +48,7 @@ class LagTest:
         self.mg_facts         = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
         self.conn_graph_facts = conn_graph_facts
         self.vm_neighbors     = self.mg_facts['minigraph_neighbors']
-        self.fanout_neighbors = self.conn_graph_facts['device_conn'] if 'device_conn' in self.conn_graph_facts else {}
+        self.fanout_neighbors = self.conn_graph_facts['device_conn'][duthost.hostname] if 'device_conn' in self.conn_graph_facts else {}
 
     def __get_lag_facts(self):
         return self.duthost.lag_facts(host = self.duthost.hostname)['ansible_facts']['lag_facts']

--- a/tests/pfc/test_pfc_pause_lossless.py
+++ b/tests/pfc/test_pfc_pause_lossless.py
@@ -224,7 +224,7 @@ def test_pfc_pause_single_lossless_priority(conn_graph_facts,
     port_list = list()
     fanout_devices = IxiaFanoutManager(fanout_graph_facts)
     fanout_devices.get_fanout_device_details(device_number=0)
-    device_conn = conn_graph_facts['device_conn']
+    device_conn = conn_graph_facts['device_conn'][duthost.hostname]
 
     for intf in fanout_devices.get_ports():
         peer_port = intf['peer_port']

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -43,7 +43,7 @@ def setup_pfc_test(duthost, ptfhost, conn_graph_facts):
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     port_list = mg_facts['minigraph_ports'].keys()
     ports = (' ').join(port_list)
-    neighbors = conn_graph_facts['device_conn']
+    neighbors = conn_graph_facts['device_conn'][duthost.hostname]
     dut_facts = duthost.setup()['ansible_facts']
     dut_eth0_ip = dut_facts['ansible_eth0']['ipv4']['address']
     dut_eth0_mac = dut_facts['ansible_eth0']['macaddress']

--- a/tests/platform_tests/mellanox/test_check_sfp_presence.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_presence.py
@@ -20,7 +20,7 @@ def test_check_sfp_presence(duthost, conn_graph_facts):
     check_intf_presence_command = 'show interface transceiver presence {}'
 
     logging.info("Use show interface status information")
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in conn_graph_facts["device_conn"][duthost.hostname]:
         check_presence_output = duthost.command(check_intf_presence_command.format(intf))
         assert check_presence_output["rc"] == 0, "Failed to read interface %s transceiver presence" % intf
         logging.info(str(check_presence_output["stdout_lines"][2]))

--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -27,7 +27,7 @@ def test_check_sfp_using_ethtool(duthost, conn_graph_facts):
         lanes_divider = 8
     else:
         lanes_divider = 4
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in conn_graph_facts["device_conn"][duthost.hostname]:
         intf_lanes = ports_config[intf]["lanes"]
         sfp_id = int(intf_lanes.split(",")[0])/lanes_divider + 1
 

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -163,7 +163,7 @@ class ContinuousReboot:
         logging.info("Check whether transceiver information of all ports are in redis")
         xcvr_info = self.duthost.command("redis-cli -n 6 keys TRANSCEIVER_INFO*")
         parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
-        interfaces = self.conn_graph_facts["device_conn"]
+        interfaces = self.conn_graph_facts["device_conn"][self.duthost.hostname]
         for intf in interfaces:
             if intf not in parsed_xcvr_info:
                 raise ContinuousRebootError("TRANSCEIVER INFO of {} is not found in DB".format(intf))

--- a/tests/platform_tests/test_link_flap.py
+++ b/tests/platform_tests/test_link_flap.py
@@ -68,7 +68,7 @@ class TestLinkFlap:
         candidates = []
         if port != 'unknown':
             status = self.__get_dut_if_status(dut, port)
-            fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, port)
+            fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, dut.hostname, port)
             self.__build_candidate_list(candidates, fanout, fanout_port, port, status)
         else:
             # Build the full list
@@ -76,7 +76,7 @@ class TestLinkFlap:
             status = self.__get_dut_if_status(dut)
 
             for dut_port in status.keys():
-                fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, dut_port)
+                fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, dut.hostname, dut_port)
                 self.__build_candidate_list(candidates, fanout, fanout_port, dut_port, status)
 
             if self.completeness_level == 'debug':

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -38,7 +38,7 @@ def teardown_module(duthost, conn_graph_facts):
     yield
 
     logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
-    interfaces = conn_graph_facts["device_conn"]
+    interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     check_critical_processes(duthost, watch_secs=10)
     check_interfaces_and_services(duthost, interfaces)
 
@@ -105,14 +105,14 @@ def test_cold_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_COLD)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_COLD)
 
 
 def test_fast_reboot(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_FAST)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_FAST)
 
 
 def test_warm_reboot(duthost, localhost, conn_graph_facts):
@@ -126,7 +126,7 @@ def test_warm_reboot(duthost, localhost, conn_graph_facts):
         if "disabled" in issu_capability:
             pytest.skip("ISSU is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_WARM)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_WARM)
 
 
 def _power_off_reboot_helper(kwargs):
@@ -183,7 +183,7 @@ def test_power_off_reboot(duthost, localhost, conn_graph_facts, psu_controller, 
         poweroff_reboot_kwargs["all_psu"] = all_psu
         poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
         poweroff_reboot_kwargs["delay_time"] = power_off_delay
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], REBOOT_TYPE_POWEROFF,
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], REBOOT_TYPE_POWEROFF,
                          _power_off_reboot_helper, poweroff_reboot_kwargs)
 
 
@@ -197,7 +197,7 @@ def test_watchdog_reboot(duthost, localhost, conn_graph_facts):
     if "" != watchdog_supported:
         pytest.skip("Watchdog is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], REBOOT_TYPE_WATCHDOG)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], REBOOT_TYPE_WATCHDOG)
 
 
 def test_continuous_reboot(duthost, localhost, conn_graph_facts):
@@ -205,4 +205,4 @@ def test_continuous_reboot(duthost, localhost, conn_graph_facts):
     @summary: This test case is to perform 3 cold reboot in a row
     """
     for i in range(3):
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"], reboot_type=REBOOT_TYPE_COLD)
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_COLD)

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -24,7 +24,7 @@ def test_reload_configuration(duthost, conn_graph_facts):
     """
     @summary: This test case is to reload the configuration and check platform status
     """
-    interfaces = conn_graph_facts["device_conn"]
+    interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     asic_type = duthost.facts["asic_type"]
 
     logging.info("Reload configuration")

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -70,7 +70,7 @@ def test_restart_swss(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to restart the swss service and check platform status
     """
-    restart_service_and_check(localhost, duthost, "swss", conn_graph_facts["device_conn"])
+    restart_service_and_check(localhost, duthost, "swss", conn_graph_facts["device_conn"][duthost.hostname])
 
 
 @pytest.mark.skip(reason="Restarting syncd is not supported yet")
@@ -78,4 +78,4 @@ def test_restart_syncd(duthost, localhost, conn_graph_facts):
     """
     @summary: This test case is to restart the syncd service and check platform status
     """
-    restart_service_and_check(localhost, duthost, "syncd", conn_graph_facts["device_conn"])
+    restart_service_and_check(localhost, duthost, "syncd", conn_graph_facts["device_conn"][duthost.hostname])

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -121,34 +121,35 @@ def test_check_sfp_status_and_configure_sfp(duthost, conn_graph_facts):
     logging.info("Check output of '%s'" % cmd_sfp_presence)
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-    for intf in conn_graph_facts["device_conn"]:
+    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
+    for intf in dev_conn:
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check output of '%s'" % cmd_xcvr_presence)
     xcvr_presence = duthost.command(cmd_xcvr_presence)
     parsed_presence = parse_output(xcvr_presence["stdout_lines"][2:])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_xcvr_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check output of '%s'" % cmd_sfp_eeprom)
     sfp_eeprom = duthost.command(cmd_sfp_eeprom)
     parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
     logging.info("Check output of '%s'" % cmd_xcvr_eeprom)
     xcvr_eeprom = duthost.command(cmd_xcvr_eeprom)
     parsed_eeprom = parse_eeprom(xcvr_eeprom["stdout_lines"])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_eeprom, "Interface is not in output of '%s'" % cmd_xcvr_eeprom
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
     logging.info("Test '%s <interface name>'" % cmd_sfp_reset)
     tested_physical_ports = set()
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         phy_intf = portmap[intf][0]
         if phy_intf in tested_physical_ports:
             logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
@@ -164,7 +165,7 @@ def test_check_sfp_status_and_configure_sfp(duthost, conn_graph_facts):
     logging.info("Check sfp presence again after reset")
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
@@ -205,13 +206,14 @@ def test_check_sfp_low_power_mode(duthost, conn_graph_facts):
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
     original_lpmode = copy.deepcopy(parsed_lpmode)
-    for intf in conn_graph_facts["device_conn"]:
+    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
+    for intf in dev_conn:
         assert intf in parsed_lpmode, "Interface is not in output of '%s'" % cmd_sfp_show_lpmode
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
     tested_physical_ports = set()
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         phy_intf = portmap[intf][0]
         if phy_intf in tested_physical_ports:
             logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
@@ -226,13 +228,13 @@ def test_check_sfp_low_power_mode(duthost, conn_graph_facts):
     logging.info("Check SFP lower power mode again after changing SFP lpmode")
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_lpmode, "Interface is not in output of '%s'" % cmd_sfp_show_lpmode
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
     tested_physical_ports = set()
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         phy_intf = portmap[intf][0]
         if phy_intf in tested_physical_ports:
             logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
@@ -247,14 +249,14 @@ def test_check_sfp_low_power_mode(duthost, conn_graph_facts):
     logging.info("Check SFP lower power mode again after changing SFP lpmode")
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_lpmode, "Interface is not in output of '%s'" % cmd_sfp_show_lpmode
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Check sfp presence again after setting lpmode")
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-    for intf in conn_graph_facts["device_conn"]:
+    for intf in dev_conn:
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -20,4 +20,4 @@ def test_xcvr_info_in_db(duthost, conn_graph_facts):
     @summary: This test case is to verify that xcvrd works as expected by checking transceiver information in DB
     """
     logging.info("Check transceiver status")
-    check_transceiver_status(duthost, conn_graph_facts["device_conn"])
+    check_transceiver_status(duthost, conn_graph_facts["device_conn"][duthost.hostname])

--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -44,9 +44,10 @@ def leaf_fanouts(conn_graph_facts):
     conn_facts = conn_graph_facts['device_conn']
 
     """ for each interface of DUT """
-    for intf in conn_facts:
-        peer_device = conn_facts[intf]['peerdevice']
-        if peer_device not in leaf_fanouts:
-            leaf_fanouts.append(peer_device)
+    for _, value in conn_facts.items():
+        for _, val in value.items():
+            peer_device = val['peerdevice']
+            if peer_device not in leaf_fanouts:
+                leaf_fanouts.append(peer_device)
 
     return leaf_fanouts

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -51,7 +51,7 @@ def run_test(fanouthosts, duthost, conn_graph_facts, leaf_fanouts, is_pfc=True, 
     @param pause_time: Pause time quanta (0-65535) in the frame. 0 means unpause.
     """
     setup_testbed(fanouthosts, duthost, leaf_fanouts)
-    conn_facts = conn_graph_facts['device_conn']
+    conn_facts = conn_graph_facts['device_conn'][duthost.hostname]
 
     int_status = duthost.show_interface(command = "status")['ansible_facts']['int_status']
 

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -84,8 +84,8 @@ def run_test_t0(fanouthosts,
         time.sleep(2)
 
         if send_pause:
-            peer_device = conn_graph_facts['device_conn'][dut_intf_paused]['peerdevice']
-            peer_port = conn_graph_facts['device_conn'][dut_intf_paused]['peerport']
+            peer_device = conn_graph_facts['device_conn'][duthost.hostname][dut_intf_paused]['peerdevice']
+            peer_port = conn_graph_facts['device_conn'][duthost.hostname][dut_intf_paused]['peerport']
             peer_port_name = eos_to_linux_intf(peer_port)
             peerdev_ans = fanouthosts[peer_device]
 

--- a/tests/testbed_setup/test_gen_spy_testbed.py
+++ b/tests/testbed_setup/test_gen_spy_testbed.py
@@ -37,10 +37,6 @@ def test_gen_spy_testbed(conn_graph_facts, hostvars, tbinfo,
         """Get interface key to sort."""
         return list(map(int, interface.lstrip("Ethernet").split("/")))
 
-    def _to_string(obj):
-        """Convert unicodes in obj to strings"""
-        return yaml.safe_load(json.dumps(obj))
-
     hostnames = tbinfo["duts"]
     connections = conn_graph_facts["device_conn"]
 

--- a/tests/testbed_setup/test_gen_spy_testbed.py
+++ b/tests/testbed_setup/test_gen_spy_testbed.py
@@ -6,7 +6,7 @@ import yaml
 
 from collections import defaultdict
 from jinja2 import Template
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts_multi_duts
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 
 
 TESTBED_TEMPLATE = "templates/spytest_testbed.yaml.j2"
@@ -29,7 +29,7 @@ def hostvars(duthosts):
             for duthost in duthosts}
 
 
-def test_gen_spy_testbed(conn_graph_facts_multi_duts, hostvars, tbinfo,
+def test_gen_spy_testbed(conn_graph_facts, hostvars, tbinfo,
                          pytestconfig):
     """Generate spytest testbed file."""
 
@@ -42,9 +42,7 @@ def test_gen_spy_testbed(conn_graph_facts_multi_duts, hostvars, tbinfo,
         return yaml.safe_load(json.dumps(obj))
 
     hostnames = tbinfo["duts"]
-    device_conn = _to_string(conn_graph_facts_multi_duts["device_conn"])
-    connections = dict(
-        zip(hostnames, conn_graph_facts_multi_duts["device_conn"]))
+    connections = conn_graph_facts["device_conn"]
 
     # devices section
     devices = []

--- a/tests/testbed_setup/test_gen_spy_testbed.py
+++ b/tests/testbed_setup/test_gen_spy_testbed.py
@@ -2,7 +2,6 @@ import logging
 import json
 import os
 import pytest
-import yaml
 
 from collections import defaultdict
 from jinja2 import Template


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

conn_graph_facts has an limitation around device_conn dictionary, due to lack of dut hostname map, the dictionary is flat with all
ports. This is not an issue when there is only one DUT. However, when there are more than one DUTs, they could and most likely will have same port name, e.g. dut1:Ethernet0 and dut2:ethernet0, So when we collect the device_conn information, the dictionary could have key collisions.

#### How did you do it?

This change make it unified for both single DUT and multi-DUT that device_conn becomes a 2 level dictionaries, first level is
dut_hostname : { second level dictionary } *
the second level is what we used to return for single DUT.

With this change, all test cases uses conn_graph_facts needs to be updated to go one level deeper to find the needed information.

The second issue was with fanouthosts, fanouthosts was also originally designed to handle only one DUT. So the lookup tables was looking up directly between dut port name v.s. fanout switch port name. When we have multi-dut in the picture, we have to look up fanout port by the combo of dut hostname and port name.

This change also updates testcase like test_link_flap.py to use the new look up method so that the test could find the right fanout switch and port.

Updated ansible tasks to access device_conn[inventory_hostname].

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
1. test_link_flap on a multi-dut testbed:
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, metadata-1.10.0, forked-1.3.0, html-1.22.1, repeat-0.8.0
collected 68 items                                                                                                                                                                       

platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet8] PASSED                                                                                             [  1%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet0] SKIPPED                                                                                            [  2%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet4] PASSED                                                                                             [  4%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet108] SKIPPED                                                                                          [  5%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet100] SKIPPED                                                                                          [  7%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet104] SKIPPED                                                                                          [  8%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet68] PASSED                                                                                            [ 10%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet96] PASSED                                                                                            [ 11%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet124] PASSED                                                                                           [ 13%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet92] PASSED                                                                                            [ 14%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet120] PASSED                                                                                           [ 16%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet56] PASSED                   
... ...
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet8] PASSED                                                                                             [ 51%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet0] SKIPPED                                                                                            [ 52%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet4] PASSED                                                                                             [ 54%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet108] SKIPPED                                                                                          [ 55%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet100] SKIPPED                                                                                          [ 57%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet104] SKIPPED                                                                                          [ 58%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet68] PASSED                                                                                            [ 60%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet96] PASSED                                                                                            [ 61%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet124] PASSED                                                                                           [ 63%]
platform_tests/test_link_flap.py::test_link_flap[str2-7050cx3-acs-07|Ethernet92] PASSED                                                                                            [ 64%]

2. Test a couple other updated tests:
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, metadata-1.10.0, forked-1.3.0, html-1.22.1, repeat-0.8.0
collected 2 items                                                                                                                                                                        

platform_tests/test_sfp.py::test_check_sfp_status_and_configure_sfp PASSED                                                                                                         [ 50%]
platform_tests/test_sfp.py::test_check_sfp_low_power_mode PASSED                                                                                                                   [100%]

================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, xdist-1.28.0, metadata-1.10.0, forked-1.3.0, html-1.22.1, repeat-0.8.0
collected 1 item                                                                                                                                                                         

platform_tests/test_reload_config.py::test_reload_configuration PASSED                                                                                                             [100%]

3. Tested remove topology and add topology