### PR TITLE
[dual-tor] augment dualtor testbed topology type to t0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,12 @@ class TestbedInfo(object):
         match = pattern.match(topo_name)
         if match == None:
             raise Exception("Unsupported testbed type - {}".format(topo_name))
-        return match.group()
+        tb_type = match.group()
+        if tb_type == 'dualtor':
+            # augment dualtor topology type to 't0' to avoid adding it
+            # everywhere.
+            tb_type = 't0'
+        return tb_type
 
 def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Unable to run announce route on dualtor testbed.

#### How did you do it?
Dual ToR are still ToRs. Augment the topology type to t0 to reduce the work needed to executed T0 testcases.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Execute announce route on a dualtor testbed.