### PR TITLE
[minigraph facts] get minigraph facts through get_extended_minigraph_facts() method

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -319,7 +319,7 @@ class BaseAclTest(object):
         """
         pass
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo):
         """Perform actions after rules have been applied.
 
         Args:
@@ -348,7 +348,7 @@ class BaseAclTest(object):
         dut.command("config acl update full {}".format(remove_rules_dut_path))
 
     @pytest.fixture(scope="class", autouse=True)
-    def acl_rules(self, duthosts, rand_one_dut_hostname, localhost, setup, acl_table, populate_vlan_arp_entries):
+    def acl_rules(self, duthosts, rand_one_dut_hostname, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo):
         """Setup/teardown ACL rules for the current set of tests.
 
         Args:
@@ -369,7 +369,7 @@ class BaseAclTest(object):
             with loganalyzer:
                 self.setup_rules(duthost, acl_table)
 
-            self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries)
+            self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo)
         except LogAnalyzerError as err:
             # Cleanup Config DB if rule creation failed
             logger.error("ACL table creation failed, attempting to clean-up...")
@@ -747,7 +747,7 @@ class TestAclWithReboot(TestBasicAcl):
     upon startup.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo):
         """Save configuration and reboot after rules are applied.
 
         Args:
@@ -768,7 +768,7 @@ class TestAclWithPortToggle(TestBasicAcl):
     Verify that ACLs still function as expected after links flap.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries):
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo):
         """Toggle ports after rules are applied.
 
         Args:
@@ -777,5 +777,5 @@ class TestAclWithPortToggle(TestBasicAcl):
             populate_vlan_arp_entries: A fixture to populate ARP/FDB tables for VLAN interfaces.
 
         """
-        port_toggle(dut)
+        port_toggle(dut, tbinfo)
         populate_vlan_arp_entries()

--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -24,9 +24,9 @@ def collect_info(duthost):
 
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost):
+def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     int_facts = duthost.interface_facts()['ansible_facts']
 
     ports = list(sorted(mg_facts['minigraph_ports'].keys(), key=lambda item: int(item.replace('Ethernet', ''))))
@@ -36,8 +36,8 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost):
     intf2 = ports[1]
     logger.info("Selected ints are {0} and {1}".format(intf1, intf2))
 
-    intf1_indice = mg_facts['minigraph_port_indices'][intf1]
-    intf2_indice = mg_facts['minigraph_port_indices'][intf2]
+    intf1_indice = mg_facts['minigraph_ptf_indices'][intf1]
+    intf2_indice = mg_facts['minigraph_ptf_indices'][intf2]
 
     po1 = get_po(mg_facts, intf1)
     po2 = get_po(mg_facts, intf2)

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -23,7 +23,7 @@ class TestWrArp:
     '''
         TestWrArp Performs control plane assisted warm-reboo
     '''
-    def __prepareVxlanConfigData(self, duthost, ptfhost):
+    def __prepareVxlanConfigData(self, duthost, ptfhost, tbinfo):
         '''
             Prepares Vxlan Configuration data for Ferret service running on PTF host
 
@@ -34,9 +34,9 @@ class TestWrArp:
             Returns:
                 None
         '''
