### PR TITLE
[multi-dut] Added fixtures for selecting nodes from multi-duts based on card type and hwsku 

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -24,6 +24,7 @@ from ansible.plugins.loader import connection_loader
 from errors import RunAnsibleModuleFail
 from errors import UnsupportedAnsibleModule
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE, NAMESPACE_PREFIX
+from tests.common.helpers.dut_utils import is_supervisor_node
 
 # HACK: This is a hack for issue https://github.com/Azure/sonic-mgmt/issues/1941 and issue
 # https://github.com/ansible/pytest-ansible/issues/47
@@ -354,11 +355,9 @@ class SonicHost(AnsibleHostBase):
             the inventory, and it is 'supervisor', then return True, else return False. In future, we can change this
             logic if possible to derive it from the DUT.
         """
-        if 'type' in self.host.options["inventory_manager"].get_host(self.hostname).get_vars():
-            node_type = self.host.options["inventory_manager"].get_host(self.hostname).get_vars()["type"]
-            if node_type is not None and node_type == 'supervisor':
-                return True
-        return False
+        im = self.host.options['inventory_manager']
+        inv_files = im._sources
+        return is_supervisor_node(inv_files, self.hostname)
 
     def is_frontend_node(self):
         """Check if the current node is a frontend node in case of multi-DUT.

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -1,0 +1,32 @@
+from tests.common.utilities import get_host_visible_vars
+
+
+def is_supervisor_node(inv_files, hostname):
+    """Check if the current node is a supervisor node in case of multi-DUT.
+     @param inv_files: List of inventory file paths, In tests,
+            you can be get it from get_inventory_files in tests.common.utilities
+     @param hostname: hostname as defined in the inventory
+    Returns:
+          Currently, we are using 'type' in the inventory to make the decision. If 'type' for the node is defined in
+          the inventory, and it is 'supervisor', then return True, else return False. In future, we can change this
+          logic if possible to derive it from the DUT.
+    """
+    node_type = get_host_visible_vars(inv_files, hostname, variable='type')
+    if node_type and node_type == 'supervisor':
+        return True
+    return False
+
+
+def is_frontend_node(inv_files, hostname):
+    """Check if the current node is a frontend node in case of multi-DUT.
+     @param inv_files: List of inventory file paths, In tests,
+            you can be get it from get_inventory_files in tests.common.utilities
+     @param hostname: hostname as defined in the inventory
+     Returns:
+          True if it is not any other type of node. Currently, the only other type of node supported is 'supervisor'
+          node. If we add more types of nodes, then we need to exclude them from this method as well.
+    """
+    return not is_supervisor_node(inv_files, hostname)
+
+
+

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -144,6 +144,20 @@ def get_variable_manager(inv_files):
     return VariableManager(loader=DataLoader(), inventory=get_inventory_manager(inv_files))
 
 
