### PR TITLE
[cont_link_flap] address issue in fixture bring_up_fanout_interfaces

### DIFF
--- a/tests/platform_tests/link_flap/conftest.py
+++ b/tests/platform_tests/link_flap/conftest.py
@@ -26,23 +26,20 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture()
-def bring_up_fanout_interfaces(request, all_ports, duthosts, fanouthosts):
+def bring_up_fanout_interfaces(request, duthosts, fanouthosts):
     """
     Bring up outer interfaces on the DUT.
 
     Args:
         request: pytest request object
-        duthost: Fixture for interacting with the DUT.
+        duthosts: Fixture for interacting with the DUT list.
         fanouthosts: Fixture for interacting with the fanouts.
     """
     yield
     if request.node.rep_call.failed:
-        dutname, portname = decode_dut_port_name(all_ports)
-
         for dut in duthosts:
-            if dutname == 'unknown' or dutname == dut.hostname:
-                candidates = build_test_candidates(dut, fanouthosts, portname)
-                for _, fanout, fanout_port in candidates:
-                    fanout.no_shutdown(fanout_port)
+            candidates = build_test_candidates(dut, fanouthosts, "all_ports")
+            for _, fanout, fanout_port in candidates:
+                fanout.no_shutdown(fanout_port)
 
         time.sleep(60)

--- a/tests/platform_tests/link_flap/conftest.py
+++ b/tests/platform_tests/link_flap/conftest.py
@@ -9,7 +9,6 @@ import time
 import pytest
 
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates
-from tests.common.helpers.dut_ports import decode_dut_port_name
 
 def pytest_addoption(parser):
     """

--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -80,7 +80,11 @@ def build_test_candidates(dut, fanouthosts, port, completeness_level=None):
     Args:
         dut: DUT host object
         fanouthosts: List of fanout switch instances.
-        port: port
+        port: port, when port == 'unknown' or 'all_ports'
+              candidate will be all ports. A warning  will
+              be generated if the port == 'unknown'.
+              caller can use 'all_ports' explicitly to mute
+              the warning.
         completeness_level: Completeness level.
 
     Returns:
@@ -89,13 +93,14 @@ def build_test_candidates(dut, fanouthosts, port, completeness_level=None):
     """
     candidates = []
 
-    if port != 'unknown':
+    if port not in [ 'unknown', 'all_ports' ]:
         status = __get_dut_if_status(dut, port)
         fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, dut.hostname, port)
         __build_candidate_list(candidates, fanout, fanout_port, port, status)
     else:
         # Build the full list
-        logger.warning("Failed to get ports enumerated as parameter. Fall back to test all ports")
+        if port == 'unknown':
+            logger.warning("Failed to get ports enumerated as parameter. Fall back to test all ports")
         status = __get_dut_if_status(dut)
 
         for dut_port in status.keys():

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -73,7 +73,7 @@ class TestContLinkFlap(object):
         # Flap all interfaces one by one on Peer Device
         for iteration in range(3):
             logging.info("%d Iteration flap all interfaces one by one on Peer Device", iteration + 1)
-            candidates = build_test_candidates(duthost, fanouthosts, 'unknown')
+            candidates = build_test_candidates(duthost, fanouthosts, 'all_ports')
 
             if not candidates:
                 pytest.skip("Didn't find any port that is admin up and present in the connection graph")


### PR DESCRIPTION
### Description of PR

Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
test_cont_link_flap was executed N times, where N is number of ports of the testbed.

#### How did you do it?
Fixture mistaenly uses all_ports enumerator, which causes test_cont_link_flap itself being parameterized with all available ports on DUT. So the test was executed N times instead of once. Where N is number of ports.

Also the warning in candidate builder is intended to give warning when port enumeration failed. Add another explicit value to get all ports without triggering the warning.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run link flap tests.

platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 69 items                                                                                                                                                                       

platform_tests/link_flap/test_cont_link_flap.py::TestContLinkFlap::test_cont_link_flap Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
FAILED                                                                                      [  1%]Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc
Loading callback plugin json of type stdout, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/json.pyc

platform_tests/link_flap/test_cont_link_flap.py::TestContLinkFlap::test_cont_link_flap ERROR                                                                                       [  1%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet8] PASSED                                                                                   [  2%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet0] SKIPPED                                                                                  [  4%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet4] PASSED                                                                                   [  5%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet108] SKIPPED                                                                                [  7%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet100] SKIPPED                                                                                [  8%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet104] SKIPPED                                                                                [ 10%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet68] PASSED                                                                                  [ 11%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet96] PASSED                                                                                  [ 13%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet124] PASSED                                                                                 [ 14%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet92] PASSED                                                                                  [ 15%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet120] PASSED                                                                                 [ 17%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str2-7050cx3-acs-06|Ethernet56] PASSED                                      