### PR TITLE
Move SONiC node type checking methods from DutHosts to SonicHost

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -11,7 +11,7 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     duthost = duthosts[enum_dut_hostname]
 
     # Check if duthost is 'supervisor' card, and skip the test if dealing with supervisor card.
-    if duthosts.is_supervisor_node(duthost):
+    if duthost.is_supervisor_node():
         pytest.skip("bgp_facts not valid on supervisor card '%s'" % enum_dut_hostname)
 
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -346,6 +346,29 @@ class SonicHost(AnsibleHostBase):
                 result[fields[0]] = fields[1]
         return result
 
+    def is_supervisor_node(self):
+        """Check if the current node is a supervisor node in case of multi-DUT.
+
+        Returns:
+            Currently, we are using 'type' in the inventory to make the decision. If 'type' for the node is defined in
+            the inventory, and it is 'supervisor', then return True, else return False. In future, we can change this
+            logic if possible to derive it from the DUT.
+        """
+        if 'type' in self.host.options["inventory_manager"].get_host(self.hostname).get_vars():
+            node_type = self.host.options["inventory_manager"].get_host(self.hostname).get_vars()["type"]
+            if node_type is not None and node_type == 'supervisor':
+                return True
+        return False
+
+    def is_frontend_node(self):
+        """Check if the current node is a frontend node in case of multi-DUT.
+
+        Returns:
+            True if it is not any other type of node. Currently, the only other type of node supported is 'supervisor'
+            node. If we add more types of nodes, then we need to exclude them from this method as well.
+        """
+        return not self.is_supervisor_node()
+
     def is_service_fully_started(self, service):
         """
         @summary: Check whether a SONiC specific service is fully started.
@@ -1075,12 +1098,12 @@ class K8sMasterHost(AnsibleHostBase):
 
     def __init__(self, ansible_adhoc, hostname, is_haproxy):
         """ Initialize an object for interacting with Ubuntu KVM using ansible modules
-        
+
         Args:
             ansible_adhoc (): The pytest-ansible fixture
             hostname (string): hostname of the Ubuntu KVM
             is_haproxy (boolean): True if node is haproxy load balancer, False if node is backend master server
-        
+
         """
         self.hostname = hostname
         self.is_haproxy = is_haproxy
@@ -1089,7 +1112,7 @@ class K8sMasterHost(AnsibleHostBase):
             'ansible_become_method': 'enable'
         }
         self.host.options['variable_manager'].extra_vars.update(evars)
-    
+
     def check_k8s_master_ready(self):
         """
         @summary: check if all Kubernetes master node statuses reflect target state "Ready"
@@ -1102,7 +1125,7 @@ class K8sMasterHost(AnsibleHostBase):
             if "NotReady" in line:
                 return False
         return True
-    
+
     def shutdown_api_server(self):
         """
         @summary: Shuts down API server container on one K8sMasterHost server
@@ -1119,7 +1142,7 @@ class K8sMasterHost(AnsibleHostBase):
     def start_api_server(self):
         """
         @summary: Starts API server container on one K8sMasterHost server
-        
+
         """
         self.shell('sudo systemctl start kubelet')
         logging.info("Starting API server on backend master server hostname: {}".format(self.hostname))
@@ -1148,7 +1171,7 @@ class K8sMasterHost(AnsibleHostBase):
 class K8sMasterCluster():
     """
     @summary: Class that encapsulates Kubernetes master cluster
-    
+
     For operating on a group of K8sMasterHost objects that compose one HA Kubernetes master cluster
     """
 
@@ -1157,7 +1180,7 @@ class K8sMasterCluster():
 
         Args:
             k8smasters: fixture that allows retrieval of K8sMasterHost objects
-        
+
         """
         self.backend_masters = []
         for hostname, k8smaster in k8smasters.items():
@@ -1165,27 +1188,27 @@ class K8sMasterCluster():
                 self.haproxy = k8smaster['host']
             else:
                 self.backend_masters.append(k8smaster)
