### PR TITLE
Make thermal related test work on both 201911 and master

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -342,7 +342,8 @@ class SonicHost(AnsibleHostBase):
         Gets the SONiC kernel version
         :return:
         """
-        return self.setup()['ansible_facts']['ansible_kernel'].split('-')[0]
+        output = self.command('uname -r')
+        return output["stdout"].split('-')[0]
 
     def get_service_props(self, service, props=["ActiveState", "SubState"]):
         """

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -158,6 +158,7 @@ class SonicHost(AnsibleHostBase):
 
         self._facts = self._gather_facts()
         self._os_version = self._get_os_version()
+        self._kernel_version = self._get_kernel_version()
 
         self.reset_critical_services_tracking_list()
 
@@ -191,6 +192,16 @@ class SonicHost(AnsibleHostBase):
         """
 
         return self._os_version
+
+    @property
+    def kernel_version(self):
+        """
+        The kernel version running on this SONiC device.
+
+        Returns:
+            str: The SONiC kernel version (e.g. "4.9.0")
+        """
+        return self._kernel_version
 
     @property
     def critical_services(self):
@@ -325,6 +336,13 @@ class SonicHost(AnsibleHostBase):
 
         output = self.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
         return output["stdout_lines"][0].strip()
+
+    def _get_kernel_version(self):
+        """
+        Gets the SONiC kernel version
+        :return:
+        """
+        return self.setup()['ansible_facts']['ansible_kernel'].split('-')[0]
 
     def get_service_props(self, service, props=["ActiveState", "SubState"]):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,8 @@ def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")
     parser.addoption("--testbed_file", action="store", default=None, help="testbed file name")
 
+    parser.addoption("--sonic_branch_name", action="store", default=None, help="sonic base branch name")
+
     # test_vrf options
     parser.addoption("--vrf_capacity", action="store", default=None, type=int, help="vrf capacity of dut (4-1000)")
     parser.addoption("--vrf_test_count", action="store", default=None, type=int, help="number of vrf to be tested (1-997)")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,8 +44,6 @@ def pytest_addoption(parser):
     parser.addoption("--testbed", action="store", default=None, help="testbed name")
     parser.addoption("--testbed_file", action="store", default=None, help="testbed file name")
 
-    parser.addoption("--sonic_branch_name", action="store", default=None, help="sonic base branch name")
-
     # test_vrf options
     parser.addoption("--vrf_capacity", action="store", default=None, type=int, help="vrf capacity of dut (4-1000)")
     parser.addoption("--vrf_test_count", action="store", default=None, type=int, help="number of vrf to be tested (1-997)")

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -130,7 +130,7 @@ def verify_show_platform_fan_output(duthost, raw_output_lines):
         pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns".format(NUM_EXPECTED_COLS))
 
 
-def test_show_platform_fan(duthosts, rand_one_dut_hostname, request):
+def test_show_platform_fan(duthosts, rand_one_dut_hostname):
     """
     @summary: Verify output of `show platform fan`
     """
@@ -139,7 +139,7 @@ def test_show_platform_fan(duthosts, rand_one_dut_hostname, request):
 
     logging.info("Verifying output of '{}' ...".format(cmd))
     fan_status_output_lines = duthost.command(cmd)["stdout_lines"]
-    verify_show_platform_fan_output(duthost, request, fan_status_output_lines)
+    verify_show_platform_fan_output(duthost, fan_status_output_lines)
 
     # TODO: Test values against platform-specific expected data
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -15,6 +15,7 @@ import re
 import pytest
 
 import util
+from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
@@ -108,18 +109,16 @@ def test_show_platform_psustatus(duthosts, rand_one_dut_hostname):
         # TODO: Compare against expected platform-specific output
 
 
-def verify_show_platform_fan_output(duthost, request, raw_output_lines):
+def verify_show_platform_fan_output(duthost, raw_output_lines):
     """
     @summary: Verify output of `show platform fan`. Expected output is
               "Fan Not detected" or a table of fan status data conaining expect number of columns.
     """
-    sonic_branch_name = request.config.getoption("--sonic_branch_name")
-    is_201911 = False
-    if sonic_branch_name is None:
-        is_201911 = '201911' in duthost.os_version
+    # workaround to make this test compatible with 201911 and master
+    if parse_version(duthost.kernel_version) > parse_version('4.9.0'):
+        NUM_EXPECTED_COLS = 8
     else:
-        is_201911 = '201911' in sonic_branch_name
-    NUM_EXPECTED_COLS = 6 if is_201911 else 8
+        NUM_EXPECTED_COLS = 6
 
     pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output")
     if len(raw_output_lines) == 1:

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -108,12 +108,18 @@ def test_show_platform_psustatus(duthosts, rand_one_dut_hostname):
         # TODO: Compare against expected platform-specific output
 
 
-def verify_show_platform_fan_output(raw_output_lines):
+def verify_show_platform_fan_output(duthost, request, raw_output_lines):
     """
     @summary: Verify output of `show platform fan`. Expected output is
