### PR TITLE
Remove the unnecessary sleep in run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -205,9 +205,6 @@ function prepare_dut()
 {
     echo "=== Preparing DUT for subsequent tests ==="
     pytest ${PYTEST_UTIL_OPTS} ${PRET_LOGGING_OPTIONS} ${UTIL_TOPOLOGY_OPTIONS} ${EXTRA_PARAMETERS} -m pretest
-
-    # Give some delay for the newly announced routes to propagate.
-    sleep 120
 }
 
 function cleanup_dut()
@@ -269,7 +266,7 @@ while getopts "h?a:b:c:d:e:f:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
         a )
             AUTO_RECOVER=${OPTARG}
             ;;
-        b ) 
+        b )
             KUBE_MASTER_ID=${OPTARG}
             SKIP_FOLDERS=${SKIP_FOLDERS//k8s/}
             ;;


### PR DESCRIPTION
The pretest step needs to run multiple scripts after test_announce_routes.py.
The time to run these scripts is enough for the routes to be propagated to
DUT. The sleep in function prepare_dut is unnecessary.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The pretest step needs to run multiple scripts after test_announce_routes.py.
The time to run these scripts is enough for the routes to be propagated to
DUT. The 2 minutes sleep in function prepare_dut is unnecessary.

#### How did you do it?
Removed 'sleep 120' in function `prepare_dut`.

#### How did you verify/test it?
Test run the pretest step.
* 08:47:43 - test_announce_routes.py completed
* Check BGP routes on DUT before pretest is done using command `show ip bgp summary`. Before pretest is done, all the IP routes were propagated to DUT.
* 08:51:11 - pretest step completed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
