### PR TITLE
[qos] Disable bgpmon and fix loganalyzer regex

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -443,6 +443,7 @@ class QosSaiBase:
             {"docker": "lldp", "service": "lldp-syncd"},
             {"docker": "lldp", "service": "lldpd"},
             {"docker": "bgp",  "service": "bgpd"},
+            {"docker": "bgp",  "service": "bgpmon"}
         ]
 
         feature_list = ['lldp', 'bgp', 'syncd', 'swss']
@@ -476,17 +477,17 @@ class QosSaiBase:
                 ".*ERR monit.* 'lldp\|lldpd_monitor' status failed.*-- 'lldpd:' is not running.",
 
                 ".*ERR monit.*'lldp_syncd' process is not running",
-                ".*ERR monit.* 'lldp\|lldp_syncd' status failed.*-- 'python2 -m lldp_syncd' is not running.",
+                ".*ERR monit.*'lldp\|lldp_syncd' status failed.*-- 'python.* -m lldp_syncd' is not running.",
 
                 ".*ERR monit.*'bgpd' process is not running",
-                ".*ERR monit.* 'bgp\|bgpd' status failed.*-- '/usr/lib/frr/bgpd' is not running.",
+                ".*ERR monit.*'bgp\|bgpd' status failed.*-- '/usr/lib/frr/bgpd' is not running.",
 
                 ".*ERR monit.*'bgpcfgd' process is not running",
-                ".*ERR monit.* 'bgp\|bgpcfgd' status failed.*-- '/usr/bin/python /usr/local/bin/bgpcfgd' is not running.",
+                ".*ERR monit.*'bgp\|bgpcfgd' status failed.*-- '/usr/bin/python.* /usr/local/bin/bgpcfgd' is not running.",
 
                 ".*ERR syncd#syncd:.*brcm_sai_set_switch_attribute:.*updating switch mac addr failed.*",
 
-                ".*ERR monit.*'bgp\|bgpmon' status failed.*'/usr/bin/python /usr/local/bin/bgpmon' is not running",
+                ".*ERR monit.*'bgp\|bgpmon' status failed.*'/usr/bin/python.* /usr/local/bin/bgpmon' is not running",
                 ".*ERR monit.*bgp\|fpmsyncd.*status failed.*NoSuchProcess process no longer exists.*",
             ]
             loganalyzer.ignore_regex.extend(ignoreRegex)


### PR DESCRIPTION

Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
bgpd is disabled before the start of the test. This was causing bgpmon errors in the syslog. This PR addresses that issue by disabling bgpmon before the start of the test.
Also fine tuned the loganalyzer regex which was failing because of python version mismatch

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran the test with the changes and it passes. 
