### PR TITLE
Fix exception in remote.py caused by sub interface

### DIFF
--- a/ansible/roles/test/files/ptftests/remote.py
+++ b/ansible/roles/test/files/ptftests/remote.py
@@ -16,10 +16,10 @@ def get_ifaces():
 
         iface = line.split(':')[0].strip()
 
-        # Skip not FP interfaces
-        if 'eth' not in iface:
+        # Skip not FP interfaces and vlan interface, like eth1.20
+        if 'eth' not in iface or '.' in iface:
             continue
-
+        
         ifaces.append(iface)
 
     # Sort before return


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
An exception will be thrown by ```platform_config_update``` in ```remote.py``` when sub interfaces (like ```eth1.10```) exist on ptf. 
```
E                   "  from cryptography.hazmat.backends import default_backend", 
E                   "Traceback (most recent call last):", 
E                   "  File \"/usr/bin/ptf\", line 619, in <module>", 
E                   "    platform_mod.platform_config_update(config)", 
E                   "  File \"ptftests/remote.py\", line 36, in platform_config_update", 
E                   "    remote_port_map = {(0, int(i.replace('eth', ''))) : i for i in get_ifaces()}", 
E                   "  File \"ptftests/remote.py\", line 36, in <dictcomp>", 
E                   "    remote_port_map = {(0, int(i.replace('eth', ''))) : i for i in get_ifaces()}", 
E                   "ValueError: invalid literal for int() with base 10: '1.10'"
```
This commit addressed the issue by filtering out sub interfaces whose name contains a '.'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix exception in remote.py caused by sub interface.
 
#### How did you do it?
Filter out sub interfaces whose name contains a '.'.

#### How did you verify/test it?
Verified by adding a vlan interface on ptf with ```ip link add link eth1 name eth1.20 type vlan id 20```, and then run a test case that depends on ptf (like ```test_bgp_speaker```). No exception is thrown.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
