### PR TITLE
[test_drop_counters.py] Added reverse to default ACL rule

### DIFF
--- a/tests/drop_packets/acl_templates/acltb_test_rule.json
+++ b/tests/drop_packets/acl_templates/acltb_test_rule.json
@@ -19,6 +19,21 @@
                                         "source-ip-address": "20.0.0.0/24"
                                     }
                                 }
+                            },
+                            "2": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 2
+                                },
+                                "l2": {
+                                    "config": {
+                                        "ethertype": "2048"
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Extended ACL rules for drop counter tests, with new permit all rule.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When user creates ACL rules, SONIC also creates default rule to drop ETHER_TYPE: 2048.
It was observed that BGP sessions going down after applying such rule and it can cause unexpected behavior for test cases.
Specifically it was observed during execution of "test_acl_drop" test case, when test did acl rules cleanup. On T1-LAG topo it could take up to 20 seconds because BGP session was dropped and several thousands of routes stared to be deleted.

#### How did you do it?
Added new rule to PERMIT ETHER_TYPE: 2048.

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
