### PR TITLE
[testbed] don't silently prefer testbed.yaml over testbed.csv

### DIFF
--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -6,7 +6,6 @@ import argparse
 import csv
 import ipaddr as ipaddress
 import json
-import logging
 import os
 import re
 import string

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -23,11 +23,11 @@ class TestbedInfo(object):
     def __init__(self, testbed_file):
         if testbed_file.endswith(".csv"):
             self.testbed_filename = testbed_file
+            self.testbed_yamlfile = testbed_file.replace(".csv", ".yaml")
             """
             TODO: don't give preference to yaml unless specified explicitly.
                   we need to make sure the ansible tasks are also can use
                   testbed.yaml first.
-            self.testbed_yamlfile = testbed_file.replace(".csv", ".yaml")
             logging.warn(
                 "Deprecated CSV format testbed file, please use yaml file"
                 )

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -23,6 +23,11 @@ class TestbedInfo(object):
 
     def __init__(self, testbed_file):
         if testbed_file.endswith(".csv"):
+            self.testbed_filename = testbed_file
+            """
+            TODO: don't give preference to yaml unless specified explicitly.
+                  we need to make sure the ansible tasks are also can use
+                  testbed.yaml first.
             self.testbed_yamlfile = testbed_file.replace(".csv", ".yaml")
             logging.warn(
                 "Deprecated CSV format testbed file, please use yaml file"
@@ -32,8 +37,7 @@ class TestbedInfo(object):
                     "Use yaml testbed file: %s", self.testbed_yamlfile
                     )
                 self.testbed_filename = self.testbed_yamlfile
-            else:
-                self.testbed_filename = testbed_file
+            """
         elif testbed_file.endswith(".yaml"):
             self.testbed_filename = testbed_file
         else:


### PR DESCRIPTION
Summary:
Use testbed file specified in command line

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Ansible playbook tasks are not ready for [v]testbed.yaml yet. Need to update these tasks before moving fully to testbed.yaml.

#### How did you do it?
For the time being, still generate testbed.yaml from testbed.csv when testbed.csv is used. But don't silently prefer testbed.yaml. This way we give everyone a chance to check in the updated testbed.yaml without breaking the test.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
