### PR TITLE
[pfcwd] use Ethernet0 mac as router mac.

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -258,15 +258,15 @@ class SetupPfcwdFunc(object):
 
 class SendVerifyTraffic():
     """ PTF test """
-    def __init__(self, ptf, eth0_mac, pfc_params):
+    def __init__(self, ptf, router_mac, pfc_params):
         """
         Args:
             ptf(AnsibleHost) : ptf instance
-            eth0_mac(string) : mac addr of eth0
+            router_mac(string) : router mac address
             ptf_params(dict) : all PFC test params specific to the DUT port
         """
         self.ptf = ptf
-        self.eth0_mac = eth0_mac
+        self.router_mac = Ethernet0_mac
         self.pfc_queue_index = pfc_params['queue_index']
         self.pfc_wd_test_pkt_count = pfc_params['test_pkt_count']
         self.pfc_wd_rx_port_id = pfc_params['rx_port_id']
@@ -289,7 +289,7 @@ class SendVerifyTraffic():
         dst_port = "[" + str(self.pfc_wd_test_port_id) + "]"
         if action == "forward" and  type(self.pfc_wd_test_port_ids) == list:
                 dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
@@ -315,7 +315,7 @@ class SendVerifyTraffic():
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,
@@ -337,7 +337,7 @@ class SendVerifyTraffic():
             dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_test_port_ids) + " ]"
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.pfc_queue_index - 1,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
@@ -359,7 +359,7 @@ class SendVerifyTraffic():
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.pfc_queue_index - 1,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,
@@ -377,7 +377,7 @@ class SendVerifyTraffic():
         Send traffic to fill up the buffer. No verification
         """
         logger.info("Send packets to {} to fill up the buffer".format(self.pfc_wd_test_port))
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
@@ -529,7 +529,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              logger.info("")
              logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)
-             self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['ansible_eth0']['macaddress'], self.pfc_wd)
+             self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['ansible_Ethernet0']['macaddress'], self.pfc_wd)
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -520,7 +520,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
         self.neighbors = setup_info['neighbors']
-        dut_facts = self.dut.setup()['ansible_facts']
+        dut_facts = self.dut.facts
         self.peer_dev_list = dict()
         self.fake_storm = request.config.getoption("--fake-storm")
 
@@ -529,7 +529,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              logger.info("")
              logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)
-             self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['ansible_Ethernet0']['macaddress'], self.pfc_wd)
+             self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd)
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -266,7 +266,7 @@ class SendVerifyTraffic():
             ptf_params(dict) : all PFC test params specific to the DUT port
         """
         self.ptf = ptf
-        self.router_mac = Ethernet0_mac
+        self.router_mac = router_mac
         self.pfc_queue_index = pfc_params['queue_index']
         self.pfc_wd_test_pkt_count = pfc_params['test_pkt_count']
         self.pfc_wd_rx_port_id = pfc_params['rx_port_id']

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -452,7 +452,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         self.timers = setup_info['pfc_timers']
         self.ports = setup_info['selected_test_ports']
         self.neighbors = setup_info['neighbors']
-        dut_facts = self.dut.setup()['ansible_facts']
+        dut_facts = self.dut.facts
         self.peer_dev_list = dict()
         self.seed = int(datetime.datetime.today().day)
         self.storm_handle = dict()
@@ -500,7 +500,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                         else:
                             self.oid_map[(port, queue)] = PfcCmd.get_queue_oid(self.dut, port, queue)
 
-                    self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['ansible_Ethernet0']['macaddress'], self.pfc_wd, queue)
+                    self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd, queue)
                     self.run_test(port, queue, detect=(bitmask & 1),
                                   storm_start=not t_idx or storm_deferred or storm_restored,
                                   first_detect_after_wb=(t_idx == 2 and not p_idx and not q_idx and not storm_deferred),

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -185,16 +185,16 @@ class SetupPfcwdFunc(object):
 
 class SendVerifyTraffic(object):
     """ PTF test """
-    def __init__(self, ptf, eth0_mac, pfc_params, queue):
+    def __init__(self, ptf, router_mac, pfc_params, queue):
         """
         Args:
             ptf(AnsibleHost) : ptf instance
-            eth0_mac(string) : mac addr of eth0
+            router_mac(string) : router mac address
             ptf_params(dict) : all PFC test params specific to the DUT port
             queue(int): queue to check the wd action
         """
         self.ptf = ptf
-        self.eth0_mac = eth0_mac
+        self.router_mac = router_mac
         self.pfc_wd_test_pkt_count = pfc_params['test_pkt_count']
         self.pfc_wd_rx_port_id = pfc_params['rx_port_id']
         self.pfc_wd_test_port =  pfc_params['test_port']
@@ -217,7 +217,7 @@ class SendVerifyTraffic(object):
         dst_port = "[" + str(self.pfc_wd_test_port_id) + "]"
         if wd_action == "forward" and  type(self.pfc_wd_test_port_ids) == list:
             dst_port = "".join(str(self.pfc_wd_test_port_ids)).replace(',', '')
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.queue,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_rx_port_id[0],
@@ -243,7 +243,7 @@ class SendVerifyTraffic(object):
             dst_port = "".join(str(self.pfc_wd_rx_port_id)).replace(',', '')
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"
-        ptf_params = {'router_mac': self.eth0_mac,
+        ptf_params = {'router_mac': self.router_mac,
                       'queue_index': self.queue,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,
@@ -500,7 +500,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                         else:
                             self.oid_map[(port, queue)] = PfcCmd.get_queue_oid(self.dut, port, queue)
 
-                    self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['ansible_eth0']['macaddress'], self.pfc_wd, queue)
+                    self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['ansible_Ethernet0']['macaddress'], self.pfc_wd, queue)
                     self.run_test(port, queue, detect=(bitmask & 1),
                                   storm_start=not t_idx or storm_deferred or storm_restored,
                                   first_detect_after_wb=(t_idx == 2 and not p_idx and not q_idx and not storm_deferred),


### PR DESCRIPTION
Some platforms do not use management port mac
as router mac, instead they use mac from different
source. This change uses Ethernet0 mac address as
router mac which should work for all platforms.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
