### PR TITLE
Do a 'config reload' after running all cases in test_container_autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -22,6 +22,10 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_STOP_THRESHOLD_SECS = 30
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 
+@pytest.fixture(autouse=True, scope='module')
+def config_reload_after_tests(duthost):
+    yield
+    config_reload(duthost)
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exception(loganalyzer, enum_dut_feature):


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The DUT may be left in bad status because the restart of some containers. For example, we noticed that LLDP will not work after ```teamd``` is restarted. To mitigate the bad influlence for following cases, a ```config reload``` is issued in a module level fixture after running all cases to reload the DUT.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to mitigate the possible bad influlence for following test cases caused by ```test_container_autorestart```.

#### How did you do it?
 Issue a ```config reload``` in a module level fixture after running all cases to reload the DUT.

#### How did you verify/test it?
Verified on DX010-4.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util autorestart/test_container_autorestart.py::test_containers_autorestart
========================================================================================= test session starts =========================================================================================
collected 14 items                                                                                                                                                                                    

autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|lldp] PASSED                                                                                             [  7%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|pmon] PASSED                                                                                             [ 14%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|sflow] SKIPPED                                                                                           [ 21%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|database] SKIPPED                                                                                        [ 28%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|snmp] ^@PASSED                                                                                             [ 35%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|telemetry] PASSED                                                                                        [ 42%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|bgp] PASSED                                                                                              [ 50%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|radv] ^@PASSED                                                                                             [ 57%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|mgmt-framework] PASSED                                                                                   [ 64%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|nat] SKIPPED                                                                                             [ 71%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|teamd] PASSED                                                                                            [ 78%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|dhcp_relay] ^@PASSED                                                                                       [ 85%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|swss] PASSED                                                                                             [ 92%]
autorestart/test_container_autorestart.py::test_containers_autorestart[str-dx010-acs-4|syncd] ^@PASSED                                                                                            [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
=============================================================================== 11 passed, 3 skipped in 1473.62 seconds ===============================================================================
```
And from ```syslog``` I confirmed that ```config reload``` was ran after all cases. 

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