-              "Fan Not detected" or a table of fan status data conaining 8 columns.
+              "Fan Not detected" or a table of fan status data conaining expect number of columns.
     """
-    NUM_EXPECTED_COLS = 8
+    sonic_branch_name = request.config.getoption("--sonic_branch_name")
+    is_201911 = False
+    if sonic_branch_name is None:
+        is_201911 = '201911' in duthost.os_version
+    else:
+        is_201911 = '201911' in sonic_branch_name
+    NUM_EXPECTED_COLS = 6 if is_201911 else 8
 
     pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output")
     if len(raw_output_lines) == 1:
@@ -125,7 +131,7 @@ def verify_show_platform_fan_output(raw_output_lines):
         pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns".format(NUM_EXPECTED_COLS))
 
 
-def test_show_platform_fan(duthosts, rand_one_dut_hostname):
+def test_show_platform_fan(duthosts, rand_one_dut_hostname, request):
     """
     @summary: Verify output of `show platform fan`
     """
@@ -134,7 +140,7 @@ def test_show_platform_fan(duthosts, rand_one_dut_hostname):
 
     logging.info("Verifying output of '{}' ...".format(cmd))
     fan_status_output_lines = duthost.command(cmd)["stdout_lines"]
-    verify_show_platform_fan_output(fan_status_output_lines)
+    verify_show_platform_fan_output(duthost, request, fan_status_output_lines)
 
     # TODO: Test values against platform-specific expected data
 

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -403,7 +403,7 @@ class FanData:
     PWM_MAX = 255
 
     # Speed tolerance
-    SPEED_TOLERANCE = 0.2
+    SPEED_TOLERANCE = 0.5
 
     # Cooling cur state file
     COOLING_CUR_STATE_FILE = 'cooling_cur_state'

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -23,14 +23,12 @@ class BaseMocker:
     # Mocker type dictionary. Vendor must register their concrete mocker class to this dictionary.
     _mocker_type_dict = {}
 
-    def __init__(self, dut, request=None):
+    def __init__(self, dut):
         """
         Constructor of a mocker.
         :param dut: DUT object representing a SONiC switch under test.
-        :param request: Pytest request object to allow vendor process command line arguments.
         """
         self.dut = dut
-        self.request = request
 
     def mock_data(self):
         """
@@ -89,7 +87,7 @@ def mocker(type_name):
 
 
 @pytest.fixture
-def mocker_factory(localhost, duthosts, rand_one_dut_hostname, request):
+def mocker_factory(localhost, duthosts, rand_one_dut_hostname):
     """
     Fixture for thermal control data mocker factory.
     :return: A function for creating thermal control related data mocker.
@@ -111,7 +109,7 @@ def mocker_factory(localhost, duthosts, rand_one_dut_hostname, request):
             from tests.platform_tests.mellanox import mellanox_thermal_control_test_helper
             mocker_type = BaseMocker.get_mocker_type(mocker_name)
             if mocker_type:
-                mocker_object = mocker_type(dut, request)
+                mocker_object = mocker_type(dut)
                 mockers.append(mocker_object)
         else:
             pytest.skip("No mocker defined for this platform %s")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Make thermal related test work on both 201911 and master

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Now thermalctld works different between 201911 and master. For example, ```show platform fan``` displays 6 columns on 201911 but 8 columns on master. This PR makes it work both on master and 201911.

#### How did you do it?

1. Add a new property kernel version in SonicHost, for 201911, the version should be 4.9.0, for master, the version should be 4.19.0 or higher.
2. Make some changes in test cases according to the kernel version

#### How did you verify/test it?

Run thermal related regression test cases

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
