### PR TITLE
[kvmtest]: allow to remove sonic vm disk on user defined location

### DIFF
--- a/ansible/roles/vm_set/tasks/stop_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/stop_sonic_vm.yml
@@ -1,5 +1,9 @@
 - set_fact:
-    disk_image: "{{ home_path }}/sonic-vm/disks/sonic_{{ dut_name }}.img"
+    sonic_vm_storage_location: "{{ home_path }}/sonic-vm"
+    when: sonic_vm_storage_location is not defined
+
+- set_fact:
+    disk_image: "{{ sonic_vm_storage_location }}/disks/sonic_{{ dut_name }}.img"
 
 - name: Destroy vm {{ dut_name }}
   virt: name={{ dut_name }}
@@ -15,5 +19,5 @@
   when: dut_name in vm_list_defined.list_vms
   become: yes
 
-- name: Copy sonic disk image for {{ dut_name }}
+- name: Remove sonic disk image for {{ dut_name }}
   file: path={{ disk_image }} state=absent

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -241,7 +241,15 @@ function remove_topo
 
   read_file ${topology}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" $@
+  if [ -n "$sonic_vm_dir" ]; then
+      ansible_options="-e sonic_vm_storage_location=$sonic_vm_dir"
+  fi
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
+        -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+        -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
+        -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
+        $ansible_options $@
 
   echo Done
 }


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
allow to remove sonic vm disk on user defined location

this is a follow-up fix for PR https://github.com/Azure/sonic-mgmt/pull/2734

#### How did you do it?

#### How did you verify/test it?
run remove topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
