### PR TITLE
[everflow] Improve the method of monitor port parsing

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -661,7 +661,7 @@ class BaseEverflowTest(object):
                 end = index + len(s)
                 name = header[index:end].strip()
                 value = ln[index:end].strip()
-                index = index + len(s)+ 2
+                index = index + len(s) + 2
                 data[name] = value
 
             session_group["data"].append(data)


### PR DESCRIPTION
Signed-off-by: Steven Guo steven_guo@edge-core.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve the method of monitor port parsing
Fixes #2302
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The modification for parsing monitor in #2302 used hard-coded method to get the monitor port and imply that the "SRC Port" and "Direction" are not configured.
#### How did you do it?
We parsed the output of mirror_session CLI and create objects to store values of each fields in SPAN and ERSPAN, then return the monitor port from the objects. 
#### How did you verify/test it?
We ran the test on t1 topology and all the test passed:
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.4.0-87-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'html': u'1.22.1', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /var/johnar/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, metadata-1.10.0, repeat-0.8.0, forked-1.3.0, html-1.22.1, xdist-1.28.0
collecting ... collected 20 items

everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_range_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_range_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_flags_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dscp_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_range_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_response_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_tcp_application_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_udp_application_mirroring[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_protocol[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_any_transport_protocol[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_invalid_tcp_rule[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_source_subnet[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dest_subnet[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_both_subnets[cli]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_fuzzy_subnets[cli]

========================= 20 passed in 167.20 seconds ==========================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
