### PR TITLE
[Vrf] test_show_bgp_summary update

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -532,10 +532,13 @@ class TestVrfFib():
             bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf {} summary json'".format(vrf))['stdout']
             bgp_summary = json.loads(bgp_summary_string)
 
-            for info in bgp_summary.itervalues():
-                for peer, attr in info['peers'].iteritems():
+            for info in bgp_summary:
+                for peer, attr in bgp_summary[info]['peers'].iteritems():
                     prefix_count = attr['prefixReceivedCount']
-                    assert int(prefix_count) == route_count, "%s should received %s route prefixs!" % (peer, route_count)
+                    if info == "ipv4Unicast" and attr['idType'] == 'ipv6':
+                        continue
+                    else:
+                        assert int(prefix_count) == route_count, "%s should received %s route prefixs!" % (peer, route_count)
 
     def test_vrf1_fib(self, partial_ptf_runner):
         partial_ptf_runner(

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -535,6 +535,7 @@ class TestVrfFib():
             for info in bgp_summary:
                 for peer, attr in bgp_summary[info]['peers'].iteritems():
                     prefix_count = attr['prefixReceivedCount']
+                    # skip ipv6 peers under 'ipv4Unicast' and compare only ipv4 peers under 'ipv4Unicast', and ipv6 peers under 'ipv6Unicast'
                     if info == "ipv4Unicast" and attr['idType'] == 'ipv6':
                         continue
                     else:


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test verify that bgp peers for each Vrf have value 'prefixReceivedCount' equal to 6400. But the problem is that output of command vtysh -c 'show bgp vrf Vrf1 summary json' is mixing ipv4 and ipv6 neighbors under 'ipv4Unicast' key, this is happening because ipv4 is default for all bgp peering's. [FRRouting-7464](https://github.com/FRRouting/frr/issues/7464)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make Vrf test_show_bgp_summary PASSED
#### How did you do it?
I've changed the way peers is being compared, and if there are ipv6 peers under 'ipv4Unicast' key they are skipped.
And only ipv6 peers under 'ipv6Unicast' is being verified. 
#### How did you verify/test it?
Run Vrf TC on t0 topo
#### Any platform specific information?
SONiC Software Version: SONiC.master.35-dirty-20201112.031542
Distribution: Debian 10.6
Kernel: 4.19.0-9-2-amd64
Build commit: 6c362a08
Build date: Thu Nov 12 11:49:55 UTC 2020
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