-        mgFacts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+        mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
         vxlanConfigData = {
-            'minigraph_port_indices': mgFacts['minigraph_port_indices'],
+            'minigraph_port_indices': mgFacts['minigraph_ptf_indices'],
             'minigraph_portchannel_interfaces': mgFacts['minigraph_portchannel_interfaces'],
             'minigraph_portchannels': mgFacts['minigraph_portchannels'],
             'minigraph_lo_interfaces': mgFacts['minigraph_lo_interfaces'],
@@ -51,7 +51,7 @@ class TestWrArp:
         ptfhost.copy(src=VXLAN_CONFIG_FILE, dest='/tmp/')
 
     @pytest.fixture(scope='class', autouse=True)
-    def setupFerret(self, duthosts, rand_one_dut_hostname, ptfhost):
+    def setupFerret(self, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         '''
             Sets Ferret service on PTF host. This class-scope fixture runs once before test start
 
@@ -120,7 +120,7 @@ class TestWrArp:
             chdir='/opt'
         )
 
-        self.__prepareVxlanConfigData(duthost, ptfhost)
+        self.__prepareVxlanConfigData(duthost, ptfhost, tbinfo)
 
         logger.info('Refreshing supervisor control with ferret configuration')
         ptfhost.shell('supervisorctl reread && supervisorctl update')

--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -50,7 +50,7 @@ def get_vips_prefix_paths(dut_t0_neigh, vips_prefix, topo_config):
     return vips_t0, vips_asn
 
 def get_bgp_v4_neighbors_from_minigraph(duthost, tbinfo):
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     # Find all V4 bgp neighbors from minigraph
     bgp_v4nei = {}

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -50,7 +50,7 @@ def change_route(operation, ptfip, neighbor, route, nexthop, port):
     assert r.status_code == 200
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost):
+def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
 
     logging.info("########### Setup for bgp speaker testing ###########")
@@ -58,7 +58,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost):
     ptfip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     logging.info("ptfip=%s" % ptfip)
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     interface_facts = duthost.interface_facts()['ansible_facts']
 
     constants_stat = duthost.stat(path="/etc/sonic/constants.yml")
@@ -86,7 +86,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost):
 
     vlan_ports = []
     for i in range(0, 3):
-        vlan_ports.append(mg_facts['minigraph_port_indices'][mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][0]['attachto']]['members'][i]])
+        vlan_ports.append(mg_facts['minigraph_ptf_indices'][mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][0]['attachto']]['members'][i]])
     logging.info("vlan_ports: %s" % str(vlan_ports))
 
     # Generate ipv6 nexthops
@@ -217,7 +217,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost, p
     extra_vars = {'announce_prefix': prefix,
                   'minigraph_portchannels': mg_facts['minigraph_portchannels'],
                   'minigraph_vlans': mg_facts['minigraph_vlans'],
-                  'minigraph_port_indices': mg_facts['minigraph_port_indices']}
+                  'minigraph_port_indices': mg_facts['minigraph_ptf_indices']}
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
     logging.info("extra_vars: %s" % str(ptfhost.host.options['variable_manager'].extra_vars))
 

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1098,13 +1098,9 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             return DEFAULT_NAMESPACE
         return "{}{}".format(NAMESPACE_PREFIX, asic_id)
 
-    def get_extended_minigraph_facts(self, tbinfo=None):
+    def get_extended_minigraph_facts(self, tbinfo):
         mg_facts = self.minigraph_facts(host = self.hostname)['ansible_facts']
         mg_facts['minigraph_ptf_indices'] = mg_facts['minigraph_port_indices'].copy()
-
-        if not tbinfo:
-            # Allow caller to not care for the ptf indices mapping
-            return mg_facts
 
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
         # multiple DUTs sharing a same PTF host. Therefore, the indeces from

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1098,9 +1098,13 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             return DEFAULT_NAMESPACE
         return "{}{}".format(NAMESPACE_PREFIX, asic_id)
 
-    def get_extended_minigraph_facts(self, tbinfo):
+    def get_extended_minigraph_facts(self, tbinfo=None):
         mg_facts = self.minigraph_facts(host = self.hostname)['ansible_facts']
         mg_facts['minigraph_ptf_indices'] = mg_facts['minigraph_port_indices'].copy()
+
+        if not tbinfo:
+            # Allow caller to not care for the ptf indices mapping
+            return mg_facts
 
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
         # multiple DUTs sharing a same PTF host. Therefore, the indeces from

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -62,7 +62,7 @@ class AdvancedReboot:
         self.vlanMaxCnt = 0
         self.hostMaxCnt = HOST_MAX_COUNT
 
-        self.__buildTestbedData()
+        self.__buildTestbedData(tbinfo)
 
     def __extractTestParam(self):
         '''
@@ -118,12 +118,12 @@ class AdvancedReboot:
         '''
         return self.tbinfo['topo']['name']
 
-    def __buildTestbedData(self):
+    def __buildTestbedData(self, tbinfo):
         '''
         Build testbed data that are needed by ptf advanced-reboot.ReloadTest class
         '''
 
-        self.mgFacts = self.duthost.minigraph_facts(host=self.duthost.hostname)['ansible_facts']
+        self.mgFacts = self.duthost.get_extended_minigraph_facts(tbinfo)
 
         self.rebootData['arista_vms'] = [
             attr['mgmt_addr'] for dev, attr in self.mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
@@ -307,7 +307,7 @@ class AdvancedReboot:
         testDataFiles = [
             {'source' : self.mgFacts['minigraph_portchannels'], 'name' : 'portchannel_interfaces'},
             {'source' : self.mgFacts['minigraph_vlans'],        'name' : 'vlan_interfaces'       },
-            {'source' : self.mgFacts['minigraph_port_indices'], 'name' : 'ports'                 },
+            {'source' : self.mgFacts['minigraph_ptf_indices'],  'name' : 'ports'                 },
             {'source' : self.mgFacts['minigraph_devices'],      'name' : 'peer_dev_info'         },
             {'source' : self.mgFacts['minigraph_neighbors'],    'name' : 'neigh_port_info'       },
         ]

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -38,10 +38,10 @@ def ansible_facts(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="module")
-def minigraph_facts(duthosts, rand_one_dut_hostname):
+def minigraph_facts(duthosts, rand_one_dut_hostname, tbinfo):
     """ DUT minigraph facts fixture """
     duthost = duthosts[rand_one_dut_hostname]
-    yield duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    yield duthost.get_extended_minigraph_facts(tbinfo)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -285,8 +285,8 @@ class Setup(object):
         self.vars["ptf_test_params"]["server_ports"] = []
         for index, item in enumerate(self.vlan_members):
             port_info = {"dut_name": item,
-                            "ptf_name": "eth{}".format(self.mg_facts["minigraph_port_indices"][item]),
-                            "index": self.mg_facts["minigraph_port_indices"][item],
+                            "ptf_name": "eth{}".format(self.mg_facts["minigraph_ptf_indices"][item]),
+                            "index": self.mg_facts["minigraph_ptf_indices"][item],
                             "ptf_ip": generated_ips[index],
                             "oid": None}
 
@@ -305,8 +305,8 @@ class Setup(object):
         redis_oid = self.duthost.command("docker exec -i database redis-cli --raw -n 2 HMGET \
                                             COUNTERS_PORT_NAME_MAP {}".format(self.portchannel_member))["stdout"]
         sai_redis_oid = int(self.duthost.command("docker exec -i database redis-cli -n 1 hget VIDTORID {}".format(redis_oid))["stdout"].replace("oid:", ""), 16)
-        self.vars["ptf_test_params"]["non_server_port"] = {"ptf_name": "eth{}".format(self.mg_facts["minigraph_port_indices"][self.portchannel_member]),
-                                                    "index": self.mg_facts["minigraph_port_indices"][self.portchannel_member],
+        self.vars["ptf_test_params"]["non_server_port"] = {"ptf_name": "eth{}".format(self.mg_facts["minigraph_ptf_indices"][self.portchannel_member]),
+                                                    "index": self.mg_facts["minigraph_ptf_indices"][self.portchannel_member],
                                                     "ip": self.mg_facts["minigraph_portchannel_interfaces"][0]["peer_addr"],
                                                     "dut_name": self.portchannel_member,
                                                     "oid": sai_redis_oid}

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -45,7 +45,7 @@ class PopulateFdb:
         self.duthost = duthost
         self.ptfhost = ptfhost
 
-    def __prepareVlanConfigData(self):
+    def __prepareVlanConfigData(self, tbinfo):
         """
             Prepares Vlan Configuration data
 
@@ -57,13 +57,13 @@ class PopulateFdb:
                 None
         """
         mgVlanPorts = []
-        mgFacts = self.duthost.minigraph_facts(host=self.duthost.hostname)["ansible_facts"]
+        mgFacts = self.duthost.get_extended_minigraph_facts(tbinfo)
         for vlan, config in mgFacts["minigraph_vlans"].items():
             for port in config["members"]:
                 mgVlanPorts.append({
                     "port": port,
                     "vlan": vlan,
-                    "index": mgFacts["minigraph_port_indices"][port]
+                    "index": mgFacts["minigraph_ptf_indices"][port]
                 })
         vlan_interfaces = {}
         for vlan in mgFacts["minigraph_vlan_interfaces"]:
@@ -82,7 +82,7 @@ class PopulateFdb:
         logger.info("Copying VLan config file to {0}".format(self.ptfhost.hostname))
         self.ptfhost.copy(src=self.VLAN_CONFIG_FILE, dest="/tmp/")
 
-    def run(self):
+    def run(self, tbinfo):
         """
             Populates DUT FDB entries
 
@@ -92,7 +92,7 @@ class PopulateFdb:
             Returns:
                 None
         """
-        self.__prepareVlanConfigData()
+        self.__prepareVlanConfigData(tbinfo)
 
         logger.info("Populate DUT FDB entries")
         ptf_runner(
@@ -112,7 +112,7 @@ class PopulateFdb:
         )
 
 @pytest.fixture
-def populate_fdb(request, duthosts, rand_one_dut_hostname, ptfhost):
+def populate_fdb(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     """
         Populates DUT FDB entries
 
@@ -127,4 +127,4 @@ def populate_fdb(request, duthosts, rand_one_dut_hostname, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
     populateFdb = PopulateFdb(request, duthost, ptfhost)
 
-    populateFdb.run()
+    populateFdb.run(tbinfo)

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -14,7 +14,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 
-def port_toggle(duthost, ports=None, wait=60, wait_after_ports_up=60, watch=False):
+def port_toggle(duthost, tbinfo, ports=None, wait=60, wait_after_ports_up=60, watch=False):
     """
     Toggle ports on DUT.
 
@@ -42,7 +42,7 @@ def port_toggle(duthost, ports=None, wait=60, wait_after_ports_up=60, watch=Fals
 
     if ports is None:
         logger.debug('ports is None, toggling all minigraph ports')
-        mg_facts = duthost.get_extended_minigraph_facts()
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         ports = mg_facts['minigraph_ports'].keys()
 
     logger.info('toggling ports:\n%s', pprint.pformat(ports))

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -42,7 +42,7 @@ def port_toggle(duthost, ports=None, wait=60, wait_after_ports_up=60, watch=Fals
 
     if ports is None:
         logger.debug('ports is None, toggling all minigraph ports')
-        mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+        mg_facts = duthost.get_extended_minigraph_facts()
         ports = mg_facts['minigraph_ports'].keys()
 
     logger.info('toggling ports:\n%s', pprint.pformat(ports))

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -193,7 +193,7 @@ def _gather_test_params(tbinfo, duthost, request):
     pkt_tx_count = request.config.getoption("--pkt_tx_count")
     swap_syncd = request.config.getoption("--copp_swap_syncd")
     topo = tbinfo["topo"]["name"]
-    bgp_graph = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]["minigraph_bgp"]
+    bgp_graph = duthost.get_extended_minigraph_facts()["minigraph_bgp"]
 
     return _COPPTestParameters(nn_target_port=nn_target_port,
                                pkt_tx_count=pkt_tx_count,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -193,7 +193,7 @@ def _gather_test_params(tbinfo, duthost, request):
     pkt_tx_count = request.config.getoption("--pkt_tx_count")
     swap_syncd = request.config.getoption("--copp_swap_syncd")
     topo = tbinfo["topo"]["name"]
-    bgp_graph = duthost.get_extended_minigraph_facts()["minigraph_bgp"]
+    bgp_graph = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_bgp"]
 
     return _COPPTestParameters(nn_target_port=nn_target_port,
                                pkt_tx_count=pkt_tx_count,

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -76,7 +76,7 @@ def crm_thresholds(duthosts, rand_one_dut_hostname):
 def crm_interface(duthosts, rand_one_dut_hostname):
     """ Return tuple of two DUT interfaces """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts()
 
     if len(mg_facts["minigraph_portchannel_interfaces"]) >= 4:
         crm_intf1 = mg_facts["minigraph_portchannel_interfaces"][0]["attachto"]

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -73,10 +73,10 @@ def crm_thresholds(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def crm_interface(duthosts, rand_one_dut_hostname):
+def crm_interface(duthosts, rand_one_dut_hostname, tbinfo):
     """ Return tuple of two DUT interfaces """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     if len(mg_facts["minigraph_portchannel_interfaces"]) >= 4:
         crm_intf1 = mg_facts["minigraph_portchannel_interfaces"][0]["attachto"]

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -28,7 +28,7 @@ def ignore_expected_loganalyzer_exceptions(loganalyzer):
 
 
 @pytest.fixture(scope="module")
-def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost):
+def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     """ Fixture which returns a list of dictionaries where each dictionary contains
         data necessary to test one instance of a DHCP relay agent running on the DuT.
         This fixture is scoped to the module, as the data it gathers can be used by
@@ -37,7 +37,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
     dhcp_relay_data_list = []
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     host_facts = duthost.setup()['ansible_facts']
 
     # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
@@ -63,7 +63,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost):
         client_iface = {}
         client_iface['name'] = vlan_info_dict['members'][0]
         client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
-        client_iface['port_idx'] = mg_facts['minigraph_port_indices'][client_iface['name']]
+        client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
 
         # Obtain uplink port indicies for this DHCP relay agent
         uplink_interfaces = []
@@ -85,7 +85,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost):
                     # If the uplink's physical interface is not a member of a portchannel, add it to our uplink interfaces list
                     if not iface_is_portchannel_member:
                         uplink_interfaces.append(iface_name)
-                    uplink_port_indices.append(mg_facts['minigraph_port_indices'][iface_name])
+                    uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
 
         dhcp_relay_data = {}
         dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -57,7 +57,7 @@ def fanouthost(request, duthosts, rand_one_dut_hostname, localhost):
 def pkt_fields(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     # Gather ansible facts
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts()
     ipv4_addr = None
     ipv6_addr = None
 
@@ -116,7 +116,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
         pytest.skip("Unsupported topology {}".format(tbinfo["topo"]))
 
     # Gather ansible facts
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     for port_channel, interfaces in mg_facts['minigraph_portchannels'].items():
         for iface in interfaces["members"]:
@@ -131,7 +131,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
     # Compose list of sniff ports
     neighbor_sniff_ports = []
     for dut_port, neigh in mg_facts['minigraph_neighbors'].items():
-        neighbor_sniff_ports.append(mg_facts['minigraph_port_indices'][dut_port])
+        neighbor_sniff_ports.append(mg_facts['minigraph_ptf_indices'][dut_port])
 
     for vlan_name, vlans_data in mg_facts["minigraph_vlans"].items():
         configured_vlans.append(int(vlans_data["vlanid"]))
@@ -140,7 +140,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
         "port_channel_members": port_channel_members,
         "vlan_members": vlan_members,
         "rif_members": rif_members,
-        "dut_to_ptf_port_map": mg_facts["minigraph_port_indices"],
+        "dut_to_ptf_port_map": mg_facts["minigraph_ptf_indices"],
         "neighbor_sniff_ports": neighbor_sniff_ports,
         "vlans": configured_vlans,
         "mg_facts": mg_facts

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -54,10 +54,10 @@ def fanouthost(request, duthosts, rand_one_dut_hostname, localhost):
 
 
 @pytest.fixture(scope="module")
-def pkt_fields(duthosts, rand_one_dut_hostname):
+def pkt_fields(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     # Gather ansible facts
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     ipv4_addr = None
     ipv6_addr = None
 

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -82,21 +82,20 @@ def testbed_params(duthosts, rand_one_dut_hostname, tbinfo):
     if tbinfo["topo"]["type"] != "t0":
         pytest.skip("Unsupported topology {}".format(tbinfo["topo"]["name"]))
 
-    minigraph_facts = \
-        duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
 
     physical_port_map = {v: k
                          for k, v
-                         in minigraph_facts["minigraph_port_indices"].items()
-                         if k in minigraph_facts["minigraph_ports"].keys()}  # Trim inactive ports
+                         in mgFacts["minigraph_ptf_indices"].items()
+                         if k in mgFacts["minigraph_ports"].keys()}  # Trim inactive ports
 
-    vlan_ports = [minigraph_facts["minigraph_port_indices"][ifname]
+    vlan_ports = [mgFacts["minigraph_ptf_indices"][ifname]
                   for ifname
-                  in minigraph_facts["minigraph_vlans"].values()[VLAN_INDEX]["members"]]
+                  in mgFacts["minigraph_vlans"].values()[VLAN_INDEX]["members"]]
 
     return {"physical_port_map": physical_port_map,
             "vlan_ports": vlan_ports,
-            "vlan_interface": minigraph_facts["minigraph_vlan_interfaces"][VLAN_INDEX]}
+            "vlan_interface": mgFacts["minigraph_vlan_interfaces"][VLAN_INDEX]}
 
 
 @pytest.fixture(scope="module")

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -317,12 +317,12 @@ def common_setup_teardown(tbinfo, duthosts, rand_one_dut_hostname):
         pytest.skip("Unsupported platform")
 
     try:
-        mg_facts   = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+        mg_facts   = duthost.get_extended_minigraph_facts(tbinfo)
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
         router_mac = duthost.facts['router_mac']
         net_ports = []
         for name, val in mg_facts['minigraph_portchannels'].items():
-            members = [mg_facts['minigraph_port_indices'][member] for member in val['members']]
+            members = [mg_facts['minigraph_ptf_indices'][member] for member in val['members']]
             net_ports.extend(members)
         yield duthost, cfg_facts, router_mac, net_ports 
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -160,7 +160,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
     # We are making sure regular traffic has a dedicated route and does not use
     # the default route.
 
-    peer_ip, _ = get_neighbor_info(duthost, spine_dest_ports[3])
+    peer_ip, _ = get_neighbor_info(duthost, spine_dest_ports[3], tbinfo)
 
     # Disable recursive route resolution as we have test case where we check
     # if better unresolved route is there then it should not be picked by Mirror state DB
@@ -209,7 +209,7 @@ def remove_route(duthost, prefix, nexthop):
 
 
 # TODO: This should be refactored to some common area of sonic-mgmt.
-def get_neighbor_info(duthost, dest_port, resolved=True):
+def get_neighbor_info(duthost, dest_port, tbinfo, resolved=True):
     """
     Get the IP and MAC of the neighbor on the specified destination port.
 
@@ -222,7 +222,7 @@ def get_neighbor_info(duthost, dest_port, resolved=True):
     if not resolved:
         return "20.20.20.100", None
 
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     for bgp_peer in mg_facts["minigraph_bgp"]:
         if bgp_peer["name"] == mg_facts["minigraph_neighbors"][dest_port]["name"] and ipaddr.IPAddress(bgp_peer["addr"]).version == 4:

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -50,7 +50,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
     spine_ports = []
 
     # Gather test facts
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     switch_capability_facts = duthost.switch_capabilities_facts()["ansible_facts"]
 
     # Get the list of T0/T2 ports
@@ -88,7 +88,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
         out_port_exclude_list = []
         for port in in_port_list:
             if port not in out_port_list and port not in out_port_exclude_list and len(out_port_list) < 4:
-                ptf_port_id = str(mg_facts["minigraph_port_indices"][port])
+                ptf_port_id = str(mg_facts["minigraph_ptf_indices"][port])
                 out_port_list.append(port)
                 out_port_lag_name.append("Not Applicable")
 
@@ -98,7 +98,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
                         for lag_member in portchannelinfo[1]["members"]:
                             if port == lag_member:
                                 continue
-                            ptf_port_id += "," + (str(mg_facts["minigraph_port_indices"][lag_member]))
+                            ptf_port_id += "," + (str(mg_facts["minigraph_ptf_indices"][lag_member]))
                             out_port_exclude_list.append(lag_member)
 
                 out_port_ptf_id_list.append(ptf_port_id)
@@ -134,21 +134,21 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
         },
         "tor": {
             "src_port": spine_ports[0],
-            "src_port_ptf_id": str(mg_facts["minigraph_port_indices"][spine_ports[0]]),
+            "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][spine_ports[0]]),
             "dest_port": tor_dest_ports,
             "dest_port_ptf_id": tor_dest_ports_ptf_id,
             "dest_port_lag_name": tor_dest_lag_name
         },
         "spine": {
             "src_port": tor_ports[0],
-            "src_port_ptf_id": str(mg_facts["minigraph_port_indices"][tor_ports[0]]),
+            "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][tor_ports[0]]),
             "dest_port": spine_dest_ports,
             "dest_port_ptf_id": spine_dest_ports_ptf_id,
             "dest_port_lag_name": spine_dest_lag_name
         },
         "port_index_map": {
             k: v
-            for k, v in mg_facts["minigraph_port_indices"].items()
+            for k, v in mg_facts["minigraph_ptf_indices"].items()
             if k in mg_facts["minigraph_ports"]
         }
     }
@@ -222,7 +222,7 @@ def get_neighbor_info(duthost, dest_port, resolved=True):
     if not resolved:
         return "20.20.20.100", None
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts()
 
     for bgp_peer in mg_facts["minigraph_bgp"]:
         if bgp_peer["name"] == mg_facts["minigraph_neighbors"][dest_port]["name"] and ipaddr.IPAddress(bgp_peer["addr"]).version == 4:

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -313,7 +313,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
             raise
 
-    def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+    def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
         duthost = duthosts[rand_one_dut_hostname]
         try:

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -81,7 +81,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     # A better solution might be to have a fixture that receives route updates and then
     # cleans up any remaining routes at the end.
 
-    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -95,7 +95,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         try:
             # Add a route to the mirror session destination IP
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
             time.sleep(3)
 
@@ -112,7 +112,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             )
 
             # Add a (better) unresolved route to the mirror session destination IP
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, resolved=False)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo, resolved=False)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
             time.sleep(3)
 
@@ -131,7 +131,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
             # Add a better route to the mirror session destination IP
             tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
             time.sleep(3)
 
@@ -163,28 +163,28 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
             # Clean up the test
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
 
         except Exception:
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
             everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
 
             tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
 
             raise
 
-    def test_everflow_neighbor_mac_change(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+    def test_everflow_neighbor_mac_change(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
         duthost = duthosts[rand_one_dut_hostname]
         try:
             # Add a route to the mirror session destination IP
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
             time.sleep(3)
 
@@ -224,23 +224,23 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
         except Exception:
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
 
             raise
 
-    def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter):
+    def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
         duthost = duthosts[rand_one_dut_hostname]
         try:
             # Create two ECMP next hops
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
             time.sleep(3)
 
             tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
             time.sleep(3)
 
@@ -261,7 +261,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
             # Add another ECMP next hop
             tx_port = setup_info[dest_port_type]["dest_port"][2]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
             time.sleep(3)
 
@@ -319,7 +319,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         try:
             # Add a route to the mirror session destination IP
             tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
             time.sleep(3)
 
@@ -337,11 +337,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
             # Add two new ECMP next hops
             tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
 
             tx_port = setup_info[dest_port_type]["dest_port"][2]
-            peer_ip_2, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+            peer_ip_2, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
             time.sleep(3)
 
@@ -412,13 +412,14 @@ class EverflowIPv4Tests(BaseEverflowTest):
             policer_mirror_session,
             dest_port_type,
             partial_ptf_runner,
-            config_method
+            config_method,
+            tbinfo
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table."""
 
         # Add explicit route for the mirror session
         tx_port = setup_info[dest_port_type]["dest_port"][0]
-        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port)
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
         everflow_utils.add_route(duthost, policer_mirror_session["session_prefixes"][0], peer_ip)
 
         try:

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -109,7 +109,7 @@ class TestFdbMacExpire:
         )
 
     @pytest.fixture(scope="class", autouse=True)
-    def copyFdbInfo(self, duthosts, rand_one_dut_hostname, ptfhost):
+    def copyFdbInfo(self, duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         """
             Compies FDB info file to PTF host
 
@@ -121,10 +121,10 @@ class TestFdbMacExpire:
                 None
         """
         duthost = duthosts[rand_one_dut_hostname]
-        mgFacts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+        mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
         ptfhost.host.options['variable_manager'].extra_vars.update({
             "minigraph_vlan_interfaces": mgFacts["minigraph_vlan_interfaces"],
-            "minigraph_port_indices": mgFacts["minigraph_port_indices"],
+            "minigraph_port_indices": mgFacts["minigraph_ptf_indices"],
             "minigraph_vlans": mgFacts["minigraph_vlans"],
         })
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -33,12 +33,12 @@ def config_facts(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope='module')
-def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts):
+def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
 
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     duthost.shell("redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(timestamp))
     duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
@@ -58,10 +58,10 @@ def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts):
             oports = []
             for ifname in ifnames:
                 if po.has_key(ifname):
-                    oports.append([str(mg_facts['minigraph_port_indices'][x]) for x in po[ifname]['members']])
+                    oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
                 else:
                     if ports.has_key(ifname):
-                        oports.append([str(mg_facts['minigraph_port_indices'][ifname])])
+                        oports.append([str(mg_facts['minigraph_ptf_indices'][ifname])])
                     else:
                         logger.info("Route point to non front panel port {}:{}".format(k, v))
                         skip = True

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -13,7 +13,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='module', autouse=True)
-def setup(duthosts, rand_one_dut_hostname):
+def setup(duthosts, rand_one_dut_hostname, tbinfo):
     """
     Sets up all the parameters needed for the interface naming mode tests
 
@@ -25,7 +25,7 @@ def setup(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
     hwsku = duthost.facts['hwsku']
-    minigraph_facts = duthost.get_extended_minigraph_facts()
+    minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_alias_facts = duthost.port_alias(hwsku=hwsku)['ansible_facts']
     up_ports = minigraph_facts['minigraph_ports'].keys()
     default_interfaces = port_alias_facts['port_name_map'].keys()

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -25,7 +25,7 @@ def setup(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
     hwsku = duthost.facts['hwsku']
-    minigraph_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    minigraph_facts = duthost.get_extended_minigraph_facts()
     port_alias_facts = duthost.port_alias(hwsku=hwsku)['ansible_facts']
     up_ports = minigraph_facts['minigraph_ports'].keys()
     default_interfaces = port_alias_facts['port_name_map'].keys()

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -56,11 +56,11 @@ def lag_facts(dut, mg_facts):
 
     facts['dst_port_ids'] = []
     for intf in mg_facts['minigraph_portchannels'][dst_lag]['members']:
-        facts['dst_port_ids'].append(mg_facts['minigraph_port_indices'][intf])
+        facts['dst_port_ids'].append(mg_facts['minigraph_ptf_indices'][intf])
 
     facts['src_port_ids'] = []
     for intf in mg_facts['minigraph_portchannels'][src_lag]['members']:
-        facts['src_port_ids'].append(mg_facts['minigraph_port_indices'][intf])
+        facts['src_port_ids'].append(mg_facts['minigraph_ptf_indices'][intf])
 
     return facts
 
@@ -94,8 +94,8 @@ def port_facts(dut, mg_facts):
                 facts['dst_router_ipv6'] = intf['addr']
                 facts['dst_host_ipv6'] = intf['peer_addr']
 
-    facts['dst_port_ids'] = [mg_facts['minigraph_port_indices'][dst_port]]
-    facts['src_port_ids'] = [mg_facts['minigraph_port_indices'][src_port]]
+    facts['dst_port_ids'] = [mg_facts['minigraph_ptf_indices'][dst_port]]
+    facts['src_port_ids'] = [mg_facts['minigraph_ptf_indices'][src_port]]
 
     return facts
 
@@ -110,7 +110,7 @@ def gather_facts(tbinfo, duthosts, rand_one_dut_hostname):
         pytest.skip("Unsupported topology")
 
     logger.info("Gathering facts on DUT ...")
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     # if minigraph_portchannel_interfaces is not empty - topology with lag
     if mg_facts['minigraph_portchannel_interfaces']:

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -16,11 +16,11 @@ def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, fib):
         pytest.skip("Not support given test bed type %s" % testbed_type)
 
     # Copy VLAN information file to PTF-docker
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     extra_vars = {
         'minigraph_vlan_interfaces': mg_facts['minigraph_vlan_interfaces'],
         'minigraph_vlans':           mg_facts['minigraph_vlans'],
-        'minigraph_port_indices':    mg_facts['minigraph_port_indices']
+        'minigraph_port_indices':    mg_facts['minigraph_ptf_indices']
     }
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
     ptfhost.template(src="../ansible/roles/test/templates/fdb.j2", dest="/root/vlan_info.txt")

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -17,11 +17,11 @@ def lldp_setup(duthosts, rand_one_dut_hostname, patch_lldpctl, unpatch_lldpctl, 
     unpatch_lldpctl(localhost, duthost)
 
 
-def test_lldp(duthosts, rand_one_dut_hostname, localhost, collect_techsupport):
+def test_lldp(duthosts, rand_one_dut_hostname, localhost, collect_techsupport, tbinfo):
     """ verify the LLDP message on DUT """
     duthost = duthosts[rand_one_dut_hostname]
 
-    mg_facts  = duthost.get_extended_minigraph_facts()
+    mg_facts  = duthost.get_extended_minigraph_facts(tbinfo)
     lldp_facts = duthost.lldp()['ansible_facts']
 
     minigraph_lldp_nei = {}
@@ -42,7 +42,7 @@ def test_lldp(duthosts, rand_one_dut_hostname, localhost, collect_techsupport):
 
 
 def test_lldp_neighbor(duthosts, rand_one_dut_hostname, localhost, eos,
-                       collect_techsupport, loganalyzer):
+                       collect_techsupport, loganalyzer, tbinfo):
     """ verify LLDP information on neighbors """
     duthost = duthosts[rand_one_dut_hostname]
 
@@ -55,7 +55,7 @@ def test_lldp_neighbor(duthosts, rand_one_dut_hostname, localhost, eos,
                 not sent since it contain invalid OIDs, bug.*",
         ])
 
-    mg_facts  = duthost.get_extended_minigraph_facts()
+    mg_facts  = duthost.get_extended_minigraph_facts(tbinfo)
     res = duthost.shell("docker exec -i lldp lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'")
     dut_system_description = res['stdout']
     lldp_facts = duthost.lldp()['ansible_facts']

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -21,7 +21,7 @@ def test_lldp(duthosts, rand_one_dut_hostname, localhost, collect_techsupport):
     """ verify the LLDP message on DUT """
     duthost = duthosts[rand_one_dut_hostname]
 
-    mg_facts  = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts  = duthost.get_extended_minigraph_facts()
     lldp_facts = duthost.lldp()['ansible_facts']
 
     minigraph_lldp_nei = {}
@@ -55,7 +55,7 @@ def test_lldp_neighbor(duthosts, rand_one_dut_hostname, localhost, eos,
                 not sent since it contain invalid OIDs, bug.*",
         ])
 
-    mg_facts  = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts  = duthost.get_extended_minigraph_facts()
     res = duthost.shell("docker exec -i lldp lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'")
     dut_system_description = res['stdout']
     lldp_facts = duthost.lldp()['ansible_facts']

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -38,13 +38,13 @@ def check_kernel_po_interface_cleaned(duthost):
     return res == '0'
 
 
-def test_po_cleanup(duthosts, rand_one_dut_hostname):
+def test_po_cleanup(duthosts, rand_one_dut_hostname, tbinfo):
     """
     test port channel are cleaned up correctly and teammgrd and teamsyncd process
     handle  SIGTERM gracefully
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     if len(mg_facts['minigraph_portchannels'].keys()) == 0:
         pytest.skip("Skip test due to there is no portchannel exists in current topology.")

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -44,7 +44,7 @@ def test_po_cleanup(duthosts, rand_one_dut_hostname):
     handle  SIGTERM gracefully
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts()
 
     if len(mg_facts['minigraph_portchannels'].keys()) == 0:
         pytest.skip("Skip test due to there is no portchannel exists in current topology.")

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -33,12 +33,12 @@ def ignore_expected_loganalyzer_exceptions(loganalyzer):
 
     yield
 
-def test_po_update(duthosts, rand_one_dut_hostname):
+def test_po_update(duthosts, rand_one_dut_hostname, tbinfo):
     """
     test port channel add/deletion as well ip address configuration
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     int_facts = duthost.interface_facts()['ansible_facts']
 
     # Initialize portchannel

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -38,7 +38,7 @@ def test_po_update(duthosts, rand_one_dut_hostname):
     test port channel add/deletion as well ip address configuration
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts()
     int_facts = duthost.interface_facts()['ansible_facts']
 
     # Initialize portchannel

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -41,7 +41,7 @@ def setup_pfc_test(duthosts, rand_one_dut_hostname, ptfhost, conn_graph_facts):
         setup_info: dictionary containing pfc timers, generated test ports and selected test ports
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts()
     port_list = mg_facts['minigraph_ports'].keys()
     ports = (' ').join(port_list)
     neighbors = conn_graph_facts['device_conn'][duthost.hostname]

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -28,7 +28,7 @@ def pytest_addoption(parser):
                      help='Fake storm for most ports instead of using pfc gen')
 
 @pytest.fixture(scope="module")
-def setup_pfc_test(duthosts, rand_one_dut_hostname, ptfhost, conn_graph_facts):
+def setup_pfc_test(duthosts, rand_one_dut_hostname, ptfhost, conn_graph_facts, tbinfo):
     """
     Sets up all the parameters needed for the PFC Watchdog tests
 
@@ -41,7 +41,7 @@ def setup_pfc_test(duthosts, rand_one_dut_hostname, ptfhost, conn_graph_facts):
         setup_info: dictionary containing pfc timers, generated test ports and selected test ports
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_list = mg_facts['minigraph_ports'].keys()
     ports = (' ').join(port_list)
     neighbors = conn_graph_facts['device_conn'][duthost.hostname]

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -26,7 +26,7 @@ def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     yield
     if request.node.rep_call.failed:
-        mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+        mg_facts = duthost.get_extended_minigraph_facts()
         ports = mg_facts['minigraph_ports'].keys()
 
         # Enable outer interfaces

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -15,7 +15,7 @@ def skip_on_simx(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture()
-def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname):
+def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):
     """
     Bring up outer interfaces on the DUT.
 
@@ -26,7 +26,7 @@ def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     yield
     if request.node.rep_call.failed:
-        mg_facts = duthost.get_extended_minigraph_facts()
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         ports = mg_facts['minigraph_ports'].keys()
 
         # Enable outer interfaces

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -26,7 +26,7 @@ class TestContLinkFlap(object):
     TestContLinkFlap class for continuous link flap
     """
 
-    def test_cont_link_flap(self, request, duthosts, rand_one_dut_hostname, fanouthosts, bring_up_dut_interfaces):
+    def test_cont_link_flap(self, request, duthosts, rand_one_dut_hostname, fanouthosts, bring_up_dut_interfaces, tbinfo):
         """
         Validates that continuous link flap works as expected
 
@@ -69,7 +69,7 @@ class TestContLinkFlap(object):
         # Flap all interfaces one by one on DUT
         for iteration in range(3):
             logging.info("%d Iteration flap all interfaces one by one on DUT", iteration + 1)
-            port_toggle(duthost, watch=True)
+            port_toggle(duthost, tbinfo, watch=True)
 
         # Flap all interfaces one by one on Peer Device
         for iteration in range(3):

--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -46,7 +46,7 @@ def test_check_sfp_using_ethtool(duthosts, rand_one_dut_hostname, conn_graph_fac
                     "Unexpected line %s in %s" % (line, str(ethtool_sfp_output["stdout_lines"]))
 
     logging.info("Check interface status")
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts()
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -17,7 +17,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_check_sfp_using_ethtool(duthosts, rand_one_dut_hostname, conn_graph_facts):
+def test_check_sfp_using_ethtool(duthosts, rand_one_dut_hostname, conn_graph_facts, tbinfo):
     """This test case is to check SFP using the ethtool.
     """
     duthost = duthosts[rand_one_dut_hostname]
@@ -46,7 +46,7 @@ def test_check_sfp_using_ethtool(duthosts, rand_one_dut_hostname, conn_graph_fac
                     "Unexpected line %s in %s" % (line, str(ethtool_sfp_output["stdout_lines"]))
 
     logging.info("Check interface status")
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -181,7 +181,7 @@ class ContinuousReboot:
         """
         logging.info("Check BGP neighbors status. Expected state - established")
         bgp_facts = self.duthost.bgp_facts()['ansible_facts']
-        mg_facts  = self.duthost.minigraph_facts(host=self.duthost.hostname)['ansible_facts']
+        mg_facts  = self.duthost.get_extended_minigraph_facts()
 
         for value in bgp_facts['bgp_neighbors'].values():
             # Verify bgp sessions are established

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -89,7 +89,7 @@ class ContinuousReboot:
         self.pre_existing_cores = 0
 
 
-    def reboot_and_check(self):
+    def reboot_and_check(self, tbinfo):
         """
         Perform the specified type of reboot and check platform status.
         @param interfaces: DUT's interfaces defined by minigraph
@@ -106,7 +106,7 @@ class ContinuousReboot:
         self.check_services()
         self.check_reboot_type()
         self.check_interfaces_and_transceivers()
-        self.check_neighbors()
+        self.check_neighbors(tbinfo)
         logging.info("Finished reboot test and health checks..")
 
 
@@ -175,13 +175,13 @@ class ContinuousReboot:
 
 
     @handle_test_error
-    def check_neighbors(self):
+    def check_neighbors(self, tbinfo):
         """
         Perform a BGP neighborship check.
         """
         logging.info("Check BGP neighbors status. Expected state - established")
         bgp_facts = self.duthost.bgp_facts()['ansible_facts']
-        mg_facts  = self.duthost.get_extended_minigraph_facts()
+        mg_facts  = self.duthost.get_extended_minigraph_facts(tbinfo)
 
         for value in bgp_facts['bgp_neighbors'].values():
             # Verify bgp sessions are established
@@ -379,7 +379,7 @@ class ContinuousReboot:
             time.sleep(1)
 
 
-    def start_continuous_reboot(self, request, duthost, ptfhost, localhost, testbed, creds,):
+    def start_continuous_reboot(self, request, duthost, ptfhost, localhost, tbinfo, creds):
         self.test_set_up()
         # Start continuous warm/fast reboot on the DUT
         for count in range(self.continuous_reboot_count):
@@ -390,7 +390,7 @@ class ContinuousReboot:
                 .format(self.reboot_count, self.continuous_reboot_count, self.reboot_type))
             reboot_type = self.reboot_type + "-reboot"
             try:
-                self.advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, testbed, creds,\
+                self.advancedReboot = AdvancedReboot(request, duthost, ptfhost, localhost, tbinfo, creds,\
                     rebootType=reboot_type, moduleIgnoreErrors=True)
             except Exception:
                 self.sub_test_result = False
@@ -402,7 +402,7 @@ class ContinuousReboot:
                     break
                 continue
             self.handle_image_installation(count)
-            self.reboot_and_check()
+            self.reboot_and_check(tbinfo)
             self.advancedReboot.newSonicImage = None
             self.test_end_time = datetime.now()
             self.create_test_report()

--- a/tests/platform_tests/test_port_toggle.py
+++ b/tests/platform_tests/test_port_toggle.py
@@ -17,7 +17,7 @@ class TestPortToggle(object):
     TestPortToggle class for testing port toggle
     """
 
-    def test_port_toggle(self, duthosts, rand_one_dut_hostname, bring_up_dut_interfaces):
+    def test_port_toggle(self, duthosts, rand_one_dut_hostname, bring_up_dut_interfaces, tbinfo):
         """
         Validates that port toggle works as expected
 
@@ -28,4 +28,4 @@ class TestPortToggle(object):
         Pass Criteria: All interfaces are up correctly.
         """
         duthost = duthosts[rand_one_dut_hostname]
-        port_toggle(duthost)
+        port_toggle(duthost, tbinfo)

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -171,7 +171,7 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, con
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts()
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
@@ -277,7 +277,7 @@ def test_check_sfp_low_power_mode(duthosts, rand_one_dut_hostname, conn_graph_fa
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts()
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -90,7 +90,7 @@ def get_port_map(duthost):
     return port_mapping
 
 
-def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, conn_graph_facts):
+def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, conn_graph_facts, tbinfo):
     """
     @summary: Check SFP status and configure SFP
 
@@ -171,7 +171,7 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, con
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
@@ -180,7 +180,7 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, con
         loganalyzer.analyze(marker)
 
 
-def test_check_sfp_low_power_mode(duthosts, rand_one_dut_hostname, conn_graph_facts):
+def test_check_sfp_low_power_mode(duthosts, rand_one_dut_hostname, conn_graph_facts, tbinfo):
     """
     @summary: Check SFP low power mode
 
@@ -277,7 +277,7 @@ def test_check_sfp_low_power_mode(duthosts, rand_one_dut_hostname, conn_graph_fa
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
-    mg_facts = duthost.get_extended_minigraph_facts()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -19,7 +19,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='module',autouse=True)
-def setup(duthosts, rand_one_dut_hostname, ptfhost):
+def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     global var
     var = {}
@@ -28,7 +28,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost):
     if 'sflow' not in feature_status or feature_status['sflow'] == 'disabled':
         pytest.skip("sflow feature is not eanbled")
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     var['router_mac']  = duthost.facts['router_mac']
     vlan_dict = mg_facts['minigraph_vlans']
     var['test_ports'] = []
@@ -37,7 +37,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost):
 
     for i in range(0,3,1):
         var['test_ports'].append(vlan_dict['Vlan1000']['members'][i])
-        var['ptf_test_indices'].append(mg_facts['minigraph_port_indices'][vlan_dict['Vlan1000']['members'][i]])
+        var['ptf_test_indices'].append(mg_facts['minigraph_ptf_indices'][vlan_dict['Vlan1000']['members'][i]])
 
     collector_ips = ['20.1.1.2' ,'30.1.1.2']
     var['dut_intf_ips'] = ['20.1.1.1','30.1.1.1']
@@ -50,7 +50,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost):
         port = interfaces['members'][0]
         var['sflow_ports'][port] = {}
         var['sflow_ports'][port]['ifindex'] = get_ifindex(duthost,port)
-        var['sflow_ports'][port]['ptf_indices'] = mg_facts['minigraph_port_indices'][interfaces['members'][0]]
+        var['sflow_ports'][port]['ptf_indices'] = mg_facts['minigraph_ptf_indices'][interfaces['members'][0]]
         var['sflow_ports'][port]['sample_rate'] = 512
     var['portmap'] = json.dumps(var['sflow_ports'])
 

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -143,7 +143,7 @@ def neighbor_ip(duthosts, rand_one_dut_hostname, tbinfo):
     # ptf-32 topo is not supported in mirroring
     if tbinfo['topo']['name'] == 'ptf32':
         pytest.skip('Unsupported Topology')
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     dst_ip = None
     if mg_facts["minigraph_portchannel_interfaces"]:
         dst_ip = mg_facts["minigraph_portchannel_interfaces"][0]['peer_addr']

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -34,7 +34,7 @@ def test_snmp_lldp(duthosts, rand_one_dut_hostname, localhost, creds):
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
     snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
-    mg_facts   = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts   = duthost.get_extended_minigraph_facts()
 
     print snmp_facts['snmp_lldp']
     for k in ['lldpLocChassisIdSubtype', 'lldpLocChassisId', 'lldpLocSysName', 'lldpLocSysDesc']:

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -15,7 +15,7 @@ def lldp_setup(duthosts, rand_one_dut_hostname, patch_lldpctl, unpatch_lldpctl, 
 
 
 @pytest.mark.bsl
-def test_snmp_lldp(duthosts, rand_one_dut_hostname, localhost, creds):
+def test_snmp_lldp(duthosts, rand_one_dut_hostname, localhost, creds, tbinfo):
     """
     Test checks for ieee802_1ab MIBs:
      - lldpLocalSystemData  1.0.8802.1.1.2.1.3
@@ -34,7 +34,7 @@ def test_snmp_lldp(duthosts, rand_one_dut_hostname, localhost, creds):
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
     snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds["snmp_rocommunity"])['ansible_facts']
-    mg_facts   = duthost.get_extended_minigraph_facts()
+    mg_facts   = duthost.get_extended_minigraph_facts(tbinfo)
 
     print snmp_facts['snmp_lldp']
     for k in ['lldpLocChassisIdSubtype', 'lldpLocChassisId', 'lldpLocSysName', 'lldpLocSysDesc']:

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -8,12 +8,12 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
-def test_interfaces(duthosts, enum_dut_hostname):
+def test_interfaces(duthosts, enum_dut_hostname, tbinfo):
     """compare the interfaces between observed states and target state"""
 
     duthost    = duthosts[enum_dut_hostname]
     host_facts = duthost.setup()['ansible_facts']
-    mg_facts   = duthost.get_extended_minigraph_facts()
+    mg_facts   = duthost.get_extended_minigraph_facts(tbinfo)
 
     verify_port(host_facts, mg_facts['minigraph_portchannels'].keys())
     for k, v in mg_facts['minigraph_portchannels'].items():

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -13,7 +13,7 @@ def test_interfaces(duthosts, enum_dut_hostname):
 
     duthost    = duthosts[enum_dut_hostname]
     host_facts = duthost.setup()['ansible_facts']
-    mg_facts   = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts   = duthost.get_extended_minigraph_facts()
 
     verify_port(host_facts, mg_facts['minigraph_portchannels'].keys())
     for k, v in mg_facts['minigraph_portchannels'].items():

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -29,9 +29,9 @@ TMP_PORTS_FILE = '/tmp/ports.json'
 
 
 @pytest.fixture(scope="module")
-def setup(localhost, ptfhost, duthosts, rand_one_dut_hostname, upgrade_path_lists):
+def setup(localhost, ptfhost, duthosts, rand_one_dut_hostname, upgrade_path_lists, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    prepare_ptf(ptfhost, duthost)
+    prepare_ptf(ptfhost, duthost, tbinfo)
     yield
     cleanup(localhost, ptfhost, duthost, upgrade_path_lists)
 
@@ -52,11 +52,11 @@ def cleanup(localhost, ptfhost, duthost, upgrade_path_lists):
     os.remove(TMP_PORTS_FILE)
 
 
-def prepare_ptf(ptfhost, duthost):
+def prepare_ptf(ptfhost, duthost, tbinfo):
     logger.info("Preparing ptfhost")
 
     # Prapare vlan conf file
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     with open(TMP_VLAN_PORTCHANNEL_FILE, "w") as file:
         file.write(json.dumps(mg_facts['minigraph_portchannels']))
@@ -69,7 +69,7 @@ def prepare_ptf(ptfhost, duthost):
                  dest=TMP_VLAN_FILE)
 
     with open(TMP_PORTS_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_port_indices']))
+        file.write(json.dumps(mg_facts['minigraph_ptf_indices']))
     ptfhost.copy(src=TMP_PORTS_FILE,
                  dest=TMP_PORTS_FILE)
 
@@ -82,10 +82,10 @@ def prepare_ptf(ptfhost, duthost):
 
 
 @pytest.fixture(scope="module")
-def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds):
+def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     lo_v6_prefix = ""
     for intf in mg_facts["minigraph_lo_interfaces"]:
         ipn = ipaddress.IPNetwork(intf['addr'])

--- a/tests/vxlan/__init__.py
+++ b/tests/vxlan/__init__.py
@@ -53,7 +53,7 @@ def vnet_test_params(request):
     return params
 
 @pytest.fixture(scope="module")
-def minigraph_facts(duthosts, rand_one_dut_hostname):
+def minigraph_facts(duthosts, rand_one_dut_hostname, tbinfo):
     """
     Fixture to get minigraph facts
 
@@ -65,7 +65,7 @@ def minigraph_facts(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    return duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    return duthost.get_extended_minigraph_facts(tbinfo)
 
 @pytest.fixture(scope="module")
 def vnet_config(minigraph_facts, vnet_test_params, scaled_vnet_params):

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -43,7 +43,7 @@ def prepare_ptf(ptfhost, mg_facts, duthost):
 
     logger.info("Put information needed by the PTF script to the PTF container.")
     vxlan_decap = {
-        "minigraph_port_indices": mg_facts["minigraph_port_indices"],
+        "minigraph_port_indices": mg_facts["minigraph_ptf_indices"],
         "minigraph_portchannel_interfaces": mg_facts["minigraph_portchannel_interfaces"],
         "minigraph_portchannels": mg_facts["minigraph_portchannels"],
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],
@@ -92,11 +92,11 @@ def generate_vxlan_config_files(duthost, mg_facts):
 
 
 @pytest.fixture(scope="module")
-def setup(duthosts, rand_one_dut_hostname, ptfhost):
+def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
 
     logger.info("Gather some facts")
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     logger.info("Prepare PTF")
     prepare_ptf(ptfhost, mg_facts, duthost)


### PR DESCRIPTION
### Description of PR
Summary:
get minigraph facts through get_extended_minigraph_facts() method

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Unify the method of getting minigraph facts. This is to get testcases ready for dualtor / multi-dut scenarios.

#### How did you do it?
- change all minigraph_facts() calls through get_extended_minigraph_facts.
- access ptf port map from minigraph_ptf_indices

#### How did you verify/test it?
Run test cases on single dut testbed and dualtor testbed.

Passed tests on single DUT testbed: arp bgp crm dhcp_relay drop_packets ecmp everflow fdb fib iface_namingmode ipfwd lldp pc snmp
(drop_packets has some failures due to known SAI issue, didn't run rest of the test, because the change is essentially the same for all tests.)

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
