### PR TITLE
[enumerators] unify naming convention of the parameter enumerators

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -5,12 +5,12 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
-def test_bgp_facts(duthosts, dut_hostname, asic_index):
+def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
-    duthost = duthosts[dut_hostname]
-    bgp_facts =duthost.bgp_facts(instance_id=asic_index)['ansible_facts']
-    namespace = duthost.get_namespace_from_asic_id(asic_index)
+    duthost = duthosts[enum_dut_hostname]
+    bgp_facts =duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
+    namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     config_facts = duthost.config_facts(host=duthost.hostname, source="running",namespace=namespace)['ansible_facts']
 
     for k, v in bgp_facts['bgp_neighbors'].items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import logging
 import string
 import re
 import getpass
+import random
 
 import pytest
 import csv
@@ -608,26 +609,31 @@ def generate_port_lists(request, port_scope):
 def pytest_generate_tests(metafunc):
     # The topology always has atleast 1 dut
     dut_indices = [0]
-    if "dut_index" in metafunc.fixturenames:
+    if "enum_dut_index" in metafunc.fixturenames:
         dut_indices = generate_params_dut_index(metafunc)
-        metafunc.parametrize("dut_index",dut_indices)
-    elif "dut_hostname" in metafunc.fixturenames:  # Fixture "dut_index" and "dut_hostname" should be mutually exclusive
+        metafunc.parametrize("enum_dut_index",dut_indices)
+    elif "enum_dut_hostname" in metafunc.fixturenames:  # Fixture "enum_dut_index" and "enum_dut_hostname" should be mutually exclusive
         dut_hostnames = generate_params_dut_hostname(metafunc)
-        metafunc.parametrize("dut_hostname", dut_hostnames)
-    if "asic_index" in metafunc.fixturenames:
-        metafunc.parametrize("asic_index",generate_param_asic_index(metafunc, dut_indices, ASIC_PARAM_TYPE_ALL))
-    if "frontend_asic_index" in metafunc.fixturenames:
-        metafunc.parametrize("frontend_asic_index",generate_param_asic_index(metafunc, dut_indices, ASIC_PARAM_TYPE_FRONTEND))
+        metafunc.parametrize("enum_dut_hostname", dut_hostnames)
+    elif "rand_one_dut_hostname" in metafunc.fixturenames:  # Fixture "enum_dut_index" and "enum_dut_hostname" should be mutually exclusive
+        dut_hostnames = generate_params_dut_hostname(metafunc)
+        if len(dut_hostnames) > 1:
+            dut_hostnames = random.sample(dut_hostnames, 1)
+        metafunc.parametrize("rand_one_dut_hostname", dut_hostnames)
+    if "enum_asic_index" in metafunc.fixturenames:
+        metafunc.parametrize("enum_asic_index",generate_param_asic_index(metafunc, dut_indices, ASIC_PARAM_TYPE_ALL))
+    if "enum_frontend_asic_index" in metafunc.fixturenames:
+        metafunc.parametrize("enum_frontend_asic_index",generate_param_asic_index(metafunc, dut_indices, ASIC_PARAM_TYPE_FRONTEND))
 
