### PR TITLE
[advanced-reboot] use generate ip->mac map for arp ping packets instead

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -617,10 +617,6 @@ class ReloadTest(BaseTest):
 
         return ifreq
 
-    def get_mac(self, iff):
-        SIOCGIFHWADDR = 0x8927          # Get hardware address
-        return ':'.join(['%02x' % ord(char) for char in self.get_if(iff, SIOCGIFHWADDR)[18:24]])
-
     @staticmethod
     def hex_to_mac(hex_mac):
         return ':'.join(hex_mac[i:i+2] for i in range(0, len(hex_mac), 2))
@@ -714,9 +710,9 @@ class ReloadTest(BaseTest):
         dst_idx  = random.choice(vlan_port_canadiates)
         src_port = self.vlan_ports[src_idx]
         dst_port = self.vlan_ports[dst_idx]
-        src_mac  = self.get_mac('eth%d' % src_port)
         src_addr = self.host_ip(vlan_ip_range, src_idx)
         dst_addr = self.host_ip(vlan_ip_range, dst_idx)
+        src_mac  = self.hex_to_mac(self.vlan_host_map[src_port][src_addr])
         packet   = simple_arp_packet(eth_src=src_mac, arp_op=1, ip_snd=src_addr, ip_tgt=dst_addr, hw_snd=src_mac)
         expect   = simple_arp_packet(eth_dst=src_mac, arp_op=2, ip_snd=dst_addr, ip_tgt=src_addr, hw_tgt=src_mac)
         self.log("ARP ping: src idx %d port %d mac %s addr %s" % (src_idx, src_port, src_mac, src_addr))


### PR DESCRIPTION
of ptf interface mac.

Otherwise, the DUT ARP and FDB table might be overwritten for the chosen
IP. Causing endless flooding loop and control plane ping not responding
with the result of:

05:08:25         "Something went wrong. Please check output below:",
05:08:25         "",
05:08:25         "FAILED:dut:Control plane didn't come up within warm up timeout",
05:08:25         "FAILED:dut:DUT is not ready for test",

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
