### PR TITLE
[pytest] Ignore specific syslog error messages when testing autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -267,14 +267,14 @@ def postcheck_critical_processes_status(duthost, container_autorestart_states):
               First we restart the containers which hit the restart limitation and then do the post check
     """
     for container_name in container_autorestart_states.keys():
-        if is_hitting_start_limit(duthost, container_name):
+        if is_hiting_start_limit(duthost, container_name):
             clear_failed_flag_and_restart(duthost, container_name)
 
     # Sleep 20 seconds such that containers have a chance to start.
     time.sleep(20)
     processes_status = duthost.all_critical_process_status()
     for container_name, processes in processes_status.items():
-        if processes["status"] is False or len(processes["exited_critical_processes"]) > 0:
+        if processes["status"] is False or len(processes["exited_critical_process"]) > 0:
             pytest.fail("Critical process(es) was not running after container '{}' was restarted.".format(container_name))
 
 


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>


### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When pytest script was ran to test the autorestart feature, there will be error messages in the syslog which will cause
the logAnalyzer to fail at the end of testing. In order to fix this issue, I examine all the error messages in the syslog 
during testing the autorestart feature and add them into whitelist. At the same time, the reason why we should ignore 
them are put in the comment of `ignore_expected_loganalyzer_exception(...)` function. 

After adding these error messages into whitelist, we need do the post check to see whether all the critical processes
are alive after testing the autorestart feature.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
I added two more functions in pytest script. One function is used to add the error messages which can be ignored into
whitelist. Another is used to do the post check to see whether all the critical processes are alive.

#### How did you verify/test it?
I tested this pytest script against a physical testbed: `str-dx010-acs-1.` Since currently `acms` process in ACMS container
was not running by default until the certificate are deployed, pytest script will fail when testing the ACMS container.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
