### PR TITLE
test bgp facts - skip for supervisor card in a SONiC chassis

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -13,7 +13,7 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     # Check if duthost is 'supervisor' card based on 'type' defined in inventory, and skip the test if dealing with supervisor card.
     host_vars = duthost.sonichost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()
     if 'type' in host_vars and host_vars['type'] == 'supervisor':
-        pytest.skip("bgp_facts not valid on supervisor card")
+        pytest.skip("bgp_facts not valid on supervisor card '%s'" % enum_dut_hostname)
 
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -10,9 +10,8 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
 
     duthost = duthosts[enum_dut_hostname]
 
-    # Check if duthost is 'supervisor' card based on 'type' defined in inventory, and skip the test if dealing with supervisor card.
-    host_vars = duthost.sonichost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()
-    if 'type' in host_vars and host_vars['type'] == 'supervisor':
+    # Check if duthost is 'supervisor' card, and skip the test if dealing with supervisor card.
+    if duthosts.is_supervisor_node(duthost):
         pytest.skip("bgp_facts not valid on supervisor card '%s'" % enum_dut_hostname)
 
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -9,7 +9,13 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
     duthost = duthosts[enum_dut_hostname]
-    bgp_facts =duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
+
+    # Check if duthost is 'supervisor' card based on 'type' defined in inventory, and skip the test if dealing with supervisor card.
+    host_vars = duthost.sonichost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()
+    if 'type' in host_vars and host_vars['type'] == 'supervisor':
+        pytest.skip("bgp_facts not valid on supervisor card")
+
+    bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     config_facts = duthost.config_facts(host=duthost.hostname, source="running",namespace=namespace)['ansible_facts']
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1648,8 +1648,8 @@ class DutHosts(object):
         """
         # TODO: Initialize the nodes in parallel using multi-threads?
         self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname) for hostname in tbinfo["duts"]])
-        self.supervisor_nodes = self._Nodes([node for node in self.nodes if self._is_supervisor_node(node)])
-        self.frontend_nodes = self._Nodes([node for node in self.nodes if self._is_frontend_node(node)])
+        self.supervisor_nodes = self._Nodes([node for node in self.nodes if self.is_supervisor_node(node)])
+        self.frontend_nodes = self._Nodes([node for node in self.nodes if self.is_frontend_node(node)])
 
     def __getitem__(self, index):
         """To support operations like duthosts[0] and duthost['sonic1_hostname']
@@ -1706,7 +1706,7 @@ class DutHosts(object):
         """
         return getattr(self.nodes, attr)
 
-    def _is_supervisor_node(self, node):
+    def is_supervisor_node(self, node):
         """ Is node a supervisor node
 
         Args:
@@ -1723,7 +1723,7 @@ class DutHosts(object):
                 return True
         return False
 
-    def _is_frontend_node(self, node):
+    def is_frontend_node(self, node):
         """ Is not a frontend node
         Args:
             node: MultiAsicSonicHost object represent a DUT in the testbed.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In a SONiC chassis, we have 'supervisor' cards (control cards) that are not running 'bgp' dockers.

If we use the multi-DUT approach, we are including the 'supervisor' card as well in the list of DUTs. Thus, test_bgp_facts gets run on 'supervisor' card as well.

We need to skip the test when duthost is a 'supervisor' card.

#### How did you do it?

A card is identified as a 'supervisor' card, if it has a 'type' field in its host vars in the ansible inventory that is set to 'supervisor'.
We use this check to figure out if the test is to be skipped.

#### How did you verify/test it?

Ran test_bgp_facts against a SONiC chassis with two linecards (board1, board2) and a supervisor card (supervisor1). Results summary below:

```
============================================================================== short test summary info ==============================================================================
PASSED ../tests/bgp/test_bgp_fact.py::test_bgp_facts[board1-None]
PASSED ../tests/bgp/test_bgp_fact.py::test_bgp_facts[board2-None]
SKIPPED [1] /data/tests/bgp/test_bgp_fact.py:17: bgp_facts not valid on supervisor card 'supervisor1'
=================================================================== 2 passed, 1 skipped in 83.83 seconds ===================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
