### PR TITLE
Updated sensors data for x86_64-arista_7170_64c platform due to updat…

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -485,7 +485,7 @@ sensors_checks:
       - dps460-i2c-10-58/PSU-2(R) Temp 2/temp2_max_alarm
 
       - dps460-i2c-10-59/PSU-1(L) Temp 1/temp1_max_alarm
-      
+
       - dps460-i2c-10-59/PSU-1(L) Temp 2/temp2_max_alarm
     compares:
       power: []
@@ -647,7 +647,7 @@ sensors_checks:
       - dps460-i2c-4-58/PSU-2(R) Temp 2/temp2_max_alarm
 
       - dps460-i2c-4-59/PSU-1(L) Temp 1/temp1_max_alarm
-      
+
       - dps460-i2c-4-59/PSU-1(L) Temp 2/temp2_max_alarm
     compares:
       power: []
@@ -830,7 +830,7 @@ sensors_checks:
       - dps460-i2c-10-58/PSU-2(R) Temp 2/temp2_max_alarm
 
       - dps460-i2c-10-59/PSU-1(L) Temp 1/temp1_max_alarm
-      
+
       - dps460-i2c-10-59/PSU-1(L) Temp 2/temp2_max_alarm
     compares:
       power: []
@@ -2395,7 +2395,7 @@ sensors_checks:
       - - w83795adg-i2c-0-2f/SFP+ Port 1 Temp/temp2_input
         - w83795adg-i2c-0-2f/SFP+ Port 1 Temp/temp2_crit
       - - w83795adg-i2c-0-2f/SFP+ Port 8 Temp/temp3_input
-        - w83795adg-i2c-0-2f/SFP+ Port 8 Temp/temp3_crit  
+        - w83795adg-i2c-0-2f/SFP+ Port 8 Temp/temp3_crit
     non_zero:
       fan:
       - w83795adg-i2c-0-2f/FANTRAY 1-A/fan1_input
@@ -2871,34 +2871,38 @@ sensors_checks:
   x86_64-arista_7170_64c:
     alarms:
       fan:
-      - dps1900-i2c-6-58/fan1/fan1_alarm
-      - dps1900-i2c-7-58/fan1/fan1_alarm
+        # to specify regular expression use backslash '\' at the beginning and end of expression
+        # Platform has two chip names:
+        # dps1900-i2c-X-58 for Sonic 201911
+        # pmbus-i2c-X-58 for Sonic master
+      - \[a-zA-Z0-9]*\-i2c-6-58\/fan1/fan1_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/fan1/fan1_alarm
       - la_cpld-i2c-93-60/fan1/fan1_fault
       - la_cpld-i2c-93-60/fan2/fan2_fault
       - la_cpld-i2c-93-60/fan3/fan3_fault
       - la_cpld-i2c-93-60/fan4/fan4_fault
       power:
-      - dps1900-i2c-6-58/iin/curr1_max_alarm
-      - dps1900-i2c-6-58/iout1/curr2_crit_alarm
-      - dps1900-i2c-6-58/iout1/curr2_max_alarm
-      - dps1900-i2c-6-58/vin/in1_alarm
-      - dps1900-i2c-6-58/vout1/in2_crit_alarm
-      - dps1900-i2c-6-58/vout1/in2_lcrit_alarm
-      - dps1900-i2c-7-58/iin/curr1_max_alarm
-      - dps1900-i2c-7-58/iout1/curr2_crit_alarm
-      - dps1900-i2c-7-58/iout1/curr2_max_alarm
-      - dps1900-i2c-7-58/vin/in1_alarm
-      - dps1900-i2c-7-58/vout1/in2_crit_alarm
-      - dps1900-i2c-7-58/vout1/in2_lcrit_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/iin/curr1_max_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/iout1/curr2_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/iout1/curr2_max_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/vin/in1_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/vout1/in2_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/vout1/in2_lcrit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/iin/curr1_max_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/iout1/curr2_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/iout1/curr2_max_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/vin/in1_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/vout1/in2_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/vout1/in2_lcrit_alarm
       temp:
         # to specify regular expression use backslash '\' at the beginning and end of expression
       - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
