### PR TITLE
Fix for test_cleanup to avoid sending large number of args to sudo command

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -19,7 +19,7 @@ def test_cleanup_testbed(duthost, request, ptfhost):
     if deep_clean:
         logger.info("Deep cleaning DUT {}".format(duthost.hostname))
         # Remove old log files.
-        duthost.shell("sudo find /var/log/ -name '*.gz' | xargs sudo rm -f", executable="/bin/bash")
+        duthost.shell("sudo find /var/log/ -name '*.gz' | sudo xargs rm -f", executable="/bin/bash")
         # Remove old core files.
         duthost.shell("sudo rm -f /var/core/*", executable="/bin/bash")
         # Remove old dump files.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix for test_cleanup to avoid sending large number of args to sudo command
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Nightly tests on one of the testbeds are failing due to:
```
E               "msg": "non-zero return code", 
E               "rc": 123, 
E               "start": "2020-10-28 18:45:30.609993", 
E               "stderr": "sudo: unable to execute /bin/rm: Argument list too long", 
E               "stderr_lines": [
E                   "sudo: unable to execute /bin/rm: Argument list too long"
E               ], 
```

#### How did you do it?
There is a limit to no. of args that can be sent to a cmd - `getconf ARG_MAX`).
The `xargs` command by default limits the number of arguments sent to a command. In the existing testcase `rm` receives all arguments passed to `sudo` by `xargs` and receives twice  the env variables (from xargs and sudo) as well. This causes the failure.

Changing to `sudo xargs rm` will ensure the limit count.

#### How did you verify/test it?

Local test on a DUT:

Repro failure:
Create files and remove:
```
# seq -w 2097152 | xargs touch

# sudo find . -name '*' | xargs sudo rm -f
sudo: unable to execute /bin/rm: Argument list too long
```

Fix by letting xargs limit args sent to rm:
```
# sudo find . -name '*' | sudo xargs  rm -f
# ls | wc -l
0
#
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
