### PR TITLE
[autorestart] parametize autorestart test

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -9,6 +9,9 @@ import pytest
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.dut_ports import decode_dut_port_name
+from tests.common import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -152,8 +155,7 @@ def get_disabled_container_list(duthost):
     disabled_containers = []
 
     container_status, succeeded = duthost.get_feature_status()
-    if not succeeded:
-        pytest.fail("Failed to get status ('enabled'|'disabled') of containers. Exiting...")
+    pytest_assert(succeeded, "Failed to get status ('enabled'|'disabled') of containers. Exiting...")
 
     for container_name, status in container_status.items():
         if status == "disabled":
@@ -187,8 +189,7 @@ def kill_process_by_pid(duthost, container_name, program_name, program_pid):
 
     # Get the exit code of 'kill' command
     exit_code = kill_cmd_result["rc"]
-    if exit_code != 0:
-        pytest.fail("Failed to stop program '{}' before test".format(program_name))
+    pytest_assert(exit_code == 0, "Failed to stop program '{}' before test".format(program_name))
 
     logger.info("Program '{}' in container '{}' was stopped successfully"
                 .format(program_name, container_name))
@@ -305,83 +306,99 @@ def postcheck_critical_processes_status(duthost, container_autorestart_states):
                              "Post checking the healthy of critical processes failed.")
 
 
