### PR TITLE
[bgp] Fix 'test_bgp_update_timer'

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -1,10 +1,17 @@
-import pytest
-import logging
+import contextlib
+import ipaddress
 import json
-from tests.common.utilities import wait_until
+import logging
+import netaddr
+import pytest
+import random
+
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.generators import generate_ips
 from tests.common.helpers.parallel import parallel_run
 from tests.common.helpers.parallel import reset_ansible_local_tmp
+from tests.common.utilities import wait_until
+
 
 logger = logging.getLogger(__name__)
 
@@ -128,3 +135,100 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
 
     if not wait_until(300, 10, duthost.check_bgp_session_state, bgp_neighbors.keys()):
         pytest.fail("not all bgp sessions are up after disable graceful restart")
+
+
+@pytest.fixture(scope="module")
+def setup_interfaces(duthost, ptfhost, request, tbinfo):
+    """Setup interfaces for the new BGP peers on PTF."""
+
+    def _is_ipv4_address(ip_addr):
+        return ipaddress.ip_address(ip_addr).version == 4
+
+    @contextlib.contextmanager
+    def _setup_interfaces_t0(mg_facts, peer_count):
+        try:
+            connections = []
+            vlan_intf = None
+            for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
+                if _is_ipv4_address(vlan_intf["addr"]):
+                    break
+            if vlan_intf is None:
+                raise ValueError("No Vlan interface defined in T0.")
+            vlan_intf_name = vlan_intf["attachto"]
+            vlan_intf_addr = "%s/%s" % (vlan_intf["addr"], vlan_intf["prefixlen"])
+            vlan_members = mg_facts["minigraph_vlans"][vlan_intf_name]["members"]
+            local_interfaces = random.sample(vlan_members, peer_count)
+            neighbor_addresses = generate_ips(
+                peer_count,
+                vlan_intf["subnet"],
+                [netaddr.IPAddress(vlan_intf["addr"])]
+            )
+
+            for local_intf, neighbor_addr in zip(local_interfaces, neighbor_addresses):
+                conn = {}
+                conn["local_intf"] = vlan_intf_name
+                conn["local_addr"] = vlan_intf_addr
+                conn["neighbor_addr"] = neighbor_addr
+                conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][local_intf]
+                connections.append(conn)
+
+            for conn in connections:
+                ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"],
+                                                  conn["neighbor_addr"]))
+
+            yield connections
+
+        finally:
+            for conn in connections:
+                ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
+
+    @contextlib.contextmanager
+    def _setup_interfaces_t1(mg_facts, peer_count):
+        try:
+            connections = []
+            ipv4_interfaces = [_ for _ in mg_facts["minigraph_interfaces"] if _is_ipv4_address(_['addr'])]
+            used_subnets = [ipaddress.ip_network(_["subnet"]) for _ in ipv4_interfaces]
+            subnet_prefixlen = used_subnets[0].prefixlen
+            used_subnets = set(used_subnets)
+            for pt in mg_facts["minigraph_portchannel_interfaces"]:
+                if _is_ipv4_address(pt["addr"]):
+                    used_subnets.add(ipaddress.ip_network(pt["subnet"]))
+            _subnets = ipaddress.ip_network(u"10.0.0.0/24").subnets(new_prefix=subnet_prefixlen)
+            subnets = (_ for _ in _subnets if _ not in used_subnets)
+
+            for intf, subnet in zip(random.sample(ipv4_interfaces, peer_count), subnets):
+                conn = {}
+                local_addr, neighbor_addr = [_ for _ in subnet][:2]
+                conn["local_intf"] = "%s:0" % intf["attachto"]
+                conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
+                conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
+                conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][intf["attachto"]]
+                connections.append(conn)
+
+            for conn in connections:
+                duthost.shell("ifconfig %s %s" % (conn["local_intf"], conn["local_addr"]))
+                # Notify bgpcfgd the interface is ready
+                duthost.shell("config interface ip add %s %s" % (conn["local_intf"], conn["local_addr"]))
+                ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"], conn["neighbor_addr"]))
+
+            yield connections
+
+        finally:
+            for conn in connections:
+                duthost.shell("ifconfig %s 0.0.0.0" % conn["local_intf"])
+                duthost.shell("config interface ip remove %s %s" % (conn["local_intf"], conn["local_addr"]))
+                ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
+
+    peer_count = getattr(request.module, "PEER_COUNT", 1)
+    if tbinfo["topo"]["type"] == "t0":
+        setup_func = _setup_interfaces_t0
+    elif tbinfo["topo"]["type"] == "t1":
+        setup_func = _setup_interfaces_t1
+    else:
+        raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])
+
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    with setup_func(mg_facts, peer_count) as connections:
+        yield connections
+
+    duthost.shell("sonic-clear arp")


### PR DESCRIPTION
Previously, new BGP sessions use virtual interface created from PTF mgmt
interface on the PTF side, and use DUT mgmt interfaeas the nexthop to
route traffic from PTF to DUT loopback interface. This imposes a
prerequisite that the DUT mgmt interface must be in the same subnet as
the PTF mgmt interface. test_bgp_update_timer will fail over those
testbeds that don't satisfy this requirement.

