### PR TITLE
Modify reboot test to check for activating state of warmboot_finalizer

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -155,11 +155,11 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, timeout=0, wait=0, 
         logger.info('waiting for warmboot-finalizer service to become activating')
         finalizer_state = get_warmboot_finalizer_state(duthost)
         while finalizer_state != 'activating':
-            time.sleep(1)
             dut_datetime_after_ssh = duthost.get_up_time()
             time_passed = float(dut_datetime_after_ssh.strftime("%s")) - float(dut_datetime.strftime("%s"))
             if time_passed > wait:
                 raise Exception('warmboot-finalizer never reached state "activating"')
+            time.sleep(1)
             finalizer_state = get_warmboot_finalizer_state(duthost)
         logger.info('waiting for warmboot-finalizer service to finish')
         finalizer_state = get_warmboot_finalizer_state(duthost)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -68,7 +68,7 @@ reboot_ctrl_dict = {
 def get_warmboot_finalizer_state(duthost):
     try:
         res = duthost.command('systemctl is-active warmboot-finalizer.service',module_ignore_errors=True)
-        finalizer_state = res['stdout'].strip()
+        finalizer_state = res['stdout'].strip() if 'stdout' in res else ""
     except RunAnsibleModuleFail as err:
         finalizer_state = err.results
     return finalizer_state


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Modify reboot script to proactively check for activating state of warmboot-finalizer
Fixes # (issue) https://github.com/Azure/sonic-mgmt/issues/2147

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Assertion at https://github.com/Azure/sonic-mgmt/blob/master/tests/common/reboot.py#L154 can lead to a failure if wait time is enough for warmboot-finalizer to finish.

#### How did you do it?
Replace the dead-sleep with proactively checking for warmboot-finalizer state to become `activating`


#### How did you verify/test it?
Executed `test_warm_reboot` to verify state from activating to inactive (final state).
```
collected 1 item

platform_tests/test_reboot.py::test_warm_reboot
17:43:39 INFO test_reboot.py:reboot_and_check:57: Run warm reboot on DUT
17:43:43 INFO reboot.py:reboot:121: waiting for ssh to drop
17:43:43 INFO reboot.py:execute_reboot_command:105: rebooting with command "warm-reboot"
17:44:23 INFO reboot.py:reboot:139: waiting for ssh to startup
17:44:37 INFO reboot.py:reboot:150: ssh has started up
17:44:37 INFO reboot.py:reboot:152: waiting for switch to initialize
17:44:37 INFO reboot.py:reboot:155: waiting for warmboot-finalizer service to become activating
17:44:53 INFO reboot.py:reboot:168: waiting for warmboot-finalizer service to finish
17:44:53 INFO reboot.py:reboot:170: warmboot finalizer service state activating
17:44:54 INFO reboot.py:reboot:174: warmboot finalizer service state activating
17:50:01 INFO reboot.py:reboot:174: warmboot finalizer service state activating
17:50:12 INFO reboot.py:reboot:174: warmboot finalizer service state inactive
17:50:22 INFO reboot.py:reboot:179: warmboot-finalizer service finished
17:50:22 INFO reboot.py:reboot:181: warm reboot finished
17:50:22 INFO reboot.py:reboot:186: DUT up since 2020-11-17 17:44:24
PASSED                [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
