### PR TITLE
[ptf] Support alt_password for PTF to DUT SSH connection

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -226,7 +226,7 @@ class ReloadTest(BaseTest):
             self.test_params['dut_hostname'],
             self.test_params['dut_username'],
             password=self.test_params['dut_password'],
-            alt_password=self.test_params['alt_password']
+            alt_password=self.test_params.get('alt_password')
         )
 
         # Check if platform type is kvm

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -225,7 +225,8 @@ class ReloadTest(BaseTest):
         self.dut_connection = DeviceConnection(
             self.test_params['dut_hostname'],
             self.test_params['dut_username'],
-            password=self.test_params['dut_password']
+            password=self.test_params['dut_password'],
+            alt_password=self.test_params['alt_password']
         )
 
         # Check if platform type is kvm

--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -1,8 +1,9 @@
 import paramiko
 import logging
 import socket
+import sys
 from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
-
+from pip._vendor.retrying import retry
 logger = logging.getLogger(__name__)
 
 DEFAULT_CMD_EXECUTION_TIMEOUT_SEC = 10
@@ -14,7 +15,7 @@ class DeviceConnection:
     Paramiko module uses fallback mechanism where it would first try to use
     ssh key and that fails, it will attempt username/password combination
     '''
-    def __init__(self, hostname, username, password=None):
+    def __init__(self, hostname, username, password=None, alt_password=None):
         '''
         Class constructor
 
@@ -25,7 +26,13 @@ class DeviceConnection:
         self.hostname = hostname
         self.username = username
         self.password = password
+        self.alt_password = alt_password
 
+
+    @retry(
+        stop_max_attempt_number=2,
+        retry_on_exception=lambda e: isinstance(e, AuthenticationException)
+    )
     def execCommand(self, cmd, timeout=DEFAULT_CMD_EXECUTION_TIMEOUT_SEC):
         '''
         Executes command on remote device
@@ -52,12 +59,16 @@ class DeviceConnection:
             stdOut = so.readlines()
             stdErr = se.readlines()
             retValue = 0
+        except AuthenticationException as authenticationException:
+            logger.error('SSH Authentication failure with message: %s' % authenticationException)
+            if self.alt_password is not None:
+                # attempt retry with alt_password
+                self.password = self.alt_password
+                raise AuthenticationException
         except SSHException as sshException:
             logger.error('SSH Command failed with message: %s' % sshException)
-        except AuthenticationException as authenticationException:
-            logger.error('SSH Authentiaction failure with message: %s' % authenticationException)
         except BadHostKeyException as badHostKeyException:
-            logger.error('SSH Authentiaction failure with message: %s' % badHostKeyException)
+            logger.error('SSH Authentication failure with message: %s' % badHostKeyException)
         except socket.timeout as e:
             # The ssh session will timeout in case of a successful reboot
             logger.error('Caught exception socket.timeout: {}, {}, {}'.format(repr(e), str(e), type(e)))

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -99,10 +99,12 @@ def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds, tbinfo):
         #TODO:Update to vm_hosts.append(value['host'].host.mgmt_ip)
         vm_hosts.append(value['host'].host.options['inventory_manager'].get_host(value['host'].hostname).vars['ansible_host'])
 
+    sonicadmin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
     ptf_params = {
         "verbose": False,
         "dut_username": creds.get('sonicadmin_user'),
         "dut_password": creds.get('sonicadmin_password'),
+        "alt_password": sonicadmin_alt_password,
         "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
         "reboot_limit_in_seconds": 30,
         "reboot_type": "warm-reboot",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In reboot/upgrades, the PTF's SSH key stored inside DUT gets deleted. Use a retry mechanism (`alt_password`) when default admin password does not work.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

For tests running on PTF container, alt password is not supported.
Use case - To enable alt_password for the tests running in PTF where there is a reboot/upgrade leading to deletion of SSH key and known hosts file inside DUT.
Note that the tests running on sonic-mgmt container have SSH retry support for device password and alt_password.
 
The error seen when key is deleted and default password does not work:
```
2020-12-15 00:47:24 : --------------------------------------------------
2020-12-15 00:47:24 : --------------------------------------------------
2020-12-15 00:47:24 : Fails:
2020-12-15 00:47:24 : --------------------------------------------------
2020-12-15 00:47:24 : FAILED:dut:Sonic upgrade failed. Target=SONiC-OS-master.586-e010d83f Current=
2020-12-15 00:47:24 : FAILED:dut:Longest downtime period must be less then 30 seconds. It was 0:02:48.229600
2020-12-15 00:47:24 : ==================================================
2020-12-15 00:47:24 : Disabling arp_responder

00:47:20.692  paramiko.transport: INFO    : Connected (version 2.0, client OpenSSH_7.9p1)
00:47:20.775  paramiko.transport: INFO    : Authentication (publickey) failed.
00:47:24.268  paramiko.transport: INFO    : Authentication (password) failed.
00:47:24.293  device_connection: ERROR   : SSH Command failed with message: Authentication failed.
00:47:25.917  root      : INFO    : *** TEST RUN END  : Tue Dec 15 00:47:25 2020
00:47:25.917  dataplane : INFO    : Thread exit
```

#### How did you do it?
Added retry mechanism when `AuthenticationException` is hit when trying the default password.
Fixed the exception catch sequence leading to auth errors being caught by `SSHException`.

Fixed an import error and typo.

#### How did you verify/test it?

Tested with the fix:
```
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
03:03:39 INFO test_upgrade_path.py:test_upgrade_path:156: Test upgrade path from https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image/580/artifact/target/sonic-vs.bin to https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image/lastSuccessfulBuild/artifact/target/sonic-vs.bin
03:03:39 INFO test_upgrade_path.py:test_upgrade_path:158: Installing https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image/580/artifact/target/sonic-vs.bin
03:04:53 INFO reboot.py:reboot:121: waiting for ssh to drop
03:04:53 INFO reboot.py:execute_reboot_command:105: rebooting with command "reboot"
03:05:03 INFO reboot.py:reboot:139: waiting for ssh to startup
03:06:09 INFO reboot.py:reboot:150: ssh has started up
03:06:09 INFO reboot.py:reboot:152: waiting for switch to initialize
03:08:09 INFO reboot.py:reboot:180: cold reboot finished
03:08:13 INFO reboot.py:reboot:183: DUT up since 2020-12-15 03:05:38
03:08:14 INFO test_upgrade_path.py:test_upgrade_path:165: Upgrading to https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image/lastSuccessfulBuild/artifact/target/sonic-vs.bin
03:09:29 INFO ssh_utils.py:prepare_testbed_ssh_keys:17: Remove old keys from ptfhost
03:09:33 INFO ssh_utils.py:prepare_testbed_ssh_keys:26: Generate public key for ptf host
PASSED                                                                                                                                                                   [100%]
------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------
```

From paramiko log, the 2nd attempt at login with alt_password is successful
```
03:14:28.850  paramiko.transport: INFO    : Connected (version 2.0, client OpenSSH_7.9p1)
03:14:28.927  paramiko.transport: INFO    : Authentication (publickey) failed.
03:14:32.421  paramiko.transport: INFO    : Authentication (password) failed.
03:14:32.447  device_connection: ERROR   : SSH Authentication failure with message: Authentication failed.
03:14:32.576  paramiko.transport: INFO    : Connected (version 2.0, client OpenSSH_7.9p1)
03:14:32.648  paramiko.transport: INFO    : Authentication (publickey) failed.
03:14:32.682  paramiko.transport: INFO    : Authentication (password) successful!
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
