### PR TITLE
Update doc testbed.Routing - t1 supports exabgp announced routes

### DIFF
--- a/ansible/doc/README.testbed.Routing.md
+++ b/ansible/doc/README.testbed.Routing.md
@@ -127,7 +127,7 @@ sshd                             RUNNING   pid 13, uptime 2 days, 10:35:21
 ```
 
 - pytest fib fixture to generate routes to exabgp
-  - currently support t0, t1-lag, extending to other topology is straighforward
+  - currently support t0, t1, t1-lag, extending to other topology is straighforward
   - fib module generate http request to exabgp instance
   
 ## Future applications:


### PR DESCRIPTION
### Description of PR
Update doc testbed.Routing, in the PR https://github.com/Azure/sonic-mgmt/pull/2143
add t1 to support exabgp announced routes
Summary:
Fixes # (improvement)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
I am trying to use t1 topology to perform bgp_gr_helper testing, and the test is passed

#### How did you do it?

#### How did you verify/test it?
Verify in bgp_gr_helper in t1 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
