### PR TITLE
Disable advanced reboot test for PR tests

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -48,7 +48,6 @@ mkdir -p logs
 tgname=1vlan
 tests="\
 monit/test_monit_status.py \
-platform_tests/test_advanced_reboot.py \
 test_interfaces.py \
 bgp/test_bgp_fact.py \
 bgp/test_bgp_gr_helper.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Temporarily disable advanced reboot test for PR tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The advanced reboot tests keep failing on one of the PR test workers. Disabling this test to avoid blocking PR tests.

#### How did you do it?
Disable the advanced reboot test for PR tests.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
