### PR TITLE
Fix test_show_platform_summary for multi-asic

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -11,7 +11,6 @@ Tests for the `show platform ...` commands in SONiC
 
 import logging
 import re
-import time
 
 import pytest
 
@@ -41,12 +40,13 @@ def test_show_platform_summary(duthost):
     summary_dict = util.parse_colon_speparated_lines(summary_output_lines)
     expected_fields = set(["Platform", "HwSKU", "ASIC"])
     actual_fields = set(summary_dict.keys())
+    new_field = set(["ASIC Count"])
 
     missing_fields = expected_fields - actual_fields
     pytest_assert(len(missing_fields) == 0, "Output missing fields: {}".format(repr(missing_fields)))
 
     unexpected_fields = actual_fields - expected_fields
-    pytest_assert(len(unexpected_fields) == 0, "Unexpected fields in output: {}".format(repr(unexpected_fields)))
+    pytest_assert(((unexpected_fields == new_field) or len(unexpected_fields) == 0), "Unexpected fields in output: {}".format(repr(unexpected_fields)))
 
     # TODO: Test values against platform-specific expected data instead of testing for missing values
     for key in expected_fields:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
A new field ```ASIC Count``` is added to the output of ```show platform summary``` and causes ```test_show_platform_summary``` failed. This PR addresses the issue by adding a new filed.
```
$ show platform summary 
Platform: x86_64-cel_seastone-r0
HwSKU: Celestica-DX010-C32
ASIC: broadcom
ASIC Count: 1
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_show_platform_summary``` for master branch.

#### How did you do it?
Add a new field ```ASIC Count``` and if the unexpected_field is exactly same with the new filed, then ignore it.

#### How did you verify/test it?
Veified on Arista-7260, running a 201911 image and DX010, running a master branch.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --
========================================================================================= test session starts =========================================================================================
collected 1 item                                                                                                                                                                                      

platform_tests/cli/test_show_platform.py::test_show_platform_summary PASSED                                                                                                                     [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
====================================================================================== 1 passed in 12.86 seconds ======================================================================================
```
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util platform_tests/cli/test_show_platform.py::test_show_platform_summary
========================================================================================= test session starts =========================================================================================
collected 1 item                                                                                                                                                                                      

platform_tests/cli/test_show_platform.py::test_show_platform_summary PASSED                                                                                                                     [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
====================================================================================== 1 passed in 12.86 seconds ======================================================================================
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
