### PR TITLE
[qos/buffer drops] Add check for port-level buffer drop counters to SAI QoS tests

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1,20 +1,23 @@
-"""
-    QoS SAI feature in SONiC.
+"""SAI thrift-based tests for the QoS feature in SONiC.
 
-    Parameters:
-        --ptf_portmap <filename> (str): file name of port index to DUT interface alias map. Default is None.
-            In case of a filename is not provided, a file containing port indeces to aliases map will be generated.
+This set of test cases verifies QoS, buffer behavior, and buffer drop counter behavior. These are dataplane
+tests that depend on the SAI thrift library in order to pause ports/queues and read buffer drop counters as well
+as generic drop counters.
 
-        --disable_test (bool): Disables experimental QoS SAI test cases. Deafult is True
+Parameters:
+    --ptf_portmap <filename> (str): file name of port index to DUT interface alias map. Default is None.
+        In case of a filename is not provided, a file containing port indeces to aliases map will be generated.
 
-        --qos_swap_syncd (bool): Used to install the RPC syncd image before running the tests. Default is True.
+    --disable_test (bool): Disables experimental QoS SAI test cases. Default is True.
 
-        --qos_dst_ports (list) Indeces of available DUT test ports to serve as destination ports. Note, This is not port
-            index on DUT, rather an index into filtered (excludes lag member ports) DUT ports. Plan is to randomize port
-            selection. Default is [0, 1, 3]
+    --qos_swap_syncd (bool): Used to install the RPC syncd image before running the tests. Default is True.
 
-        --qos_src_ports (list) Indeces of available DUT test ports to serve as source port. Similar note as in
-            qos_dst_ports applies. Default is [2]
+    --qos_dst_ports (list) Indices of available DUT test ports to serve as destination ports. Note: This is not port
+        index on DUT, rather an index into filtered (excludes lag member ports) DUT ports. Plan is to randomize port
+        selection. Default is [0, 1, 3].
+
+    --qos_src_ports (list) Indices of available DUT test ports to serve as source port. Similar note as in
+        qos_dst_ports applies. Default is [2].
 """
 
 import logging
@@ -32,10 +35,16 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+
 class TestQosSai(QosSaiBase):
+    """TestQosSai derives from QosSaiBase and contains collection of QoS SAI test cases.
+
+    Note:
+        This test implicitly verifies that buffer drop counters (i.e. SAI_PORT_IN/OUT_DROPPED_PKTS)
+        are working as expected by verifying the drop counters everywhere that normal drop counters
+        are verified.
     """
-        TestQosSai derives from QosSaiBase and contains collection of QoS SAI test cases.
-    """
+
     SUPPORTED_PGSHARED_WATERMARK_SKUS = ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
     SUPPORTED_HEADROOM_SKUS = [
         'Arista-7060CX-32S-C32',

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -6,7 +6,7 @@ as generic drop counters.
 
 Parameters:
     --ptf_portmap <filename> (str): file name of port index to DUT interface alias map. Default is None.
-        In case of a filename is not provided, a file containing port indeces to aliases map will be generated.
+        In case a filename is not provided, a file containing a port indices to aliases map will be generated.
 
     --disable_test (bool): Disables experimental QoS SAI test cases. Default is True.
 

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -608,7 +608,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
-            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send 1 packet to trigger pfc
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -626,7 +626,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
-            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send packets short of ingress drop
             send_packet(self, src_port_id, pkt, pkts_num_trig_ingr_drp - pkts_num_trig_pfc - 1 - 2 * margin)
@@ -644,7 +644,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
-            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send 1 packet to trigger ingress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -662,7 +662,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[INGRESS_PORT_BUFFER_DROP] > recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
-            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -40,6 +40,8 @@ PFC_PRIO_3 = 5
 PFC_PRIO_4 = 6
 TRANSMITTED_OCTETS = 10
 TRANSMITTED_PKTS = 11
+INGRESS_PORT_BUFFER_DROP = 12
+EGRESS_PORT_BUFFER_DROP = 13
 QUEUE_0 = 0
 QUEUE_1 = 1
 QUEUE_2 = 2
@@ -603,8 +605,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send 1 packet to trigger pfc
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -619,8 +623,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send packets short of ingress drop
             send_packet(self, src_port_id, pkt, pkts_num_trig_ingr_drp - pkts_num_trig_pfc - 1 - 2 * margin)
@@ -635,8 +641,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send 1 packet to trigger ingress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -651,8 +659,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port ingress drop
             assert(recv_counters[INGRESS_DROP] > recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] > recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(recv_counters[EGRESS_PORT_BUFFER_DROP] == recv_counters_base[EGRESS_PORT_BUFFER_DROP])
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
@@ -758,10 +768,14 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
             assert(xmit_2_counters[EGRESS_DROP] == xmit_2_counters_base[EGRESS_DROP])
+            assert(xmit_2_counters[EGRESS_PORT_BUFFER_DROP] == xmit_2_counters_base[EGRESS_PORT_BUFFER_DROP])
             assert(xmit_3_counters[EGRESS_DROP] == xmit_3_counters_base[EGRESS_DROP])
+            assert(xmit_3_counters[EGRESS_PORT_BUFFER_DROP] == xmit_3_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_2_id])
 
