### PR TITLE
[copp] Send traffic over a set period of time for COPP testing

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -1,6 +1,6 @@
-# ptf --test-dir saitests copp_tests  --qlen=100000 --platform nn -t "verbose=True;pkt_tx_count=100000;target_port=3" --device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://10.3.147.47:10900
+# ptf --test-dir saitests copp_tests --qlen=100000 --platform nn -t "verbose=True;target_port=3" --device-socket 0-3@tcp://127.0.0.1:10900 --device-socket 1-3@tcp://10.3.147.47:10900
 # or
-# ptf --test-dir saitests copp_tests  --qlen=100000 --platform nn -t "verbose=True;pkt_tx_count=100000;target_port=10" --device-socket 0-10@tcp://127.0.0.1:10900 --device-socket 1-10@tcp://10.3.147.47:10900
+# ptf --test-dir saitests copp_tests --qlen=100000 --platform nn -t "verbose=True;target_port=10" --device-socket 0-10@tcp://127.0.0.1:10900 --device-socket 1-10@tcp://10.3.147.47:10900
 #
 # copp_test.${name_test}
 #
@@ -15,17 +15,17 @@
 # IP2METest
 # DefaultTest
 
+import datetime
+import os
 import ptf
+import signal
+import threading
+import time
+
+import ptf.testutils as testutils
+
 from ptf.base_tests import BaseTest
 from ptf import config
-import ptf.testutils as testutils
-from ptf.testutils import *
-from ptf.dataplane import match_exp_pkt
-import os
-import signal
-import datetime
-import subprocess
-import threading
 
 
 class ControlPlaneBaseTest(BaseTest):
@@ -34,20 +34,18 @@ class ControlPlaneBaseTest(BaseTest):
     PPS_LIMIT_MIN = PPS_LIMIT * 0.9
     PPS_LIMIT_MAX = PPS_LIMIT * 1.1
     NO_POLICER_LIMIT = PPS_LIMIT * 1.4
-    PKT_TX_COUNT = 100000
-    TARGET_PORT = "3"  # historically we have port 3 as a target port
-    TASK_TIMEOUT = 300 # Wait up to 5 minutes for tasks to complete
+    TARGET_PORT = "3"  # Historically we have port 3 as a target port
+    TASK_TIMEOUT = 300  # Wait up to 5 minutes for tasks to complete
+
+    DEFAULT_PRE_SEND_INTERVAL_SEC = 1
+    DEFAULT_SEND_INTERVAL_SEC = 10
+    DEFAULT_RECEIVE_WAIT_TIME = 1
 
     def __init__(self):
         BaseTest.__init__(self)
         self.log_fp = open('/tmp/copp.log', 'a')
         test_params = testutils.test_params_get()
         self.verbose = 'verbose' in test_params and test_params['verbose']
-
-        self.pkt_tx_count = test_params.get('pkt_tx_count', self.PKT_TX_COUNT)
-        if self.pkt_tx_count == 0:
-            self.pkt_tx_count = self.PKT_TX_COUNT
-        self.pkt_rx_limit = self.pkt_tx_count * 0.90
 
         target_port_str = test_params.get('target_port', self.TARGET_PORT)
         self.target_port = int(target_port_str)
@@ -56,13 +54,13 @@ class ControlPlaneBaseTest(BaseTest):
 
         self.myip = test_params.get('myip', None)
         self.peerip = test_params.get('peerip', None)
-      
-        return
+
+        self.needPreSend = None
 
     def log(self, message, debug=False):
         current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         if (debug and self.verbose) or (not debug):
-            print "%s : %s" % (current_time, message)
+            print("%s : %s" % (current_time, message))
         self.log_fp.write("%s : %s\n" % (current_time, message))
 
     def setUp(self):
@@ -79,13 +77,15 @@ class ControlPlaneBaseTest(BaseTest):
                 assert True
 
         self.dataplane.flush()
-        if config["log_dir"] != None:
+
+        if config["log_dir"] is not None:
             filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
             self.dataplane.start_pcap(filename)
 
     def tearDown(self):
-        if config["log_dir"] != None:
+        if config["log_dir"] is not None:
             self.dataplane.stop_pcap()
