### PR TITLE
Run sflow pytest only on t0 topology

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -13,7 +13,7 @@ from tests.common.utilities import wait_until
 from netaddr import *
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('t0')
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Run sflow pytest only in t0 topology

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

In setup fixture, it will try to get the Vlan1000's configuration, but only topology-t0 has Vlan1000 configuration.

#### How did you do it?

Change the topology from any to t0 for sflow pytest.

#### How did you verify/test it?

Run sflow pytest on t1, the result will get KeyError in setup fixture.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

### Details if related

Signed-off-by: Fred Yu fred_yu@edge-core.com
