### PR TITLE
[multi DUT] making test_nbr_health multi-DUT ready

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -52,27 +52,27 @@ def check_bgp_facts(hostname, host):
     if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
         return "neighbor {} bgp not configured correctly".format(hostname)
 
-def test_neighbors_health(duthosts, localhost, nbrhosts, eos):
+def test_neighbors_health(duthosts, localhost, nbrhosts, eos, dut_hostname):
     """Check each neighbor device health"""
 
     fails = []
-    for duthost in duthosts:
-        config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-        nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
-        for k, v in nei_meta.items():
-            failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'])
-            if failmsg:
-                fails.append(failmsg)
+    duthost = duthosts[dut_hostname]
+    config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
+    for k, v in nei_meta.items():
+        failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'])
+        if failmsg:
+            fails.append(failmsg)
 
-            eoshost = nbrhosts[k]['host']
-            failmsg = check_eos_facts(k, v['mgmt_addr'], eoshost)
-            if failmsg:
-                fails.append(failmsg)
+        eoshost = nbrhosts[k]['host']
+        failmsg = check_eos_facts(k, v['mgmt_addr'], eoshost)
+        if failmsg:
+            fails.append(failmsg)
 
-            failmsg = check_bgp_facts(k, eoshost)
-            if failmsg:
-                fails.append(failmsg)
+        failmsg = check_bgp_facts(k, eoshost)
+        if failmsg:
+            fails.append(failmsg)
 
-        # TODO: check link, bgp, etc. on
+    # TODO: check link, bgp, etc. on
 
     pytest_assert(len(fails) == 0, "\n".join(fails))


### PR DESCRIPTION
Summary:
making test_nbr_health multi-DUT ready.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Making nbr health check ready for multi-DUT tests.

#### How did you do it?
Enumerate the dut hostnames and test them individually.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run nbr health test case on multi-DUT testbed and single DUT testbed.

platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 2 items                                                                                                                                                                        

test_nbr_health.py::test_neighbors_health[str2-7050cx3-acs-06] PASSED                                                                                                              [ 50%]
test_nbr_health.py::test_neighbors_health[str2-7050cx3-acs-07] PASSED                                                                                                              [100%]

------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------------------------------------------------------
