### PR TITLE
[tests] use duthost facts property to get router mac instead of ansible_Ethernet0

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -18,6 +18,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_module
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
+from tests.conftest import duthost
 
 logger = logging.getLogger(__name__)
 
@@ -109,10 +110,8 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
                       for ifname
                       in mg_facts["minigraph_vlans"].values()[0]["members"]]
 
-    host_facts = duthost.setup()["ansible_facts"]
-
     setup_information = {
-        "router_mac": host_facts["ansible_Ethernet0"]["macaddress"],
+        "router_mac": duthost.facts["router_mac"],
         "downstream_port_ids": downstream_port_ids,
         "upstream_port_ids": upstream_port_ids,
         "acl_table_ports": acl_table_ports,

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -42,7 +42,7 @@ class TestWrArp:
             'minigraph_lo_interfaces': mgFacts['minigraph_lo_interfaces'],
             'minigraph_vlans': mgFacts['minigraph_vlans'],
             'minigraph_vlan_interfaces': mgFacts['minigraph_vlan_interfaces'],
-            'dut_mac': duthost.setup()['ansible_facts']['ansible_Ethernet0']['macaddress']
+            'dut_mac': duthost.facts['router_mac']
         }
         with open(VXLAN_CONFIG_FILE, 'w') as file:
             file.write(json.dumps(vxlanConfigData, indent=4))

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -122,7 +122,6 @@ class AdvancedReboot:
         '''
         Build testbed data that are needed by ptf advanced-reboot.ReloadTest class
         '''
-        hostFacts = self.duthost.setup()['ansible_facts']
 
         self.mgFacts = self.duthost.minigraph_facts(host=self.duthost.hostname)['ansible_facts']
 
@@ -135,7 +134,7 @@ class AdvancedReboot:
         self.vlanMaxCnt = len(self.mgFacts['minigraph_vlans'].values()[0]['members']) - 1
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
-        self.rebootData['dut_mac'] = hostFacts['ansible_Ethernet0']['macaddress']
+        self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
         self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
         self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
 

--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -313,7 +313,7 @@ class Setup(object):
 
     def generate_router_mac(self):
         """ Get DUT MAC address which will be used by PTF as Ethernet destination MAC address during sending traffic """
-        self.vars["ptf_test_params"]["router_mac"] = self.ansible_facts["ansible_Ethernet0"]["macaddress"]
+        self.vars["ptf_test_params"]["router_mac"] = self.duthost.facts["router_mac"]
 
 
     def prepare_arp_responder(self):

--- a/tests/common/fixtures/populate_fdb.py
+++ b/tests/common/fixtures/populate_fdb.py
@@ -73,7 +73,7 @@ class PopulateFdb:
         vlanConfigData = {
             "vlan_ports": mgVlanPorts,
             "vlan_interfaces": vlan_interfaces,
-            "dut_mac": self.duthost.setup()["ansible_facts"]["ansible_Ethernet0"]["macaddress"]
+            "dut_mac": self.duthost.facts["router_mac"]
         }
 
         with open(self.VLAN_CONFIG_FILE, 'w') as file:

--- a/tests/common/plugins/ptfadapter/README.md
+++ b/tests/common/plugins/ptfadapter/README.md
@@ -17,9 +17,9 @@ Example test case code using PTF adapter:
 import ptf.testutils as testutils
 import ptf.mask as mask
 
-def test_some_traffic(ptfadapter):
+def test_some_traffic(duthost, ptfadapter):
     pkt = testutils.simple_tcp_packet(
-        eth_dst=host_facts['ansible_Ethernet0']['macaddress'],
+        eth_dst=duthost.facts["router_mac"],
         eth_src=ptfadapter.dataplane.get_mac(0, 0),
         ip_src='1.1.1.1',
         ip_dst='192.168.0.1',

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -317,10 +317,9 @@ def common_setup_teardown(tbinfo, duthosts, rand_one_dut_hostname):
         pytest.skip("Unsupported platform")
 
     try:
-        host_facts  = duthost.setup()['ansible_facts']
         mg_facts   = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-        router_mac = host_facts['ansible_Ethernet0']['macaddress']
+        router_mac = duthost.facts['router_mac']
         net_ports = []
         for name, val in mg_facts['minigraph_portchannels'].items():
             members = [mg_facts['minigraph_port_indices'][member] for member in val['members']]

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -172,13 +172,12 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    host_facts  = duthost.setup()['ansible_facts']
     conf_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
     # reinitialize data plane due to above changes on PTF interfaces
     ptfadapter.reinit()
 
-    router_mac = host_facts['ansible_Ethernet0']['macaddress']
+    router_mac = duthost.facts['router_mac']
 
     port_index_to_name = { v: k for k, v in conf_facts['port_index_map'].items() }
 

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -223,11 +223,10 @@ class TestFdbMacExpire:
             )
 
         fdbAgingTime = request.config.getoption('--fdb_aging_time')
