### PR TITLE
[minigraph]: Add ToR loopback addresses for dual ToR topos

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 class DualTorParser:
 
     def __init__(self, hostname, testbed_facts, host_vars, vm_config):
@@ -27,6 +28,24 @@ class DualTorParser:
         upper_tor, lower_tor = sorted(self.testbed_facts['duts'])
         self.dual_tor_facts['positions'] = {'upper': upper_tor, 'lower': lower_tor}
 
+    def parse_loopback_ips(self):
+        '''
+        Parses the IPv4 and IPv6 loopback IPs for the DUTs
+
+        Similar to `parse_tor_position`, the ToR which comes first alphabetically is always assigned the first IP
+        '''
+
+        loopback_ips = defaultdict(dict)
+
+        ipv4_loopbacks = sorted(self.vm_config['DUT']['loopback']['ipv4'])
+        ipv6_loopbacks = sorted(self.vm_config['DUT']['loopback']['ipv6'])
+
+        for i, dut in enumerate(sorted(self.testbed_facts['duts'])):
+            loopback_ips[dut]['ipv4'] = ipv4_loopbacks[i]
+            loopback_ips[dut]['ipv6'] = ipv6_loopbacks[i] 
+
+        self.dual_tor_facts['loopback'] = loopback_ips     
+
     def generate_cable_names(self):
         cables = []
 
@@ -44,6 +63,7 @@ class DualTorParser:
             self.parse_neighbor_tor()
             self.parse_tor_position()
             self.generate_cable_names()
+            self.parse_loopback_ips()
 
         return self.dual_tor_facts
 

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -39,14 +39,31 @@
       <Device i:type="{{ vm_topo_config['dut_type'] }}">
         <Hostname>{{ inventory_hostname }}</Hostname>
         <HwSku>{{ hwsku }}</HwSku>
+{% if 'loopback' in dual_tor_facts %}
+        <Address xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>{{ dual_tor_facts['loopback'][inventory_hostname]['ipv4'] }}</a:IPPrefix>
+        </Address>
+        <AddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>{{ dual_tor_facts['loopback'][inventory_hostname]['ipv6'] }}</a:IPPrefix>
+        </AddressV6>
+{% endif %}
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
            <a:IPPrefix>{{ ansible_host }}</a:IPPrefix>
         </ManagementAddress>
       </Device>
 {% if 'neighbor' in dual_tor_facts %}
+{% set neighbor_hostname = dual_tor_facts['neighbor']['hostname'] %}
       <Device i:type="{{ vm_topo_config['dut_type'] }}">
-        <Hostname>{{ dual_tor_facts['neighbor']['hostname'] }}</Hostname>
+        <Hostname>{{ neighbor_hostname }}</Hostname>
         <HwSku>{{ dual_tor_facts['neighbor']['hwsku'] }}</HwSku>
+{% if 'loopback' in dual_tor_facts %}
+        <Address xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>{{ dual_tor_facts['loopback'][neighbor_hostname]['ipv4'] }}</a:IPPrefix>
+        </Address>
+        <AddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>{{ dual_tor_facts['loopback'][neighbor_hostname]['ipv6'] }}</a:IPPrefix>
+        </AddressV6>
+{% endif %}
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
            <a:IPPrefix>{{ dual_tor_facts['neighbor']['ip'] }}</a:IPPrefix>
         </ManagementAddress>


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Existing minigraph generation does not include loopback IPs for ToRs in the PNG section. This information is needed for dual ToR topologies

#### How did you do it?
While collecitng dual ToR facts, parse loopback IPs from the topology YAML file

#### How did you verify/test it?
Deploy minigraph on dual ToR setup, verify that loopback IPs were parsed and populated in config DB

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
