### PR TITLE
[copp] Clean-up apt lists before updating and installing NN packages

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -136,7 +136,8 @@ def _install_nano(dut, creds):
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
 
         cmd = '''docker exec -e http_proxy={} -e https_proxy={} syncd bash -c " \
-                apt-get update \
+                rm -rf /var/lib/apt/lists/* \
+                && apt-get update \
                 && apt-get install -y python-pip build-essential libssl-dev python-dev wget cmake \
                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
                 && tar xvfz 1.0.0.tar.gz && cd nanomsg-1.0.0 \


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Clean-up apt lists before updating and installing NN packages

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We discovered that it's actually possible for apt to end up in a partial/corrupted state after successive test runs. As a result, it's safest if we clear the apt list before the update during the test run.

#### How did you do it?
Added an extra pre-step for the NN agent setup that clears the apt list.

#### How did you verify/test it?
Ran the COPP tests on DUTs that were in the bad state and verified that they were passing after running them with this fix.

Also ran the tests on platforms that were in an OK state and verified that there was no regression.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
