### PR TITLE
Update ixia_fixture to fix collection errors

### DIFF
--- a/tests/common/ixia/ixia_fixtures.py
+++ b/tests/common/ixia/ixia_fixtures.py
@@ -9,7 +9,7 @@ from ixnetwork_restpy import SessionAssistant
 try:
     from ixnetwork_open_traffic_generator.ixnetworkapi import IxNetworkApi
 except ImportError as e:
-    raise pytest.skip.Exception("Test case is skiped: " + repr(e), allow_module_level=True)
+    raise pytest.skip.Exception("Test case is skipped: " + repr(e), allow_module_level=True)
 
 @pytest.fixture(scope = "module")
 def ixia_api_serv_ip(tbinfo):

--- a/tests/common/ixia/ixia_fixtures.py
+++ b/tests/common/ixia/ixia_fixtures.py
@@ -6,7 +6,10 @@ included in this file.
 
 import pytest
 from ixnetwork_restpy import SessionAssistant
-from ixnetwork_open_traffic_generator.ixnetworkapi import IxNetworkApi
+try:
+    from ixnetwork_open_traffic_generator.ixnetworkapi import IxNetworkApi
+except ImportError as e:
+    raise pytest.skip.Exception("Test case is skiped: " + repr(e), allow_module_level=True)
 
 @pytest.fixture(scope = "module")
 def ixia_api_serv_ip(tbinfo):
@@ -149,14 +152,14 @@ def ixia_api_server_session(
 
 @pytest.fixture(scope = "function")
 def ixia_api(ixia_api_serv_ip,
-             ixia_api_serv_port, 
-             ixia_api_serv_user, 
+             ixia_api_serv_port,
+             ixia_api_serv_user,
              ixia_api_serv_passwd):
 
     api_session = IxNetworkApi(address=ixia_api_serv_ip,
                                port=ixia_api_serv_port,
                                username=ixia_api_serv_user,
                                password=ixia_api_serv_passwd)
-    
+
     yield api_session
     api_session.assistant.Session.remove()


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Errors were reported during pytest collecting test cases because ImportError for IxNetworkApi, which is available only on ixia devices.
```
ImportError while importing test module '/var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_A7260/tests/pfc/test_pfc_pause_lossless.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
pfc/test_pfc_pause_lossless.py:10: in <module>
    from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, \
common/ixia/ixia_fixtures.py:9: in <module>
    from ixnetwork_open_traffic_generator.ixnetworkapi import IxNetworkApi
E   ImportError: No module named ixnetwork_open_traffic_generator.ixnetworkapi
```
This commit attempts to catch import exception and skips cases when exception is caught.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to address pytest collection error caused by import exception.

#### How did you do it?
Add a logic to catch import exception, and skip cases if exception is caught.

#### How did you verify/test it?
Verified on Arista-7260 by running pytest collecting command.
```
pytest --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv -m pretest --collect-only

SKIPPED [3] /data/Networking-acs-sonic-mgmt/tests/common/ixia/ixia_fixtures.py:13: Test case is skiped: ImportError('No module named ixnetwork_open_traffic_generator.ixnetworkapi',)
====================================================================== 3 skipped, 1209 deselected, 12 warnings in 47.55 seconds =======================================================================
```
We can see that 3 cases were skipped and no error was observed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.