### PR TITLE
[ser] refacoring Broadcom SER test

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1121,6 +1121,21 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         cmd = 'show bgp ipv4' if ipaddress.ip_network(unicode(prefix)).version == 4 else 'show bgp ipv6'
         return json.loads(self.shell('vtysh -c "{} {} json"'.format(cmd, prefix))['stdout'])
 
+    def get_asic_name(self):
+        asic = "unknown"
+        output = self.shell("lspci", module_ignore_errors=True)["stdout"]
+        if ("Broadcom Limited Device b960" in output or
+            "Broadcom Limited Broadcom BCM56960" in output):
+            asic = "th"
+        elif "Broadcom Limited Device b971" in output:
+            asic = "th2"
+        elif "Broadcom Limited Device b850" in output:
+            asic = "td2"
+        elif "Broadcom Limited Device b870" in output:
+            asic = "td3"
+
+        return asic
+
 
 class K8sMasterHost(AnsibleHostBase):
     """

--- a/tests/platform_tests/broadcom/files/ser_injector.py
+++ b/tests/platform_tests/broadcom/files/ser_injector.py
@@ -29,7 +29,7 @@ How to create skip list on an new ASIC:
     3. on target DUT: 'python ser_injector.py -v -c thorough | tee ser.log', copy
        the timeout set to the matching asic.
     4. If a new ASIC is not known to this script yet. Update asci name
-       and lspci signature in get_asic_type() function
+       and lspci signature in get_asic_name() function
 """
 SKIP_MEMORY_PER_ASIC = {
     'td2' : [
@@ -247,7 +247,7 @@ def run_cmd(cmd):
     stdout, stderr = out.communicate()
     return stdout, stderr
 
-def get_asic_type():
+def get_asic_name():
     asic = "unknown"
     stdout, _ = run_cmd("lspci")
     output = stdout.decode("utf-8")
@@ -267,7 +267,7 @@ def get_asic_type():
 def get_skip_list_per_asic():
     global SKIP_MEMORY_PER_ASIC
 
-    asic = get_asic_type()
+    asic = get_asic_name()
 
     return SKIP_MEMORY_PER_ASIC[asic] if asic in SKIP_MEMORY_PER_ASIC else []
 
@@ -318,7 +318,7 @@ class BcmMemory():
             self.memory_address[int(key)] = val
 
     def read_memory_from_file(self):
-        file_name = '/tmp/{}-mem-info.json'.format(get_asic_type())
+        file_name = '/tmp/{}-mem-info.json'.format(get_asic_name())
         try:
             with open(file_name, 'r') as info:
                 contents = json.load(info)
@@ -334,7 +334,7 @@ class BcmMemory():
         contents = { 'cached_memory' : self.cached_memory,
                      'uncached_memory' : self.uncached_memory,
                      'memory_address' : self.memory_address }
-        file_name = '/tmp/{}-mem-info.json'.format(get_asic_type())
+        file_name = '/tmp/{}-mem-info.json'.format(get_asic_name())
         try:
             with open(file_name, 'w') as info:
                 json.dump(contents, info, indent=4)
@@ -497,7 +497,7 @@ class SerTest(object):
                         print('--- stall detected. Stop testing')
                     break
 
-        print("SER test on ASIC : {}".format(get_asic_type()))
+        print("SER test on ASIC : {}".format(get_asic_name()))
         if VERBOSE:
             print("SER Test memories candidates (%s): %s" % (len(self.test_candidates), self.test_candidates))
             print("SER Test succeeded for memories (%s): %s" % (len(self.mem_verified), self.mem_verified))

--- a/tests/platform_tests/broadcom/files/ser_injector.py
+++ b/tests/platform_tests/broadcom/files/ser_injector.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
-import subprocess
+import argparse
+import json
+import random
 import re
+import subprocess
 import sys
 import time
-import random
-import argparse
 from collections import defaultdict
 
 # Global parameter for memory scanners
@@ -17,61 +18,213 @@ SRAM_SCAN_ENTRIES = 16384
 DEFAULT_SER_INJECTION_INTERVAL_SEC = 0.1
 DEFAULT_SYSLOG_POLLING_INTERVAL_SEC = 0.1
 
-# The following memory tables do not get corrected when a ser is injected into them! Let's take them out for now
-# until the underlying reason is answered by Broadcom
-UNTESTABLE_MEMORY_TABLES = [u'L3_ENTRY_IPV6_MULTICAST.ipipe0', u'L3_DEFIP_ALPM_IPV6_64.ipipe0', u'EGR_IP_TUNNEL_MPLS.epipe0',
-                            u'MODPORT_MAP_MIRROR.ipipe0', u'L3_DEFIP_ALPM_IPV6_128.ipipe0', u'L3_ENTRY_IPV4_MULTICAST.ipipe0',
-                            u'L3_ENTRY_IPV6_UNICAST.ipipe0', u'L3_DEFIP_ALPM_IPV4.ipipe0', u'FP_GLOBAL_MASK_TCAM.ipipe0',
-                            u'FP_STORM_CONTROL_METERS.ipipe0', u'FP_GM_FIELDS.ipipe0']
+"""
+Follow memory cannot be tested on corresponding platforms for reasons
+    1). The memory was reported to be corrected at a different location without name.
+    2). The memory was reported to be corrected only when corrupting another location.
 
-# Correction address issue: when corruption these following addresses, the correction came up from a different
-# address. Therefore the test failed to correlate the corruption and correction.
-CORRECTION_MISS_ALIGNS = [u'THDI_PORT_SP_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP_PIPE3.mmu_xpe0',
-                          u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE2.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE3.mmu_xpe0', u'IFP_TCAM.ipipe0',
-                          u'MMU_THDU_OFFSET_QUEUE_PIPE1.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP_PIPE1.mmu_xpe0',
-                          u'MMU_THDU_CONFIG_PORT_PIPE2.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE1.mmu_xpe0', u'EGR_IP_TUNNEL_IPV6.epipe0',
-                          u'MMU_THDU_CONFIG_QUEUE_PIPE3.mmu_xpe0', u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC0.mmu_xpe0',
-                          u'THDI_PORT_SP_CONFIG_PIPE3.mmu_xpe0', u'THDI_PORT_SP_CONFIG_PIPE0.mmu_xpe0',
-                          u'MMU_THDU_CONFIG_PORT_PIPE3.mmu_xpe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE1.mmu_xpe0',
-                          u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE2.mmu_sc0',
-                          u'IFP_TCAM_WIDE_PIPE2.ipipe0', u'VLAN_XLATE.ipipe0', u'MMU_THDU_CONFIG_QUEUE_PIPE1.mmu_xpe0',
-                          u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE0.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_7.mmu_xpe0',
-                          u'MMU_THDU_Q_TO_QGRP_MAP_PIPE0.mmu_xpe0', u'MMU_THDU_CONFIG_QGROUP_PIPE1.mmu_xpe0',
-                          u'MMU_THDU_OFFSET_QGROUP_PIPE2.mmu_xpe0', u'MMU_THDU_CONFIG_PORT_PIPE1.mmu_xpe0',
-                          u'MMU_THDU_CONFIG_QGROUP_PIPE3.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE1.mmu_sc0',
-                          u'MMU_WRED_DROP_CURVE_PROFILE_3.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE2.mmu_xpe0',
-                          u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE1.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE2.mmu_xpe0',
-                          u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC1.mmu_xpe0', u'MMU_THDU_CONFIG_QGROUP_PIPE2.mmu_xpe0',
-                          u'MMU_THDU_CONFIG_QUEUE_PIPE2.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE2.mmu_xpe0',
-                          u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE0.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE1.mmu_xpe0',
-                          u'MMU_WRED_DROP_CURVE_PROFILE_5.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE2.mmu_xpe0',
-                          u'MMU_THDM_DB_QUEUE_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE0.mmu_xpe0',
-                          u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE3.mmu_xpe0', u'EGR_VLAN_XLATE.epipe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE1.mmu_xpe0',
-                          u'MPLS_ENTRY_DOUBLE.ipipe0', u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE0.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_2.mmu_xpe0',
-                          u'IFP_TCAM_WIDE_PIPE1.ipipe0', u'MMU_THDU_OFFSET_QUEUE_PIPE2.mmu_xpe0', u'THDI_PORT_SP_CONFIG_PIPE1.mmu_xpe0',
-                          u'L3_ENTRY_IPV4_UNICAST.ipipe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE3.mmu_xpe0',
-                          u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE0.mmu_sc0', u'MMU_THDU_OFFSET_QUEUE_PIPE3.mmu_xpe0',
-                          u'MMU_WRED_DROP_CURVE_PROFILE_4.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE0.mmu_xpe0', u'VLAN_MAC.ipipe0',
-                          u'MMU_THDU_CONFIG_QGROUP_PIPE0.mmu_xpe0', u'IFP_TCAM_WIDE_PIPE3.ipipe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE0.mmu_xpe0',
-                          u'MMU_THDU_OFFSET_QGROUP_PIPE0.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE3.mmu_xpe0',
-                          u'MMU_WRED_DROP_CURVE_PROFILE_1.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE3.mmu_sc0', u'L2_ENTRY.ipipe0',
-                          u'MMU_WRED_DROP_CURVE_PROFILE_8.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_0.mmu_xpe0',
-                          u'MMU_THDU_RESUME_PORT_PIPE2.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE3.mmu_xpe0',
-                          u'MMU_THDM_DB_QUEUE_CONFIG_PIPE1.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE1.mmu_xpe0',
-                          u'MMU_THDU_RESUME_PORT_PIPE3.mmu_xpe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE0.mmu_xpe0',
-                          u'MMU_THDU_RESUME_PORT_PIPE0.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE1.mmu_xpe0', u'IFP_TCAM_WIDE_PIPE0.ipipe0',
-                          u'MMU_THDU_Q_TO_QGRP_MAP_PIPE2.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_6.mmu_xpe0',
-                          u'MMU_THDM_DB_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE3.mmu_sed0',
-                          u'TCB_THRESHOLD_PROFILE_MAP_XPE1.mmu_xpe0', u'ING_VP_VLAN_MEMBERSHIP.ipipe0', u'ING_DNAT_ADDRESS_TYPE.ipipe0',
-                          u'L3_TUNNEL.ipipe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE2.mmu_sed0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE0.mmu_sed0',
-                          u'ING_SNAT.ipipe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE0.mmu_sed0', u'MMU_THDM_DB_QUEUE_OFFSET_C_PIPE0.mmu_xpe0',
-                          u'TCB_THRESHOLD_PROFILE_MAP_XPE3.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP1_PIPE2.mmu_xpe0', u'EGR_VP_VLAN_MEMBERSHIP.epipe0',
-                          u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE2.mmu_sed0', u'MMU_THDU_RESUME_PORT0_PIPE0.mmu_xpe0',
-                          u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE3.mmu_sed0', u'MMU_THDU_CONFIG_PORT_PIPE0.mmu_xpe0',
-                          u'MMU_THDU_CONFIG_QUEUE_PIPE0.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_1_B.mmu_xpe0',
-                          u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE1.mmu_sed0', u'TCB_THRESHOLD_PROFILE_MAP_XPE0.mmu_xpe0',
-                          u'MMU_MTRO_CONFIG_L0_MEM_PIPE1.mmu_sed0', u'INTFO_TC2PRI_MAPPING.mmu_glb0', u'TCB_THRESHOLD_PROFILE_MAP_XPE2.mmu_xpe0',
-                          u'MMU_THDM_DB_PORTSP_CONFIG_C_PIPE3.mmu_xpe0']
+How to create skip list on an new ASIC:
+    1. configure target DUT to not timeout ssh connections.
+    2. copy ser_injector.py to target DUT.
+    3. on target DUT: 'python ser_injector.py -v -c thorough | tee ser.log', copy
+       the timeout set to the matching asic.
+    4. If a new ASIC is not known to this script yet. Update asci name
+       and lspci signature in get_asic_type() function
+"""
+SKIP_MEMORY_PER_ASIC = {
+    'td2' : [
+        # cannot pass
+        u'L3_DEFIP_ALPM_IPV4.ipipe0', u'L3_ENTRY_IPV6_MULTICAST.ipipe0', u'L3_ENTRY_IPV6_UNICAST.ipipe0',
+        u'FP_GM_FIELDS.ipipe0', u'L3_ENTRY_IPV4_MULTICAST.ipipe0', u'L3_DEFIP_ALPM_IPV6_64.ipipe0',
+        u'L3_DEFIP_ALPM_IPV6_128.ipipe0', u'FP_GLOBAL_MASK_TCAM.ipipe0', u'MODPORT_MAP_MIRROR.ipipe0',
+        u'EGR_IP_TUNNEL_MPLS.epipe0',
+        # fail only with basic mode
+        u'EGR_IP_TUNNEL_IPV6.epipe0', u'EGR_DVP_ATTRIBUTE_1.epipe0', u'EGR_MPLS_VC_AND_SWAP_LABEL_TABLE.epipe0',
+        u'L3_TUNNEL_DATA_ONLY.ipipe0',
+        ],
+    'td3' : [
+        # cannot pass
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE3.mmu_sc0', u'ING_SNAT.ipipe0',
+        u'TCB_THRESHOLD_PROFILE_MAP_XPE2.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP1_PIPE2.mmu_xpe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE0.mmu_sc0', u'ING_VP_VLAN_MEMBERSHIP.ipipe0',
+        u'L3_ENTRY_IPV4_UNICAST.ipipe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE1.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_2.mmu_xpe0', u'MMU_THDU_CONFIG_PORT_PIPE3.mmu_xpe0',
+        u'THDI_PORT_SP_CONFIG_PIPE3.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_4.mmu_xpe0',
+        u'MMU_THDU_Q_TO_QGRP_MAP_PIPE0.mmu_xpe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE0.mmu_sed0',
+        u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE0.mmu_xpe0',
+        u'MMU_THDU_Q_TO_QGRP_MAP_PIPE2.mmu_xpe0', u'FP_STORM_CONTROL_METERS.ipipe0',
+        u'THDI_PORT_SP_CONFIG_PIPE1.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE1.mmu_xpe0', u'VLAN_XLATE.ipipe0',
+        u'MMU_THDU_OFFSET_QGROUP_PIPE1.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE0.mmu_sed0',
+        u'MMU_THDM_DB_QUEUE_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDU_CONFIG_PORT_PIPE2.mmu_xpe0',
+        u'MMU_THDU_CONFIG_PORT_PIPE1.mmu_xpe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE1.mmu_xpe0',
+        u'MMU_MTRO_CONFIG_L0_MEM_PIPE1.mmu_sed0', u'IFP_TCAM.ipipe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE1.mmu_sed0', u'L3_TUNNEL.ipipe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE1.mmu_xpe0', u'L2_ENTRY.ipipe0', u'L3_DEFIP_ALPM_IPV6_128.ipipe0',
+        u'FP_GLOBAL_MASK_TCAM.ipipe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE3.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE3.mmu_xpe0', u'FP_GM_FIELDS.ipipe0',
+        u'TCB_THRESHOLD_PROFILE_MAP_XPE1.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE2.mmu_xpe0',
+        u'EGR_IP_TUNNEL_IPV6.epipe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE0.mmu_xpe0', u'MODPORT_MAP_MIRROR.ipipe0',
+        u'VLAN_MAC.ipipe0', u'MMU_THDU_CONFIG_QUEUE_PIPE2.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE2.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE0.mmu_xpe0',
+        u'MMU_THDU_OFFSET_QGROUP_PIPE3.mmu_xpe0', u'MMU_THDU_CONFIG_QGROUP_PIPE3.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_7.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_3.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE2.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE1.mmu_xpe0',
+        u'INTFO_TC2PRI_MAPPING.mmu_glb0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE2.mmu_sed0', u'MPLS_ENTRY_DOUBLE.ipipe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE1.mmu_sc0', u'MMU_THDU_OFFSET_QUEUE_PIPE0.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_1_B.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_1.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE2.mmu_xpe0', u'EGR_IP_TUNNEL_MPLS.epipe0', u'L3_DEFIP_ALPM_IPV4.ipipe0',
+        u'THDI_PORT_SP_CONFIG_PIPE2.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_0.mmu_xpe0',
+        u'MMU_THDU_Q_TO_QGRP_MAP_PIPE3.mmu_xpe0', u'TCB_THRESHOLD_PROFILE_MAP_XPE0.mmu_xpe0',
+        u'EGR_VP_VLAN_MEMBERSHIP.epipe0', u'MMU_WRED_DROP_CURVE_PROFILE_8.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE3.mmu_xpe0', u'MMU_THDU_CONFIG_QUEUE_PIPE0.mmu_xpe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE1.mmu_xpe0',
+        u'EGR_VLAN_XLATE.epipe0', u'L3_DEFIP_ALPM_IPV6_64.ipipe0', u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC0.mmu_xpe0',
+        u'L3_ENTRY_IPV6_MULTICAST.ipipe0', u'MMU_THDU_OFFSET_QGROUP_PIPE2.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QUEUE_PIPE1.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE0.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE1.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE1.mmu_xpe0',
+        u'MMU_THDU_CONFIG_PORT_PIPE0.mmu_xpe0', u'L3_ENTRY_IPV6_UNICAST.ipipe0', u'ING_DNAT_ADDRESS_TYPE.ipipe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE0.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE1.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'L3_ENTRY_IPV4_MULTICAST.ipipe0',
+        u'MMU_THDU_CONFIG_QUEUE_PIPE3.mmu_xpe0', u'THDI_PORT_SP_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_5.mmu_xpe0', u'TCB_THRESHOLD_PROFILE_MAP_XPE3.mmu_xpe0',
+        u'MMU_THDU_RESUME_PORT_PIPE3.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE3.mmu_xpe0',
+        u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC1.mmu_xpe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE3.mmu_sed0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE2.mmu_sc0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_6.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE3.mmu_sed0',
+        u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE0.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_C_PIPE3.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE2.mmu_xpe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE1.mmu_xpe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE2.mmu_sed0', u'IFP_TCAM_WIDE_PIPE3.ipipe0',
+        u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE3.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP_PIPE0.mmu_xpe0',
+        u'IFP_TCAM_WIDE_PIPE2.ipipe0',
+        # fail only with basic mode
+        u'MODPORT_MAP_SUBPORT_MIRROR.ipipe0', u'EGR_VLAN_XLATE_2_DOUBLE.epipe0', u'PKT_FLOW_SELECT_TCAM_2.ipipe0',
+        u'EGR_ZONE_3_EDITOR_CONTROL_TCAM.epipe0', u'RH_ECMP_FLOWSET_PIPE0.ipipe0', u'EGR_VLAN_XLATE_1_DOUBLE.epipe0',
+        u'RH_ECMP_FLOWSET.ipipe0', u'DST_COMPRESSION_PIPE1.ipipe0', u'EGR_FIELD_EXTRACTION_PROFILE_2_TCAM.epipe0',
+        u'VLAN_XLATE_2_DOUBLE.ipipe0', u'L3_DEFIP.ipipe0', u'EGR_PKT_FLOW_SELECT_TCAM.epipe0',
+        u'FLEX_RTAG7_HASH_TCAM.ipipe0', u'L2_ENTRY_SINGLE.ipipe0', u'VLAN_XLATE_1_SINGLE.ipipe0',
+        u'EGR_FIELD_EXTRACTION_PROFILE_1_TCAM.epipe0', u'EXACT_MATCH_LOGICAL_TABLE_SELECT.ipipe0',
+        u'SRC_COMPRESSION.ipipe0', u'EGR_VLAN_XLATE_1_SINGLE.epipe0', u'RH_HGT_FLOWSET_PIPE0.ipipe0',
+        u'VLAN_SUBNET.ipipe0', u'RH_LAG_FLOWSET_PIPE1.ipipe0', u'MY_STATION_TCAM_2.ipipe0',
+        u'EGR_ZONE_4_EDITOR_CONTROL_TCAM.epipe0', u'RH_LAG_FLOWSET.ipipe0', u'RH_HGT_FLOWSET_PIPE1.ipipe0',
+        u'L3_DEFIP_PAIR_128.ipipe0', u'L3_ENTRY_ONLY_SINGLE.ipipe0', u'MPLS_ENTRY_SINGLE.ipipe0',
+        u'EGR_ZONE_2_EDITOR_CONTROL_TCAM.epipe0', u'EXACT_MATCH_LOGICAL_TABLE_SELECT_PIPE1.ipipe0',
+        u'IFP_TCAM_PIPE1.ipipe0', u'L3_ENTRY_QUAD.ipipe0', u'RH_ECMP_FLOWSET_PIPE1.ipipe0',
+        u'VLAN_XLATE_2_SINGLE.ipipe0', u'L2_ENTRY_ONLY_SINGLE.ipipe0', u'EGR_ZONE_1_EDITOR_CONTROL_TCAM.epipe0',
+        u'SRC_COMPRESSION_PIPE0.ipipe0', u'L3_ENTRY_ONLY_DOUBLE.ipipe0', u'SRC_COMPRESSION_PIPE1.ipipe0',
+        u'SUBPORT_ID_TO_SGPP_MAP.ipipe0', u'PKT_FLOW_SELECT_TCAM_0.ipipe0',
+        u'EXACT_MATCH_LOGICAL_TABLE_SELECT_PIPE0.ipipe0', u'L3_ENTRY_SINGLE.ipipe0', u'DST_COMPRESSION.ipipe0',
+        u'L2_USER_ENTRY.ipipe0', u'L3_ENTRY_ONLY_QUAD.ipipe0', u'PKT_FLOW_SELECT_TCAM_1.ipipe0',
+        u'IP_PARSER1_MICE_TCAM_0.ipipe0', u'PHB_SELECT_TCAM.ipipe0', u'MY_STATION_TCAM.ipipe0',
+        u'CPU_COS_MAP.ipipe0', u'L3_DEFIP_ALPM_RAW.ipipe0', u'DST_COMPRESSION_PIPE0.ipipe0',
+        u'IFP_LOGICAL_TABLE_SELECT.ipipe0', u'IFP_LOGICAL_TABLE_SELECT_PIPE0.ipipe0', u'VLAN_XLATE_1_DOUBLE.ipipe0',
+        u'RH_HGT_FLOWSET.ipipe0', u'IFP_TCAM_PIPE0.ipipe0', u'IP_PARSER1_MICE_TCAM_1.ipipe0',
+        u'EGR_IP_TUNNEL_MPLS_DOUBLE_WIDE.epipe0', u'IFP_LOGICAL_TABLE_SELECT_PIPE1.ipipe0', u'L3_ENTRY_DOUBLE.ipipe0',
+        u'IP_PARSER2_MICE_TCAM_1.ipipe0', u'IP_PARSER2_MICE_TCAM_0.ipipe0', u'RH_LAG_FLOWSET_PIPE0.ipipe0',
+        u'EGR_VLAN_XLATE_2_SINGLE.epipe0', u'EGR_QOS_CTRL_TCAM.epipe0', u'EGR_ZONE_0_EDITOR_CONTROL_TCAM.epipe0',
+        # fail randomly with basic mode
+        u'IFP_POLICY_TABLE_WIDE_PIPE0.ipipe0', u'IFP_POLICY_TABLE_WIDE.ipipe0', u'IFP_POLICY_TABLE_WIDE_PIPE1.ipipe0',
+        u'IFP_METER_TABLE_PIPE1.ipipe0', u'IFP_METER_TABLE.ipipe0',
+        ],
+    'th' : [
+        # cannot pass
+        u'EGR_IP_TUNNEL_MPLS.epipe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE1.mmu_xpe0',
+        u'MMU_THDU_RESUME_PORT_PIPE3.mmu_xpe0', u'MMU_THDU_CONFIG_QUEUE_PIPE2.mmu_xpe0', u'MPLS_ENTRY_DOUBLE.ipipe0',
+        u'MMU_THDU_CONFIG_QUEUE_PIPE3.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_8.mmu_xpe0',
+        u'IFP_TCAM_WIDE_PIPE2.ipipe0', u'FP_GM_FIELDS.ipipe0', u'FP_STORM_CONTROL_METERS.ipipe0',
+        u'MMU_THDU_OFFSET_QUEUE_PIPE1.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_2.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE1.mmu_xpe0', u'THDI_PORT_SP_CONFIG_PIPE1.mmu_xpe0',
+        u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE1.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE3.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE0.mmu_xpe0', u'MMU_THDU_CONFIG_QGROUP_PIPE3.mmu_xpe0',
+        u'EGR_IP_TUNNEL_IPV6.epipe0', u'MODPORT_MAP_MIRROR.ipipe0', u'MMU_THDU_OFFSET_QGROUP_PIPE1.mmu_xpe0',
+        u'THDI_PORT_SP_CONFIG_PIPE0.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE3.mmu_xpe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE1.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE0.mmu_sc0',
+        u'L3_DEFIP_ALPM_IPV6_128.ipipe0', u'IFP_TCAM_WIDE_PIPE3.ipipe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE0.mmu_xpe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE2.mmu_sc0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE2.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE2.mmu_xpe0', u'VLAN_XLATE.ipipe0',
+        u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'VLAN_MAC.ipipe0', u'MMU_THDU_CONFIG_QUEUE_PIPE1.mmu_xpe0',
+        u'MMU_THDU_RESUME_PORT_PIPE2.mmu_xpe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE1.mmu_xpe0',
+        u'L3_DEFIP_ALPM_IPV4.ipipe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE3.mmu_sc0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE0.mmu_xpe0', u'IFP_TCAM_WIDE_PIPE1.ipipe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE3.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_6.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE2.mmu_xpe0', u'FP_GLOBAL_MASK_TCAM.ipipe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE0.mmu_xpe0', u'L3_ENTRY_IPV4_MULTICAST.ipipe0',
+        u'THDI_PORT_SP_CONFIG_PIPE3.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE3.mmu_xpe0',
+        u'MMU_THDU_OFFSET_QGROUP_PIPE2.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_4.mmu_xpe0',
+        u'MMU_THDU_OFFSET_QGROUP_PIPE3.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_THDU_Q_TO_QGRP_MAP_PIPE1.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE0.mmu_xpe0',
+        u'IFP_TCAM_WIDE_PIPE0.ipipe0', u'L3_ENTRY_IPV6_MULTICAST.ipipe0', u'MMU_THDU_OFFSET_QUEUE_PIPE2.mmu_xpe0',
+        u'IFP_TCAM.ipipe0', u'THDI_PORT_SP_CONFIG_PIPE2.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE2.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_3.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP_PIPE0.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_1.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE1.mmu_sc0',
+        u'MMU_THDU_RESUME_PORT_PIPE1.mmu_xpe0', u'EGR_VLAN_XLATE.epipe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE3.mmu_xpe0',
+        u'L3_ENTRY_IPV4_UNICAST.ipipe0', u'MMU_WRED_DROP_CURVE_PROFILE_7.mmu_xpe0',
+        u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC0.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE3.mmu_xpe0',
+        u'MMU_THDU_CONFIG_PORT_PIPE2.mmu_xpe0', u'L2_ENTRY.ipipe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_THDU_CONFIG_PORT_PIPE1.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE0.mmu_xpe0',
+        u'MMU_THDU_CONFIG_PORT_PIPE3.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_0.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE1.mmu_xpe0', u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC1.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'MMU_WRED_DROP_CURVE_PROFILE_5.mmu_xpe0',
+        u'L3_DEFIP_ALPM_IPV6_64.ipipe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE1.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE0.mmu_xpe0',
+        u'L3_ENTRY_IPV6_UNICAST.ipipe0',
+        ],
+    'th2' : [
+        # cannot pass
+        u'TCB_THRESHOLD_PROFILE_MAP_XPE3.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE0.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE3.mmu_xpe0', u'VLAN_MAC.ipipe0', u'EGR_VP_VLAN_MEMBERSHIP.epipe0',
+        u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE1.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE3.mmu_xpe0',
+        u'MMU_THDU_RESUME_PORT_PIPE3.mmu_xpe0', u'MMU_THDU_CONFIG_QUEUE_PIPE2.mmu_xpe0',
+        u'TCB_THRESHOLD_PROFILE_MAP_XPE1.mmu_xpe0', u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE2.mmu_sed0',
+        u'MMU_THDU_OFFSET_QGROUP_PIPE2.mmu_xpe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE0.mmu_xpe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE2.mmu_sed0',
+        u'L3_ENTRY_IPV6_MULTICAST.ipipe0', u'MMU_WRED_DROP_CURVE_PROFILE_0.mmu_xpe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE0.mmu_sed0', u'VLAN_XLATE.ipipe0',
+        u'MMU_THDU_RESUME_PORT_PIPE1.mmu_xpe0', u'L3_ENTRY_IPV4_MULTICAST.ipipe0',
+        u'MMU_THDU_OFFSET_QUEUE_PIPE0.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE0.mmu_xpe0',
+        u'INTFO_TC2PRI_MAPPING.mmu_glb0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE1.mmu_xpe0',
+        u'MMU_MTRO_CONFIG_L0_MEM_PIPE3.mmu_sed0', u'MMU_THDU_OFFSET_QGROUP_PIPE0.mmu_xpe0',
+        u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC1.mmu_xpe0', u'MMU_THDU_CONFIG_QUEUE_PIPE0.mmu_xpe0',
+        u'IFP_TCAM_WIDE_PIPE0.ipipe0', u'L3_DEFIP_ALPM_IPV6_64.ipipe0', u'MMU_WRED_DROP_CURVE_PROFILE_6.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_5.mmu_xpe0', u'IFP_TCAM_WIDE_PIPE2.ipipe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE3.mmu_sed0', u'MMU_THDU_CONFIG_QGROUP_PIPE1.mmu_xpe0',
+        u'THDI_PORT_SP_CONFIG_PIPE3.mmu_xpe0', u'MMU_THDU_RESUME_PORT_PIPE2.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_CONFIG_PIPE1.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_C_PIPE3.mmu_xpe0',
+        u'L3_TUNNEL.ipipe0', u'MPLS_ENTRY_DOUBLE.ipipe0', u'ING_DNAT_ADDRESS_TYPE.ipipe0',
+        u'THDI_PORT_SP_CONFIG_PIPE0.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE3.mmu_xpe0', u'L3_DEFIP_ALPM_IPV4.ipipe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE0.mmu_xpe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE0.mmu_sed0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE3.mmu_xpe0', u'MMU_THDM_DB_PORTSP_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_3.mmu_xpe0', u'IFP_TCAM_WIDE_PIPE1.ipipe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE2.mmu_xpe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE3.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_2.mmu_xpe0', u'MMU_THDU_CONFIG_PORT_PIPE1.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_7.mmu_xpe0', u'L3_ENTRY_IPV4_UNICAST.ipipe0', u'IFP_TCAM_WIDE_PIPE3.ipipe0',
+        u'MMU_THDU_CONFIG_QGROUP_PIPE3.mmu_xpe0', u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE2.mmu_xpe0',
+        u'MMU_MTRO_EGRMETERINGCONFIG_MEM_PIPE1.mmu_sed0', u'MMU_REPL_GROUP_INITIAL_COPY_COUNT_SC0.mmu_xpe0',
+        u'MMU_THDU_CONFIG_QUEUE_PIPE3.mmu_xpe0', u'THDI_PORT_SP_CONFIG_PIPE2.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_8.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE2.mmu_xpe0',
+        u'TCB_THRESHOLD_PROFILE_MAP_XPE0.mmu_xpe0', u'MMU_THDU_CONFIG_PORT_PIPE0.mmu_xpe0',
+        u'MMU_THDU_OFFSET_QUEUE_PIPE1.mmu_xpe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE2.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE1.mmu_xpe0', u'L3_DEFIP_ALPM_IPV6_128.ipipe0',
+        u'MMU_THDM_DB_QUEUE_CONFIG_PIPE3.mmu_xpe0', u'MODPORT_MAP_MIRROR.ipipe0', u'IFP_TCAM.ipipe0',
+        u'MMU_THDM_DB_PORTSP_CONFIG_PIPE1.mmu_xpe0', u'EGR_VLAN_XLATE.epipe0', u'FP_GM_FIELDS.ipipe0',
+        u'MMU_THDU_CONFIG_QUEUE_PIPE1.mmu_xpe0', u'MMU_MTRO_CONFIG_L0_MEM_PIPE1.mmu_sed0',
+        u'THDI_PORT_SP_CONFIG_PIPE1.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP_PIPE1.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE0.mmu_xpe0', u'MMU_THDM_MCQE_PORTSP_CONFIG_PIPE0.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_4.mmu_xpe0', u'TCB_THRESHOLD_PROFILE_MAP_XPE2.mmu_xpe0',
+        u'FP_STORM_CONTROL_METERS.ipipe0', u'L2_ENTRY.ipipe0', u'EGR_IP_TUNNEL_IPV6.epipe0',
+        u'MMU_THDU_OFFSET_QUEUE_PIPE3.mmu_xpe0', u'MMU_THDU_OFFSET_QUEUE_PIPE2.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE2.mmu_xpe0', u'MMU_THDU_CONFIG_PORT_PIPE2.mmu_xpe0',
+        u'L3_ENTRY_IPV6_UNICAST.ipipe0', u'MMU_THDU_Q_TO_QGRP_MAP_PIPE0.mmu_xpe0',
+        u'MMU_WRED_DROP_CURVE_PROFILE_1.mmu_xpe0', u'MMU_THDM_DB_QUEUE_CONFIG_PIPE2.mmu_xpe0',
+        u'EGR_IP_TUNNEL_MPLS.epipe0', u'MMU_THDM_MCQE_QUEUE_CONFIG_PIPE3.mmu_xpe0',
+        u'MMU_THDM_DB_QUEUE_OFFSET_0_PIPE1.mmu_xpe0', u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE1.mmu_xpe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_PIPE0.mmu_xpe0', u'ING_SNAT.ipipe0',
+        u'MMU_THDM_MCQE_QUEUE_OFFSET_B_PIPE1.mmu_xpe0', u'MMU_THDU_OFFSET_QGROUP_PIPE3.mmu_xpe0',
+        u'ING_VP_VLAN_MEMBERSHIP.ipipe0', u'MMU_THDU_CONFIG_PORT_PIPE3.mmu_xpe0', u'FP_GLOBAL_MASK_TCAM.ipipe0',
+        ]
+}
 
 # Stop trying if stall has been detected for so many consecutive iterations
 # Combined with the test duration below. If we don't make progress for so
@@ -93,6 +246,31 @@ def run_cmd(cmd):
     out = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     stdout, stderr = out.communicate()
     return stdout, stderr
+
+def get_asic_type():
+    asic = "unknown"
+    stdout, _ = run_cmd("lspci")
+    output = stdout.decode("utf-8")
+    if ("Broadcom Limited Device b960" in output or
+        "Broadcom Limited Broadcom BCM56960" in output):
+        asic = "th"
+    elif "Broadcom Limited Device b971" in output:
+        asic = "th2"
+    elif "Broadcom Limited Device b850" in output:
+        asic = "td2"
+    elif "Broadcom Limited Device b870" in output:
+        asic = "td3"
+
+    return asic
+
+
+def get_skip_list_per_asic():
+    global SKIP_MEMORY_PER_ASIC
+
+    asic = get_asic_type()
+
+    return SKIP_MEMORY_PER_ASIC[asic] if asic in SKIP_MEMORY_PER_ASIC else []
+
 
 class BcmMemory():
     '''
@@ -132,6 +310,37 @@ class BcmMemory():
 
         return attr
 
+    def rekey_memory_address(self, mem):
+        # Reading from file will change key type from int to str.
+        # for the test to run correctly, the key needs to be
+        # adjusted back to int.
+        for key, val in mem.items():
+            self.memory_address[int(key)] = val
+
+    def read_memory_from_file(self):
+        file_name = '/tmp/{}-mem-info.json'.format(get_asic_type())
+        try:
+            with open(file_name, 'r') as info:
+                contents = json.load(info)
+            self.cached_memory = contents['cached_memory']
+            self.uncached_memory = contents['uncached_memory']
+            self.rekey_memory_address(contents['memory_address'])
+        except IOError as e:
+            return False
+
+        return True
+
+    def write_memory_to_file(self):
+        contents = { 'cached_memory' : self.cached_memory,
+                     'uncached_memory' : self.uncached_memory,
+                     'memory_address' : self.memory_address }
+        file_name = '/tmp/{}-mem-info.json'.format(get_asic_type())
+        try:
+            with open(file_name, 'w') as info:
+                json.dump(contents, info, indent=4)
+        except IOError as e:
+            pass
+
     def read_memory(self):
         '''
         @summary: Read different memory tables using cache command. It update both cached_memory and uncached_memory
@@ -148,6 +357,9 @@ class BcmMemory():
                        ALTERNATE_EMIRROR_BITMAP.ipipe0
                        BCAST_BLOCK_MASK.ipipe0
         '''
+        if self.read_memory_from_file():
+            return
+
         stdout, stderr = run_cmd(['bcmcmd', 'cache'])
 
         cache_flag = False
@@ -172,6 +384,8 @@ class BcmMemory():
             self.memory_address[self.cached_memory[mem]['address']].append(mem)
             if VERBOSE:
                 print('--- found cache memory {} : {} : {}'.format(mem, hex(self.cached_memory[mem]['address']), self.memory_address[self.cached_memory[mem]['address']]))
+
+        self.write_memory_to_file()
 
     def get_cached_memory(self):
         '''
@@ -211,6 +425,7 @@ class SerTest(object):
         self.miss_counts = {}
         self.bcmMemory = BcmMemory()
 
+
     def test_memory(self, completeness='basic'):
         '''
         @summary: perform SER memory test
@@ -219,16 +434,18 @@ class SerTest(object):
         global MEMORY_SCAN_ENTRIES
         global SRAM_SCAN_INTERVAL_USEC
         global SRAM_SCAN_ENTRIES
-        global UNTESTABLE_MEMORY_TABLES
-        global CORRECTION_MISS_ALIGNS
+
+        skip_list = []
 
         self.bcmMemory.read_memory()
         if completeness == 'thorough':
-            self.test_candidates = list(set(self.bcmMemory.get_cached_memory().keys()) - set(UNTESTABLE_MEMORY_TABLES))
+            self.test_candidates = list(set(self.bcmMemory.get_cached_memory().keys()))
         elif completeness == 'diagnose':
-            self.test_candidates = CORRECTION_MISS_ALIGNS
+            # Re-probing the normally skipped entries
+            self.test_candidates = get_skip_list_per_asic()
         else:
-            self.test_candidates = list(set(self.bcmMemory.get_cached_memory().keys()) - set(UNTESTABLE_MEMORY_TABLES) - set(CORRECTION_MISS_ALIGNS))
+            skip_list = get_skip_list_per_asic()
+            self.test_candidates = list(set(self.bcmMemory.get_cached_memory().keys()) - set(skip_list))
 
         if completeness == 'debug':
             batch_size = min(1, len(self.test_candidates))
@@ -280,10 +497,11 @@ class SerTest(object):
                         print('--- stall detected. Stop testing')
                     break
 
+        print("SER test on ASIC : {}".format(get_asic_type()))
         if VERBOSE:
             print("SER Test memories candidates (%s): %s" % (len(self.test_candidates), self.test_candidates))
             print("SER Test succeeded for memories (%s): %s" % (len(self.mem_verified), self.mem_verified))
-            print("SER Test misaligned memories (%s): %s" % (len(CORRECTION_MISS_ALIGNS), CORRECTION_MISS_ALIGNS))
+            print("SER Test skipped memories (%s): %s" % (len(skip_list), skip_list))
         else:
             print("SER Test memories candidates (%s)" % (len(self.test_candidates)))
             print("SER Test succeeded for memories (%s)" % (len(self.mem_verified)))
@@ -339,6 +557,9 @@ class SerTest(object):
         @return: Flag if SER injection entry matches log line entry
         '''
         m = re.search("^.*addr:(.*) port.*index: (\d+)", log)
+        if not m:
+            print("--- cannot parse log {}".format(log))
+            return None, None
 
         address = int(m.group(1), 16)
         mem_entry = int(m.group(2))


### PR DESCRIPTION
Summary:
Refactoring SER test.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
SER test is failing randomly on TD2/TH/TH2 platforms and consistently on TD3 platform.

#### How did you do it?
- Persist the memory information to a file for quick retest.
- Split skipping memory entries according to the ASIC type.
- Protect against truncated log entry parsing error.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
TD2/TD3/TH/TH2: with the fix passed multiple times basic and confident level test.
