### PR TITLE
Add test server side mux Y cable simulator

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python
+"""This script is to simulate mux on test server.
+
+It exposes HTTP API for external parties to query and switch mux active/standby status. When the APIs
+are called, it use ovs commands to get and set the OVS bridge for simulating mux behavior.
+
+This script should be started keep running in background when a topology is created by 'testbed-cli.sh add-topo'.
+"""
+from __future__ import print_function
+import json
+import re
+import subprocess
+import sys
+
+from collections import defaultdict
+
+from flask import Flask, request, jsonify
+
+
+app = Flask(__name__)
+
+
+def run_cmd(cmdline):
+    """Use subprocess to run a command line with shell=True
+
+    Args:
+        cmdline (string): The command line to be executed.
+
+    Raises:
+        Exception: If return code of running command line is not zero, an exception is raised.
+
+    Returns:
+        string: The stdout of running the command line.
+    """
+    process = subprocess.Popen(
+        cmdline, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    stdout, stderr = process.communicate()
+    ret_code = process.returncode
+
+    if ret_code != 0:
+        raise Exception('ret_code={}, error message="{}". cmd={}'.format(ret_code, stderr, cmdline))
+
+    return stdout.decode('utf-8')
+
+
+def get_mux_connections(vm_set, port_index):
+    """Use the 'ovs-ofctl show' command to get details of the bridge and interfaces simulating mux.
+
+    Example bridge name: 'mbr-vms17-8-0'. In the bridge name, 'vms17-8' is vm_set. '0' is port_index.
+
+    Example output of 'ovs-ofctl show' command:
+      azure@str2-acs-serv-17:~$ sudo ovs-ofctl --names show mbr-vms17-8-0
+      OFPT_FEATURES_REPLY (xid=0x2): dpid:000098039b0322d9
+      n_tables:254, n_buffers:0
+      capabilities: FLOW_STATS TABLE_STATS PORT_STATS QUEUE_STATS ARP_MATCH_IP
+      actions: output enqueue set_vlan_vid set_vlan_pcp strip_vlan mod_dl_src mod_dl_dst mod_nw_src mod_nw_dst mod_nw_tos mod_tp_src mod_tp_dst
+       1(muxy-vms17-8-0): addr:f2:3d:28:15:99:37
+           config:     0
+           state:      0
+           current:    10GB-FD COPPER
+           speed: 10000 Mbps now, 0 Mbps max
+       2(enp59s0f1.3216): addr:98:03:9b:03:22:d9
+           config:     0
+           state:      0
+           current:    AUTO_NEG
+           advertised: 10GB-FD AUTO_NEG AUTO_PAUSE
+           supported:  10GB-FD AUTO_NEG AUTO_PAUSE
+           speed: 0 Mbps now, 10000 Mbps max
+       3(enp59s0f1.3272): addr:98:03:9b:03:22:d9
+           config:     0
+           state:      0
+           current:    AUTO_NEG
+           advertised: 10GB-FD AUTO_NEG AUTO_PAUSE
+           supported:  10GB-FD AUTO_NEG AUTO_PAUSE
+           speed: 0 Mbps now, 10000 Mbps max
+       LOCAL(mbr-vms17-8-0): addr:98:03:9b:03:22:d9
+           config:     0
+           state:      0
+           speed: 0 Mbps now, 0 Mbps max
+      OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0
+
+    Example result or parsing the output using regex:
+      >>> re.findall(r'(\d|LOCAL)\((\S+)\):\s+addr:[0-9a-f:]{17}', out)
+      [('1', 'muxy-vms17-8-0'), ('2', 'enp59s0f1.3216'), ('3', 'enp59s0f1.3272'), ('LOCAL', 'mbr-vms17-8-0')]
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+        port_index (int or string): Index of the port.
+
+    Returns:
+        dict: Returns the mux connection details in a dictionary. Example:
+            {
+                "bridge": "mbr-vms17-8-0",
+                "vm_set": "vms17-8",
+                "port_index": 0,
+                "ports": {
+                    "nic": "muxy-vms17-8-0",
+                    "tor_a": "enp59s0f1.3216",
+                    "tor_b": "enp59s0f1.3272"
+                },
+                "active_side": "tor_a"
+            }
+    """
+    cmdline = 'ovs-ofctl --names show mbr-{}-{}'.format(vm_set, port_index)
+    out = run_cmd(cmdline)
+
+    parsed = re.findall(r'(\d|LOCAL)\((\S+)\):\s+addr:[0-9a-f:]{17}', out)
+    # Example of 'parsed':
+
+    mux_status = defaultdict(dict)
+    mux_status['vm_set'] = vm_set
+    mux_status['port_index'] = port_index
+    mux_status['ports']['nic'] = parsed[0][1]
+    mux_status['ports']['tor_a'] = parsed[1][1]
+    mux_status['ports']['tor_b'] = parsed[2][1]
+    mux_status['bridge'] = parsed[3][1]
+    return mux_status
+
+
+def get_flows(vm_set, port_index):
+    """Use the 'ovs-ofctl dump-flows' command to get the open flow details of a bridge simulating mux.
+
+    Example output of the 'ovs-ofctl dump-flows' command:
+      azure@str2-acs-serv-17:~$ sudo ovs-ofctl --names dump-flows mbr-vms17-8-0
+       cookie=0x0, duration=86737.831s, table=0, n_packets=446, n_bytes=44412, in_port="muxy-vms17-8-0" actions=output:"enp59s0f1.3216",output:"enp59s0f1.3272"
+       cookie=0x0, duration=86737.819s, table=0, n_packets=10251, n_bytes=1179053, in_port="enp59s0f1.3216" actions=output:"muxy-vms17-8-0"
+
+    Example result of parsing the output using regex:
+      >>> re.findall(r'in_port="(\S+)"\s+actions=(\S+)', out)
+      [('muxy-vms17-8-0', 'output:"enp59s0f1.3216",output:"enp59s0f1.3272"'), ('enp59s0f1.3216', 'output:"muxy-vms17-8-0"')]
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+        port_index (int or string): Index of the port.
+
+    Returns:
+        dict: Return the result in dict. Example:
+            {
+                "muxy-vms17-8-0":
+                [
+                    {
+                        "action": "output",
+                        "out_port": "enp59s0f1.3216"
+                    },
+                    {
+                        "action": "output",
+                        "out_port": "enp59s0f1.3272"
+                    }
+                ],
+                "enp59s0f1.3216":
+                [
+                    {
+                        "action": "output",
+                        "out_port": "muxy-vms17-8-0"
+                    }
+                ]
+            }
+    """
+
+    cmdline = 'ovs-ofctl --names dump-flows mbr-{}-{}'.format(vm_set, port_index)
+    out = run_cmd(cmdline)
+
+    parsed = re.findall(r'in_port="(\S+)"\s+actions=(\S+)', out)
+
+    flows = {}
+    for in_port, actions_desc in parsed:
+        actions = []
+        for field in actions_desc.split(','):
+            action, out_port = re.search(r'(\S+):"(\S+)"', field).groups()
+            actions.append({'action': action, 'out_port': out_port})
+        flows[in_port] = actions
+
+    return flows
+
+
+def get_active_port(flows):
+    """Find the active port name based on knowledge that down stream traffic is only output to the 'nic' interface.
+
+    Args:
+        flows (dict): Open flow details of the mux, result returned from function get_flows
+
+    Returns:
+        string or None: Name of the active port or None if something is wrong.
+    """
+    for in_port, actions in flows.items():
+        if len(actions) == 1:
+            return in_port
+    return None
+
+
+def get_mux_status(vm_set, port_index):
+    """Use other functions to get overall status of the mux.
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+        port_index ([type]): Index of the port.
+
+    Raises:
+        Exception: If no active port is found, raise an exception.
+
+    Returns:
+        dict: A dictionary contains full mux status, including connection details, open flow details and active side
+        information. Example:
+            {
+                "bridge": "mbr-vms17-8-0",
+                "vm_set": "vms17-8",
+                "port_index": 0,
+                "ports": {
+                    "nic": "muxy-vms17-8-0",
+                    "tor_a": "enp59s0f1.3216",
+                    "tor_b": "enp59s0f1.3272"
+                },
+                "active_side": "tor_a",
+                "flows": {
+                    "muxy-vms17-8-0":
+                    [
+                        {
+                            "action": "output",
+                            "out_port": "enp59s0f1.3216"
+                        },
+                        {
+                            "action": "output",
+                            "out_port": "enp59s0f1.3272"
+                        }
+                    ],
+                    "enp59s0f1.3216":
+                    [
+                        {
+                            "action": "output",
+                            "out_port": "muxy-vms17-8-0"
+                        }
+                    ]
+                }
+            }
+    """
+
+    mux_status = get_mux_connections(vm_set, port_index)
+    flows = get_flows(vm_set, port_index)
+    mux_status['flows'] = flows
+    active_port = get_active_port(flows)
+    if not active_port:
+        raise Exception('Unable to find active port. flows: {}'.format(json.dumps(flows)))
+    for side, port in mux_status['ports'].items():
+        if port == active_port:
+            mux_status['active_side'] = side
+    return mux_status
+
+
+def set_active_side(vm_set, port_index, new_active_side):
+    """Change the open flow configurations to set the active side to the value specified by argument 'new_active_side'.
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+        port_index ([type]): Index of the port.
+        new_active_side (string): Either "tor_a" or "tor_b".
+
+    Returns:
+        dict: Return the new full mux status in a dictionary.
+    """
+    mux_status = get_mux_status(vm_set, port_index)
+    if mux_status['active_side'] == new_active_side:
+        return mux_status
+
+    flows = get_flows(vm_set, port_index)
+    active_port = get_active_port(flows)
+    nic_port = mux_status['ports']['nic']
+    new_active_port = mux_status['ports'][new_active_side]
+    run_cmd('ovs-ofctl --names del-flows mbr-{}-{} in_port="{}"'.format(vm_set, port_index, active_port))
+    run_cmd('ovs-ofctl --names add-flow  mbr-{}-{} in_port="{}",actions=output:"{}"'
+        .format(vm_set, port_index, new_active_port, nic_port))
+    mux_status['active_side'] = new_active_side
+    return mux_status
+
+
+def _validate_param(vm_set, port_index=None):
+    """Validate the vm_set and port_index argument.
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+        port_index ([type]): Index of the port.
+
+    Returns:
+        tuple: Return the result in a tuple. The first item is either True or False. The second item is extra message.
+    """
+    pattern = 'mbr-{}'.format(vm_set)
+    if port_index:
+        pattern += '-{}'.format(port_index)
+    cmdline = 'ip link | grep {}'.format(pattern)
+    try:
+        out = run_cmd(cmdline)
+        return True, ''
+    except Exception as e:
+        return False, repr(e)
+
+
+def _validate_posted_data(data):
+    """Validate json data in POST request.
+
+    Args:
+        data (dict): Data included in the POST request.
+
+    Returns:
+        tuple: Return the result in a tuple. The first item is either True or False. The second item is extra message.
+    """
+    if 'active_side' in data and data['active_side'] in ['tor_a', 'tor_b']:
+        return True, ''
+    return False, 'Bad posted data, expected: {"active_side": "tor_a|tor_b"}'
+
+
+@app.route('/mux/<vm_set>/<port_index>', methods=['GET', 'POST'])
+def mux_cable(vm_set, port_index):
+    """Handler for requests to /mux/<vm_set>/<port_index>.
+
+    For GET request, return detailed status of mux specified by vm_set and port_index.
+    For POST request, set mux active side to the one specified in the posted json data.
+
+    Args:
+        vm_set (string): The vm_set of test setup. Parsed by flask from request URL.
+        port_index (string): Index of the port. Parsed by flask from request URL.
+
+    Returns:
+        object: Return a flask response object.
+    """
+    valid, msg = _validate_param(vm_set, port_index)
+    if not valid:
+        return jsonify({'err_msg': msg}), 400
+
+    if request.method == 'GET':
+        # Get mux status
+        try:
+            mux_status = get_mux_status(vm_set, port_index)
+            return jsonify(mux_status)
+        except Exception as e:
+            return jsonify({'err_msg': 'Get mux status failed: {}'.format(repr(e))}), 500
+    else:
+        # Set the active side of mux
+        data = request.get_json()
+        valid, msg = _validate_posted_data(data)
+        if not valid:
+            return jsonify({'err_msg': msg}), 400
+
+        try:
+            mux_status = set_active_side(vm_set, port_index, data['active_side'])
+            return jsonify(mux_status)
+        except Exception as e:
+            return jsonify({'err_msg': 'Set active side failed: {}'.format(repr(e))}), 500
+
+
+def get_mux_bridges(vm_set):
+    """List all the mux bridges of specified vm_set.
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+
+    Returns:
+        list: List of all the bridge names of specified vm_set.
+    """
+    bridge_prefix = 'mbr-{}-'.format(vm_set)
+    cmdline = 'ls /sys/class/net | grep {}'.format(bridge_prefix)
+    out = run_cmd(cmdline)
+    mux_bridges = [line for line in out.split('\n') if line.startswith(bridge_prefix)]
+    return mux_bridges
+
+
+@app.route('/mux/<vm_set>', methods=['GET'])
+def all_mux_status(vm_set):
+    """Handler for requests to /mux/<vm_set>.
+
+    For GET request, return detailed status of all the mux Y cables belong to the specified vm_set.
+
+    Args:
+        vm_set (string): The vm_set of test setup.
+
+    Returns:
+        object: Return a flask response object.
+    """
+    bridge_prefix = 'mbr-{}-'.format(vm_set)
+    try:
+        mux_bridges = get_mux_bridges(vm_set)
+        all_mux_status = {}
+        for bridge in mux_bridges:
+            port_index = int(bridge.replace(bridge_prefix, ''))
+            all_mux_status[bridge] = get_mux_status(vm_set, port_index)
+        return jsonify(all_mux_status)
+    except Exception as e:
+        return jsonify({'err_msg': 'Get all mux status failed, vm_set: {}, exception: {}'.format(vm_set, repr(e))}), 500
+
+
+if __name__ == '__main__':
+    usage = '''
+    Start mux simulator server at specified port.
+    $ sudo python <prog> <port>
+    '''
+    if len(sys.argv) < 2:
+        print(usage)
+        sys.exit(1)
+    print('Mux simulator listening at port {}'.format(sys.argv[1]))
+    app.run(host='0.0.0.0', port=sys.argv[1])

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -123,4 +123,10 @@
     include_tasks: start_ptf_tgen.yml
     when: topo == 'fullmesh'
 
+  - name: Start mux simulator
+    include_tasks: control_mux_simulator.yml
+    vars:
+      mux_simulator_action: start
+    when: "'dualtor' in topo"
+
   when: container_type == "PTF"

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -1,4 +1,12 @@
 
+- name: Get absolute path of {{ root_path }}
+  command: "realpath {{ root_path }}"
+  register: real_root_path
+
+- name: Set variable abs_root_path
+  set_fact:
+    abs_root_path: "{{ real_root_path.stdout }}"
+
 - name: Start mux simulator
   block:
 
@@ -7,18 +15,10 @@
     become: yes
     environment: "{{ proxy_env | default({}) }}"
 
-  - name: Get absolute path of {{ root_path }}
-    command: "realpath {{ root_path }}"
-    register: real_root_path
-
-  - name: Set {{ root_path }} to absolute path
-    set_fact:
-      root_path: "{{ real_root_path.stdout }}"
-
   - name: Copy the mux simulator to test server
     copy:
       src: mux_simulator.py
-      dest: "{{ root_path }}"
+      dest: "{{ abs_root_path }}"
       mode: 0755
 
   - name: Set default mux_simulator_port
@@ -41,7 +41,7 @@
 
   - name: Record vm_set of testbed using mux-simulator
     lineinfile:
-      path: "{{ root_path }}/mux_simulator.setups.txt"
+      path: "{{ abs_root_path }}/mux_simulator.setups.txt"
       line: "{{ vm_set_name }}"
       state: present
       create: yes
@@ -53,12 +53,12 @@
 
   - name: Remove the record of testbed using mux-simulator
     lineinfile:
-      path: "{{ root_path }}/mux_simulator.setups.txt"
+      path: "{{ abs_root_path }}/mux_simulator.setups.txt"
       line: "{{ vm_set_name }}"
       state: absent
 
   - name: Check if the record file is empty
-    command: "grep -P '\\S' {{ root_path }}/mux_simulator.setups.txt"
+    command: "grep -P '\\S' {{ abs_root_path }}/mux_simulator.setups.txt"
     register: record_file_content
     ignore_errors: yes
 
@@ -66,6 +66,7 @@
     systemd:
       name: mux-simulator
       state: stopped
+    become: yes
     ignore_errors: yes
     when: record_file_content.rc != 0
 

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -1,0 +1,43 @@
+
+- name: Start mux simulator
+  block:
+
+  - name: Install flask
+    pip: name=flask version=1.1.2 state=forcereinstall executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+
+  - name: Copy the mux simulator to test server
+    copy:
+      src: mux_simulator.py
+      dest: "{{ root_path }}"
+      mode: 0755
+
+  - name: Set default mux_simulator_port
+    set_fact:
+      mux_simulator_port: 8080
+    when: mux_simulator_port is not defined
+
+  - name: Start mux simulator and keep it running in background
+    shell: cd {{ root_path }}; ./mux_simulator.py {{ mux_simulator_port }} 2>&1 &
+    become: yes
+
+  when: mux_simulator_action == "start"
+
+- name: Stop mux simulator
+  block:
+
+  - name: Get mux_simulator pid
+    command: pgrep -f "mux_simulator.py"
+    register: mux_simulator_pids
+    ignore_errors: yes
+
+  - name: Kill the mux_simulator
+    command: kill -9 {{ mux_simulator_pid }}
+    become: yes
+    ignore_errors: yes
+    loop: "{{ mux_simulator_pids.stdout_lines }}"
+    loop_control:
+      loop_var: mux_simulator_pid
+
+  when: mux_simulator_action == "stop"

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -7,6 +7,14 @@
     become: yes
     environment: "{{ proxy_env | default({}) }}"
 
+  - name: Get absolute path of {{ root_path }}
+    command: "realpath {{ root_path }}"
+    register: real_root_path
+
+  - name: Set {{ root_path }} to absolute path
+    set_fact:
+      root_path: "{{ real_root_path.stdout }}"
+
   - name: Copy the mux simulator to test server
     copy:
       src: mux_simulator.py
@@ -18,26 +26,47 @@
       mux_simulator_port: 8080
     when: mux_simulator_port is not defined
 
-  - name: Start mux simulator and keep it running in background
-    shell: cd {{ root_path }}; ./mux_simulator.py {{ mux_simulator_port }} 2>&1 &
+  - name: Generate mux-simulator systemd service file
+    template:
+      src: mux-simulator.service.j2
+      dest: /etc/systemd/system/mux-simulator.service
     become: yes
+
+  - name: Start the mux-simulator service
+    systemd:
+      name: mux-simulator
+      state: started
+      daemon_reload: yes
+    become: yes
+
+  - name: Record vm_set of testbed using mux-simulator
+    lineinfile:
+      path: "{{ root_path }}/mux_simulator.setups.txt"
+      line: "{{ vm_set_name }}"
+      state: present
+      create: yes
 
   when: mux_simulator_action == "start"
 
 - name: Stop mux simulator
   block:
 
-  - name: Get mux_simulator pid
-    command: pgrep -f "mux_simulator.py"
-    register: mux_simulator_pids
+  - name: Remove the record of testbed using mux-simulator
+    lineinfile:
+      path: "{{ root_path }}/mux_simulator.setups.txt"
+      line: "{{ vm_set_name }}"
+      state: absent
+
+  - name: Check if the record file is empty
+    command: "grep -P '\\S' {{ root_path }}/mux_simulator.setups.txt"
+    register: record_file_content
     ignore_errors: yes
 
-  - name: Kill the mux_simulator
-    command: kill -9 {{ mux_simulator_pid }}
-    become: yes
+  - name: Stop the mux-simulator service if no setup is using it
+    systemd:
+      name: mux-simulator
+      state: stopped
     ignore_errors: yes
-    loop: "{{ mux_simulator_pids.stdout_lines }}"
-    loop_control:
-      loop_var: mux_simulator_pid
+    when: record_file_content.rc != 0
 
   when: mux_simulator_action == "stop"

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -36,16 +36,6 @@
   become: yes
   environment: "{{ proxy_env | default({}) }}"
 
-- name: Get default pip_executable
-  set_fact:
-    pip_executable: pip
-  when: pip_executable is not defined and host_distribution_version.stdout != "20.04"
-
-- name: Get default pip_executable
-  set_fact:
-    pip_executable: pip3
-  when: pip_executable is not defined and host_distribution_version.stdout == "20.04"
-
 - name: remove old python packages
   pip: name=docker-py state=absent executable={{ pip_executable }}
   become: yes

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -92,6 +92,16 @@
   become: yes
   when: host_distribution_version.stdout == "20.04"
 
+- name: Get default pip_executable
+  set_fact:
+    pip_executable: pip
+  when: pip_executable is not defined and host_distribution_version.stdout != "20.04"
+
+- name: Get default pip_executable
+  set_fact:
+    pip_executable: pip3
+  when: pip_executable is not defined and host_distribution_version.stdout == "20.04"
+
 - include_tasks: docker.yml
 
 - name: Ensure {{ ansible_user }} in docker,sudo group

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -8,6 +8,13 @@
   when: ptf_imagename is defined and ptf_imagename == "docker-keysight-api-server"
 
 - block:
+
+  - name: Stop mux simulator
+    include_tasks: control_mux_simulator.yml
+    vars:
+      mux_simulator_action: stop
+    when: "'dualtor' in topo"
+
   - name: Get duts ports
     include_tasks: get_dut_port.yml
     loop: "{{ duts_name.split(',') }}"

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/env python {{ root_path }}/mux_simulator.py {{ mux_simulator_port }}
+ExecStart=/usr/bin/env python {{ abs_root_path }}/mux_simulator.py {{ mux_simulator_port }}

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=mux simulator
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/env python {{ root_path }}/mux_simulator.py {{ mux_simulator_port }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add test server side mux Y cable simulator

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In dualtor testbed, mux Y cable is simulated by OVS in test server. An OVS
bridge is created for each of the mux. The PTF interface and test server
VLAN interfaces are attached to the bridge. The VLAN interfaces are
connected to DUT ports through fanout switches.
```
                          +--------------+
                          |              +----- upper_if
          PTF (host_if) --+  OVS bridge  |
                          |              +----- lower_if
                          +--------------+
```
Open flow rules are configured for the OVS bridge to simulate upstream
broadcasting and downstream dropping traffic from standby side.

To further simulate mux Y cable active/standby querying and setting, a
process need to be started in the test server. The process needs to expose
APIs for querying and setting active/standby status. On DUT side, a plugin
can be injected to intercept the calls to mux Y cable. Instead of calling
the actual mux driver functions, the APIs of mux simulator are called.
Then the process checks and updates open flow configurations of the OVS
bridge accordingly

#### How did you do it?
This change added a program that can expose such HTTP APIs for the injected
plugin on DUT side to query and set mux Y cable active/standby status.

The program is a python script based on Flask. It is copied to test server
and started as background process by running 'testbed-cli.sh add-topo'
for dualtor type topology. It is stopped by running 
'testbed-cli.sh remove-topo'.

#### How did you verify/test it?
Use curl to get and post the HTTP APIs.

#### Any platform specific information?
Only used by dualtor topology.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