-        hostFacts = duthost.setup()['ansible_facts']
 
         testParams = {
             "testbed_type": tbinfo["topo"]["name"],
-            "router_mac": hostFacts['ansible_Ethernet0']['macaddress'],
+            "router_mac": duthost.facts["router_mac"],
             "fdb_info": self.FDB_INFO_FILE,
             "dummy_mac_prefix": self.DUMMY_MAC_PREFIX,
         }

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -26,10 +26,9 @@ def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, fib):
     ptfhost.template(src="../ansible/roles/test/templates/fdb.j2", dest="/root/vlan_info.txt")
 
     # Start PTF runner
-    host_facts = duthost.setup()['ansible_facts']
     params = {
         'testbed_type': testbed_type,
-        'router_mac': host_facts['ansible_Ethernet0']['macaddress'],
+        'router_mac': duthost.facts['router_mac'],
         'vlan_info': '/root/vlan_info.txt'
     }
     log_file = "/tmp/dir_bcast.BcastTest.{}.log".format(datetime.now().strftime("%Y-%m-%d-%H:%M:%S"))

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -592,7 +592,6 @@ class QosSaiBase:
                 dutTestParams (dict): DUT host test params
         """
         duthost = duthosts[rand_one_dut_hostname]
-        dutFacts = duthost.setup()['ansible_facts']
         mgFacts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
         topo = tbinfo["topo"]["name"]
 
@@ -600,7 +599,7 @@ class QosSaiBase:
             "topo": topo,
             "hwsku": mgFacts["minigraph_hwsku"],
             "basicParams": {
-                "router_mac": '' if topo in self.SUPPORTED_T0_TOPOS else dutFacts['ansible_Ethernet0']['macaddress'],
+                "router_mac": '' if topo in self.SUPPORTED_T0_TOPOS else duthost.facts["router_mac"],
                 "server": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
                 "port_map_file": ptf_portmap_file,
                 "sonic_asic_type": duthost.facts['asic_type'],

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -29,7 +29,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost):
         pytest.skip("sflow feature is not eanbled")
 
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
-    var['host_facts']  = duthost.setup()['ansible_facts']
+    var['router_mac']  = duthost.facts['router_mac']
     vlan_dict = mg_facts['minigraph_vlans']
     var['test_ports'] = []
     var['ptf_test_indices'] = []
@@ -156,7 +156,7 @@ def verify_sflow_interfaces(duthost, intf, status, sampling_rate):
 def partial_ptf_runner(request, ptfhost, tbinfo):
     def _partial_ptf_runner(**kwargs):
         params = {'testbed_type': tbinfo['topo']['name'],
-                  'router_mac': var['host_facts']['ansible_Ethernet0']['macaddress'],
+                  'router_mac': var['router_mac'],
                   'dst_port' : var['ptf_test_indices'][2],
                   'agent_id' : var['mgmt_ip'],
                   'sflow_ports_file' : "/tmp/sflow_ports.json"}

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -109,7 +109,7 @@ def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds):
         "portchannel_ports_file": TMP_VLAN_PORTCHANNEL_FILE,
         "vlan_ports_file": TMP_VLAN_FILE,
         "ports_file": TMP_PORTS_FILE,
-        "dut_mac": duthost.setup()['ansible_facts']['ansible_Ethernet0']['macaddress'],
+        "dut_mac": duthost.facts["router_mac"],
         "dut_vlan_ip": "192.168.0.1",
         "default_ip_range": "192.168.100.0/18",
         "vlan_ip_range": mg_facts['minigraph_vlan_interfaces'][0]['subnet'],

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -108,9 +108,6 @@ def get_cfg_facts(duthost):
 
     return tmp_facts
 
-def get_host_facts(duthost):
-    return duthost.setup()['ansible_facts']
-
 def get_vrf_intfs(cfg_facts):
     intf_tables = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE']
     vrf_intfs = {}
@@ -337,10 +334,12 @@ def gen_vrf_neigh_file(vrf, ptfhost, render_file):
     ptfhost.template(src="vrf/vrf_neigh.j2", dest=render_file)
 
 # fixtures
+
 @pytest.fixture(scope="module")
-def host_facts(duthosts, rand_one_dut_hostname):
+def dut_facts(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
-    return get_host_facts(duthost)
+    return duthost.facts
+
 
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):
@@ -363,7 +362,7 @@ def restore_config_db(localhost, duthost, ptfhost):
         cleanup_vlan_peer(ptfhost, g_vars['vlan_peer_vrf2ns_map'])
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost, host_facts):
+def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     # backup config_db.json
@@ -419,10 +418,10 @@ def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost, host_
 
 
 @pytest.fixture
-def partial_ptf_runner(request, ptfhost, tbinfo, host_facts):
+def partial_ptf_runner(request, ptfhost, tbinfo, dut_facts):
     def _partial_ptf_runner(testname, **kwargs):
         params = {'testbed_type': tbinfo['topo']['name'],
-                  'router_mac': host_facts['ansible_Ethernet0']['macaddress']}
+                  'router_mac': dut_facts['router_mac']}
         params.update(kwargs)
         ptf_runner(host=ptfhost,
                    testdir="ptftests",

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -2,7 +2,7 @@ import pytest
 
 from test_vrf import g_vars
 from test_vrf import setup_vrf              # lgtm[py/unused-import]
-from test_vrf import host_facts             # lgtm[py/unused-import]
+from test_vrf import dut_facts             # lgtm[py/unused-import]
 from test_vrf import gen_vrf_neigh_file
 from test_vrf import partial_ptf_runner     # lgtm[py/unused-import]
 
@@ -17,7 +17,7 @@ class TestVrfAttrSrcMac():
     new_vrf1_router_mac = '00:12:34:56:78:9a'
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_vrf_attr_src_mac(self, duthosts, rand_one_dut_hostname, ptfhost, host_facts):
+    def setup_vrf_attr_src_mac(self, duthosts, rand_one_dut_hostname, ptfhost, dut_facts):
         duthost = duthosts[rand_one_dut_hostname]
         # -------- Setup ----------
         extra_vars = { 'router_mac': self.new_vrf1_router_mac }
@@ -34,7 +34,7 @@ class TestVrfAttrSrcMac():
         yield
 
         # -------- Teardown ----------
-        extra_vars = { 'router_mac': host_facts['ansible_Ethernet0']['macaddress'] }
+        extra_vars = { 'router_mac': dut_facts['router_mac'] }
         duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
         duthost.template(src="vrf_attr_src_mac.j2", dest="/tmp/vrf_attr_src_mac.json")
 
@@ -55,7 +55,7 @@ class TestVrfAttrSrcMac():
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
-    def test_vrf1_neigh_with_new_router_mac(self, ptfhost, host_facts, tbinfo):
+    def test_vrf1_neigh_with_new_router_mac(self, ptfhost, tbinfo):
         # send packets with new router_mac
         ptf_runner(ptfhost,
                 "ptftests",

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -50,7 +50,7 @@ def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],
         "minigraph_vlans": mg_facts["minigraph_vlans"],
         "minigraph_vlan_interfaces": mg_facts["minigraph_vlan_interfaces"],
-        "dut_mac": dut_facts["ansible_Ethernet0"]["macaddress"],
+        "dut_mac": dut_facts["router_mac"],
         "vnet_interfaces": vnet_config["vnet_intf_list"],
         "vnet_routes": vnet_config["vnet_route_list"] + vnet_config["vnet_subnet_routes"],
         "vnet_local_routes": vnet_config["vnet_local_routes"],
@@ -73,7 +73,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, minigraph_facts, vnet_config
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    dut_facts = duthost.setup(gather_subset="!all,!any,network", filter="ansible_Ethernet*")["ansible_facts"]
+    dut_facts = duthost.facts
 
     prepare_ptf(ptfhost, minigraph_facts, dut_facts, vnet_config)
 


### PR DESCRIPTION
…le_Ethernet0

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
