### PR TITLE
creategraph - Support comments and empty lines in the lab_devices and lab links csv files

### DIFF
--- a/ansible/files/creategraph.py
+++ b/ansible/files/creategraph.py
@@ -35,7 +35,7 @@ class LabGraph(object):
 
     def read_devices(self):
         csv_dev = open(self.devcsv)
-        csv_devices = csv.DictReader(csv_dev)
+        csv_devices = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_dev))
         devices_root = etree.SubElement(self.pngroot, 'Devices')
         for row in csv_devices:
             attrs = {}
@@ -48,7 +48,7 @@ class LabGraph(object):
  
     def read_links(self):
         csv_file = open(self.linkcsv)
-        csv_links = csv.DictReader(csv_file)
+        csv_links = csv.DictReader(filter(lambda row: row[0]!='#' and len(row.strip())!=0, csv_file))
         links_root = etree.SubElement(self.pngroot, 'DeviceInterfaceLinks')
         for link in csv_links:
             attrs = {}


### PR DESCRIPTION
…b_links csv files

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The devices and links between them are added to a csv files lab_devices.csv and lab_links.csv. These files are fed into creategraph.py to generate to lab_connection_graph.xml file.

When dealing with many testbeds, all the devices and links are added to these files without any spaces or comments - making it hard to read.

Need to add capability to add empty lines and comments in these csv files.

Sample lab devices file:

```
Hostname,ManagementIp,HwSku,Type

# DUTs
str-msn2700-01,10.251.0.188/23,Mellanox-2700,DevSonic

# Fanouts
str-7260-10,10.251.0.13/23,Arista-7260QX-64,FanoutLeaf
str-7260-11,10.251.0.234/23,Arista-7260QX-64,FanoutRoot

# Testbed servers
str-acs-serv-01,10.251.0.245/23,TestServ,Server
```

#### How did you do it?
When using csv.DictReader - filter out empty lines and those starting with '#'

#### How did you verify/test it?

- ran creategraph.py with files with no comment and empty lines and with comments and empty lines.
- compared the generated lab_connection_graph.xml and made sure that that there are no differences.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
