### PR TITLE
[Vrf] Added missing ptftests folder to test_vrf_attr

### DIFF
--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -7,6 +7,7 @@ from test_vrf import gen_vrf_neigh_file
 from test_vrf import partial_ptf_runner     # lgtm[py/unused-import]
 
 from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory
 
 pytestmark = [
     pytest.mark.topology('t0')
@@ -22,7 +23,7 @@ class TestVrfAttrSrcMac():
         # -------- Setup ----------
         extra_vars = { 'router_mac': self.new_vrf1_router_mac }
         duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
-        duthost.template(src="vrf_attr_src_mac.j2", dest="/tmp/vrf_attr_src_mac.json")
+        duthost.template(src="vrf/vrf_attr_src_mac.j2", dest="/tmp/vrf_attr_src_mac.json")
 
         duthost.shell("config load -y /tmp/vrf_attr_src_mac.json")
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:** test_vrf_attr fails due to missing ptftests folder on PTF and incorrect patch to jinja template **vrf_attr_src_mac.j2**
 
```
E RunAnsibleModuleFail: run module shell failed, Ansible Results =>
ptf: error: invalid value for --test-dir: directory ptftests does not exist

E RunAnsibleModuleFail: run module shell failed, Ansible Results =>
Could not find or access 'vrf_attr_src_mac.j2'
Searched in: sonic-mgmt/tests/templates/vrf_attr_src_mac.j2 on the Ansible Controller.
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix test_vrf_attr and make it working. 
#### How did you do it?
Edited patch to jinja template and added copy_ptftests_directory fixture.
#### How did you verify/test it?
Run test_vrf_attr TC on topo t0
```
vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf_src_mac_cfg PASSED
vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf2_neigh_with_default_router_mac PASSED
vrf/test_vrf_attr.py::TestVrfAttrIpAction::test_vrf1_fwd_pkts_without_ip_opt PASSED
vrf/test_vrf_attr.py::TestVrfAttrIpAction::test_vrf2_fwd_pkts_with_ip_opt PASSED
```
#### Any platform specific information?
```
SONiC.master.67-dirty-20201218.064842
Distribution: Debian 10.7
Kernel: 4.19.0-9-2-amd64
Build commit: 317a4b34
Build date: Fri Dec 18 06:57:50 UTC 2020
Platform: x86_64-arista_7170_64c
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
