### PR TITLE
Changes to support Nokia-7215 SONiC pizza box

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -3095,6 +3095,40 @@ sensors_checks:
       - adt7473-i2c-0-2e/+3.3V/in2_input
       temp: []
     psu_skips: {}
+  
+  armhf-nokia_ixs7215_52x-r0:
+    alarms:
+      fan:
+      - adt7473-i2c-0-2e/rear fan 1/fan1_alarm
+      - adt7473-i2c-0-2e/rear fan 2/fan2_alarm
+      power:
+      - adt7473-i2c-0-2e/+3.3V/in2_alarm
+      temp:
+      - adt7473-i2c-0-2e/temp1/temp1_alarm
+      - adt7473-i2c-0-2e/temp1/temp1_fault
+      - adt7473-i2c-0-2e/Board Temp/temp2_alarm
+      - adt7473-i2c-0-2e/temp3/temp3_alarm
+      - adt7473-i2c-0-2e/temp3/temp3_fault
+    compares:
+      fan: []
+      power:
+      - - adt7473-i2c-0-2e/+3.3V/in2_input
+        - adt7473-i2c-0-2e/+3.3V/in2_max
+      temp:
+      - - adt7473-i2c-0-2e/temp1/temp1_input
+        - adt7473-i2c-0-2e/temp1/temp1_crit
+      - - adt7473-i2c-0-2e/Board Temp/temp2_input
+        - adt7473-i2c-0-2e/Board Temp/temp2_crit
+      - - adt7473-i2c-0-2e/temp3/temp3_input
+        - adt7473-i2c-0-2e/temp3/temp3_crit
+    non_zero:
+      fan:
+      - adt7473-i2c-0-2e/rear fan 1/fan1_input
+      - adt7473-i2c-0-2e/rear fan 2/fan2_input
+      power:
+      - adt7473-i2c-0-2e/+3.3V/in2_input
+      temp: []
+    psu_skips: {}
 
   x86_64-juniper_qfx5210-r0:
     alarms:

--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -56,6 +56,8 @@ class BcastTest(BaseTest):
         self.setUpVlan(self.test_params['vlan_info'])
         if self.test_params['testbed_type'] == 't0':
             self.src_ports = range(1, 25) + range(28, 32)
+        if self.test_params['testbed_type'] == 't0-52':
+            self.src_ports = range(0, 52)
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
         if self.test_params['testbed_type'] == 't0-116':

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -33,7 +33,7 @@ def parse_intf_status(lines):
     return result
 
 
-def check_interface_status(dut, asic_index, interfaces):
+def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
     """
     @summary: Check the admin and oper status of the specified interfaces on DUT.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -68,10 +68,11 @@ def check_interface_status(dut, asic_index, interfaces):
             return False
 
         # Cross check the interface SFP presence status
-        check_presence_output = dut.command(check_intf_presence_command.format(intf))
-        presence_list = check_presence_output["stdout_lines"][2].split()
-        assert intf in presence_list, "Wrong interface name in the output: %s" % str(presence_list)
-        assert 'Present' in presence_list, "Status is not expected, presence status: %s" % str(presence_list)
+        if intf not in xcvr_skip_list:
+            check_presence_output = dut.command(check_intf_presence_command.format(intf))
+            presence_list = check_presence_output["stdout_lines"][2].split()
+            assert intf in presence_list, "Wrong interface name in the output: %s" % str(presence_list)
+            assert 'Present' in presence_list, "Status is not expected, presence status: %s" % str(presence_list)
 
     logging.info("Check interface status using the interface_facts module")
     intf_facts = dut.interface_facts(up_ports=mg_ports, namespace=namespace)["ansible_facts"]
@@ -83,27 +84,26 @@ def check_interface_status(dut, asic_index, interfaces):
     return True
 
 # This API to check the interface information actoss all front end ASIC's
-def check_all_interface_information(dut, interfaces):
+def check_all_interface_information(dut, interfaces, xcvr_skip_list):
     for asic_index in dut.get_frontend_asic_ids():
         # Get the interfaces pertaining to that asic
         interface_list = get_port_map(dut, asic_index)
         interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
-
-        if not all_transceivers_detected(dut, asic_index, interfaces_per_asic):
+        if not all_transceivers_detected(dut, asic_index, interfaces_per_asic, xcvr_skip_list):
             logging.info("Not all transceivers are detected")
             return False
-        if not check_interface_status(dut, asic_index, interfaces_per_asic):
+        if not check_interface_status(dut, asic_index, interfaces_per_asic, xcvr_skip_list):
             logging.info("Not all interfaces are up")
             return False
 
     return True
 
 # This API to check the interface information per asic.
-def check_interface_information(dut, asic_index, interfaces):
-    if not all_transceivers_detected(dut, asic_index, interfaces):
+def check_interface_information(dut, asic_index, interfaces, xcvr_skip_list):
+    if not all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
         logging.info("Not all transceivers are detected on asic %s" % asic_index)
         return False
-    if not check_interface_status(dut, asic_index, interfaces):
+    if not check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
         logging.info("Not all interfaces are up on asic %s" % asic_index)
         return False
 

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -120,8 +120,10 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_
             cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|%s"' % intf
             docker_cmd = asichost.get_docker_cmd(cmd, "database")
             port_xcvr_dom_sensor = dut.command(docker_cmd)
-            assert port_xcvr_dom_sensor["stdout"].find(field) >= 0, \
-                "Expected field %s is not found in %s while checking %s" % (field, port_xcvr_dom_sensor["stdout"], intf)
+            for field in expected_fields:
+                assert port_xcvr_dom_sensor["stdout"].find(field) >= 0, \
+                    "Expected field %s is not found in %s while checking %s" % (
+                    field, port_xcvr_dom_sensor["stdout"], intf)
 
 
 def check_transceiver_status(dut, asic_index, interfaces, xcvr_skip_list):

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -5,7 +5,6 @@ This script contains re-usable functions for checking status of transceivers.
 """
 import logging
 import re
