### PR TITLE
[drop counters] Change test_egress_drop_on_down_link test logic

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -150,10 +150,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
 
 @pytest.fixture
 def rif_port_down(duthosts, rand_one_dut_hostname, setup, fanouthosts, loganalyzer):
-    """Shut RIF interface and return neighbor IP address attached to this interface.
-
-    The RIF member is shut from the fanout side so that the ARP entry remains in
-    place on the DUT."""
+    """Shut RIF interface and return neighbor IP address attached to this interface."""
     duthost = duthosts[rand_one_dut_hostname]
     wait_after_ports_up = 30
 


### PR DESCRIPTION
Signed-off-by: Antonina Melnyk antoninax.melnyk@intel.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Change test case logic and check that packets are not dropped

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test_egress_drop_on_down_link test case was not passing. After investigation, I figured out that this is because when the test is shutting the neighbor link the ARP entry for that interface is cleared, so the packets destined for the neighbor IP hit the default route, and the packets are not dropped. Removing ARP entry after interface going down is normal behavior.

#### How did you do it?
Change test case logic and check that packets are not dropped.

#### How did you verify/test it?
Run it locally

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Documentation is updated in [PR#725](https://github.com/Azure/SONiC/pull/725)  to SONiC repository