### PR TITLE
[slow disk] pass module into the workaround function

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -106,7 +106,7 @@ def install_new_sonic_image(module, new_image_url):
                      msg="Remove config_db.json in preference of minigraph.xml")
 
 
-def work_around_for_slow_disks():
+def work_around_for_slow_disks(module):
     # Increase hung task timeout to 600 seconds to avoid kernel panic
     # while writing lots of data to a slow disk.
     exec_command(module, cmd="sysctl -w kernel.hung_task_timeout_secs=600", ignore_error=True)
@@ -124,7 +124,7 @@ def main():
     new_image_url   = module.params['new_image_url']
 
     try:
-        work_around_for_slow_disks()
+        work_around_for_slow_disks(module)
         reduce_installed_sonic_images(module, disk_used_pcent)
         install_new_sonic_image(module, new_image_url)
     except:


### PR DESCRIPTION
Summary:
Address regression caused by PR #2715 .

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR #2715 introduced an issue where the workaround function doesn't have module parameter to call exec_command with.

#### How did you do it?
Pass in the module parameter so that workaround function can execute command properly.

#### How did you verify/test it?
Run upgrade_sonic task against an DUT.
