### PR TITLE
[dhcp-pkt-fwd] The src port and dst port of Relayed Packet are both 67

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -161,7 +161,7 @@ class DhcpPktFwdBase:
         """
         ether = scapy.Ether(dst=dutMac, src=self.DHCP_RELAY["mac"], type=0x0800)
         ip = scapy.IP(src=self.DHCP_RELAY["loopback"], dst=self.DHCP_SERVER["ip"], len=328, ttl=64)
-        udp = scapy.UDP(sport=self.DHCP_SERVER["port"], dport=self.DHCP_CLIENT["port"], len=308)
+        udp = scapy.UDP(sport=self.DHCP_SERVER["port"], dport=self.DHCP_SERVER["port"], len=308)
         bootp = scapy.BOOTP(
             op=1,
             htype=1,
@@ -228,7 +228,7 @@ class DhcpPktFwdBase:
         """
         ether = scapy.Ether(dst=dutMac, src=self.DHCP_RELAY["mac"], type=0x0800)
         ip = scapy.IP(src=self.DHCP_RELAY["loopback"], dst=self.DHCP_SERVER["ip"], len=336, ttl=64)
-        udp = scapy.UDP(sport=self.DHCP_CLIENT["port"], dport=self.DHCP_SERVER["port"], len=316)
+        udp = scapy.UDP(sport=self.DHCP_SERVER["port"], dport=self.DHCP_SERVER["port"], len=316)
         bootp = scapy.BOOTP(
             op=1,
             htype=1,


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The src port and dst port of Relayed Packet are both 67
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The failure I encounter is in the broadcom AS7726-32X platform, and the root cause is the dhcp packet which contains src port 68 and dst port 67 will be trap to CPU and not forward.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
