### PR TITLE
[test_arpall] collect interface MAC address for debug

### DIFF
--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -15,11 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 def collect_info(duthost):
-    logger.info('************* Collect information for debug *************')
-    duthost.shell('ip link')
-    duthost.shell('ip addr')
-    duthost.shell('grep . /sys/class/net/Ethernet*/address', module_ignore_errors=True)
-    duthost.shell('grep . /sys/class/net/PortChannel*/address', module_ignore_errors=True)
+    if duthost.facts['asic_type'] == "mellanox":
+        logger.info('************* Collect information for debug *************')
+        duthost.shell('ip link')
+        duthost.shell('ip addr')
+        duthost.shell('grep . /sys/class/net/Ethernet*/address', module_ignore_errors=True)
+        duthost.shell('grep . /sys/class/net/PortChannel*/address', module_ignore_errors=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -11,6 +11,17 @@ pytestmark = [
     pytest.mark.topology('t1')
 ]
 
+logger = logging.getLogger(__name__)
+
+
+def collect_info(duthost):
+    logger.info('************* Collect information for debug *************')
+    duthost.shell('ip link')
+    duthost.shell('ip addr')
+    duthost.shell('grep . /sys/class/net/Ethernet*/address', module_ignore_errors=True)
+    duthost.shell('grep . /sys/class/net/PortChannel*/address', module_ignore_errors=True)
+
+
 @pytest.fixture(scope="module")
 def common_setup_teardown(duthost, ptfhost):
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
@@ -21,7 +32,7 @@ def common_setup_teardown(duthost, ptfhost):
     # Select port index 0 & 1 two interfaces for testing
     intf1 = ports[0]
     intf2 = ports[1]
-    logging.info("Selected ints are {0} and {1}".format(intf1, intf2))
+    logger.info("Selected ints are {0} and {1}".format(intf1, intf2))
 
     intf1_indice = mg_facts['minigraph_port_indices'][intf1]
     intf2_indice = mg_facts['minigraph_port_indices'][intf2]
@@ -33,15 +44,21 @@ def common_setup_teardown(duthost, ptfhost):
         # Make sure selected interfaces are not in portchannel
         if po1 is not None:
             duthost.shell('config portchannel member del {0} {1}'.format(po1, intf1))
+            collect_info(duthost)
             duthost.shell('config interface startup {0}'.format(intf1))
+            collect_info(duthost)
 
         if po2 is not None:
             duthost.shell('config portchannel member del {0} {1}'.format(po2, intf2))
+            collect_info(duthost)
             duthost.shell('config interface startup {0}'.format(intf2))
+            collect_info(duthost)
 
         # Change SONiC DUT interface IP to test IP address
         duthost.shell('config interface ip add {0} 10.10.1.2/28'.format(intf1))
+        collect_info(duthost)
         duthost.shell('config interface ip add {0} 10.10.1.20/28'.format(intf2))
+        collect_info(duthost)
 
         if (po1 is not None) or (po2 is not None):
             time.sleep(40)
@@ -135,7 +152,7 @@ def test_arp_garp_no_update(common_setup_teardown):
     for ip in switch_arptable['arptable']['v4'].keys():
         pytest_assert(ip != '10.10.1.7')
 
-    # Test Gratuitous ARP upate case, when received garp, no arp reply, update arp table if it was solved before
+    # Test Gratuitous ARP update case, when received garp, no arp reply, update arp table if it was solved before
     log_file = "/tmp/arptest.ExpectReply.{0}.log".format(datetime.now().strftime("%Y-%m-%d-%H:%M:%S"))
     ptf_runner(ptfhost, 'ptftests', "arptest.ExpectReply", '/root/ptftests', params=params, log_file=log_file)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add debug code in test_arpall.py to collect interface MAC address during configuration change in setup phase.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Script test_arpall.py may fail intermittently on some platforms. PTF log
shows that the interface under test may have different MAC address
after configuration change during setup phase. This change inserted
code for collecting interface MAC address for debug during setup phase.

#### How did you do it?
Insert code to collect interface MAC address during configuration change in setup phase.

#### How did you verify/test it?
Test run the test_arall.py script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
