### PR TITLE
Enhancements to everflow testcases infrastructure to support multi-asic

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -615,3 +615,11 @@ class BaseEverflowTest(object):
         logging.info("Selected monitor port %s (index=%s)", monitor_port, setup["port_index_map"][monitor_port])
 
         return setup["port_index_map"][monitor_port]
+
+    def _get_tx_port_id_list(self, tx_ports):
+        tx_port_ids = []
+        for port in tx_ports:
+            members = port.split(',')
+            for member in members:
+                tx_port_ids.append(int(member))
+        return tx_port_ids

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -2,6 +2,7 @@
 import pytest
 import ptf.testutils as testutils
 
+import everflow_test_utilities as everflow_utils
 from everflow_test_utilities import BaseEverflowTest
 
 # Module-level fixtures
@@ -27,6 +28,19 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "ffbe:0225:7c6b:a982:d48b:230e:f271:0000"
     DEFAULT_DST_IP = "ffbe:0225:7c6b:a982:d48b:230e:f271:0001"
+    tx_port_ids = []
+
+    @pytest.fixture(scope='class',  autouse=True)
+    def setup_mirror_session_dest_ip_route(self, duthosts, rand_one_dut_hostname, tbinfo, setup_info, setup_mirror_session):
+
+        duthost = duthosts[rand_one_dut_hostname]
+        tx_port = setup_info["tor"]["dest_port"][0]
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+        EverflowIPv6Tests.tx_port_ids = self._get_tx_port_id_list([setup_info["tor"]["dest_port_ptf_id"][0]])
+        time.sleep(5)
+        yield
+        everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
 
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on Source IPv6 addresses."""
@@ -41,7 +55,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on Destination IPv6 addresses."""
@@ -56,7 +71,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on the Next Header field."""
@@ -67,7 +83,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on the L4 Source Port."""
@@ -78,7 +95,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on the L4 Destination Port."""
@@ -89,7 +107,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on a range of L4 Source Ports."""
@@ -100,7 +119,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on a range of L4 Destination Ports."""
@@ -111,7 +131,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on TCP Flags."""
@@ -122,7 +143,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on DSCP."""
@@ -133,7 +155,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
@@ -151,7 +174,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
@@ -166,7 +190,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match a SYN -> SYN-ACK pattern."""
@@ -183,7 +208,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
@@ -197,7 +223,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match a TCP handshake between a client and server."""
@@ -216,7 +243,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
@@ -232,7 +260,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match UDP traffic between a client and server application."""
@@ -251,7 +280,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
@@ -266,7 +296,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
@@ -282,7 +313,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             ptfadapter,
@@ -295,7 +327,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             ptfadapter,
@@ -309,7 +342,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
@@ -327,7 +361,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             ptfadapter,
@@ -342,7 +377,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
@@ -369,7 +405,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match packets with a Destination IPv6 Subnet."""
@@ -387,7 +424,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match packets with both source and destination subnets."""
@@ -405,7 +443,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match packets with non-standard subnet sizes."""
@@ -423,7 +462,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            setup_mirror_session,
                                            ptfadapter,
                                            duthost,
-                                           test_packet)
+                                           test_packet,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def _base_tcpv6_packet(self,
                            ptfadapter,

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -32,12 +32,16 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     @pytest.fixture(scope='class',  autouse=True)
     def setup_mirror_session_dest_ip_route(self, duthosts, rand_one_dut_hostname, tbinfo, setup_info, setup_mirror_session):
+        """
+        Setup the route for mirror session destination ip and update monitor port list.
+        Remove the route as part of cleanup.
+        """
 
         duthost = duthosts[rand_one_dut_hostname]
         tx_port = setup_info["tor"]["dest_port"][0]
         peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
         everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-        EverflowIPv6Tests.tx_port_ids = self._get_tx_port_id_list([setup_info["tor"]["dest_port_ptf_id"][0]])
+        self.tx_port_ids = self._get_tx_port_id_list([setup_info["tor"]["dest_port_ptf_id"][0]])
         time.sleep(5)
         yield
         everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
@@ -56,7 +60,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on Destination IPv6 addresses."""
@@ -72,7 +76,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on the Next Header field."""
@@ -84,7 +88,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on the L4 Source Port."""
@@ -96,7 +100,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on the L4 Destination Port."""
@@ -108,7 +112,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on a range of L4 Source Ports."""
@@ -120,7 +124,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on a range of L4 Destination Ports."""
@@ -132,7 +136,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on TCP Flags."""
@@ -144,7 +148,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match on DSCP."""
@@ -156,7 +160,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
@@ -175,7 +179,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
@@ -191,7 +195,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match a SYN -> SYN-ACK pattern."""
@@ -209,7 +213,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
@@ -224,7 +228,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match a TCP handshake between a client and server."""
@@ -244,7 +248,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
@@ -261,7 +265,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match UDP traffic between a client and server application."""
@@ -281,7 +285,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
@@ -297,7 +301,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
@@ -314,7 +318,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             ptfadapter,
@@ -328,7 +332,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             ptfadapter,
@@ -343,7 +347,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
@@ -362,7 +366,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             ptfadapter,
@@ -378,7 +382,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
@@ -406,7 +410,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match packets with a Destination IPv6 Subnet."""
@@ -425,7 +429,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match packets with both source and destination subnets."""
@@ -444,7 +448,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, duthosts, rand_one_dut_hostname):
         """Verify that we can match packets with non-standard subnet sizes."""
