### PR TITLE
[vmtopology]: Fix no attribute 'host_ifaces' issue for start/stop vm

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -239,8 +239,7 @@ class VMTopology(object):
         return
 
     def create_ovs_bridge(self, bridge_name, mtu):
-        if bridge_name not in self.host_ifaces:
-            VMTopology.cmd('ovs-vsctl add-br %s' % bridge_name)
+        VMTopology.cmd('ovs-vsctl --may-exist add-br %s' % bridge_name)
 
         if mtu != DEFAULT_MTU:
             VMTopology.cmd('ifconfig %s mtu %d' % (bridge_name, mtu))
@@ -250,17 +249,16 @@ class VMTopology(object):
         return
 
     def destroy_bridges(self):
+        host_ifaces = VMTopology.ifconfig('ifconfig -a')
         for vm in self.vm_names:
-            for ifname in self.host_ifaces:
+            for ifname in host_ifaces:
                 if re.compile(OVS_FP_BRIDGE_REGEX % vm).match(ifname):
                     self.destroy_ovs_bridge(ifname)
 
         return
 
     def destroy_ovs_bridge(self, bridge_name):
-        if bridge_name in self.host_ifaces:
-            VMTopology.cmd('ifconfig %s down' % bridge_name)
-            VMTopology.cmd('ovs-vsctl del-br %s' % bridge_name)
+        VMTopology.cmd('ovs-vsctl --if-exists del-br %s' % bridge_name)
 
         return
 


### PR DESCRIPTION
### Description of PR
In the #2446 , it already removed to get host_ifaces from __init__ method.
For `create_bridge` method, the host_ifaces is not necessary can use the ovs
argument `--may-exist` to check the bridge existed case

For `destroy_bridge` method, it can use local varilabe to record the host_ifaces,
And can use the `--if-exists` argument to checkt bridge existed case

Signed-off-by: Gord Chen <gord_chen@edge-core.com>

Summary:
Fixes #2498 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix #2498 

#### How did you do it?
Test Start/Stop VM to reproduce

#### How did you verify/test it?
Test Start/Stop VM and verify the ovs bridges are success to create/destroy

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
