### PR TITLE
[multi-asic] Update drop counters tests for multi-asic platforms

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -11,6 +11,7 @@ import ptf.packet as packet
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.device_utils import fanout_switch_port_lookup
+from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"
@@ -107,6 +108,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
         port_channel_members, vlan_members, rif_members, dut_to_ptf_port_map, neighbor_sniff_ports, vlans, mg_facts
     """
     duthost = duthosts[rand_one_dut_hostname]
+    intf_per_namespace = {}
     port_channel_members = {}
     vlan_members = {}
     configured_vlans = []
@@ -114,6 +116,10 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
 
     if tbinfo["topo"]["type"] == "ptf":
         pytest.skip("Unsupported topology {}".format(tbinfo["topo"]))
+
+    #Gather interface facts per asic
+    for ns in duthost.get_asic_namespace_list():
+        intf_per_namespace[ns if ns is not DEFAULT_NAMESPACE else ''] = duthost.interface_facts(namespace=ns)['ansible_facts']['ansible_interface_facts']
 
     # Gather ansible facts
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -127,7 +133,6 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
             vlan_members[iface] = vlan_id
 
     rif_members = {item["attachto"]: item["attachto"] for item in mg_facts["minigraph_interfaces"]}
-
     # Compose list of sniff ports
     neighbor_sniff_ports = []
     for dut_port, neigh in mg_facts['minigraph_neighbors'].items():
@@ -143,7 +148,8 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
         "dut_to_ptf_port_map": mg_facts["minigraph_ptf_indices"],
         "neighbor_sniff_ports": neighbor_sniff_ports,
         "vlans": configured_vlans,
-        "mg_facts": mg_facts
+        "mg_facts": mg_facts,
+        "intf_per_namespace": intf_per_namespace
     }
     return setup_information
 
@@ -195,6 +201,7 @@ def ports_info(ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports)
     """
     Return:
         dut_iface - DUT interface name expected to receive packtes from PTF
+        asic_index - asic which owns the dut_iface, significant on a multi-asic platform.
         ptf_tx_port_id - Port ID used by PTF for sending packets from expected PTF interface
         dst_mac - DUT interface destination MAC address
         src_mac - PTF interface source MAC address
@@ -202,8 +209,17 @@ def ports_info(ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports)
     duthost = duthosts[rand_one_dut_hostname]
     data = {}
     data["dut_iface"] = random.choice(tx_dut_ports.keys())
+    # Check which asic owns this interface
+    for ns in duthost.get_asic_namespace_list():
+        if data["dut_iface"] in setup['intf_per_namespace'][ns if ns is not DEFAULT_NAMESPACE else '']:
+            break
+
+    # Get the asic index
+    asic_index = duthost.get_asic_id_from_namespace(ns)
+    data["asic_index"] = asic_index
+
     data["ptf_tx_port_id"] = setup["dut_to_ptf_port_map"][data["dut_iface"]]
-    data["dst_mac"] = duthost.get_dut_iface_mac(data["dut_iface"])
+    data["dst_mac"] = setup['intf_per_namespace'][ns if ns is not DEFAULT_NAMESPACE else ''][data["dut_iface"]]['macaddress']
     data["src_mac"] = ptfadapter.dataplane.ports[(0, data["ptf_tx_port_id"])].mac()
     return data
 

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -50,7 +50,7 @@ def enable_counters(duthosts, rand_one_dut_hostname):
     for cmd in cmd_list:
         duthost.command(cmd)
 
-    namespace_list = duthost.get_frontend_asic_namespace_list() if duthost.is_multi_asic else ['']
+    namespace_list = duthost.get_asic_namespace_list() if duthost.is_multi_asic else ['']
     for namespace in namespace_list:
         cmd_get_cnt_status = "sonic-db-cli -n '{}' CONFIG_DB HGET \"FLEX_COUNTER_TABLE|{}\" FLEX_COUNTER_STATUS"
         previous_cnt_status[namespace] = {item: duthost.command(cmd_get_cnt_status.format(namespace, item.upper()))["stdout"] for item in ["port", "rif"]}

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -21,9 +21,11 @@ logger = logging.getLogger(__name__)
 
 PKT_NUMBER = 1000
 
-# CLI commands to obtain drop counters
-GET_L2_COUNTERS = "portstat -j"
-GET_L3_COUNTERS = "intfstat -j"
+# CLI commands to obtain drop counters.
+NAMESPACE_PREFIX = "sudo ip netns exec {} "
+NAMESPACE_SUFFIX = "-n {} "
+GET_L2_COUNTERS = "portstat -j "
+GET_L3_COUNTERS = "intfstat -j "
 ACL_COUNTERS_UPDATE_INTERVAL = 10
 LOG_EXPECT_ACL_RULE_CREATE_RE = ".*Successfully created ACL rule.*"
 LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
