### PR TITLE
[Platform API] Add missing tests for new API methods in DeviceBase class

### DIFF
--- a/tests/common/helpers/platform_api/component.py
+++ b/tests/common/helpers/platform_api/component.py
@@ -43,6 +43,13 @@ def get_status(conn, comp_idx):
     return component_api(conn, comp_idx, 'get_status')
 
 
+def get_position_in_parent(conn, comp_idx):
+    return component_api(conn, comp_idx, 'get_position_in_parent')
+
+
+def is_replaceable(conn, comp_idx):
+    return component_api(conn, comp_idx, 'is_replaceable')
+
 #
 # Methods defined in ComponentBase class
 #

--- a/tests/common/helpers/platform_api/fan_drawer_fan.py
+++ b/tests/common/helpers/platform_api/fan_drawer_fan.py
@@ -40,6 +40,14 @@ def get_serial(conn, fan_drawer_idx, fan_idx):
 def get_status(conn, fan_drawer_idx, fan_idx):
     return fan_drawer_fan_api(conn, fan_drawer_idx, fan_idx, 'get_status')
 
+
+def get_position_in_parent(conn, fan_drawer_idx, fan_idx):
+    return fan_drawer_fan_api(conn, fan_drawer_idx, fan_idx, 'get_position_in_parent')
+
+
+def is_replaceable(conn, fan_drawer_idx, fan_idx):
+    return fan_drawer_fan_api(conn, fan_drawer_idx, fan_idx, 'is_replaceable')
+
 #
 # Methods defined in fanBase class
 #

--- a/tests/common/helpers/platform_api/module.py
+++ b/tests/common/helpers/platform_api/module.py
@@ -43,6 +43,13 @@ def get_status(conn, mod_idx):
     return module_api(conn, mod_idx, 'get_status')
 
 
+def get_position_in_parent(conn, mod_idx):
+    return module_api(conn, mod_idx, 'get_position_in_parent')
+
+
+def is_replaceable(conn, mod_idx):
+    return module_api(conn, mod_idx, 'is_replaceable')
+
 #
 # Methods defined in ModuleBase class
 #

--- a/tests/common/helpers/platform_api/psu_fan.py
+++ b/tests/common/helpers/platform_api/psu_fan.py
@@ -40,6 +40,13 @@ def get_serial(conn, psu_idx, fan_idx):
 def get_status(conn, psu_idx, fan_idx):
     return psu_fan_api(conn, psu_idx, fan_idx, 'get_status')
 
+
+def get_position_in_parent(conn, psu_idx, fan_idx):
+    return psu_fan_api(conn, psu_idx, fan_idx, 'get_position_in_parent')
+
+
+def is_replaceable(conn, psu_idx, fan_idx):
+    return psu_fan_api(conn, psu_idx, fan_idx, 'is_replaceable')
 #
 # Methods defined in fanBase class
 #

--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -130,6 +130,20 @@ class TestComponentApi(PlatformApiTestBase):
                 self.expect(isinstance(status, bool), "Component {}: Status appears incorrect".format(i))
         self.assert_expectations()
 
+    def test_get_position_in_parent(self, platform_api_conn):
+        for i in range(self.num_components):
+            position = component.get_position_in_parent(platform_api_conn, i)
+            if self.expect(position is not None, "Failed to perform get_position_in_parent for component {}".format(i)):
+                self.expect(isinstance(position, int), "Position value must be an integer value for component {}".format(i))
+        self.assert_expectations()
+
+    def test_is_replaceable(self, platform_api_conn):
+        for i in range(self.num_components):
+            replaceable = component.is_replaceable(platform_api_conn, i)
+            if self.expect(replaceable is not None, "Failed to perform is_replaceable for component {}".format(i)):
+                self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value for component {}".format(i))
+        self.assert_expectations()
+
     #
     # Functions to test methods defined in ComponentBase class
     #

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -153,6 +153,24 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
+    def test_get_position_in_parent(self, platform_api_conn):
+        for j in range(self.num_fan_drawers):
+            num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
+            for i in range(num_fans):
+                position = fan_drawer_fan.get_position_in_parent(platform_api_conn, j, i)
+                if self.expect(position is not None, "Failed to perform get_position_in_parent for drawer {} fan {}".format(j, i)):
+                    self.expect(isinstance(position, int), "Position value must be an integer value for drawer {} fan {}".format(j, i))
+        self.assert_expectations()
+
+    def test_is_replaceable(self, platform_api_conn):
+        for j in range(self.num_fan_drawers):
+            num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
+            for i in range(num_fans):
+                replaceable = fan_drawer_fan.is_replaceable(platform_api_conn, j, i)
+                if self.expect(replaceable is not None, "Failed to perform is_replaceable for drawer {} fan {}".format(j, i)):
+                    self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value for drawer {} fan {}".format(j, i))
+        self.assert_expectations()
+
     #
     # Functions to test methods defined in FanBase class
     #

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -121,6 +121,20 @@ class TestModuleApi(PlatformApiTestBase):
                 self.expect(isinstance(status, bool), "Module {} status appears incorrect".format(i))
         self.assert_expectations()
 
+    def test_get_position_in_parent(self, platform_api_conn):
+        for i in range(self.num_modules):
+            position = module.get_position_in_parent(platform_api_conn, i)
+            if self.expect(position is not None, "Failed to perform get_position_in_parent for module {}".format(i)):
+                self.expect(isinstance(position, int), "Position value must be an integer value for module {}".format(i))
+        self.assert_expectations()
+
+    def test_is_replaceable(self, platform_api_conn):
+        for i in range(self.num_modules):
+            replaceable = module.is_replaceable(platform_api_conn, i)
+            if self.expect(replaceable is not None, "Failed to perform is_replaceable for module {}".format(i)):
+                self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value for module {}".format(i))
+        self.assert_expectations()
+
     #
     # Functions to test methods defined in ModuleBase class
     #

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -153,6 +153,24 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
+    def test_get_position_in_parent(self, platform_api_conn):
+        for j in range(self.num_psus):
+            num_fans = psu.get_num_fans(platform_api_conn, j)
+            for i in range(num_fans):
+                position = psu_fan.get_position_in_parent(platform_api_conn, j, i)
+                if self.expect(position is not None, "Failed to perform get_position_in_parent for PSU {} fan {}".format(j, i)):
+                    self.expect(isinstance(position, int), "Position value must be an integer value for PSU {} fan {}".format(j, i))
+        self.assert_expectations()
+
+    def test_is_replaceable(self, platform_api_conn):
+        for j in range(self.num_psus):
+            num_fans = psu.get_num_fans(platform_api_conn, j)
+            for i in range(num_fans):
+                replaceable = psu_fan.is_replaceable(platform_api_conn, j, i)
+                if self.expect(replaceable is not None, "Failed to perform is_replaceable for PSU {} fan {}".format(j, i)):
+                    self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value for PSU {} fan {}".format(j, i))
+        self.assert_expectations()
+
     #
     # Functions to test methods defined in FanBase class
     #


### PR DESCRIPTION
Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

New methods, `get_position_in_parent()` and `is_replaceable()` were added to the DeviceBase class recently. These test cases were added to some platform device tests, but not all. Even though these methods may not be relevant to all device types which inherit from DeviceBase, we should still ensure they are implemented properly, and thus should be tested for completeness.

#### How did you do it?

Add test cases where appropriate

#### How did you verify/test it?

Run platform API tests, ensure the new tests run and function properly.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