-import json
 
 
 def parse_transceiver_info(output_lines):
@@ -38,7 +37,7 @@ def parse_transceiver_dom_sensor(output_lines):
     return result
 
 
-def all_transceivers_detected(dut, asic_index, interfaces):
+def all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
     """
     Check if transceiver information of all the specified interfaces have been detected.
     """
@@ -53,7 +52,7 @@ def all_transceivers_detected(dut, asic_index, interfaces):
     return True
 
 
-def check_transceiver_basic(dut, asic_index, interfaces):
+def check_transceiver_basic(dut, asic_index, interfaces, xcvr_skip_list):
     """
     @summary: Check whether all the specified interface are in TRANSCEIVER_INFO redis DB.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -66,10 +65,11 @@ def check_transceiver_basic(dut, asic_index, interfaces):
     xcvr_info = dut.command(docker_cmd)
     parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
     for intf in interfaces:
-        assert intf in parsed_xcvr_info, "TRANSCEIVER INFO of %s is not found in DB" % intf
+        if intf not in xcvr_skip_list:
+            assert intf in parsed_xcvr_info, "TRANSCEIVER INFO of %s is not found in DB" % intf
 
 
-def check_transceiver_details(dut, asic_index, interfaces):
+def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     """
     @summary: Check the detailed TRANSCEIVER_INFO content of all the specified interfaces.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -79,15 +79,16 @@ def check_transceiver_details(dut, asic_index, interfaces):
     logging.info("Check detailed transceiver information of each connected port")
     expected_fields = ["type", "hardware_rev", "serial", "manufacturer", "model"]
     for intf in interfaces:
-        cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_INFO|%s"' % intf
-        docker_cmd = asichost.get_docker_cmd(cmd, "database")
-        port_xcvr_info = dut.command(docker_cmd)
-        for field in expected_fields:
-            assert port_xcvr_info["stdout"].find(field) >= 0, \
-                "Expected field %s is not found in %s while checking %s" % (field, port_xcvr_info["stdout"], intf)
+        if intf not in xcvr_skip_list:
+            cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_INFO|%s"' % intf
+            docker_cmd = asichost.get_docker_cmd(cmd, "database")
+            port_xcvr_info = dut.command(docker_cmd)
+            for field in expected_fields:
+                assert port_xcvr_info["stdout"].find(field) >= 0, \
+                    "Expected field %s is not found in %s while checking %s" % (field, port_xcvr_info["stdout"], intf)
 
 
-def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces):
+def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_list):
     """
     @summary: Check whether all the specified interface are in TRANSCEIVER_DOM_SENSOR redis DB.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -100,10 +101,11 @@ def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces):
     xcvr_dom_sensor = dut.command(docker_cmd)
     parsed_xcvr_dom_sensor = parse_transceiver_dom_sensor(xcvr_dom_sensor["stdout_lines"])
     for intf in interfaces:
-        assert intf in parsed_xcvr_dom_sensor, "TRANSCEIVER_DOM_SENSOR of %s is not found in DB" % intf
+        if intf not in xcvr_skip_list:
+            assert intf in parsed_xcvr_dom_sensor, "TRANSCEIVER_DOM_SENSOR of %s is not found in DB" % intf
 
 
-def check_transceiver_dom_sensor_details(dut, asic_index, interfaces):
+def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_list):
     """
     @summary: Check the detailed TRANSCEIVER_DOM_SENSOR content of all the specified interfaces.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -114,20 +116,21 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces):
     expected_fields = ["temperature", "voltage", "rx1power", "rx2power", "rx3power", "rx4power", "tx1bias",
                        "tx2bias", "tx3bias", "tx4bias", "tx1power", "tx2power", "tx3power", "tx4power"]
     for intf in interfaces:
