### PR TITLE
[copp] Anchor copp setup to use python2

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -158,11 +158,11 @@ def _install_nano(dut, creds):
         cmd = '''docker exec -e http_proxy={} -e https_proxy={} syncd bash -c " \
                 rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
-                && apt-get install -y python-pip build-essential libssl-dev python-dev wget cmake \
+                && apt-get install -y python-pip build-essential libssl-dev python-dev python-setuptools wget cmake \
                 && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
-                && tar xvfz 1.0.0.tar.gz && cd nanomsg-1.0.0 \
-                && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -fr nanomsg-1.0.0 \
-                && rm -f 1.0.0.tar.gz && pip install cffi==1.7.0 && pip install --upgrade cffi==1.7.0 && pip install nnpy \
+                && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
+                && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
+                && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy \
                 && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
                 && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
                 " '''.format(http_proxy, https_proxy)


### PR DESCRIPTION
`syncd` is still based on `stretch` on some platforms (and older versions) and `buster` on others. This causes issues in the nn_agent installation because tools like `pip` default to `python3` in newer debian releases like `buster`. So, we need to do the following to ensure the copp setup is consistent across platforms:

- Explicitly call pip2 instead of pip
- Explicitly install python2 setup tools

Signed-off-by: Danny Allen <daall@microsoft.com>

Summary: [copp] Anchor copp setup to use python2
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`syncd` is still based on `stretch` on some platforms (and older versions) and `buster` on others. This causes issues in the nn_agent installation because tools like `pip` default to `python3` in newer debian releases like `buster`.

#### How did you do it?
We need to do the following to ensure the copp setup is consistent across platforms:

- Explicitly call pip2 instead of pip
- Explicitly install python2 setup tools

#### How did you verify/test it?
Re-ran tests against `stretch` (201911) and `buster` (master).

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
