### PR TITLE
Add the bgpmon checks in test_bgp_facts.py

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -18,6 +18,9 @@ def test_bgp_facts(duthosts, dut_hostname, asic_index):
         assert v['state'] == 'established'
         # Verify local ASNs in bgp sessions
         assert v['local AS'] == int(config_facts['DEVICE_METADATA']['localhost']['bgp_asn'].decode("utf-8"))
+        # Check bgpmon functionality by validate STATE DB contains this neighbor as well
+        state_fact = duthost.shell('sonic-db-cli STATE_DB HGET "NEIGH_STATE_TABLE|{}" "state"'.format(k), module_ignore_errors=False)['stdout_lines']
+        assert state_fact[0] == "Established"
 
     for k, v in config_facts['BGP_NEIGHBOR'].items():
         # Compare the bgp neighbors name with config db bgp neighbors name


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshminarasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test code to validate the STATE_DB BGP  state was removed inverdently in one of the earlier commit. 
Adding it back in this PR

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add the changes for PR https://github.com/Azure/sonic-mgmt/pull/2241/  which was removed inverdently in the PR https://github.com/Azure/sonic-mgmt/pull/2245

#### How did you do it?
Add the changes from PR https://github.com/Azure/sonic-mgmt/pull/2241/ back

#### How did you verify/test it?
Run the test in single asic platform
```
arlakshm@6ba71dd9c27a:/data/public/my_repo/sonic-mgmt/tests$ ANSIBLE_KEEP_REMOTE_FILES=1  py.test --inventory "/data/files/veos_vtb" --host-pattern str-s6000-acs-8 --module-path "../ansible/library/" --testbed  vms12-t1-lag-1 --testbed_file "/data/files/vtestbed.csv"  --log-cli-level info   -ra -vvv --disable_loganalyzer "bgp/test_bgp_fact.py" --skip_sanity

/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
^[[A==================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/public/my_repo/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collecting ...
---------------------------------------------------------------------------------------------------- live log collection ----------------------------------------------------------------------------------------------------
02:26:37 INFO conftest.py:generate_params_dut_hostname:558: DUTs in testbed topology: ['str-s6000-acs-8']
02:26:37 INFO conftest.py:generate_param_asic_index:516: generating num_asics asic indicies for  DUT [[0]] in
02:26:38 INFO conftest.py:generate_param_asic_index:537: dut_index 0 dut name str-s6000-acs-8  asics params = [None]
collected 1 item

bgp/test_bgp_fact.py::test_bgp_facts[str-s6000-acs-8-None]
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
02:26:38 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
02:26:38 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
02:26:50 INFO conftest.py:creds:417: dut str-s6000-acs-8 belongs to groups [u'sonic', 'fanout']
02:26:50 INFO conftest.py:creds:429: skip empty var file ../ansible/group_vars/all/env.yml
02:26:50 INFO conftest.py:creds:429: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
02:26:51 INFO __init__.py:sanity_check:45: Start pre-test sanity check
02:26:51 INFO __init__.py:sanity_check:55: Found marker: m.name=topology, m.args=('any',), m.kwargs={}
02:26:51 INFO __init__.py:sanity_check:55: Found marker: m.name=device_type, m.args=('vs',), m.kwargs={}
02:26:51 INFO __init__.py:sanity_check:89: Sanity check settings: skip_sanity=True, check_items=set(['services', 'bgp', 'interfaces', 'processes', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False
02:26:51 INFO __init__.py:sanity_check:92: Skip sanity check according to command line argument or configuration of test script.
02:26:51 INFO __init__.py:loganalyzer:16: Log analyzer is disabled
PASSED                                                                                                                                                                                                                [100%]

================================================================================================ 1 passed in 107.29 seconds =================================================================================================
arlakshm@6ba71dd9c27a:/data/public/my_repo/sonic-mgmt/tests$
```
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
