### PR TITLE
Temporarily disable test_lldp.py to unblock mutually dependent LLDP fixes

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -55,7 +55,6 @@ bgp/test_bgp_speaker.py \
 cacl/test_cacl_application.py \
 cacl/test_cacl_function.py \
 dhcp_relay/test_dhcp_relay.py \
-lldp/test_lldp.py \
 ntp/test_ntp.py \
 pc/test_po_cleanup.py \
 route/test_default_route.py \
@@ -72,6 +71,14 @@ test_features.py \
 test_procdockerstatsd.py \
 iface_namingmode/test_iface_namingmode.py \
 platform_tests/test_cpu_memory_usage.py"
+
+# FIXME: The lldp test has been temporarily disabled for https://github.com/Azure/sonic-mgmt/pull/2413
+# and https://github.com/Azure/sonic-buildimage/pull/5698. The reason is that these two PRs dependent on each other.
+# If PR#2413 is not merged, PR#5698 would fail PR test and cannot be merged. If PR#2413 is merged firstly, all
+# sonic-mgmt-pr testing would fail before a new image with PR#5698 is ready. The workaround is to temporarily disable
+# LLDP for sonic-mgmt-pr testing. Merge PR#2413 to unblock PR#5698. After a new image with PR#5698 is ready, then
+# enable LLDP testing again.
+# lldp/test_lldp.py
 
 # FIXME: This test has been disabled and needs to be fixed and put back in:
 # pc/test_po_update.py


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Temporarily disable test_lldp.py to unblock mutually dependent LLDP fixes


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR https://github.com/Azure/sonic-mgmt/pull/2413 and
https://github.com/Azure/sonic-buildimage/pull/5698 depends on each other.
If PR#2413 is not merged, PR#5698 would fail PR test and cannot be merged.
If PR#2413 is merged firstly, all sonic-mgmt-pr testing would fail before a new
image with PR#5698 is ready. 

#### How did you do it?
The workaround is to temporarily disable LLDP
for sonic-mgmt-pr testing. Merge PR#2413 to unblock PR#5698. After a new
image with PR#5698 is ready, then enable LLDP KVM testing again.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