+
         self.log_fp.close()
 
     def timeout(self, seconds, message):
@@ -105,118 +105,142 @@ class ControlPlaneBaseTest(BaseTest):
             self.timeout_thr.cancel()
             self.timeout_thr = None
 
-    def copp_test(self, packet, count, send_intf, recv_intf):
+    def copp_test(self, packet, send_intf, recv_intf):
         '''
         Pre-send some packets for a second to absorb the CBS capacity.
         '''
         if self.needPreSend:
-            sendInFirst=0
-            endTime = datetime.datetime.now() + datetime.timedelta(seconds=1)
-            while datetime.datetime.now() < endTime:
+            pre_send_count = 0
+            end_time = datetime.datetime.now() + datetime.timedelta(seconds=self.DEFAULT_PRE_SEND_INTERVAL_SEC)
+            while datetime.datetime.now() < end_time:
                 testutils.send_packet(self, send_intf, packet)
-                sendInFirst += 1
-            rcv_pkt_cnt = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0],timeout=0.01)
-            self.log("Send %d and receive %d packets in the first second (PolicyTest)" % (sendInFirst,  rcv_pkt_cnt))
+                pre_send_count += 1
+
+            rcv_pkt_cnt = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=0.01)
+            self.log("Send %d and receive %d packets in the first second (PolicyTest)" % (pre_send_count, rcv_pkt_cnt))
             self.dataplane.flush()
 
-        b_c_0 = self.dataplane.get_counters(*send_intf)
-        b_c_1 = self.dataplane.get_counters(*recv_intf)
-        b_n_0 = self.dataplane.get_nn_counters(*send_intf)
-        b_n_1 = self.dataplane.get_nn_counters(*recv_intf)
+        pre_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
+        pre_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)
+        pre_test_nn_tx_counter = self.dataplane.get_nn_counters(*send_intf)
+        pre_test_nn_rx_counter = self.dataplane.get_nn_counters(*recv_intf)
 
-        start_time=datetime.datetime.now()
+        start_time = datetime.datetime.now()
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=self.DEFAULT_SEND_INTERVAL_SEC)
 
-        for i in xrange(count):
+        send_count = 0
+        while datetime.datetime.now() < end_time:
             testutils.send_packet(self, send_intf, packet)
+            send_count += 1
 
-        end_time=datetime.datetime.now()
+        self.log("Sent out %d packets in %ds" % (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
 
-        total_rcv_pkt_cnt = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0])
+        time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)  # Wait a little bit for all the packets to make it through
+        recv_count = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0])
 
-        e_c_0 = self.dataplane.get_counters(*send_intf)
-        e_c_1 = self.dataplane.get_counters(*recv_intf)
-        e_n_0 = self.dataplane.get_nn_counters(*send_intf)
-        e_n_1 = self.dataplane.get_nn_counters(*recv_intf)
+        post_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
+        post_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)
+        post_test_nn_tx_counter = self.dataplane.get_nn_counters(*send_intf)
+        post_test_nn_rx_counter = self.dataplane.get_nn_counters(*recv_intf)
+
+        ptf_tx_count = int(post_test_ptf_tx_counter[1] - pre_test_ptf_tx_counter[1])
+        nn_tx_count = int(post_test_nn_tx_counter[1] - pre_test_nn_tx_counter[1])
+        ptf_rx_count = int(post_test_ptf_rx_counter[0] - pre_test_ptf_rx_counter[0])
+        nn_rx_count = int(post_test_nn_rx_counter[0] - pre_test_nn_rx_counter[0])
+
         self.log("", True)
         self.log("Counters before the test:", True)
-        self.log("If counter (0, n): %s" % str(b_c_0), True)
-        self.log("NN counter (0, n): %s" % str(b_n_0), True)
-        self.log("If counter (1, n): %s" % str(b_c_1), True)
-        self.log("NN counter (1, n): %s" % str(b_n_1), True)
+        self.log("If counter (0, n): %s" % str(pre_test_ptf_tx_counter), True)
+        self.log("NN counter (0, n): %s" % str(pre_test_nn_tx_counter), True)
+        self.log("If counter (1, n): %s" % str(pre_test_ptf_rx_counter), True)
+        self.log("NN counter (1, n): %s" % str(pre_test_nn_rx_counter), True)
         self.log("", True)
         self.log("Counters after the test:", True)
