### PR TITLE
[veos_vtb] Add connection variable to 'sonic' group

### DIFF
--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -54,6 +54,8 @@ all:
     sonic:
       vars:
         mgmt_subnet_mask_length: 24
+        ansible_connection: multi_passwd_ssh
+        ansible_altpassword: YourPaSsWoRd
       hosts:
         vlab-01:
           ansible_host: 10.250.0.101


### PR DESCRIPTION
By default, Ansible will search for group variables from the directory
where inventory file locates. For vtestbed Pytest users who calls Pytest
with `tests/veos_vtb`, Ansible fails to find the groups variables
defined under `ansible/group_vars`, thus fail to use `multi_passwd_ss`.
So let's add those connection variables directly to `veos_vtb`

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If calling `pytest` with `tests/veos_vtb`, `Ansible` will fails to get groups variables in `ansible/group_vars`, in which connection variables are defined for `sonic` group.

#### How did you do it?
Add those connection variables to `veos_vtb`

#### How did you verify/test it?
Run pytest with `--inventory tests/veos_vtb`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
