### PR TITLE
[techsupport] Changed default values of --loop_num and --loop_delay a…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,9 +63,9 @@ def pytest_addoption(parser):
     ############################
     # test_techsupport options #
     ############################
-    parser.addoption("--loop_num", action="store", default=10, type=int,
+    parser.addoption("--loop_num", action="store", default=2, type=int,
                     help="Change default loop range for show techsupport command")
-    parser.addoption("--loop_delay", action="store", default=10, type=int,
+    parser.addoption("--loop_delay", action="store", default=2, type=int,
                     help="Change default loops delay")
     parser.addoption("--logs_since", action="store", type=int,
                     help="number of minutes for show techsupport command")

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -14,8 +14,8 @@ pytestmark = [
 ]
 
 SUCCESS_CODE = 0
-DEFAULT_LOOP_RANGE = 10
-DEFAULT_LOOP_DELAY = 10
+DEFAULT_LOOP_RANGE = 2
+DEFAULT_LOOP_DELAY = 2
 
 pytest.tar_stdout = ""
 
@@ -271,7 +271,7 @@ def test_techsupport(request, config, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     loop_range = request.config.getoption("--loop_num") or DEFAULT_LOOP_RANGE
     loop_delay = request.config.getoption("--loop_delay") or DEFAULT_LOOP_DELAY
-    since = request.config.getoption("--logs_since") or str(randint(1, 23)) + " minute ago"
+    since = request.config.getoption("--logs_since") or str(randint(1, 5)) + " minute ago"
 
     logger.debug("Loop_range is {} and loop_delay is {}".format(loop_range, loop_delay))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: when someone will try to run the `test_techsupport.py` and don't pass `--loop_num` and `--loop_delay` arguments, the test execution time will be more than 1 hour.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### How did you do it?
Changed default values of `--loop_num` and `--loop_delay` arguments

#### How did you verify/test it?
Just run the test with no arguments

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

