### PR TITLE
[ VRF ] Returned t0 configuration for run vrf cases

### DIFF
--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -162,6 +162,11 @@ configuration_properties:
     dut_asn: 4200065100
     dut_type: ToRRouter
     swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 4200064600
     tor_asn_start: 4200065500

--- a/ansible/vars/topo_t0.yml
+++ b/ansible/vars/topo_t0.yml
@@ -81,6 +81,15 @@ configuration_properties:
     swrole: leaf
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
 
 configuration:
   ARISTA01T1:

--- a/ansible/vars/topo_t1-64-lag-clet.yml
+++ b/ansible/vars/topo_t1-64-lag-clet.yml
@@ -103,6 +103,11 @@ configuration_properties:
     dut_type: LeafRouter
     nhipv4: 10.10.246.100
     nhipv6: FC0A::C9
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
   spine:
     swrole: spine
     podset_number: 200

--- a/ansible/vars/topo_t1-64-lag.yml
+++ b/ansible/vars/topo_t1-64-lag.yml
@@ -107,6 +107,11 @@ configuration_properties:
     dut_type: LeafRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
   spine:
     swrole: spine
   tor:

--- a/ansible/vars/topo_t1-64.yml
+++ b/ansible/vars/topo_t1-64.yml
@@ -263,6 +263,11 @@ configuration_properties:
     dut_type: LeafRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
   spine:
     swrole: spine
   tor:

--- a/ansible/vars/topo_t1-lag.yml
+++ b/ansible/vars/topo_t1-lag.yml
@@ -111,6 +111,11 @@ configuration_properties:
     dut_type: LeafRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
   spine:
     swrole: spine
   tor:

--- a/ansible/vars/topo_t1.yml
+++ b/ansible/vars/topo_t1.yml
@@ -135,6 +135,11 @@ configuration_properties:
     dut_type: LeafRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
   spine:
     swrole: spine
   tor:

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -64,28 +64,28 @@ def gen_fib_info(ptfhost, tbinfo, cfg_facts):
     downlink_ports_str = " ".join(get_downlink_ports(topology, topo_type))
 
     fibs = []
-
+    common_config_topo = tbinfo['topo']['properties']['configuration_properties']['common']
     podset_number = 5  # Limit the number of podsets to limit test execution time
-    tor_number = 16
-    tor_subnet_number = 2
+    tor_number = common_config_topo.get("tor_number", 16)
+    tor_subnet_number = common_config_topo.get("tor_subnet_number", 2)
+    max_tor_subnet_number = common_config_topo.get("max_tor_subnet_number", 16)
+    tor_subnet_size = common_config_topo.get("tor_subnet_size", 128)
 
     # routes to uplink
     routes_uplink_v4 = []
     routes_uplink_v6 = []
     if topo_type == "t0":
         routes_uplink_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
-                                            0, 0, 0,
-                                            "", "")
+                                            0, 0, 0, "", "", tor_subnet_size, max_tor_subnet_number)
         routes_uplink_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
-                                            0, 0, 0,
-                                            "", "")
+                                            0, 0, 0, "", "", tor_subnet_size, max_tor_subnet_number)
     elif topo_type == "t1":
         routes_uplink_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
-                                            0, 0, 0,
-                                            "", "", router_type="spine")
+                                            0, 0, 0, "", "", tor_subnet_size, max_tor_subnet_number,
+                                            router_type="spine")
         routes_uplink_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
-                                            0, 0, 0,
-                                            "", "", router_type="spine")
+                                            0, 0, 0, "", "", tor_subnet_size, max_tor_subnet_number,
+                                            router_type="spine")
 
     for prefix, _, _ in routes_uplink_v4:
         fibs.append("{} {}".format(prefix, uplink_ports_str))
@@ -97,12 +97,12 @@ def gen_fib_info(ptfhost, tbinfo, cfg_facts):
     if topo_type == "t1":
         for tor_index in range(tor_number):
             routes_downlink_v4.extend(generate_routes("v4", podset_number, tor_number, tor_subnet_number,
-                                      0, 0, 0,
-                                      "", "", router_type="tor", tor_index=tor_index))
+                                      0, 0, 0, "", "", tor_subnet_size, max_tor_subnet_number,
+                                      router_type="tor", tor_index=tor_index))
 
             routes_downlink_v6.extend(generate_routes("v6", podset_number, tor_number, tor_subnet_number,
-                                      0, 0, 0,
-                                      "", "", router_type="tor", tor_index=tor_index))
+                                      0, 0, 0, "", "", tor_subnet_size, max_tor_subnet_number,
+                                      router_type="tor", tor_index=tor_index))
 
     for prefix, _, _ in routes_downlink_v4:
         fibs.append("{} {}".format(prefix, downlink_ports_str))


### PR DESCRIPTION
Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
As described in #2538, when run vrf test suite  "AnsibleUndefinedVariable: 'dict object' has no attribute 'podset_number'" appears. The reason is that these attributes were deleted from topo_t0.yml by commit #1233

Summary:
Return back needed configuration for VRF test cases. Fixes #2468

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [+ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Want to have ability to run full  VRF test suite
#### How did you do it?
Returned required configuration of t0 for VRF TC.
#### How did you verify/test it?
Run cases which requires t0 changes:
`
vrf/test_vrf.py::TestVrfIsolation::test_neigh_isolate_vrf1_from_vrf2 PASSED
vrf/test_vrf.py::TestVrfIsolation::test_neigh_isolate_vrf2_from_vrf1 PASSED
vrf/test_vrf.py::TestVrfIsolation::test_fib_isolate_vrf1_from_vrf2 PASSED
vrf/test_vrf.py::TestVrfIsolation::test_fib_isolate_vrf2_from_vrf1 PASSED
`
#### Any platform specific information?
SONiC Software Version: SONiC.master.35-dirty-20201112.031542
Distribution: Debian 10.6
Kernel: 4.19.0-9-2-amd64
Build commit: 6c362a08
Build date: Thu Nov 12 11:49:55 UTC 2020
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
