### PR TITLE
test_pfc_pause - fix file path issue and use PTF fixtures

### DIFF
--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -180,12 +180,10 @@ def gen_testbed_t0(duthost):
 
     return vlan_members, ptf_intfs, vlan_ip_addrs, vlan_mac_addrs
 
-def setup_testbed(fanouthosts, ptfhost, leaf_fanouts, ptf_local_path, ptf_remote_path):
+def setup_testbed(fanouthosts, ptfhost, leaf_fanouts):
     """
     @Summary: Set up the testbed
     @param leaf_fanouts: Leaf fanout switches
-    @param ptf_local_path: local path of PTF script
-    @param ptf_remote_dest: remote path of PTF script
     """
 
     """ Copy the PFC generator to leaf fanout switches """
@@ -200,14 +198,3 @@ def setup_testbed(fanouthosts, ptfhost, leaf_fanouts, ptf_local_path, ptf_remote
     for peer_device in leaf_fanouts:
         peerdev_ans = fanouthosts[peer_device]
         stop_pause(peerdev_ans, PFC_GEN_FILE)
-
-    """ Remove existing python scripts on PTF """
-    result = ptfhost.find(paths=['~/'], patterns="*.py")['files']
-    files = [ansible_stdout_to_str(x['path']) for x in result]
-
-    for file in files:
-        ptfhost.file(path=file, mode="absent")
-
-    """ Copy the PFC test script to the PTF container """
-    file_src = os.path.join(os.path.dirname(__file__), ptf_local_path)
-    ptfhost.copy(src=file_src, dest=ptf_remote_path, force=True)

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -2,6 +2,7 @@ from netaddr import IPAddress, IPNetwork
 from qos_fixtures import lossless_prio_dscp_map, leaf_fanouts
 import json
 import re
+import os
 import ipaddress
 import random
 
@@ -192,7 +193,8 @@ def setup_testbed(fanouthosts, ptfhost, leaf_fanouts, ptf_local_path, ptf_remote
         peerdev_ans = fanouthosts[peer_device]
         cmd = "sudo kill -9 $(pgrep -f %s) </dev/null >/dev/null 2>&1 &" % (PFC_GEN_FILE)
         peerdev_ans.host.shell(cmd)
-        peerdev_ans.host.copy(src=PFC_GEN_LOCAL_PATH, dest=PFC_GEN_REMOTE_PATH, force=True)
+        file_src = os.path.join(os.path.dirname(__file__), PFC_GEN_LOCAL_PATH)
+        peerdev_ans.host.copy(src=file_src, dest=PFC_GEN_REMOTE_PATH, force=True)
 
     """ Stop PFC storm at the leaf fanout switches """
     for peer_device in leaf_fanouts:

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -209,4 +209,5 @@ def setup_testbed(fanouthosts, ptfhost, leaf_fanouts, ptf_local_path, ptf_remote
         ptfhost.file(path=file, mode="absent")
 
     """ Copy the PFC test script to the PTF container """
-    ptfhost.copy(src=ptf_local_path, dest=ptf_remote_path, force=True)
+    file_src = os.path.join(os.path.dirname(__file__), ptf_local_path)
+    ptfhost.copy(src=file_src, dest=ptf_remote_path, force=True)

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -9,14 +9,16 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from qos_fixtures import lossless_prio_dscp_map, leaf_fanouts
 from qos_helpers import ansible_stdout_to_str, eos_to_linux_intf, start_pause, stop_pause, setup_testbed, gen_testbed_t0, PFC_GEN_FILE, PFC_GEN_REMOTE_PATH
 
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+
 pytestmark = [
     pytest.mark.topology('t0')
 ]
 
 PFC_PKT_COUNT = 1000000000
 
-PTF_FILE_LOCAL_PATH = '../../ansible/roles/test/files/ptftests/pfc_pause_test.py'
-PTF_FILE_REMOTE_PATH = '~/pfc_pause_test.py'
+PTF_FILE_REMOTE_PATH = '~/ptftests/pfc_pause_test.py'
 PTF_PKT_COUNT = 50
 PTF_PKT_INTVL_SEC = 0.1
 PTF_PASS_RATIO_THRESH = 0.6
@@ -118,7 +120,7 @@ def run_test_t0(fanouthosts,
                        + "queue_paused=%s;" % queue_paused
                        + "dut_has_mac=False")
 
-        cmd = 'ptf --test-dir %s %s --test-params="%s"' % (os.path.dirname(PTF_FILE_REMOTE_PATH), intf_info, test_params)
+        cmd = 'ptf --test-dir %s pfc_pause_test %s --test-params="%s"' % (os.path.dirname(PTF_FILE_REMOTE_PATH), intf_info, test_params)
         print cmd
         stdout = ansible_stdout_to_str(ptfhost.shell(cmd)['stdout'])
         words = stdout.split()
@@ -207,9 +209,7 @@ def test_pfc_pause_lossless(fanouthosts,
     """
     setup_testbed(fanouthosts=fanouthosts,
                   ptfhost=ptfhost,
-                  leaf_fanouts=leaf_fanouts,
-                  ptf_local_path=PTF_FILE_LOCAL_PATH,
-                  ptf_remote_path=PTF_FILE_REMOTE_PATH)
+                  leaf_fanouts=leaf_fanouts)
 
     errors = []
 
@@ -280,9 +280,7 @@ def test_no_pfc(fanouthosts,
     """
     setup_testbed(fanouthosts=fanouthosts,
                   ptfhost=ptfhost,
-                  leaf_fanouts=leaf_fanouts,
-                  ptf_local_path=PTF_FILE_LOCAL_PATH,
-                  ptf_remote_path=PTF_FILE_REMOTE_PATH)
+                  leaf_fanouts=leaf_fanouts)
 
     errors = []
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_pfc_pause - fix file path issue and use PTF fixtures
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To fix errors that are seen in `qos/test_pfc_pause.py`

```    
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module copy failed, Ansible Results =>
E           {
E               "changed": false, 
E               "failed": true, 
E               "invocation": {
E                   "dest": "~/pfc_gen.py", 
E                   "force": true, 
E                   "module_args": {
E                       "dest": "~/pfc_gen.py", 
E                       "force": true, 
E                       "src": "../../ansible/roles/test/files/helpers/pfc_gen.py"
E                   }, 
E                   "src": "../../ansible/roles/test/files/helpers/pfc_gen.py"
E               }, 
E               "msg": "Could not find or access '../../ansible/roles/test/files/helpers/pfc_gen.py"
E           }
```

Additionally, enhanced the test to use available fixtures to transfer PTF files.

This test needs further update/refactoring to use latest fixtures and plugins.

#### How did you do it?

Updated the path error.
Changed PTF transfer to use fixture.

#### How did you verify/test it?
Tested `qos/test_pfc_pause.py::test_no_pfc` and the previous error is not seen anymore.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
