### PR TITLE
[qos] Fix parameter overwrite issue

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -82,7 +82,9 @@ class TestQosSai(QosSaiBase):
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig[xoffProfile]["dscp"],
             "ecn": qosConfig[xoffProfile]["ecn"],
             "pg": qosConfig[xoffProfile]["pg"],
@@ -95,10 +97,9 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": qosConfig["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig[xoffProfile]["pkts_num_trig_pfc"],
             "pkts_num_trig_ingr_drp": qosConfig[xoffProfile]["pkts_num_trig_ingr_drp"],
-        }
+        })
         if "pkts_num_margin" in qosConfig[xoffProfile].keys():
             testParams["pkts_num_margin"] = qosConfig[xoffProfile]["pkts_num_margin"]
-        testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams)
 
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2"])
@@ -124,7 +125,9 @@ class TestQosSai(QosSaiBase):
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"]
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig[xonProfile]["dscp"],
             "ecn": qosConfig[xonProfile]["ecn"],
             "pg": qosConfig[xonProfile]["pg"],
@@ -140,12 +143,11 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_trig_pfc": qosConfig[xonProfile]["pkts_num_trig_pfc"],
             "pkts_num_dismiss_pfc": qosConfig[xonProfile]["pkts_num_dismiss_pfc"]
-        }
+        })
         if "pkts_num_hysteresis" in qosConfig[xonProfile].keys():
             testParams["pkts_num_hysteresis"] = qosConfig[xonProfile]["pkts_num_hysteresis"]
         if "pkts_num_margin" in qosConfig[xonProfile].keys():
             testParams["pkts_num_margin"] = qosConfig[xonProfile]["pkts_num_margin"]
-        testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PFCXonTest", testParams=testParams)
 
     def testQosSaiHeadroomPoolSize(self, ptfhost, dutTestParams, dutConfig, dutQosConfig, ingressLosslessProfile):
@@ -173,7 +175,9 @@ class TestQosSai(QosSaiBase):
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
         testPortIps = dutConfig["testPortIps"]
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "testbed_type": dutTestParams["topo"],
             "dscps": qosConfig["hdrm_pool_size"]["dscps"],
             "ecn": qosConfig["hdrm_pool_size"]["ecn"],
@@ -187,8 +191,7 @@ class TestQosSai(QosSaiBase):
             "pkts_num_trig_pfc": qosConfig["hdrm_pool_size"]["pkts_num_trig_pfc"],
             "pkts_num_hdrm_full": qosConfig["hdrm_pool_size"]["pkts_num_hdrm_full"],
             "pkts_num_hdrm_partial": qosConfig["hdrm_pool_size"]["pkts_num_hdrm_partial"],
-        }
-        testParams.update(dutTestParams["basicParams"])
+        })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.HdrmPoolSizeTest", testParams=testParams)
 
     @pytest.mark.parametrize("bufPool", ["wm_buf_pool_lossless", "wm_buf_pool_lossy"])
@@ -230,7 +233,9 @@ class TestQosSai(QosSaiBase):
         else:
             pytest.fail("Unknown pool type")
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig[bufPool]["dscp"],
             "ecn": qosConfig[bufPool]["ecn"],
             "pg": qosConfig[bufPool]["pg"],
@@ -244,8 +249,7 @@ class TestQosSai(QosSaiBase):
             "pkts_num_fill_shared": triggerDrop - 1,
             "cell_size": qosConfig[bufPool]["cell_size"],
             "buf_pool_roid": buf_pool_roid
-        }
-        testParams.update(dutTestParams["basicParams"])
+        })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.BufferPoolWatermarkTest", testParams=testParams)
 
     def testQosSaiLossyQueue(self, ptfhost, dutTestParams, dutConfig, dutQosConfig, ingressLossyProfile):
@@ -269,7 +273,9 @@ class TestQosSai(QosSaiBase):
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"]
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig["lossy_queue_1"]["dscp"],
             "ecn": qosConfig["lossy_queue_1"]["ecn"],
             "pg": qosConfig["lossy_queue_1"]["pg"],
@@ -283,13 +289,12 @@ class TestQosSai(QosSaiBase):
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_trig_egr_drp": qosConfig["lossy_queue_1"]["pkts_num_trig_egr_drp"],
-        }
+        })
         if "packet_size" in qosConfig["lossy_queue_1"].keys():
             testParams["packet_size"] = qosConfig["lossy_queue_1"]["packet_size"]
             testParams["cell_size"] = qosConfig["lossy_queue_1"]["cell_size"]
         if "pkts_num_margin" in qosConfig["lossy_queue_1"].keys():
             testParams["pkts_num_margin"] = qosConfig["lossy_queue_1"]["pkts_num_margin"]
-        testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.LossyQueueTest", testParams=testParams)
 
     def testQosSaiDscpQueueMapping(self, ptfhost, dutTestParams, dutConfig):
@@ -308,13 +313,14 @@ class TestQosSai(QosSaiBase):
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
-        }
-        testParams.update(dutTestParams["basicParams"])
+        })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.DscpMappingPB", testParams=testParams)
 
     def testQosSaiDwrr(self, ptfhost, dutTestParams, dutConfig, dutQosConfig):
