### PR TITLE
[KVM warm-reboot] Increase reboot limit for KVM warm-reboot test

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -83,7 +83,7 @@ class AdvancedReboot:
         # Set default reboot limit if it is not given
         if self.rebootLimit is None:
             if self.kvmTest:
-                self.rebootLimit = 150 # Default reboot limit for kvm
+                self.rebootLimit = 200 # Default reboot limit for kvm
             else:
                 self.rebootLimit = 30 # Default reboot limit for physical devices
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increase the empirical reboot limit for KVM warm-reboot test
This PR aims to mitigate the KVM warm-reboot test failures due to the over-limit downtime. Additional investigation is needed to make sure the KVM warm-reboot is well functional. 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR aims to mitigate the KVM warm-reboot test failures due to the over-limit downtime. Additional investigation is needed to make sure the KVM warm-reboot is well functional. 

#### How did you do it?
Increase reboot limit for KVM warm-reboot test

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
