### PR TITLE
[pytest] Skip ‘dsserve’ process in syncd when testing autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -347,8 +347,10 @@ def test_containers_autorestart(duthosts, rand_one_dut_hostname, tbinfo):
 
         for critical_process in critical_process_list:
             # Skip 'dsserve' process since it was not managed by supervisord
+            # TODO: Should remove the following two lines once the issue was solved in the image.
             if container_name == "syncd" and critical_process == "dsserve":
                 continue
+
             program_status, program_pid = get_program_info(duthost, container_name, critical_process)
             verify_autorestart_with_critical_process(duthost, container_name, critical_process,
                                                      program_status, program_pid)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -346,6 +346,7 @@ def test_containers_autorestart(duthosts, rand_one_dut_hostname, tbinfo):
             pytest.fail("Failed to get critical group and process lists of container '{}'".format(container_name))
 
         for critical_process in critical_process_list:
+            # Skip 'dsserve' process since it was not managed by supervisord
             if container_name == "syncd" and critical_process == "dsserve":
                 continue
             program_status, program_pid = get_program_info(duthost, container_name, critical_process)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -346,6 +346,8 @@ def test_containers_autorestart(duthosts, rand_one_dut_hostname, tbinfo):
             pytest.fail("Failed to get critical group and process lists of container '{}'".format(container_name))
 
         for critical_process in critical_process_list:
+            if container_name == "syncd" and critical_process == "dsserve":
+                continue
             program_status, program_pid = get_program_info(duthost, container_name, critical_process)
             verify_autorestart_with_critical_process(duthost, container_name, critical_process,
                                                      program_status, program_pid)


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the `critical_processes` file of syncd container, `dsserve` was the first critical process. The pytest script will read this file to get the first critical processes and check its PID, running status by retrieving the result of command `docker exec syncd supervisorctl status`. Since `dsserve` process was not managed by supervisord, the pytest script can not verify the PID and running status of `dsserve` process, then fail.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In the `critical_processes` file of `syncd` container, `dsserve` was the first critical process. The pytest script will read this file to get the first critical processes and check its PID, running status by retrieving the result of command `docker exec syncd supervisorctl status`. Since `dsserve` process was not managed by supervisord, the pytest script can not verify the PID and running status of `dsserve` process, then fail.

#### How did you do it?
The script will skip the `dsserve` process in `syncd` container during the testing the autorestart feature.

#### How did you verify/test it?
I tested this change on the virtual testbed and also against the lab device `str-dx010-acs-1`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