-        self.log("If counter (0, n): %s" % str(e_c_0), True)
-        self.log("NN counter (0, n): %s" % str(e_n_0), True)
-        self.log("If counter (1, n): %s" % str(e_c_1), True)
-        self.log("NN counter (1, n): %s" % str(e_n_1), True)
+        self.log("If counter (0, n): %s" % str(post_test_ptf_tx_counter), True)
+        self.log("NN counter (0, n): %s" % str(post_test_nn_tx_counter), True)
+        self.log("If counter (1, n): %s" % str(post_test_ptf_rx_counter), True)
+        self.log("NN counter (1, n): %s" % str(post_test_nn_rx_counter), True)
         self.log("")
-        self.log("Sent through NN to local ptf_nn_agent:    %d" % int(e_c_0[1] - b_c_0[1]))
-        self.log("Sent through If to remote ptf_nn_agent:   %d" % int(e_n_0[1] - b_n_0[1]))
-        self.log("Recv from If on remote ptf_nn_agent:      %d" % int(e_c_1[0] - b_c_1[0]))
-        self.log("Recv from NN on from remote ptf_nn_agent: %d" % int(e_n_1[0] - b_n_1[0]))
+        self.log("Sent through NN to local ptf_nn_agent:    %d" % ptf_tx_count)
+        self.log("Sent through If to remote ptf_nn_agent:   %d" % nn_tx_count)
+        self.log("Recv from If on remote ptf_nn_agent:      %d" % ptf_rx_count)
+        self.log("Recv from NN on from remote ptf_nn_agent: %d" % nn_rx_count)
 
         time_delta = end_time - start_time
-        time_delta_ms = (time_delta.microseconds + time_delta.seconds * 10**6) / 10**3
-        tx_pps = int(count/(float(time_delta_ms)/1000))
-        rx_pps = int(total_rcv_pkt_cnt/(float(time_delta_ms)/1000))
+        time_delta_ms = (time_delta.microseconds + time_delta.seconds * 10**6) / 1000
+        tx_pps = int(send_count / (float(time_delta_ms) / 1000))
+        rx_pps = int(recv_count / (float(time_delta_ms) / 1000))
 
-        return total_rcv_pkt_cnt, time_delta, time_delta_ms, tx_pps, rx_pps
+        return send_count, recv_count, time_delta, time_delta_ms, tx_pps, rx_pps
 
     def contruct_packet(self, port_number):
-        raise NotImplemented
+        raise NotImplementedError
 
-    def check_constraints(self, total_rcv_pkt_cnt, time_delta_ms, rx_pps):
-        raise NotImplemented
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
+        raise NotImplementedError
 
     def one_port_test(self, port_number):
         packet = self.contruct_packet(port_number)
-        total_rcv_pkt_cnt, time_delta, time_delta_ms, tx_pps, rx_pps = self.copp_test(str(packet), self.pkt_tx_count, (0, port_number), (1, port_number))
-        self.printStats(self.pkt_tx_count, total_rcv_pkt_cnt, time_delta, tx_pps, rx_pps)
-        self.check_constraints(total_rcv_pkt_cnt, time_delta_ms, rx_pps)
+        send_count, recv_count, time_delta, time_delta_ms, tx_pps, rx_pps = \
+            self.copp_test(str(packet), (0, port_number), (1, port_number))
 
-        return
+        self.printStats(send_count, recv_count, time_delta, tx_pps, rx_pps)
+        self.check_constraints(send_count, recv_count, time_delta_ms, rx_pps)
 
+    # FIXME: better make it decorator
     def run_suite(self):
-        self.timeout(self.TASK_TIMEOUT, "The test case hasn't been completed in %d seconds" % self.TASK_TIMEOUT) # FIXME: better make it decorator
+        self.timeout(self.TASK_TIMEOUT, "The test case hasn't been completed in %d seconds" % self.TASK_TIMEOUT)
         self.one_port_test(self.target_port)
         self.cancel_timeout()
 
