### PR TITLE
Ignore test_snmp_phy_entity for 201911 images

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -101,7 +101,7 @@ XCVR_DOM_KEY_TEMPLATE = 'TRANSCEIVER_DOM_SENSOR|{}'
 
 @pytest.fixture(autouse=True, scope="module")
 def check_image_version(duthost):
-    """Skip the test for unsupproted images."""
+    """Skip the test for unsupported images."""
     if "201911" in duthost.os_version:
         pytest.skip('Test not supported for 201911 images. Skipping the test')
     yield

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -3,6 +3,7 @@ import pytest
 import time
 
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_require
 from tests.platform_tests.thermal_control_test_helper import mocker_factory
 
 pytestmark = [
@@ -102,8 +103,7 @@ XCVR_DOM_KEY_TEMPLATE = 'TRANSCEIVER_DOM_SENSOR|{}'
 @pytest.fixture(autouse=True, scope="module")
 def check_image_version(duthost):
     """Skip the test for unsupported images."""
-    if "201911" in duthost.os_version:
-        pytest.skip('Test not supported for 201911 images. Skipping the test')
+    pytest_require("201911" not in duthost.os_version, "Test not supported for 201911 images. Skipping the test")
     yield
 
 

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -99,6 +99,14 @@ XCVR_KEY_TEMPLATE = 'TRANSCEIVER_INFO|{}'
 XCVR_DOM_KEY_TEMPLATE = 'TRANSCEIVER_DOM_SENSOR|{}'
 
 
+@pytest.fixture(autouse=True, scope="module")
+def check_image_version(duthost):
+    """Skip the test for unsupproted images."""
+    if "201911" in duthost.os_version:
+        pytest.skip('Test not supported for 201911 images. Skipping the test')
+    yield
+
+
 @pytest.fixture(scope="module")
 def snmp_physical_entity_info(duthost, localhost, creds):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip `test_snmp_phy_entity` testcase on 201911 images. This testcase is primarily targeted to be executed on 202012 images.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Nightly tests are failing for `test_snmp_phy_entity` tests on 201911 images.

#### How did you do it?
Added a module scoped skip fixture.

#### How did you verify/test it?
Executed the test on a 201911 image, and it was successfully skipped:
```
snmp/test_snmp_phy_entity.py::test_fan_info 
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
22:34:25 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:34:25 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
SKIPPED                                                                                                                                                                                                               [ 28%]
snmp/test_snmp_phy_entity.py::test_psu_info 
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
22:34:25 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:34:25 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
SKIPPED                                                                                                                                                                                                               [ 42%]
snmp/test_snmp_phy_entity.py::test_thermal_info 
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
22:34:25 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:34:25 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
SKIPPED                                                                                                                                                                                                               [ 57%]
snmp/test_snmp_phy_entity.py::test_transceiver_info 
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
22:34:25 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:34:25 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
SKIPPED                                                                                                                                                                                                               [ 71%]
snmp/test_snmp_phy_entity.py::test_turn_off_psu_and_check_psu_info 
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
22:34:25 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:34:25 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
SKIPPED                                                                                                                                                                                                               [ 85%]
snmp/test_snmp_phy_entity.py::test_remove_insert_fan_and_check_fan_info 
------------------------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------------------------
22:34:25 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:34:25 INFO __init__.py:check_test_completeness:128: Test has no defined levels. Continue without test completeness checks
SKIPPED                                                                                                                                                                                                               [100%]

================================================================================================ 7 skipped in 13.35 seconds =================================================================================================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
