### PR TITLE
[sensors]: Improve test verbosity/readability

### DIFF
--- a/tests/platform_tests/test_sensors.py
+++ b/tests/platform_tests/test_sensors.py
@@ -1,11 +1,15 @@
-import pytest
+import json
 import logging
+import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology('any')
 ]
+
+def to_json(obj):
+    return json.dumps(obj, indent=4)
 
 def test_sensors(duthost, creds):
     # Get platform name
@@ -14,12 +18,25 @@ def test_sensors(duthost, creds):
     # Prepare check list
     sensors_checks = creds['sensors_checks']
 
-    # Gather sensors
     if platform not in sensors_checks.keys():
         pytest.skip("Skip test due to not support check sensors for current platform({})".format(platform))
 
+    logging.info("Sensor checks:\n{}".format(to_json(sensors_checks[platform])))
+
+    # Gather sensor facts
     sensors_facts = duthost.sensors_facts(checks=sensors_checks[platform])['ansible_facts']
 
-    pytest_assert(not sensors_facts['sensors']['alarm'], "sensors facts: {}".format(sensors_facts))
-    if sensors_facts['sensors']['warning']:
-        logging.debug("Show warnings: %s" % sensors_facts['sensors']['warning'])
+    logging.info("Sensor facts:\n{}".format(to_json(sensors_facts)))
+
+    # Analyze sensor alarms
+    is_sensor_alarm = sensors_facts['sensors']['alarm']
+    sensor_alarms = sensors_facts['sensors']['alarms']
+
+    pytest_assert(not is_sensor_alarm, "Sensor alarms:\n{}".format(to_json(sensor_alarms)))
+
+    # Analyze sensor warnings
+    is_sensor_warning = sensors_facts['sensors']['warning']
+    sensor_warnings = sensors_facts['sensors']['warnings']
+
+    if is_sensor_warning:
+        logging.warning("Sensor warnings:\n{}".format(to_json(sensor_warnings)))


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:**
Improve sensors test verbosity/readability

**Sample:**
```
================================================================================================== FAILURES ===================================================================================================
________________________________________________________________________________________________ test_sensors _________________________________________________________________________________________________

duthost = <tests.common.devices.SonicHost object at 0x7fb2011e9910>
creds = {'ansible_become_pass': 'YourPaSsWoRd', 'ansible_ssh_pass': 'password', 'ansible_ssh_user': 'user', 'bgp_slb_passive_range': '10.255.0.0/25', ...}

    def test_sensors(duthost, creds):
        # Get platform name
        platform = duthost.facts['platform']

        # Prepare check list
        sensors_checks = creds['sensors_checks']

        if platform not in sensors_checks.keys():
            pytest.skip("Skip test due to not support check sensors for current platform({})".format(platform))

        logging.info("Sensor checks:\n{}".format(to_json(sensors_checks[platform])))

        # Gather sensor facts
        sensors_facts = duthost.sensors_facts(checks=sensors_checks[platform])['ansible_facts']

        logging.info("Sensor facts:\n{}".format(to_json(sensors_facts)))

        # Analyze sensor alarms
        is_sensor_alarm = sensors_facts['sensors']['alarm']
        sensor_alarms = sensors_facts['sensors']['alarms']

>       pytest_assert(not is_sensor_alarm, "Sensor alarms:\n{}".format(to_json(sensor_alarms)))
E       Failed: Sensor alarms:
E       {
E           "temp_reasons": [
E               "Path tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input is not exist",
E               "Path tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input is not exist"
E           ],
E           "fan_reasons": [],
E           "fan": false,
E           "temp": true,
E           "power": true,
E           "power_reasons": [
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_crit_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_max_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_crit_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_max_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in1)/in1_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in2)/in2_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in3_crit_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in3_lcrit_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail (out)/in4_crit_alarm is not exist",
E               "Path tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail (out)/in4_lcrit_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_crit_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_max_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_crit_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_max_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in1)/in1_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in2)/in2_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in3_crit_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in3_lcrit_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail (out)/in4_crit_alarm is not exist",
E               "Path tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail (out)/in4_lcrit_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_max_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_max_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in1)/in1_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in2)/in2_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_crit_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_lcrit_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail (out)/in4_crit_alarm is not exist",
E               "Path tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail (out)/in4_lcrit_alarm is not exist",
E               "Path tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm is not exist",
E               "Path tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_max_alarm is not exist",
E               "Path tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_alarm is not exist",
E               "Path tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in2)/in2_alarm is not exist",
E               "Path tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_crit_alarm is not exist",
E               "Path tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_lcrit_alarm is not exist"
E           ]
E       }
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Improve sensors test verbosity/readability

#### How did you do it?
* N/A

#### How did you verify/test it?
1. py.test platform_tests/test_sensors.py

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
* N/A