Add a fixture `setup_interfaces` to setup interfaces to be used for
newly created BGP sessions in test case.
For T0, the DUT side interfaces will always be the vlan interface, the
PTF side interfaces are chosen from those interfaces that connect to
vlan member interfaces. The PTF side interfaces are assigned with the IP
addresses within the vlan subnet.
For T1, the DUT side interfaces will be the virtual interfaces created
from those non-portchannle-member interfaes, the PTF side are their
corresponding PTF intercepting interfaces. And each interface pair is
assigned addresses belong to the same subnet.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix `test_bgp_update_timer` failure in testbeds which `DUT` mgmt interface IP is in a different subnet to the `PTF` management IP.

#### How did you do it?
For `T0`, for a new BGP session, the DUT side uses the `vlan` interface, the PTF side uses the interface that is connected to one of the DUT `vlan` member interface and it is assigned an address within the `vlan` subnet.
For `T1`, for a new BGP session, create a virtual interface from a non-portchannel interface and use it over the DUT side, the PTF side uses the corresponding intercepting interface of the non-portchannel interface. This pair will be assigned addresses within the same subnet.
* `t0`
```
admin@str2-7260cx3-acs-9:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 4200065100 vrf-id 0
BGP table version 12801
RIB entries 12805, using 2356120 bytes of memory
Peers 6, using 125520 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.33      4  4200064600       3218       6419         0      0       0  00:13:29   6400            ARISTA01T1
10.0.0.35      4  4200064600       3218       3536         0      0       0  00:13:27   6400            ARISTA02T1
10.0.0.37      4  4200064600          0          0         0      0       0  never      Active          ARISTA03T1
10.0.0.39      4  4200064600       3218       3536         0      0       0  00:13:27   6400            ARISTA04T1
192.168.0.2    4       61000          9       3210         0      0       0  00:06:58   0               pseudoswitch0
192.168.0.3    4       61001          9       3210         0      0       0  00:06:37   0               pseudoswitch1
```
* `t1`
```
admin@str-msn2700-02:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12739
RIB entries 12851, using 2364584 bytes of memory
Peers 26, using 543920 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       3196         29         0      0       0  00:06:16             6370  ARISTA01T2
10.0.0.3       4  61000          4      12819         0      0       0  00:01:04                0  pseudoswitch0
10.0.0.5       4  65200       3196         29         0      0       0  00:06:17             6370  ARISTA03T2
10.0.0.7       4  61001          3       6410         0      0       0  00:00:32                0  pseudoswitch1
10.0.0.9       4  65200       3196         29         0      0       0  00:06:17             6370  ARISTA05T2
10.0.0.13      4  65200       3196         29         0      0       0  00:06:18             6370  ARISTA07T2
10.0.0.17      4  65200       3196         29         0      0       0  00:06:16             6370  ARISTA09T2
10.0.0.21      4  65200       3196         29         0      0       0  00:06:18             6370  ARISTA11T2
10.0.0.25      4  65200       3196         29         0      0       0  00:06:16             6370  ARISTA13T2
10.0.0.29      4  65200       3196         29         0      0       0  00:06:16             6370  ARISTA15T2
10.0.0.33      4  64001         13       9622         0      0       0  00:06:04               34  ARISTA01T0
10.0.0.35      4  64002         11       9620         0      0       0  00:05:35               33  ARISTA02T0
10.0.0.37      4  64003         12       9620         0      0       0  00:05:35               34  ARISTA03T0
10.0.0.39      4  64004         11       9620         0      0       0  00:05:35               33  ARISTA04T0
10.0.0.41      4  64005         11       9620         0      0       0  00:05:38               33  ARISTA05T0
10.0.0.43      4  64006         12       9622         0      0       0  00:06:11               33  ARISTA06T0
10.0.0.45      4  64007         11       9620         0      0       0  00:05:29               33  ARISTA07T0
10.0.0.47      4  64008         12       9622         0      0       0  00:06:11               33  ARISTA08T0
10.0.0.49      4  64009         11       9620         0      0       0  00:05:36               33  ARISTA09T0
10.0.0.51      4  64010         11       9620         0      0       0  00:05:27               33  ARISTA10T0
10.0.0.53      4  64011         11       9620         0      0       0  00:05:31               33  ARISTA11T0
10.0.0.55      4  64012         11       9621         0      0       0  00:05:42               33  ARISTA12T0
10.0.0.57      4  64013         12       9622         0      0       0  00:06:02               33  ARISTA13T0
10.0.0.59      4  64014         12       9622         0      0       0  00:06:07               33  ARISTA14T0
10.0.0.61      4  64015         12       9622         0      0       0  00:06:02               33  ARISTA15T0
10.0.0.63      4  64016         12       9622         0      0       0  00:06:09               33  ARISTA16T0
```
#### How did you verify/test it?
Test over testbed that DUT mgmt IP is not within the same subnet as PTF mgmt IP.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
