### PR TITLE
[Ansible] Fix connection keyword precedence issue

### DIFF
--- a/ansible/roles/test/tasks/check_sw_vm_interfaces.yml
+++ b/ansible/roles/test/tasks/check_sw_vm_interfaces.yml
@@ -44,7 +44,8 @@
     args:
       host: "{{ vms[item]['mgmt_addr'] }}"
       login: "{{ switch_login[hwsku_map[peer_hwsku]] }}"
-    connection: switch
+    vars:
+      ansible_connection: switch
     ignore_errors: yes
     when: vms["{{ item }}"]['hwsku'] == 'Arista-VM'
     with_items: "{{ vms }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The `connection` keyword in playbook `check_sw_vm_interfaces.yml` has
lower precedence than the `ansible_connection` variable defined in
`sonic` group. Use task variable to shadow its counterparts in group
variable files.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes #2387 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
As the description.

#### How did you do it?
Use task variable to override the `ansible_connection` defined in `sonic` group variable files.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