-        cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|%s"' % intf
-        docker_cmd = asichost.get_docker_cmd(cmd, "database")
-        port_xcvr_dom_sensor = dut.command(docker_cmd)
+        if intf not in xcvr_skip_list:
+            cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|%s"' % intf
+            docker_cmd = asichost.get_docker_cmd(cmd, "database")
+            port_xcvr_dom_sensor = dut.command(docker_cmd)
             assert port_xcvr_dom_sensor["stdout"].find(field) >= 0, \
                 "Expected field %s is not found in %s while checking %s" % (field, port_xcvr_dom_sensor["stdout"], intf)
 
 
-def check_transceiver_status(dut, asic_index, interfaces):
+def check_transceiver_status(dut, asic_index, interfaces, xcvr_skip_list):
     """
     @summary: Check transceiver information of all the specified interfaces in redis DB.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     @param interfaces: List of interfaces that need to be checked.
     """
-    check_transceiver_basic(dut, asic_index, interfaces)
-    check_transceiver_details(dut, asic_index, interfaces)
-    check_transceiver_dom_sensor_basic(dut, asic_index, interfaces)
-    check_transceiver_dom_sensor_details(dut, asic_index, interfaces)
+    check_transceiver_basic(dut, asic_index, interfaces, xcvr_skip_list)
+    check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list)
+    check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_list)
+    check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_list)

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -117,7 +117,6 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces):
         cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|%s"' % intf
         docker_cmd = asichost.get_docker_cmd(cmd, "database")
         port_xcvr_dom_sensor = dut.command(docker_cmd)
-        for field in expected_fields:
             assert port_xcvr_dom_sensor["stdout"].find(field) >= 0, \
                 "Expected field %s is not found in %s while checking %s" % (field, port_xcvr_dom_sensor["stdout"], intf)
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -307,6 +307,11 @@ def hash_keys(duthost):
     if duthost.facts['asic_type'] in ["barefoot"]:
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
+    if duthost.facts['platform'] in ['armhf-nokia_ixs7215_52x-r0']:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+        if 'ingress-port' in hash_keys:
+            hash_keys.remove('ingress-port')
 
     return hash_keys
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -307,6 +307,7 @@ def hash_keys(duthost):
     if duthost.facts['asic_type'] in ["barefoot"]:
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
+    # removing ingress-port and ip-proto from hash_keys not supported by Marvell SAI
     if duthost.facts['platform'] in ['armhf-nokia_ixs7215_52x-r0']:
         if 'ip-proto' in hash_keys:
             hash_keys.remove('ip-proto')

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -10,7 +10,7 @@ pytestmark = [
 
 def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, fib):
     duthost = duthosts[rand_one_dut_hostname]
-    support_testbed_types = frozenset(['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116'])
+    support_testbed_types = frozenset(['t0', 't0-16', 't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116'])
     testbed_type = tbinfo['topo']['name']
     if testbed_type not in support_testbed_types:
         pytest.skip("Not support given test bed type %s" % testbed_type)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import os
+import logging
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from .args.advanced_reboot_args import add_advanced_reboot_args
 from .args.cont_warm_reboot_args import add_cont_warm_reboot_args
@@ -28,9 +29,11 @@ def xcvr_skip_list(duthosts, rand_one_dut_hostname):
         for int_n in int_skip_info['interfaces']:
             if int_skip_info['interfaces'][int_n]['port_type'] == "RJ45":
                 intf_skip_list.append(int_n)