@@ -337,7 +343,9 @@ class TestQosSai(QosSaiBase):
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"]
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "ecn": qosConfig["lossy_queue_1"]["ecn"],
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
@@ -352,8 +360,7 @@ class TestQosSai(QosSaiBase):
             "q6_num_of_pkts": qosConfig["wrr"]["q6_num_of_pkts"],
             "limit": qosConfig["wrr"]["limit"],
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
-        }
-        testParams.update(dutTestParams["basicParams"])
+        })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.WRRtest", testParams=testParams)
 
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
@@ -388,7 +395,9 @@ class TestQosSai(QosSaiBase):
         elif "wm_pg_shared_lossy" in pgProfile:
             pktsNumFillShared = int(qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig[pgProfile]["dscp"],
             "ecn": qosConfig[pgProfile]["ecn"],
             "pg": qosConfig[pgProfile]["pg"],
@@ -400,10 +409,9 @@ class TestQosSai(QosSaiBase):
             "pkts_num_fill_min": qosConfig[pgProfile]["pkts_num_fill_min"],
             "pkts_num_fill_shared": pktsNumFillShared,
             "cell_size": qosConfig[pgProfile]["cell_size"],
-        }
+        })
         if "packet_size" in qosConfig[pgProfile].keys():
             testParams["packet_size"] = qosConfig[pgProfile]["packet_size"]
-        testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PGSharedWatermarkTest", testParams=testParams)
 
     def testQosSaiPgHeadroomWatermark(self, ptfhost, dutTestParams, dutConfig, dutQosConfig, resetWatermark):
@@ -427,7 +435,9 @@ class TestQosSai(QosSaiBase):
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig["wm_pg_headroom"]["dscp"],
             "ecn": qosConfig["wm_pg_headroom"]["ecn"],
             "pg": qosConfig["wm_pg_headroom"]["pg"],
@@ -439,10 +449,9 @@ class TestQosSai(QosSaiBase):
             "pkts_num_trig_pfc": qosConfig["wm_pg_headroom"]["pkts_num_trig_pfc"],
             "pkts_num_trig_ingr_drp": qosConfig["wm_pg_headroom"]["pkts_num_trig_ingr_drp"],
             "cell_size": qosConfig["wm_pg_headroom"]["cell_size"],
-        }
+        })
         if "pkts_num_margin" in qosConfig["wm_pg_headroom"].keys():
             testParams["pkts_num_margin"] = qosConfig["wm_pg_headroom"]["pkts_num_margin"]
-        testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.PGHeadroomWatermarkTest", testParams=testParams)
 
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
@@ -457,7 +466,7 @@ class TestQosSai(QosSaiBase):
                 dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
                     and test ports
                 dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
-                resetWatermark (Fxiture): reset queue watermarks
+                resetWatermark (Fixture): reset queue watermarks
 
             Returns:
                 None
@@ -471,7 +480,9 @@ class TestQosSai(QosSaiBase):
         triggerDrop = qosConfig[queueProfile]["pkts_num_trig_ingr_drp"] if "wm_q_shared_lossless" in queueProfile \
                       else qosConfig[queueProfile]["pkts_num_trig_egr_drp"]
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dscp": qosConfig[queueProfile]["dscp"],
             "ecn": qosConfig[queueProfile]["ecn"],
             "queue": qosConfig[queueProfile]["queue"],
@@ -483,10 +494,9 @@ class TestQosSai(QosSaiBase):
             "pkts_num_fill_min": qosConfig[queueProfile]["pkts_num_fill_min"],
             "pkts_num_trig_drp": triggerDrop,
             "cell_size": qosConfig[queueProfile]["cell_size"],
-        }
+        })
         if "packet_size" in qosConfig[queueProfile].keys():
             testParams["packet_size"] = qosConfig[queueProfile]["packet_size"]
-        testParams.update(dutTestParams["basicParams"])
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.QSharedWatermarkTest", testParams=testParams)
 
     def testQosSaiDscpToPgMapping(self, request, ptfhost, dutTestParams, dutConfig):
@@ -509,13 +519,14 @@ class TestQosSai(QosSaiBase):
         if disableTest:
             pytest.skip("DSCP to PG mapping test disabled")
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
-        }
-        testParams.update(dutTestParams["basicParams"])
+        })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.DscpToPgMapping", testParams=testParams)
 
     def testQosSaiDwrrWeightChange(self, ptfhost, dutTestParams, dutConfig, dutQosConfig, updateSchedProfile):
@@ -539,7 +550,9 @@ class TestQosSai(QosSaiBase):
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"]
 
-        testParams = {
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
             "ecn": qosConfig["wrr_chg"]["ecn"],
             "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
             "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
@@ -554,6 +567,5 @@ class TestQosSai(QosSaiBase):
             "q6_num_of_pkts": qosConfig["wrr_chg"]["q6_num_of_pkts"],
             "limit": qosConfig["wrr_chg"]["limit"],
             "pkts_num_leak_out": qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
-        }
-        testParams.update(dutTestParams["basicParams"])
+        })
         self.runPtfTest(ptfhost, testCase="sai_qos_tests.WRRtest", testParams=testParams)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Some tests like headroom pool size have src port ids and dst port id hardcoded in qos.yml to ensure that we can actually fill up the headroom pool. In all the tests, we initialize the 'testParams' dict with values from qos.yml and then update it with a set of basicParams that we have derived. The basicParams includes src and dst port ids which will overwrite the ones that we pulled from qos.yml

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you do it?
Consume the basicParams first and then update with values from qos.yml

#### How did you verify/test it?
Ran qos sai test on Th2 and all have passed. 