### PR TITLE
[run_tests.sh] Add module_utils path

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -89,6 +89,7 @@ function setup_environment()
     export ANSIBLE_CONFIG=${BASE_PATH}/ansible
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
     export ANSIBLE_CONNECTION_PLUGINS=${BASE_PATH}/ansible/plugins/connection
+    export ANSIBLE_MODULE_UTILS=${BASE_PATH}/ansible/module_utils
 }
 
 function setup_test_options()


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For Pytest, we need to let pytest-ansible aware of the `module_utils`
path.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
* Pytest `conn_graph_facts` fixture failed with error:
```
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module conn_graph_facts failed, Ansible Results =>
E           {
E               "failed": true,
E               "msg": "Could not find imported module support code for conn_graph_facts.  Looked for either print_debug_msg.py or debug_utils.py"
E           }
```

#### How did you do it?
Add the environment variable `ANSIBLE_MODULE_UTILS` to the test runner script.

#### How did you verify/test it?
Run Pytest.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
