### PR TITLE
[arp_responder]: Add IPv6 support

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -15,7 +15,7 @@ import scapy.all as scapy2
 scapy2.conf.use_pcap=True
 import scapy.arch.pcapdnet
 
-NEIGH_ADV_ICMP_MSG_TYPE = 135
+NEIGH_SOLICIT_ICMP_MSG_TYPE = 135
 
 def hexdump(data):
     print " ".join("%02x" % ord(d) for d in data)
@@ -48,7 +48,7 @@ class Interface(object):
             self.socket.close()
 
     def bind(self):
-        self.socket = scapy2.conf.L2listen(iface=self.iface, filter='arp || ip6[40] = {}'.format(NEIGH_ADV_ICMP_MSG_TYPE))
+        self.socket = scapy2.conf.L2listen(iface=self.iface, filter='arp || ip6[40] = {}'.format(NEIGH_SOLICIT_ICMP_MSG_TYPE))
 
     def handler(self):
         return self.socket

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -87,7 +87,7 @@ class Poller(object):
 
 class ARPResponder(object):
     ARP_PKT_LEN = 64
-    NDP_PKT_LEN = 86
+    NDP_PKT_LEN = 90
     ARP_OP_REQUEST = 1
     def __init__(self, ip_sets):
         self.arp_chunk = binascii.unhexlify('08060001080006040002') # defines a part of the packet for ARP Reply
@@ -139,9 +139,14 @@ class ARPResponder(object):
         return
         
     def extract_ndp_info(self, data):
+        vlan_offset = 0
+
+        if len(data) == 90:
+            vlan_offset = 4
+
         remote_mac = data[6:12]
-        remote_ip = data[22:38]
-        target_ip = data[62:78]
+        remote_ip = data[22 + vlan_offset:38 + vlan_offset]
+        target_ip = data[62 + vlan_offset:78 + vlan_offset]
 
         return remote_mac, remote_ip, target_ip
 

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -15,6 +15,8 @@ import scapy.all as scapy2
 scapy2.conf.use_pcap=True
 import scapy.arch.pcapdnet
 
+NEIGH_ADV_ICMP_MSG_TYPE = 135
+
 def hexdump(data):
     print " ".join("%02x" % ord(d) for d in data)
 
@@ -46,7 +48,7 @@ class Interface(object):
             self.socket.close()
 
     def bind(self):
-        self.socket = scapy2.conf.L2listen(iface=self.iface, filter='arp || ip6[40] = 135')
+        self.socket = scapy2.conf.L2listen(iface=self.iface, filter='arp || ip6[40] = {}'.format(NEIGH_ADV_ICMP_MSG_TYPE))
 
     def handler(self):
         return self.socket


### PR DESCRIPTION
* Filter for both ARP and Neighbor Solicitation messages
* Create Neighbor Advertisement messages as configured to reply to NS
messages

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ARP responder only supports IPv4 ARP requests/replies

#### How did you do it?
Add Neighbor Solicitation messages to the BPF query used to filter incoming packets
Distinguish ARP vs NDP messages based on length
Construct appropriate NA messages to reply to NS messages

#### How did you verify/test it?
Send NA messages from a machine to arp_responder running on a PTF, and verify that NS messages were sent back.
Run a set of nightly test cases to verify that existing ARP functionality was not impacted.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
