### PR TITLE
[copp] Stabilize non-policer copp tests on slower server skus

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -39,7 +39,7 @@ class ControlPlaneBaseTest(BaseTest):
 
     DEFAULT_PRE_SEND_INTERVAL_SEC = 1
     DEFAULT_SEND_INTERVAL_SEC = 10
-    DEFAULT_RECEIVE_WAIT_TIME = 1
+    DEFAULT_RECEIVE_WAIT_TIME = 3
 
     def __init__(self):
         BaseTest.__init__(self)

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -148,6 +148,7 @@ def ignore_expected_loganalyzer_exceptions(loganalyzer):
         ".*ERR monit.*'lldp_syncd' process is not running.*",
         ".*ERR monit.*'lldp\|lldp_syncd' status failed.*'python2 -m lldp_syncd' is not running.*",
         ".*snmp#snmp-subagent.*",
+        ".*kernel reports TIME_ERROR: 0x4041: Clock Unsynchronized.*"
     ]
 
     if loganalyzer:  # Skip if loganalyzer is disabled


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Stabilize non-policer copp tests on slower server skus
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We encountered a couple new problems after switching to the new style of running everflow tests.

#### How did you do it?
1. Added a new loganalyzer statement to ignore the NTP time error that pops up because we reset everything.
2. Gave the tests a little longer to collect all the packets because we noticed slower servers were still struggling to keep up with PTF.

#### How did you verify/test it?
Re-ran the tests locally.

#### Any platform specific information?
n/a

#### Supported testbed topology if it's a new test case?
n/a

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
