### PR TITLE
[drop counters] Add sleep after MTU configuration to avoid test case fail

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -9,6 +9,7 @@ import json
 import ptf.packet as packet
 import ptf.testutils as testutils
 
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from drop_packets import *  # FIXME
 
@@ -217,6 +218,10 @@ def base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_du
         pytest.fail("Incorrect 'discard_group' specified. Supported values: 'L2' or 'L3'")
 
 
+def get_intf_mtu(duthost, intf):
+    return int(duthost.shell("/sbin/ifconfig {} | grep -i mtu | awk '{{print $NF}}'".format(intf))["stdout"])
+
+
 @pytest.fixture
 def mtu_config(duthosts, rand_one_dut_hostname):
     """ Fixture which prepare port MTU configuration for 'test_ip_pkt_with_exceeded_mtu' test case """
@@ -238,7 +243,8 @@ def mtu_config(duthosts, rand_one_dut_hostname):
             else:
                 raise Exception("Unsupported interface parameter - {}".format(iface))
             cls.iface = iface
-            time.sleep(3)
+            check_mtu = lambda: get_intf_mtu(duthost, iface) == mtu
+            pytest_assert(wait_until(5, 1, check_mtu), "MTU on interface {} not updated".format(iface))
 
         @classmethod
         def restore_mtu(cls):

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -238,6 +238,7 @@ def mtu_config(duthosts, rand_one_dut_hostname):
             else:
                 raise Exception("Unsupported interface parameter - {}".format(iface))
             cls.iface = iface
+            time.sleep(3)
 
         @classmethod
         def restore_mtu(cls):


### PR DESCRIPTION
Signed-off-by: Antonina Melnyk antoninax.melnyk@intel.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add sleep after MTU configuration to avoid test_ip_pkt_with_exceeded_mtu fail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
I ran the test_ip_pkt_with_exceeded_mtu test case several times and it was not passing. After debugging, I figured out that this is because it takes some time to apply a new MTU configuration. If a new MTU configuration is not applied then sent packets do not exceed router interface MTU and are not dropped.

#### How did you do it?
Add sleep after MTU configuration.

#### How did you verify/test it?
Ran the test locally, it now passes reliably.

```
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[rif_members] PASSED                      [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
