### PR TITLE
[Multi Asic] changes to test_default_route to support multi asic platforms

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -10,14 +10,15 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-def test_default_route_set_src(duthosts, rand_one_dut_hostname):
+def test_default_route_set_src(duthosts, rand_one_dut_hostname, enum_asic_index):
     """
     check if ipv4 and ipv6 default src address match Loopback0 address
 
     """
     duthost = duthosts[rand_one_dut_hostname]
+    asichost = duthost.get_asic(enum_asic_index)
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    config_facts = asichost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
 
     lo_ipv4 = None
     lo_ipv6 = None
@@ -35,24 +36,25 @@ def test_default_route_set_src(duthosts, rand_one_dut_hostname):
     pytest_assert(lo_ipv4, "cannot find ipv4 Loopback0 address")
     pytest_assert(lo_ipv6, "cannot find ipv6 Loopback0 address")
 
-    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(u"0.0.0.0/0"))
+    rtinfo = asichost.get_ip_route_info(ipaddress.ip_network(u"0.0.0.0/0"))
     pytest_assert(rtinfo['set_src'], "default route do not have set src. {}".format(rtinfo))
     pytest_assert(rtinfo['set_src'] == lo_ipv4.ip, \
             "default route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv4.ip))
 
-    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
+    rtinfo = asichost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
     pytest_assert(rtinfo['set_src'], "default v6 route do not have set src. {}".format(rtinfo))
     pytest_assert(rtinfo['set_src'] == lo_ipv6.ip, \
             "default v6 route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv6.ip))
 
-def test_default_ipv6_route_next_hop_global_address(duthosts, rand_one_dut_hostname):
+def test_default_ipv6_route_next_hop_global_address(duthosts, rand_one_dut_hostname, enum_asic_index):
     """
     check if ipv6 default route nexthop address uses global address
 
     """
     duthost = duthosts[rand_one_dut_hostname]
+    asichost = duthost.get_asic(enum_asic_index)
 
-    rtinfo = duthost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
+    rtinfo = asichost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
     pytest_assert(rtinfo['nexthops'] > 0, "cannot find ipv6 nexthop for default route")
     for nh in rtinfo['nexthops']:
         pytest_assert(not nh[0].is_link_local, \


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR has changes to support the tests in the file `test_default_route.py` for multi asic platforms

#### How did you verify/test it?
**Verification single asic**
```
arlakshm@41033a037655:/data/sonic-mgmt/tests$ ./run_tests.sh -n vms-kvm-t1-lag  -d vlab03 -c route/test_default_route.py -f vtestbed.csv -i veos_vtb  -u -e '--skip_sanity --disable_loganalyzer'
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
==================================================================================================== test session starts ====================================================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, repeat-0.8.0, metadata-1.10.0, html-1.22.1, ansible-2.2.2
collected 2 items

route/test_default_route.py::test_default_route_set_src[None] PASSED                                                                                                                                                  [ 50%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[None] PASSED                                                                                                                             [100%]

---------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml -----------------------------------------------------------------------------------
================================================================================================= 2 passed in 15.80 seconds =================================================================================================arlakshm@41033a037655:/data/sonic-mgmt/tests$
```

**- Verification on multi asic**
```
arlakshm@6592658efdea:/data/sonic-mgmt/tests$ ./run_tests.sh -d multi_asic_1 -n vms13-t1-lag-2 -c route/test_default_route.py -i /data/files/veos_vtb -f /data/files/vtestbed.csv -u -e '--skip_sanity --deep_clean --disable_loganalyzer  '
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
==================================================================================================== test session starts ====================================================================================================platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collected 12 items

route/test_default_route.py::test_default_route_set_src[0] PASSED                                                                                                                                                     [  8%]
route/test_default_route.py::test_default_route_set_src[1] PASSED                                                                                                                                                     [ 16%]
route/test_default_route.py::test_default_route_set_src[2] PASSED                                                                                                                                                     [ 25%]
route/test_default_route.py::test_default_route_set_src[3] PASSED                                                                                                                                                     [ 33%]
route/test_default_route.py::test_default_route_set_src[4] PASSED                                                                                                                                                     [ 41%]
route/test_default_route.py::test_default_route_set_src[5] PASSED                                                                                                                                                     [ 50%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[0] PASSED                                                                                                                                [ 58%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[1] PASSED                                                                                                                                [ 66%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[2] PASSED                                                                                                                                [ 75%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[3] PASSED                                                                                                                                [ 83%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[4] PASSED                                                                                                                                [ 91%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[5] PASSED                                                                                                                                [100%]

---------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml -----------------------------------------------------------------------------------

================================================================================================ 12 passed in 17.86 seconds =================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
