### PR TITLE
[ptfhost_utils]: Make PTF portmap file generation available as common fixture

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,5 +1,5 @@
 import os
-from natsort.natsort import natsorted
+from natsort import natsorted
 import pytest
 import logging
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,4 +1,5 @@
 import os
+from natsort.natsort import natsorted
 import pytest
 import logging
 
@@ -120,3 +121,32 @@ def copy_arp_responder_py(ptfhost):
 
     logger.info("Delete arp_responder.py from ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.file(path=os.path.join(OPT_DIR, ARP_RESPONDER_PY), state="absent")
+
+@pytest.fixture(scope='class')
+def ptf_portmap_file(duthost, ptfhost):
+    """
+        Prepare and copys port map file to PTF host
+
+        Args:
+            request (Fixture): pytest request object
+            duthost (AnsibleHost): Device Under Test (DUT)
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+
+        Returns:
+            filename (str): returns the filename copied to PTF host
+    """
+    intfInfo = duthost.show_interface(command = "status")['ansible_facts']['int_status']
+    portList = natsorted([port for port in intfInfo if port.startswith('Ethernet') and intfInfo[port]['speed'] != '10G'])
+    portMapFile = "/tmp/default_interface_to_front_map.ini"
+    with open(portMapFile, 'w') as file:
+        file.write("# ptf host interface @ switch front port name\n")
+        file.writelines(
+            map(
+                    lambda (index, port): "{0}@{1}\n".format(index, port),
+                    enumerate(portList)
+                )
+            )
+
+    ptfhost.copy(src=portMapFile, dest="/root/")
+
+    yield "/root/{}".format(portMapFile.split('/')[-1])

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -23,6 +23,7 @@ import pytest
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file          # lgtm[py/unused-import]
 from qos_sai_base import QosSaiBase
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Make PTF portmap file generation available as common fixture
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
