### PR TITLE
[FIB] Updated packets to send per next hop group when check balancing 

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -56,7 +56,7 @@ class FibTest(BaseTest):
     # Class variables
     #---------------------------------------------------------------------
     DEFAULT_BALANCING_RANGE = 0.25
-    BALANCING_TEST_TIMES = 10000
+    BALANCING_TEST_TIMES = 625
     DEFAULT_BALANCING_TEST_RATIO = 0.0001
     ACTION_FWD = 'fwd'
     ACTION_DROP = 'drop'
@@ -173,7 +173,7 @@ class FibTest(BaseTest):
         # Send a packet with a random IP in the range
         if ip_range.length() > 2:
             self.check_ip_route(src_port, ip_range.get_random_ip(), exp_port_list, ipv4)
-
+        time.sleep(0.01)
         # Test traffic balancing across ECMP/LAG members
         if (self.test_balancing and self.pkt_action == self.ACTION_FWD
                 and len(exp_port_list) > 1
@@ -181,9 +181,11 @@ class FibTest(BaseTest):
             logging.info("Check IP range balancing...")
             dst_ip = ip_range.get_random_ip()
             hit_count_map = {}
-            for i in range(0, self.balancing_test_times):
+            # Change balancing_test_times according to number of next hop groups
+            for i in range(0, self.balancing_test_times*len(exp_port_list)):
                 (matched_index, received) = self.check_ip_route(src_port, dst_ip, exp_port_list, ipv4)
                 hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
+                time.sleep(0.01)
             self.check_balancing(next_hop.get_next_hop(), hit_count_map)
 
     def check_ip_route(self, src_port, dst_ip_addr, dst_port_list, ipv4=True):

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -12,6 +12,7 @@ Usage:          Examples of how to use log analyzer
 #---------------------------------------------------------------------
 import logging
 import random
+import time
 
 import ptf
 import ptf.packet as scapy


### PR DESCRIPTION
Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When run fib case on t0 topology we receive check_balancing error. After investigation was found, that BGP sessions flaps because PTF generates too many packets to test each IP range. This affects TCP sessions on VMs side. For t0 topology we have 4 next hop groups(Port Channels). For t1 topology number for next_hop groups is 16.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [+ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make fib TC passed on t0
#### How did you do it?
Test case itself sends every time 10000 packets for all topos.
To include specialty of each topo I decided to use weighting factors based on topo type, as an ethalon I've taken load per group in  t1 topo. New BALANCING_TEST_TIMES = 625 (10000/16). Based of number of next_hop group in topo this BALANCING_TEST_TIMES will be multiply on this number for checking balancing.

Also small delays (0.01 sec) was being added when send balancing traffic not to overload TCP sessions. 
#### How did you verify/test it?
Run fib TC on t0 topo
#### Any platform specific information?
SONiC Software Version: SONiC.master.35-dirty-20201112.031542
Distribution: Debian 10.6
Kernel: 4.19.0-9-2-amd64
Build commit: 6c362a08
Build date: Thu Nov 12 11:49:55 UTC 2020
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

