### PR TITLE
[test_basic_fib] Assign MAC address of src interface to packets to avoid FDB hopping

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -218,7 +218,7 @@ class FibTest(BaseTest):
         dport = random.randint(0, 65535)
         ip_src = "10.0.0.1"
         ip_dst = dst_ip_addr
-        src_mac = self.dataplane.get_mac(0, 0)
+        src_mac = self.dataplane.get_mac(0, src_port)
 
         pkt = simple_tcp_packet(
                             pktlen=self.pktlen,
@@ -267,7 +267,7 @@ class FibTest(BaseTest):
         dport = random.randint(0, 65535)
         ip_src = '2000::1'
         ip_dst = dst_ip_addr
-        src_mac = self.dataplane.get_mac(0, 0)
+        src_mac = self.dataplane.get_mac(0, src_port)
 
         pkt = simple_tcpv6_packet(
                                 pktlen=self.pktlen,

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -4,7 +4,7 @@ import json
 import logging
 import tempfile
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, change_mac_addresses   # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 from datetime import datetime
 


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is a workaround for https://github.com/Azure/sonic-buildimage/issues/6313

Test case ```test_basic_fib``` will use the MAC address of eth0 of ptf as the src MAC of all packets. Since packets will be transfered to DUT via different interfaces, the FDB entry on DUT will be updated frequently, which is possible to trigger some error log.
```
Dec 29 05:42:11.146519 str-dx010-acs-4 ERR swss#fdbsyncd: :- pops: Failed to get content for table key FDB_TABLE|Vlan1000:24:8a:07:4c:f5:00
```
This PR assigns different MAC address for packets to work around this issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to improve ```test_basic_fib``` to work around https://github.com/Azure/sonic-buildimage/issues/6313.

#### How did you do it?
Assign different MAC address for packets.

#### How did you verify/test it?
Verified on Arista-7260. No error log is observed after this update.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