@@ -38,20 +40,31 @@ COMBINED_ACL_DROP_COUNTER = False
 def enable_counters(duthosts, rand_one_dut_hostname):
     """ Fixture which enables RIF and L2 counters """
     duthost = duthosts[rand_one_dut_hostname]
-    cmd_list = ["intfstat -D", "counterpoll port enable", "counterpoll rif enable", "sonic-clear counters",
-                "sonic-clear rifcounters"]
-    cmd_get_cnt_status = "redis-cli -n 4 HGET \"FLEX_COUNTER_TABLE|{}\" \"FLEX_COUNTER_STATUS\""
 
-    previous_cnt_status = {item: duthost.command(cmd_get_cnt_status.format(item.upper()))["stdout"] for item in ["port", "rif"]}
+    previous_cnt_status = {}
+    # Separating comands based on whether they need to be done per namespace or globally.
+    cmd_list = ["intfstat -D", "sonic-clear counters"]
+    cmd_list_per_ns = ["counterpoll port enable", "counterpoll rif enable", "sonic-clear rifcounters"]
 
+    """ Fixture which enables RIF and L2 counters """
     for cmd in cmd_list:
         duthost.command(cmd)
-    yield
-    for port, status in previous_cnt_status.items():
-        if status == "disable":
-            logger.info("Restoring counter '{}' state to disable".format(port))
-            duthost.command("counterpoll {} disable".format(port))
 
+    namespace_list = duthost.get_frontend_asic_namespace_list() if duthost.is_multi_asic else ['']
+    for namespace in namespace_list:
+        cmd_get_cnt_status = "sonic-db-cli -n '{}' CONFIG_DB HGET \"FLEX_COUNTER_TABLE|{}\" FLEX_COUNTER_STATUS"
+        previous_cnt_status[namespace] = {item: duthost.command(cmd_get_cnt_status.format(namespace, item.upper()))["stdout"] for item in ["port", "rif"]}
+
+        CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
+        for cmd in cmd_list_per_ns:
+            duthost.command(CMD_PREFIX + cmd, _uses_shell=True)
+    yield
+    for namespace in namespace_list:
+        for port, status in previous_cnt_status[namespace].items():
+            if status == "disable":
+                logger.info("Restoring counter '{}' state to disable".format(port))
+                CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
+                duthost.command(CMD_PREFIX + "counterpoll {} disable".format(port))
 
 @pytest.fixture
 def acl_setup(duthosts, rand_one_dut_hostname, loganalyzer):
@@ -109,17 +122,26 @@ def parse_combined_counters(duthosts, rand_one_dut_hostname):
                     COMBINED_ACL_DROP_COUNTER = True
                     break
 
-
-def get_pkt_drops(duthost, cli_cmd):
+def get_pkt_drops(duthost, cli_cmd, asic_index):
     """
     @summary: Parse output of "portstat" or "intfstat" commands and convert it to the dictionary.
     @param module: The AnsibleModule object
     @param cli_cmd: one of supported CLI commands - "portstat -j" or "intfstat -j"
     @return: Return dictionary of parsed counters
     """
-    stdout = duthost.command(cli_cmd)
-    stdout = stdout["stdout"]
+    # Get namespace from asic_index.
+    namespace = duthost.get_namespace_from_asic_id(asic_index)
 
+    # Frame the correct cli command
+    if cli_cmd == GET_L3_COUNTERS:
+        CMD_PREFIX = NAMESPACE_PREFIX if duthost.is_multi_asic else ''
+        cli_cmd = CMD_PREFIX + cli_cmd
+    elif cli_cmd == GET_L2_COUNTERS:
+        CMD_SUFFIX = NAMESPACE_SUFFIX if duthost.is_multi_asic else ''
+        cli_cmd = cli_cmd + CMD_SUFFIX
+
+    stdout = duthost.command(cli_cmd.format(namespace))
+    stdout = stdout["stdout"]
     match = re.search("Last cached time was.*\n", stdout)
     if match:
         stdout = re.sub("Last cached time was.*\n", "", stdout)
@@ -130,9 +152,9 @@ def get_pkt_drops(duthost, cli_cmd):
         raise Exception("Failed to parse output of '{}', err={}".format(cli_cmd, str(err)))
 
 
