### PR TITLE
Skip gathering dualtor facts on single tor testbed

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -65,9 +65,15 @@
   - topo_facts: topo={{ topo }}
     delegate_to: localhost
 
+  - name: set default dualtor facts
+    set_fact:
+      dual_tor_facts: {}
+    when: "'dualtor' not in topo"
+    
   - name: gather dual ToR information
     dual_tor_facts: hostname="{{ inventory_hostname }}" testbed_facts="{{ testbed_facts }}" hostvars="{{ hostvars }}" vm_config="{{ vm_topo_config }}"
     delegate_to: localhost
+    when: "'dualtor' in topo"
 
   - name: set default vm file path
     set_fact:


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
I noticed that the ```dual_tor_facts``` plugin costs around 5 minutes to gather dualtor facts when deploying or generating minigraph. The generated dualtor facts is not used on single tor testbed though.
This commit updates the task file for deploying minigraph to skip dual_tor_facts plugin on single tor testbed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to updates ```ansible/config_sonic_basedon_testbed.yml``` to skip ```dual_tor_facts``` plugin on single tor testbed.

#### How did you do it?
Add a condition check for ```dual_tor_facts``` tasks.

#### How did you verify/test it?
Verified by deploying minigraph on Arista7260. The task finished without exception, and the generated minigraph files are exactly the same.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
