### PR TITLE
Ignore test_system_health for 201911 images

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pytest
 import time
+from pkg_resources import parse_version
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_require
 from device_mocker import device_mocker_factory
@@ -53,7 +54,8 @@ EXPECT_PSU_INVALID_VOLTAGE = '{} voltage is out of range'
 @pytest.fixture(autouse=True, scope="module")
 def check_image_version(duthost):
     """Skip the test for unsupported images."""
-    pytest_require("201911" not in duthost.os_version, "Test not supported for 201911 images. Skipping the test")
+    pytest_require(parse_version(duthost.kernel_version) > parse_version('4.9.0'),
+                   "Test not supported for 201911 images. Skipping the test")
     yield
 
 

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import time
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_require
 from device_mocker import device_mocker_factory
 
 pytestmark = [
@@ -47,6 +48,13 @@ EXPECT_PSU_MISSING = '{} is missing or not available'
 EXPECT_PSU_NO_POWER = '{} is out of power'
 EXPECT_PSU_HOT = '{} temperature is too hot'
 EXPECT_PSU_INVALID_VOLTAGE = '{} voltage is out of range'
+
+
+@pytest.fixture(autouse=True, scope="module")
+def check_image_version(duthost):
+    """Skip the test for unsupported images."""
+    pytest_require("201911" not in duthost.os_version, "Test not supported for 201911 images. Skipping the test")
+    yield
 
 
 def test_service_checker(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
Signed-off-by: Antonina Melnyk antoninax.melnyk@intel.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip `test_system_health` testcase on 201911 images. This testcase is primarily targeted to be executed on 202012 images.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`test_system_health` tests are failing on 201911 images because this feature is not supported by 201911 release.

#### How did you do it?
Added a module scoped skip fixture.

#### How did you verify/test it?
Executed the test on a 201911 image, and it was successfully skipped:
```
system_health/test_system_health.py::test_service_checker SKIPPED                                                                                                                                       [ 25%]
system_health/test_system_health.py::test_device_checker SKIPPED                                                                                                                                        [ 50%]
system_health/test_system_health.py::test_external_checker SKIPPED                                                                                                                                      [ 75%]
system_health/test_system_health.py::test_system_health_config SKIPPED                                                                                                                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
