### PR TITLE
[multi-asic] Updated acl_facts

### DIFF
--- a/ansible/library/acl_facts.py
+++ b/ansible/library/acl_facts.py
@@ -116,6 +116,8 @@
 # }
 
 from ansible.module_utils.basic import *
+from collections import defaultdict
+from sonic_py_common import multi_asic
 
 
 DOCUMENTATION = '''
@@ -162,29 +164,44 @@ def get_acl_rule_counters(module):
     @param module: The AnsibleModule object
     @return: Return ACL rule counters data in dict
     """
-    rc, stdout, stderr = module.run_command('aclshow -a')
-    if rc != 0:
-        module.fail_json(msg='Failed to get acl counter data, rc=%s, stdout=%s, stderr=%s' % (rc, stdout, stderr))
-
+    counter_aggrgeate_map = defaultdict(list)
     counters = []
-    output_lines = stdout.splitlines()[2:]  # Skip the header lines in output
-    for line in output_lines:
-        line_expanded = line.split()
-        if len(line_expanded) == 5:
-            try:
-                packets_count = int(line_expanded[3])
-            except ValueError:
-                packets_count = 0
-            try:
-                bytes_count = int(line_expanded[4])
-            except ValueError:
-                bytes_count = 0
-            counter = dict(rule_name=line_expanded[0],
-                           table_name=line_expanded[1],
-                           priority=line_expanded[2],
-                           packets_count=packets_count,
-                           bytes_count=bytes_count)
-            counters.append(counter)
+
+    namespace_list = multi_asic.get_namespace_list()
+    for ns in namespace_list:
+        cmd = 'sudo ip netns exec {} '.format(ns) if ns else ''
+        rc, stdout, stderr = module.run_command(cmd + 'aclshow -a')
+        if rc != 0:
+            module.fail_json(msg='Failed to get acl counter data, rc=%s, stdout=%s, stderr=%s' % (rc, stdout, stderr))
+        
+        output_lines = stdout.splitlines()[2:]  # Skip the header lines in output
+        for line in output_lines:
+            line_expanded = line.split()
+            if len(line_expanded) == 5:
+                try:
+                    packets_count = int(line_expanded[3])
+                except ValueError:
+                    packets_count = 0
+                try:
+                    bytes_count = int(line_expanded[4])
+                except ValueError:
+                    bytes_count = 0
+
+                key = (line_expanded[0],line_expanded[1],line_expanded[2])
+                if key in counter_aggrgeate_map:
+                     counter_aggrgeate_map[key][0] = packets_count + counter_aggrgeate_map[key][0]
+                     counter_aggrgeate_map[key][1] = bytes_count + counter_aggrgeate_map[key][1]
+                else:
+                     counter_aggrgeate_map[key].append(packets_count)
+                     counter_aggrgeate_map[key].append(bytes_count)
+
+    for k, v in counter_aggrgeate_map.items():
+         counter = dict(rule_name=k[0],
+                       table_name=k[1],
+                       priority=k[2],
+                       packets_count=v[0],
+                       bytes_count=v[1])
+         counters.append(counter)
 
     return counters
 


### PR DESCRIPTION
What I did:-
Enhance ACL Facts to support multi-asic platforms.

How I did:

- ACL Fact read ACL Rules counters information for all network namespaces (if multi-asic platform) and aggregate them else read from host namespace.

- ACL Rules counters are maintained as dictionary of tuple (rule_name, table_name, priority) and counters for this same tuple are aggregated from each asic.

- The library is not enhanced to take asic-index (not needed as of now ) but to provide to global ACL rule counter  view to user/application.

How I verify:-
Verified for both Single Asic and Multi Asic platforms.
ACL Fact Output remain same as before this change.