### PR TITLE
[multi-dut] making test_show_features multi-dut ready

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,9 +7,10 @@ pytestmark = [
 ]
 
 # Test Functions
-def test_show_features(duthost):
+def test_show_features(duthosts, dut_hostname):
     """Verify show features command output against CONFIG_DB
     """
+    duthost = duthosts[dut_hostname]
     features_dict, succeeded = duthost.get_feature_status()
     pytest_assert(succeeded, "failed to obtain feature status")
     for cmd_key, cmd_value in features_dict.items():


### PR DESCRIPTION
Summary:
making test_show_features multi-dut ready

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
making test_show_features multi-dut ready

#### How did you do it?
- enumerate dut hostnames of the testbed and run test individually.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test_show_feature on single dut and multi-dut testbeds.

platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 1 item                                                                                                                                                                         

test_features.py::test_show_features[str-dx010-acs-1] PASSED                                                                                                                       [100%]


platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 2 items                                                                                                                                                                        

test_features.py::test_show_features[str2-7050cx3-acs-06] PASSED                                                                                                                   [ 50%]
test_features.py::test_show_features[str2-7050cx3-acs-07] PASSED                                                                                                                   [100%]
