### PR TITLE
Revert "[KVM warm-reboot] Increase reboot limit for KVM warm-reboot test"

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -83,7 +83,7 @@ class AdvancedReboot:
         # Set default reboot limit if it is not given
         if self.rebootLimit is None:
             if self.kvmTest:
-                self.rebootLimit = 200 # Default reboot limit for kvm
+                self.rebootLimit = 150 # Default reboot limit for kvm
             else:
                 self.rebootLimit = 30 # Default reboot limit for physical devices
 


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#2727

This PR was merged too early. It is better to have more investigation to understand the extra KVM warm-reboot down time before merging it.