### PR TITLE
[LogAnalyzer] Ignore error reported by route_check.py and mgmt-framework

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -5,3 +5,4 @@ r, ".* ERR syncd#syncd: brcm_sai_get_port_stats:.* port stats get failed with er
 r, ".* NOTICE kernel:.*profile=""/usr/sbin/ntpd"" name=""sbin"" pid=.* comm=""ntpd"" requested_mask=.*"
 r, ".* ERR snmp#snmp-subagent.*"
 r, ".* ERR route_check.py.*"
+r, ".* INFO mgmt-framework#supervisord: rest-server.*"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -4,3 +4,4 @@ r, ".* ERR liblogging-stdlog: omfwd: error 11 sending via udp: Resource temporar
 r, ".* ERR syncd#syncd: brcm_sai_get_port_stats:.* port stats get failed with error.*"
 r, ".* NOTICE kernel:.*profile=""/usr/sbin/ntpd"" name=""sbin"" pid=.* comm=""ntpd"" requested_mask=.*"
 r, ".* ERR snmp#snmp-subagent.*"
+r, ".* ERR route_check.py.*"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Add a workaround for https://github.com/Azure/sonic-buildimage/issues/5804.
The route_check.py script will write an ERROR log in syslog when some error is detected, which will cause LogAnalyzer report test errors.
Actually, the error should be reported by monit according to the monit configuration file. This commit add a pattern to loganalyzer_common_ignore to ignore error message reported by route_check.
2. Fix false alarm brought by mgmt-framework
The mgmt-framework#supervisord will write some log at INFO level, which should cause no problem. However, the msg contains "ERROR" word, and LogAnalyzer will treat it as an errer and produce an false alarm. This commit address the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to ignore error msg reported by rouce_check.py directly.

#### How did you do it?
Add a pattern to loganalyzer_common_ignore.

#### How did you verify/test it?
Verified on Arista-7260cx3
1. Add a static route whose nexthop is not reachable
```
ip route add 1.1.1.1 via 192.168.1.101
```
2. Run a test case, and run route_check.py manually to produce some error in syslog
3. The test case passed without error.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A