### PR TITLE
[ptf map] address ptf map indexing issue

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1059,7 +1059,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
                 for port, index in mg_facts['minigraph_ptf_indeces'].items():
                     if index in map:
                         mg_facts['minigraph_ptf_indeces'][port] = map[index]
-        except ValueError:
+        except (ValueError, KeyError):
             pass
 
         return mg_facts


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #2480 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
test_lag_2 is failing on single DUT and KVM testbeds.

#### How did you do it?
For DUTs that doesn't have ptf port to map, the ptf_map would be an empty dictionary. Indexing it with dut_index will cause KeyError. Ignore these KeyErrors.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 24 items                                                                                                                                                                       

pc/test_lag_2.py::test_lag[str-dx010-acs-1|PortChannel0005-single_lag] PASSED         