### PR TITLE
config_facts enhancements for multi-asic and support in SonicAsic

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1334,6 +1334,24 @@ class SonicAsic(object):
             complex_args['instance_id'] = self.asic_index
         return self.sonichost.bgp_facts(*module_args, **complex_args)
 
+    def config_facts(self, *module_args, **complex_args):
+        """ Wrapper method for config_facts ansible module.
+        If number of asics in SonicHost are more than 1, then add 'namespace' param for this Asic
+        If 'host' is not specified in complex_args, add it - as it is a mandatory param for the config_facts module
+
+        Args:
+            module_args: other ansible module args passed from the caller
+            complex_args: other ansible keyword args
+
+        Returns:
+            if SonicHost has only 1 asic, then return the config_facts for the global namespace, else config_facts for namespace for my asic_index.
+        """
+        if 'host' not in complex_args:
+            complex_args['host'] = self.sonichost.hostname
+        if self.sonichost.facts['num_asic'] != 1:
+            complex_args['namespace'] = 'asic{}'.format(self.asic_index)
+        return self.sonichost.config_facts(*module_args, **complex_args)
+
 
 class MultiAsicSonicHost(object):
     """ This class represents a Multi-asic SonicHost It has two attributes:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently, the config_facts ansible module lacks the following:
- Support config_db's that have no PORT metadata. This is the case for the global config_db.json on a multi-asic Sonic DUT, or the supervisor card in a chassis.
- Capability to get "persistent" config facts for a particular namespace - where we have to parse config_db<asicNum>.json file, instead of config_db.json

Also, we need add wrapper method for config_facts to SonicAsic class for being able to use it for multi-asic multi-dut testbeds.

#### How did you do it?
In config_facts ansible module:
- To support no PORT metadata,  in create_maps method define the port maps as empty dictionary. If 'PORT' is in the config, then only populate these port maps. So, if there is no 'PORT" in the config, return empty dictionaries.

- To support 'persistent' config_facts across namespace, changed PERSISTENT_CONFIG_PATH to be '/etc/sonic/config_db{}.json". If namespace is passed, we will format PERSISTENT_CONFIG_PATH with asic_id based on the namespace, else we will format this with an empty string.

SonicAsic:

- Added the wrapper config_facts method to SonicAsic class.

#### How did you verify/test it?

Tested it against pizza box, multi-asic pizza box, and chassis with multi-asic line cards and supervisor card.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
