### PR TITLE
[crm]: Fixed topology check and interface selection for test_crm_fdb_entry

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -807,16 +807,15 @@ def test_acl_counter(duthosts, rand_one_dut_hostname, collector):
 
 def test_crm_fdb_entry(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    # Test is applicable only for topologies which contain disabled host interface ports
-    topology = tbinfo["topo"]["properties"]["topology"]
-    if "disabled_host_interfaces" not in topology:
-        pytest.skip("Unsupported topology, test requires disabled ports for dummy VLAN interface")
+    if "t0" not in tbinfo["topo"]["name"].lower():
+        pytest.skip("Unsupported topology, expected to run only on 'T0*' topology")
     get_fdb_stats = "redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available"
+    topology = tbinfo["topo"]["properties"]["topology"]
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     port_dict = dict(zip(cfg_facts['port_index_map'].values(), cfg_facts['port_index_map'].keys()))
-    # Use for test disabled in topo host port to create dummy VLAN interface
-    disabled_port_id = [id for id in topology["disabled_host_interfaces"]][0]
-    iface = port_dict[disabled_port_id]
+    # Use for test 1st in list hosts interface port to add into dummy VLAN
+    host_port_id = [id for id in topology["host_interfaces"]][0]
+    iface = port_dict[host_port_id]
     vlan_id = 2
     cmd_add_vlan_member = "config vlan member add {vid} {iface}"
     cmd_add_vlan = "config vlan add {}".format(vlan_id)


### PR DESCRIPTION
Signed-off-by: Mykhailo Onipko <monipko@barefootnetworks.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #  
Removed hardcoded value "Ethernet0" and replaced by automatic selection depends on topo

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To add possibility run CRM test on t0-64 topo

#### How did you do it?

#### How did you verify/test it?

run test_crm_fdb_entry on t0-64

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
