### PR TITLE
Adding non-broadcast packet testcases to test_vlan.py

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -345,3 +345,112 @@ def test_vlan_tc3_send_invalid_vid(ptfadapter, vlan_ports_list):
         testutils.send(ptfadapter, src_port, invalid_tagged_pkt)
         logger.info("Check on " + str(dst_ports) + "...")
         testutils.verify_no_packet_any(ptfadapter, masked_invalid_tagged_pkt, dst_ports)
+
+
+@pytest.mark.bsl
+def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
+    """
+    Test case #4
+    Send packets w/ src and dst specified over tagged ports in vlan
+    Verify that bidirectional communication between two tagged ports work
+    """
+    duthost.command('sonic-clear fdb all')  # clear mac learning
+
+    vlan_ids = vlan_ports_list[0]['permit_vlanid'].keys()
+    tagged_test_vlan = vlan_ids[0]
+    untagged_test_vlan = vlan_ids[1]
+
+    ports_for_test = []
+
+    for vlan_port in vlan_ports_list:
+        if vlan_port['pvid'] != tagged_test_vlan:
+            ports_for_test.append(vlan_port['port_index'][0])
+
+    # take two tagged ports for test
+    src_port = ports_for_test[0]
+    dst_port = ports_for_test[-1]
+
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port)
+    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port)
+
+    transmit_tagged_pkt = build_non_broadcast_packet(vlan_id=tagged_test_vlan, src_mac=src_mac, dst_mac=dst_mac)
+    return_transmit_tagged_pkt = build_non_broadcast_packet(vlan_id=tagged_test_vlan, src_mac=dst_mac, dst_mac=src_mac)
+
+    logger.info("Tagged packet to be sent from {} to {}".format(src_mac, dst_mac))
+
+    testutils.send(ptfadapter, src_port, transmit_tagged_pkt)
+
+    result_dst_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=dst_port,
+                                      timeout=1, exp_pkt=transmit_tagged_pkt)
+
+    if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
+        logger.info("One Way Tagged Packet Transmission Works")
+    else:
+        ptfadapter.fail("Expected packet was not received")
+
+    logger.info("Untagged packet to be sent from {} to {}".format(dst_mac, src_mac))
+
+    testutils.send(ptfadapter, dst_port, return_transmit_tagged_pkt)
+
+    result_src_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=src_port,
+                                      timeout=1, exp_pkt=return_transmit_tagged_pkt)
+
+    if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
+        logger.info("Two Way Tagged Packet Transmission Works")
+    else:
+        ptfadapter.fail("Expected packet was not received")
+
+
+@pytest.mark.bsl
+def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
+    """
+    Test case #5
+    Send packets w/ src and dst specified over untagged ports in vlan
+    Verify that bidirectional communication between two untagged ports work
+    """
+
+    duthost.command('sonic-clear fdb all')  # clear mac learning
+
+    vlan_ids = vlan_ports_list[0]['permit_vlanid'].keys()
+    tagged_test_vlan = vlan_ids[0]
+    untagged_test_vlan = vlan_ids[1]
+
+    ports_for_test = []
+
+    for vlan_port in vlan_ports_list:
+        if vlan_port['pvid'] != tagged_test_vlan:
+            ports_for_test.append(vlan_port['port_index'][0])
+
+    # take two tagged ports for test
+    src_port = ports_for_test[0]
+    dst_port = ports_for_test[-1]
+
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port)
+    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port)
+
+    transmit_untagged_pkt = build_non_broadcast_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
+    return_transmit_untagged_pkt = build_non_broadcast_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
+
+    logger.info("Untagged packet to be sent from {} to {}".format(src_mac, dst_mac))
+
+    testutils.send(ptfadapter, src_port, transmit_untagged_pkt)
+
+    result_dst_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=dst_port,
+                                      timeout=1, exp_pkt=transmit_untagged_pkt)
+
+    if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
+        logger.info("One Way Untagged Packet Transmission Works")
+    else:
+        ptfadapter.fail("Expected packet was not received")
+
+    logger.info("Untagged packet to be sent from {} to {}".format(dst_mac, src_mac))
+
+    testutils.send(ptfadapter, dst_port, return_transmit_untagged_pkt)
+
+    result_src_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=src_port,
+                                      timeout=1, exp_pkt=return_transmit_untagged_pkt)
+
+    if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
+        logger.info("Two Way Untagged Packet Transmission Works")
+    else:
+        ptfadapter.fail("Expected packet was not received")

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -231,6 +231,20 @@ def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff
                                 ip_ttl=ttl)
     return pkt
 
