### PR TITLE
[pytest/lacp]: use lacp timer if lacp rate cmd is not available

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1140,7 +1140,18 @@ class EosHost(AnsibleHostBase):
         out = self.eos_config(
             lines=['lacp rate %s' % mode],
             parents='interface %s' % interface_name)
-        logging.info("Set interface [%s] lacp rate to [%s]" % (interface_name, mode))
+        if out['changed'] == False:
+            # new eos deprecate lacp rate and use lacp timer command
+            out = self.eos_config(
+                lines=['lacp timer %s' % mode],
+                parents='interface %s' % interface_name)
+            if out['changed'] == False:
+                logging.warning("Unable to set interface [%s] lacp timer to [%s]" % (interface_name, mode))
+                raise Exception("Unable to set interface [%s] lacp timer to [%s]" % (interface_name, mode))
+            else:
+                logging.info("Set interface [%s] lacp timer to [%s]" % (interface_name, mode))
+        else:
+            logging.info("Set interface [%s] lacp rate to [%s]" % (interface_name, mode))
         return out
 
     def kill_bgpd(self):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes  #2041 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
eos has deprecated lacp rate cmd in latest eos

Signed-off-by: Guohan Lu <lguohan@gmail.com>

#### How did you do it?
use lacp timer if lacp rate cmd is not available

#### How did you verify/test it?
```
lgh@54edb99ee27f:/var/src/sonic-mgmt/tests$ ./run_tests.sh -i veos_vtb -d vlab-01 -n vms-kvm-t0 -f vtestbed.csv -k debug -l warning -m individual -q 1 -a False -e --disable_loganalyzer -u -c pc/test_lag_2.py -p logs
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
================================================================================================= test session starts ==================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, metadata-1.10.0, html-1.22.1, repeat-0.8.0, ansible-2.2.2
collected 3 items                                                                                                                                                                                                      

pc/test_lag_2.py::test_lag[unknown|unknown-single_lag] PASSED                                                                                                                                                    [ 33%]
pc/test_lag_2.py::test_lag[unknown|unknown-lacp_rate] PASSED                                                                                                                                                     [ 66%]
pc/test_lag_2.py::test_lag[unknown|unknown-fallback] SKIPPED                                                                                                                                                     [100%]

------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/pc/test_lag_2.xml -------------------------------------------------------------------------
=============================================================================================== short test summary info ================================================================================================
SKIPPED [1] /var/src/sonic-mgmt/tests/common/helpers/assertions.py:13: Skip fallback for lag PortChannel0001 due to fallback was not set for it
======================================================================================== 2 passed, 1 skipped in 1041.82 seconds ========================================================================================
lgh@54edb99ee27f:/var/src/sonic-mgmt/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