-    def printStats(self, pkt_send_count, total_rcv_pkt_cnt, time_delta, tx_pps, rx_pps):
+    def printStats(self, pkt_send_count, recv_count, time_delta, tx_pps, rx_pps):
         self.log("")
         self.log('test stats')
         self.log('Packet sent = %10d' % pkt_send_count)
-        self.log('Packet rcvd = %10d' % total_rcv_pkt_cnt)
+        self.log('Packet rcvd = %10d' % recv_count)
         self.log('Test time = %s' % str(time_delta))
         self.log('TX PPS = %d' % tx_pps)
         self.log('RX PPS = %d' % rx_pps)
 
-        return
 
 class NoPolicyTest(ControlPlaneBaseTest):
     def __init__(self):
         ControlPlaneBaseTest.__init__(self)
-        self.needPreSend=False
+        self.needPreSend = False
 
-    def check_constraints(self, total_rcv_pkt_cnt, time_delta_ms, rx_pps):
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
+        pkt_rx_limit = send_count * 0.90
+
         self.log("")
         self.log("Checking constraints (NoPolicy):")
-        self.log("rx_pps (%d) > NO_POLICER_LIMIT (%d): %s" % (int(rx_pps), int(self.NO_POLICER_LIMIT), str(rx_pps > self.NO_POLICER_LIMIT)))
-        self.log("total_rcv_pkt_cnt (%d) > pkt_rx_limit (%d): %s" % \
-                (int(total_rcv_pkt_cnt), int(self.pkt_rx_limit), str(total_rcv_pkt_cnt > self.pkt_rx_limit)))
+        self.log(
+            "rx_pps (%d) > NO_POLICER_LIMIT (%d): %s" %
+            (int(rx_pps), int(self.NO_POLICER_LIMIT), str(rx_pps > self.NO_POLICER_LIMIT))
+        )
+        self.log(
+            "recv_count (%d) > pkt_rx_limit (%d): %s" %
+            (int(recv_count), int(pkt_rx_limit), str(recv_count > pkt_rx_limit))
+        )
 
         assert(rx_pps > self.NO_POLICER_LIMIT)
-        assert(total_rcv_pkt_cnt > self.pkt_rx_limit)
+        assert(recv_count > pkt_rx_limit)
+
 
 class PolicyTest(ControlPlaneBaseTest):
     def __init__(self):
         ControlPlaneBaseTest.__init__(self)
-        self.needPreSend=True
+        self.needPreSend = True
 
-    def check_constraints(self, total_rcv_pkt_cnt, time_delta_ms, rx_pps):
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
         self.log("")
         self.log("Checking constraints (PolicyApplied):")
