### PR TITLE
[test_show_ndp] Filter out arp entries with no MAC address

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -772,12 +772,17 @@ class TestNeighbors():
         ndp_output = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show ndp'.format(ifmode))['stdout']
         logger.info('ndp:\n{}'.format(ndp_output))
 
-        for item in arptable['v6']:
-            if (arptable['v6'][item]['interface'] != 'eth0') and (arptable['v6'][item]['interface'] not in minigraph_portchannels):
+        for addr, detail in arptable['v6'].items():
+            if (
+                    detail['macaddress'] != 'None' and
+                    detail['interface'] != 'eth0' and
+                    detail['interface'] not in minigraph_portchannels
+            ):
                 if mode == 'alias':
-                    assert re.search(r'{}.*\s+{}'.format(item, setup['port_name_map'][arptable['v6'][item]['interface']]), ndp_output) is not None
+                    assert re.search(r'{}.*\s+{}'.format(addr, setup['port_name_map'][detail['interface']]), ndp_output) is not None
                 elif mode == 'default':
-                    assert re.search(r'{}.*\s+{}'.format(item, arptable['v6'][item]['interface']), ndp_output) is not None
+                    assert re.search(r'{}.*\s+{}'.format(addr, detail['interface']), ndp_output) is not None
+
 
 class TestShowIP():
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

As `nbrshow` only shows entries that has `lldaddr`, we need to enforce
same behavior to filter out entries without MAC address, to guarantee it
will be shown in the output of `show ndp`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The output of `ip neigh` might contains `FAILED` entries like the following without `lladdr`:
```
fe80::2a99:3aff:fe17:1c8c dev Ethernet112  FAILED
fe80::2a99:3aff:fe17:1c8c dev Ethernet80  FAILED
fe80::2a99:3aff:fe17:1c8c dev Ethernet68  FAILED
```
And those entries will be excluded by `nbrshow`, which will be called by `show nbr`.
In this case, `test_show_ndp` will fail due to the failure to find a match for those `FAILED` arp entries.

#### How did you do it?
Let `test_show_ndp` only checks entries that has `lladdr`.

#### How did you verify/test it?
Test `test_show_ndp`
```
iface_namingmode/test_iface_namingmode.py::TestNeighbors::test_show_ndp[alias] PASSED                                                                                       [ 50%]
iface_namingmode/test_iface_namingmode.py::TestNeighbors::test_show_ndp[default] PASSED                                                                                     [100%]
```
#### Any platform specific information?
Arista 7060 T1

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
