### PR TITLE
[add-topo] address add-topo root fanout config issue

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -30,10 +30,11 @@
 
 - name: Find the root fanout switch
   set_fact:
-    ansible_host: "{{ lab_devices[item]['mgmtip'] }}"
-    root_dev: "{{ item }}"
-  with_items: "{{ lab_devices }}"
-  when: lab_devices[item]['Type'] == 'FanoutRoot'
+    ansible_host: "{{ item.value['mgmtip'] }}"
+    root_dev: "{{ item.key }}"
+    root_hwsku: "{{ item.value['HwSku'] }}"
+  with_dict: "{{ lab_devices }}"
+  when: item.value['Type'] == 'FanoutRoot'
 
 - set_fact:
     root_conn: "{{ lab.ansible_facts['device_conn'][root_dev] }}"

--- a/ansible/roles/fanout/templates/arista_7260_connect.j2
+++ b/ansible/roles/fanout/templates/arista_7260_connect.j2
@@ -5,7 +5,7 @@ config
 {% if intf in root_conn %}
 {% set peer_dev = root_conn[intf]['peerdevice'] %}
 {% set peer_port = root_conn[intf]['peerport'] %}
-{% if 'Fanout' not in lab_devices[peer_dev]['Type'] and not deploy_leaf %}
+{% if peer_dev in lab_devices and 'Fanout' not in lab_devices[peer_dev]['Type'] and not deploy_leaf %}
  interface {{ intf }}
   switchport trunk allowed vlan remove {{ dev_vlans | list | join(',') }}
 {% if peer_dev == server and peer_port == server_port %}
@@ -14,7 +14,7 @@ config
   no shutdown
 {% endif %}
 {% endif %}
-{% if 'Fanout' in lab_devices[peer_dev]['Type']  and deploy_leaf %}
+{% if peer_dev in lab_devices and 'Fanout' in lab_devices[peer_dev]['Type']  and deploy_leaf %}
  interface {{ intf }}
   switchport trunk allowed vlan remove {{ dev_vlans | list | join(',') }}
 {% if peer_dev == leaf_name %}


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add-topo is recently failing on setting root fanout switch vlans.

#### How did you do it?
- Properly traverse through the device dictionary.
- Add protection in fanout template to avoid error when peer
  device is not known.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Remove-top and add-topo