### PR TITLE
[bgp] Bind IP directly to interface

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -199,15 +199,14 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
             for intf, subnet in zip(random.sample(ipv4_interfaces, peer_count), subnets):
                 conn = {}
                 local_addr, neighbor_addr = [_ for _ in subnet][:2]
-                conn["local_intf"] = "%s:0" % intf["attachto"]
+                conn["local_intf"] = "%s" % intf["attachto"]
                 conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
                 conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
                 conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][intf["attachto"]]
                 connections.append(conn)
 
             for conn in connections:
-                duthost.shell("ifconfig %s %s" % (conn["local_intf"], conn["local_addr"]))
-                # Notify bgpcfgd the interface is ready
+                # bind the ip to the interface and notify bgpcfgd 
                 duthost.shell("config interface ip add %s %s" % (conn["local_intf"], conn["local_addr"]))
                 ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"], conn["neighbor_addr"]))
 
@@ -215,7 +214,6 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
 
         finally:
             for conn in connections:
-                duthost.shell("ifconfig %s 0.0.0.0" % conn["local_intf"])
                 duthost.shell("config interface ip remove %s %s" % (conn["local_intf"], conn["local_addr"]))
                 ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
 


### PR DESCRIPTION
Previously, `_setup_interface_t1` will bind the IP to the virtual
interface, which will cause orchagent crash in the interface deletion
from table `INTERFACE`. We could directly assign the IP to the interface
instead of using IP aliasing.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For t1 testbed, the removal of IP from the virtual interface will crash `orchagent`.

#### How did you do it?
Use the interface instead of IP aliasing.

#### How did you verify/test it?
Test `test_bgp_update_timer` over `t1` with master image.
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer PASSED                                                                                                                  [100%]
```

#### Any platform specific information?
`t1`

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
