### PR TITLE
[multi-dut] Make test_posttest and test_pretest multi-dut ready

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -15,7 +15,8 @@ pytestmark = [
 ]
 
 
-def test_collect_techsupport(duthost):
+def test_collect_techsupport(duthosts, dut_hostname):
+    duthost = duthosts[dut_hostname]
     """
     A util for collecting techsupport after tests.
 
@@ -34,7 +35,8 @@ def test_collect_techsupport(duthost):
 
     assert True
 
-def test_restore_container_autorestart(duthost):
+def test_restore_container_autorestart(duthosts, dut_hostname):
+    duthost = duthosts[dut_hostname]
     state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)
     if not os.path.exists(state_file_name):
         return
@@ -59,7 +61,8 @@ def test_restore_container_autorestart(duthost):
     SNMP_RELOADING_TIME = 30
     time.sleep(SNMP_RELOADING_TIME)
 
-def test_recover_rsyslog_rate_limit(duthost):
+def test_recover_rsyslog_rate_limit(duthosts, dut_hostname):
+    duthost = duthosts[dut_hostname]
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
         # Something unexpected happened.

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -62,26 +62,22 @@ def collect_dut_info(dut):
     return { 'intf_status' : status }
 
 
-def test_update_testbed_metadata(duthosts, dut_hostname, tbinfo):
-    duthost = duthosts[dut_hostname]
+def test_update_testbed_metadata(duthosts, tbinfo):
     metadata = {}
     tbname = tbinfo['conf-name']
     pytest_require(tbname, "skip test due to lack of testbed name.")
 
-    dutinfo = collect_dut_info(duthost)
-    metadata[duthost.hostname] = dutinfo
+    for dut in duthosts:
+        dutinfo = collect_dut_info(dut)
+        metadata[dut.hostname] = dutinfo
+
+    info = { tbname : metadata }
+    folder = 'metadata'
+    filepath = os.path.join(folder, tbname + '.json')
     try:
-        folder = 'metadata'
-        filepath = os.path.join(folder, tbname + '.json')
         if not os.path.exists(folder):
             os.mkdir(folder)
-        with open(filepath, 'a+') as yf:
-            try:
-                info = json.load(yf)
-                info[tbname].update(metadata)
-            except (KeyError, ValueError) as e:
-                info = {tbname: metadata}
-            yf.truncate(0)
+        with open(filepath, 'w') as yf:
             json.dump(info, yf, indent=4)
     except IOError as e:
         logger.warning('Unable to create file {}: {}'.format(filepath, e))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Make test_posttest and test_pretest multi-dut ready
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Make test_posttest and test_pretest multi-dut ready

#### What is the motivation for this PR?
MULTI-DUT test conversion.

#### How did you do it?
Incorporated the new duthosts fixture to test both DUTs in multi-dut setup.
In case of `test_update_testbed_metadata` -- new changes are added to handle two DUTs' information in one testbed dict.


#### How did you verify/test it?
Executed pre and post tests locally successfully.

`test_pretest`
```
PASSED                                                                                                                                                                                                                                               [ 12%]
test_pretest.py::test_cleanup_testbed[str2-7050cx3-acs-09]
------- live log setup -----
PASSED                                                                                                                                                                                                                                               [ 25%]
test_pretest.py::test_disable_container_autorestart[str2-7050cx3-acs-08]
------- live log setup -----
------- live log call -----
22:32:27 INFO test_pretest.py:test_disable_container_autorestart:46: Disable container autorestart
PASSED                                                                                                                                                                                                                                               [ 37%]
test_pretest.py::test_disable_container_autorestart[str2-7050cx3-acs-09]
------- live log setup -----
------- live log call -----
22:33:07 INFO test_pretest.py:test_disable_container_autorestart:46: Disable container autorestart
PASSED                                                                                                                                                                                                                                               [ 50%]
test_pretest.py::test_update_testbed_metadata[str2-7050cx3-acs-08]
------- live log setup -----
PASSED                                                                                                                                                                                                                                               [ 62%]
test_pretest.py::test_update_testbed_metadata[str2-7050cx3-acs-09]
------- live log setup -----
PASSED                                                                                                                                                                                                                                               [ 75%]
test_pretest.py::test_disable_rsyslog_rate_limit[str2-7050cx3-acs-08]
------- live log setup -----
PASSED                                                                                                                                                                                                                                               [ 87%]
test_pretest.py::test_disable_rsyslog_rate_limit[str2-7050cx3-acs-09]
------- live log setup -----
PASSED                                                                                                                                                                                                                                               [100%]
------- live log teardown -----
22:34:41 INFO __init__.py:sanity_check:127: Start post-test sanity check
22:34:41 INFO __init__.py:sanity_check:130: No post-test check is required. Done post-test sanity check
```

`test_posttest`:

```
------- live log call -----
22:45:12 INFO test_posttest.py:test_collect_techsupport:26: Collecting techsupport since yesterday
PASSED                                                                                                                                                                                                                                               [ 16%]
test_posttest.py::test_collect_techsupport[str2-7050cx3-acs-09]
------- live log setup -----
22:46:08 INFO __init__.py:loganalyzer:16: Log analyzer is disabled
------- live log call -----
22:46:08 INFO test_posttest.py:test_collect_techsupport:26: Collecting techsupport since yesterday
PASSED                                                                                                                                                                                                                                               [ 33%]
test_posttest.py::test_restore_container_autorestart[str2-7050cx3-acs-08]
------- live log setup -----
22:47:03 INFO __init__.py:loganalyzer:16: Log analyzer is disabled
------- live log call -----
22:47:04 INFO test_posttest.py:test_restore_container_autorestart:48: Recover container autorestart
PASSED                                                                                                                                                                                                                                               [ 50%]
test_posttest.py::test_restore_container_autorestart[str2-7050cx3-acs-09]
------- live log setup -----
22:47:41 INFO __init__.py:loganalyzer:16: Log analyzer is disabled
------- live log call -----
22:47:42 INFO test_posttest.py:test_restore_container_autorestart:48: Recover container autorestart
PASSED                                                                                                                                                                                                                                               [ 66%]
test_posttest.py::test_recover_rsyslog_rate_limit[str2-7050cx3-acs-08]
------- live log setup -----
22:48:19 INFO __init__.py:loganalyzer:16: Log analyzer is disabled
PASSED                                                                                                                                                                                                                                               [ 83%]
test_posttest.py::test_recover_rsyslog_rate_limit[str2-7050cx3-acs-09]
------- live log setup -----
22:48:46 INFO __init__.py:loganalyzer:16: Log analyzer is disabled
PASSED                                                                                                                                                                                                                                               [100%]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
