### PR TITLE
[autorestart] ignore more error messages observed in tests

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -66,8 +66,10 @@ def ignore_expected_loganalyzer_exception(loganalyzer, enum_dut_feature):
             ".*ERR syncd#syncd.*processQuadEvent.*",
             ".*WARNING syncd#syncd.*skipping since it causes crash.*",
             ".*ERR swss#portsyncd.*readData.*netlink reports an error=-33 on reading a netlink socket.*",
+            ".*ERR teamd#teamsyncd.*readData.*netlink reports an error=-33 on reading a netlink socket.*",
             ".*ERR swss#orchagent.*set status: SAI_STATUS_ATTR_NOT_IMPLEMENTED_0.*",
             ".*ERR swss#orchagent.*setIntfVlanFloodType.*",
+            ".*ERR snmp#snmpd.*",
         ]
     ignore_regex_dict = {
         'common' : [

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -81,6 +81,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, enum_dut_feature):
         'pmon' : [
             ".*ERR pmon#xcvrd.*initializeGlobalConfig.*",
             ".*ERR pmon#thermalctld.*Caught exception while initializing thermal manager.*",
+            ".*ERR pmon#xcvrd.*Could not establish the active side.*",
         ],
         'swss' : swss_syncd_teamd_regex,
         'syncd' : swss_syncd_teamd_regex,


### PR DESCRIPTION
Summary:
Add more log ignore regexes.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
autorestart test fails randomly with loganalyzer errors.

#### How did you do it?
ignore more error logs that could come up during test. We are checking the system health status after the test. so ignoring these logs are not fatal.

#### How did you verify/test it?
Run autorestart test and get a pass.

autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|lldp] PASSED                                                                            [  3%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|pmon] PASSED                                                                            [  7%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|sflow] SKIPPED                                                                          [ 10%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|database] SKIPPED                                                                       [ 14%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|snmp] PASSED                                                                            [ 17%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|telemetry] PASSED                                                                       [ 21%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|bgp] PASSED                                                                             [ 25%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|radv] PASSED                                                                            [ 28%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|mgmt-framework] PASSED                                                                  [ 32%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|nat] SKIPPED                                                                            [ 35%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|teamd] PASSED                                                                           [ 39%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|dhcp_relay] PASSED                                                                      [ 42%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|swss] PASSED                                                                            [ 46%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-06|syncd] PASSED                                                                           [ 50%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|lldp] SKIPPED                                                                           [ 53%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|pmon] SKIPPED                                                                           [ 57%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|sflow] SKIPPED                                                                          [ 60%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|database] SKIPPED                                                                       [ 64%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|snmp] SKIPPED                                                                           [ 67%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|telemetry] SKIPPED                                                                      [ 71%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|bgp] SKIPPED                                                                            [ 75%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|radv] SKIPPED                                                                           [ 78%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|mgmt-framework] SKIPPED                                                                 [ 82%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|nat] SKIPPED                                                                            [ 85%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|teamd] SKIPPED                                                                          [ 89%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|dhcp_relay] SKIPPED                                                                     [ 92%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|swss] SKIPPED                                                                           [ 96%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str2-7050cx3-acs-07|syncd] SKIPPED                                                                          [100%]