### PR TITLE
Fix exception in handling 'show ipv6 bgp neighbor/peer'

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -145,13 +145,13 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
             cmd = "show ipv6 bgp peers {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
             # For compatibility on EOS of old version
             cmd_backup = "show ipv6 bgp neighbors {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
-        output_lines = host.eos_command(commands=[cmd])['stdout_lines'][0]
-        if len(output_lines) == 0 and cmd_backup != "":
-            output_lines = host.eos_command(commands=[cmd])['stdout_lines'][0]
-        pytest_assert(len(output_lines) != 0, "Failed to retrieve routes from VM {}".format(hostname))
+        res = host.eos_command(commands=[cmd], module_ignore_errors=True)
+        if res['failed'] and cmd_backup != "":
+            res = host.eos_command(commands=[cmd_backup], module_ignore_errors=True)
+        pytest_assert(not res['failed'], "Failed to retrieve routes from VM {}".format(hostname))
         routes = {}
         entry = None
-        for line in output_lines:
+        for line in res['stdout_lines'][0]:
             addr = re.findall(BGP_ENTRY_HEADING + r"(.+)", line)
             if addr:
                 if entry:


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The command to retrieve ipv6 neigh is different in different verison ceos.
In latest ceos, the command is 
```
show ipv6 bgp peers 10.10.10.1 received-routes detail
``` 
In previous version, the command would be
```
show ipv6 bgp neighbors fc00::1 received-routes detail
```
The previous commit has found this issue, but there were some bug
1. module error was not ignored
2. cmd_backup was never used (typo)
This PR will fix those bugs. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to address some issues in ```test_traffic_shift``` when dealing with various command to retrieve ipv6 routes.

#### How did you do it?
1. Fix typo (cmd->cmd_backup)
2. Ignore module error

#### How did you verify/test it?
Verified on dx010-6, running master image
```
py.test --inventory ../ansible/str,../ansible/veos,../ansible/str2 --host-pattern str2-dx010-acs-6 --module-path ../ansible --testbed vms20-t1-dx010-6 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level info --collect_techsupport=False --topology=t1,any,util bgp/test_traffic_shift.py
========================================================================================= test session starts =========================================================================================
collected 2 items                                                                                                                                                                                     

bgp/test_traffic_shift.py::test_TSA 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
01:33:42 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
01:33:42 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
01:33:58 INFO conftest.py:generate_params_dut_hostname:606: DUTs in testbed topology: ['str2-dx010-acs-6']
01:33:58 INFO conftest.py:creds:336: dut str2-dx010-acs-6 belongs to groups [u'sonic', u'sonic_dx010_100', u'str', u'str2', 'fanout']
01:33:58 INFO conftest.py:creds:348: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
01:33:58 INFO conftest.py:creds:348: skip empty var file ../ansible/group_vars/all/README.yml
01:34:00 INFO __init__.py:sanity_check:46: Start pre-test sanity check
01:34:00 INFO __init__.py:sanity_check:56: Found marker: m.name=topology, m.args=('t1',), m.kwargs={}
01:34:00 INFO __init__.py:sanity_check:90: Sanity check settings: skip_sanity=True, check_items=set(['monit', 'processes', 'interfaces', 'bgp', 'services', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False
01:34:00 INFO __init__.py:sanity_check:93: Skip sanity check according to command line argument or configuration of test script.
01:34:13 INFO __init__.py:loganalyzer:33: Add start marker into DUT syslog
01:34:15 INFO __init__.py:loganalyzer:35: Load config and analyze log
01:34:17 INFO test_traffic_shift.py:common_setup_teardown:45: Configuring bgp monitor session on DUT
01:34:20 INFO test_traffic_shift.py:common_setup_teardown:58: Starting bgp monitor session on PTF
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
01:34:52 INFO test_traffic_shift.py:test_TSA:240: Starting bgpmon on DUT
01:35:37 INFO test_traffic_shift.py:verify_all_routes_announce_to_bgpmon:116: Verifying all routes are announced to BGPMON
01:35:37 INFO test_traffic_shift.py:verify_loopback_route_with_community:196: Verifying only loopback routes are announced to bgp neighbors
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA16T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA11T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA10T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA11T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA09T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA09T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA06T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA08T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA07T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA07T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA01T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA01T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA05T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA05T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA02T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA03T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA03T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA04T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA15T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA15T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA14T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA12T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA13T2
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv4) are announced to ARISTA13T0
01:36:53 INFO test_traffic_shift.py:verify_loopback_route_with_community:196: Verifying only loopback routes are announced to bgp neighbors
^@01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA16T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA11T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA10T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA11T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA09T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA09T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA06T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA08T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA07T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA07T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA01T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA01T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA05T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA05T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA02T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA03T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA03T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA04T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA15T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA15T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA14T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA12T0
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA13T2
01:38:52 INFO test_traffic_shift.py:verify_loopback_route_with_community:211: Verifying only loopback routes(ipv6) are announced to ARISTA13T0
PASSED                                                                                                                                                                                          [ 50%]
bgp/test_traffic_shift.py::test_TSB 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
01:39:02 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
01:39:02 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
01:39:03 INFO __init__.py:loganalyzer:33: Add start marker into DUT syslog
01:39:04 INFO __init__.py:loganalyzer:35: Load config and analyze log
01:39:05 INFO test_traffic_shift.py:common_setup_teardown:45: Configuring bgp monitor session on DUT
01:39:06 INFO test_traffic_shift.py:common_setup_teardown:58: Starting bgp monitor session on PTF
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
01:39:35 INFO test_traffic_shift.py:test_TSB:266: Starting bgpmon on DUT
01:40:21 INFO test_traffic_shift.py:verify_all_routes_announce_to_bgpmon:116: Verifying all routes are announced to BGPMON
01:40:21 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:176: Verifying all routes(ipv4) are announced to bgp neighbors
01:43:13 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA16T0
01:43:15 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA11T0
01:43:16 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA10T0
01:43:17 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA11T2
01:43:17 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA09T2
01:43:17 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA09T0
01:43:18 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA06T0
01:43:19 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA08T0
01:43:20 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA07T0
01:43:22 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA07T2
01:43:22 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA01T2
01:43:22 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA01T0
01:43:23 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA05T2
01:43:23 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA05T0
01:43:24 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA02T0
01:43:25 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA03T0
01:43:26 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA03T2
01:43:26 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA04T0
01:43:28 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA15T0
01:43:29 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA15T2
01:43:29 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA14T0
01:43:30 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA12T0
01:43:31 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA13T2
01:43:31 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv4) are announced to ARISTA13T0
01:43:32 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:176: Verifying all routes(ipv6) are announced to bgp neighbors
^@01:46:47 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA16T0
01:46:48 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA11T0
01:46:49 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA10T0
01:46:50 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA11T2
01:46:50 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA09T2
01:46:50 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA09T0
01:46:51 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA06T0
01:46:52 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA08T0
01:46:53 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA07T0
01:46:54 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA07T2
01:46:54 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA01T2
01:46:54 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA01T0
01:46:55 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA05T2
01:46:55 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA05T0
01:46:56 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA02T0
01:46:57 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA03T0
01:46:59 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA03T2
01:46:59 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA04T0
01:47:00 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA15T0
01:47:01 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA15T2
01:47:01 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA14T0
01:47:02 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA12T0
01:47:03 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA13T2
01:47:03 INFO test_traffic_shift.py:verify_all_routes_announce_to_neighs:180: Verifying all routes(ipv6) are announced to ARISTA13T0
PASSED                                                                                                                                                                                          [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 2 passed in 814.76 seconds ======================================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.