-        self.log("PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" % \
-                (int(self.PPS_LIMIT_MIN), int(rx_pps), int(self.PPS_LIMIT_MAX), str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX)))
+        self.log(
+            "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
+            (int(self.PPS_LIMIT_MIN),
+             int(rx_pps),
+             int(self.PPS_LIMIT_MAX),
+             str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
+        )
 
         assert(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX)
 
@@ -235,16 +259,18 @@ class ARPTest(PolicyTest):
         src_ip = self.myip
         dst_ip = self.peerip
 
-        packet = simple_arp_packet(
-                       eth_dst='ff:ff:ff:ff:ff:ff',
-                       eth_src=src_mac,
-                       arp_op=1,
-                       ip_snd=src_ip,
-                       ip_tgt=dst_ip,
-                       hw_snd=src_mac,
-                       hw_tgt='ff:ff:ff:ff:ff:ff')
+        packet = testutils.simple_arp_packet(
+            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_src=src_mac,
+            arp_op=1,
+            ip_snd=src_ip,
+            ip_tgt=dst_ip,
+            hw_snd=src_mac,
+            hw_tgt='ff:ff:ff:ff:ff:ff'
+        )
 
         return packet
+
 
 # SONIC configuration has no packets to CPU for DHCP-T1 Topo
 class DHCPTopoT1Test(PolicyTest):
@@ -260,23 +286,25 @@ class DHCPTopoT1Test(PolicyTest):
 
     def contruct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
-        packet = simple_udp_packet(pktlen=100,
-                          eth_dst='ff:ff:ff:ff:ff:ff',
-                          eth_src=src_mac,
-                          dl_vlan_enable=False,
-                          vlan_vid=0,
-                          vlan_pcp=0,
-                          dl_vlan_cfi=0,
-                          ip_src='0.0.0.0',
-                          ip_dst='255.255.255.255',
-                          ip_tos=0,
-                          ip_ttl=64,
-                          udp_sport=68,
-                          udp_dport=67,
-                          ip_ihl=None,
-                          ip_options=False,
-                          with_udp_chksum=True
-                          )
+
+        packet = testutils.simple_udp_packet(
+            pktlen=100,
+            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_src=src_mac,
+            dl_vlan_enable=False,
+            vlan_vid=0,
+            vlan_pcp=0,
+            dl_vlan_cfi=0,
+            ip_src='0.0.0.0',
+            ip_dst='255.255.255.255',
+            ip_tos=0,
+            ip_ttl=64,
+            udp_sport=68,
+            udp_dport=67,
+            ip_ihl=None,
+            ip_options=False,
+            with_udp_chksum=True
+        )
 
         return packet
 
@@ -292,23 +320,25 @@ class DHCPTest(NoPolicyTest):
 
     def contruct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
-        packet = simple_udp_packet(pktlen=100,
-                          eth_dst='ff:ff:ff:ff:ff:ff',
-                          eth_src=src_mac,
-                          dl_vlan_enable=False,
-                          vlan_vid=0,
-                          vlan_pcp=0,
-                          dl_vlan_cfi=0,
-                          ip_src='0.0.0.0',
-                          ip_dst='255.255.255.255',
-                          ip_tos=0,
-                          ip_ttl=64,
-                          udp_sport=68,
-                          udp_dport=67,
-                          ip_ihl=None,
-                          ip_options=False,
-                          with_udp_chksum=True
-                          )
+
+        packet = testutils.simple_udp_packet(
+            pktlen=100,
+            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_src=src_mac,
+            dl_vlan_enable=False,
+            vlan_vid=0,
+            vlan_pcp=0,
+            dl_vlan_cfi=0,
+            ip_src='0.0.0.0',
+            ip_dst='255.255.255.255',
+            ip_tos=0,
+            ip_ttl=64,
+            udp_sport=68,
+            udp_dport=67,
+            ip_ihl=None,
+            ip_options=False,
+            with_udp_chksum=True
+        )
 
         return packet
 
@@ -324,12 +354,15 @@ class LLDPTest(NoPolicyTest):
 
     def contruct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
-        packet = simple_eth_packet(
-                       eth_dst='01:80:c2:00:00:0e',
-                       eth_src=src_mac,
-                       eth_type=0x88cc
-                 )
+
+        packet = testutils.simple_eth_packet(
+            eth_dst='01:80:c2:00:00:0e',
+            eth_src=src_mac,
+            eth_type=0x88cc
+        )
+
         return packet
+
 
 # SONIC configuration has no policer limiting for UDLD
 class UDLDTest(NoPolicyTest):
@@ -346,13 +379,16 @@ class UDLDTest(NoPolicyTest):
     # = 117 = 103 (0x67) + 6 (dst MAC) + 6 (dst MAC) + 2 (len)
     def contruct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
-        packet = simple_eth_packet(
-                       pktlen=117,
-                       eth_dst='01:00:0c:cc:cc:cc',
-                       eth_src=src_mac,
-                       eth_type=0x0067
-                 )
+
+        packet = testutils.simple_eth_packet(
+            pktlen=117,
+            eth_dst='01:00:0c:cc:cc:cc',
+            eth_src=src_mac,
+            eth_type=0x0067
+        )
+
         return packet
+
 
 # SONIC configuration has no policer limiting for BGP
 class BGPTest(NoPolicyTest):
@@ -366,13 +402,16 @@ class BGPTest(NoPolicyTest):
     def contruct_packet(self, port_number):
         dst_mac = self.peer_mac[port_number]
         dst_ip = self.peerip
-        packet = simple_tcp_packet(
-                      eth_dst=dst_mac,
-                      ip_dst=dst_ip,
-                      ip_ttl=1,
-                      tcp_dport=179
-                      )
+
+        packet = testutils.simple_tcp_packet(
+            eth_dst=dst_mac,
+            ip_dst=dst_ip,
+            ip_ttl=1,
+            tcp_dport=179
+        )
+
         return packet
+
 
 # SONIC configuration has no policer limiting for LACP
 class LACPTest(NoPolicyTest):
@@ -384,17 +423,18 @@ class LACPTest(NoPolicyTest):
         self.run_suite()
 
     def contruct_packet(self, port_number):
-        packet = simple_eth_packet(
-               pktlen=14,
-               eth_dst='01:80:c2:00:00:02',
-               eth_type=0x8809
-               ) / (chr(0x01)*50)
+        packet = testutils.simple_eth_packet(
+            pktlen=14,
+            eth_dst='01:80:c2:00:00:02',
+            eth_type=0x8809
+        ) / (chr(0x01)*50)
 
         return packet
 
+
 # SNMP packets are trapped as IP2ME packets.
 # IP2ME configuration in SONIC contains policer CIR=600
-class SNMPTest(PolicyTest): #FIXME: trapped as ip2me. mellanox should add support for SNMP trap
+class SNMPTest(PolicyTest):  # FIXME: trapped as ip2me. mellanox should add support for SNMP trap
     def __init__(self):
         PolicyTest.__init__(self)
 
@@ -406,16 +446,19 @@ class SNMPTest(PolicyTest): #FIXME: trapped as ip2me. mellanox should add suppor
         src_mac = self.my_mac[port_number]
         dst_mac = self.peer_mac[port_number]
         dst_ip = self.peerip
-        packet = simple_udp_packet(
-                          eth_dst=dst_mac,
-                          ip_dst=dst_ip,
-                          eth_src=src_mac,
-                          udp_dport=161
-                          )
+
+        packet = testutils.simple_udp_packet(
+            eth_dst=dst_mac,
+            ip_dst=dst_ip,
+            eth_src=src_mac,
+            udp_dport=161
+        )
+
         return packet
 
-# SONIC configuration has no policer limiting for SSH
-class SSHTest(PolicyTest): # FIXME: ssh is policed now
+
+# SONIC config contains policer CIR=600 for SSH
+class SSHTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
 
@@ -428,15 +471,17 @@ class SSHTest(PolicyTest): # FIXME: ssh is policed now
         src_ip = self.myip
         dst_ip = self.peerip
 
-        packet = simple_tcp_packet(
-                eth_dst=dst_mac,
-                ip_dst=dst_ip,
-                ip_src=src_ip,
-                tcp_flags='F',
-                tcp_sport=22,
-                tcp_dport=22)
+        packet = testutils.simple_tcp_packet(
+            eth_dst=dst_mac,
+            ip_dst=dst_ip,
+            ip_src=src_ip,
+            tcp_flags='F',
+            tcp_sport=22,
+            tcp_dport=22
+        )
 
         return packet
+
 
 # IP2ME configuration in SONIC contains policer CIR=600
 class IP2METest(PolicyTest):
@@ -451,23 +496,24 @@ class IP2METest(PolicyTest):
         for port in self.dataplane.ports.iterkeys():
             if port[0] == 0:
                 continue
-            packet = self.contruct_packet(port[1])
-            total_rcv_pkt_cnt, time_delta, time_delta_ms, tx_pps, rx_pps = self.copp_test(str(packet), self.pkt_tx_count, (0, port_number), (1, port_number))
-            self.printStats(self.pkt_tx_count, total_rcv_pkt_cnt, time_delta, tx_pps, rx_pps)
-            self.check_constraints(total_rcv_pkt_cnt, time_delta_ms, rx_pps)
 
-        return
+            packet = self.contruct_packet(port[1])
+            send_count, recv_count, time_delta, time_delta_ms, tx_pps, rx_pps = \
+                self.copp_test(str(packet), (0, port_number), (1, port_number))
+
+            self.printStats(send_count, recv_count, time_delta, tx_pps, rx_pps)
+            self.check_constraints(send_count, recv_count, time_delta_ms, rx_pps)
 
     def contruct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
         dst_mac = self.peer_mac[port_number]
         dst_ip = self.peerip
 
-        packet = simple_tcp_packet(
-                      eth_src=src_mac,
-                      eth_dst=dst_mac,
-                      ip_dst=dst_ip
-                      )
+        packet = testutils.simple_tcp_packet(
+            eth_src=src_mac,
+            eth_dst=dst_mac,
+            ip_dst=dst_ip
+        )
 
         return packet
 
@@ -485,12 +531,13 @@ class DefaultTest(PolicyTest):
         src_ip = self.myip
         dst_ip = self.peerip
 
-        packet = simple_tcp_packet(
-                eth_dst=dst_mac,
-                ip_dst=dst_ip,
-                ip_src=src_ip,
-                tcp_sport=10000,
-                tcp_dport=10000,
-                ip_ttl=1)
+        packet = testutils.simple_tcp_packet(
+            eth_dst=dst_mac,
+            ip_dst=dst_ip,
+            ip_src=src_ip,
+            tcp_sport=10000,
+            tcp_dport=10000,
+            ip_ttl=1
+        )
 
         return packet

--- a/tests/copp/conftest.py
+++ b/tests/copp/conftest.py
@@ -8,14 +8,6 @@ def pytest_addoption(parser):
     """
 
     parser.addoption(
-        "--pkt_tx_count",
-        action="store",
-        type=int,
-        default=100000,
-        help="How many packets to send to the DUT"
-    )
-
-    parser.addoption(
         "--copp_swap_syncd",
         action="store_true",
         default=False,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -13,9 +13,6 @@
         of these test cases.
 
     Parameters:
-        --pkt_tx_count <n> (int): How many packets to send during each individual test case.
-            Default is 100000.
-
         --copp_swap_syncd: Used to install the RPC syncd image before running the tests. Default
             is disabled.
 
@@ -42,7 +39,6 @@ pytestmark = [
 
 _COPPTestParameters = namedtuple("_COPPTestParameters",
                                  ["nn_target_port",
-                                  "pkt_tx_count",
                                   "swap_syncd",
                                   "topo",
                                   "myip",
@@ -163,7 +159,6 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type):
     """
 
     params = {"verbose": False,
-              "pkt_tx_count": test_params.pkt_tx_count,
               "target_port": test_params.nn_target_port,
               "myip": test_params.myip,
               "peerip": test_params.peerip}
@@ -192,7 +187,6 @@ def _gather_test_params(tbinfo, duthost, request):
         Fetches the test parameters from pytest.
     """
 
-    pkt_tx_count = request.config.getoption("--pkt_tx_count")
     swap_syncd = request.config.getoption("--copp_swap_syncd")
     topo = tbinfo["topo"]["name"]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -215,7 +209,6 @@ def _gather_test_params(tbinfo, duthost, request):
     logging.info("nn_target_port {} nn_target_interface {}".format(nn_target_port, nn_target_interface))
 
     return _COPPTestParameters(nn_target_port=nn_target_port,
-                               pkt_tx_count=pkt_tx_count,
                                swap_syncd=swap_syncd,
                                topo=topo,
                                myip=myip,


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We noticed that the COPP test was flaky for some new testbeds that we onboarded and found out the reason was that the servers they were connected to were able to send traffic much faster than our older testbeds. This caused a lot of flakiness in the calculations that the COPP test is using to decide if a policer is working or not.

#### How did you do it?
To account for this, we decided to limit the test based on transmit time instead of # of packets sent. This has a few benefits:

1) We don't have to worry about the rx/tx rate that the server is able to sustain. We can just send traffic for a while and then base all our calculations on what the server was able to send. This is also helpful in the case multiple testbeds are utilizing the same server concurrently.

2) Sending the traffic over a longer window of time gives us a more stable `rx_pps` calculation, which makes it much less likely that the odd test run will be outside of the 10% tolerance we've built in.

3) Test timing is more deterministic.

I also cleaned up the code a little bit to conform to pep8 standards.

#### How did you verify/test it?
Ran ~20 runs on 3 different servers, all passed and had results well within threshold values for both policer and non-policer test cases.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
