### PR TITLE
[Mellanox] Add a threshold for fan max speed

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -7,6 +7,8 @@ import logging
 from tests.common.mellanox_data import get_platform_data
 from tests.common.utilities import wait_until
 
+MAX_FAN_SPEED_THRESHOLD = 0.1
+
 
 def check_sysfs(dut):
     """
@@ -151,7 +153,7 @@ def _is_fan_speed_in_range(sysfs_facts):
     for fan_id, fan_info in sysfs_facts['fan_info'].items():
         try:
             fan_min_speed = int(fan_info["min_speed"])
-            fan_max_speed = int(fan_info["max_speed"])
+            fan_max_speed = int(int(fan_info["max_speed"]) * (1 + MAX_FAN_SPEED_THRESHOLD))
             fan_speed_set = int(fan_info["speed_set"])
             fan_speed_get = int(fan_info["speed_get"])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a threshold for fan max speed. When fan speed is 100%, it might exceed max fan speed defined in sysfs, add a tolerant value for that.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Add a threshold for fan max speed. When fan speed is 100%, it might exceed max fan speed defined in sysfs, add a tolerant value for that.

#### How did you do it?

Set the threshold to 10% for now.

#### How did you verify/test it?

Manually run the test.

#### Any platform specific information?

Mellanox platforms.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
