### PR TITLE
[install image] work around for slow disk devices

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -105,6 +105,13 @@ def install_new_sonic_image(module, new_image_url):
                      cmd="rm -f /host/old_config/config_db.json",
                      msg="Remove config_db.json in preference of minigraph.xml")
 
+
+def work_around_for_slow_disks():
+    # Increase hung task timeout to 600 seconds to avoid kernel panic
+    # while writing lots of data to a slow disk.
+    exec_command(module, cmd="sysctl -w kernel.hung_task_timeout_secs=600", ignore_error=True)
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -117,6 +124,7 @@ def main():
     new_image_url   = module.params['new_image_url']
 
     try:
+        work_around_for_slow_disks()
         reduce_installed_sonic_images(module, disk_used_pcent)
         install_new_sonic_image(module, new_image_url)
     except:


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Some dut triggers kernel panic while installing new image due to harddrive is too slow and taking too long to sync contents to disk.

#### How did you do it?
Some devices has slow hard drive, installing image could trigger kernel crash due to task seemingly hang.

Increase the hung task timeout value to 600 seconds to work around this issue.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Tested the configuration on dut triggers kernel panic consistently.