-def ensure_no_l3_drops(duthost):
+def ensure_no_l3_drops(duthost, asic_index):
     """ Verify L3 drop counters were not incremented """
-    intf_l3_counters = get_pkt_drops(duthost, GET_L3_COUNTERS)
+    intf_l3_counters = get_pkt_drops(duthost, GET_L3_COUNTERS, asic_index)
     unexpected_drops = {}
     for iface, value in intf_l3_counters.items():
         try:
@@ -146,9 +168,9 @@ def ensure_no_l3_drops(duthost):
         pytest.fail("L3 'RX_ERR' was incremented for the following interfaces:\n{}".format(unexpected_drops))
 
 
-def ensure_no_l2_drops(duthost):
+def ensure_no_l2_drops(duthost, asic_index):
     """ Verify L2 drop counters were not incremented """
-    intf_l2_counters = get_pkt_drops(duthost, GET_L2_COUNTERS)
+    intf_l2_counters = get_pkt_drops(duthost, GET_L2_COUNTERS, asic_index)
     unexpected_drops = {}
     for iface, value in intf_l2_counters.items():
         try:
@@ -167,39 +189,44 @@ def str_to_int(value):
     return int(value.replace(",", ""))
 
 
-def verify_drop_counters(duthost, dut_iface, get_cnt_cli_cmd, column_key):
+def verify_drop_counters(duthost, asic_index, dut_iface, get_cnt_cli_cmd, column_key):
     """ Verify drop counter incremented on specific interface """
-    get_drops = lambda: int(get_pkt_drops(duthost, get_cnt_cli_cmd)[dut_iface][column_key].replace(",", ""))
+    get_drops = lambda: int(get_pkt_drops(duthost, get_cnt_cli_cmd, asic_index)[dut_iface][column_key].replace(",", ""))
     check_drops_on_dut = lambda: PKT_NUMBER == get_drops()
-    if not wait_until(5, 1, check_drops_on_dut):
+    if not wait_until(30, 5, check_drops_on_dut):
         fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; Sent == {}".format(
             column_key, dut_iface, column_key, get_drops(), PKT_NUMBER
         )
         pytest.fail(fail_msg)
 
 
