### PR TITLE
Remove unnecessary "supervisorctl start" for platform_api_server

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -45,7 +45,6 @@ def start_platform_api_service(duthost, localhost):
         # Reload the supervisor config and Start the HTTP server
         duthost.command('docker exec -i pmon supervisorctl reread')
         duthost.command('docker exec -i pmon supervisorctl update')
-        duthost.command('docker exec -i pmon supervisorctl start platform_api_server.conf')
 
         res = localhost.wait_for(host=dut_ip, port=SERVER_PORT, state='started', delay=1, timeout=5)
         assert 'exception' not in res


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
There is a typo in ```tests/platform_tests/api/conftest.py``` where 
```
duthost.command('docker exec -i pmon supervisorctl start platform_api_server.conf')
```
should be
```
duthost.command('docker exec -i pmon supervisorctl start platform_api_server')
```
The previous version of supervisorctl will always return 0 for such error.
```
24/11/2020 16:19:21 DEBUG devices.py:_run:92: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_DX010_MST/tests/platform_tests/api/conftest.py::start_platform_api_service#48: [str-dx010-acs-4] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["docker", "exec", "-i", "pmon", "supervisorctl", "start", "platform_api_server.conf"], "end": "2020-11-24 16:19:22.767186", "_ansible_no_log": false, "stdout": "platform_api_server.conf: ERROR (no such process)", "changed": true, "rc": 0, "start": "2020-11-24 16:19:22.088850", "stderr": "", "delta": "0:00:00.678336", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "docker exec -i pmon supervisorctl start platform_api_server.conf", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["platform_api_server.conf: ERROR (no such process)"], "failed": false}
```
But a recent update in ```supervisor``` in master branch has surfaced this issue and caused errors in platform_test.
Actually, the ```supervisorctl start platform_api_server``` is not necessary because it is configured to autostart.
This PR addressed the issue by removing unnecessary ```supervisorctl start platform_api_server```.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix errors caused by uncessary ```supervisorctl start platform_api_server```.

#### How did you do it?
This PR addressed the issue by removing unnecessary ```supervisorctl start platform_api_server```.

#### How did you verify/test it?
Verified on DX010-4, running a master image
```
py.test --inventory ../ansible/str,../ansible/veos,../ansible/str2 --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t1,any,util platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_name
========================================================================================= test session starts =========================================================================================
collected 1 item                                                                                                                                                                                      

platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_name PASSED                                                                                                             [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
====================================================================================== 1 passed in 42.71 seconds ======================================================================================
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.