### PR TITLE
[vm_topology]: make debug log more readable

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -687,7 +687,7 @@ class VMTopology(object):
     @staticmethod
     def cmd(cmdline):
         with open(cmd_debug_fname, 'a') as fp:
-            pprint("CMD: %s" % cmdline, fp)
+            fp.write("CMD: %s\n" % cmdline)
         cmd = cmdline.split(' ')
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
@@ -697,7 +697,7 @@ class VMTopology(object):
             raise Exception("ret_code=%d, error message=%s. cmd=%s" % (ret_code, stderr, cmdline))
 
         with open(cmd_debug_fname, 'a') as fp:
-            pprint("OUTPUT: %s" % stdout, fp)
+            fp.write("OUTPUT: \n%s" % stdout.decode('utf-8'))
         return stdout.decode('utf-8')
 
     @staticmethod

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -9,7 +9,6 @@ import docker
 from ansible.module_utils.basic import *
 import traceback
 import hashlib
-from pprint import pprint
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
debug log:

CMD: brctl show
OUTPUT:
bridge name bridge id       STP enabled interfaces
br-b-vms6-1     8000.0aa124afe340   no      VM0100-back
                            VM0101-back
                            VM0102-back
                            VM0103-back
                            ptf-vms6-1-b

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
make debug log of vm_topology more readable

#### How did you do it?

#### How did you verify/test it?
check the uploaded log file.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
