### PR TITLE
[link flap] replace bring_up_fanout_interfaces with in place restoration

### DIFF
--- a/tests/platform_tests/link_flap/conftest.py
+++ b/tests/platform_tests/link_flap/conftest.py
@@ -4,12 +4,6 @@ Pytest configuration used by the link flap tests.
 Teardowns used by the link flap tests.
 """
 
-import time
-
-import pytest
-
-from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates
-
 def pytest_addoption(parser):
     """
     Adds options to pytest that are used by the Link flap tests.
@@ -23,22 +17,3 @@ def pytest_addoption(parser):
         help="Orchagent CPU threshold",
     )
 
-
-@pytest.fixture()
-def bring_up_fanout_interfaces(request, duthosts, fanouthosts):
-    """
-    Bring up outer interfaces on the DUT.
-
-    Args:
-        request: pytest request object
-        duthosts: Fixture for interacting with the DUT list.
-        fanouthosts: Fixture for interacting with the fanouts.
-    """
-    yield
-    if request.node.rep_call.failed:
-        for dut in duthosts:
-            candidates = build_test_candidates(dut, fanouthosts, "all_ports")
-            for _, fanout, fanout_port in candidates:
-                fanout.no_shutdown(fanout_port)
-
-        time.sleep(60)

--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -129,16 +129,24 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False):
     pytest_assert(__check_if_status(dut, dut_port, 'up', verbose=True), "Fail: dut port {}: link operational down".format(dut_port))
 
     logger.info("Shutting down fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
-    fanout.shutdown(fanout_port)
-    pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'down', True), "dut port {} didn't go down as expected".format(dut_port))
 
-    if watch:
-        time.sleep(1)
-        watch_system_status(dut)
+    need_recovery = True
+    try:
+        fanout.shutdown(fanout_port)
+        pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'down', True), "dut port {} didn't go down as expected".format(dut_port))
 
-    logger.info("Bring up fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
-    fanout.no_shutdown(fanout_port)
-    pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
+        if watch:
+            time.sleep(1)
+            watch_system_status(dut)
+
+        logger.info("Bring up fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
+        fanout.no_shutdown(fanout_port)
+        need_recovery = False
+        pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
+    finally:
+        if need_recovery:
+            fanout.no_shutdown(fanout_port)
+            wait_until(30, 1, __check_if_status, dut, dut_port, 'up', True)
 
 
 def watch_system_status(dut):

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -10,7 +10,7 @@ import logging
 import time
 import pytest
 
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common import port_toggle
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates, toggle_one_link, check_orch_cpu_utilization, check_bgp_routes
 from tests.common.utilities import wait_until
@@ -26,7 +26,7 @@ class TestContLinkFlap(object):
     TestContLinkFlap class for continuous link flap
     """
 
-    def test_cont_link_flap(self, request, duthost, fanouthosts, bring_up_fanout_interfaces, bring_up_dut_interfaces):
+    def test_cont_link_flap(self, request, duthost, fanouthosts, bring_up_dut_interfaces):
         """
         Validates that continuous link flap works as expected
 
@@ -75,8 +75,7 @@ class TestContLinkFlap(object):
             logging.info("%d Iteration flap all interfaces one by one on Peer Device", iteration + 1)
             candidates = build_test_candidates(duthost, fanouthosts, 'all_ports')
 
-            if not candidates:
-                pytest.skip("Didn't find any port that is admin up and present in the connection graph")
+            pytest_require(candidates, "Didn't find any port that is admin up and present in the connection graph")
 
             for dut_port, fanout, fanout_port in candidates:
                 toggle_one_link(duthost, dut_port, fanout, fanout_port, watch=True)

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -49,7 +49,7 @@ class TestLinkFlap(object):
 
 
 @pytest.mark.platform('physical')
-def test_link_flap(request, duthosts, enum_dut_portname, fanouthosts, bring_up_fanout_interfaces):
+def test_link_flap(request, duthosts, enum_dut_portname, fanouthosts):
     """
     Validates that link flap works as expected
     """


### PR DESCRIPTION
### Description of PR

Summary:
Improve efficiency of link flap tests.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
bring_up_fanout_interfaces is retoring all fanout ports, which takes long time and unnecessary. The tests will only ever shutdown one fanout port then restore it. If anything fails, there is only up to one fanout port to be restored.

#### How did you do it?
replace bring_up_fanout_interfaces with a in place restoration in the helper function toggles fanout switch port.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run link flap tests.

platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 33 items                                                                                                                                          ------------------------------
                                                                                                                                                            ==============================
platform_tests/link_flap/test_cont_link_flap.py::TestContLinkFlap::test_cont_link_flap PASSED                                                        [  3%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet8] PASSED                                                         [  6%] ==============================
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet0] PASSED                                                         [  9%] mp/logs-01 -c platform_tests/l
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet4] PASSED                                                         [ 12%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet108] PASSED                                                       [ 15%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet100] PASSED                                                       [ 18%] ore team. Support for it is no
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet104] PASSED                                                       [ 21%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet68] PASSED                                                        [ 24%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet96] PASSED                                                        [ 27%] ==============================
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet124] PASSED                                                       [ 30%]
platform_tests/link_flap/test_link_flap.py::test_link_flap[str-dx010-acs-1|Ethernet92] PASSED                                                        [ 33%]
