### PR TITLE
[upgrade_sonic] Support upgrading all DUTs in testbed

### DIFF
--- a/ansible/upgrade_sonic.yml
+++ b/ansible/upgrade_sonic.yml
@@ -4,11 +4,51 @@
 #   ansible-playbook upgrade_sonic.yml -i lab -l devicename -e "upgrade_type=sonic" -e "image_url='http://8.8.8.8/sonic-broadcom.bin'"
 # upgrade via onie:
 #   ansible-playbook upgrade_sonic.yml -i lab -l devicename -e "upgrade_type=onie" -e "image_url='http://8.8.8.8/sonic-broadcom.bin'"
-
+# upgrade DUTs listed in testbed
+#   ansible-playbook upgrade-sonic.yaml -i lab -e "testbed_name=vms1-1" -e "testbed_file=testbed.csv" -e "upgrade_type=onie" -e "image_url='http://8.8.8.8/sonic-broadcom.bin'"
 - hosts: all
   gather_facts: no
   tasks:
 
+    - name: Add DUTs defined in testbed
+      block:
+        - name: Set default testbed file
+          set_fact:
+            testbed_file: testbed.csv
+          when: testbed_file is not defined
+
+        - name: Gather testbed information
+          test_facts:
+            testbed_name: "{{ testbed_name }}"
+            testbed_file: "{{ testbed_file }}"
+
+        - name: Stop upgrade if the target DUT doesn't belong to the testbed
+          fail: msg="The upgrade target doesn't belong to the testbed {{ testbed_name }}"
+          when: ansible_play_hosts | length == 1 and inventory_hostname not in testbed_facts['duts']
+
+        - name: Create upgrade targets group
+          add_host:
+            name: "{{ item }}"
+            groups: upgrade_targets
+          loop: "{{ testbed_facts['duts'] }}"
+      delegate_to: localhost
+      run_once: True
+      when:
+        - testbed_name is defined
+
+    - name: Add DUTs if no testbed present
+      add_host:
+        name: "{{ item }}"
+        groups: upgrade_targets
+      loop: "{{ ansible_play_hosts }}"
+      delegate_to: localhost
+      run_once: True
+      when:
+        - testbed_name is not defined
+
+- hosts: upgrade_targets
+  gather_facts: no
+  tasks:
     - set_fact:
         real_ansible_host: "{{ ansible_ssh_host }}"
 
@@ -63,7 +103,7 @@
 
         # Reboot may need some time to update firmware firstly.
         # Increasing the async time to 300 seconds to avoid reboot being interrupted.
-        - name: Reboot the switch {{ inventory_hostname }}
+        - name: Reboot switch
           become: true
           shell: reboot
           async: 300
@@ -73,7 +113,7 @@
       when: upgrade_type == "sonic"
 
     # Delay 180 seconds to wait for firmware updating before reboot, then start polling switch
-    - name: Wait for switch {{ inventory_hostname }} to come back (to SONiC)
+    - name: Wait for switch to come back (to SONiC)
       local_action: wait_for
       args:
         host: "{{ real_ansible_host }}"


### PR DESCRIPTION
Add support of extra param `testbed_name` and `testbed_file`, and
`upgrade_sonic.yml` will upgrade the DUTs listed in the testbed entry
specified by `testbed_name`.

1. Support previous usage, use `-l` to limit the DUTs.
2. Support use extra variable `testbed_name` to upgrade all DUTs defined
in this testbed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Better fit multi-DUT usage.

#### How did you do it?
Dynamically create a host group `upgrade_targets` from the DUTs listed in the testbed by `testbed_name` in the first play.
And limit the second upgrade play with the hosts in group `upgrade_targets`.

#### How did you verify/test it?
Run `upgrade_sonic.py` to upgrade dual-tor testbed:
```
PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************
acs-devrepo.corp.microsoft.com : ok=2    changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
str2-7050cx3-acs-08        : ok=9    changed=3    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0
str2-7050cx3-acs-09        : ok=8    changed=3    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0

Thursday 12 November 2020  10:34:23 +0000 (0:00:15.465)       0:08:37.223 *****
===============================================================================
Remove some old sonic image(s) and install new image ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 256.15s
Wait for switch to come back (to SONiC) ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 180.38s
Wait for SONiC initialization ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 60.04s
Remove some old sonic image(s) after installing new image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 15.47s
Set all bgp interfaces admin-up --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.90s
save bgp admin-up states ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.24s
Reboot switch --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.69s
Create upgrade targets group ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.38s
Gather testbed information -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.35s
Wait for switch to come back (to ONIE) -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.05s
fail ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.05s
define disk_used_pcent if not defined --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.05s
set_fact -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.05s
Reboot into ONIE ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.05s
Install SONiC image in ONIE ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.05s
Set next boot device to ONIE ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.05s
Stop upgrade if the target DUT doesn't belong to the testbed ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.04s
Pause {{pause_time}} seconds for ONIE initialization ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.04s
Set default testbed file ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.04s
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