+def get_inventory_files(request):
+    """Use request.config.getoption('ansible_inventory') to the get list of inventory files.
+       The 'ansible_inventory' option could have already been converted to a list by #enchance_inventory fixture.
+       Args:
+            request: request paramater for pytest.
+    """
+    if isinstance(request.config.getoption("ansible_inventory"), list):
+        # enhance_inventory fixture changes ansible_inventory to a list.
+        inv_files = request.config.getoption("ansible_inventory")
+    else:
+        inv_files = [inv_file.strip() for inv_file in request.config.getoption("ansible_inventory").split(",")]
+    return inv_files
+
+
 def get_host_vars(inv_files, hostname, variable=None):
     """Use ansible's InventoryManager to get value of variables defined for the specified host in the specified
     inventory files.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -802,10 +802,10 @@ def pytest_generate_tests(metafunc):
 
     if "enum_asic_index" in metafunc.fixturenames:
         metafunc.parametrize("enum_asic_index",
-                             generate_param_asic_index(metafunc, duts_in_testbed, tbname, dut_indices, ASIC_PARAM_TYPE_ALL))
+                             generate_param_asic_index(metafunc, duts_in_testbed, dut_indices, ASIC_PARAM_TYPE_ALL))
     if "enum_frontend_asic_index" in metafunc.fixturenames:
         metafunc.parametrize("enum_frontend_asic_index",
-                             generate_param_asic_index(metafunc, duts_in_testbed, tbname, dut_indices, ASIC_PARAM_TYPE_FRONTEND))
+                             generate_param_asic_index(metafunc, duts_in_testbed, dut_indices, ASIC_PARAM_TYPE_FRONTEND))
 
     if "enum_dut_portname" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname", generate_port_lists(metafunc, "all_ports"))


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When dealing with SONiC Chassis you have cards of different type
  - linecards with front-panel ports
  - supervisor card
  - fabric cards

Also, you could have linecards with different hwsku's in the same chassis.

When using the parameterized approach for multi-dut to select test cases to run on a chassis, we need to make sure that we parameterize the tests to provide all the required coverage.
 
#### How did you do it?
Added the following fixtures that can be used for parameterizing tests for chassis:
  - rand_one_frontend_dut_hostname - returns a random dut that is a frontend node.
  - enum_supervisor_dut_hostname - returns a dut that is a supervisor node. For pizza box (single dut) this will the pizza box itself.
     - A supervisor node is defined as having 'type' variable in the inventory as 'supervisor'
     - For pizza box (single dut) the single dut itself will be the supervisor node.
   - enum_frontend_dut_hostname - returns all duts that are frontend nodes
     - A frontend node is defined as a node that is not a supervisor.
   - enum_rand_one_per_hwsku_frontend_hostname - returns 1 random frontend dut per hwsksu amongst all the frontend nodes.
         - hwsku for a node is derived from the 'hwsku' or 'sonic_hwsku' variable in the inventory for the node.

To achieve the above:
  - Added dut_utils under common/helpers to:
    - get_inventory_variable - get the value of a variable in the inventory for a given node.
    - is_supervisor_node - check if 'type' variable is defined in the inventory for the node and is 'supervisor'
    - is_frontend_node - check if node is not a supervisor node.

  - Modified SonicHost.is_supervisor_node to use dut_utils.is_supervisor_node.
 
#### How did you verify/test it?
 Created a sample test case to exercise the selection of DUT's in a multi-dut testbed.
```
import logging

def test_one_frontend_node(rand_one_frontend_dut_hostname,):
    logging.info("Running test against " + rand_one_frontend_dut_hostname)

def test_all_frontend_nodes(enum_frontend_dut_hostname):
    logging.info("Running test against " + enum_frontend_dut_hostname)

def test_superivisor(enum_supervisor_dut_hostname):
    logging.info("Running test against " + enum_supervisor_dut_hostname)

def test_all_nodes(enum_dut_hostname):
    logging.info("Running test against " + enum_dut_hostname)

def test_one_node(rand_one_dut_hostname):
    logging.info("Running test against " + rand_one_dut_hostname)

def test_one_per_hwsku(enum_rand_one_per_hwsku_frontend_hostname):
    logging.info("Running test against " + enum_rand_one_per_hwsku_frontend_hostname)

```

The test were run against a Chassis testbed with the following cads:
- board1 - frontend node (linecard) with hwsku1
- board2 - frontend node (linecard) with hwsku1
- board3 - frontend node (linecard) with hwsku2
- board4 - supervisor node 

The pytest results of running the sample test above against the testbed above is shown below.

```

=========================== short test summary info ============================
PASSED ../tests/sample_test.py::test_one_frontend_node
      21:46:20 INFO sample_test.py:test_one_frontend_node:5: Running test against board1

PASSED ../tests/sample_test.py::test_all_frontend_nodes[board1]
PASSED ../tests/sample_test.py::test_all_frontend_nodes[board2]
PASSED ../tests/sample_test.py::test_all_frontend_nodes[board3]

PASSED ../tests/sample_test.py::test_superivisor[board4]

PASSED ../tests/sample_test.py::test_all_nodes[board1]
PASSED ../tests/sample_test.py::test_all_nodes[board2]
PASSED ../tests/sample_test.py::test_all_nodes[board3]
PASSED ../tests/sample_test.py::test_all_nodes[board4]

PASSED ../tests/sample_test.py::test_one_node
      21:46:39 INFO sample_test.py:test_one_node:21: Running test against board4

PASSED ../tests/sample_test.py::test_one_per_hwsku[board1]
PASSED ../tests/sample_test.py::test_one_per_hwsku[board3]

========================== 12 passed in 82.67 seconds ==========================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
