### PR TITLE
[Platform API][Module] Use proper variable to index lists

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -234,7 +234,7 @@ class TestModuleApi(PlatformApiTestBase):
 
             for comp_idx in range(num_components):
                 component = module.get_component(platform_api_conn, mod_idx, comp_idx)
-                self.expect(component and component == component_list[mod_idx], "Module {}: Component {} is incorrect".format(mod_idx, comp_idx))
+                self.expect(component and component == component_list[comp_idx], "Module {}: Component {} is incorrect".format(mod_idx, comp_idx))
         self.assert_expectations()
 
     def test_fans(self, duthost, localhost, platform_api_conn):
@@ -256,7 +256,7 @@ class TestModuleApi(PlatformApiTestBase):
 
             for fan_idx in range(num_fans):
                 fan = module.get_fan(platform_api_conn, mod_idx, fan_idx)
-                self.expect(fan and fan == fan_list[mod_idx], "Module {}: Fan {} is incorrect".format(mod_idx, fan_idx))
+                self.expect(fan and fan == fan_list[fan_idx], "Module {}: Fan {} is incorrect".format(mod_idx, fan_idx))
         self.assert_expectations()
 
     def test_psus(self, duthost, localhost, platform_api_conn):
@@ -278,7 +278,7 @@ class TestModuleApi(PlatformApiTestBase):
 
             for psu_idx in range(num_psus):
                 psu = module.get_psu(platform_api_conn, mod_idx, psu_idx)
-                self.expect(psu and psu == psu_list[mod_idx], "Module {}: PSU {} is incorrect".format(mod_idx, psu_idx))
+                self.expect(psu and psu == psu_list[psu_idx], "Module {}: PSU {} is incorrect".format(mod_idx, psu_idx))
         self.assert_expectations()
 
     def test_thermals(self, duthost, localhost, platform_api_conn):
@@ -300,7 +300,7 @@ class TestModuleApi(PlatformApiTestBase):
 
             for therm_idx in range(num_thermals):
                 thermal = module.get_thermal(platform_api_conn, mod_idx, therm_idx)
-                self.expect(thermal and thermal == thermal_list[mod_idx], "Thermal {} is incorrect".format(mod_idx, therm_idx))
+                self.expect(thermal and thermal == thermal_list[therm_idx], "Thermal {} is incorrect".format(mod_idx, therm_idx))
         self.assert_expectations()
 
     def test_sfps(self, duthost, localhost, platform_api_conn):
@@ -322,5 +322,5 @@ class TestModuleApi(PlatformApiTestBase):
 
             for sfp_idx in range(num_sfps):
                 sfp = module.get_sfp(platform_api_conn, mod_idx, sfp_idx)
-                self.expect(sfp and sfp == sfp_list[mod_idx], "Module {}: SFP {} is incorrect".format(mod_idx, sfp_idx))
+                self.expect(sfp and sfp == sfp_list[sfp_idx], "Module {}: SFP {} is incorrect".format(mod_idx, sfp_idx))
         self.assert_expectations()


### PR DESCRIPTION
### Description of PR

Summary:

Use proper variables to index lists of devices contained in modules

Fixes https://github.com/Azure/sonic-mgmt/issues/2505

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Fix bug when indexing lists

#### How did you do it?

Use the proper variable to index list

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