-def base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_dut_ports=None):
+def base_verification(discard_group, pkt, ptfadapter, duthost, asic_index, ports_info, tx_dut_ports=None):
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
     """
     # Clear SONiC counters
     duthost.command("sonic-clear counters")
-    duthost.command("sonic-clear rifcounters")
+
+    # Clear RIF counters per namespace.
+    namespace = duthost.get_namespace_from_asic_id(asic_index)
+    CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
+    duthost.command(CMD_PREFIX+"sonic-clear rifcounters")
+
     send_packets(pkt, duthost, ptfadapter, ports_info["ptf_tx_port_id"], PKT_NUMBER)
     if discard_group == "L2":
-        verify_drop_counters(duthost, ports_info["dut_iface"], GET_L2_COUNTERS, L2_COL_KEY)
-        ensure_no_l3_drops(duthost)
+        verify_drop_counters(duthost, asic_index, ports_info["dut_iface"], GET_L2_COUNTERS, L2_COL_KEY)
+        ensure_no_l3_drops(duthost, asic_index)
     elif discard_group == "L3":
         if COMBINED_L2L3_DROP_COUNTER:
-            verify_drop_counters(duthost, ports_info["dut_iface"], GET_L2_COUNTERS, L2_COL_KEY)
-            ensure_no_l3_drops(duthost)
+            verify_drop_counters(duthost, asic_index, ports_info["dut_iface"], GET_L2_COUNTERS, L2_COL_KEY)
+            ensure_no_l3_drops(duthost, asic_index)
         else:
             if not tx_dut_ports:
                 pytest.fail("No L3 interface specified")
 
-            verify_drop_counters(duthost, tx_dut_ports[ports_info["dut_iface"]], GET_L3_COUNTERS, L3_COL_KEY)
-            ensure_no_l2_drops(duthost)
+            verify_drop_counters(duthost, asic_index, tx_dut_ports[ports_info["dut_iface"]], GET_L3_COUNTERS, L3_COL_KEY)
+            ensure_no_l2_drops(duthost, asic_index)
     elif discard_group == "ACL":
         if not tx_dut_ports:
             pytest.fail("No L3 interface specified")
@@ -212,17 +239,21 @@ def base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_du
             )
             pytest.fail(fail_msg)
         if not COMBINED_ACL_DROP_COUNTER:
-            ensure_no_l3_drops(duthost)
-            ensure_no_l2_drops(duthost)
+            ensure_no_l3_drops(duthost, asic_index)
+            ensure_no_l2_drops(duthost, asic_index)
     elif discard_group == "NO_DROPS":
-        ensure_no_l2_drops(duthost)
-        ensure_no_l3_drops(duthost)
+        ensure_no_l2_drops(duthost, asic_index)
+        ensure_no_l3_drops(duthost, asic_index)
     else:
         pytest.fail("Incorrect 'discard_group' specified. Supported values: 'L2', 'L3', 'ACL' or 'NO_DROPS'")
 
 
-def get_intf_mtu(duthost, intf):
-    return int(duthost.shell("/sbin/ifconfig {} | grep -i mtu | awk '{{print $NF}}'".format(intf))["stdout"])
+def get_intf_mtu(duthost, intf, asic_index):
+    # Get namespace from asic_index.
+    namespace = duthost.get_namespace_from_asic_id(asic_index)
+
+    CMD_PREFIX = NAMESPACE_PREFIX.format(namespace) if duthost.is_multi_asic else ''
+    return int(duthost.shell(CMD_PREFIX + "/sbin/ifconfig {} | grep -i mtu | awk '{{print $NF}}'".format(intf))["stdout"])
 
 
 @pytest.fixture
@@ -235,27 +266,30 @@ def mtu_config(duthosts, rand_one_dut_hostname):
         default_mtu = 9100
 
         @classmethod
-        def set_mtu(cls, mtu, iface):
-            cls.mtu = duthost.command("redis-cli -n 4 hget \"PORTCHANNEL|{}\" mtu".format(iface))["stdout"]
+        def set_mtu(cls, mtu, iface, asic_index):
+            namespace = duthost.get_namespace_from_asic_id(asic_index) if duthost.is_multi_asic else ''
+            cls.mtu = duthost.command("sonic-db-cli -n '{}' CONFIG_DB hget \"PORTCHANNEL|{}\" mtu".format(namespace, iface))["stdout"]
             if not cls.mtu:
                 cls.mtu = cls.default_mtu
             if "PortChannel" in iface:
-                duthost.command("redis-cli -n 4 hset \"PORTCHANNEL|{}\" mtu {}".format(iface, mtu))["stdout"]
+                duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORTCHANNEL|{}\" mtu {}".format(namespace, iface, mtu))["stdout"]
             elif "Ethernet" in iface:
-                duthost.command("redis-cli -n 4 hset \"PORT|{}\" mtu {}".format(iface, mtu))["stdout"]
+                duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORT|{}\" mtu {}".format(namespace, iface, mtu))["stdout"]
             else:
                 raise Exception("Unsupported interface parameter - {}".format(iface))
             cls.iface = iface
-            check_mtu = lambda: get_intf_mtu(duthost, iface) == mtu
+            check_mtu = lambda: get_intf_mtu(duthost, iface, asic_index) == mtu
             pytest_assert(wait_until(5, 1, check_mtu), "MTU on interface {} not updated".format(iface))
+            cls.asic_index = asic_index
 
         @classmethod
         def restore_mtu(cls):
             if cls.iface:
+                namespace = duthost.get_namespace_from_asic_id(cls.asic_index) if duthost.is_multi_asic else ''
                 if "PortChannel" in cls.iface:
-                    duthost.command("redis-cli -n 4 hset \"PORTCHANNEL|{}\" mtu {}".format(cls.iface, cls.mtu))["stdout"]
+                    duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORTCHANNEL|{}\" mtu {}".format(namespace, cls.iface, cls.mtu))["stdout"]
                 elif "Ethernet" in cls.iface:
-                    duthost.command("redis-cli -n 4 hset \"PORT|{}\" mtu {}".format(cls.iface, cls.mtu))["stdout"]
+                    duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORT|{}\" mtu {}".format(namespace, cls.iface, cls.mtu))["stdout"]
                 else:
                     raise Exception("Trying to restore MTU on unsupported interface - {}".format(cls.iface))
 
@@ -283,7 +317,8 @@ def do_test():
         @param sniff_ports: DUT ports to check that packets were not egressed from
         """
         check_if_skip()
-        base_verification(discard_group, pkt, ptfadapter, duthost, ports_info, tx_dut_ports)
+        asic_index = ports_info["asic_index"]
+        base_verification(discard_group, pkt, ptfadapter, duthost, asic_index, ports_info, tx_dut_ports)
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
@@ -347,7 +382,8 @@ def test_acl_drop(do_test, ptfadapter, duthosts, rand_one_dut_hostname, setup, t
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"]
         )
