### PR TITLE
[lldpctl patch] patch lldpctl script to work around ansible bug

### DIFF
--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -17,6 +17,14 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="module", autouse="True")
+def lldp_setup(duthosts, rand_one_dut_hostname, patch_lldpctl, unpatch_lldpctl, localhost):
+    duthost = duthosts[rand_one_dut_hostname]
+    patch_lldpctl(localhost, duthost)
+    yield
+    unpatch_lldpctl(localhost, duthost)
+
+
 def lag_facts(dut, mg_facts):
     facts = {}
 

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -8,6 +8,15 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+
+@pytest.fixture(scope="module", autouse="True")
+def lldp_setup(duthosts, rand_one_dut_hostname, patch_lldpctl, unpatch_lldpctl, localhost):
+    duthost = duthosts[rand_one_dut_hostname]
+    patch_lldpctl(localhost, duthost)
+    yield
+    unpatch_lldpctl(localhost, duthost)
+
+
 def test_lldp(duthosts, rand_one_dut_hostname, localhost, collect_techsupport):
     """ verify the LLDP message on DUT """
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -5,6 +5,15 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+
+@pytest.fixture(scope="module", autouse="True")
+def lldp_setup(duthosts, rand_one_dut_hostname, patch_lldpctl, unpatch_lldpctl, localhost):
+    duthost = duthosts[rand_one_dut_hostname]
+    patch_lldpctl(localhost, duthost)
+    yield
+    unpatch_lldpctl(localhost, duthost)
+
+
 @pytest.mark.bsl
 def test_snmp_lldp(duthosts, rand_one_dut_hostname, localhost, creds):
     """


### PR DESCRIPTION
Summary:
Fixes #2558 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Ansible 2.8.12 has a bug in lldp module, when lldpctl -f keyvalue shows multiple unknown-tlvs for a single interface, it will throw
exception.

#### How did you do it?
This change is to work around the ansible lldp module issue for the time being.

#### How did you verify/test it?
Run lldp/test_lldp.py, test passes.
Run snmp/test_snmp_lldp.py. test passes.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