-def test_containers_autorestart(duthosts, rand_one_dut_hostname, tbinfo):
+def run_test_on_single_container(duthost, container_name, tbinfo):
+    container_autorestart_states = duthost.get_container_autorestart_states()
+    disabled_containers = get_disabled_container_list(duthost)
+
+    skip_condition = disabled_containers[:]
+    skip_condition.append("database")
+    if tbinfo["topo"]["type"] != "t0":
+        skip_condition.append("radv")
+
+    # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
+    pytest_require(container_name not in skip_condition,
+                   "Skipping test for container {}".format(container_name))
+
+    is_running = is_container_running(duthost, container_name)
+    pytest_assert(is_running, "Container '{}' is not running. Exiting...".format(container_name))
+
+    bgp_neighbors = duthost.get_bgp_neighbors()
+    up_bgp_neighbors = [ k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established" ]
+
+    logger.info("Start testing the container '{}'...".format(container_name))
+
+    restore_disabled_state = False
+    if container_autorestart_states[container_name] == "disabled":
+        logger.info("Change auto-restart state of container '{}' to be 'enabled'".format(container_name))
+        duthost.shell("sudo config feature autorestart {} enabled".format(container_name))
+        restore_disabled_state = True
+
+    # Currently we select 'rsyslogd' as non-critical processes for testing based on
+    # the assumption that every container has an 'rsyslogd' process running and it is not
+    # considered to be a critical process
+    program_status, program_pid = get_program_info(duthost, container_name, "rsyslogd")
+    verify_no_autorestart_with_non_critical_process(duthost, container_name, "rsyslogd",
+                                                    program_status, program_pid)
+
+    critical_group_list, critical_process_list, succeeded = duthost.get_critical_group_and_process_lists(container_name)
+    pytest_assert(succeeded, "Failed to get critical group and process lists of container '{}'".format(container_name))
+
+    for critical_process in critical_process_list:
+        # Skip 'dsserve' process since it was not managed by supervisord
+        # TODO: Should remove the following two lines once the issue was solved in the image.
+        if container_name == "syncd" and critical_process == "dsserve":
+            continue
+
+        program_status, program_pid = get_program_info(duthost, container_name, critical_process)
+        verify_autorestart_with_critical_process(duthost, container_name, critical_process,
+                                                 program_status, program_pid)
+        # Sleep 20 seconds in order to let the processes come into live after container is restarted.
+        # We will uncomment the following line once the "extended" mode is added
+        # time.sleep(20)
+        # We are currently only testing one critical process, that is why we use 'break'. Once
+        # we add the "extended" mode, we will remove this statement
+        break
+
+    for critical_group in critical_group_list:
+        group_program_info = get_group_program_info(duthost, container_name, critical_group)
+        for program_name in group_program_info:
+            verify_autorestart_with_critical_process(duthost, container_name, program_name,
+                                                     group_program_info[program_name][0],
+                                                     group_program_info[program_name][1])
+            # We are currently only testing one critical program for each critical group, which is
+            # why we use 'break' statement. Once we add the "extended" mode, we will remove this
+            # statement
+            break
+
+    # After these two containers are restarted, we need wait to give their dependent containers
+    # a chance to restart
+    if container_name in ["syncd", "swss"]:
+        logger.info("Sleep 20 seconds after testing the container '{}'...".format(container_name))
+        time.sleep(20)
+
+    if restore_disabled_state:
+        logger.info("Restore auto-restart state of container '{}' to 'disabled'".format(container_name))
+        duthost.shell("sudo config feature autorestart {} disabled".format(container_name))
+
+    logger.info("End of testing the container '{}'".format(container_name))
+
+    postcheck_critical_processes_status(duthost, container_autorestart_states)
+
+    if not duthost.check_bgp_session_state(up_bgp_neighbors, "established"):
+        config_reload(duthost)
+        pytest.fail("Some BGP sessions went down after testing feature {}".format(container_name))
+
+
+def test_containers_autorestart(duthosts, enum_dut_feature, rand_one_dut_hostname, tbinfo):
     """
     @summary: Test the auto-restart feature of each container against two scenarios: killing
               a non-critical process to verify the container is still running; killing each
               critical process to verify the container will be stopped and restarted
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    container_autorestart_states = duthost.get_container_autorestart_states()
-    disabled_containers = get_disabled_container_list(duthost)
+    dut_name, feature = decode_dut_port_name(enum_dut_feature)
+    pytest_require(dut_name == rand_one_dut_hostname and feature != "unknown",
+                   "Skip test on dut host {} (chosen {}) feature {}".format(dut_name, rand_one_dut_hostname, feature))
 
-    for container_name in container_autorestart_states.keys():
-        # Skip testing the database container, radv container on T1 devices and containers/services which are disabled
-        if (container_name in disabled_containers or container_name == "database"
-                or (container_name == "radv" and tbinfo["topo"]["type"] != "t0")):
-            logger.warning("Skip testing the container '{}'".format(container_name))
-            continue
+    duthost = duthosts[dut_name]
+    run_test_on_single_container(duthost, feature, tbinfo)
 
-        is_running = is_container_running(duthost, container_name)
-        if not is_running:
-            pytest.fail("Container '{}' is not running. Exiting...".format(container_name))
-
-        logger.info("Start testing the container '{}'...".format(container_name))
-
-        restore_disabled_state = False
-        if container_autorestart_states[container_name] == "disabled":
-            logger.info("Change auto-restart state of container '{}' to be 'enabled'".format(container_name))
-            duthost.shell("sudo config feature autorestart {} enabled".format(container_name))
-            restore_disabled_state = True
-
-        # Currently we select 'rsyslogd' as non-critical processes for testing based on
-        # the assumption that every container has an 'rsyslogd' process running and it is not
-        # considered to be a critical process
-        program_status, program_pid = get_program_info(duthost, container_name, "rsyslogd")
-        verify_no_autorestart_with_non_critical_process(duthost, container_name, "rsyslogd",
-                                                        program_status, program_pid)
-
-        critical_group_list, critical_process_list, succeeded = duthost.get_critical_group_and_process_lists(container_name)
-        if not succeeded:
-            pytest.fail("Failed to get critical group and process lists of container '{}'".format(container_name))
-
-        for critical_process in critical_process_list:
-            # Skip 'dsserve' process since it was not managed by supervisord
-            # TODO: Should remove the following two lines once the issue was solved in the image.
-            if container_name == "syncd" and critical_process == "dsserve":
-                continue
-
-            program_status, program_pid = get_program_info(duthost, container_name, critical_process)
-            verify_autorestart_with_critical_process(duthost, container_name, critical_process,
-                                                     program_status, program_pid)
-            # Sleep 20 seconds in order to let the processes come into live after container is restarted.
-            # We will uncomment the following line once the "extended" mode is added
-            # time.sleep(20)
-            # We are currently only testing one critical process, that is why we use 'break'. Once
-            # we add the "extended" mode, we will remove this statement
-            break
-
-        for critical_group in critical_group_list:
-            group_program_info = get_group_program_info(duthost, container_name, critical_group)
-            for program_name in group_program_info:
-                verify_autorestart_with_critical_process(duthost, container_name, program_name,
-                                                         group_program_info[program_name][0],
-                                                         group_program_info[program_name][1])
-                # We are currently only testing one critical program for each critical group, which is
-                # why we use 'break' statement. Once we add the "extended" mode, we will remove this
-                # statement
-                break
-
-        # After these two containers are restarted, we need wait to give their dependent containers
-        # a chance to restart
-        if container_name in ["syncd", "swss"]:
-            logger.info("Sleep 20 seconds after testing the container '{}'...".format(container_name))
-            time.sleep(20)
-
-        if restore_disabled_state:
-            logger.info("Restore auto-restart state of container '{}' to 'disabled'".format(container_name))
-            duthost.shell("sudo config feature autorestart {} disabled".format(container_name))
-
-        logger.info("End of testing the container '{}'".format(container_name))
-
-    postcheck_critical_processes_status(duthost, container_autorestart_states)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -2,7 +2,6 @@
 Test the auto-restart feature of containers
 """
 import logging
-import time
 from collections import defaultdict
 
 import pytest

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -39,6 +39,7 @@ try:
 except Exception as e:
     logging.error("Hack for https://github.com/ansible/pytest-ansible/issues/47 failed: {}".format(repr(e)))
 
+logger = logging.getLogger(__name__)
 
 class AnsibleHostBase(object):
     """
@@ -1666,13 +1667,13 @@ class DutHosts(object):
         """
         if type(index) == int:
             return self.nodes[index]
-        elif type(index) == str:
+        elif type(index) in [ str, unicode ]:
             for node in self.nodes:
                 if node.hostname == index:
                     return node
             raise KeyError("No node has hostname '{}'".format(index))
         else:
-            raise IndexError("Bad index '{}'".format(index))
+            raise IndexError("Bad index '{}' type {}".format(index, type(index)))
 
     # Below method are to support treating an instance of DutHosts as a list
     def __iter__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -603,6 +603,35 @@ def generate_port_lists(request, port_scope):
     return ret if ret else empty
 
 
+def generate_dut_feature_list(request):
+    empty = [ encode_dut_port_name('unknown', 'unknown') ]
+
+    tbname = request.config.getoption("--testbed")
+    if not tbname:
+        return empty
+
+    folder = 'metadata'
+    filepath = os.path.join(folder, tbname + '.json')
+
+    try:
+        with open(filepath, 'r') as yf:
+            metadata = json.load(yf)
+    except IOError as e:
+        return empty
+
+    if tbname not in metadata:
+        return empty
+
+    meta = metadata[tbname]
+    ret = []
+    for dut, val in meta.items():
+        if 'features' not in val:
+            continue
+        for feature, _ in val['features'].items():
+            ret.append(encode_dut_port_name(dut, feature))
+
+    return ret if ret else empty
+
 def pytest_generate_tests(metafunc):
     # The topology always has atleast 1 dut
     dut_indices = [0]
@@ -632,3 +661,6 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("enum_dut_portchannel_oper_up", generate_port_lists(metafunc, "oper_up_pcs"))
     if "enum_dut_portchannel_admin_up" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portchannel_admin_up", generate_port_lists(metafunc, "admin_up_pcs"))
+
+    if "enum_dut_feature" in metafunc.fixturenames:
+        metafunc.parametrize("enum_dut_feature", generate_dut_feature_list(metafunc))

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -41,7 +41,8 @@ def test_disable_container_autorestart(duthosts, enum_dut_hostname, disable_cont
 
 def collect_dut_info(dut):
     status = dut.show_interface(command='status')['ansible_facts']['int_status']
-    return { 'intf_status' : status }
+    features, _ = dut.get_feature_status()
+    return { 'intf_status' : status, 'features' : features }
 
 
 def test_update_testbed_metadata(duthosts, tbinfo):


### PR DESCRIPTION
### Description of PR
Summary:
Improve autorestart test.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
autorestart test run test in a loop for multiple containers. We don't get to see which container caused failure easily. And when a container fails, it stops the rest of the test.

Also noticed that autorestart could leave all BGP sessions down. Also don't know which container restart caused it.

#### How did you do it?
- Add infrastructure to enumerate dut features.
- Address an issue with DutHosts nodes indexing.
- Parameterize autorestart test.
- Add BGP session check and recover code to autorestart.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run autorestart test on multi-dut testbed and single dut testbed. Single testbed passes the test on 201911 branch image. Dualtor testbed is running master image and there are some failures.

autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|lldp] PASSED                                                                            [  3%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|pmon] PASSED                                                                            [  7%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|pmon] ERROR                                                                             [  7%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|sflow] SKIPPED                                                                          [ 10%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|database] SKIPPED                                                                       [ 14%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|snmp] PASSED                                                                            [ 17%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|telemetry] PASSED                                                                       [ 21%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|bgp] PASSED                                                                             [ 25%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|radv] PASSED                                                                            [ 28%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|radv] ERROR                                                                             [ 28%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|mgmt-framework] PASSED                                                                  [ 32%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|nat] SKIPPED                                                                            [ 35%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|teamd] FAILED                                                                           [ 39%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|teamd] ERROR                                                                            [ 39%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|dhcp_relay] PASSED                                                                      [ 42%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|swss] PASSED                                                                            [ 46%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|swss] ERROR                                                                             [ 46%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|syncd] FAILED                                                                           [ 50%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|lldp] SKIPPED                                                                           [ 53%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|pmon] SKIPPED                                                                           [ 57%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|sflow] SKIPPED                                                                          [ 60%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|database] SKIPPED                                                                       [ 64%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|snmp] SKIPPED                                                                           [ 67%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|telemetry] SKIPPED                                                                      [ 71%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|bgp] SKIPPED                                                                            [ 75%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|radv] SKIPPED                                                                           [ 78%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|mgmt-framework] SKIPPED                                                                 [ 82%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|nat] SKIPPED                                                                            [ 85%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|teamd] SKIPPED                                                                          [ 89%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|dhcp_relay] SKIPPED                                                                     [ 92%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|swss] SKIPPED                                                                           [ 96%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-09|syncd] SKIPPED                                                                          [100%]

ERROR autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|pmon] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-11-15-08:03:54': ["Nov...
ERROR autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|radv] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-11-15-08:11:05': ['Nov...
ERROR autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|teamd] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-11-15-08:17:36': ['No...
ERROR autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|swss] - LogAnalyzerError: {'match_messages': {'/tmp/syslog.2020-11-15-08:21:59': ['Nov...
FAILED autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|teamd] - Failed: Some BGP sessions went down after testing feature teamd
FAILED autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-08|syncd] - Failed: Failed to restart container 'syncd'