### PR TITLE
Update log_analyzer ignore message as part of teamd autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -71,7 +71,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer):
         ".*WARNING syncd#syncd.*saiDiscover: skipping since it causes crash.*",
     ]
     teamd_ignoreRegex = [
-        ".*ERR teamd#teamsyncd.*readData.*netlink reports an error=-33 on reading a netlink socket.*",
+        ".*ERR swss#portsyncd.*readData.*netlink reports an error=-33 on reading a netlink socket.*",
     ]
     systemd_ignoreRegex = [
         ".*ERR systemd.*Failed to start .* container*",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update log_analyzer ignore message as part of teamd autorestart
Fixes # (issue) Errors seen in nightly tests due to log_analyzer not catching the ERR messages that should be ignored.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Update log_analyzer text to expect netlink socket logs from `swss#portsyncd` instead of `teamd#teamsyncd`
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
