### PR TITLE
[rdma] Tests pfc behavior on lossless and lossy priorites across reboots

### DIFF
--- a/tests/pfc/conftest.py
+++ b/tests/pfc/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tests.conftest import generate_port_lists, generate_priority_lists
+
+@pytest.fixture(autouse=True, scope="module")
+def rand_one_oper_up_intf(request):
+    """
+    Fixture that randomly selects one oper up interface
+
+    Args:
+        request (object): pytest request object
+
+    Yields:
+        interface (str): string containing 'hostname|selected intf'
+
+    """
+    oper_up_intfs = generate_port_lists(request, "oper_up_ports")
+    if oper_up_intfs:
+        yield random.sample(oper_up_intfs, 1)[0]
+    else:
+        yield 'unknown|unknown'
+
+@pytest.fixture(autouse=True, scope="module")
+def rand_lossless_prio(request):
+    """
+    Fixture that randomly selects a lossless priority
+
+    Args:
+        request (object): pytest request object
+
+    Yields:
+        lossless priority (str): string containing 'hostname|lossless priority'
+
+    """
+    lossless_prios = generate_priority_lists(request, "lossless")
+    if lossless_prios:
+        yield random.sample(lossless_prios, 1)[0]
+    else:
+        yield 'unknown|unknown'
+
+@pytest.fixture(autouse=True, scope="module")
+def rand_lossy_prio(request):
+    """
+    Fixture that randomly selects a lossy priority
+
+    Args:
+        request (object): pytest request object
+
+    Yields:
+        lossy priority (str): string containing 'hostname|lossy priority'
+
+    """
+    lossy_prios = generate_priority_lists(request, "lossy")
+    if lossy_prios:
+        yield random.sample(lossy_prios, 1)[0]
+    else:
+        yield 'unknown|unknown'

--- a/tests/pfc/test_pfc_pause_lossless.py
+++ b/tests/pfc/test_pfc_pause_lossless.py
@@ -1,14 +1,18 @@
+import logging
 import pytest
 
-from tests.common.helpers.assertions import pytest_require
+from files.helper import run_pfc_test
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list
+from tests.common.reboot import reboot
+from tests.common.utilities import wait_until
 
-from files.helper import run_pfc_test
+logger = logging.getLogger(__name__)
 
 @pytest.mark.topology("tgen")
 
@@ -67,7 +71,6 @@ def test_pfc_pause_single_lossless_prio(ixia_api,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True)
 
