### PR TITLE
[qos] Headroom pool watermark test

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -615,6 +615,8 @@ qos_params:
             pkts_num_trig_egr_drp: 9887
             pkts_num_fill_egr_min: 8
             cell_size: 208
+        hdrm_pool_wm_multiplier: 4
+        cell_size: 208
     th2:
         40000_300m:
             pkts_num_leak_out: 0
@@ -811,3 +813,5 @@ qos_params:
             pkts_num_trig_egr_drp: 10692
             pkts_num_fill_egr_min: 16
             cell_size: 208
+        hdrm_pool_wm_multiplier: 4
+        cell_size: 208

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -72,6 +72,13 @@ class QosSaiBase:
         bufferScale /= (bufferScale + 1)
         bufferProfile.update({"static_th": int(bufferProfile["size"]) + int(bufferScale * bufferSize)})
 
+        poolHeadroom = self.__runRedisCommandOrAssert(
+            duthost,
+            argv = ["redis-cli", "-n", "4", "HGET", pool, "xoff"]
+        )
+        if poolHeadroom:
+           bufferProfile.update({"poolXoff": int(poolHeadroom[0])})
+
     def __updateVoidRoidParams(self, duthost, bufferProfile):
         """
             Updates buffer profile with VOID/ROID params
@@ -142,9 +149,7 @@ class QosSaiBase:
             pytest_assert("xon" in bufferProfile.keys() and "xoff" in bufferProfile.keys(),
                           "Could not find xon and/or xoff values for profile '{0}'".format(bufferProfileName))
 
-        disableTest = request.config.getoption("--disable_test")
-        if not disableTest:
-            self.__updateVoidRoidParams(duthost, bufferProfile)
+        self.__updateVoidRoidParams(duthost, bufferProfile)
 
         return bufferProfile
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -72,13 +72,6 @@ class QosSaiBase:
         bufferScale /= (bufferScale + 1)
         bufferProfile.update({"static_th": int(bufferProfile["size"]) + int(bufferScale * bufferSize)})
 
-        poolHeadroom = self.__runRedisCommandOrAssert(
-            duthost,
-            argv = ["redis-cli", "-n", "4", "HGET", pool, "xoff"]
-        )
-        if poolHeadroom:
-           bufferProfile.update({"poolXoff": int(poolHeadroom[0])})
-
     def __updateVoidRoidParams(self, duthost, bufferProfile):
         """
             Updates buffer profile with VOID/ROID params

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -212,6 +212,59 @@ class TestQosSai(QosSaiBase):
 
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest", testParams=testParams)
 
