### PR TITLE
[multi-DUT] making test_interfaces multi-DUT ready

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,14 +1,17 @@
 from netaddr import IPAddress
 import pytest
 
+from tests.common.helpers.assertions import pytest_assert
+
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')
 ]
 
-def test_interfaces(duthost):
+def test_interfaces(duthosts, dut_hostname):
     """compare the interfaces between observed states and target state"""
 
+    duthost    = duthosts[dut_hostname]
     host_facts = duthost.setup()['ansible_facts']
     mg_facts   = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 
@@ -18,7 +21,8 @@ def test_interfaces(duthost):
         # verify no ipv4 address for each port channel member
         for member in v['members']:
             ans_ifname = "ansible_%s" % member
-            assert not host_facts[ans_ifname].has_key("ipv4")
+            pytest_assert("ipv4" not in host_facts[ans_ifname],
+                          "LAG member {} has IP address {}".format(ans_ifname, host_facts[ans_ifname]))
 
     verify_port(host_facts, mg_facts['minigraph_vlans'].keys())
 
@@ -27,7 +31,8 @@ def test_interfaces(duthost):
         # verify no ipv4 address for each vlan member
         for member in v['members']:
             ans_ifname = "ansible_%s" % member
-            assert not host_facts[ans_ifname].has_key("ipv4")
+            pytest_assert("ipv4" not in host_facts[ans_ifname],
+                          "vlan member {} has IP address {}".format(ans_ifname, host_facts[ans_ifname]))
 
     verify_ip_address(host_facts, mg_facts['minigraph_portchannel_interfaces'])
     verify_ip_address(host_facts, mg_facts['minigraph_vlan_interfaces'])
@@ -36,7 +41,7 @@ def test_interfaces(duthost):
 def verify_port(host_facts, ports):
     for port in ports:
         ans_ifname = "ansible_%s" % port
-        assert host_facts[ans_ifname]['active']
+        pytest_assert(host_facts[ans_ifname]['active'], "interface {} is not active".format(ans_ifname))
 
 def verify_ip_address(host_facts, intfs):
     for intf in intfs:
@@ -63,5 +68,4 @@ def verify_ip_address(host_facts, intfs):
             if IPAddress(addr['address']) == ip:
                 found = True
                 break
-        if not found:
-            pytest.fail("%s not found in the list %s" % (ip, ips_found))
+        pytest_assert(found, "{} not found in the list {}".format(ip, ips_found))


### PR DESCRIPTION
### Description of PR
Summary:
making test_interfaces multi-DUT ready

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
making test_interfaces multi-DUT ready

#### How did you do it?
- enumerate DUTs of testbed to run test.
- improve asserts.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test on a multi-DUT testbed.

platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 2 items                                                                                                                                                                        

test_interfaces.py::test_interfaces[str2-7050cx3-acs-06] PASSED                                                                                                                    [ 50%]
test_interfaces.py::test_interfaces[str2-7050cx3-acs-07] PASSED                                                                                                                    [100%]
