### PR TITLE
Check CRM limit for route performance test

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -172,11 +172,18 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
 
 def test_perf_add_remove_routes(duthost, request, ip_versions):
     # Number of routes for test
-    num_routes = request.config.getoption("--num_routes")
+    set_num_routes = request.config.getoption("--num_routes")
 
     # Generate interfaces and neighbors
     NUM_NEIGHS = 8
     intf_neighs, str_intf_nexthop = generate_intf_neigh(NUM_NEIGHS, ip_versions)
+
+    route_tag = "ipv{}_route".format(ip_versions)
+    used_routes_count = duthost.get_crm_resources().get("main_resources").get(route_tag).get("used")
+    avail_routes_count = duthost.get_crm_resources().get("main_resources").get(route_tag).get("available")
+    num_routes = min(avail_routes_count, set_num_routes)
+    logger.info("IP route utilization before test start: Used: {}, Available: {}, Test count: {}"\
+        .format(used_routes_count, avail_routes_count, num_routes))
 
     # Generate ip prefixes of routes
     if (ip_versions == 4):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `test_route_perf` test failure - `L3 route add failed with error Table full`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Failure of `test_route_perf` in S6100 platforms
The test_route_perf test adds the ipv4 and ipv6 routes based on the input arg `--num_routes` (default 10000 routes)
This test fails where the available limit is less than the number of routes being added.
Error:
```
['Nov  3 19:08:26.930925 str-s6100-acs-5 ERR syncd#syncd: [none] _brcm_sai_l3_route_config:2078 L3 route add failed with error Table full (0xfffffffa).
ERR syncd#syncd: [none] brcm_sai_create_route_entry:413 L3 route add failed with error -13.
ERR syncd#syncd: :- processEvent: attr: SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID: oid:0x5000000000d21
ERR syncd#syncd: :- processEvent: failed to execute api: create, key: SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"3000:26a0:1::/64","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000042"}, status: SAI_STATUS_TABLE_FULL
ERR syncd#syncd: :- syncd_main: Runtime error: :- processEvent: failed to execute api: create, key: SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"3000:26a0:1::/64","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000042"}, status: SAI_STATUS_TABLE_FULL
ERR swss#orchagent: :- on_switch_shutdown_request: Syncd stopped
WARNING syncd#syncd: :- saiDiscover: skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID
ERR syncd#syncd: [none] _brcm_sai_port_wred_stats_get:5068 Hardware failure -4 in getting WRED stat 69 for port 1
ERR syncd#syncd: [none] brcm_sai_get_port_stats:2097 port wred stats get failed with error Table empty (0xfffffffb).
```

#### How did you do it?
Added a check for setting the route addition limit based on CRM resource availability.
```
admin@sonic:~$ crm show resources all


Resource Name           Used Count    Available Count
--------------------  ------------  -----------------
ipv4_route                    6475              67253
ipv6_route                    6476               1716
```

Based on the available count, decide the number of routes to test with.

#### How did you verify/test it?
Tested `test_route_perf` test on S6100 platform and it passed without any Table Full errors.
```
route/test_route_perf.py::test_perf_add_remove_routes[4] passed     [ 50%]
route/test_route_perf.py::test_perf_add_remove_routes[6] passed     [100%]
```
#### Any platform specific information? 

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
