### PR TITLE
[multi-dut] add infrastructure to update dut port to ptf port index map

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1045,6 +1045,24 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             return DEFAULT_NAMESPACE
         return "{}{}".format(NAMESPACE_PREFIX, asic_id)
 
+    def get_minigraph_facts(self, tbinfo):
+        mg_facts = self.minigraph_facts(host = self.hostname)['ansible_facts']
+
+        # Fix the ptf port index for multi-dut testbeds. These testbeds have
+        # multiple DUTs sharing a same PTF host. Therefore, the indeces from
+        # the minigraph facts are not always match up with PTF port indeces.
+        try:
+            dut_index = tbinfo['duts'].index(self.hostname)
+            map = tbinfo['topo']['ptf_map'][dut_index]
+            if map:
+                for port, index in mg_facts['minigraph_port_indices'].items():
+                    if index in map:
+                        mg_facts['minigraph_port_indices'][port] = map[index]
+        except ValueError:
+            pass
+
+        return mg_facts
+
 
 class EosHost(AnsibleHostBase):
     """

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1045,8 +1045,9 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             return DEFAULT_NAMESPACE
         return "{}{}".format(NAMESPACE_PREFIX, asic_id)
 
-    def get_minigraph_facts(self, tbinfo):
+    def get_extended_minigraph_facts(self, tbinfo):
         mg_facts = self.minigraph_facts(host = self.hostname)['ansible_facts']
+        mg_facts['minigraph_ptf_indeces'] = mg_facts['minigraph_port_indices'].copy()
 
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
         # multiple DUTs sharing a same PTF host. Therefore, the indeces from
@@ -1055,9 +1056,9 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             dut_index = tbinfo['duts'].index(self.hostname)
             map = tbinfo['topo']['ptf_map'][dut_index]
             if map:
-                for port, index in mg_facts['minigraph_port_indices'].items():
+                for port, index in mg_facts['minigraph_ptf_indeces'].items():
                     if index in map:
-                        mg_facts['minigraph_port_indices'][port] = map[index]
+                        mg_facts['minigraph_ptf_indeces'][port] = map[index]
         except ValueError:
             pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,9 +116,6 @@ class TestbedInfo(object):
 
     def calculate_ptf_index_map(self, line):
         map = defaultdict()
-        if len(line['duts']) <= 1:
-            # No need to calculate map for single DUT testbed
-            return map
 
         # For multi-DUT testbed, because multiple DUTs are sharing a same
         # PTF docker, the ptf docker interface index will not be exactly
@@ -133,9 +130,10 @@ class TestbedInfo(object):
 
         topology = topo_facts['topology']
         if 'host_interfaces' in topology:
-            for ports in topology['host_interfaces']:
+            for _ports in topology['host_interfaces']:
                 # Example: ['0.0,1.0', '0.1,1.1', '0.2,1.2', ... ]
                 # if there is no '@' then they are shared, no need to update.
+                ports = str(_ports)
                 for port in ports.split(','):
                     if '@' in port and '.' in port:
                         dut_index, port_index, ptf_index = _parse_dut_port_index(port)
@@ -148,8 +146,9 @@ class TestbedInfo(object):
         if 'VMs' in topology:
             for _, vm in topology['VMs'].items():
                 if 'vlans' in vm:
-                    for port in vm['vlans']:
+                    for _port in vm['vlans']:
                         # Example: ['0.31@34', '1.31@35']
+                        port = str(_port)
                         if '@' in port and '.' in port:
                             dut_index, port_index, ptf_index = self._parse_dut_port_index(port)
                             if port_index != ptf_index:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -21,7 +21,7 @@ pytestmark = [
 ]
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthost, ptfhost, tbinfo):
+def common_setup_teardown(ptfhost):
     logger.info("########### Setup for lag testing ###########")
 
     # Copy PTF test into PTF-docker for test LACP DU
@@ -31,22 +31,16 @@ def common_setup_teardown(duthost, ptfhost, tbinfo):
         dst = "/tmp/%s" % test_file
         ptfhost.copy(src=src, dest=dst)
 
-    # Inlucde testbed topology configuration
-    topo_name = tbinfo['topo']['name']
-    topo_type = tbinfo['topo']['type']
-
-    support_testbed_types = frozenset(['t1-lag', 't0', 't0-116', 'dualtor'])
-    pytest_require(topo_name in support_testbed_types, "Not support given test bed type {} topology {}".format(topo_type, topo_name))
-
     yield ptfhost
 
 class LagTest:
-    def __init__(self, duthost, ptfhost, nbrhosts, fanouthosts, conn_graph_facts):
+    def __init__(self, duthost, tbinfo, ptfhost, nbrhosts, fanouthosts, conn_graph_facts):
         self.duthost     = duthost
+        self.tbinfo      = tbinfo
         self.ptfhost     = ptfhost
         self.nbrhosts    = nbrhosts
         self.fanouthosts = fanouthosts
-        self.mg_facts         = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+        self.mg_facts         = duthost.get_minigraph_facts(tbinfo)
         self.conn_graph_facts = conn_graph_facts
         self.vm_neighbors     = self.mg_facts['minigraph_neighbors']
         self.fanout_neighbors = self.conn_graph_facts['device_conn'][duthost.hostname] if 'device_conn' in self.conn_graph_facts else {}
@@ -242,7 +236,7 @@ class LagTest:
 @pytest.mark.parametrize("testcase", ["single_lag",
                                       "lacp_rate",
                                       "fallback"])
-def test_lag(common_setup_teardown, duthosts, nbrhosts, fanouthosts, conn_graph_facts, all_pcs, testcase):
+def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, conn_graph_facts, all_pcs, testcase):
     ptfhost = common_setup_teardown
 
     dut_name, dut_lag = decode_dut_port_name(all_pcs)
@@ -252,7 +246,7 @@ def test_lag(common_setup_teardown, duthosts, nbrhosts, fanouthosts, conn_graph_
         if dut_name in [ 'unknown', duthost.hostname ]:
             lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
 
-            test_instance = LagTest(duthost, ptfhost, nbrhosts, fanouthosts, conn_graph_facts)
+            test_instance = LagTest(duthost, tbinfo, ptfhost, nbrhosts, fanouthosts, conn_graph_facts)
 
             # Test for each lag
             if dut_lag == "unknown":

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -40,7 +40,7 @@ class LagTest:
         self.ptfhost     = ptfhost
         self.nbrhosts    = nbrhosts
         self.fanouthosts = fanouthosts
-        self.mg_facts         = duthost.get_minigraph_facts(tbinfo)
+        self.mg_facts         = duthost.get_extended_minigraph_facts(tbinfo)
         self.conn_graph_facts = conn_graph_facts
         self.vm_neighbors     = self.mg_facts['minigraph_neighbors']
         self.fanout_neighbors = self.conn_graph_facts['device_conn'][duthost.hostname] if 'device_conn' in self.conn_graph_facts else {}
@@ -134,7 +134,7 @@ class LagTest:
         iface_behind_lag_member = []
         for neighbor_intf in self.vm_neighbors.keys():
             if peer_device == self.vm_neighbors[neighbor_intf]['name']:
-                iface_behind_lag_member.append(self.mg_facts['minigraph_port_indices'][neighbor_intf])
+                iface_behind_lag_member.append(self.mg_facts['minigraph_ptf_indeces'][neighbor_intf])
 
         neighbor_lag_intfs = []
         for po_intf in po_interfaces:


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In the single DUT scenario, the DUT interface indeces exactly match with the ptf port indeces. However, in multi-dut scneario, this is not always true. Multiple DUTs are sharing the same ptf host, therefore their interface indeces need to be translated to ptf port indeces according to the topology definition.

#### How did you do it?
In this change, a translate map is captured from topology definition. And member method get_extended_minigraph_facts() is added to SonicHost to help getting the minigrap facts and then extend it with ptf port indices with mg_facts['minigraph_ptf_indeces'].

Changed test_lag_2 to use the new method to map to the correct ptf port.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Tested the infrastructure with updated lag_2 test.

platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 24 items                                                                                                                                                                       

pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0001-single_lag] PASSED                                                                                                  [  4%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0001-lacp_rate] PASSED                                                                                                   [  8%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0001-fallback] SKIPPED                                                                                                   [ 12%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0003-single_lag] PASSED                                                                                                  [ 16%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0003-lacp_rate] PASSED                                                                                                   [ 20%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0003-fallback] SKIPPED                                                                                                   [ 25%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0002-single_lag] PASSED                                                                                                  [ 29%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0002-lacp_rate] PASSED                                                                                                   [ 33%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0002-fallback] SKIPPED                                                                                                   [ 37%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0004-single_lag] PASSED                                                                                                  [ 41%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0004-lacp_rate] PASSED                                                                                                   [ 45%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0004-fallback] SKIPPED                                                                                                   [ 50%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0001-single_lag] PASSED                                                                                                  [ 54%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0001-lacp_rate] PASSED                                                                                                   [ 58%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0001-fallback] SKIPPED                                                                                                   [ 62%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0003-single_lag] PASSED                                                                                                  [ 66%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0003-lacp_rate] PASSED                                                                                                   [ 70%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0003-fallback] SKIPPED                                                                                                   [ 75%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0002-single_lag] PASSED                                                                                                  [ 79%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0002-lacp_rate] PASSED                                                                                                   [ 83%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0002-fallback] SKIPPED                                                                                                   [ 87%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0004-single_lag] PASSED                                                                                                  [ 91%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0004-lacp_rate] PASSED                                                                                                   [ 95%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-07|PortChannel0004-fallback] SKIPPED                                                                                                   [100%]

------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
