### PR TITLE
[kvm] Enable loganalyzer for KVM tests

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -36,7 +36,6 @@ PYTEST_CLI_COMMON_OPTS="\
 -m individual \
 -q 1 \
 -a False \
--e --disable_loganalyzer \
 -O"
 
 cd $SONIC_MGMT_DIR/tests


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable loganalyzer for KVM tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We often experience widespread failures due to persistent loganalyzer failures. The goal is to try to reduce these by running loganalyzer during PR tests here and also during buildimage PR tests.

#### How did you do it?
Remove the disable flag.

#### How did you verify/test it?
Tested locally, also going to let it run several times on Jenkins to verify.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
