### PR TITLE
[SONiC Fanout] Config template for SONiC Fanout switch with buffer configuration

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -7,8 +7,13 @@
   port_alias: hwsku="{{ device_info["HwSku"] }}"
 
 - name: build fanout vlan config
-  template: src=sonic_deploy.j2
+  fail: msg="SONiC fanout switch with HwSku {{ device_info.HwSku }} not supported"
+  when: device_info.HwSku != "Arista-7060CX-32S-C32"
+
+- name: build fanout startup config for Arista 7060 SONiC leaf fanout
+  template: src=sonic_deploy_arista_7060.j2
             dest=/etc/sonic/vlan.json
+  when: device_info.HwSku == "Arista-7060CX-32S-C32"
   become: yes
 
 - name: disable all copp rules
@@ -18,10 +23,6 @@
 
 - name: generate config_db.json
   shell: sonic-cfggen -H -j /etc/sonic/vlan.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
-  become: yes
-
-- name: reload config_db.json
-  shell: config reload -y
   become: yes
 
 - name: stop and disable lldp service

--- a/ansible/roles/fanout/templates/sonic_deploy_arista_7060.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_arista_7060.j2
@@ -1,0 +1,214 @@
+{
+
+"DEVICE_METADATA": {
+    "localhost": {
+        "hwsku": "{{ device_info["HwSku"] }}",
+        "hostname": "{{ inventory_hostname }}"
+    }
+},
+
+"PORT": {
+{% for alias in device_conn %}
+    "{{ alias }}": {
+        "admin_status": "up",
+        "speed": "100000",
+        "fec": "rs"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
+"VLAN": {
+{% for vlanid in device_vlan_list | unique %}
+    "Vlan{{ vlanid }}": {
+        "vlanid": "{{ vlanid }}"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
+{% set ns = {'firstPrinted': False} %}
+"VLAN_MEMBER": {
+{% for alias in device_port_vlans %}
+{% if device_port_vlans[alias]['mode'] == 'Access' %}
+{% if ns.firstPrinted %},{% endif %}
+    "Vlan{{ device_port_vlans[alias]['vlanids'] }}|{{ alias }}": {
+        "tagging_mode" : "untagged"
+    }
+{% if ns.update({'firstPrinted': True}) %} {% endif %}
+{% elif device_port_vlans[alias]['mode'] == 'Trunk' %}
+  {% for vlanid in device_port_vlans[alias]['vlanlist'] %}
+{% if ns.firstPrinted %},{% endif %}
+    "Vlan{{ vlanid }}|{{ alias }}": {
+        "tagging_mode" : "tagged"
+    }
+{% if ns.update({'firstPrinted': True}) %} {% endif %}
+  {% endfor %}
+{% endif %}
+{% endfor %}
+},
+
+"MGMT_INTERFACE": {
+    "eth0|{{ device_info["ManagementIp"] }}": {
+        "gwaddr": "{{ device_info["ManagementGw"] }}"
+    }
+},
+
+"FLEX_COUNTER_TABLE": {
+    "PFCWD": {
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "PORT": {
+        "FLEX_COUNTER_STATUS": "enable"
+    },
+    "QUEUE": {
+        "FLEX_COUNTER_STATUS": "enable"
+    }
+},
+
+"QUEUE": {
+{% for alias in device_conn %}
+    "{{ alias }}|0": {
+        "scheduler": "[SCHEDULER|scheduler.0]"
+    },
+    "{{ alias }}|1": {
+        "scheduler": "[SCHEDULER|scheduler.0]"
+    },
+    "{{ alias }}|2": {
+        "scheduler": "[SCHEDULER|scheduler.0]"
+    },
+    "{{ alias }}|3": {
+        "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
+        "scheduler": "[SCHEDULER|scheduler.1]"
+    },
+    "{{ alias }}|4": {
+        "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
+        "scheduler": "[SCHEDULER|scheduler.1]"
+    },
+    "{{ alias }}|5": {
+        "scheduler": "[SCHEDULER|scheduler.0]"
+    },
+    "{{ alias }}|6": {
+        "scheduler": "[SCHEDULER|scheduler.0]"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
+"BUFFER_QUEUE": {
+{% for alias in device_conn %}
+    "{{ alias }}|0-2": {
+        "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "{{ alias }}|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "{{ alias }}|5-6": {
+        "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
+"BUFFER_PG": {
+{% for alias in device_conn %}
+    "{{ alias }}|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "{{ alias }}|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+},
+
+"CABLE_LENGTH": {
+    "AZURE": {
+{% for alias in device_conn %}
+    "{{ alias }}": "300m"{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+},
+
+"VERSIONS": {
+    "DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+},
+
+"PFC_WD": {
+    "GLOBAL": {
+        "POLL_INTERVAL": "200"
+    }
+},
+
+"WRED_PROFILE": {
+    "AZURE_LOSSLESS": {
+        "red_max_threshold": "2097152",
+        "red_drop_probability": "5",
+        "wred_green_enable": "true",
+        "ecn": "ecn_all",
+        "green_min_threshold": "250000",
+        "red_min_threshold": "1048576",
+        "wred_yellow_enable": "true",
+        "yellow_min_threshold": "1048576",
+        "green_max_threshold": "2097152",
+        "green_drop_probability": "5",
+        "yellow_max_threshold": "2097152",
+        "yellow_drop_probability": "5",
+        "wred_red_enable": "true"
+    }
+},
+
+"SCHEDULER": {
+    "scheduler.0": {
+        "type": "DWRR",
+        "weight": "14"
+    },
+    "scheduler.1": {
+        "type": "DWRR",
+        "weight": "15"
+    }
+},
+
+"BUFFER_POOL": {
+    "egress_lossless_pool": {
+        "type": "egress",
+        "mode": "static",
+        "size": "15982720"
+    },
+    "egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "9243812"
+    },
+    "ingress_lossless_pool": {
+        "xoff": "4194112",
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "10875072"
+    }
+},
+
+"BUFFER_PROFILE": {
+    "egress_lossless_profile": {
+        "static_th": "15982720",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "1518"
+    },
+    "egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "1518"
+    },
+    "ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "pg_lossless_100000_300m_profile": {
+        "xon_offset": "2288",
+        "dynamic_th": "0",
+        "xon": "2288",
+        "xoff": "268736",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "1248"
+    }
+}
+
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Configuration template for SONiC leaf fanout switch

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
New `j2` template included for SONiC fanout configuration support for 7060 switches.

#### What is the motivation for this PR?
To run SONiC on leaf fanout switches.

#### How did you do it?
Added new template, modified playbook to fail for unsupported HwSku, and disabled `config reload` for fanout switches.

#### How did you verify/test it?

*SONiC Fanout configuration playbook*
```
TASK [fanout : Find the root fanout switch] ********************************************************************************************************************************************************************************
Thursday 29 October 2020  17:33:33 +0000 (0:00:00.036)       0:00:08.981 ******
skipping: [str-7060cx-32s-08]

TASK [fanout : set_fact] ***************************************************************************************************************************************************************************************************
Thursday 29 October 2020  17:33:33 +0000 (0:00:00.038)       0:00:09.020 ******
skipping: [str-7060cx-32s-08]

TASK [fanout : Change root fanout port vlan] *******************************************************************************************************************************************************************************
Thursday 29 October 2020  17:33:33 +0000 (0:00:00.043)       0:00:09.063 ******
skipping: [str-7060cx-32s-08]

PLAY RECAP *****************************************************************************************************************************************************************************************************************
str-7060cx-32s-08          : ok=12   changed=3    unreachable=0    failed=0    skipped=24   rescued=0    ignored=0

Thursday 29 October 2020  17:33:33 +0000 (0:00:00.026)       0:00:09.089 ******
===============================================================================
```

*Results of test_qos_sai tests executed on a SONiC DUT connected to SONiC leaf Fanout switch*
```
================ test session starts ================
collected 18 items                                                                                                                                                                                                         

qos/test_qos_sai.py::TestQosSai::testParameter PASSED                                                                                                                                                                [  5%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_1] PASSED                                                                                                                                               [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[xoff_2] PASSED                                                                                                                                               [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_1] PASSED                                                                                                                                                 [ 22%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[xon_2] PASSED                                                                                                                                                 [ 27%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize PASSED                                                                                                                                                   [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[wm_buf_pool_lossless] SKIPPED                                                                                                                         [ 38%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[wm_buf_pool_lossy] SKIPPED                                                                                                                            [ 44%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue PASSED                                                                                                                                                         [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping PASSED                                                                                                                                                   [ 55%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr PASSED                                                                                                                                                               [ 61%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossless] PASSED                                                                                                                           [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[wm_pg_shared_lossy] PASSED                                                                                                                              [ 72%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark PASSED                                                                                                                                                [ 77%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossless] PASSED                                                                                                                             [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[wm_q_shared_lossy] PASSED                                                                                                                                [ 88%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping SKIPPED                                                                                                                                                   [ 94%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange PASSED                                                                                                                                                   [100%]

================ short test summary info ================
================ 15 passed, 3 skipped in 1634.65 seconds ================

```

*SONiC Fanout switches of unsupported type will fail the fanout playbook:*
```
TASK [fanout : build fanout vlan config] ***********************************************************************************************************************************************************************************
Thursday 29 October 2020  18:29:59 +0000 (0:00:01.600)       0:00:02.595 ******
fatal: [str-7060cx-32s-08]: FAILED! => {"changed": false, "msg": "SONiC fanout switch with HwSku ABC-123 not supported"}

PLAY RECAP *****************************************************************************************************************************************************************************************************************
str-7060cx-32s-08          : ok=5    changed=0    unreachable=0    failed=1    skipped=8    rescued=0    ignored=0

Thursday 29 October 2020  18:29:59 +0000 (0:00:00.036)       0:00:02.631 ******
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
