### PR TITLE
Try to disable apparmor for ntpd during add-topo

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -148,6 +148,19 @@
     sysctl_set: yes
   become: yes
 
+- name: Create link for disabling apparmor for ntpd
+  file:
+    src: /etc/apparmor.d/usr.sbin.ntpd
+    dest: /etc/apparmor.d/disable/usr.sbin.ntpd
+    state: link
+  become: yes
+  ignore_errors: yes
+
+- name: Disable apparmor for ntpd
+  command: apparmor_parser -R /etc/apparmor.d/usr.sbin.ntpd
+  become: yes
+  ignore_errors: yes
+
 - name: Setup external front port
   include_tasks: external_port.yml
   when: external_port is defined


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/Azure/sonic-buildimage/issues/5975

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This is to address the NTP testing failed issue reported here:
https://github.com/Azure/sonic-buildimage/issues/5975
The reason is that apparmor is enabled for ntpd. 

#### How did you do it?
The workaround is to always try to disable apparmor for ntpd during add-topo.
If disabling failed, generally it is because apparmor is not enabled for NTP on 
the test server. So, 'ignore_errors: yes' is added to the tasks.

#### How did you verify/test it?
Test run the added tasks on test servers:
```
- hosts: servers:&vm_host
  gather_facts: no
  tasks:

  - name: Create link for disabling apparmor for ntpd
    file:
      src: /etc/apparmor.d/usr.sbin.ntpd
      dest: /etc/apparmor.d/disable/usr.sbin.ntpd
      state: link
    become: yes
    ignore_errors: yes

  - name: Disable apparmor for ntpd
    command: apparmor_parser -R /etc/apparmor.d/usr.sbin.ntpd
    become: yes
    ignore_errors: yes
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
