### PR TITLE
Fix bug in test_bgpmon

### DIFF
--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -124,6 +124,8 @@ def test_bgpmon(duthost, common_setup_teardown, ptfadapter):
     """
     local_addr, peer_addr, peer_ports = common_setup_teardown
     exp_packet = build_syn_pkt(local_addr, peer_addr)
+    # Flush dataplane
+    ptfadapter.dataplane.flush()
     # Load bgp monitor config
     logger.info("Configured bgpmon and verifying packet on {}".format(peer_ports))
     duthost.command("sonic-cfggen -j {} -w".format(BGPMON_CONFIG_FILE))
@@ -142,6 +144,8 @@ def test_bgpmon_no_resolve_via_default(duthost, common_setup_teardown, ptfadapte
         # Disable resolve-via-default
         duthost.command("vtysh -c \"configure terminal\" \
                         -c \"no ip nht resolve-via-default\"")
+        # Flush dataplane
+        ptfadapter.dataplane.flush()
         duthost.command("sonic-cfggen -j {} -w".format(BGPMON_CONFIG_FILE))
         # Verify no syn packet is received
         pytest_assert(0 == testutils.count_matched_packets_all_ports(test=ptfadapter, exp_packet=exp_packet, ports=peer_ports, timeout=BGP_CONNECT_TIMEOUT),


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2562

The ptfadapter is a module level fixture, which means it's not cleared between ```test_bgpmon``` and ```test_bgpmon_no_resolve_via_default```.  As a result, the TCP sync packet captured in ```test_bgpmon``` might be counted in
```test_bgpmon_no_resolve_via_default``` and cause test failure.
This commit add a flush of the ptfadapter's dataplane before beginning counting packet to address the issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix bug in ```test_bgpmon```.

#### How did you do it?
Clear the dataplane of ptfadapter before counting the packets.

#### How did you verify/test it?
Verified on DX010-4 for over 30 times, and no failure was seen.
```
 py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level info --collect_techsupport=False --topology=t0,any,util bgp/test_bgpmon.py
========================================================================================= test session starts =========================================================================================
collected 2 items                                                                                                                                                                                     

bgp/test_bgpmon.py::test_bgpmon 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
12:29:32 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
12:29:32 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
12:29:40 INFO ptfhost_utils.py:change_mac_addresses:86: Change interface MAC addresses on ptfhost 'vms7-11'
12:29:40 INFO ptfhost_utils.py:remove_ip_addresses:99: Remove existing IPs on ptfhost 'vms7-11'
12:29:44 INFO conftest.py:generate_params_dut_hostname:606: DUTs in testbed topology: ['str-dx010-acs-4']
12:29:44 INFO conftest.py:creds:336: dut str-dx010-acs-4 belongs to groups [u'sonic', u'sonic_dx010_100', u'str', 'fanout']
12:29:44 INFO conftest.py:creds:348: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
12:29:44 INFO conftest.py:creds:348: skip empty var file ../ansible/group_vars/all/README.yml
12:29:47 INFO __init__.py:sanity_check:46: Start pre-test sanity check
12:29:47 INFO __init__.py:sanity_check:56: Found marker: m.name=topology, m.args=('any',), m.kwargs={}
12:29:47 INFO __init__.py:sanity_check:90: Sanity check settings: skip_sanity=True, check_items=set(['monit', 'processes', 'interfaces', 'bgp', 'services', 'dbmemory']), allow_recover=False, recover_method=adaptive, post_check=False
12:29:47 INFO __init__.py:sanity_check:93: Skip sanity check according to command line argument or configuration of test script.
12:29:55 INFO __init__.py:loganalyzer:17: Log analyzer is disabled
12:30:01 INFO test_bgpmon.py:common_setup_teardown:71: Generated peer address 11.0.0.1
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
12:30:02 INFO test_bgpmon.py:test_bgpmon:130: Configured bgpmon and verifying packet on [28, 29, 30, 31]
PASSED                                                                                                                                                                                          [ 50%]
bgp/test_bgpmon.py::test_bgpmon_no_resolve_via_default 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
12:30:05 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
12:30:05 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
12:30:05 INFO __init__.py:loganalyzer:17: Log analyzer is disabled
12:30:12 INFO test_bgpmon.py:common_setup_teardown:71: Generated peer address 11.0.0.1
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
12:30:13 INFO test_bgpmon.py:test_bgpmon_no_resolve_via_default:142: Configured bgpmon and verifying no packet on [28, 29, 30, 31] when resolve-via-default is disabled
PASSED                                                                                                                                                                                          [100%]
------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------
12:30:47 INFO ptfhost_utils.py:remove_ip_addresses:104: Remove IPs to restore ptfhost 'vms7-11'


------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
====================================================================================== 2 passed in 75.51 seconds ======================================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.