-   
+
     def get_master_vip(self):
         """
         @summary: Retrieve VIP of Kubernetes master cluster
-        
+
         """
         return self.haproxy.mgmt_ip
 
     def shutdown_all_api_server(self):
         """
         @summary: shut down API server on all backend master servers
-        
+
         """
         for k8smaster in self.backend_masters:
             logger.info("Shutting down API Server on master node {}".format(k8smaster['host'].hostname))
             k8smaster['host'].shutdown_api_server()
-    
+
     def start_all_api_server(self):
         """
         @summary: Start API server on all backend master servers
-        
+
         """
         for k8smaster in self.backend_masters:
             logger.info("Starting API server on master node {}".format(k8smaster['host'].hostname))
@@ -1194,7 +1217,7 @@ class K8sMasterCluster():
     def check_k8s_masters_ready(self):
         """
         @summary: Ensure that Kubernetes master is in healthy state
-        
+
         """
         for k8smaster in self.backend_masters:
             assert k8smaster['host'].check_k8s_master_ready()
@@ -1202,11 +1225,11 @@ class K8sMasterCluster():
     def ensure_all_kubelet_running(self):
         """
         @summary: Ensures kubelet is started on all backend masters, start kubelet if necessary
-        
+
         """
         for k8smaster in self.backend_masters:
             k8smaster['host'].ensure_kubelet_running()
-            
+
 
 class EosHost(AnsibleHostBase):
     """
@@ -1648,8 +1671,8 @@ class DutHosts(object):
         """
         # TODO: Initialize the nodes in parallel using multi-threads?
         self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname) for hostname in tbinfo["duts"]])
-        self.supervisor_nodes = self._Nodes([node for node in self.nodes if self.is_supervisor_node(node)])
-        self.frontend_nodes = self._Nodes([node for node in self.nodes if self.is_frontend_node(node)])
+        self.supervisor_nodes = self._Nodes([node for node in self.nodes if node.is_supervisor_node()])
+        self.frontend_nodes = self._Nodes([node for node in self.nodes if node.is_frontend_node()])
 
     def __getitem__(self, index):
         """To support operations like duthosts[0] and duthost['sonic1_hostname']
@@ -1705,35 +1728,6 @@ class DutHosts(object):
             on that MultiAsicSonicHost
         """
         return getattr(self.nodes, attr)
-
-    def is_supervisor_node(self, node):
-        """ Is node a supervisor node
-
-        Args:
-            node: MultiAsicSonicHost object represent a DUT in the testbed.
-
-        Returns:
-            Currently, we are using 'type' in the inventory to make the decision.
-                if 'type' for the node is defined in the inventory, and it is 'supervisor', then return True, else return False
-            In future, we can change this logic if possible to derive it from the DUT.
-        """
-        if 'type' in node.host.options["inventory_manager"].get_host(node.hostname).get_vars():
-            card_type = node.host.options["inventory_manager"].get_host(node.hostname).get_vars()["type"]
-            if card_type is not None and card_type == 'supervisor':
-                return True
-        return False
-
-    def is_frontend_node(self, node):
-        """ Is not a frontend node
-        Args:
-            node: MultiAsicSonicHost object represent a DUT in the testbed.
-
-        Returns:
-            True if it is not any other type of node.
-            Currently, the only other type of node supported is 'supervisor' node. If we add more types of nodes, then
-            we need to exclude them from this method as well.
-        """
-        return node not in self.supervisor_nodes
 
 
 class FanoutHost(object):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Move SONiC node type checking methods from DutHosts to SonicHost

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For multi-DUT setup, we need a convenient way to check the node type. Originally
we have methods is_supervisor_node and is_frontend_node methods defined in
class DutHosts. It turns out that the better place to define these methods is in the
SonicHost class. 

#### How did you do it?
This change refactored the DutHosts class and moved these two methods to the SonicHost class. The affected script test_bgp_fact.py is also updated.

#### How did you verify/test it?
Test run the test_bgp_fact.py script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
