### PR TITLE
Disable route_check for test_lag

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -1,9 +1,7 @@
 import pytest
 
-import json
 import time
 import logging
-import os
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
@@ -13,11 +11,13 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
+from tests.common.fixtures.duthost_utils import disable_route_checker_module
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.usefixtures('disable_route_checker_module')
 ]
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Test case ```test_lag``` was failing occasionally on some platforms because ```route_check``` reported mismatch, which is caused by shutdown of PortChannel interfaces.
```
Dec 27 08:22:57.781597 str2-7050cx3-acs-01 ERR monit[541]: 'routeCheck' status failed (255) -- results: { {#012    "missed_ROUTE_TABLE_routes": [#012        "100.1.0.32/32"#012    ]#012} }#012 Failed. Look at reported mismatches above
```
Since the error is explainable, this PR disabled route_check to mitigate false errors.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to address test errors in ```test_lag``` caused by ```route_check```.

#### How did you do it?
Disable ```route_check``` for ```test_lag```.

#### How did you verify/test it?
Verified on A7050, T0.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
