### PR TITLE
[pfc] Fix variable return type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -683,7 +683,7 @@ def generate_dut_feature_list(request):
     return ret if ret else empty
 
 def generate_priority_lists(request, prio_scope):
-    empty = None 
+    empty = []
 
     tbname = request.config.getoption("--testbed")
     if not tbname:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes the error seen during test case collection introduced by #2599. Initialize the variable as a list
https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-mgmt-testing/job/sonic-mgmt-pr/2462/consoleFull
```
____________________________________________________ ERROR collecting pfc/test_pfc_pause_lossless.py ______________________________________________________
/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:234: in pytest_pycollect_makeitem
    res = list(collector._genfunctions(name, obj))
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:410: in _genfunctions
    self.ihook.pytest_generate_tests(metafunc=metafunc)
/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
conftest.py:748: in pytest_generate_tests
    metafunc.parametrize("enum_dut_lossless_prio", generate_priority_lists(metafunc, 'lossless'))
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:1004: in parametrize
    function_definition=self.definition,
/usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:125: in _for_parametrize
    parameters = cls._parse_parametrize_parameters(argvalues, force_tuple)
/usr/local/lib/python2.7/dist-packages/_pytest/mark/structures.py:119: in _parse_parametrize_parameters
    ParameterSet.extract_from(x, force_tuple=force_tuple) for x in argvalues
E   TypeError: 'NoneType' object is not iterable
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Tried test case collection with the fix. No longer seeing the error