@@ -778,10 +792,14 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] > recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
             assert(xmit_2_counters[EGRESS_DROP] == xmit_2_counters_base[EGRESS_DROP])
+            assert(xmit_2_counters[EGRESS_PORT_BUFFER_DROP] == xmit_2_counters_base[EGRESS_PORT_BUFFER_DROP])
             assert(xmit_3_counters[EGRESS_DROP] == xmit_3_counters_base[EGRESS_DROP])
+            assert(xmit_3_counters[EGRESS_PORT_BUFFER_DROP] == xmit_3_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_3_id])
 
@@ -791,6 +809,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             # queue counters value is not of our interest here
             recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[src_port_id])
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             recv_counters_base = recv_counters
 
             time.sleep(30)
@@ -804,10 +823,14 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
             assert(xmit_2_counters[EGRESS_DROP] == xmit_2_counters_base[EGRESS_DROP])
+            assert(xmit_2_counters[EGRESS_PORT_BUFFER_DROP] == xmit_2_counters_base[EGRESS_PORT_BUFFER_DROP])
             assert(xmit_3_counters[EGRESS_DROP] == xmit_3_counters_base[EGRESS_DROP])
+            assert(xmit_3_counters[EGRESS_PORT_BUFFER_DROP] == xmit_3_counters_base[EGRESS_PORT_BUFFER_DROP])
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
@@ -975,6 +998,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
                 recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
                 # assert no ingress drop
                 assert(recv_counters[INGRESS_DROP] == recv_counters_bases[sidx_dscp_pg_tuples[i][0]][INGRESS_DROP])
+                assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_bases[sidx_dscp_pg_tuples[i][0]][INGRESS_PORT_BUFFER_DROP])
 
             print >> sys.stderr, "all but the last pg hdrms filled"
             sys.stderr.flush()
@@ -988,10 +1012,12 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             recv_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[self.src_port_ids[sidx_dscp_pg_tuples[i][0]]])
             # assert ingress drop
             assert(recv_counters[INGRESS_DROP] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] > recv_counters_bases[sidx_dscp_pg_tuples[i][0]][INGRESS_PORT_BUFFER_DROP])
 
             # assert no egress drop at the dut xmit port
             xmit_counters, queue_counters = sai_thrift_read_port_counters(self.client, port_list[self.dst_port_id])
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             print >> sys.stderr, "pg hdrm filled"
             sys.stderr.flush()
@@ -1117,7 +1143,9 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
                 assert (non_marked_data >= limit*0.95)
                 assert (marked_cnt == (num_of_pkts - not_marked_cnt))
                 assert (port_counters[EGRESS_DROP]  == 0)
+                assert (port_counters[EGRESS_PORT_BUFFER_DROP] == 0)
                 assert (port_counters[INGRESS_DROP] == 0)
+                assert (port_counters[INGRESS_PORT_BUFFER_DROP] == 0)
 
         finally:
             # RELEASE PORT
@@ -1401,8 +1429,10 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port no egress drop
             assert(xmit_counters[EGRESS_DROP] == xmit_counters_base[EGRESS_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] == xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
             # send 1 packet to trigger egress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
@@ -1416,8 +1446,10 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             assert(recv_counters[pg] == recv_counters_base[pg])
             # recv port no ingress drop
             assert(recv_counters[INGRESS_DROP] == recv_counters_base[INGRESS_DROP])
+            assert(recv_counters[INGRESS_PORT_BUFFER_DROP] == recv_counters_base[INGRESS_PORT_BUFFER_DROP])
             # xmit port egress drop
             assert(xmit_counters[EGRESS_DROP] > xmit_counters_base[EGRESS_DROP])
+            assert(xmit_counters[EGRESS_PORT_BUFFER_DROP] > xmit_counters_base[EGRESS_PORT_BUFFER_DROP])
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])

--- a/tests/saitests/switch.py
+++ b/tests/saitests/switch.py
@@ -663,6 +663,9 @@ def sai_thrift_read_port_counters(client,port):
     port_cnt_ids.append(SAI_PORT_STAT_PFC_7_TX_PKTS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_OCTETS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_UCAST_PKTS)
+    port_cnt_ids.append(SAI_PORT_STAT_IN_DROPPED_PKTS)
+    port_cnt_ids.append(SAI_PORT_STAT_OUT_DROPPED_PKTS)
+
     counters_results=[]
     counters_results = client.sai_thrift_get_port_stats(port,port_cnt_ids,len(port_cnt_ids))
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

DEPENDS ON https://github.com/Azure/sonic-swss/pull/1509 for 201911

Summary: Add check for port-level buffer drop counters to SAI QoS tests

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We now have counters in the SAI that can check for buffer drops. We want to verify that these counters work as expected.

#### How did you do it?
Since the QoS SAI tests are already validating that packets are dropped in the buffer as expected on ingress/egress depending on the specific buffer configuration of a given DUT, I added an additional check for the new buffer drop counters to these tests.

#### How did you verify/test it?
Ran the tests multiple times on different platforms. Also manually checked during the tests that the counters were increasing as expected on a 30s polling interval.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
