### PR TITLE
[testbed-cli]: add -d option to specify sonic vm image location

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -21,6 +21,7 @@ function usage
   echo "    -k <vmtype>     : vm type (veos|ceos) (default: 'veos')"
   echo "    -n <vm_num>     : vm num (default: 0)"
   echo "    -s <msetnumber> : master set identifier on specified <k8s-server-name> (default: 1)"
+  echo "    -d <dir>        : sonic vm directory (default: $HOME/sonic-vm)"
   echo
   echo "Positional Arguments:"
   echo "    <server-name>         : Hostname of server on which to start VMs"
@@ -212,7 +213,15 @@ function add_topo
 
   echo "$dut" "$duts"
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" $@
+  if [ -n "$sonic_vm_dir" ]; then
+      ansible_options="-e sonic_vm_storage_location=$sonic_vm_dir"
+  fi
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
+        -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+        -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
+        -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
+        $ansible_options $@
 
   ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$duts" $@
 
@@ -287,7 +296,15 @@ function refresh_dut
 
   read_file ${topology}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -vvv -i $vmfile testbed_refresh_dut.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
+  if [ -n "$sonic_vm_dir" ]; then
+      ansible_options="-e sonic_vm_storage_location=$sonic_vm_dir"
+  fi
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -vvv -i $vmfile testbed_refresh_dut.yml --vault-password-file="${passwd}" -l "$server" \
+        -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+        -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
+        -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" \
+        $ansible_options $@
 
   echo Done
 }
@@ -421,8 +438,9 @@ tbfile=testbed.csv
 vm_type=veos
 vm_num=0
 msetnumber=1
+sonic_vm_dir=""
 
-while getopts "t:m:k:n:s:" OPTION; do
+while getopts "t:m:k:n:s:d:" OPTION; do
     case $OPTION in
     t)
         tbfile=$OPTARG
@@ -438,6 +456,9 @@ while getopts "t:m:k:n:s:" OPTION; do
         ;;
     s)
         msetnumber=$OPTARG
+        ;;
+    d)
+        sonic_vm_dir=$OPTARG
         ;;
     *)
         usage


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
allow user to specify sonic kvm image location.

#### How did you do it?
add -d option in testbed-cli.sh

#### How did you verify/test it?
run add-topo and refresh-dut and verify it works.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
