### PR TITLE
test_bgp_gr_helper support t1 topology

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -47,7 +47,7 @@ def test_bgp_gr_helper_routes_perserved(duthost, nbrhosts, setup_bgp_graceful_re
         for member in po[ifname]['members']:
             nbr_ports.append(dev_nbr[member]['port'])
     else:
-        pytest.skip("Do not support peer device not connected via port channel")
+        nbr_ports.append(dev_nbr[ifname]['port'])
     logger.info("neighbor device connected ports {}".format(nbr_ports))
 
     # get nexthop ip


### PR DESCRIPTION
### Description of PR
In original test case, it will skip the port configurations without portchannel.
This patch remove this limitation and to allow to perform in the t1 topology

Signed-off-by: Gord Chen gord_chen@edge-core.com
Summary:
Fixes # (improvement)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_bgp_gr_helper should be test in the t1 topology

#### How did you do it?

#### How did you verify/test it?
Run the bgp_gr_helper in the t1 topology
```
johnar@e75b4aac9fae:~/sonic-mgmt/tests$ pytest -ra --inventory=lab,veos --host-pattern=3-17_t1-8vm --module-path ../ansible/library/ --testbed=3-17_t1-8vm --testbed_file=testbed.csv bgp/test_bgp_gr_helper.py --disable_loganalyzer --topology t1
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================================================================================== test session starts ==============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/johnar/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, metadata-1.10.0, repeat-0.8.0, forked-1.3.0, html-1.22.1, xdist-1.28.0
collected 1 item

bgp/test_bgp_gr_helper.py.                                                                                                                                                                               [100%]

========================================================================================== 1 passed in 586.11 seconds ===========================================================================================
johnar@e75b4aac9fae:~/sonic-mgmt/tests$
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