+    def testQosSaiHeadroomPoolWatermark(self, duthosts, rand_one_dut_hostname,  ptfhost, dutTestParams, dutConfig, dutQosConfig, ingressLosslessProfile, resetWatermark):
+        """
+            Test QoS SAI Headroom pool watermark
+
+            Args:
+                duthosts (AnsibleHost): Dut hosts
+                rand_one_dut_hostname (AnsibleHost): select one of the duts in multi dut testbed
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+                ingressLosslessProfile (Fxiture): Map of egress lossless buffer profile attributes
+                resetWatermark (Fixture): reset watermarks
+
+            Returns:
+                None
+
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+        duthost = duthosts[rand_one_dut_hostname]
+        cmd_output = duthost.shell("show headroom-pool watermark", module_ignore_errors=True)
+        if dutTestParams["hwsku"] not in self.SUPPORTED_HEADROOM_SKUS or cmd_output['rc'] != 0:
+            pytest.skip("Headroom pool watermark is not supported")
+
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        testPortIps = dutConfig["testPortIps"]
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "testbed_type": dutTestParams["topo"],
+            "dscps": qosConfig["hdrm_pool_size"]["dscps"],
+            "ecn": qosConfig["hdrm_pool_size"]["ecn"],
+            "pgs": qosConfig["hdrm_pool_size"]["pgs"],
+            "src_port_ids": qosConfig["hdrm_pool_size"]["src_port_ids"],
+            "src_port_ips": [testPortIps[port] for port in qosConfig["hdrm_pool_size"]["src_port_ids"]],
+            "dst_port_id": qosConfig["hdrm_pool_size"]["dst_port_id"],
+            "dst_port_ip": testPortIps[qosConfig["hdrm_pool_size"]["dst_port_id"]],
+            "pgs_num": qosConfig["hdrm_pool_size"]["pgs_num"],
+            "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
+            "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
+            "pkts_num_hdrm_full": qosConfig["hdrm_pool_size"]["pkts_num_hdrm_full"],
+            "pkts_num_hdrm_partial": qosConfig["hdrm_pool_size"]["pkts_num_hdrm_partial"],
+            "hdrm_pool_wm_multiplier": dutQosConfig["param"]["hdrm_pool_wm_multiplier"],
+            "cell_size": dutQosConfig["param"]["cell_size"],
+            "buf_pool_roid": ingressLosslessProfile["bufferPoolRoid"],
+            "max_headroom": ingressLosslessProfile["poolXoff"]
+        })
+        self.runPtfTest(ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest", testParams=testParams)
+
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
     def testQosSaiBufferPoolWatermark(self, request, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig, ingressLosslessProfile, egressLossyProfile, resetWatermark):
         """

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -212,7 +212,7 @@ class TestQosSai(QosSaiBase):
 
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest", testParams=testParams)
 
-    def testQosSaiHeadroomPoolWatermark(self, duthosts, rand_one_dut_hostname,  ptfhost, dutTestParams, dutConfig, dutQosConfig, ingressLosslessProfile, resetWatermark):
+    def testQosSaiHeadroomPoolWatermark(self, duthosts, rand_one_dut_hostname,  ptfhost, dutTestParams, dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize, resetWatermark):
         """
             Test QoS SAI Headroom pool watermark
 
@@ -261,7 +261,7 @@ class TestQosSai(QosSaiBase):
             "hdrm_pool_wm_multiplier": dutQosConfig["param"]["hdrm_pool_wm_multiplier"],
             "cell_size": dutQosConfig["param"]["cell_size"],
             "buf_pool_roid": ingressLosslessProfile["bufferPoolRoid"],
-            "max_headroom": ingressLosslessProfile["poolXoff"]
+            "max_headroom": sharedHeadroomPoolSize
         })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest", testParams=testParams)
 

--- a/tests/saitests/switch.py
+++ b/tests/saitests/switch.py
@@ -758,6 +758,17 @@ def sai_thrift_read_buffer_pool_watermark(client, buffer_pool_id):
         return None
     return wm_vals[0]
 
+def sai_thrift_read_headroom_pool_watermark(client, buffer_pool_id):
+    buffer_pool_wm_ids = [
+        SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES
+    ]
+
+    wm_vals = client.sai_thrift_get_buffer_pool_stats(buffer_pool_id, buffer_pool_wm_ids)
+    if not wm_vals:
+        print >> sys.stderr, "sai_thrift_read_headroom_pool_watermark returns empty list"
+        return None
+    return wm_vals[0]
+
 def sai_thrift_create_vlan_member(client, vlan_id, port_id, tagging_mode):
     vlan_member_attr_list = []
     attribute_value = sai_thrift_attribute_value_t(s32=vlan_id)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Depends on Azure/sonic-swss#1453

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add tests for the headroom pool watermark feature

#### How did you verify/test it?
Ran the test on Th2 on an image with the headroom pool wm feature changes and it passed
```
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
ansible: 2.8.7
rootdir: /var/nejo/Networking-acs-sonic-mgmt
plugins: ansible-2.2.2
collected 904 items / 903 deselected / 1 selected                                                                                                                                        

qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark PASSED                                                                                                            [100%]
```