### PR TITLE
[testbed] Update vlan list on root fanout when leaf fanout is re-deployed.

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260_connect.j2
+++ b/ansible/roles/fanout/templates/arista_7260_connect.j2
@@ -1,5 +1,8 @@
 !
 config
+{% if deploy_leaf %}
+vlan {{ dev_vlans | list | join(',') }}
+{% endif %}
 {% for i in range(1,65) %}
 {% set intf =  'Ethernet' + i|string  %}
 {% if intf in root_conn %}


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The vlan list on root fanout is not updated when leaf fanout is re-deployed. As a result, the allowed vlan trunk added to a certain
interface on root fanout will not work. This commit address the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix the issue that vlan list on root fanout is not updated.

#### How did you do it?
Update the template for deploying vlan on root fanout to update vlan list when leaf fanout is re-deployed.

#### How did you verify/test it?
Verified on root fanout by running ``` ansible-playbook fanout.yml -i str2 --limit str2-7260cx3-acs-fan-12 -v```.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.