### PR TITLE
Check pmon daemon statue before test 'show platform psustatus'

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -17,6 +17,7 @@ import pytest
 import util
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.daemon_utils import check_pmon_daemon_status
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -99,6 +99,9 @@ def test_show_platform_psustatus(duthosts, rand_one_dut_hostname):
     @summary: Verify output of `show platform psustatus`
     """
     duthost = duthosts[rand_one_dut_hostname]
+    logging.info("Check pmon daemon status")
+    assert check_pmon_daemon_status(duthost), "Not all pmon daemons running."
+
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus"])
 
     logging.info("Verifying output of '{}' ...".format(cmd))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Check pmon daemon status before test 'show platform psustatus
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If the test case show_platform_psustatus fail, show the pmon daemon
status. The test need psud update psustatus to STATE_DB related tables.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