-    except:
-        # return empty list if hwsku.json does not exist
-        intf_skip_list = []
+
+    except Exception:
+        # hwsku.json does not exist will return empty skip list
+        logging.debug(
+            "hwsku.json absent or port_type for interfaces not included for hwsku {}".format(hwsku))
 
     return intf_skip_list
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -25,9 +25,9 @@ def xcvr_skip_list(duthosts, rand_one_dut_hostname):
     intf_skip_list = []
     try:
         out = duthost.command("cat {}".format(f_path))
-        int_skip_info = json.loads(out["stdout"])
-        for int_n in int_skip_info['interfaces']:
-            if int_skip_info['interfaces'][int_n]['port_type'] == "RJ45":
+        hwsku_info = json.loads(out["stdout"])
+        for int_n in hwsku_info['interfaces']:
+            if hwsku_info['interfaces'][int_n]['port_type'] == "RJ45":
                 intf_skip_list.append(int_n)
 
     except Exception:

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
-
+import json
+import os
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from .args.advanced_reboot_args import add_advanced_reboot_args
 from .args.cont_warm_reboot_args import add_cont_warm_reboot_args
@@ -14,6 +15,24 @@ def skip_on_simx(duthosts, rand_one_dut_hostname):
     if "simx" in platform:
         pytest.skip('skipped on this platform: {}'.format(platform))
 
+@pytest.fixture(scope="module")
+def xcvr_skip_list(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    platform = duthost.facts['platform']
+    hwsku = duthost.facts['hwsku']
+    f_path = os.path.join('/usr/share/sonic/device', platform, hwsku, 'hwsku.json')
+    intf_skip_list = []
+    try:
+        out = duthost.command("cat {}".format(f_path))
+        int_skip_info = json.loads(out["stdout"])
+        for int_n in int_skip_info['interfaces']:
+            if int_skip_info['interfaces'][int_n]['port_type'] == "RJ45":
+                intf_skip_list.append(int_n)
+    except:
+        # return empty list if hwsku.json does not exist
+        intf_skip_list = []
+
+    return intf_skip_list
 
 @pytest.fixture()
 def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -34,22 +34,23 @@ MAX_WAIT_TIME_FOR_REBOOT_CAUSE = 120
 
 
 @pytest.fixture(scope="module", autouse=True)
-def teardown_module(duthosts, rand_one_dut_hostname, conn_graph_facts):
+def teardown_module(duthosts, rand_one_dut_hostname, conn_graph_facts, xcvr_skip_list):
     duthost = duthosts[rand_one_dut_hostname]
     yield
 
     logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
     check_critical_processes(duthost, watch_secs=10)
-    check_interfaces_and_services(duthost, interfaces)
+    check_interfaces_and_services(duthost, interfaces, xcvr_skip_list)
 
 
-def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
+def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None):
     """
     Perform the specified type of reboot and check platform status.
     @param localhost: The Localhost object.
     @param dut: The AnsibleHost object of DUT.
     @param interfaces: DUT's interfaces defined by minigraph
+    @param xcvr_skip_list: list of DUT's interfaces for which transeiver checks are skipped
     @param reboot_type: The reboot type, pre-defined const that has name convention of REBOOT_TYPE_XXX.
     @param reboot_helper: The helper function used only by power off reboot
     @param reboot_kwargs: The argument used by reboot_helper
@@ -58,7 +59,7 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
 
     reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
 
-    check_interfaces_and_services(dut, interfaces, reboot_type)
+    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
 
 
 def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type = None):
@@ -107,15 +108,15 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type =
         check_sysfs(dut)
 
 
-def test_cold_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts):
+def test_cold_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
     duthost = duthosts[rand_one_dut_hostname]
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_COLD)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
 
 
-def test_fast_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts):
+def test_fast_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
@@ -125,10 +126,10 @@ def test_fast_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_fact
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting fast reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_FAST)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_FAST)
 
 
-def test_warm_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts):
+def test_warm_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform cold reboot and check platform status
     """
@@ -145,7 +146,7 @@ def test_warm_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_fact
         if "disabled" in issu_capability:
             pytest.skip("ISSU is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_WARM)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM)
 
 
 def _power_off_reboot_helper(kwargs):
@@ -168,12 +169,13 @@ def _power_off_reboot_helper(kwargs):
         psu_ctrl.turn_on_psu(psu["psu_id"])
 
 
-def test_power_off_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, psu_controller, power_off_delay):
+def test_power_off_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list, psu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object
     @param localhost: Fixture for interacting with localhost through ansible
     @param conn_graph_facts: Fixture parse and return lab connection graph
