### PR TITLE
Fix issue: psu_fan.get_status_led argument error

### DIFF
--- a/tests/common/helpers/platform_api/psu_fan.py
+++ b/tests/common/helpers/platform_api/psu_fan.py
@@ -69,5 +69,5 @@ def set_status_led(conn, psu_idx, fan_idx, color):
     return psu_fan_api(conn, psu_idx, fan_idx, 'set_status_led', [color])
 
 
-def get_status_led(conn, fan_idx):
+def get_status_led(conn, psu_idx, fan_idx):
     return psu_fan_api(conn, psu_idx, fan_idx, 'get_status_led')

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -147,7 +147,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, i)
             if self.expect(num_fans is not None, "Unable to retrieve fan_drawer {} number of fans".format(i)):
                 self.expect(isinstance(num_fans, int), "fan drawer {} number of fans appear to be incorrect".format(i))
-                self.compare_value_with_platform_facts('num_fans', name, i)
+                self.compare_value_with_platform_facts('num_fans', num_fans, i)
         self.assert_expectations()
 
     def test_get_all_fans(self, duthost, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -444,11 +444,11 @@ class TestSfpApi(PlatformApiTestBase):
             except Exception:
                 pytest.fail("SFP {}: num_thermals is not an integer".format(sfp_id))
 
-            thermal_list = sfp.get_all_thermals(platform_api_conn, i)
+            thermal_list = sfp.get_all_thermals(platform_api_conn, sfp_id)
             pytest_assert(thermal_list is not None, "Failed to retrieve thermals for sfp {}".format(sfp_id))
             pytest_assert(isinstance(thermal_list, list) and len(thermal_list) == num_thermals, "Thermals appear to be incorrect for sfp {}".format(sfp_id))
 
             for thermal_index in range(num_thermals):
-                thermal = sfp.get_thermal(platform_api_conn, i, thermal_index)
-                self.expect(thermal and thermal == thermal_list[i], "Thermal {} is incorrect for sfp {}".format(thermal_index, sfp_id))
+                thermal = sfp.get_thermal(platform_api_conn, sfp_id, thermal_index)
+                self.expect(thermal and thermal == thermal_list[thermal_index], "Thermal {} is incorrect for sfp {}".format(thermal_index, sfp_id))
         self.assert_expectations()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes psu_fan.get_status_led accept 4 arguments, but only 3 defined

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Fixes psu_fan.get_status_led accept 4 arguments, but only 3 defined

#### How did you do it?

Add psu_idx to the argument list

#### How did you verify/test it?

Manually run the test

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
