### PR TITLE
[pytest] Test the system uptime in streaming telemetry

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -167,7 +167,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_1st = 0
     for line_info in system_uptime_info:
-        if "Total:" in line_info:
+        if "total:" in line_info:
             try:
                 system_uptime_1st = int(line_info.split(":")[1].strip())
             except ValueError as err:
@@ -178,7 +178,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_2nd = 0
     for line_info in system_uptime_info:
-        if "Total:" in line_info:
+        if "total:" in line_info:
             try:
                 system_uptime_2nd = int(line_info.split(":")[1].strip())
             except ValueError as err:

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -141,13 +141,13 @@ def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, setup_streami
 def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_telemetry, localhost):
     """
     @summary: Run pyclient from ptfdocker and test the dataset 'system uptime' to check
-              whether the value of 'system uptime' was an integer and whether the value was
+              whether the value of 'system uptime' was float number and whether the value was
               updated correctly.
     """
     logger.info("start test the dataset 'system uptime'")
     duthost = duthosts[rand_one_dut_hostname]
     dut_ip = duthost.mgmt_ip
-    cmd = 'python /gnxi/gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x platform/sysuptime -xt OTHERS \
+    cmd = 'python /gnxi/gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x proc/uptime -xt OTHERS \
            -o "ndastreamingservertest"'.format(dut_ip, TELEMETRY_PORT)
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_1st = 0
@@ -155,7 +155,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_tel
     for line_info in system_uptime_info:
         if "total" in line_info:
             try:
-                system_uptime_1st = int(line_info.split(":")[1].strip())
+                system_uptime_1st = float(line_info.split(":")[1].strip())
                 found_system_uptime_field = True
             except ValueError as err:
                 pytest.fail("The value of system uptime was not an integer. Error message was '{}'".format(err))
@@ -171,7 +171,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_tel
     for line_info in system_uptime_info:
         if "total" in line_info:
             try:
-                system_uptime_2nd = int(line_info.split(":")[1].strip())
+                system_uptime_2nd = float(line_info.split(":")[1].strip())
                 found_system_uptime_field = True
             except ValueError as err:
                 pytest.fail("The value of system uptime was not an integer. Error message was '{}'".format(err))

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -60,7 +60,7 @@ def verify_telemetry_dockerimage(duthosts, rand_one_dut_hostname):
         pytest.skip("docker-sonic-telemetry is not part of the image")
 
 @pytest.fixture
-def post_setup_streaming_telemetry(duthosts, rand_one_dut_hostname, localhost,  ptfhost):
+def setup_streaming_telemetry(duthosts, rand_one_dut_hostname, localhost,  ptfhost):
     """
     @summary: Post setting up the streaming telemetry before running the test.
     """
@@ -122,7 +122,7 @@ def test_telemetry_enabledbydefault(duthosts, rand_one_dut_hostname):
             status_expected = "enabled";
             pytest_assert(str(v) == status_expected, "Telemetry feature is not enabled")
 
-def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, post_setup_streaming_telemetry, localhost):
+def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_telemetry, localhost):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[rand_one_dut_hostname]
@@ -138,7 +138,7 @@ def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, post_setup_st
     inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
     pytest_assert(inerrors_match is not None, "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
 
-def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, post_setup_streaming_telemetry, localhost):
+def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_telemetry, localhost):
     """
     @summary: Run pyclient from ptfdocker and test the dataset 'system uptime' to check
               whether the value of 'system uptime' was an integer and whether the value was

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -158,7 +158,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_tel
                 system_uptime_1st = float(line_info.split(":")[1].strip())
                 found_system_uptime_field = True
             except ValueError as err:
-                pytest.fail("The value of system uptime was not an integer. Error message was '{}'".format(err))
+                pytest.fail("The value of system uptime was not a float. Error message was '{}'".format(err))
 
     if not found_system_uptime_field:
         pytest.fail("The field of system uptime was not found.")
@@ -174,7 +174,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_tel
                 system_uptime_2nd = float(line_info.split(":")[1].strip())
                 found_system_uptime_field = True
             except ValueError as err:
-                pytest.fail("The value of system uptime was not an integer. Error message was '{}'".format(err))
+                pytest.fail("The value of system uptime was not a float. Error message was '{}'".format(err))
 
     if not found_system_uptime_field:
         pytest.fail("The field of system uptime was not found.")

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -147,18 +147,18 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
     if not docker_present:
         pytest.skip("docker-sonic-telemetry is not part of the image")
 
-    logger.info('start telemetry output testing')
+    logger.info("start test the dataset 'system uptime'")
     setup_telemetry_forpyclient(duthost)
 
-    # wait till telemetry is restarted
+    # Wait until telemetry was restarted
     pytest_assert(wait_until(100, 10, duthost.is_service_fully_started, "telemetry"), "TELEMETRY not started.")
-    logger.info('telemetry process restarted. Now run pyclient on ptfdocker')
+    logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
 
-    # Wait until the TCP port is open
+    # Wait until the TCP port was opened
     dut_ip = duthost.mgmt_ip
     wait_tcp_connection(localhost, dut_ip, TELEMETRY_PORT, timeout_s=60)
 
-    # pyclient should be available on ptfhost. If not fail pytest.
+    # pyclient should be available on ptfhost. If it was not available, then fail pytest.
     file_exists = ptfhost.stat(path="/gnxi/gnmi_cli_py/py_gnmicli.py")
     pytest_assert(file_exists["stat"]["exists"] is True)
 
@@ -173,6 +173,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
             except ValueError as err:
                 pytest.fail("The value of system uptime was not an integer. Error message was '{}'".format(err))
 
+    # Sleep 10 seconds to wait that the value of system uptime was added another 10 seconds.
     time.sleep(10)
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_2nd = 0
@@ -183,5 +184,5 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
             except ValueError as err:
                 pytest.fail("The value of system uptime was not an integer. Error message was '{}'".format(err))
 
-    if system_uptime_2nd - system_time_1st < 10:
+    if system_uptime_2nd - system_uptime_1st < 10:
         pytest.fail("The value of system uptime was not updated correctly.")

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -167,7 +167,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_1st = 0
     for line_info in system_uptime_info:
-        if "total:" in line_info:
+        if "total" in line_info:
             try:
                 system_uptime_1st = int(line_info.split(":")[1].strip())
             except ValueError as err:
@@ -178,7 +178,7 @@ def test_sysuptime(duthosts, rand_one_dut_hostname, ptfhost, localhost):
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_2nd = 0
     for line_info in system_uptime_info:
-        if "total:" in line_info:
+        if "total" in line_info:
             try:
                 system_uptime_2nd = int(line_info.split(":")[1].strip())
             except ValueError as err:


### PR DESCRIPTION

Signed-off-by: Yong Zhao <yozhao@microsoft.com>

Summary:

Fixes # (issue)

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR aims to add a function in `test_telemetry.py` to test the new dataset `system uptime` in non-db client of streaming telemetry.

#### How did you do it?
The ptf docker container will send the request/query to telemetry server by running the command `python /gnxi/gnmi_cli_py/py_gnmicli.py -g -t <DuT_IP> -p Telemetry_Port -m get -x platform/sysuptime -xt OTHERS -o "ndastreamingservertest"` and then get the response which includes a field showing the string of `system uptime`.

This function will first verify whether the string was an integer and then decide whether the `system uptime` was updated correctly.

#### How did you verify/test it?
I ran this test against the lab device `str-dx010-acs-1`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
