### PR TITLE
[vtestbed]Update veos_vtb for addressing ptf login issue

### DIFF
--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -33,6 +33,23 @@ all:
         vlab-04:
         vlab-05:
         vlab-06:
+    ptf:
+      hosts:
+        ptf-01:
+          ansible_host: 10.250.0.102
+          ansible_hostv6: fec0::ffff:afa:2
+        ptf-02:
+          ansible_host: 10.250.0.106
+          ansible_hostv6: fec0::ffff:afa:6
+        ptf-03:
+          ansible_host: 10.250.0.108
+          ansible_hostv6: fec0::ffff:afa:8
+        ptf-04:
+          ansible_host: 10.250.0.109
+          ansible_hostv6: fec0::ffff:afa:9
+      vars:
+          ansible_user: root
+          ansible_password: root
     sonic:
       hosts:
         vlab-01:
@@ -93,27 +110,7 @@ all:
           ansible_hostv6: fec0::ffff:afa:4
           type: simx
           hwsku: MSN3700
-        ptf-01:
-          ansible_host: 10.250.0.102
-          ansible_hostv6: fec0::ffff:afa:2
-          ansible_user: root
-          ansible_password: root
-        ptf-02:
-          ansible_host: 10.250.0.106
-          ansible_hostv6: fec0::ffff:afa:6
-          ansible_user: root
-          ansible_password: root
-        ptf-03:
-          ansible_host: 10.250.0.108
-          ansible_hostv6: fec0::ffff:afa:8
-          ansible_user: root
-          ansible_password: root
-        ptf-04:
-          ansible_host: 10.250.0.109
-          ansible_hostv6: fec0::ffff:afa:9
-          ansible_user: root
-          ansible_password: root
-
+        
 # The groups below are helpers to limit running playbooks to a specific server only
 server_1:
   vars:


### PR DESCRIPTION

Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to address the ptf login issue on vtestbed.
The ptf hosts are placed under sonic group, and the ansible_user will be overwriten by that in ansible/group_vars/sonic/variables, which is ```admin``` in default. As a result, the login to ptf container will failed on vtestbed because of incorrect user name. This commit address this issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to address the ptf login issue on vtestbed.

#### How did you do it?
Move ptf vars in a separated group ```ptf```.

#### How did you verify/test it?
Verified on vtestbed (T0 topo) by running ```test_announce_routes```.
```
py.test --inventory ../ansible/veos_vtb --host-pattern vlab-01 --module-path ../ansible/library/ --testbed vms-kvm-t1 --testbed_file ../ansible/vtestbed.csv --junit-xml=tr.xml --log-cli-level warn -k 'not test_restart_syncd' --topology=t1,t0,any,util test_announce_routes.py
========================================================================================= test session starts =========================================================================================
collected 1 item                                                                                                                                                                                      

test_announce_routes.py::test_announce_routes ^@PASSED                                                                                                                                            [100%]

-------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/tr.xml --------------------------------------------------------------------------
===================================================================================== 1 passed in 467.62 seconds ======================================================================================
```
#### Any platform specific information?
Only for vtestbed.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.
