### PR TITLE
[Mellanox] Fixes issue: PSU fan status might be Not OK due to speed out of range

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -647,6 +647,9 @@ class RandomFanStatusMocker(CheckMockerResultMixin, FanStatusMocker):
         presence = 0
         direction = NOT_AVAILABLE
         naming_rule = FAN_NAMING_RULE['fan']
+        # All system fan is controlled to have the same speed, so only
+        # get a random value once here
+        speed = random.randint(60, 100)
         while fan_index <= MockerHelper.FAN_NUM:
             try:
                 if (fan_index - 1) % MockerHelper.FAN_NUM_PER_DRAWER == 0:
@@ -664,7 +667,6 @@ class RandomFanStatusMocker(CheckMockerResultMixin, FanStatusMocker):
                 fan_index += 1
                 if presence == 1:
                     fan_data.mock_status(random.randint(0, 1))
-                    speed = random.randint(60, 100)
                     fan_data.mock_speed(speed)
                     fan_data.mock_target_speed(speed)
                     self.expected_data[fan_data.name] = [

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -366,6 +366,9 @@ class FanData:
     # Speed tolerance
     SPEED_TOLERANCE = 0.2
 
+    # Cooling cur state file
+    COOLING_CUR_STATE_FILE = 'cooling_cur_state'
+
     def __init__(self, mock_helper, naming_rule, index):
         """
         Constructor of FAN data.
@@ -434,6 +437,10 @@ class FanData:
             self.mocked_status = 'OK' if status == 0 else 'Not OK'
         else:
             self.mocked_status = 'OK'
+
+    @classmethod
+    def mock_cooling_cur_state(cls, mock_helper, value):
+        mock_helper.mock_thermal_value(cls.COOLING_CUR_STATE_FILE, str(value))
 
     def get_max_speed(self):
         """
@@ -650,6 +657,7 @@ class RandomFanStatusMocker(CheckMockerResultMixin, FanStatusMocker):
         # All system fan is controlled to have the same speed, so only
         # get a random value once here
         speed = random.randint(60, 100)
+        FanData.mock_cooling_cur_state(self.mock_helper, speed/10)
         while fan_index <= MockerHelper.FAN_NUM:
             try:
                 if (fan_index - 1) % MockerHelper.FAN_NUM_PER_DRAWER == 0:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue: PSU fan status might be Not OK due to speed out of range

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

System fans and PSU fans are controlled together to have the same speed, so we need mock one speed for those fans instead of mock different speed for different fans.

#### How did you do it?

Only set mock speed value once

#### How did you verify/test it?

Manual test.

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
