### PR TITLE
[conn_graph_facts] Strip the list for single DUT

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -343,6 +343,11 @@ def main():
         results = {k: v for k, v in locals().items()
                    if (k.startswith("device_") and v)}
 
+        # TODO: Currently the results values are heterogeneous, let's change
+        # them all into dictionaries in the future.
+        if m_args['hosts'] is None:
+            results = {k: v[0] if isinstance(v, list) else v for k, v in results.items()}
+
         module.exit_json(ansible_facts=results)
     except (IOError, OSError):
         module.fail_json(msg="Can not find lab graph file under {}".format(LAB_GRAPHFILE_PATH))

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -9,7 +9,7 @@ def conn_graph_facts(duthosts, localhost):
     return get_graph_facts(duthosts[0], localhost,
                            [dh.hostname for dh in duthosts])
 
- 
+
 @pytest.fixture(scope="module")
 def fanout_graph_facts(localhost, duthost, conn_graph_facts):
     facts = dict()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

`conn_graph_facts` currently doesn't distinguish between single host and
multiple hosts, the returns are nested list for single host input, like:
```
'device_info': [{u'HwSku': u'Arista-7060CX-32S',
                   u'ManagementGw': u'10.64.246.1',
                   u'ManagementIp': u'10.64.247.234/23',
                   u'Type': u'FanoutLeaf',
                   u'mgmtip': u'10.64.247.234'}]
```
So stripping the unneccessary outer list here to solve some introduced
regressions in testcases using this fixture like `pfcwd`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
run `pfcwd` related testcases.
```
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions PASSED                                                                                                      [100%]
pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy PASSED                                                                                     [100%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[no_storm] PASSED                                                                                                [ 33%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[storm] PASSED                                                                                                   [ 66%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm] PASSED                                                                                             [100%]
pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore PASSED                                                                               [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
