### PR TITLE
Make the minigraph_facts module backward compatible

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -9,7 +9,6 @@ import copy
 import ipaddr as ipaddress
 from collections import defaultdict
 from natsort import natsorted
-from sonic_py_common import multi_asic
 
 from lxml import etree as ET
 from lxml.etree import QName
@@ -61,7 +60,12 @@ def parse_png(png, hname):
     console_port = ''
     mgmt_dev = ''
     mgmt_port = ''
-    namespace_list = multi_asic.get_namespace_list()
+    try:
+        from sonic_py_common import multi_asic
+        namespace_list = multi_asic.get_namespace_list()
+    except ImportError:
+        namespace_list = ['']
+
     for child in png:
         if child.tag == str(QName(ns, "DeviceInterfaceLinks")):
             for link in child.findall(str(QName(ns, "DeviceLinkBase"))):
@@ -165,7 +169,7 @@ def parse_dpg(dpg, hname):
             else:
                 intf['mask'] = str(prefix_len)
             intf.update({'attachto': intfname, 'prefixlen': int(prefix_len)})
-                    
+
             # TODO: remove peer_addr after dependency removed
             ipaddr_val = int(ipn.ip)
             peer_addr_val = None
@@ -179,7 +183,7 @@ def parse_dpg(dpg, hname):
                     peer_addr_val = ipaddr_val + 1
                 else:
                     peer_addr_val = ipaddr_val - 1
-                    
+
             if peer_addr_val is not None:
                 intf['peer_addr'] = ipaddress.IPAddress(peer_addr_val)
             intfs.append(intf)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Make the minigraph_facts module backward compatible with SONiC images that do not have library sonic_py_common.multi_asic.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The minigraph_facts module uses library `sonic_py_common.multi_asic.get_namespace_list`
to get the namespace list and store the value in variable `namespace_list`. On older SONiC
image, `sonic_py_common.multi_asic` is not available. Running this module will fail with
`ImportError`. 

#### How did you do it?
This change improved this module to make it backward compatible with older SONiC 
images by protecting `sonic_py_common.multi_asic` importing using `try...except`. When 
ImportError is caught, just assign value [''] to variable `namespace_list`.

#### How did you verify/test it?
Test run the minigaph_facts module on image supports sonic_py_common.multi_asic and on image does not support sonic_py_common.multi_asic.

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