+    @param xcvr_skip_list: list of DUT's interfaces for which transeiver checks are skipped
     @param psu_controller: The python object of psu controller
     @param power_off_delay: Pytest parameter. The delay between turning off and on the PSU
     """
@@ -203,11 +205,11 @@ def test_power_off_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph
         poweroff_reboot_kwargs["all_psu"] = all_psu
         poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
         poweroff_reboot_kwargs["delay_time"] = power_off_delay
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], REBOOT_TYPE_POWEROFF,
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                          _power_off_reboot_helper, poweroff_reboot_kwargs)
 
 
-def test_watchdog_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts):
+def test_watchdog_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
@@ -218,13 +220,13 @@ def test_watchdog_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_
     if "" != watchdog_supported:
         pytest.skip("Watchdog is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], REBOOT_TYPE_WATCHDOG)
+    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)
 
 
-def test_continuous_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts):
+def test_continuous_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to perform 3 cold reboot in a row
     """
     duthost = duthosts[rand_one_dut_hostname]
     for i in range(3):
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], reboot_type=REBOOT_TYPE_COLD)
+        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -61,7 +61,7 @@ def reboot_and_check(localhost, dut, interfaces, reboot_type=REBOOT_TYPE_COLD, r
     check_interfaces_and_services(dut, interfaces, reboot_type)
 
 
-def check_interfaces_and_services(dut, interfaces, reboot_type = None):
+def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type = None):
     """
     Perform a further check after reboot-cause, including transceiver status, interface status
     @param localhost: The Localhost object.
@@ -81,7 +81,7 @@ def check_interfaces_and_services(dut, interfaces, reboot_type = None):
             return
 
     logging.info("Wait %d seconds for all the transceivers to be detected" % MAX_WAIT_TIME_FOR_INTERFACES)
-    assert wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, check_all_interface_information, dut, interfaces), \
+    assert wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, check_interface_information, dut, interfaces, xcvr_skip_list), \
         "Not all transceivers are detected or interfaces are up in %d seconds" % MAX_WAIT_TIME_FOR_INTERFACES
 
 
@@ -90,7 +90,7 @@ def check_interfaces_and_services(dut, interfaces, reboot_type = None):
         # Get the interfaces pertaining to that asic
         interface_list = get_port_map(dut, asic_index)
         interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
-        check_transceiver_basic(dut, asic_index, interfaces_per_asic)
+        check_transceiver_basic(dut, asic_index, interfaces_per_asic, xcvr_skip_list)
 
     logging.info("Check pmon daemon status")
     assert check_pmon_daemon_status(dut), "Not all pmon daemons running."

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -82,7 +82,7 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type =
             return
 
     logging.info("Wait %d seconds for all the transceivers to be detected" % MAX_WAIT_TIME_FOR_INTERFACES)
-    assert wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, check_interface_information, dut, interfaces, xcvr_skip_list), \
+    assert wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, check_all_interface_information, dut, interfaces, xcvr_skip_list), \
         "Not all transceivers are detected or interfaces are up in %d seconds" % MAX_WAIT_TIME_FOR_INTERFACES
 
 

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -20,7 +20,7 @@ pytestmark = [
 ]
 
 
-def test_reload_configuration(duthosts, rand_one_dut_hostname, conn_graph_facts):
+def test_reload_configuration(duthosts, rand_one_dut_hostname, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to reload the configuration and check platform status
     """
@@ -35,7 +35,7 @@ def test_reload_configuration(duthosts, rand_one_dut_hostname, conn_graph_facts)
     wait_critical_processes(duthost)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    assert wait_until(300, 20, check_all_interface_information, duthost, interfaces), \
+    assert wait_until(300, 20, check_all_interface_information, duthost, interfaces, xcvr_skip_list), \
         "Not all transceivers are detected in 300 seconds"
 
     logging.info("Check transceiver status")
@@ -43,7 +43,7 @@ def test_reload_configuration(duthosts, rand_one_dut_hostname, conn_graph_facts)
         # Get the interfaces pertaining to that asic
         interface_list = get_port_map(duthost, asic_index)
         interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
-        check_transceiver_basic(duthost, asic_index, interfaces_per_asic)
+        check_transceiver_basic(duthost, asic_index, interfaces_per_asic, xcvr_skip_list)
 
     if asic_type in ["mellanox"]:
 

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -46,7 +46,7 @@ def is_service_hiting_start_limit(duthost, container_name):
 
     return False
 
