### PR TITLE
[dualtor]Add a new dual tor topo dualtor-56

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -40,7 +40,7 @@ class DualTorParser:
         '''
         Gathers facts related to a dual ToR configuration
         '''
-        if self.testbed_facts['topo'] == 'dualtor':
+        if 'dualtor' in self.testbed_facts['topo']:
             self.parse_neighbor_tor()
             self.parse_tor_position()
             self.generate_cable_names()

--- a/ansible/roles/eos/templates/dualtor-56-leaf.j2
+++ b/ansible/roles/eos/templates/dualtor-56-leaf.j2
@@ -1,0 +1,1 @@
+dualtor-leaf.j2

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,4 +1,4 @@
-{% if topo == 'dualtor' %}
+{% if 'dualtor' in topo %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for tunnel in tunnel_configs %}

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -21,7 +21,7 @@
             <a:Reference i:nil="true"/>
             <a:Value>Profile0</a:Value>
           </a:DeviceProperty>
-{% if topo == 'dualtor' %}
+{% if 'dualtor' in topo %}
           <a:DeviceProperty>
             <a:Name>GeminiEnabled</a:Name>
             <a:Reference i:nil="true" />

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -11,7 +11,7 @@
         <StartDevice>{{ inventory_hostname }}</StartDevice>
         <StartPort>{{ port_alias[dut_intfs[if_index]] }}</StartPort>
       </DeviceLinkBase>
-{% if topo == 'dualtor' %}
+{% if 'dualtor' in topo %}
 {% set cable_position = 'U' if inventory_hostname == dual_tor_facts['positions']['upper'] else 'L' %}
       <DeviceLinkBase>
         <ElementType>LogicalLink</ElementType>

--- a/ansible/vars/topo_dualtor-56.yml
+++ b/ansible/vars/topo_dualtor-56.yml
@@ -152,6 +152,15 @@ configuration_properties:
     swrole: leaf
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
 
 configuration:
   ARISTA01T1:

--- a/ansible/vars/topo_dualtor-56.yml
+++ b/ansible/vars/topo_dualtor-56.yml
@@ -1,0 +1,303 @@
+topology:
+  dut_num: 2
+  host_interfaces:
+    - 0.0,1.0
+    - 0.1,1.1
+    - 0.2,1.2
+    - 0.3,1.3
+    - 0.4,1.4
+    - 0.5,1.5
+    - 0.6,1.6
+    - 0.7,1.7
+    - 0.8,1.8
+    - 0.9,1.9
+    - 0.10,1.10
+    - 0.11,1.11
+    - 0.16,1.16
+    - 0.17,1.17
+    - 0.18,1.18
+    - 0.19,1.19
+    - 0.20,1.20
+    - 0.21,1.21
+    - 0.22,1.22
+    - 0.23,1.23
+    - 0.24,1.24
+    - 0.25,1.25
+    - 0.26,1.26
+    - 0.27,1.27
+    - 0.28,1.28
+    - 0.29,1.29
+    - 0.30,1.30
+    - 0.31,1.31
+    - 0.32,1.32
+    - 0.33,1.33
+    - 0.34,1.34
+    - 0.35,1.35
+    - 0.36,1.36
+    - 0.37,1.37
+    - 0.38,1.38
+    - 0.39,1.39
+    - 0.44,1.44
+    - 0.45,1.45
+    - 0.46,1.46
+    - 0.47,1.47
+    - 0.48,1.48
+    - 0.49,1.49
+    - 0.50,1.50
+    - 0.51,1.51
+    - 0.52,1.52
+    - 0.53,1.53
+    - 0.54,1.54
+    - 0.55,1.55
+  disabled_host_interfaces:
+    - 0.2,1.2
+    - 0.3,1.3
+    - 0.6,1.6
+    - 0.7,1.7
+    - 0.10,1.10
+    - 0.11,1.11
+    - 0.18,1.18
+    - 0.19,1.19
+    - 0.22,1.22
+    - 0.23,1.23
+    - 0.26,1.26
+    - 0.27,1.27
+    - 0.30,1.30
+    - 0.31,1.31
+    - 0.34,1.34
+    - 0.35,1.35
+    - 0.38,1.38
+    - 0.39,1.39
+    - 0.46,1.46
+    - 0.47,1.47
+    - 0.50,1.50
+    - 0.51,1.51
+    - 0.54,1.54
+    - 0.55,1.55
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - "0.12@48"
+        - "0.13@49"
+        - "1.12@50"
+        - "1.13@51"
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - "0.14@52"
+        - "0.15@53"
+        - "1.14@54"
+        - "1.15@55"
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - "0.40@56"
+        - "0.41@57"
+        - "1.40@58"
+        - "1.41@59"
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - "0.42@60"
+        - "0.43@61"
+        - "1.42@62"
+        - "1.43@63"
+      vm_offset: 3
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.32/32
+        - 10.1.0.33/32
+      ipv6:
+        - FC00:1::32/128
+        - FC00:1::33/128
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 4, 5, 8, 9, 16, 17, 20, 21, 24, 25, 28, 29, 32, 33, 36, 37, 44, 45, 48, 49, 52, 53]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+          mac: 00:aa:bb:cc:dd:ee
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [0, 1, 4, 5, 8, 9, 16, 17, 20, 21, 24, 25]
+          prefix: 192.168.100.1/21
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200:
+          id: 200
+          intfs: [28, 29, 32, 33, 36, 37, 44, 45, 48, 49, 52, 53]
+          prefix: 192.168.200.1/21
+          prefix_v6: fc02:200::1/64
+          tag: 200
+    tunnel_configs:
+      default_tunnel_config: tunnel_ipinip
+      tunnel_ipinip:
+        MuxTunnel0:
+          type: IPInIP
+          attach_to: Loopback0
+          dscp: uniform
+          ecn_encap: standard
+          ecn_decap: copy_from_outer
+          ttl_mode: pipe
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+        - 10.0.1.56
+        - FC00::1:71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Port-Channel2:
+        ipv4: 10.0.1.57/31
+        ipv6: fc00::1:72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+        - 10.0.1.58
+        - FC00::1:75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Port-Channel2:
+        ipv4: 10.0.1.59/31
+        ipv6: fc00::1:76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+        - 10.0.1.60
+        - FC00::1:79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Port-Channel2:
+        ipv4: 10.0.1.61/31
+        ipv6: fc00::1:7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+        - 10.0.1.62
+        - FC00::1:7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Port-Channel2:
+        ipv4: 10.0.1.63/31
+        ipv6: fc00::1:7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64

