### PR TITLE
[Mellanox] Fix issue: thermal control test cases fail to recover all sysfs files

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -112,6 +112,7 @@ class MockerHelper:
         self.dut = dut
         #self.unlink_file_list = {}
         self._extract_num_of_fans_and_fan_drawers()
+        self.deinit_retry = 5
 
     def _extract_num_of_fans_and_fan_drawers(self):
         """
@@ -235,10 +236,27 @@ class MockerHelper:
         Destructor of MockerHelper. Re-link all sys fs files.
         :return:
         """
+        failed_recover_files = {}
         for file_path, link_target in self.unlink_file_list.items():
-            self.dut.command('rm -f {}'.format(file_path))
-            self.dut.command('ln -s {} {}'.format(link_target, file_path))
+            try:
+                self.dut.command('ln -f -s {} {}'.format(link_target, file_path))
+            except Exception as e:
+                # Catch any exception for later retry
+                failed_recover_files[file_path] = link_target
+
         self.unlink_file_list.clear()
+        # If there is any failed recover files, retry it
+        if failed_recover_files:
+            self.deinit_retry -= 1
+            if self.deinit_retry > 0:
+                self.unlink_file_list = failed_recover_files
+                self.deinit()
+            else:
+                # We don't want to retry it infinite, and 5 times retry
+                # is enough, so if it still fails after the retry, it
+                # means there is probably an issue with our sysfs, we need
+                # mark it fail here
+                assert 0, "Failed to recover all sysfs files, failed files: {}".format(failed_recover_files)
 
 
 class FanDrawerData:

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -4,6 +4,7 @@ import random
 import logging
 from tests.platform_tests.thermal_control_test_helper import *
 from tests.common.mellanox_data import get_platform_data
+from tests.common.reboot import reboot
 from minimum_table import get_min_table
 
 NOT_AVAILABLE = 'N/A'
@@ -256,7 +257,9 @@ class MockerHelper:
                 # is enough, so if it still fails after the retry, it
                 # means there is probably an issue with our sysfs, we need
                 # mark it fail here
-                assert 0, "Failed to recover all sysfs files, failed files: {}".format(failed_recover_files)
+                error_message = "Failed to recover all sysfs files, failed files: {}".format(failed_recover_files)
+                logging.error(error_message)
+                raise RuntimeError(error_message)
 
 
 class FanDrawerData:

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -4,7 +4,6 @@ import random
 import logging
 from tests.platform_tests.thermal_control_test_helper import *
 from tests.common.mellanox_data import get_platform_data
-from tests.common.reboot import reboot
 from minimum_table import get_min_table
 
 NOT_AVAILABLE = 'N/A'

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -87,13 +87,13 @@ def mocker(type_name):
 
 
 @pytest.fixture
-def mocker_factory(localhost):
+def mocker_factory(localhost, duthosts, rand_one_dut_hostname):
     """
     Fixture for thermal control data mocker factory.
     :return: A function for creating thermal control related data mocker.
     """
     mockers = []
-    duthost = None
+    duthost = duthosts[rand_one_dut_hostname]
 
     def _create_mocker(dut, mocker_name):
         """
@@ -102,7 +102,6 @@ def mocker_factory(localhost):
         :param mocker_name: Name of a mocker type.
         :return: Created mocker instance.
         """
-        duthost = dut
         platform = dut.facts['platform']
         mocker_object = None
 

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
+from tests.common.reboot import reboot
 
 DUT_THERMAL_POLICY_FILE = '/usr/share/sonic/device/{}/thermal_policy.json'
 DUT_THERMAL_POLICY_BACKUP_FILE = '/usr/share/sonic/device/{}/thermal_policy.json.bak'
@@ -86,12 +87,13 @@ def mocker(type_name):
 
 
 @pytest.fixture
-def mocker_factory():
+def mocker_factory(localhost):
     """
     Fixture for thermal control data mocker factory.
     :return: A function for creating thermal control related data mocker.
     """
     mockers = []
+    duthost = None
 
     def _create_mocker(dut, mocker_name):
         """
@@ -100,6 +102,7 @@ def mocker_factory():
         :param mocker_name: Name of a mocker type.
         :return: Created mocker instance.
         """
+        duthost = dut
         platform = dut.facts['platform']
         mocker_object = None
 
@@ -115,8 +118,12 @@ def mocker_factory():
 
     yield _create_mocker
 
-    for m in mockers:
-        m.deinit()
+    try:
+        for m in mockers:
+            m.deinit()
+    except Exception as e:
+        reboot(duthost, localhost)
+        assert 0, "Caught exception while recovering from mock - {}".format(repr(e))
 
 
 class FanStatusMocker(BaseMocker):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue that thermal control test cases fail to recover all sysfs. In thermal control test cases, it might remove some existing sysfs files and create fake one, and it will recover all sysfs files after the test. The current way to recover sysfs is by removing and relink files. But there is chance that SONiC platform API may create a new file between removing and relink files, and it would cause the relink fail. The solution is to use "ln -f" here.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Fixes issue that thermal control test cases fail to recover all sysfs

#### How did you do it?

Use ln -f.

#### How did you verify/test it?

Manually run the regression.

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
