### PR TITLE
[cold reboot] Added changes for reboot cause check of cold reboot test case

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -39,7 +39,9 @@ reboot_ctrl_dict = {
         "command": "reboot",
         "timeout": 300,
         "wait": 120,
-        "cause": "'reboot'",
+        # We are searching two types of reboot cause.
+        # This change relates to changes of PR #6130 in sonic-buildimage repository
+        "cause": r"'reboot'|Non-Hardware \(reboot",
         "test_reboot_cause_only": False
     },
     REBOOT_TYPE_FAST: {


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added changes for reboot cause check of cold reboot test case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR [#6130](https://github.com/Azure/sonic-buildimage/pull/6130) of sonic-buildimage changed the output of CLI command _'show reboot-cause'_ and test_cold_reboot was failed.

**The old version of CLI command output**
```
$ show reboot-cause                                                                                                                                                     
User issued 'reboot' command [User: , Time: Wed 23 Dec 2020 12:57:33 PM UTC] 
```
**The new version of CLI command output**
```
$ show reboot-cause 
Non-Hardware (reboot, time: 2020-12-23 10:56:50 UTC)
```
#### How did you do it?
Added two types of _'show reboot-cause'_ output to check of cold reboot test case.
#### How did you verify/test it?
`py.test --testbed=testbed-t1 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t1 -- 
 module-path=../ansible/library platform_tests/test_reboot.py::test_cold_reboot`

`platform_tests/test_reboot.py::test_cold_reboot PASSED`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