+def build_non_broadcast_packet(vlan_id, src_mac, dst_mac,
+                        src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
+
+    pkt = testutils.simple_icmp_packet(pktlen=100 if vlan_id == 0 else 104,
+                                eth_dst=dst_mac,
+                                eth_src=src_mac,
+                                dl_vlan_enable=False if vlan_id == 0 else True,
+                                vlan_vid=vlan_id,
+                                vlan_pcp=0,
+                                ip_src=src_ip,
+                                ip_dst=dst_ip,
+                                ip_ttl=ttl)
+    return pkt
+
 def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], device_number=0, timeout=1):
     for port in ports:
         result = testutils.dp_poll(test, device_number=device_number, port_number=port,

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -374,7 +374,7 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=dst_mac, dst_mac=src_mac)
 
-    logger.info ("Tagged packet to be sent from {} to {}".format(src_mac, dst_mac))
+    logger.info ("Tagged packet to be sent from port {} to port {}".format(src_port, dst_port))
 
     testutils.send(ptfadapter, src_port, transmit_tagged_pkt)
 
@@ -383,10 +383,11 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
 
     if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
         logger.info ("One Way Tagged Packet Transmission Works")
+        logger.info ("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
     else:
-        ptfadapter.fail("Expected packet was not received")
+        test.fail("Expected packet was not received")
 
-    logger.info ("Tagged packet to be sent from {} to {}".format(dst_mac, src_mac))
+    logger.info ("Tagged packet to be sent from port {} to port {}".format(dst_port, src_port))
 
     testutils.send(ptfadapter, dst_port, return_transmit_tagged_pkt)
 
@@ -395,8 +396,9 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
 
     if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
         logger.info ("Two Way Tagged Packet Transmission Works")
+        logger.info ("Tagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
     else:
-        ptfadapter.fail("Expected packet was not received")
+        test.fail("Expected packet was not received")
 
 @pytest.mark.bsl
 def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
@@ -425,7 +427,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
 
-    logger.info ("Untagged packet to be sent from {} to {}".format(src_mac, dst_mac))
+    logger.info ("Untagged packet to be sent from port {} to port {}".format(src_port, dst_port))
 
     testutils.send(ptfadapter, src_port, transmit_untagged_pkt)
 
@@ -434,10 +436,11 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
 
     if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
         logger.info ("One Way Untagged Packet Transmission Works")
+        logger.info ("Untagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
     else:
-        ptfadapter.fail("Expected packet was not received")
+        test.fail("Expected packet was not received")
 
-    logger.info ("Untagged packet to be sent from {} to {}".format(dst_mac, src_mac))  
+    logger.info ("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))  
 
     testutils.send(ptfadapter, dst_port, return_transmit_untagged_pkt)
 
@@ -447,5 +450,6 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
 
     if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
         logger.info ("Two Way Untagged Packet Transmission Works")
+        logger.info ("Untagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
     else:
-        ptfadapter.fail("Expected packet was not received")
+        test.fail("Expected packet was not received")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
To test bidirectional (non-broadcast) packet transmission on tagged and untagged ports  within the same VLAN
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To test bidirectional packet transmission on tagged and untagged ports within the same VLAN

#### How did you do it?

Send untagged and tagged (non-broadcast) packet bidirectionally across two ports

#### How did you verify/test it?

Tested on PTF testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
