### PR TITLE
[port_toggle] Calculate port toggle timeout based on dut type and port count

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -6,7 +6,7 @@ SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS
 
 SWITCH_MODELS = {
     "x86_64-mlnx_msn2700-r0": {
-        "chip_type": "spectrum",
+        "chip_type": "spectrum1",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -57,7 +57,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2740-r0": {
-        "chip_type": "spectrum",
+        "chip_type": "spectrum1",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -105,7 +105,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2410-r0": {
-        "chip_type": "spectrum",
+        "chip_type": "spectrum1",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -156,7 +156,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2010-r0": {
-        "chip_type": "spectrum",
+        "chip_type": "spectrum1",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -200,7 +200,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2100-r0": {
-        "chip_type": "spectrum",
+        "chip_type": "spectrum1",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -302,7 +302,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn3700-r0": {
-        "chip_type": "spectru2",
+        "chip_type": "spectrum2",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -6,6 +6,7 @@ SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS
 
 SWITCH_MODELS = {
     "x86_64-mlnx_msn2700-r0": {
+        "chip_type": "spectrum",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -56,6 +57,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2740-r0": {
+        "chip_type": "spectrum",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -103,6 +105,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2410-r0": {
+        "chip_type": "spectrum",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -153,6 +156,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2010-r0": {
+        "chip_type": "spectrum",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -196,6 +200,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn2100-r0": {
+        "chip_type": "spectrum",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": True,
@@ -239,6 +244,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn3800-r0": {
+        "chip_type": "spectrum2",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -296,6 +302,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn3700-r0": {
+        "chip_type": "spectru2",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -349,6 +356,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn3700c-r0": {
+        "chip_type": "spectrum2",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -402,6 +410,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn4700-r0": {
+        "chip_type": "spectrum3",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -455,6 +464,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn4600c-r0": {
+        "chip_type": "spectrum3",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -508,6 +518,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn3420-r0": {
+        "chip_type": "spectrum2",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -561,6 +572,7 @@ SWITCH_MODELS = {
         }
     },
     "x86_64-mlnx_msn4410-r0": {
+        "chip_type": "spectrum3",
         "reboot": {
             "cold_reboot": True,
             "fast_reboot": False,
@@ -628,3 +640,8 @@ def get_platform_data(dut):
     """
     dut_platform = dut.facts["platform"]
     return SWITCH_MODELS[dut_platform]
+
+
+def get_chip_type(dut):
+    platform_data = get_platform_data(dut)
+    return platform_data.get("chip_type")

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -136,6 +136,9 @@ def get_port_toggle_wait_time(duthost, port_count):
         if chip_type == 'spectrum':
             # spectrum based switch usually has less powerful cpu
             port_down_wait_time = 40
+            port_up_wait_time = 70
+        else:
+            port_down_wait_time = 30
 
         port_down_wait_time = int(port_down_wait_time * port_count_factor)
         port_up_wait_time = int(port_up_wait_time * port_count_factor)

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -133,7 +133,7 @@ def get_port_toggle_wait_time(duthost, port_count):
             port_count_factor = port_count / base_port_count
         from .mellanox_data import get_chip_type
         chip_type = get_chip_type(duthost)
-        if chip_type == 'spectrum':
+        if chip_type == 'spectrum1':
             # spectrum based switch usually has less powerful cpu
             port_down_wait_time = 40
             port_up_wait_time = 70

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -12,34 +12,36 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 
-def port_toggle(duthost, tbinfo, ports=None, wait=60, wait_after_ports_up=60, watch=False):
+def port_toggle(duthost, tbinfo, ports=None, wait_time_getter=None, wait_after_ports_up=60, watch=False):
     """
     Toggle ports on DUT.
 
     Args:
         duthost: DUT host object
         ports: Specify list of ports, None if toggle all ports
-        wait: Time to wait for interface to become up
+        wait_time_getter: A call back function to get port toggle wait time.
         wait_after_ports_up: Time to wait after interfaces become up
         watch: Logging system state
     """
 
-    def __get_down_ports():
+    def __get_down_ports(expect_up=True):
         """Check interface status and return the down ports in a set
         """
-        total_down_ports = set()
         ports_down = duthost.interface_facts(up_ports=ports)['ansible_facts']['ansible_interface_link_down_ports']
         db_ports_down = duthost.show_interface(command='status', up_ports=ports)['ansible_facts']\
             ['ansible_interface_link_down_ports']
-        total_down_ports.update(ports_down)
-        total_down_ports.update(db_ports_down)
-        return total_down_ports
+        if expect_up:
+            return set(ports_down) | set(db_ports_down)
+        else:
+            return set(ports_down) & set(db_ports_down)
 
     if ports is None:
         logger.debug('ports is None, toggling all minigraph ports')
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         ports = mg_facts['minigraph_ports'].keys()
-
+    if not wait_time_getter:
+        wait_time_getter = get_port_toggle_wait_time
+    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports))
     logger.info('toggling ports:\n%s', pprint.pformat(ports))
 
     cmds_down = []
@@ -70,12 +72,12 @@ def port_toggle(duthost, tbinfo, ports=None, wait=60, wait_after_ports_up=60, wa
         logger.info('Wait for ports to become down.')
         start_time = datetime.datetime.now()
         while True:
-            down_ports = __get_down_ports()
+            down_ports = __get_down_ports(expect_up=False)
             if len(down_ports) == len(ports):
                 shutdown_ok = True
                 break
             time.sleep(5)
-            if (datetime.datetime.now() - start_time).seconds > 20:
+            if (datetime.datetime.now() - start_time).seconds > port_down_wait_time:
                 break
 
         if not shutdown_ok:
@@ -96,7 +98,7 @@ def port_toggle(duthost, tbinfo, ports=None, wait=60, wait_after_ports_up=60, wa
                 startup_ok = True
                 break
             time.sleep(5)
-            if (datetime.datetime.now() - start_time).seconds > wait:
+            if (datetime.datetime.now() - start_time).seconds > port_up_wait_time:
                 break
 
         if not startup_ok:
@@ -110,3 +112,32 @@ def port_toggle(duthost, tbinfo, ports=None, wait=60, wait_after_ports_up=60, wa
 
     logger.info('wait %d seconds for system to startup', wait_after_ports_up)
     time.sleep(wait_after_ports_up)
+
+
+def get_port_toggle_wait_time(duthost, port_count):
+    """
+    Port toggle wait time depends on many factors: port count, cpu type. This function allow user to customize port
+    toggle wait time according to DUT host information and port count.
+    :param duthost: DUT host object
+    :param port_count: total port count to be toggled
+    :return: port down wait time and port up wait time
+    """
+    port_down_wait_time, port_up_wait_time = 20, 60
+    asic_type = duthost.facts["asic_type"]
+    if asic_type == 'mellanox':
+        # default t0 topology has 28 ports to toggle
+        base_port_count = 28.0
+        if port_count <= base_port_count:
+            port_count_factor = 1
+        else:
+            port_count_factor = port_count / base_port_count
+        from .mellanox_data import get_chip_type
+        chip_type = get_chip_type(duthost)
+        if chip_type == 'spectrum':
+            # spectrum based switch usually has less powerful cpu
+            port_down_wait_time = 40
+
+        port_down_wait_time = int(port_down_wait_time * port_count_factor)
+        port_up_wait_time = int(port_up_wait_time * port_count_factor)
+
+    return port_down_wait_time, port_up_wait_time


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Calculate port toggle timeout based on dut type and port count. The fix now only affect Mellanox platform, for other vendors, the default timeout values are still set as before.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Currently port toggle test case waits 20 seconds for all ports down and 60 seconds for all ports up. However, the wait time could be affected by dut type and port count. This case may fail on some platforms whose CPU is not so powerful.

#### How did you do it?

Add a function to calculate port toggle timeout based on dut type and port count

#### How did you verify/test it?

Manually run the test case on a few platforms

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
