### PR TITLE
[vlan_port] Remove deprecated param 'is_multi_duts'

### DIFF
--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -117,20 +117,18 @@ class VlanPort(object):
 
         return stdout
 
+
 def main():
 
     module = AnsibleModule(argument_spec=dict(
         cmd=dict(required=True, choices=['create', 'remove', 'list']),
         external_port=dict(required=True, type='str'),
         vlan_ids=dict(required=True, type='dict'),
-        is_multi_duts=dict(required=False, type='bool', default=False),
     ))
 
     cmd = module.params['cmd']
     external_port = module.params['external_port']
     vlan_ids = module.params['vlan_ids']
-    is_multi_duts = module.params['is_multi_duts']
-
 
     fp_ports = {}
 
@@ -143,14 +141,8 @@ def main():
         vp.remove_vlan_ports()
 
     fp_port_templ = external_port + ".%s"
-    if is_multi_duts:
-        fp_ports = {}
-        for dut_vlans in vlan_ids:
-            dut_vlans.sort()
-            fp_ports.append([fp_port_templ % vid for vid in dut_vlans])
-    else:
-        for a_port_index, vid in vlan_ids.items():
-            fp_ports[a_port_index] = fp_port_templ % vid
+    for a_port_index, vid in vlan_ids.items():
+        fp_ports[a_port_index] = fp_port_templ % vid
 
     module.exit_json(changed=False, ansible_facts={'dut_fp_ports': fp_ports})
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
As `vlan_port` is called in a loop when there are multiple DUTs, there
is no need for `vlan_port` to deal with multi-DUTs.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
As in the description.

#### How did you do it?
Remove the param `is_multi_duts`.

#### How did you verify/test it?
Run `add-topo` or `remove-topo`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
