### PR TITLE
Revert "[kvmtest]: disable test_iface_namingmode"

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -69,10 +69,8 @@ tacacs/test_ro_user.py \
 telemetry/test_telemetry.py \
 test_features.py \
 test_procdockerstatsd.py \
+iface_namingmode/test_iface_namingmode.py \
 platform_tests/test_cpu_memory_usage.py"
-
-# FIXME: disable this test due to https://github.com/Azure/sonic-buildimage/issues/5697
-# iface_namingmode/test_iface_namingmode.py
 
 # FIXME: The lldp test has been temporarily disabled for https://github.com/Azure/sonic-mgmt/pull/2413
 # and https://github.com/Azure/sonic-buildimage/pull/5698. The reason is that these two PRs dependent on each other.


### PR DESCRIPTION
This reverts commit 9f1dbbda4bb78fadb8fdbaa99c95a67a5fd18435.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
enable test_iface_namingmode test

#### How did you do it?
add the test to kvmtest.sh

#### How did you verify/test it?
lldpmgrd crash issue address in https://github.com/Azure/sonic-buildimage/commit/4ed2ff805f9a7c93ad7ce4724738ed5e7cebc90c

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
