### PR TITLE
Fix test_cont_link_flap 

### DIFF
--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -191,10 +191,10 @@ def check_bgp_routes(dut, start_time_ip_route_counts, ipv4=False):
         ipv4: Version of IP
     """
     if ipv4:
-        end_time_ip_route_counts = dut.shell("show ip route summary | grep Total | awk '{print $2}'")["stdout"]
+        end_time_ip_route_counts = dut.shell("vtysh -c 'show ip route summary' | grep Total | awk '{print $2}'")["stdout"]
         logger.info("IPv4 routes at end: %s", end_time_ip_route_counts)
     else:
-        end_time_ip_route_counts = dut.shell("show ipv6 route summary | grep Total | awk '{print $2}'")["stdout"]
+        end_time_ip_route_counts = dut.shell("vtysh -c 'show ipv6 route summary' | grep Total | awk '{print $2}'")["stdout"]
         logger.info("IPv6 routes at end: %s", end_time_ip_route_counts)
 
     incr_ip_route_counts = abs(int(float(start_time_ip_route_counts)) - int(float(end_time_ip_route_counts)))

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -38,7 +38,7 @@ class TestContLinkFlap(object):
             3.) Watch for memory (show system-memory) ,orchagent CPU Utilization
                 and Redis_memory.
 
-        Pass Criteria: All routes must be re-learned with < 5% increase in Redis and 
+        Pass Criteria: All routes must be re-learned with < 5% increase in Redis and
             ORCH agent CPU consumption below threshold after 3 mins after stopping flaps.
         """
         duthost = duthosts[rand_one_dut_hostname]
@@ -53,11 +53,11 @@ class TestContLinkFlap(object):
         logging.info("Redis Memory: %s M", start_time_redis_memory)
 
         # Record ipv4 route counts at start
-        start_time_ipv4_route_counts = duthost.shell("show ip route summary | grep Total | awk '{print $2}'")["stdout"]
+        start_time_ipv4_route_counts = duthost.shell("vtysh -c 'show ip route summary' | grep Total | awk '{print $2}'")["stdout"]
         logging.info("IPv4 routes at start: %s", start_time_ipv4_route_counts)
 
         # Record ipv6 route counts at start
-        start_time_ipv6_route_counts = duthost.shell("show ipv6 route summary | grep Total | awk '{print $2}'")["stdout"]
+        start_time_ipv6_route_counts = duthost.shell("vtysh -c 'show ipv6 route summary' | grep Total | awk '{print $2}'")["stdout"]
         logging.info("IPv6 routes at start %s", start_time_ipv6_route_counts)
 
         # Make Sure Orch CPU < orch_cpu_threshold before starting test.


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Test case ```test_cont_link_flap``` consistently failed on master image. It was because recent update in ```show``` library made ```show ip route sum``` not availabe on lattest image. As a result, the command ```show ip route sum``` will not be able to retrieve routes count and an exception was thrown.
```
07/12/2020 17:51:39 INFO link_flap_utils.py:check_bgp_routes:195: IPv4 routes at end: 
07/12/2020 17:51:39 ERROR utilities.py:wait_until:43: Exception caught while checking check_bgp_routes: ValueError('could not convert string to float: ',)
07/12/2020 17:51:39 DEBUG utilities.py:wait_until:50: check_bgp_routes is False, wait 1 seconds and check again
```
This commit replaces 'show ip route sum' with vtysh command to fix the issue.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_cont_link_flap``` on master image.

#### How did you do it?
This commit replaces ```show ip route sum``` with vtysh command to fix the issue.

#### How did you verify/test it?
Verified on DX010-4, running lattest image.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util  platform_tests/link_flap/test_cont_link_flap.py
========================================================================================= test session starts =========================================================================================
collected 1 item                                                                                                                                                                                      

platform_tests/link_flap/test_cont_link_flap.py::TestContLinkFlap::test_cont_link_flap ^@^@^@^@^@^@^@^@PASSED                                                                                                   [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 2664.16 seconds =====================================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