-      - dps1900-i2c-6-58/PSU1 primary hotspot temp/temp1_alarm
-      - dps1900-i2c-6-58/PSU1 inlet temp/temp2_alarm
-      - dps1900-i2c-7-58/PSU2 primary hotspot temp/temp1_alarm
-      - dps1900-i2c-7-58/PSU2 inlet temp/temp2_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/PSU1 primary hotspot temp/temp1_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/PSU1 inlet temp/temp2_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/PSU2 primary hotspot temp/temp1_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/PSU2 inlet temp/temp2_alarm
       - lm73-i2c-96-48/Front air temp/temp1_max_alarm
       - lm73-i2c-96-48/Front air temp/temp1_min_alarm
       - max6658-i2c-8-4c/Temp sensor near ASIC/temp1_crit_alarm
@@ -2914,14 +2918,14 @@ sensors_checks:
     compares:
       fan: []
       power:
-      - - dps1900-i2c-6-58/iin/curr1_input
-        - dps1900-i2c-6-58/iin/curr1_max
-      - - dps1900-i2c-6-58/iout1/curr2_input
-        - dps1900-i2c-6-58/iout1/curr2_max
-      - - dps1900-i2c-7-58/iin/curr1_input
-        - dps1900-i2c-7-58/iin/curr1_max
-      - - dps1900-i2c-7-58/iout1/curr2_input
-        - dps1900-i2c-7-58/iout1/curr2_max
+      - - \[a-zA-Z0-9]*\-i2c-6-58/iin/curr1_input
+        - \[a-zA-Z0-9]*\-i2c-6-58/iin/curr1_max
+      - - \[a-zA-Z0-9]*\-i2c-6-58/iout1/curr2_input
+        - \[a-zA-Z0-9]*\-i2c-6-58/iout1/curr2_max
+      - - \[a-zA-Z0-9]*\-i2c-7-58/iin/curr1_input
+        - \[a-zA-Z0-9]*\-i2c-7-58/iin/curr1_max
+      - - \[a-zA-Z0-9]*\-i2c-7-58/iout1/curr2_input
+        - \[a-zA-Z0-9]*\-i2c-7-58/iout1/curr2_max
       temp:
         # to specify regular expression use backslash '\' at the beginning and end of expression
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input

--- a/ansible/library/sensors_facts.py
+++ b/ansible/library/sensors_facts.py
@@ -15,7 +15,7 @@ description:
     - Retrieved raw values will be inserted to the 'raw' key.
     - Recognized alarms will be inserted to the 'alarms' key.
     - 'alarm' key will be set to True if the device has any alarm situation.
-    - If there's only one PSU on the device, 'warning' is set to True and 'warnings' have a message about it. 
+    - If there's only one PSU on the device, 'warning' is set to True and 'warnings' have a message about it.
     - sensors data: group_vars/sonic/sku-sensors/data.yml
 '''
 
@@ -159,8 +159,7 @@ class SensorsModule(object):
             if '\\' not in key:
                 pattern = re.compile(re.escape(key))
             else:
-                key.replace('\\', '')
-                pattern = re.compile(key)
+                pattern = re.compile(key.replace('\\', ''))
             for cur_value in cur_values.keys():
                 res = re.match(pattern, cur_value)
                 if res is not None:
@@ -202,7 +201,7 @@ class SensorsModule(object):
             reasons = '%s_reasons' % hw_part
             for (path_input, path_max) in compare_list:
                 if skip_the_value(path_input):
-                    continue                
+                    continue
                 value_input = self.get_raw_value(path_input)
                 value_max = self.get_raw_value(path_max)
                 if value_input is None:


### PR DESCRIPTION
…es in Arista driver submodules

Signed-off-by: Nazar Tkachuk <nazarx.tkachuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Updated sensors data for x86_64-arista_7170_64c platform due to updates in Arista driver submodules PR #5686
Fixes # (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
CT sensors is failed on SONiC master due to renamed chip

#### How did you do it?
Updated approach for getting sensors date with regex to support backward compatibility (SONiC master and SONiC 201911)

#### How did you verify/test it?
Run CT sensors with updates
And test is failed with another reason due to issue in sonic-buildimage https://github.com/Azure/sonic-buildimage/pull/6026
`Failed: Sensor alarms:
E       {
E           "temp_reasons": [
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/PSU1 primary hotspot temp/temp1_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/PSU1 inlet temp/temp2_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/PSU2 primary hotspot temp/temp1_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/PSU2 inlet temp/temp2_alarm is not exist"
E           ], 
E           "fan_reasons": [], 
E           "fan": false, 
E           "temp": true, 
E           "power": false, 
E           "power_reasons": []`

#### Any platform specific information?
Verified only for x86_64-arista_7170_64c platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
