### PR TITLE
Make test_fdb dualtor ready

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -183,7 +183,7 @@ def fdb_cleanup(duthosts, rand_one_dut_hostname):
 
 @pytest.mark.bsl
 @pytest.mark.parametrize("pkt_type", PKT_TYPES)
-def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type, tbinfo):
+def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type):
 
     # Perform FDB clean up before each test and at the end of the final test
     fdb_cleanup(duthosts, rand_one_dut_hostname)
@@ -195,7 +195,6 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
     2. verify show mac command on DUT for learned mac.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts   = duthost.get_extended_minigraph_facts(tbinfo)
     conf_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
     # reinitialize data plane due to above changes on PTF interfaces
@@ -203,7 +202,7 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
 
     router_mac = duthost.facts['router_mac']
 
-    port_index_to_name = { v: k for k, v in mg_facts['minigraph_port_indices'].items() }
+    port_index_to_name = { v: k for k, v in conf_facts['port_index_map'].items() }
 
     # Only take interfaces that are in ptf topology
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
@@ -237,8 +236,6 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
             dummy_mac_count += 1
         if "dynamic" in l.lower():
             total_mac_count += 1
-
-    print res
 
     assert vlan_member_count > 0
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -206,8 +206,10 @@ def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost
 
     # Only take interfaces that are in ptf topology
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
-    available_ports_idx = [ idx for idx, name in ptf_ports_available_in_topo.items()
-    if idx in port_index_to_name and conf_facts['PORT'][port_index_to_name[idx]].get('admin_status', 'down') == 'up' ]
+    available_ports_idx = []
+    for idx, name in ptf_ports_available_in_topo.items():
+        if idx in port_index_to_name and conf_facts['PORT'][port_index_to_name[idx]].get('admin_status', 'down') == 'up':
+            available_ports_idx.append(idx)
 
     vlan_table = {}
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix ```test_fdb``` exception on dualtor testbed.
An exception will be thrown when ```test_fdb``` is running on dualtor testbed.
```
ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
        available_ports_idx = [ idx for idx, name in ptf_ports_available_in_topo.items()
>       if conf_facts['PORT'][port_index_to_name[idx]].get('admin_status', 'down') == 'up' ]
E       KeyError: 34
``` 
It's because the number of ports on ptf containes is larger than that on DUT, since there will be an injected interface for each DUT's interface connected to VM. 
For example, there are 32 ports on a dualtor DUT, but  there are 36 ports on ptf. So an exception will be thrown when attempting to map ptf port indices to DUT port indices.
This PR addressed the issue by adding a check for existence of idx in port_index_to_name.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_fdb``` on dualtor testbed.

#### How did you do it?
Adding a check for existence of idx in ```port_index_to_name```.

#### How did you verify/test it?
Verified on both dualtor and single tor testbed.
```
 py.test --inventory ../ansible/str2,../ansible/veos --host-pattern str2-7050cx3-acs-08 --module-path ../ansible --testbed vms17-dual-t0-7050-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level warn --collect_techsupport=False --topology=t0,any,util fdb/test_fdb.py
========================================================================================= test session starts =========================================================================================
collected 4 items                                                                                                                                                                                     

fdb/test_fdb.py::test_fdb[ethernet] PASSED                                                                                                                                                      [ 25%]
fdb/test_fdb.py::test_fdb[arp_request] PASSED                                                                                                                                                   [ 50%]
fdb/test_fdb.py::test_fdb[arp_reply] ^@PASSED                                                                                                                                                     [ 75%]
fdb/test_fdb.py::test_fdb[cleanup] PASSED                                                                                                                                                       [100%]

------------------------------------------------------------------ generated xml file: /data/Networking-acs-sonic-mgmt/tests/tr.xml -------------------------------------------------------------------
===================================================================================== 4 passed in 400.02 seconds ======================================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