@@ -463,7 +467,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            duthost,
                                            test_packet,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
+                                           dest_ports=self.tx_port_ids)
 
     def _base_tcpv6_packet(self,
                            ptfadapter,

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -61,13 +61,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-
-    @pytest.fixture(params=["tor", "spine"])
-    def dest_port_type(self, request):
+    
+    @pytest.fixture
+    def setup_dest_port_type(self, request):
         """
-        Get the dest port for this test case.
-
-        Used to parametrize test cases based on dest port type to validate forwarding behavior.
+        This fixture get the dest port type and can perform action based
+        on that. As of now cleanup is being done here.
 
         Args:
             request: Pytest request object
@@ -75,13 +74,25 @@ class EverflowIPv4Tests(BaseEverflowTest):
         Returns:
             A destination port type in {tor, spine}.
         """
-        return request.param
+        yield request.param
+        
+        duthosts = request.getfixturevalue("duthosts")
+        rand_one_dut_hostname = request.getfixturevalue("rand_one_dut_hostname")
+        setup_info = request.getfixturevalue("setup_info")
+        setup_mirror_session =  request.getfixturevalue("setup_mirror_session")
+        tbinfo = request.getfixturevalue("tbinfo")
 
-    # FIXME: We use a lot of try-catch here to clean up routes, but it's a bit messy.
-    # A better solution might be to have a fixture that receives route updates and then
-    # cleans up any remaining routes at the end.
+        duthost = duthosts[rand_one_dut_hostname]
 
-    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
+        for index in range(0, min(3, len(setup_info[request.param]["dest_port"]))):
+            tx_port = setup_info[request.param]["dest_port"][index]
+            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+
+
+    @pytest.mark.parametrize('setup_dest_port_type', ["tor", "spine"], indirect=['setup_dest_port_type'])
+    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -92,121 +103,106 @@ class EverflowIPv4Tests(BaseEverflowTest):
             - Route creation and removal
         """
         duthost = duthosts[rand_one_dut_hostname]
-        try:
-            # Add a route to the mirror session destination IP
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-            time.sleep(3)
+        dest_port_type = setup_dest_port_type
 
-            # Verify that mirrored traffic is sent along the route we installed
-            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
-            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
+        # Add a route to the mirror session destination IP
+        tx_port = setup_info[dest_port_type]["dest_port"][0]
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+        time.sleep(3)
 
-            # Add a (better) unresolved route to the mirror session destination IP
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo, resolved=False)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
-            time.sleep(3)
+        # Verify that mirrored traffic is sent along the route we installed
+        rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
 
-            # Verify that mirrored traffic is still sent along the original route
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
+        # Add a (better) unresolved route to the mirror session destination IP
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo, resolved=False)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+        time.sleep(3)
 
-            # Remove the unresolved route
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+        # Verify that mirrored traffic is still sent along the original route
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
 
-            # Add a better route to the mirror session destination IP
-            tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
-            time.sleep(3)
+        # Remove the unresolved route
+        everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
 
-            # Verify that mirrored traffic uses the new route
-            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
+        # Add a better route to the mirror session destination IP
+        tx_port = setup_info[dest_port_type]["dest_port"][1]
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip)
+        time.sleep(3)
 
-            # Remove the better route.
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
-            time.sleep(3)
+        # Verify that mirrored traffic uses the new route
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
 
-            # Verify that mirrored traffic switches back to the original route
-            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
+        # Remove the better route.
+        everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
+        time.sleep(3)
 
-            # Clean up the test
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.remove_route(duthost, setup_mirror_session['session_prefixes'][0], peer_ip)
+        # Verify that mirrored traffic switches back to the original route
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
 
-        except Exception:
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
-
-            tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
-
-            raise
-
-    def test_everflow_neighbor_mac_change(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
+    @pytest.mark.parametrize('setup_dest_port_type', ["tor", "spine"], indirect=['setup_dest_port_type'])
+    def test_everflow_neighbor_mac_change(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
         duthost = duthosts[rand_one_dut_hostname]
+        dest_port_type = setup_dest_port_type
+        # Add a route to the mirror session destination IP
+        tx_port = setup_info[dest_port_type]["dest_port"][0]
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+        time.sleep(3)
+
+        # Verify that mirrored traffic is sent along the route we installed
+        rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
+
+        # Update the MAC on the neighbor interface for the route we installed
+        if setup_info[dest_port_type]["dest_port_lag_name"][0] != "Not Applicable":
+            tx_port = setup_info[dest_port_type]["dest_port_lag_name"][0]
+
+        duthost.shell("ip neigh replace {} lladdr 00:11:22:33:44:55 nud permanent dev {}".format(peer_ip, tx_port))
+        time.sleep(3)
         try:
-            # Add a route to the mirror session destination IP
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-            time.sleep(3)
-
-            # Verify that mirrored traffic is sent along the route we installed
-            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
-            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
-
-            # Update the MAC on the neighbor interface for the route we installed
-            if setup_info[dest_port_type]["dest_port_lag_name"][0] != "Not Applicable":
-                tx_port = setup_info[dest_port_type]["dest_port_lag_name"][0]
-
-            duthost.shell("ip neigh replace {} lladdr 00:11:22:33:44:55 nud permanent dev {}".format(peer_ip, tx_port))
-            time.sleep(3)
-
             # Verify that everything still works
             self._run_everflow_test_scenarios(
                 ptfadapter,
@@ -217,205 +213,191 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 [tx_port_ptf_id]
             )
 
+        finally:
             # Clean up the test
             duthost.shell("ip neigh del {} dev {}".format(peer_ip, tx_port))
             duthost.shell("ping {} -c3".format(peer_ip))
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
 
-        except Exception:
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-
-            raise
-
-    def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
+        # Verify that everything still works
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
+    
+    @pytest.mark.parametrize('setup_dest_port_type', ["tor", "spine"], indirect=['setup_dest_port_type'])
+    def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
         duthost = duthosts[rand_one_dut_hostname]
-        try:
-            # Create two ECMP next hops
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
-            time.sleep(3)
+        dest_port_type = setup_dest_port_type
+        # Create two ECMP next hops
+        tx_port = setup_info[dest_port_type]["dest_port"][0]
+        peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+        time.sleep(3)
 
-            tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
-            time.sleep(3)
+        tx_port = setup_info[dest_port_type]["dest_port"][1]
+        peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+        time.sleep(3)
 
-            # Verify that mirrored traffic is sent to one of the next hops
-            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
-            tx_port_ptf_ids = [
-                setup_info[dest_port_type]["dest_port_ptf_id"][0],
-                setup_info[dest_port_type]["dest_port_ptf_id"][1]
-            ]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                tx_port_ptf_ids
-            )
+        # Verify that mirrored traffic is sent to one of the next hops
+        rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+        tx_port_ptf_ids = [
+            setup_info[dest_port_type]["dest_port_ptf_id"][0],
+            setup_info[dest_port_type]["dest_port_ptf_id"][1]
+        ]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            tx_port_ptf_ids
+        )
 
-            # Add another ECMP next hop
-            tx_port = setup_info[dest_port_type]["dest_port"][2]
-            peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-            time.sleep(3)
+        # Add another ECMP next hop
+        tx_port = setup_info[dest_port_type]["dest_port"][2]
+        peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+        time.sleep(3)
 
-            # Verify that mirrored traffic is not sent to this new next hop
-            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][2]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id],
-                expect_recv=False
-            )
+        # Verify that mirrored traffic is not sent to this new next hop
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][2]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id],
+            expect_recv=False
+        )
 
-            # Remove the extra hop
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-            time.sleep(3)
+        # Remove the extra hop
+        everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
+        time.sleep(3)
 
-            # Verify that mirrored traffic is not sent to the deleted next hop
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id],
-                expect_recv=False
-            )
+        # Verify that mirrored traffic is not sent to the deleted next hop
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id],
+            expect_recv=False
+        )
 
-            # Verify that mirrored traffic is still sent to one of the original next hops
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                tx_port_ptf_ids
-            )
+        # Verify that mirrored traffic is still sent to one of the original next hops
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            tx_port_ptf_ids
+        )
 
-            # Clean up the test
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
-
-        except Exception:
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)   
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
-
-            raise
-
-    def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
+    @pytest.mark.parametrize('setup_dest_port_type', ["tor", "spine"], indirect=['setup_dest_port_type'])
+    def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
         duthost = duthosts[rand_one_dut_hostname]
-        try:
-            # Add a route to the mirror session destination IP
-            tx_port = setup_info[dest_port_type]["dest_port"][0]
-            peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
-            time.sleep(3)
+        dest_port_type = setup_dest_port_type
+        # Add a route to the mirror session destination IP
+        tx_port = setup_info[dest_port_type]["dest_port"][0]
+        peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+        time.sleep(3)
 
-            # Verify that mirrored traffic is sent along the route we installed
-            rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
-            tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
+        # Verify that mirrored traffic is sent along the route we installed
+        rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
 
-            # Add two new ECMP next hops
-            tx_port = setup_info[dest_port_type]["dest_port"][1]
-            peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
+        # Add two new ECMP next hops
+        tx_port = setup_info[dest_port_type]["dest_port"][1]
+        peer_ip_1, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
 
-            tx_port = setup_info[dest_port_type]["dest_port"][2]
-            peer_ip_2, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
-            everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
-            time.sleep(3)
+        tx_port = setup_info[dest_port_type]["dest_port"][2]
+        peer_ip_2, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
+        everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
+        time.sleep(3)
 
-            # Verify that traffic is still sent along the original next hop
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id]
-            )
+        # Verify that traffic is still sent along the original next hop
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id]
+        )
 
-            # Verify that traffic is not sent along either of the new next hops
-            tx_port_ptf_ids = [
-                setup_info[dest_port_type]["dest_port_ptf_id"][1],
-                setup_info[dest_port_type]["dest_port_ptf_id"][2]
-            ]
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                tx_port_ptf_ids,
-                expect_recv=False
-            )
+        # Verify that traffic is not sent along either of the new next hops
+        tx_port_ptf_ids = [
+            setup_info[dest_port_type]["dest_port_ptf_id"][1],
+            setup_info[dest_port_type]["dest_port_ptf_id"][2]
+        ]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            tx_port_ptf_ids,
+            expect_recv=False
+        )
 
-            # Remove the original next hop
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
-            time.sleep(3)
+        # Remove the original next hop
+        everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
+        time.sleep(3)
 
-            # Verify that mirrored traffic is no longer sent along the original next hop
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                [tx_port_ptf_id],
-                expect_recv=False
-            )
+        # Verify that mirrored traffic is no longer sent along the original next hop
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            [tx_port_ptf_id],
+            expect_recv=False
+        )
 
-            # Verify that mirrored traffis is now sent along either of the new next hops
-            self._run_everflow_test_scenarios(
-                ptfadapter,
-                setup_info,
-                setup_mirror_session,
-                duthost,
-                rx_port_ptf_id,
-                tx_port_ptf_ids
-            )
-
-            # Clean up the tests
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
-        except Exception:
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_0)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_1)
-            everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip_2)
-
-            raise
-
+        # Verify that mirrored traffis is now sent along either of the new next hops
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            duthost,
+            rx_port_ptf_id,
+            tx_port_ptf_ids
+        )
+    
+    @pytest.mark.parametrize('setup_dest_port_type', ["tor", "spine"])
     def test_everflow_dscp_with_policer(
             self,
             duthost,
             setup_info,
             policer_mirror_session,
-            dest_port_type,
+            setup_dest_port_type,
             partial_ptf_runner,
             config_method,
             tbinfo
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table."""
+        dest_port_type = setup_dest_port_type
 
         # Add explicit route for the mirror session
         tx_port = setup_info[dest_port_type]["dest_port"][0]

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -61,6 +61,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
+
     @pytest.fixture(params=["tor", "spine"])
     def dest_port_type(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, tbinfo, request):
         """

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -61,26 +61,24 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-    
-    @pytest.fixture
-    def setup_dest_port_type(self, dest_port_type, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, tbinfo):
+    @pytest.fixture(params=["tor", "spine"])
+    def dest_port_type(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, tbinfo, request):
         """
-        This fixture get the dest port type and can perform action based
+        This fixture parametrize  dest_port_type and can perform action based
         on that. As of now cleanup is being done here.
         """
-        yield dest_port_type
+        yield request.param
         
         duthost = duthosts[rand_one_dut_hostname]
 
-        for index in range(0, min(3, len(setup_info[dest_port_type]["dest_port"]))):
-            tx_port = setup_info[dest_port_type]["dest_port"][index]
+        for index in range(0, min(3, len(setup_info[request.param]["dest_port"]))):
+            tx_port = setup_info[request.param]["dest_port"][index]
             peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
             everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip)
             everflow_utils.remove_route(duthost, setup_mirror_session["session_prefixes"][1], peer_ip)
 
 
-    @pytest.mark.parametrize('dest_port_type', ["tor", "spine"])
-    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
+    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -91,7 +89,6 @@ class EverflowIPv4Tests(BaseEverflowTest):
             - Route creation and removal
         """
         duthost = duthosts[rand_one_dut_hostname]
-        dest_port_type = setup_dest_port_type
 
         # Add a route to the mirror session destination IP
         tx_port = setup_info[dest_port_type]["dest_port"][0]
@@ -161,11 +158,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             [tx_port_ptf_id]
         )
 
