### PR TITLE
[SonicHost] Ignore non-zero return code from 'supervisorctl status' in critical_process_status()

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -454,7 +454,7 @@ class SonicHost(AnsibleHostBase):
             return result
 
         # get process status for the service
-        output = self.command("docker exec {} supervisorctl status".format(service))
+        output = self.command("docker exec {} supervisorctl status".format(service), module_ignore_errors=True)
         logging.info("====== supervisor process status for service {} ======".format(service))
 
         for l in output['stdout_lines']:


### PR DESCRIPTION
### Description of PR

#### Summary

Ignore non-zero return code from `supervisorctl status` command when called from `SonicHost.critical_process_status()`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

As part of migrating all Python code in SONiC to Python 3, we must upgrade supervisor to version >= 4.0.0, as this is the first version which supports Python 3. However, as of version 4.0.0, the return codes from `supervisorctl status` have changed, such that if _any_ process is not in a `RUNNING` state--even if it is expected (expected exit or even stopped by user)--it will return `3`. Thus, we need to ignore the return code from `supervisorctl status`.

- Example of the issue: https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image-pr/6854/console

- Discussion of supervisorctl behavior change: https://github.com/Supervisor/supervisor/issues/1223

#### How did you do it?

Add `module_ignore_errors=True` argument to `self.command("docker exec {} supervisorctl status".format(service))` call

#### How did you verify/test it?

Run tests against a DUT, ensure sanity check passes. Do this with both supervisor 3.x and 4.x.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
