### PR TITLE
Fix the next hop ips for T0-56 topo

### DIFF
--- a/ansible/vars/topo_t0-56.yml
+++ b/ansible/vars/topo_t0-56.yml
@@ -144,8 +144,8 @@ configuration_properties:
     leaf_asn_start: 64600
     tor_asn_start: 65100
     failure_rate: 0
-    nhipv4: 10.10.246.100
-    nhipv6: FC0A::C9
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
 
 configuration:
   ARISTA01T1:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix the next hop ips for T0-56 topo


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### What is the motivation for this PR?
Exabgp sessions were not getting setup with the VMs because of incorrect v4 and v6 neighbor ips

#### How did you verify/test it?
Prior to the change, routes were not getting advertised. With the fix, routes are populated on the DUT. 


