### PR TITLE
[acl] ignore monit errors if test image is 201911 branch

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -54,6 +54,10 @@ LOG_EXPECT_ACL_TABLE_REMOVE_RE = ".*Successfully deleted ACL table.*"
 LOG_EXPECT_ACL_RULE_CREATE_RE = ".*Successfully created ACL rule.*"
 LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
 
+LOG_IGNORE_RE = [
+                    ".*ERR monit.*"
+                ]
+
 
 @pytest.fixture(scope="module")
 def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
@@ -276,6 +280,8 @@ def acl_table(duthosts, rand_one_dut_hostname, acl_table_config, backup_and_rest
 
     try:
         loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_CREATE_RE]
+        if "201911" in duthost.os_version:
+            loganalyzer.ignore_regex.extend(LOG_IGNORE_RE)
         with loganalyzer:
             logger.info("Creating ACL table from config file: \"{}\"".format(config_file))
 
@@ -366,6 +372,8 @@ class BaseAclTest(object):
 
         try:
             loganalyzer.expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
+            if "201911" in duthost.os_version:
+                loganalyzer.ignore_regex.extend(LOG_IGNORE_RE)
             with loganalyzer:
                 self.setup_rules(duthost, acl_table)
 


### PR DESCRIPTION
### Description of PR
Summary:
ignore monit errors if test image is 201911 branch

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ACL test has a scenario where DUT is rebooted. After reboot, all services will take some time to become ready.

With 201911 image, monit will start to complain critical processes are not running very early after boot up. That causes ACL test cases to fail.

#### How did you do it?
ignore monit errors if test image is 201911 branch

#### How did you verify/test it?
Run acl test against dut running 201911 image. With the change, test passes:

184 passed, 184 skipped in 724.19 seconds

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