-    if "all_ports" in metafunc.fixturenames:
-        metafunc.parametrize("all_ports", generate_port_lists(metafunc, "all_ports"))
-    if "oper_up_ports" in metafunc.fixturenames:
-        metafunc.parametrize("oper_up_ports", generate_port_lists(metafunc, "oper_up_ports"))
-    if "admin_up_ports" in metafunc.fixturenames:
-        metafunc.parametrize("admin_up_ports", generate_port_lists(metafunc, "admin_up_ports"))
-    if "all_pcs" in metafunc.fixturenames:
-        metafunc.parametrize("all_pcs", generate_port_lists(metafunc, "all_pcs"))
-    if "oper_up_pcs" in metafunc.fixturenames:
-        metafunc.parametrize("oper_up_pcs", generate_port_lists(metafunc, "oper_up_pcs"))
-    if "admin_up_pcs" in metafunc.fixturenames:
-        metafunc.parametrize("admin_up_pcs", generate_port_lists(metafunc, "admin_up_pcs"))
+    if "enum_dut_portname" in metafunc.fixturenames:
+        metafunc.parametrize("enum_dut_portname", generate_port_lists(metafunc, "all_ports"))
+    if "enum_dut_portname_oper_up" in metafunc.fixturenames:
+        metafunc.parametrize("enum_dut_portname_oper_up", generate_port_lists(metafunc, "oper_up_ports"))
+    if "enum_dut_portname_admin_up" in metafunc.fixturenames:
+        metafunc.parametrize("aname_admin_updmin_up_ports", generate_port_lists(metafunc, "admin_up_ports"))
+    if "enum_dut_portchannel" in metafunc.fixturenames:
+        metafunc.parametrize("enum_dut_portchannel", generate_port_lists(metafunc, "all_pcs"))
+    if "enum_dut_portchannel_oper_up" in metafunc.fixturenames:
+        metafunc.parametrize("enum_dut_portchannel_oper_up", generate_port_lists(metafunc, "oper_up_pcs"))
+    if "enum_dut_portchannel_admin_up" in metafunc.fixturenames:
+        metafunc.parametrize("enum_dut_portchannel_admin_up", generate_port_lists(metafunc, "admin_up_pcs"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -609,17 +609,20 @@ def generate_port_lists(request, port_scope):
 def pytest_generate_tests(metafunc):
     # The topology always has atleast 1 dut
     dut_indices = [0]
+
+    # Enumerators ("enum_dut_index", "enum_dut_hostname", "rand_one_dut_hostname") are mutually exclusive
     if "enum_dut_index" in metafunc.fixturenames:
         dut_indices = generate_params_dut_index(metafunc)
         metafunc.parametrize("enum_dut_index",dut_indices)
-    elif "enum_dut_hostname" in metafunc.fixturenames:  # Fixture "enum_dut_index" and "enum_dut_hostname" should be mutually exclusive
+    elif "enum_dut_hostname" in metafunc.fixturenames:
         dut_hostnames = generate_params_dut_hostname(metafunc)
         metafunc.parametrize("enum_dut_hostname", dut_hostnames)
-    elif "rand_one_dut_hostname" in metafunc.fixturenames:  # Fixture "enum_dut_index" and "enum_dut_hostname" should be mutually exclusive
+    elif "rand_one_dut_hostname" in metafunc.fixturenames:
         dut_hostnames = generate_params_dut_hostname(metafunc)
         if len(dut_hostnames) > 1:
             dut_hostnames = random.sample(dut_hostnames, 1)
         metafunc.parametrize("rand_one_dut_hostname", dut_hostnames)
+
     if "enum_asic_index" in metafunc.fixturenames:
         metafunc.parametrize("enum_asic_index",generate_param_asic_index(metafunc, dut_indices, ASIC_PARAM_TYPE_ALL))
     if "enum_frontend_asic_index" in metafunc.fixturenames:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -630,7 +630,7 @@ def pytest_generate_tests(metafunc):
     if "enum_dut_portname_oper_up" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname_oper_up", generate_port_lists(metafunc, "oper_up_ports"))
     if "enum_dut_portname_admin_up" in metafunc.fixturenames:
-        metafunc.parametrize("aname_admin_updmin_up_ports", generate_port_lists(metafunc, "admin_up_ports"))
+        metafunc.parametrize("enum_dut_portname_admin_up", generate_port_lists(metafunc, "admin_up_ports"))
     if "enum_dut_portchannel" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portchannel", generate_port_lists(metafunc, "all_pcs"))
     if "enum_dut_portchannel_oper_up" in metafunc.fixturenames:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -236,10 +236,10 @@ class LagTest:
 @pytest.mark.parametrize("testcase", ["single_lag",
                                       "lacp_rate",
                                       "fallback"])
-def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, conn_graph_facts, all_pcs, testcase):
+def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, conn_graph_facts, enum_dut_portchannel, testcase):
     ptfhost = common_setup_teardown
 
-    dut_name, dut_lag = decode_dut_port_name(all_pcs)
+    dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel)
 
     some_test_ran = False
     for duthost in duthosts:

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -49,13 +49,13 @@ class TestLinkFlap(object):
 
 
 @pytest.mark.platform('physical')
-def test_link_flap(request, duthosts, all_ports, fanouthosts, bring_up_fanout_interfaces):
+def test_link_flap(request, duthosts, enum_dut_portname, fanouthosts, bring_up_fanout_interfaces):
     """
     Validates that link flap works as expected
     """
     tlf = TestLinkFlap(request)
 
-    dutname, portname = decode_dut_port_name(all_ports)
+    dutname, portname = decode_dut_port_name(enum_dut_portname)
     for dut in duthosts:
         if dutname == 'unknown' or dutname == dut.hostname:
             tlf.run_link_flap_test(dut, fanouthosts, portname)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,10 +7,10 @@ pytestmark = [
 ]
 
 # Test Functions
-def test_show_features(duthosts, dut_hostname):
+def test_show_features(duthosts, enum_dut_hostname):
     """Verify show features command output against CONFIG_DB
     """
-    duthost = duthosts[dut_hostname]
+    duthost = duthosts[enum_dut_hostname]
     features_dict, succeeded = duthost.get_feature_status()
     pytest_assert(succeeded, "failed to obtain feature status")
     for cmd_key, cmd_value in features_dict.items():

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -8,10 +8,10 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
-def test_interfaces(duthosts, dut_hostname):
+def test_interfaces(duthosts, enum_dut_hostname):
     """compare the interfaces between observed states and target state"""
 
