### PR TITLE
[copp] Update COPP tests to handle coppmgr config format

### DIFF
--- a/tests/copp/scripts/update_copp_config.py
+++ b/tests/copp/scripts/update_copp_config.py
@@ -1,36 +1,80 @@
 #!/usr/bin/python
-"""
-    Script to modify a COPP configuration to follow a specified rate limit.
+"""Script to modify a COPP configuration to follow a specified rate limit.
 
-    This is used by the COPP tests to reduce the rate limit below that of the
-    PTF host's sending rate.
+This is used by the COPP tests to reduce the rate limit below that of the
+PTF host's sending rate.
 
-    Example::
+Example:
+    python update_copp_config.py <rate limit in pps> <input file> <output file> <config_format>
+    python update_copp_config.py 600 /tmp/copp_config.json /tmp/new_copp_config.json app_db
 
-        $ python update_copp_config.py <rate limit in pps> <input file> <output file>
-        $ python update_copp_config.py 600 /tmp/copp_config.json /tmp/new_copp_config.json
+Note:
+    Historically, there was a 00-copp.config.json file in the SWSS docker that specified
+    the parameters for each trap group like so:
+
+    [
+        "COPP_TABLE:default": {
+            "cir": "600",
+            "cbs": "600",
+            ...
+        },
+        "COPP_TABLE:trap.group.bgp.lacp": {
+            ...
+        },
+        ...
+    ]
+
+    This is the "app_db" format used for 202006 images and earlier.
+
+    In newer SONiC versions, there is a copp_cfg.json file on the host that specifies the parameters
+    for each trap group like so:
+
+    {
+        "COPP_GROUP": {
+            "default": {
+                "cir":"600",
+                "cbs":"600",
+                ...
+            },
+            "queue4_group1": {
+                ...
+            },
+            ...
+        },
+        ...
+    }
+
+    This is the "config_db" format used for 202012 images and later (including the master branch).
 """
 import json
 import sys
 
-def generate_limited_pps_config(pps_limit, input_config_file, output_config_file):
+
+def generate_limited_pps_config(pps_limit, input_config_file, output_config_file, config_format="app_db"):
+    """Modifies a COPP config to use the specified rate limit.
+
+    Notes:
+        This only affects COPP policies that enforce a rate limit. Other
+        policies are left alone.
+
+    Args:
+        pps_limit (int): The rate limit to enforce expressed in PPS (packets-per-second)
+        input_config_file (str): The name of the file containing the initial config
+        output_config_file (str): The name of the file to output the modified config
+        config_format (str): The format of the input COPP config file
+
     """
-        Modifies a COPP config to use the specified rate limit.
-
-        Notes:
-            This only affects COPP policies that enforce a rate limit. Other
-            policies are left alone.
-
-        Args:
-            pps_limit (int): The rate limit to enforce expressed in PPS (packets-per-second)
-            input_config_file (str): The name of the file containing the initial config
-            output_config_file (str): The name of the file to output the modified config
-    """
-
     with open(input_config_file) as input_stream:
         copp_config = json.load(input_stream)
 
-    for trap_group in copp_config:
+    if config_format == "app_db":
+        trap_groups = copp_config
+    elif config_format == "config_db":
+        trap_groups = [{x: y} for x, y in copp_config["COPP_GROUP"].items()]
+    else:
+        raise ValueError("Invalid config format specified")
+
+    for trap_group in trap_groups:
         for _, group_config in trap_group.items():
             # Notes:
             # CIR (committed information rate) - bandwidth limit set by the policer
@@ -48,6 +92,13 @@ def generate_limited_pps_config(pps_limit, input_config_file, output_config_file
     with open(output_config_file, "w+") as output_stream:
         json.dump(copp_config, output_stream)
 
+
 if __name__ == "__main__":
     ARGS = sys.argv[1:]
-    generate_limited_pps_config(ARGS[0], ARGS[1], ARGS[2])
+
+    if len(ARGS) < 4:
+        config_format = "app_db"
+    else:
+        config_format = ARGS[3]
+
+    generate_limited_pps_config(ARGS[0], ARGS[1], ARGS[2], config_format)


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update COPP tests to handle coppmgr config format

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The way COPP consumes initial configurations recently changed, breaking the tests when run against the master branch.

#### How did you do it?
I added a version check that will use the new COPP config format on newer OS versions to lower the rate-limit on policers.

#### How did you verify/test it?
Ran test against master branch and it is successfully able to edit the config file and lower the rate-limit.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
