### PR TITLE
[acl] update acl test to make it almost dualtor ready

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1048,7 +1048,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
     def get_extended_minigraph_facts(self, tbinfo):
         mg_facts = self.minigraph_facts(host = self.hostname)['ansible_facts']
-        mg_facts['minigraph_ptf_indeces'] = mg_facts['minigraph_port_indices'].copy()
+        mg_facts['minigraph_ptf_indices'] = mg_facts['minigraph_port_indices'].copy()
 
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
         # multiple DUTs sharing a same PTF host. Therefore, the indeces from
@@ -1057,9 +1057,9 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             dut_index = tbinfo['duts'].index(self.hostname)
             map = tbinfo['topo']['ptf_map'][dut_index]
             if map:
-                for port, index in mg_facts['minigraph_ptf_indeces'].items():
+                for port, index in mg_facts['minigraph_ptf_indices'].items():
                     if index in map:
-                        mg_facts['minigraph_ptf_indeces'][port] = map[index]
+                        mg_facts['minigraph_ptf_indices'][port] = map[index]
         except (ValueError, KeyError):
             pass
 

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -134,7 +134,7 @@ class LagTest:
         iface_behind_lag_member = []
         for neighbor_intf in self.vm_neighbors.keys():
             if peer_device == self.vm_neighbors[neighbor_intf]['name']:
-                iface_behind_lag_member.append(self.mg_facts['minigraph_ptf_indeces'][neighbor_intf])
+                iface_behind_lag_member.append(self.mg_facts['minigraph_ptf_indices'][neighbor_intf])
 
         neighbor_lag_intfs = []
         for po_intf in po_interfaces:


### PR DESCRIPTION
### Description of PR
Summary:
Improve acl test so that it can be run on dualtor testbed.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
acl test is quite stable on both T0 and T1 topology. It should also be able to run on dualtor testbed.

#### How did you do it?
- Get the correct ptf port map for IO test.
- Fixed a typo in port map key.
- Update test_lag_2.py after the key change.

#### How did you verify/test it?
Run acl test on both single and dualtor testbed. Not all tests passed on dualtor testbed yet. Failures are all on t1 to server direction on pass through testcases. But not all t1 to server direction pass through testcases failed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