-    duthost    = duthosts[dut_hostname]
+    duthost    = duthosts[enum_dut_hostname]
     host_facts = duthost.setup()['ansible_facts']
     mg_facts   = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -52,11 +52,11 @@ def check_bgp_facts(hostname, host):
     if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
         return "neighbor {} bgp not configured correctly".format(hostname)
 
-def test_neighbors_health(duthosts, localhost, nbrhosts, eos, dut_hostname):
+def test_neighbors_health(duthosts, localhost, nbrhosts, eos, enum_dut_hostname):
     """Check each neighbor device health"""
 
     fails = []
-    duthost = duthosts[dut_hostname]
+    duthost = duthosts[enum_dut_hostname]
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
     for k, v in nei_meta.items():

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -15,8 +15,8 @@ pytestmark = [
 ]
 
 
-def test_collect_techsupport(duthosts, dut_hostname):
-    duthost = duthosts[dut_hostname]
+def test_collect_techsupport(duthosts, enum_dut_hostname):
+    duthost = duthosts[enum_dut_hostname]
     """
     A util for collecting techsupport after tests.
 
@@ -35,8 +35,8 @@ def test_collect_techsupport(duthosts, dut_hostname):
 
     assert True
 
-def test_restore_container_autorestart(duthosts, dut_hostname):
-    duthost = duthosts[dut_hostname]
+def test_restore_container_autorestart(duthosts, enum_dut_hostname):
+    duthost = duthosts[enum_dut_hostname]
     state_file_name = "/tmp/autorestart_state_{}.json".format(duthost.hostname)
     if not os.path.exists(state_file_name):
         return
@@ -61,8 +61,8 @@ def test_restore_container_autorestart(duthosts, dut_hostname):
     SNMP_RELOADING_TIME = 30
     time.sleep(SNMP_RELOADING_TIME)
 
-def test_recover_rsyslog_rate_limit(duthosts, dut_hostname):
-    duthost = duthosts[dut_hostname]
+def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
+    duthost = duthosts[enum_dut_hostname]
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
         # Something unexpected happened.

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -14,8 +14,8 @@ pytestmark = [
     pytest.mark.disable_loganalyzer
 ]
 
-def test_cleanup_testbed(duthosts, dut_hostname, request, ptfhost):
-    duthost = duthosts[dut_hostname]
+def test_cleanup_testbed(duthosts, enum_dut_hostname, request, ptfhost):
+    duthost = duthosts[enum_dut_hostname]
     deep_clean = request.config.getoption("--deep_clean")
     if deep_clean:
         logger.info("Deep cleaning DUT {}".format(duthost.hostname))
@@ -30,8 +30,8 @@ def test_cleanup_testbed(duthosts, dut_hostname, request, ptfhost):
     if ptfhost:
         ptfhost.shell("if [[ -f /etc/rsyslog.conf ]]; then mv /etc/rsyslog.conf /etc/rsyslog.conf.orig; uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")
 
-def test_disable_container_autorestart(duthosts, dut_hostname):
-    duthost = duthosts[dut_hostname]
+def test_disable_container_autorestart(duthosts, enum_dut_hostname):
+    duthost = duthosts[enum_dut_hostname]
     command_output = duthost.shell("show feature autorestart", module_ignore_errors=True)
     if command_output['rc'] != 0:
         logging.info("Feature autorestart utility not supported. Error: {}".format(command_output['stderr']))
@@ -83,8 +83,8 @@ def test_update_testbed_metadata(duthosts, tbinfo):
         logger.warning('Unable to create file {}: {}'.format(filepath, e))
 
 
-def test_disable_rsyslog_rate_limit(duthosts, dut_hostname):
-    duthost = duthosts[dut_hostname]
+def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
+    duthost = duthosts[enum_dut_hostname]
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
         # Something unexpected happened.


### PR DESCRIPTION
### Description of PR

Summary: unify naming convention of the parameter enumerators.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Due the the ambiguity of parameter enumerators, some testcase has been written with unintended enumeration. Which causes the testcase being executed many times during nightly test.

#### How did you do it?
- Prefix enumerators with enum_ when the parameter is enumerating all  applicable entities.
- Prefix enumerators with rand_ when the parameter is randomly select  some applicable entities.
- Introduce rand_one_dut_hostname to enumerate one randomly chosen  dut hostname.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Tested against test_link_flap, test_lag_2, test_pretest, test_posttest, and test_interfaces.

Tested the new enumerator rand_one_dut_hostname with instrumented code.

All above tests passed.