### PR TITLE
[test_fdb] Fix test_fdb failure caused by FDB aging.

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -72,3 +73,18 @@ def disable_route_checker_module(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     for func in _disable_route_checker(duthost):
         yield func
+
+@pytest.fixture(scope='module')
+def disable_fdb_aging(duthost):
+    """
+    Disable fdb aging by bcmcmd 'age 0'.
+    The original config will be recovered after running test.
+    """
+    cmd = "bcmcmd \'age {}\'"
+    output = duthost.shell("bcmcmd \'age\'")['stdout']
+    default_age = re.findall("Current age timer is (\d+).", output)
+    duthost.shell(cmd.format(0))
+    yield
+    # recover default aging time
+    duthost.shell(cmd.format(default_age))
+

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -53,7 +53,7 @@ def send_arp_request(ptfadapter, source_port, source_mac, dest_mac):
     :return:
     """
     pkt = testutils.simple_arp_packet(pktlen=60,
-                eth_dst='ff:ff:ff:ff:ff:ff',
+                eth_dst=dest_mac,
                 eth_src=source_mac,
                 vlan_vid=0,
                 vlan_pcp=0,

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -148,7 +148,8 @@ def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type):
             fdb[member].update(dummy_macs)
 
     time.sleep(FDB_POPULATE_SLEEP_TIMEOUT)
-
+    # Flush dataplane
+    ptfadapter.dataplane.flush()
     return fdb
 
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -9,9 +9,11 @@ import pprint
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
+from tests.common.fixtures.duthost_utils import disable_fdb_aging
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.usefixtures('disable_fdb_aging')
 ]
 
 DEFAULT_FDB_ETHERNET_TYPE = 0x1234


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The test case ```test_fdb``` is failing consistently on some testbed (like A7260). The root cause for the failure is the double loop among all interfaces costs too much time, which is beyond the fdb age (10 minutes in default). This PR address the issue by introducing a module level fixture to disable FDB aging.
This commit also clears the dataplane of testutil to ensure that the packet queue inside testutil is not filled up. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_fdb``` failure caused by expired FDB entry.

#### How did you do it?
 This PR address the issue by introducing a module level fixture to disable FDB aging.

#### How did you verify/test it?
Verified on A7260 (122 interfaces).
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level info --collect_techsupport=False --topology=t0,any,util fdb/test_fdb.py
collected 1 item                                                                                                                                                                                      

fdb/test_fdb.py::test_fdb[arp_reply] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
07:04:04 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
......
07:04:31 INFO __init__.py:loganalyzer:17: Log analyzer is disabled
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
07:49:45 INFO test_fdb.py:test_fdb:207: "show mac" output on DUT:
[u'  No.    Vlan  MacAddress         Port         Type',
 u'-----  ------  -----------------  -----------  -------',
 u'    1    1000  02:11:22:33:5E:03  Ethernet204  Dynamic',
 u'    2    1000  02:11:22:33:09:03  Ethernet18   Dynamic',
......
 u' 1232    1000  02:11:22:33:31:06  Ethernet114  Dynamic',
 u'Total number of entries 1232 ']
PASSED                                                                                                                                                                                          [100%]
------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------
07:49:46 INFO ptfhost_utils.py:remove_ip_addresses:104: Remove IPs to restore ptfhost 'vms7-8'


------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 1 passed in 2743.41 seconds =====================================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
