### PR TITLE
[arp cleaner] add a fixture to cleanup accumulated arp entries

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,7 +437,8 @@ def clear_neigh_entries(duthosts, tbinfo):
         learn the same set of arp entries during tests. But currently the test only
         cleans up on the dut under test. So the other dut will accumulate arp entries
         until kernel start to barf.
-        Adding this fixture to cleanup after each test module.
+        Adding this fixture to flush out IPv4/IPv6 static ARP entries after each test
+        moduel is done.
     """
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,6 +430,23 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
     record_testsuite_property("os_version", duthost.os_version)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def clear_neigh_entries(duthosts, tbinfo):
+    """
+        This is a stop bleeding change for dualtor testbed. Because dualtor duts will
+        learn the same set of arp entries during tests. But currently the test only
+        cleans up on the dut under test. So the other dut will accumulate arp entries
+        until kernel start to barf.
+        Adding this fixture to cleanup after each test module.
+    """
+
+    yield
+
+    if tbinfo['topo']['name'] == 'dualtor':
+        for dut in duthosts:
+            dut.command("sudo ip neigh flush nud permanent")
+
+
 @pytest.fixture(scope="module")
 def disable_container_autorestart():
     def disable_container_autorestart(duthost, testcase="", feature_list=None):


### PR DESCRIPTION
Summary:
Clear stale neighbor entries from both ToRs on dualtor testbed between tests.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Nightly test on dualtor testbed fails after a few testcases because one ToR would becomes intermittently unreachable due to kernel arp entries overflow.

#### How did you do it?
dualtor testbeds have both tors learning same arp entries from any server at the same time. But tests currently only know how to cleanup arp on the dut chosen to run test.

So the standby dut will accumulate the arp entries in kernel until kernel start to barf.

This change temporarily mitigates the issue by flush out IPv4/IPv6 static arp entries after each test module.

#### How did you verify/test it?
Nightly test resumed to normal passing rate with the change, and tors stayed healthy.