-    @pytest.mark.parametrize('dest_port_type', ["tor", "spine"])
-    def test_everflow_neighbor_mac_change(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
+    def test_everflow_neighbor_mac_change(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
         duthost = duthosts[rand_one_dut_hostname]
-        dest_port_type = setup_dest_port_type
         # Add a route to the mirror session destination IP
         tx_port = setup_info[dest_port_type]["dest_port"][0]
         peer_ip, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
@@ -216,11 +211,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             [tx_port_ptf_id]
         )
     
-    @pytest.mark.parametrize('dest_port_type', ["tor", "spine"])
-    def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
+    def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
         duthost = duthosts[rand_one_dut_hostname]
-        dest_port_type = setup_dest_port_type
         # Create two ECMP next hops
         tx_port = setup_info[dest_port_type]["dest_port"][0]
         peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
@@ -290,11 +283,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tx_port_ptf_ids
         )
 
-    @pytest.mark.parametrize('dest_port_type', ["tor", "spine"])
-    def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, setup_dest_port_type, ptfadapter, tbinfo):
+    def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
         duthost = duthosts[rand_one_dut_hostname]
-        dest_port_type = setup_dest_port_type
         # Add a route to the mirror session destination IP
         tx_port = setup_info[dest_port_type]["dest_port"][0]
         peer_ip_0, _ = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
