### PR TITLE
[syslog] Fixes syslog test case to add a route to PTF server

### DIFF
--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -58,7 +58,7 @@ def config_dut(tbinfo, duthosts, rand_one_dut_hostname):
     if not gw:
         assert("No IPv4 default GW found for eth0")
     duthost.shell("sudo ip route add {}/32 via {} dev eth0".format(local_syslog_srv_ip, gw))
-    logger.debug("Added new route to PTF witch command: sudo ip route add {}/32 via {} dev eth0".format(local_syslog_srv_ip, gw))
+    logger.debug("Added new route to PTF with command: sudo ip route add {}/32 via {} dev eth0".format(local_syslog_srv_ip, gw))
 
     # Add Rsyslog destination for testing
     logger.info("test_syslog_srv_ip %s", local_syslog_srv_ip)


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Current syslog test implementation is not making sure the DUT has a route to the PTF server.
This causing the test to fail as a result of:
Failed: Test syslog message not seen on the server after 10s

#### How did you do it?
1.  Get default GW of eth0 interface.
2.  Get PTF server IP address.
3. Add a static route from eth0 default GW to the PTF server.
4. At the end of the test, remove this route.

#### How did you verify/test it?
1. Try to ping to PTF server from DUT and get: "Destination Host Unreachable"
2. Run test and see it is passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