-
 def test_pfc_pause_multi_lossless_prio(ixia_api,
                                        ixia_testbed,
                                        conn_graph_facts,
@@ -105,6 +108,134 @@ def test_pfc_pause_multi_lossless_prio(ixia_api,
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
     bg_prio_list = lossy_prio_list
+
+    run_pfc_test(api=ixia_api,
+                 testbed_config=ixia_testbed,
+                 conn_data=conn_graph_facts,
+                 fanout_data=fanout_graph_facts,
+                 duthost=duthost,
+                 dut_port=dut_port,
+                 global_pause=False,
+                 pause_prio_list=pause_prio_list,
+                 test_prio_list=test_prio_list,
+                 bg_prio_list=bg_prio_list,
+                 prio_dscp_map=prio_dscp_map,
+                 test_traffic_pause=True)
+
+@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
+def test_pfc_pause_single_lossless_prio_reboot(ixia_api,
+                                               ixia_testbed,
+                                               conn_graph_facts,
+                                               fanout_graph_facts,
+                                               localhost,
+                                               duthosts,
+                                               rand_one_dut_hostname,
+                                               rand_one_oper_up_intf,
+                                               rand_lossless_prio,
+                                               all_prio_list,
+                                               prio_dscp_map,
+                                               reboot_type):
+    """
+    Test if PFC can pause a single lossless priority even after various types of reboot
+
+    Args:
+        ixia_api (pytest fixture): IXIA session
+        ixia_testbed (pytest fixture): L2/L3 config of a T0 testbed
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        localhost (pytest fixture): localhost handle
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_oper_up_intf (str): port to test, e.g., 's6100-1|Ethernet0'
+        rand_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
+        all_prio_list (pytest fixture): list of all the priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        reboot_type (str): reboot type to be issued on the DUT
+
+    Returns:
+        None
+    """
+
+    dut_hostname, dut_port = rand_one_oper_up_intf.split('|')
+    dut_hostname2, lossless_prio = rand_lossless_prio.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname == dut_hostname2,
+                   "Priority and port are not mapped to the expected DUT")
+
+    duthost = duthosts[rand_one_dut_hostname]
+    lossless_prio = int(lossless_prio)
+
+    pause_prio_list = [lossless_prio]
+    test_prio_list = [lossless_prio]
+    bg_prio_list = [p for p in all_prio_list]
+    bg_prio_list.remove(lossless_prio)
+
+    logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    logger.info("Wait until the system is stable")
+    pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),
+                  "Not all critical services are fully started")
+
+    run_pfc_test(api=ixia_api,
+                 testbed_config=ixia_testbed,
+                 conn_data=conn_graph_facts,
+                 fanout_data=fanout_graph_facts,
+                 duthost=duthost,
+                 dut_port=dut_port,
+                 global_pause=False,
+                 pause_prio_list=pause_prio_list,
+                 test_prio_list=test_prio_list,
+                 bg_prio_list=bg_prio_list,
+                 prio_dscp_map=prio_dscp_map,
+                 test_traffic_pause=True)
+
+@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
+def test_pfc_pause_multi_lossless_prio_reboot(ixia_api,
+                                              ixia_testbed,
+                                              conn_graph_facts,
+                                              fanout_graph_facts,
+                                              localhost,
+                                              duthosts,
+                                              rand_one_dut_hostname,
+                                              rand_one_oper_up_intf,
+                                              lossless_prio_list,
+                                              lossy_prio_list,
+                                              prio_dscp_map,
+                                              reboot_type):
+    """
+    Test if PFC can pause multiple lossless priorities even after various types of reboot
+
+    Args:
+        ixia_api (pytest fixture): IXIA session
+        ixia_testbed (pytest fixture): L2/L3 config of a T0 testbed
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        localhost (pytest fixture): localhost handle
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_oper_up_intf (str): port to test, e.g., 's6100-1|Ethernet0'
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        lossy_prio_list (pytest fixture): list of all the lossy priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        reboot_type (str): reboot type to be issued on the DUT
+
+    Returns:
+        None
+    """
+
+    dut_hostname, dut_port = rand_one_oper_up_intf.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname,
+                   "Port is not mapped to the expected DUT")
+
+    duthost = duthosts[rand_one_dut_hostname]
+    pause_prio_list = lossless_prio_list
+    test_prio_list = lossless_prio_list
+    bg_prio_list = lossy_prio_list
+
+    logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    logger.info("Wait until the system is stable")
+    pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),
+                  "Not all critical services are fully started")
 
     run_pfc_test(api=ixia_api,
                  testbed_config=ixia_testbed,

--- a/tests/pfc/test_pfc_pause_lossy.py
+++ b/tests/pfc/test_pfc_pause_lossy.py
@@ -1,14 +1,18 @@
+import logging
 import pytest
 
-from tests.common.helpers.assertions import pytest_require
+from files.helper import run_pfc_test
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list
+from tests.common.reboot import reboot
+from tests.common.utilities import wait_until
 
-from files.helper import run_pfc_test
+logger = logging.getLogger(__name__)
 
 @pytest.mark.topology("tgen")
 
@@ -67,7 +71,6 @@ def test_pfc_pause_single_lossy_prio(ixia_api,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False)
 
-
 def test_pfc_pause_multi_lossy_prio(ixia_api,
                                     ixia_testbed,
                                     conn_graph_facts,
@@ -105,6 +108,134 @@ def test_pfc_pause_multi_lossy_prio(ixia_api,
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
     bg_prio_list = lossless_prio_list
+
+    run_pfc_test(api=ixia_api,
+                 testbed_config=ixia_testbed,
+                 conn_data=conn_graph_facts,
+                 fanout_data=fanout_graph_facts,
+                 duthost=duthost,
+                 dut_port=dut_port,
+                 global_pause=False,
+                 pause_prio_list=pause_prio_list,
+                 test_prio_list=test_prio_list,
+                 bg_prio_list=bg_prio_list,
+                 prio_dscp_map=prio_dscp_map,
+                 test_traffic_pause=False)
+
+@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
+def test_pfc_pause_single_lossy_prio_reboot(ixia_api,
+                                            ixia_testbed,
+                                            conn_graph_facts,
+                                            fanout_graph_facts,
+                                            localhost,
+                                            duthosts,
+                                            rand_one_dut_hostname,
+                                            rand_one_oper_up_intf,
+                                            rand_lossy_prio,
+                                            all_prio_list,
+                                            prio_dscp_map,
+                                            reboot_type):
+    """
+    Test if PFC will impact a single lossy priority after various kinds of reboots
+
+    Args:
+        ixia_api (pytest fixture): IXIA session
+        ixia_testbed (pytest fixture): L2/L3 config of a T0 testbed
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        localhost (pytest fixture): localhost handle
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_oper_up_intf (str): port to test, e.g., 's6100-1|Ethernet0'
+        rand_lossy_prio (str): lossy priority to test, e.g., 's6100-1|2'
+        all_prio_list (pytest fixture): list of all the priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        reboot_type (str): reboot type to be issued on the DUT
+
+    Returns:
+        None
+    """
+
+    dut_hostname, dut_port = rand_one_oper_up_intf.split('|')
+    dut_hostname2, lossy_prio = rand_lossy_prio.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname == dut_hostname2,
+                   "Priority and port are not mapped to the expected DUT")
+
+    duthost = duthosts[rand_one_dut_hostname]
+    lossy_prio = int(lossy_prio)
+
+    pause_prio_list = [lossy_prio]
+    test_prio_list = [lossy_prio]
+    bg_prio_list = [p for p in all_prio_list]
+    bg_prio_list.remove(lossy_prio)
+
+    logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    logger.info("Wait until the system is stable")
+    pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),
+                  "Not all critical services are fully started")
+
+    run_pfc_test(api=ixia_api,
+                 testbed_config=ixia_testbed,
+                 conn_data=conn_graph_facts,
+                 fanout_data=fanout_graph_facts,
+                 duthost=duthost,
+                 dut_port=dut_port,
+                 global_pause=False,
+                 pause_prio_list=pause_prio_list,
+                 test_prio_list=test_prio_list,
+                 bg_prio_list=bg_prio_list,
+                 prio_dscp_map=prio_dscp_map,
+                 test_traffic_pause=False)
+
+@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
+def test_pfc_pause_multi_lossy_prio_reboot(ixia_api,
+                                           ixia_testbed,
+                                           conn_graph_facts,
+                                           fanout_graph_facts,
+                                           localhost,
+                                           duthosts,
+                                           rand_one_dut_hostname,
+                                           rand_one_oper_up_intf,
+                                           lossless_prio_list,
+                                           lossy_prio_list,
+                                           prio_dscp_map,
+                                           reboot_type):
+    """
+    Test if PFC will impact multiple lossy priorities after various kinds of reboots
+
+    Args:
+        ixia_api (pytest fixture): IXIA session
+        ixia_testbed (pytest fixture): L2/L3 config of a T0 testbed
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        localhost (pytest fixture): localhost handle
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_oper_up_intf (str): port to test, e.g., 's6100-1|Ethernet0'
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        lossy_prio_list (pytest fixture): list of all the lossy priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        reboot_type (str): reboot type to be issued on the DUT
+
+    Returns:
+        None
+    """
+
+    dut_hostname, dut_port = rand_one_oper_up_intf.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname,
+                   "Port is not mapped to the expected DUT")
+
+    duthost = duthosts[rand_one_dut_hostname]
+    pause_prio_list = lossy_prio_list
+    test_prio_list = lossy_prio_list
+    bg_prio_list = lossless_prio_list
+
+    logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    logger.info("Wait until the system is stable")
+    pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),
+                  "Not all critical services are fully started")
 
     run_pfc_test(api=ixia_api,
                  testbed_config=ixia_testbed,


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This test verifies the PFC behavior on lossless and lossy priorities after various types of reboots

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Tested only the reboot code flow in each testcase. The pfc send/verify method is reused from existing testcase which was earlier verified on ixia setup