@@ -373,7 +364,6 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tx_port_ptf_ids
         )
     
-    @pytest.mark.parametrize('dest_port_type', ["tor", "spine"])
     def test_everflow_dscp_with_policer(
             self,
             duthost,


### PR DESCRIPTION
Why/What I did:

Following changes are being done to everflow testcases infrastructure to support multi-asic (in subsequent PR's)

- For test_everflow_testbed.py updated existing fixture dest_port_type to set_up_dest_port_type with indirect clause which helps in taking any action based of generate parameter value. This will be needed for multi-asic where based on dest-port type corresponding asic need to take some action (Next PR will have this change)

- All the cleanup has been moved into above fixture and thus remove the use of try/except from testcases. It was one of TODO item in the test case

- For test_everflow_ipv6.py added explicit route for mirror destination ip so that mirror destination ports are deterministic. This is needed for mutli-asic where default route on each asic can be different and thus monitor port can be different.

How I verify:

Verified these changes work for both single and multi-asic.

Test Results:

` sudo sudo ANSIBLE_KEEP_REMOTE_FILES=1 py.test --inventory "../ansible/str" --host-pattern str-xxx-on-2 --module-path "../ansible/library/" --testbed vms13-5-t1-lag --testbed_file "../ansible/testbed.csv"  --show-capture=no --log-cli-level debug  --showlocals -ra -vvv "everflow/test_everflow_testbed.py" --skip_sanity --disable_loganalyzer

================================ 10 passed, 30 skipped in 526.82 seconds ================================

 sudo sudo ANSIBLE_KEEP_REMOTE_FILES=1 py.test --inventory "../ansible/str" --host-pattern str-xxx-on-2 --module-path "../ansible/library/" --testbed vms13-5-t1-lag --testbed_file "../ansible/testbed.csv"  --show-capture=no --log-cli-level debug  --showlocals -ra -vvv "everflow/test_everflow_ipv6.py" --skip_sanity --disable_loganalyzer

=========================================================================================== 20 passed in 82.62 seconds ===========================================
`