-def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service, interfaces):
+def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service, interfaces, xcvr_skip_list):
     """
     Restart specified service and check platform status
     """
@@ -66,11 +66,11 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     wait_critical_processes(dut)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    pytest_assert(wait_until(300, 20, check_interface_information, dut, enum_frontend_asic_index, interfaces),
+    pytest_assert(wait_until(300, 20, check_interface_information, dut, enum_frontend_asic_index, interfaces, xcvr_skip_list),
                   "Not all interface information are detected within 300 seconds")
 
     logging.info("Check transceiver status on asic %s" % enum_frontend_asic_index)
-    check_transceiver_basic(dut, enum_frontend_asic_index, interfaces)
+    check_transceiver_basic(dut, enum_frontend_asic_index, interfaces, xcvr_skip_list)
 
     if dut.facts["asic_type"] in ["mellanox"]:
 
@@ -87,7 +87,7 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     check_critical_processes(dut, 60)
 
 
-def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, localhost, conn_graph_facts):
+def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to restart the swss service and check platform status
     """
@@ -103,12 +103,12 @@ def test_restart_swss(duthosts, rand_one_dut_hostname, enum_frontend_asic_index,
         all_interfaces = new_intf_dict
         logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, all_interfaces))
 
-    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "swss", all_interfaces)
+    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "swss", all_interfaces, xcvr_skip_list)
 
 @pytest.mark.skip(reason="Restarting syncd is not supported yet")
-def test_restart_syncd(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts):
+def test_restart_syncd(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, localhost, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to restart the syncd service and check platform status
     """
     duthost = duthosts[rand_one_dut_hostname]
-    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "syncd", conn_graph_facts["device_conn"][duthost.hostname])
+    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "syncd", conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list)

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -16,7 +16,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_xcvr_info_in_db(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, conn_graph_facts):
+def test_xcvr_info_in_db(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to verify that xcvrd works as expected by checking transceiver information in DB
     """
@@ -32,4 +32,4 @@ def test_xcvr_info_in_db(duthosts, rand_one_dut_hostname, enum_frontend_asic_ind
         all_interfaces = {k:v for k, v in interface_list.items() if k in conn_graph_facts["device_conn"][duthost.hostname]}
         logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, all_interfaces))
 
-    check_transceiver_status(duthost, enum_frontend_asic_index, all_interfaces);
+    check_transceiver_status(duthost, enum_frontend_asic_index, all_interfaces, xcvr_skip_list);


### PR DESCRIPTION
 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Need to support Nokia-7215 SONiC box

#### How did you do it?
- hwsku 
   Nokia IXS7215  it has hwsku- 'Nokia 7215' based on arm arch , it has total 52 ports. 
   T0-52 topology is supported to run with this platform.
- port configuration - 
  Nokia IXS7215 platform has 48 1G Copper ports, and 4 10G SFP+
Changes made:
Added sensor data for this platform
ansible/group_vars/sonic/sku-sensors-data.yml
  - added sensors data for platform armhf-nokia_ixs7215_52x-r0
Added support for Nokia-7215 platform support for mg_facts
 ansible/library/minigraph_facts.py
    - Nokia-7215 hwsku to mg facts
Added t0-52 support to run dir_bacast test
 ansible/roles/test/files/ptftests/dir_bcast_test.py
    - Add src ports for t0-52 topology
Skip transceiver info for fixed 1g copper ports on Nokia-7215
 tests/common/platform/transceiver_utils.py
    - Exceptions for 1g copper ports for hwsku Nokia-7215
Limit advertised routes for this Platform  below asic limits
tests/common/plugins/fib.py
    - Change podset number for Nokia-7215 hwsku to limit advertised routes under hw scaling limit
Add t0-52 to supported testbed 
 tests/ipfwd/test_dir_bcast.py
    - Add t0-52 to supported testbed set
Remove hash key ip-proto and ingress-port not supported for this platform   

 tests/platform_tests/conftest.py:
 Added new fixture xcvr_skip_list to get a list of port from hwsku.json to be skipped for any sfp related check based on port type(for e.g RJ45 ports)

changes to following files to utilize this fixture xcvr_skip_list and skip ports from transceiver check:
 tests/common/platform/transceiver_utils.py
tests/common/platform/interface_utils.py
 tests/platform_tests/test_reboot.py
 tests/platform_tests/test_reload_config.py
 tests/platform_tests/test_sequential_restart.py

#### How did you verify/test it?

Ran all the t0 and applicable 'any' tests against a Nokia-7215 box. 


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
