### PR TITLE
Remove host interfaces fetching operations from __init__ method of the VMTopology class

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -160,14 +160,19 @@ class VMTopology(object):
         self.vm_names = vm_names
         self.fp_mtu = fp_mtu
         self.max_fp_num = max_fp_num
-
-        self.host_ifaces = VMTopology.ifconfig('ifconfig -a')
-
         return
 
     def init(self, vm_set_name, topo, vm_base, duts_fp_ports, duts_name, ptf_exists=True):
         self.vm_set_name = vm_set_name
         self.duts_name = duts_name
+
+        if ptf_exists:
+            self.pid = VMTopology.get_pid(PTF_NAME_TEMPLATE % vm_set_name)
+        else:
+            self.pid = None
+
+        self.update()
+
         self.VMs = {}
         if 'VMs' in topo:
             self.vm_base = vm_base
@@ -194,14 +199,7 @@ class VMTopology(object):
 
         self.injected_fp_ports = self.extract_vm_vlans()
 
-        if ptf_exists:
-            self.pid = VMTopology.get_pid(PTF_NAME_TEMPLATE % vm_set_name)
-        else:
-            self.pid = None
-
         self.bp_bridge = ROOT_BACK_BR_TEMPLATE % self.vm_set_name
-
-        self.update()
 
         return
 


### PR DESCRIPTION
Summary:
Fixes # (improvement)
The __init_ method of VMTopoogy class calls the ifconfig method to init host_ifaces. 
Move to the init method to use the update() method to replace this operation. 
The update() method supports the retry mechanism and can avoid the "ifconfig -a" 
conflict issue if there are multiple job perform add/remove topo

Signed-off-by: Gord Chen <gord_chen@edge-core.com>

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The update method support retry mechanism

#### How did you do it?

#### How did you verify/test it?
Use add/remove topo to test

#### Any platform specific information?
AS7816-64X

#### Supported testbed topology if it's a new test case?

### Documentation 
