### PR TITLE
[Sub-ports] Added new sub-ports test cases

### DIFF
--- a/tests/sub_port_interfaces/Sub-ports-test-plan.md
+++ b/tests/sub_port_interfaces/Sub-ports-test-plan.md
@@ -1,6 +1,6 @@
 # Sub-port interfaces Test Plan
 
-## Rev 0.1
+## Rev 0.3
 
 - [Revision](#revision)
 - [Overview](#overview)
@@ -10,13 +10,17 @@
 - [Test Cases](#Test-cases)
   - [test_packet_routed_with_valid_vlan](#Test-case-test_packet_routed_with_valid_vlan)
   - [test_packet_routed_with_invalid_vlan](#Test-case-test_packet_routed_with_invalid_vlan)
+  - [test_admin_status_down_disables_forwarding](#Test-case-test_admin_status_down_disables_forwarding)
+  - [test_max_numbers_of_sub_ports](#Test-case-test_max_numbers_of_sub_ports)
+  - [test_mtu_inherited_from_parent_port](#Test-case-test_mtu_inherited_from_parent_port)
+  - [test_vlan_config_impact](#Test-case-test_vlan_config_impact)
 
 
 ## Revision
 
 | Rev |     Date    |       Author             | Change Description                 |
 |:---:|:-----------:|:-------------------------|:-----------------------------------|
-| 0.1 |  30/11/2020 | Intel: Oleksandr Kozodoi |          Initial version           |
+| 0.3 |  02/23/2021 | Intel: Oleksandr Kozodoi |          Initial version           |
 
 
 ## Overview
@@ -31,12 +35,12 @@ Purpose of the test is to verify a SONiC switch system correctly performs sub-po
 
 ## Testbed
 
-Supported topologies: t0
+Supported topologies: t0, t1
 
 ## Setup configuration
 
 Each sub-ports test case needs traffic transmission.
-Traffic starts transmission, if DUT and PTF directly connected interfaces have the same VLAN IDs. So we need configure correct sub-ports on the DUT and PTF.
+Traffic starts transmission, if DUT and PTF directly connected interfaces have the same VLAN IDs. So we need configure correct sub-ports on the DUT and PTF. 
 
 For example the customized testbed with applied T0 topo for test_packet_routed test case looks as follows:
 
@@ -58,7 +62,7 @@ For example the customized testbed with applied T0 topo for test_packet_routed t
       |_________________________________|
 
 ```
-Port mapping:
+#### Port mapping for port:
 | DUT        |             |  PTF       |             |
 |:----------:|:-----------:|:-----------|:------------|
 |**Sub-port**|**IP**       |**Sub-port**|**IP**       |
@@ -67,6 +71,15 @@ Port mapping:
 |Ethernet8.10|172.16.4.1/30|eth2.10     |172.16.4.2/30|
 |Ethernet8.20|172.16.4.5/30|eth2.20     |172.16.4.6/30|
 
+#### Port mapping for port in LAG:
+| DUT        |             |  PTF       |             |
+|:----------:|:-----------:|:-----------|:------------|
+|**Sub-port**|**IP**       |**Sub-port**|**IP**       |
+|PortChannel1.10|172.16.0.1/30|bond1.10     |172.16.0.2/30|
+|PortChannel1.20|172.16.0.5/30|bond1.20     |172.16.0.6/30|
+|PortChannel2.10|172.16.4.1/30|bond2.10     |172.16.4.2/30|
+|PortChannel2.20|172.16.4.5/30|bond2.20     |172.16.4.6/30|
+
 After end of the test session teardown procedure turns testbed to the initial state.
 
 ## Python scripts to setup and run test
@@ -74,6 +87,8 @@ After end of the test session teardown procedure turns testbed to the initial st
 Sub-ports test suite is located in tests/sub_port_interfaces folder. There is one files test_sub_port_interfaces.py
 
 ### Setup of DUT switch
+
+Parent ports of sub-ports are members of Vlan1000 in the t0 topology. So we need to remove parent ports from Vlan1000 before tests running.
 
 During setup procedure python mgmt scripts perform DUT configuration via jinja template to convert it in to the JSON file containing configuration to be pushed to the SONiC config DB via sonic-cfggen. Setup procedure configures sub-port interfaces with fixture ```define_sub_ports_configuration```.
 
@@ -90,6 +105,7 @@ sub_port_config.j2
     }
 }
 ```
+Also, all test cases support LAG ports. So we need to configure additional PortChannel ports on the DUT and bond ports on the PTF before test running. We should use ```create_lag_port``` function and ```create_bond_port``` function for this. [Port mapping for port in LAG](#Port-mapping-for-port-in-LAG).
 
 ## Test cases
 
@@ -173,6 +189,7 @@ Validates that admin status DOWN disables packet forwarding.
 
 - reload_dut_config function: reload DUT configuration
 - reload_ptf_config function: remove all sub-ports configuration
+- teardown_test_class function: reload DUT configuration after running of test suite
 
 ## Test case test_max_numbers_of_sub_ports
 
@@ -198,9 +215,6 @@ Validates that 256 sub-ports can be created per port or LAG.
 
 - reload_dut_config function: reload DUT configuration
 - reload_ptf_config function: remove all sub-ports configuration
-
-### NOTE
-The running of the test case takes about 80 minutes.
 
 ## Test case test_mtu_inherited_from_parent_port
 

--- a/tests/sub_port_interfaces/Sub-ports-test-plan.md
+++ b/tests/sub_port_interfaces/Sub-ports-test-plan.md
@@ -14,9 +14,9 @@
 
 ## Revision
 
-| Rev |     Date    |       Author           | Change Description                 |
-|:---:|:-----------:|:-----------------------|:-----------------------------------|
-| 0.1 |  30/11/2020 | BFN: Oleksandr Kozodoi |          Initial version           |
+| Rev |     Date    |       Author             | Change Description                 |
+|:---:|:-----------:|:-------------------------|:-----------------------------------|
+| 0.1 |  30/11/2020 | Intel: Oleksandr Kozodoi |          Initial version           |
 
 
 ## Overview
@@ -135,6 +135,113 @@ DUT and PTF directly connected interfaces have different VLAN IDs
 - Create ICMP packet.
 - Send ICMP request packet from PTF to DUT.
 - Verify that DUT doesn't sends ICMP reply packet to PTF.
+
+### Test teardown
+
+- reload_dut_config function: reload DUT configuration
+- reload_ptf_config function: remove all sub-ports configuration
+
+## Test case test_admin_status_down_disables_forwarding
+
+### Test objective
+
+Validates that admin status DOWN disables packet forwarding.
+
+### Test set up
+- apply_config_on_the_dut fixture(scope="function"): enable and configures sub-port interfaces on the DUT
+- apply_config_on_the_ptf fixture(scope="function"): enable and configures sub-port interfaces on the PTF
+
+### Test steps
+
+- Setup configuration of sub-ports on the DUT.
+- Setup configuration of sub-ports on the PTF.
+- Shutdown sub-ports on the DUT
+- Create ICMP packet.
+- Send ICMP request packet from PTF to DUT.
+- Verify that DUT doesn't send ICMP reply packet to PTF.
+- Create ICMP packet.
+- Send ICMP request packet from PTF to another sub-port of DUT.
+- Verify that DUT sends ICMP reply packet to PTF.
+- Startup sub-port on the DUT
+- Create ICMP packet.
+- Send ICMP request packet from PTF to DUT.
+- Verify that DUT sends ICMP reply packet to PTF.
+- Clear configuration of sub-ports on the DUT.
+- Clear configuration of sub-ports on the PTF.
+
+### Test teardown
+
+- reload_dut_config function: reload DUT configuration
+- reload_ptf_config function: remove all sub-ports configuration
+
+## Test case test_max_numbers_of_sub_ports
+
+### Test objective
+
+Validates that 256 sub-ports can be created per port or LAG.
+
+### Test set up
+- apply_config_on_the_dut fixture(scope="function"): enable and configures sub-port interfaces on the DUT
+- apply_config_on_the_ptf fixture(scope="function"): enable and configures sub-port interfaces on the PTF
+
+### Test steps
+
+- Setup configuration of 256 sub-ports on the DUT.
+- Setup configuration of 256 sub-ports on the PTF.
+- Create ICMP packet.
+- Send ICMP request packet from PTF to DUT.
+- Verify that DUT sends ICMP reply packet to PTF.
+- Clear configuration of sub-ports on the DUT.
+- Clear configuration of sub-ports on the PTF.
+
+### Test teardown
+
+- reload_dut_config function: reload DUT configuration
+- reload_ptf_config function: remove all sub-ports configuration
+
+### NOTE
+The running of the test case takes about 80 minutes.
+
+## Test case test_mtu_inherited_from_parent_port
+
+### Test objective
+
+Validates that MTU settings of sub-ports inherited from parent port.
+
+### Test set up
+- apply_config_on_the_dut fixture(scope="function"): enable and configures sub-port interfaces on the DUT
+
+### Test steps
+
+- Setup correct configuration of sub-ports on the DUT.
+- Get MTU value of sub-port
+- Get MTU value of parent port
+- Clear configuration of sub-ports on the DUT.
+
+### Test teardown
+
+- reload_dut_config function: reload DUT configuration
+
+## Test case test_vlan_config_impact
+
+### Test objective
+
+Validates that removal of VLAN doesn't impact sub-port RIF with same VLAN ID.
+
+### Test set up
+- apply_config_on_the_dut fixture(scope="function"): enable and configures sub-port interfaces on the DUT
+- apply_config_on_the_ptf fixture(scope="function"): enable and configures sub-port interfaces on the PTF
+
+### Test steps
+
+- Setup correct configuration of sub-ports on the DUT.
+- Create a VLAN RIF with the same VLAN ID of sub-port.
+- Added PortChannel interface to VLAN members 
+- Delete a VLAN RIF.
+- Make sure sub-port is available in redis-db.
+- Verify that DUT sends ICMP reply packet to PTF.
+- Clear configuration of sub-ports on the DUT.
+- Clear configuration of sub-ports on the PTF.
 
 ### Test teardown
 

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -42,6 +42,10 @@ def define_sub_ports_configuration(request, duthost, ptfhost):
     if 'invalid' in request.node.name:
         vlan_ranges_ptf = range(11, 31, 10)
 
+    if 'max_numbers' in request.node.name:
+        vlan_ranges_dut = range(1, 257)
+        vlan_ranges_ptf = range(1, 257)
+
     interface_ranges = range(1, 2)
     ip_subnet = u'172.16.0.0/16'
     prefix = 30

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -1,5 +1,6 @@
 import os
 import ipaddress
+import time
 import jinja2
 
 import pytest
@@ -10,10 +11,13 @@ from tests.common.utilities import wait_until
 from sub_ports_helpers import DUT_TMP_DIR
 from sub_ports_helpers import TEMPLATE_DIR
 from sub_ports_helpers import SUB_PORTS_TEMPLATE
-from sub_ports_helpers import check_sub_ports_creation
+from sub_ports_helpers import check_sub_port
+from sub_ports_helpers import remove_member_from_vlan
+from sub_ports_helpers import get_port
+from sub_ports_helpers import remove_sub_port
+from sub_ports_helpers import remove_lag_port
 
-
-@pytest.fixture
+@pytest.fixture(params=['port', 'port_in_lag'])
 def define_sub_ports_configuration(request, duthost, ptfhost):
     """
     Define configuration of sub-ports for TC run
@@ -39,6 +43,7 @@ def define_sub_ports_configuration(request, duthost, ptfhost):
             }
         }
     """
+    sub_ports_config = {}
     vlan_ranges_dut = range(10, 30, 10)
     vlan_ranges_ptf = range(10, 30, 10)
 
@@ -49,20 +54,23 @@ def define_sub_ports_configuration(request, duthost, ptfhost):
         vlan_ranges_dut = range(1, 257, 64)
         vlan_ranges_ptf = range(1, 257, 64)
 
-    interface_ranges = range(1, 2)
+        # Linux has the limitation of 15 characters on an interface name,
+        # but name of LAG port should have prefix 'PortChannel' and suffix
+        # '<0-9999>' on SONiC. So max length of LAG port suffix have be 3 characters
+        # For example: 'PortChannel1.96'
+        if request.param == 'port_in_lag':
+            vlan_ranges_dut = range(1, 97, 24)
+            vlan_ranges_ptf = range(1, 97, 24)
+
+    interface_ranges = range(1, 3)
     ip_subnet = u'172.16.0.0/16'
     prefix = 30
     subnet = ipaddress.ip_network(ip_subnet)
 
-    cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-    config_vlan_members = cfg_facts['VLAN_MEMBER']['Vlan1000']
-    config_port_indices = {v: k for k, v in cfg_facts['port_index_map'].items() if k in config_vlan_members and v in interface_ranges}
-    ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
-    ptf_ports = [v for k, v in ptf_ports_available_in_topo.items() if k in interface_ranges]
+    config_port_indices, ptf_ports = get_port(duthost, ptfhost, interface_ranges, request.param)
 
     subnets = [i for i, _ in zip(subnet.subnets(new_prefix=22), config_port_indices)]
 
-    sub_ports_config = {}
     for port, ptf_port, subnet in zip(config_port_indices.values(), ptf_ports, subnets):
         for vlan_id_dut, vlan_id_ptf, net in zip(vlan_ranges_dut, vlan_ranges_ptf, subnet.subnets(new_prefix=30)):
             hosts_list = [i for i in net.hosts()]
@@ -74,17 +82,20 @@ def define_sub_ports_configuration(request, duthost, ptfhost):
 
     yield {
         'sub_ports': sub_ports_config,
+        'dut_ports': config_port_indices,
+        'ptf_ports': ptf_ports
     }
 
 
 @pytest.fixture
-def apply_config_on_the_dut(define_sub_ports_configuration, duthost):
+def apply_config_on_the_dut(define_sub_ports_configuration, duthost, reload_dut_config):
     """
     Apply Sub-ports configuration on the DUT and remove after tests
 
     Args:
-        setup_env: Dictonary of parameters for configuration DUT
+        define_sub_ports_configuration: Dictonary of parameters for configuration DUT
         duthost: DUT host object
+        reload_dut_config: fixture for teardown of DUT
 
     Yields:
         Dictonary of parameters for configuration DUT and PTF host
@@ -93,6 +104,11 @@ def apply_config_on_the_dut(define_sub_ports_configuration, duthost):
         'sub_ports': define_sub_ports_configuration['sub_ports'],
     }
 
+    parent_port_list = [sub_port.split('.')[0] for sub_port in define_sub_ports_configuration['sub_ports'].keys()]
+
+    for port in set(parent_port_list):
+        remove_member_from_vlan(duthost, '1000', port)
+
     sub_ports_config_path = os.path.join(DUT_TMP_DIR, SUB_PORTS_TEMPLATE)
     config_template = jinja2.Template(open(os.path.join(TEMPLATE_DIR, SUB_PORTS_TEMPLATE)).read())
 
@@ -100,22 +116,22 @@ def apply_config_on_the_dut(define_sub_ports_configuration, duthost):
     duthost.copy(content=config_template.render(sub_ports_vars), dest=sub_ports_config_path)
     duthost.command('sonic-cfggen -j {} --write-to-db'.format(sub_ports_config_path))
 
-    py_assert(wait_until(3, 1, check_sub_ports_creation, duthost, sub_ports_vars['sub_ports']),
-                  "Some sub-ports were not created")
+    for sub_port in sub_ports_vars['sub_ports']:
+        py_assert(wait_until(3, 1, check_sub_port, duthost, sub_port),
+                  "Sub-port {} was not created".format(sub_port))
 
     yield sub_ports_vars
-    reload_dut_config(duthost)
 
 
 @pytest.fixture
-def apply_config_on_the_ptf(define_sub_ports_configuration, ptfhost):
+def apply_config_on_the_ptf(define_sub_ports_configuration, ptfhost, reload_ptf_config):
     """
     Apply Sub-ports configuration on the PTF and remove after tests
 
     Args:
-        setup_env: Dictonary of parameters for configuration DUT
+        define_sub_ports_configuration: Dictonary of parameters for configuration DUT
         ptfhost: PTF host object
-
+        reload_ptf_config: fixture for teardown of PTF
     """
     sub_ports = define_sub_ports_configuration['sub_ports']
 
@@ -125,28 +141,68 @@ def apply_config_on_the_ptf(define_sub_ports_configuration, ptfhost):
         ptfhost.shell("ip address add {} dev {}".format(sub_port_info['neighbor_ip'], sub_port_info['neighbor_port']))
         ptfhost.shell("ip link set {} up".format(sub_port_info['neighbor_port']))
 
-    yield
-    reload_ptf_config(ptfhost, sub_ports)
 
-
-def reload_dut_config(duthost):
+@pytest.fixture
+def reload_dut_config(request, duthost, define_sub_ports_configuration):
     """
     DUT's configuration reload on teardown
 
     Args:
+        request: pytest request object
         duthost: DUT host object
-
+        define_sub_ports_configuration: Dictonary of parameters for configuration DUT
     """
-    config_reload(duthost)
+    yield
+    sub_ports = define_sub_ports_configuration['sub_ports']
+    dut_ports = define_sub_ports_configuration['dut_ports']
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+
+    for sub_port, sub_port_info in sub_ports.items():
+        remove_sub_port(duthost, sub_port, sub_port_info['ip'])
+
+    if 'port_in_lag' in request.node.name:
+        for lag_port in dut_ports.values():
+            remove_lag_port(duthost, cfg_facts, lag_port)
+
+    duthost.shell('sudo config load -y /etc/sonic/config_db.json')
 
 
-def reload_ptf_config(ptfhost, sub_ports):
+@pytest.fixture
+def reload_ptf_config(request, ptfhost, define_sub_ports_configuration):
     """
     PTF's configuration reload on teardown
 
     Args:
+        request: pytest request object
         ptfhost: PTF host object
+        define_sub_ports_configuration: Dictonary of parameters for configuration DUT
     """
+    yield
+    sub_ports = define_sub_ports_configuration['sub_ports']
+
     for sub_port_info in sub_ports.values():
         ptfhost.shell("ip address del {} dev {}".format(sub_port_info['neighbor_ip'], sub_port_info['neighbor_port']))
         ptfhost.shell("ip link del {}".format(sub_port_info['neighbor_port']))
+
+    if 'port_in_lag' in request.node.name:
+        ptf_ports = define_sub_ports_configuration['ptf_ports']
+        for bond_port, port_name in ptf_ports.items():
+            ptfhost.shell("ip link set {} nomaster".format(bond_port))
+            ptfhost.shell("ip link set {} nomaster".format(port_name))
+            ptfhost.shell("ip link set {} up".format(port_name))
+            ptfhost.shell("ip link del {}".format(bond_port))
+
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def teardown_test_class(duthost):
+    """
+    Reload DUT configuration after running of test suite
+
+    Args:
+        duthost: DUT host object
+    """
+    yield
+    config_reload(duthost)

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -18,7 +18,7 @@ from sub_ports_helpers import remove_sub_port
 from sub_ports_helpers import remove_lag_port
 
 @pytest.fixture(params=['port', 'port_in_lag'])
-def define_sub_ports_configuration(request, duthost, ptfhost):
+def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
     """
     Define configuration of sub-ports for TC run
 

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -17,6 +17,20 @@ from sub_ports_helpers import get_port
 from sub_ports_helpers import remove_sub_port
 from sub_ports_helpers import remove_lag_port
 
+
+def pytest_addoption(parser):
+    """
+    Adds options to pytest that are used by the sub-ports tests.
+    """
+    parser.addoption(
+        "--max_numbers_of_sub_ports",
+        action="store",
+        type=int,
+        default=4,
+        help="Max numbers of sub-ports for test_max_numbers_of_sub_ports test case",
+    )
+
+
 @pytest.fixture(params=['port', 'port_in_lag'])
 def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
     """
@@ -44,6 +58,7 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
         }
     """
     sub_ports_config = {}
+    max_numbers_of_sub_ports = request.config.getoption("--max_numbers_of_sub_ports")
     vlan_ranges_dut = range(10, 30, 10)
     vlan_ranges_ptf = range(10, 30, 10)
 
@@ -51,16 +66,17 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
         vlan_ranges_ptf = range(11, 31, 10)
 
     if 'max_numbers' in request.node.name:
-        vlan_ranges_dut = range(1, 257, 64)
-        vlan_ranges_ptf = range(1, 257, 64)
+        vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
+        vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)
 
         # Linux has the limitation of 15 characters on an interface name,
         # but name of LAG port should have prefix 'PortChannel' and suffix
         # '<0-9999>' on SONiC. So max length of LAG port suffix have be 3 characters
-        # For example: 'PortChannel1.96'
+        # For example: 'PortChannel1.99'
         if request.param == 'port_in_lag':
-            vlan_ranges_dut = range(1, 97, 24)
-            vlan_ranges_ptf = range(1, 97, 24)
+            max_numbers_of_sub_ports = max_numbers_of_sub_ports if max_numbers_of_sub_ports <= 99 else 99
+            vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
+            vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)
 
     interface_ranges = range(1, 3)
     ip_subnet = u'172.16.0.0/16'

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -227,6 +227,13 @@ def check_sub_port(duthost, sub_port):
     return sub_port in out
 
 
+def check_sub_ports_creation(duthost, sub_ports):
+    """
+    """
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    return set(sub_ports) == set(config_facts['VLAN_SUB_INTERFACE'].keys())
+
+
 def get_mac_dut(duthost, interface):
     """
     Get MAC address of DUT interface
@@ -266,10 +273,8 @@ def get_port_mtu(duthost, interface):
     out = ''
 
     if '.' in interface:
-        pattern = re.compile(r'%s\s+\S+\s+(\d+)' % interface)
-        out = duthost.shell("show subinterface status {}".format(interface))["stdout"]
-    else:
-        pattern = re.compile(r'%s\s+\S+\s+\S+\s+(\d+)' % interface)
-        out = duthost.shell("show interface status {}".format(interface))["stdout"]
+        out = duthost.show_and_parse("show subinterface status {}".format(interface))
+        return out[0]['mtu']
 
-    return pattern.search(out).group(1)
+    out = duthost.show_and_parse("show interface status {}".format(interface))
+    return out[0]['mtu']

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -148,23 +148,10 @@ def setup_vlan(duthost, vlan_id):
         duthost: DUT host object
         vlan_id: VLAN id
     """
-    cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-    portchannel_interfaces = cfg_facts.get('PORTCHANNEL_INTERFACE', {})
-
     duthost.shell('config vlan add %s' % vlan_id)
-    for portchannel, ips in portchannel_interfaces.items():
-        duthost.shell('config interface shutdown {}'.format(portchannel))
-        for ip in ips:
-            duthost.shell('config interface ip remove {} {}'.format(portchannel, ip))
-
-        duthost.shell('config vlan member add --untagged {} {}'.format(vlan_id, portchannel))
 
     pytest_assert(wait_until(3, 1, __check_vlan, duthost, vlan_id),
                   "VLAN RIF Vlan{} didn't create as expected".format(vlan_id))
-
-    for portchannel in portchannel_interfaces.keys():
-        pytest_assert(wait_until(3, 1, __check_vlan_member, duthost, vlan_id, portchannel),
-                      "VLAN RIF Vlan{} doesn't have {} member as expected".format(vlan_id, portchannel))
 
 
 def __check_vlan(duthost, vlan_id, removed=False):

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -2,8 +2,8 @@
 Tests sub-port interfaces in SONiC.
 """
 
-import pytest
 import random
+import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from sub_ports_helpers import generate_and_verify_traffic
@@ -15,7 +15,7 @@ from sub_ports_helpers import remove_vlan
 from sub_ports_helpers import check_sub_port
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0', 't1')
 ]
 
 class TestSubPorts(object):
@@ -23,7 +23,7 @@ class TestSubPorts(object):
     TestSubPorts class for testing sub-port interfaces
     """
 
-    def test_packet_routed_with_valid_vlan(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+    def test_packet_routed_with_valid_vlan(self, duthost, ptfhost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
         """
         Validates that packet routed if sub-ports have valid VLAN ID.
 
@@ -153,7 +153,8 @@ class TestSubPorts(object):
         sub_ports = apply_config_on_the_dut['sub_ports']
         sub_ports_new[sub_ports.keys()[0]] = sub_ports[sub_ports.keys()[0]]
         sub_ports_new[sub_ports.keys()[-1]] = sub_ports[sub_ports.keys()[-1]]
-        rand_sub_ports = sub_ports.keys()[random.randint(1, len(sub_ports))]
+
+        rand_sub_ports = sub_ports.keys()[random.randint(1, len(sub_ports)-1)]
         sub_ports_new[rand_sub_ports] = sub_ports[rand_sub_ports]
 
         for sub_port, value in sub_ports_new.items():
@@ -166,7 +167,7 @@ class TestSubPorts(object):
                                         pkt_action='fwd')
 
 
-    def test_mtu_inherited_from_parent_port(self, duthost, ptfadapter, apply_config_on_the_dut):
+    def test_mtu_inherited_from_parent_port(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
         """
         Validates that MTU settings of sub-ports inherited from parent port
 

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -4,7 +4,14 @@ Tests sub-port interfaces in SONiC.
 
 import pytest
 
+from tests.common.helpers.assertions import pytest_assert
 from sub_ports_helpers import generate_and_verify_traffic
+from sub_ports_helpers import get_port_mtu
+from sub_ports_helpers import shutdown_port
+from sub_ports_helpers import startup_port
+from sub_ports_helpers import setup_vlan
+from sub_ports_helpers import remove_vlan
+from sub_ports_helpers import check_sub_port
 
 pytestmark = [
     pytest.mark.topology('t0')
@@ -50,7 +57,7 @@ class TestSubPorts(object):
             2.) Setup different VLAN IDs on directly connected interfaces of sub-ports on the PTF.
             3.) Create ICMP packet.
             4.) Send ICMP request packet from PTF to DUT.
-            5.) Verify that DUT doesn't sends ICMP reply packet to PTF.
+            5.) Verify that DUT doesn't send ICMP reply packet to PTF.
             6.) Clear configuration of sub-ports on the DUT.
             7.) Clear configuration of sub-ports on the DUT.
 
@@ -66,3 +73,150 @@ class TestSubPorts(object):
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
                                         pkt_action='drop')
+
+
+    def test_admin_status_down_disables_forwarding(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+        """
+        Validates that admin status DOWN disables packet forwarding.
+
+        Test steps:
+            1.) Setup configuration of sub-ports on the DUT.
+            2.) Setup configuration of sub-ports on the PTF.
+            3.) Shutdown sub-ports on the DUT
+            4.) Create ICMP packet.
+            5.) Send ICMP request packet from PTF to DUT.
+            6.) Verify that DUT doesn't send ICMP reply packet to PTF.
+            7.) Create ICMP packet.
+            8.) Send ICMP request packet from PTF to another sub-port of DUT.
+            9.) Verify that DUT sends ICMP reply packet to PTF.
+            10.) Startup sub-port on the DUT
+            11.) Create ICMP packet.
+            12.) Send ICMP request packet from PTF to DUT.
+            13.) Verify that DUT sends ICMP reply packet to PTF.
+            14.) Clear configuration of sub-ports on the DUT.
+            15.) Clear configuration of sub-ports on the PTF.
+
+        Pass Criteria: PTF doesn't get ICMP reply packet from disabled sub-ports of DUT.
+        """
+        sub_ports = apply_config_on_the_dut['sub_ports']
+
+        for sub_port, value in sub_ports.items():
+            shutdown_port(duthost, sub_port)
+            generate_and_verify_traffic(duthost=duthost,
+                                        ptfadapter=ptfadapter,
+                                        src_port=value['neighbor_port'],
+                                        ip_src=value['neighbor_ip'],
+                                        dst_port=sub_port,
+                                        ip_dst=value['ip'],
+                                        pkt_action='drop')
+
+            for next_sub_port, next_value in sub_ports.items():
+                if next_sub_port != sub_port:
+                    generate_and_verify_traffic(duthost=duthost,
+                                                ptfadapter=ptfadapter,
+                                                src_port=next_value['neighbor_port'],
+                                                ip_src=next_value['neighbor_ip'],
+                                                dst_port=next_sub_port,
+                                                ip_dst=next_value['ip'],
+                                                pkt_action='fwd')
+
+            startup_port(duthost, sub_port)
+            generate_and_verify_traffic(duthost=duthost,
+                                        ptfadapter=ptfadapter,
+                                        src_port=value['neighbor_port'],
+                                        ip_src=value['neighbor_ip'],
+                                        dst_port=sub_port,
+                                        ip_dst=value['ip'],
+                                        pkt_action='fwd')
+
+
+    def test_max_numbers_of_sub_ports(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+        """
+        Validates that 256 sub-ports can be created per port or LAG
+
+        Test steps:
+            1.) Setup configuration of 256 sub-ports on the DUT.
+            2.) Setup configuration of 256 sub-ports on the PTF.
+            3.) Create ICMP packet.
+            4.) Send ICMP request packet from PTF to DUT.
+            5.) Verify that DUT sends ICMP reply packet to PTF.
+            6.) Clear configuration of sub-ports on the DUT.
+            7.) Clear configuration of sub-ports on the PTF.
+
+        Pass Criteria: PTF gets ICMP reply packet from DUT.
+
+        Note:
+            The running of the test case takes about 80 minutes.
+        """
+        sub_ports = apply_config_on_the_dut['sub_ports']
+
+        for sub_port, value in sub_ports.items():
+            generate_and_verify_traffic(duthost=duthost,
+                                        ptfadapter=ptfadapter,
+                                        src_port=value['neighbor_port'],
+                                        ip_src=value['neighbor_ip'],
+                                        dst_port=sub_port,
+                                        ip_dst=value['ip'],
+                                        pkt_action='fwd')
+
+
+    def test_mtu_inherited_from_parent_port(self, duthost, ptfadapter, apply_config_on_the_dut):
+        """
+        Validates that MTU settings of sub-ports inherited from parent port
+
+        Test steps:
+            1.) Setup correct configuration of sub-ports on the DUT.
+            3.) Get MTU value of sub-port
+            4.) Get MTU value of parent port
+            6.) Clear configuration of sub-ports on the DUT.
+
+        Pass Criteria: MTU settings of sub-ports inherited from parent port.
+        """
+        sub_ports = apply_config_on_the_dut['sub_ports']
+
+        for sub_port in sub_ports.keys():
+            sub_port_mtu = int(get_port_mtu(duthost, sub_port))
+            # Get name of parent port from name of sub-port
+            port = sub_port.split('.')[0]
+            port_mtu = int(get_port_mtu(duthost, port))
+
+            pytest_assert(sub_port_mtu == port_mtu, "MTU of {} doesn't inherit MTU of {}".format(sub_port, port))
+
+
+    def test_vlan_config_impact(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+        """
+        Validates that removal of VLAN doesn't impact sub-port RIF with same VLAN ID.
+
+        Test steps:
+            1.) Setup correct configuration of sub-ports on the DUT.
+            3.) Create a VLAN RIF with the same VLAN ID of sub-port.
+            4.) Added PortChannel interface to VLAN members.
+            5.) Delete a VLAN RIF.
+            6.) Make sure sub-port is available in redis-db.
+            7.) Verify that DUT sends ICMP reply packet to PTF.
+            8.) Clear configuration of sub-ports on the DUT.
+            9.) Clear configuration of sub-ports on the PTF.
+
+        Pass Criteria:
+            1.) Sub-port is available in redis-db.
+            2.) PTF gets ICMP reply packet from DUT.
+        """
+        sub_ports = apply_config_on_the_dut['sub_ports']
+
+        for sub_port, value in sub_ports.items():
+            # Get VLAN ID from name of sub-port
+            vlan_vid = int(sub_port.split('.')[1])
+            # Create a VLAN RIF
+            setup_vlan(duthost, vlan_vid)
+            # Delete a VLAN RIF
+            remove_vlan(duthost, vlan_vid)
+
+            pytest_assert(check_sub_port(duthost, sub_port), "Sub-port {} was deleted".format(sub_port))
+
+            generate_and_verify_traffic(duthost=duthost,
+                                        ptfadapter=ptfadapter,
+                                        src_port=value['neighbor_port'],
+                                        ip_src=value['neighbor_ip'],
+                                        dst_port=sub_port,
+                                        ip_dst=value['ip'],
+                                        pkt_action='fwd')

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -167,7 +167,7 @@ class TestSubPorts(object):
                                         pkt_action='fwd')
 
 
-    def test_mtu_inherited_from_parent_port(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+    def test_mtu_inherited_from_parent_port(self, duthost, apply_config_on_the_dut, apply_config_on_the_ptf):
         """
         Validates that MTU settings of sub-ports inherited from parent port
 

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -3,6 +3,7 @@ Tests sub-port interfaces in SONiC.
 """
 
 import pytest
+import random
 
 from tests.common.helpers.assertions import pytest_assert
 from sub_ports_helpers import generate_and_verify_traffic
@@ -148,9 +149,14 @@ class TestSubPorts(object):
         Note:
             The running of the test case takes about 80 minutes.
         """
+        sub_ports_new = dict()
         sub_ports = apply_config_on_the_dut['sub_ports']
+        sub_ports_new[sub_ports.keys()[0]] = sub_ports[sub_ports.keys()[0]]
+        sub_ports_new[sub_ports.keys()[-1]] = sub_ports[sub_ports.keys()[-1]]
+        rand_sub_ports = sub_ports.keys()[random.randint(1, len(sub_ports))]
+        sub_ports_new[rand_sub_ports] = sub_ports[rand_sub_ports]
 
-        for sub_port, value in sub_ports.items():
+        for sub_port, value in sub_ports_new.items():
             generate_and_verify_traffic(duthost=duthost,
                                         ptfadapter=ptfadapter,
                                         src_port=value['neighbor_port'],


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Added new sub-ports tests:

1. [test_admin_status_down_disables_forwarding](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/44ed7ecb8657ee109a6a25c10d44d46f60256d40/tests/sub_port_interfaces/Sub-ports-test-plan.md#test-case-test_admin_status_down_disables_forwarding)
2. [test_max_numbers_of_sub_ports](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/44ed7ecb8657ee109a6a25c10d44d46f60256d40/tests/sub_port_interfaces/Sub-ports-test-plan.md#test-case-test_max_numbers_of_sub_ports)
3. [test_mtu_inherited_from_parent_port](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/44ed7ecb8657ee109a6a25c10d44d46f60256d40/tests/sub_port_interfaces/Sub-ports-test-plan.md#test-case-test_mtu_inherited_from_parent_port)
4. [test_vlan_config_impact](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/44ed7ecb8657ee109a6a25c10d44d46f60256d40/tests/sub_port_interfaces/Sub-ports-test-plan.md#test-case-test_vlan_config_impact)

- Updated Test Plan
- Added support of LAG port
- Added support of t1 topology
- Changed pre-configuration of test cases
- Updated teardown of test cases

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Coverage of sub-ports feature by test cases to improve the quality of SONiC.
#### How did you do it?
Added new test cases to PyTest.
Implementation is based on the [Sub-ports design spec](https://github.com/Azure/SONiC/blob/master/doc/subport/sonic-sub-port-intf-hld.md)
#### How did you verify/test it?
`py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library sub_port_interfaces`
#### Any platform specific information?
SONiC Software Version: SONiC.master.130-dirty-20210221.030317
Distribution: Debian 10.8
Kernel: 4.19.0-12-2-amd64
Build commit: ce3b2cbf
Build date: Sun Feb 21 10:23:58 UTC 2021
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
#### Supported testbed topology if it's a new test case?
T0, T1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