--- a/ansible/veos
+++ b/ansible/veos
@@ -25,6 +25,7 @@ all:
           - t0-64-32
           - t0-116
           - dualtor
+          - dualtor-56
       children:
         server_1:
         server_2:

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -23,6 +23,7 @@ all:
           - t0-64-32
           - t0-116
           - dualtor
+          - dualtor-56
       children:
         server_1:
     lab:

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -183,7 +183,7 @@ class TestbedInfo(object):
         if match == None:
             raise Exception("Unsupported testbed type - {}".format(topo_name))
         tb_type = match.group()
-        if tb_type == 'dualtor':
+        if 'dualtor' in tb_type:
             # augment dualtor topology type to 't0' to avoid adding it
             # everywhere.
             tb_type = 't0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,7 +443,7 @@ def clear_neigh_entries(duthosts, tbinfo):
 
     yield
 
-    if tbinfo['topo']['name'] == 'dualtor':
+    if 'dualtor' in tbinfo['topo']['name']:
         for dut in duthosts:
             dut.command("sudo ip neigh flush nud permanent")
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This commit is to add a new dual tor topology ```dualtor-56```.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to add a new dual tor topology ```dualtor-56```, which is based on ```t0-56``` topo and implemented in dual tor structure.

#### How did you do it?


#### How did you verify/test it?
Verified by deploying a new ```dualtor-56``` testbed and run ```test_link_flap``` and ```test_lag_2```. All testcases passed.
The bgp status was also verified.
```
# show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 43693
RIB entries 12809, using 2356856 bytes of memory
Peers 4, using 83680 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600      19711      30104         0      0       0  01:00:14             6401  ARISTA01T1
10.0.0.59      4  64600      30046      37796         0      0       0  00:11:15             6401  ARISTA02T1
10.0.0.61      4  64600      19826      36462         0      0       0  01:07:36             6401  ARISTA03T1
10.0.0.63      4  64600      26197      39356         0      0       0  00:04:34             6401  ARISTA04T1

Total number of neighbors 4
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.