-    base_verification("ACL", pkt, ptfadapter, duthost, ports_info, tx_dut_ports)
+    asic_index = ports_info["asic_index"]
+    base_verification("ACL", pkt, ptfadapter, duthost, asic_index, ports_info, tx_dut_ports)
 
     # Verify packets were not egresed the DUT
     exp_pkt = expected_packet_mask(pkt)
@@ -417,8 +453,12 @@ def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, duthosts, rand_one_dut_ho
 
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"],
                     pkt_fields["ipv4_src"])
+
+    # Get the asic_index
+    asic_index = ports_info["asic_index"]
+
     # Set temporal MTU. This will be restored by 'mtu' fixture
-    mtu_config.set_mtu(tmp_port_mtu, tx_dut_ports[ports_info["dut_iface"]])
+    mtu_config.set_mtu(tmp_port_mtu, tx_dut_ports[ports_info["dut_iface"]], asic_index)
 
     pkt = testutils.simple_tcp_packet(
         pktlen=9100,


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Update the drop counters tests to support multi-asic
Dependent on changes done in #2728 for common utilities change and #2726 for interface_facts change

#### What is the motivation for this PR?

#### How did you do it?
The changes included in this PR 
  * Introduced the interfaces_per_namespace field to populate the interfaces per namespace on test start.
  * find and pass asic_index to the tests. The asic_index is obtained from the port which is which is select randomly for test.  
  * Add the namespace PREFIX/SUFFIX to certain commands if needed for l2/l3 interface stat/clear commands. There are certain commands which supports the "-namespace" option. The other commands are invoked with the "sudo ip netns exec <namespace> <cmd>" format.
  * use sonic-db-cli instead of redis-cli, as sonic-db-cli supports the namespace parameter.

#### How did you verify/test it?
The test was run on single ASIC and multi-aisc platforms. [ There are some known failures, which needs to be worked on outside this PR ]

```
ON SINGLE ASIC platforms

jujoseph@e43a137fd9cd:/var/mgmt/sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i ../ansible/str -f ../ansible/testbed.csv -c drop_packets/test_drop_counters.py -u
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/mgmt/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 99 items

drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[port_channel_members] SKIPPED                                                                                                                                                              [  1%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[vlan_members] SKIPPED                                                                                                                                                                      [  2%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[rif_members] SKIPPED                                                                                                                                                                       [  3%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[port_channel_members] SKIPPED                                                                                                                                                               [  4%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[vlan_members] SKIPPED                                                                                                                                                                       [  5%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[rif_members] SKIPPED                                                                                                                                                                        [  6%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members]PASSED                                                                                                                                                          [  7%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members] SKIPPED                                                                                                                                                                [  8%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members]PASSED                                                                                                                                                                   [  9%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[port_channel_members]PASSED                                                                                                                                                             [ 10%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members] SKIPPED                                                                                                                                                                   [ 11%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[rif_members]PASSED                                                                                                                                                                      [ 12%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[port_channel_members]PASSED                                                                                                                                                             [ 13%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[vlan_members] SKIPPED                                                                                                                                                                   [ 14%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[rif_members]PASSED                                                                                                                                                                      [ 15%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[port_channel_members]PASSED                                                                                                                                                                       [ 16%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members] SKIPPED                                                                                                                                                                             [ 17%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[rif_members]PASSED                                                                                                                                                                                [ 18%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-ipv4]PASSED                                                                                                                                                       [ 19%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-ipv6]PASSED                                                                                                                                                       [ 20%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-ipv4] SKIPPED                                                                                                                                                             [ 21%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-ipv6] SKIPPED                                                                                                                                                             [ 22%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-ipv4]                                                                                                                                                                      [ 23%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-ipv6]PASSED                                                                                                                                                                [ 24%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[port_channel_members] FAILED                                                                                                                                                                  [ 25%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[vlan_members] SKIPPED                                                                                                                                                                         [ 26%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[rif_members] FAILED                                                                                                                                                                           [ 27%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv4-src]PASSED                                                                                                                                                            [ 28%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv6-srcPASSED                                                                                                                                                             [ 29%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv4-dst] FAILED                                                                                                                                                           [ 30%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv4-dst] ERROR                                                                                                                                                            [ 30%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv6-dst]FAILED                                                                                                                                                            [ 31%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv6-dst] ERROR                                                                                                                                                            [ 31%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-src] SKIPPED                                                                                                                                                                  [ 32%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src] SKIPPED                                                                                                                                                                  [ 33%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-dst] SKIPPED                                                                                                                                                                  [ 34%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-dst] SKIPPED                                                                                                                                                                  [ 35%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv4-src]PASSED                                                                                                                                                                     [ 36%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv6-src]PASSED                                                                                                                                                                     [ 37%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv4-dst]PASSED                                                                                                                                                                     [ 38%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv6-dst] PASSED                                                                                                                                                                    [ 39%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[port_channel_members] PASSED                                                                                                                                                                  [ 40%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[vlan_members] SKIPPED                                                                                                                                                                         [ 41%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[rif_members] PASSED                                                                                                                                                                           [ 42%]
drop_packets/test_drop_counters.py::test_loopback_filter[port_channel_members] SKIPPED                                                                                                                                                                   [ 43%]
drop_packets/test_drop_counters.py::test_loopback_filter[vlan_members] SKIPPED                                                                                                                                                                           [ 44%]
drop_packets/test_drop_counters.py::test_loopback_filter[rif_members] SKIPPED                                                                                                                                                                            [ 45%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[port_channel_members] PASSED                                                                                                                                                            [ 46%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[vlan_members] SKIPPED                                                                                                                                                                   [ 47%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[rif_members] PASSED                                                                                                                                                                     [ 48%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-version-1] PASSED                                                                                                                                                         [ 49%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-chksum-10] PASSED                                                                                                                                                         [ 50%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-ihl-1] PASSED                                                                                                                                                             [ 51%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-version-1] SKIPPED                                                                                                                                                                [ 52%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-chksum-10] SKIPPED                                                                                                                                                                [ 53%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-ihl-1] SKIPPED                                                                                                                                                                    [ 54%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-version-1] PASSED                                                                                                                                                                  [ 55%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-chksum-10] PASSED                                                                                                                                                                  [ 56%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-ihl-1] PASSED                                                                                                                                                                      [ 57%]
drop_packets/test_drop_counters.py::test_absent_ip_header[port_channel_members] PASSED                                                                                                                                                                   [ 58%]
drop_packets/test_drop_counters.py::test_absent_ip_header[vlan_members] SKIPPED                                                                                                                                                                          [ 59%]
drop_packets/test_drop_counters.py::test_absent_ip_header[rif_members] PASSED                                                                                                                                                                            [ 60%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-01:00:5e:00:01:02] PASSED                                                                                                                                     [ 61%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-ff:ff:ff:ff:ff:ff] PASSED                                                                                                                                     [ 62%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-01:00:5e:00:01:02] SKIPPED                                                                                                                                            [ 63%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-ff:ff:ff:ff:ff:ff] SKIPPED                                                                                                                                            [ 64%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-01:00:5e:00:01:02] PASSED                                                                                                                                              [ 65%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-ff:ff:ff:ff:ff:ff] PASSED                                                                                                                                              [ 66%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v1-general_query] SKIPPED                                                                                                                                           [ 67%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v3-general_query] SKIPPED                                                                                                                                           [ 68%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v1-membership_report] SKIPPED                                                                                                                                       [ 69%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v2-membership_report] SKIPPED                                                                                                                                       [ 70%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v3-membership_report] SKIPPED                                                                                                                                       [ 71%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v2-leave_group] SKIPPED                                                                                                                                             [ 72%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v1-general_query] SKIPPED                                                                                                                                                   [ 73%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v3-general_query] SKIPPED                                                                                                                                                   [ 74%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v1-membership_report] SKIPPED                                                                                                                                               [ 75%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v2-membership_report] SKIPPED                                                                                                                                               [ 76%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v3-membership_report] SKIPPED                                                                                                                                               [ 77%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v2-leave_group] SKIPPED                                                                                                                                                     [ 78%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v1-general_query] SKIPPED                                                                                                                                                    [ 79%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v3-general_query] SKIPPED                                                                                                                                                    [ 80%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v1-membership_report] SKIPPED                                                                                                                                                [ 81%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v2-membership_report] SKIPPED                                                                                                                                                [ 82%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v3-membership_report] SKIPPED                                                                                                                                                [ 83%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v2-leave_group] SKIPPED                                                                                                                                                      [ 84%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[port_channel_members] SKIPPED                                                                                                                                                                [ 85%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[vlan_members] SKIPPED                                                                                                                                                                        [ 86%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[rif_members] SKIPPED                                                                                                                                                                         [ 87%]
drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members] PASSED                                                                                                                                                                           [ 88%]
drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members] ERROR                                                                                                                                                                            [ 88%]
drop_packets/test_drop_counters.py::test_acl_drop[vlan_members] SKIPPED                                                                                                                                                                                  [ 89%]
drop_packets/test_drop_counters.py::test_acl_drop[rif_members] ERROR                                                                                                                                                                                     [ 90%]
drop_packets/test_drop_counters.py::test_acl_drop[rif_members] ERROR                                                                                                                                                                                     [ 90%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[port_channel_members] ERROR                                                                                                                                                         [ 91%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[port_channel_members] ERROR                                                                                                                                                         [ 91%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[vlan_members] SKIPPED                                                                                                                                                               [ 92%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[rif_members] ERROR                                                                                                                                                                  [ 93%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[rif_members] ERROR                                                                                                                                                                  [ 93%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[port_channel_members]FAILED                                                                                                                                                                   [ 94%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[vlan_members] SKIPPED                                                                                                                                                                         [ 95%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[rif_members] FAILED                                                                                                                                                                           [ 96%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[port_channel_members]PASSED                                                                                                                                                            [ 97%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[vlan_members] SKIPPED                                                                                                                                                                  [ 98%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[rif_members] PASSED                                                                                                                                                                    [100%]

ON MULTI-ASIC platforms

jujoseph@e43a137fd9cd:/var/mgmt/sonic-mgmt/tests$ ./run_tests.sh -d str2-n-acs-1 -n vms17-t1-n-acs-1 -i ../ansible/str2 -f ../ansible/testbed.csv -c drop_packets/test_drop_counters.py -u -e "--deep_clean  --disable_loganalyzer"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/mgmt/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 99 items

drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[port_channel_members] SKIPPED                                                                                                                                                              [  1%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[vlan_members] SKIPPED                                                                                                                                                                      [  2%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[rif_members] SKIPPED                                                                                                                                                                       [  3%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[port_channel_members] SKIPPED                                                                                                                                                               [  4%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[vlan_members] SKIPPED                                                                                                                                                                       [  5%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[rif_members] SKIPPED                                                                                                                                                                        [  6%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members] PASSED                                                                                                                                                         [  7%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members] SKIPPED                                                                                                                                                                [  8%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members] SKIPPED                                                                                                                                                                 [  9%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[port_channel_members] PASSED                                                                                                                                                            [ 10%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members] SKIPPED                                                                                                                                                                   [ 11%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[rif_members] SKIPPED                                                                                                                                                                    [ 12%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[port_channel_members] PASSED                                                                                                                                                            [ 13%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[vlan_members] SKIPPED                                                                                                                                                                   [ 14%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[rif_members] SKIPPED                                                                                                                                                                    [ 15%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[port_channel_members] PASSED                                                                                                                                                                      [ 16%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members] SKIPPED                                                                                                                                                                             [ 17%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[rif_members] SKIPPED                                                                                                                                                                              [ 18%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-ipv4] PASSED                                                                                                                                                      [ 19%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-ipv6] PASSED                                                                                                                                                      [ 20%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-ipv4] SKIPPED                                                                                                                                                             [ 21%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-ipv6] SKIPPED                                                                                                                                                             [ 22%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-ipv4] SKIPPED                                                                                                                                                              [ 23%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-ipv6] SKIPPED                                                                                                                                                              [ 24%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[port_channel_members] PASSED                                                                                                                                                                  [ 25%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[vlan_members] SKIPPED                                                                                                                                                                         [ 26%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[rif_members] SKIPPED                                                                                                                                                                          [ 27%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv4-src] PASSED                                                                                                                                                           [ 28%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv6-src] PASSED                                                                                                                                                           [ 29%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv4-dst] PASSED                                                                                                                                                           [ 30%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv6-dst] PASSED                                                                                                                                                           [ 31%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-src] SKIPPED                                                                                                                                                                  [ 32%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src] SKIPPED                                                                                                                                                                  [ 33%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-dst] SKIPPED                                                                                                                                                                  [ 34%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-dst] SKIPPED                                                                                                                                                                  [ 35%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv4-src] SKIPPED                                                                                                                                                                   [ 36%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv6-src] SKIPPED                                                                                                                                                                   [ 37%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv4-dst] SKIPPED                                                                                                                                                                   [ 38%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-ipv6-dst] SKIPPED                                                                                                                                                                   [ 39%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[port_channel_members] PASSED                                                                                                                                                                  [ 40%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[vlan_members] SKIPPED                                                                                                                                                                         [ 41%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[rif_members] SKIPPED                                                                                                                                                                          [ 42%]
drop_packets/test_drop_counters.py::test_loopback_filter[port_channel_members] SKIPPED                                                                                                                                                                   [ 43%]
drop_packets/test_drop_counters.py::test_loopback_filter[vlan_members] SKIPPED                                                                                                                                                                           [ 44%]
drop_packets/test_drop_counters.py::test_loopback_filter[rif_members] SKIPPED                                                                                                                                                                            [ 45%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[port_channel_members] FAILED                                                                                                                                                            [ 46%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[vlan_members] SKIPPED                                                                                                                                                                   [ 47%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[rif_members] SKIPPED                                                                                                                                                                    [ 48%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-version-1] FAILED                                                                                                                                                         [ 49%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-chksum-10] PASSED                                                                                                                                                         [ 50%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-ihl-1] FAILED                                                                                                                                                             [ 51%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-version-1] SKIPPED                                                                                                                                                                [ 52%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-chksum-10] SKIPPED                                                                                                                                                                [ 53%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-ihl-1] SKIPPED                                                                                                                                                                    [ 54%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-version-1] SKIPPED                                                                                                                                                                 [ 55%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-chksum-10] SKIPPED                                                                                                                                                                 [ 56%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-ihl-1] SKIPPED                                                                                                                                                                     [ 57%]
drop_packets/test_drop_counters.py::test_absent_ip_header[port_channel_members] FAILED                                                                                                                                                                   [ 58%]
drop_packets/test_drop_counters.py::test_absent_ip_header[vlan_members] SKIPPED                                                                                                                                                                          [ 59%]
drop_packets/test_drop_counters.py::test_absent_ip_header[rif_members] SKIPPED                                                                                                                                                                           [ 60%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-01:00:5e:00:01:02] PASSED                                                                                                                                     [ 61%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-ff:ff:ff:ff:ff:ff] PASSED                                                                                                                                     [ 62%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-01:00:5e:00:01:02] SKIPPED                                                                                                                                            [ 63%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-ff:ff:ff:ff:ff:ff] SKIPPED                                                                                                                                            [ 64%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-01:00:5e:00:01:02] SKIPPED                                                                                                                                             [ 65%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-ff:ff:ff:ff:ff:ff] SKIPPED                                                                                                                                             [ 66%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v1-general_query] SKIPPED                                                                                                                                           [ 67%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v3-general_query] SKIPPED                                                                                                                                           [ 68%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v1-membership_report] SKIPPED                                                                                                                                       [ 69%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v2-membership_report] SKIPPED                                                                                                                                       [ 70%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v3-membership_report] SKIPPED                                                                                                                                       [ 71%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-v2-leave_group] SKIPPED                                                                                                                                             [ 72%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v1-general_query] SKIPPED                                                                                                                                                   [ 73%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v3-general_query] SKIPPED                                                                                                                                                   [ 74%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v1-membership_report] SKIPPED                                                                                                                                               [ 75%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v2-membership_report] SKIPPED                                                                                                                                               [ 76%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v3-membership_report] SKIPPED                                                                                                                                               [ 77%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v2-leave_group] SKIPPED                                                                                                                                                     [ 78%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v1-general_query] SKIPPED                                                                                                                                                    [ 79%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v3-general_query] SKIPPED                                                                                                                                                    [ 80%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v1-membership_report] SKIPPED                                                                                                                                                [ 81%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v2-membership_report] SKIPPED                                                                                                                                                [ 82%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v3-membership_report] SKIPPED                                                                                                                                                [ 83%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-v2-leave_group] SKIPPED                                                                                                                                                      [ 84%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[port_channel_members] SKIPPED                                                                                                                                                                [ 85%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[vlan_members] SKIPPED                                                                                                                                                                        [ 86%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[rif_members] SKIPPED                                                                                                                                                                         [ 87%]
drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members] ERROR                                                                                                                                                                            [ 88%]
drop_packets/test_drop_counters.py::test_acl_drop[vlan_members] SKIPPED                                                                                                                                                                                  [ 89%]
drop_packets/test_drop_counters.py::test_acl_drop[rif_members] SKIPPED                                                                                                                                                                                   [ 90%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[port_channel_members] SKIPPED                                                                                                                                                       [ 91%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[vlan_members] SKIPPED                                                                                                                                                               [ 92%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[rif_members] SKIPPED                                                                                                                                                                [ 93%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[port_channel_members] PASSED                                                                                                                                                                  [ 94%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[vlan_members] SKIPPED                                                                                                                                                                         [ 95%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[rif_members] SKIPPED                                                                                                                                                                          [ 96%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[port_channel_members] PASSED                                                                                                                                                           [ 97%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[vlan_members] SKIPPED                                                                                                                                                                  [ 98%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[rif_members] SKIPPED                                                                                                                                                                   [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
