### PR TITLE
[SonicHost] Also ignore non-zero return code from 'supervisorctl status' when checking PMon container

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -412,7 +412,7 @@ class SonicHost(AnsibleHostBase):
         if succeeded and container_name == "pmon":
             expected_critical_group_list = []
             expected_critical_process_list = []
-            process_list = self.shell("docker exec {} supervisorctl status".format(container_name))
+            process_list = self.shell("docker exec {} supervisorctl status".format(container_name), module_ignore_errors=True))
             for process_info in process_list["stdout_lines"]:
                 process_name = process_info.split()[0].strip()
                 process_status = process_info.split()[1].strip()

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -412,7 +412,7 @@ class SonicHost(AnsibleHostBase):
         if succeeded and container_name == "pmon":
             expected_critical_group_list = []
             expected_critical_process_list = []
-            process_list = self.shell("docker exec {} supervisorctl status".format(container_name), module_ignore_errors=True))
+            process_list = self.shell("docker exec {} supervisorctl status".format(container_name), module_ignore_errors=True)
             for process_info in process_list["stdout_lines"]:
                 process_name = process_info.split()[0].strip()
                 process_status = process_info.split()[1].strip()


### PR DESCRIPTION
## Description of PR


Summary:

This PR is an addendum to https://github.com/Azure/sonic-mgmt/pull/2474, which ignores any non-zero return value from calls to `supervisorctl status`. However, in my previous PR, I missed making the same change to this second call to `supervisorctl status`.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

As part of migrating all Python code in SONiC to Python 3, we must upgrade supervisor to version >= 4.0.0, as this is the first version which supports Python 3. However, as of version 4.0.0, the return codes from `supervisorctl status` have changed, such that if _any_ process is not in a `RUNNING` state--even if it is expected (expected exit or even stopped by user)--it will return `3`. Thus, we need to ignore the return code from `supervisorctl status`.

- Example of the issue: https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image-pr/7176/consoleFull

- Discussion of supervisorctl behavior change: https://github.com/Supervisor/supervisor/issues/1223

#### How did you do it?

Add `module_ignore_errors=True` argument to `self.shell("docker exec {} supervisorctl status".format(service))` call

#### How did you verify/test it?

Run tests against a DUT, ensure sanity check passes. Do this with both supervisor 3.x and 4.x.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 