### PR TITLE
Update the fib test to support DualToR

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -4,7 +4,7 @@ Description:    This file contains the FIB test for SONIC
                 Design is available in https://github.com/Azure/SONiC/wiki/FIB-Scale-Test-Plan
 
 Usage:          Examples of how to use log analyzer
-                ptf --test-dir fib fib_test.FibTest  --platform remote -t 'router_mac="00:02:03:04:05:00";route_info="fib/route_info.txt";testbed_type=t1'
+                ptf --test-dir ptftests fib_test.FibTest --platform-dir ptftests --qlen=2000 --platform remote -t 'setup_info="/root/test_fib_setup_info.json";testbed_mtu=1514;ipv4=True;test_balancing=True;ipv6=True' --relax --debug info --log-file /tmp/fib_test.FibTest.ipv4.True.ipv6.True.2020-12-22-08:17:05.log --socket-recv-size 16384
 '''
 
 #---------------------------------------------------------------------
@@ -13,15 +13,20 @@ Usage:          Examples of how to use log analyzer
 import logging
 import random
 import time
+import json
 
 import ptf
 import ptf.packet as scapy
-import ptf.dataplane as dataplane
 
 from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
-from ptf.testutils import *
+from ptf.testutils import test_params_get
+from ptf.testutils import simple_tcp_packet
+from ptf.testutils import simple_tcpv6_packet
+from ptf.testutils import send_packet
+from ptf.testutils import verify_packet_any_port
+from ptf.testutils import verify_no_packet_any
 
 import fib
 
@@ -36,7 +41,7 @@ class FibTest(BaseTest):
     that packets are forwarded through one of the ports specified in route's ECMP group.
 
     This class receives a text file describing the bgp routes added to the switch.
-    File contains informaiton about each bgp route which was added to the switch.
+    File contains information about each bgp route which was added to the switch.
 
     #-----------------------------------------------------------------------
 
@@ -58,13 +63,14 @@ class FibTest(BaseTest):
     #---------------------------------------------------------------------
     DEFAULT_BALANCING_RANGE = 0.25
     BALANCING_TEST_TIMES = 625
-    DEFAULT_BALANCING_TEST_RATIO = 0.0001
+    DEFAULT_BALANCING_TEST_NUMBER = 1
     ACTION_FWD = 'fwd'
     ACTION_DROP = 'drop'
 
     _required_params = [
-        'fib_info',
-        'router_mac',
+        'fib_info_files',
+        'ptf_test_port_map',
+        'router_macs'
     ]
 
     def __init__(self):
@@ -75,17 +81,16 @@ class FibTest(BaseTest):
         self.test_params = test_params_get()
         self.check_required_params()
 
-    #---------------------------------------------------------------------
+    def check_required_params(self):
+        for param in self._required_params:
+            if param not in self.test_params:
+                raise Exception("Missing required parameter {}".format(param))
 
     def setUp(self):
         '''
         @summary: Setup for the test
         Some test parameters are used:
-         - fib_info: the FIB information generated according to the testbed
-         - router_mac: the MAC address of the DUT used to create the eth_dst
-           of the packet
-         - testbed_type: the type of the testbed used to determine the source
-           port
+         - setup_info: various configuration required by the FIB ptf test
          - src_ports: this list should include all enabled ports, both up links
                      and down links.
          - pkt_action: expect to receive test traffic or not. Default: fwd
@@ -96,22 +101,26 @@ class FibTest(BaseTest):
          - ip_options       enable ip option header in ipv4 pkts. Default: False(disable)
          - src_vid          vlan tag id of src pkts. Default: None(untag)
          - dst_vid          vlan tag id of dst pkts. Default: None(untag)
-
-        TODO: Have a separate line in fib_info/file to indicate all UP ports
         '''
         self.dataplane = ptf.dataplane_instance
-        fib_info = self.test_params.get('fib_info', None)
-        self.fib = fib.Fib(self.test_params['fib_info']) if fib_info is not None else None
-        self.router_mac = self.test_params.get('router_mac', None)
-        self.pktlen = self.test_params.get('testbed_mtu', 1500)
 
+        self.fibs = []
+        for fib_info_file in self.test_params.get('fib_info_files'):
+            self.fibs.append(fib.Fib(fib_info_file))
+
+        ptf_test_port_map = self.test_params.get('ptf_test_port_map')
+        with open(ptf_test_port_map) as f:
+            self.ptf_test_port_map = json.load(f)
+
+        self.router_macs = self.test_params.get('router_macs')
+        self.pktlen = self.test_params.get('testbed_mtu', 1500)
         self.test_ipv4 = self.test_params.get('ipv4', True)
         self.test_ipv6 = self.test_params.get('ipv6', True)
-
         self.test_balancing = self.test_params.get('test_balancing', True)
         self.balancing_range = self.test_params.get('balancing_range', self.DEFAULT_BALANCING_RANGE)
         self.balancing_test_times = self.test_params.get('balancing_test_times', self.BALANCING_TEST_TIMES)
-        self.balancing_test_ratio = self.test_params.get('balancing_test_ratio', self.DEFAULT_BALANCING_TEST_RATIO)
+        self.balancing_test_number = self.test_params.get('balancing_test_number', self.DEFAULT_BALANCING_TEST_NUMBER)
+        self.balancing_test_count = 0
 
         self.pkt_action = self.test_params.get('pkt_action', self.ACTION_FWD)
         self.ttl = self.test_params.get('ttl', 64)
@@ -120,78 +129,77 @@ class FibTest(BaseTest):
         self.dst_vid = self.test_params.get('dst_vid', None)
 
         self.src_ports = self.test_params.get('src_ports', None)
-        if self.src_ports is None:
-            # Provide the list of all UP interfaces with index in sequence order starting from 0
-            if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag' or self.test_params['testbed_type'] == 't0-64-32':
-                self.src_ports = range(0, 32)
-            if self.test_params['testbed_type'] == 't1-64-lag' or self.test_params['testbed_type'] == 't1-64-lag-clet':
-                self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
-            if self.test_params['testbed_type'] == 't0':
-                self.src_ports = range(1, 25) + range(28, 32)
-            if self.test_params['testbed_type'] == 't0-52':
-                self.src_ports = range(0, 52)
-            if self.test_params['testbed_type'] == 't0-56':
-                self.src_ports = [0, 1, 4, 5, 8, 9] + range(12, 18) + [20, 21, 24, 25, 28, 29, 32, 33, 36, 37] + range(40, 46) + [48, 49, 52, 53]
-            if self.test_params['testbed_type'] == 't0-64':
-                self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
-            if self.test_params['testbed_type'] == 't0-116':
-                self.src_ports = range(0, 120)
-            if self.test_params['testbed_type'] == 't0-120':
-                down_ports = [7, 15, 23, 31, 39, 47, 53, 59, 65, 71, 77, 79, 81, 83, 87, 88, 91, 95, 96, 98, 102, 103, 111, 119]
-                all_ports = range(0, 120)
-                self.src_ports = [i for i in all_ports if i not in down_ports]
-    #---------------------------------------------------------------------
-
-    def check_required_params(self):
-        for param in self._required_params:
-            if param not in self.test_params:
-                raise Exception("Missing required parameter {}".format(param))
+        if not self.src_ports:
+            self.src_ports = [int(port) for port in self.ptf_test_port_map.keys()]
 
     def check_ip_ranges(self, ipv4=True):
-        if ipv4:
-            ip_ranges = self.fib.ipv4_ranges()
-        else:
-            ip_ranges = self.fib.ipv6_ranges()
+        for dut_index, fib in enumerate(self.fibs):
+            if ipv4:
+                ip_ranges = fib.ipv4_ranges()
+            else:
+                ip_ranges = fib.ipv6_ranges()
 
-        for ip_range in ip_ranges:
-            if ip_range.get_first_ip() in self.fib:
-                next_hop = self.fib[ip_range.get_first_ip()]
-                self.check_ip_range(ip_range, next_hop, ipv4)
+            if len(ip_ranges) > 150:
+                covered_ip_ranges = ip_ranges[:100] + random.sample(ip_ranges[100:], 50)  # Limit test execution time
+            else:
+                covered_ip_ranges = ip_ranges[:]
 
-    def check_ip_range(self, ip_range, next_hop, ipv4=True):
-        # Get the expected list of ports that would receive the packets
-        exp_port_list = next_hop.get_next_hop_list()
-        # Choose random one source port from all ports excluding the expected ones
-        src_port = random.choice([port for port in self.src_ports if port not in exp_port_list])
+            for ip_range in covered_ip_ranges:
+                if ip_range.get_first_ip() in fib:
+                    self.check_ip_range(ip_range, dut_index, ipv4)
 
-        if not exp_port_list:
-            logging.info("Skip check IP range {} with nexthop {}".format(ip_range, next_hop))
-            return
+            random.shuffle(covered_ip_ranges)
+            self.check_balancing(covered_ip_ranges, dut_index, ipv4)
 
-        logging.info("Check IP range:" + str(ip_range) + " on " + str(exp_port_list) + "...")
+    def get_src_and_exp_ports(self, dst_ip):
+        while True:
+            src_port = int(random.choice(self.src_ports))
+            active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
+            next_hop = self.fibs[active_dut_index][dst_ip]
+            exp_port_list = next_hop.get_next_hop_list()
+            if src_port in exp_port_list:
+                continue
+            break
+        return src_port, exp_port_list, next_hop
 
-        # Send a packet with the first IP in the range
-        self.check_ip_route(src_port, ip_range.get_first_ip(), exp_port_list, ipv4)
-        # Send a packet with the last IP in the range
-        if ip_range.length() > 1:
-            self.check_ip_route(src_port, ip_range.get_last_ip(), exp_port_list, ipv4)
-        # Send a packet with a random IP in the range
-        if ip_range.length() > 2:
-            self.check_ip_route(src_port, ip_range.get_random_ip(), exp_port_list, ipv4)
-        time.sleep(0.01)
+    def check_ip_range(self, ip_range, dut_index, ipv4=True):
+
+        dst_ips = []
+        dst_ips.append(ip_range.get_first_ip())
+        if ip_range.length > 1:
+            dst_ips.append(ip_range.get_last_ip())
+        if ip_range.length > 2:
+            dst_ips.append(ip_range.get_random_ip())
+
+        for dst_ip in dst_ips:
+            src_port, exp_ports, _ = self.get_src_and_exp_ports(dst_ip)
+            if not exp_ports:
+                logging.info('Skip checking ip range {} with exp_ports {}'.format(ip_range, exp_ports))
+                return
+            logging.info('Checking ip range {}, src_port={}, exp_ports={}, dst_ip={}, dut_index={}'\
+                .format(ip_range, src_port, exp_ports, dst_ip, dut_index))
+            self.check_ip_route(src_port, dst_ip, exp_ports, ipv4)
+
+    def check_balancing(self, ip_ranges, dut_index, ipv4=True):
         # Test traffic balancing across ECMP/LAG members
-        if (self.test_balancing and self.pkt_action == self.ACTION_FWD
-                and len(exp_port_list) > 1
-                and random.random() < self.balancing_test_ratio):
-            logging.info("Check IP range balancing...")
-            dst_ip = ip_range.get_random_ip()
-            hit_count_map = {}
-            # Change balancing_test_times according to number of next hop groups
-            for i in range(0, self.balancing_test_times*len(exp_port_list)):
-                (matched_index, received) = self.check_ip_route(src_port, dst_ip, exp_port_list, ipv4)
-                hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
-                time.sleep(0.01)
-            self.check_balancing(next_hop.get_next_hop(), hit_count_map)
+        if self.test_balancing and self.pkt_action == self.ACTION_FWD:
+            for ip_range in ip_ranges:
+                dst_ip = ip_range.get_random_ip()
+                src_port, exp_port_list, next_hop = self.get_src_and_exp_ports(dst_ip)
+                if len(exp_port_list) <= 1:
+                    # Only 1 expected output port is not enough for balancing test.
+                    continue
+                hit_count_map = {}
+                # Change balancing_test_times according to number of next hop groups
+                logging.info('Checking ip range balancing {}, src_port={}, exp_ports={}, dst_ip={}, dut_index={}'\
+                    .format(ip_range, src_port, exp_port_list, dst_ip, dut_index))
+                for i in range(0, self.balancing_test_times*len(exp_port_list)):
+                    (matched_index, received) = self.check_ip_route(src_port, dst_ip, exp_port_list, ipv4)
+                    hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
+                self.check_hit_count_map(next_hop.get_next_hop(), hit_count_map)
+                self.balancing_test_count += 1
+                if self.balancing_test_count >= self.balancing_test_number:
+                    break
 
     def check_ip_route(self, src_port, dst_ip_addr, dst_port_list, ipv4=True):
         if ipv4:
@@ -208,6 +216,7 @@ class FibTest(BaseTest):
 
         matched_port = dst_port_list[matched_index]
         logging.info("Received packet at " + str(matched_port))
+        time.sleep(0.02)
 
         return (matched_port, received)
 
@@ -220,13 +229,16 @@ class FibTest(BaseTest):
         '''
         sport = random.randint(0, 65535)
         dport = random.randint(0, 65535)
-        ip_src = "10.0.0.1"
+        ip_src = "30.0.0.1"
         ip_dst = dst_ip_addr
         src_mac = self.dataplane.get_mac(0, src_port)
 
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
+        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
+
         pkt = simple_tcp_packet(
                             pktlen=self.pktlen,
-                            eth_dst=self.router_mac,
+                            eth_dst=router_mac,
                             eth_src=src_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
@@ -238,7 +250,7 @@ class FibTest(BaseTest):
                             vlan_vid=self.src_vid or 0)
         exp_pkt = simple_tcp_packet(
                             self.pktlen,
-                            eth_src=self.router_mac,
+                            eth_src=exp_router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
                             tcp_sport=sport,
@@ -251,7 +263,20 @@ class FibTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
 
         send_packet(self, src_port, pkt)
-        logging.info("Sending packet from port " + str(src_port) + " to " + ip_dst)
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(pkt.src,
+                    pkt.dst,
+                    pkt['IP'].src,
+                    pkt['IP'].dst,
+                    sport,
+                    dport))
+        logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(exp_router_mac,
+                    'any',
+                    ip_src,
+                    ip_dst,
+                    sport,
+                    dport))
 
         if self.pkt_action == self.ACTION_FWD:
             return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
@@ -269,13 +294,16 @@ class FibTest(BaseTest):
         '''
         sport = random.randint(0, 65535)
         dport = random.randint(0, 65535)
-        ip_src = '2000::1'
+        ip_src = '2000:0030::1'
         ip_dst = dst_ip_addr
         src_mac = self.dataplane.get_mac(0, src_port)
 
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
+        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
+
         pkt = simple_tcpv6_packet(
                                 pktlen=self.pktlen,
-                                eth_dst=self.router_mac,
+                                eth_dst=router_mac,
                                 eth_src=src_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,
@@ -286,7 +314,7 @@ class FibTest(BaseTest):
                                 vlan_vid=self.src_vid or 0)
         exp_pkt = simple_tcpv6_packet(
                                 pktlen=self.pktlen,
-                                eth_src=self.router_mac,
+                                eth_src=exp_router_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,
                                 tcp_sport=sport,
@@ -298,13 +326,26 @@ class FibTest(BaseTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
 
         send_packet(self, src_port, pkt)
-        logging.info("Sending packet from port " + str(src_port) + " to " + ip_dst)
+        logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(pkt.src,
+                    pkt.dst,
+                    pkt['IPv6'].src,
+                    pkt['IPv6'].dst,
+                    sport,
+                    dport))
+        logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(exp_router_mac,
+                    'any',
+                    ip_src,
+                    ip_dst,
+                    sport,
+                    dport))
 
         if self.pkt_action == self.ACTION_FWD:
             return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
         elif self.pkt_action == self.ACTION_DROP:
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
-    #---------------------------------------------------------------------
+
     def check_within_expected_range(self, actual, expected):
         '''
         @summary: Check if the actual number is within the accepted range of the expected number
@@ -315,15 +356,13 @@ class FibTest(BaseTest):
         percentage = (actual - expected) / float(expected)
         return (percentage, abs(percentage) <= self.balancing_range)
 
-    #---------------------------------------------------------------------
-    def check_balancing(self, dest_port_list, port_hit_cnt):
+    def check_hit_count_map(self, dest_port_list, port_hit_cnt):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
         @param dest_port_list : a list of ECMP entries and in each ECMP entry a list of ports
         @param port_hit_cnt : a dict that records the number of packets each port received
         @return bool
         '''
-
         logging.info("%-10s \t %-10s \t %10s \t %10s \t %10s" % ("type", "port(s)", "exp_cnt", "act_cnt", "diff(%)"))
         result = True
 
@@ -345,8 +384,6 @@ class FibTest(BaseTest):
                 result &= r
 
         assert result
-
-    #---------------------------------------------------------------------
 
     def runTest(self):
         """

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -373,14 +373,14 @@ class FibTest(BaseTest):
                 total_entry_hit_cnt += port_hit_cnt.get(member, 0)
             (p, r) = self.check_within_expected_range(total_entry_hit_cnt, float(total_hit_cnt)/len(dest_port_list))
             logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
-                         % ("ECMP", str(ecmp_entry), total_hit_cnt/len(dest_port_list), total_entry_hit_cnt, str(round(p, 4)*100) + '%'))
+                         % ("ECMP", str(ecmp_entry), total_hit_cnt//len(dest_port_list), total_entry_hit_cnt, str(round(p, 4)*100) + '%'))
             result &= r
             if len(ecmp_entry) == 1 or total_entry_hit_cnt == 0:
                 continue
             for member in ecmp_entry:
                 (p, r) = self.check_within_expected_range(port_hit_cnt.get(member, 0), float(total_entry_hit_cnt)/len(ecmp_entry))
                 logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
-                              % ("LAG", str(member), total_entry_hit_cnt/len(ecmp_entry), port_hit_cnt.get(member, 0), str(round(p, 4)*100) + '%'))
+                              % ("LAG", str(member), total_entry_hit_cnt//len(ecmp_entry), port_hit_cnt.get(member, 0), str(round(p, 4)*100) + '%'))
                 result &= r
 
         assert result

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -331,14 +331,14 @@ class HashTest(BaseTest):
                 total_entry_hit_cnt += port_hit_cnt.get(member, 0)
             (p, r) = self.check_within_expected_range(total_entry_hit_cnt, float(total_hit_cnt)/len(dest_port_list))
             logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
-                        % ("ECMP", str(ecmp_entry), total_hit_cnt/len(dest_port_list), total_entry_hit_cnt, str(round(p, 4)*100) + '%'))
+                        % ("ECMP", str(ecmp_entry), total_hit_cnt//len(dest_port_list), total_entry_hit_cnt, str(round(p, 4)*100) + '%'))
             result &= r
             if len(ecmp_entry) == 1 or total_entry_hit_cnt == 0:
                 continue
             for member in ecmp_entry:
                 (p, r) = self.check_within_expected_range(port_hit_cnt.get(member, 0), float(total_entry_hit_cnt)/len(ecmp_entry))
                 logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
-                            % ("LAG", str(member), total_entry_hit_cnt/len(ecmp_entry), port_hit_cnt.get(member, 0), str(round(p, 4)*100) + '%'))
+                            % ("LAG", str(member), total_entry_hit_cnt//len(ecmp_entry), port_hit_cnt.get(member, 0), str(round(p, 4)*100) + '%'))
                 result &= r
 
         assert result

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -7,6 +7,8 @@ Description:    This file contains the hash test for SONiC
 #---------------------------------------------------------------------
 import logging
 import random
+import json
+import time
 
 from ipaddress import ip_address, ip_network
 
@@ -15,7 +17,11 @@ import ptf.packet as scapy
 
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
-from ptf.testutils import *
+from ptf.testutils import test_params_get
+from ptf.testutils import simple_tcp_packet
+from ptf.testutils import simple_tcpv6_packet
+from ptf.testutils import send_packet
+from ptf.testutils import verify_packet_any_port
 
 import fib
 import lpm
@@ -26,7 +32,13 @@ class HashTest(BaseTest):
     # Class variables
     #---------------------------------------------------------------------
     DEFAULT_BALANCING_RANGE = 0.25
-    BALANCING_TEST_TIMES = 10000
+    BALANCING_TEST_TIMES = 625
+
+    _required_params = [
+        'fib_info_files',
+        'ptf_test_port_map',
+        'router_macs'
+    ]
 
     def __init__(self):
         '''
@@ -34,68 +46,114 @@ class HashTest(BaseTest):
         '''
         BaseTest.__init__(self)
         self.test_params = test_params_get()
+        self.check_required_params()
 
-    #---------------------------------------------------------------------
+    def check_required_params(self):
+        for param in self._required_params:
+            if param not in self.test_params:
+                raise Exception("Missing required parameter {}".format(param))
 
     def setUp(self):
         '''
         @summary: Setup for the test
         '''
         self.dataplane = ptf.dataplane_instance
-        self.fib = fib.Fib(self.test_params['fib_info'])
-        self.testbed_type = self.test_params['testbed_type']
-        self.router_mac = self.test_params['router_mac']
-        self.in_ports = self.test_params['in_ports']
 
+        self.fibs = []
+        for fib_info_file in self.test_params.get('fib_info_files'):
+            self.fibs.append(fib.Fib(fib_info_file))
+
+        ptf_test_port_map = self.test_params.get('ptf_test_port_map')
+        with open(ptf_test_port_map) as f:
+            self.ptf_test_port_map = json.load(f)
+
+        self.router_macs = self.test_params.get('router_macs')
         self.src_ip_range = [unicode(x) for x in self.test_params['src_ip_range'].split(',')]
         self.dst_ip_range = [unicode(x) for x in self.test_params['dst_ip_range'].split(',')]
         self.src_ip_interval = lpm.LpmDict.IpInterval(ip_address(self.src_ip_range[0]), ip_address(self.src_ip_range[1]))
         self.dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(self.dst_ip_range[0]), ip_address(self.dst_ip_range[1]))
         self.vlan_ids = self.test_params.get('vlan_ids', [])
         self.hash_keys = self.test_params.get('hash_keys', ['src-ip', 'dst-ip', 'src-port', 'dst-port'])
-        self.dst_macs = self.test_params.get('dst_macs', [])    # TODO
+        self.src_ports = [int(port) for port in self.ptf_test_port_map.keys()]
 
         self.balancing_range = self.test_params.get('balancing_range', self.DEFAULT_BALANCING_RANGE)
+        self.balancing_test_times = self.test_params.get('balancing_test_times', self.BALANCING_TEST_TIMES)
 
-    #---------------------------------------------------------------------
+    def get_src_and_exp_ports(self, dst_ip):
+        while True:
+            src_port = int(random.choice(self.src_ports))
+            active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
+            next_hop = self.fibs[active_dut_index][dst_ip]
+            exp_port_list = next_hop.get_next_hop_list()
+            if src_port in exp_port_list:
+                continue
+            break
+        return src_port, exp_port_list, next_hop
+
+    def get_ingress_ports(self, exp_port_list, dst_ip):
+        # To test ingress-port hash, we need to ensure that the exp_port_list be identical for all the ingress ports.
+        # For dualtor topology, the exp_port_list could be T1 facing ports on either one of the ToR if the ingress
+        # ports include all ports. For example:
+        # scenario 1: Ingress port is one of PTF ports connected to VLAN interfaces of both ToRs. Then exp_port_list
+        #             should be T1 faccing ports of the active side ToR. (Before test, we always set active side of all
+        #             mux cables to same side.)
+        # scenario 2: Ingress port is one of PTF ports connected to T1 facing ports of upper ToR. Then exp_port_list
+        #             will be upper ToR's T1 facing ports.
+        # scenario 3: Ingress port is one of PTF ports connected to T1 facing ports of lower ToR. Then exp_port_list
+        #             will be lower ToR's T1 facing ports.
+        # Scenario 2&3 could cause problem. That's why we need to further filter the ingress ports.
+        ports = list(set(self.src_ports) - set(exp_port_list))
+        filtered_ports = []
+        for port in ports:
+            active_dut_index = self.ptf_test_port_map[str(port)]['target_dut']
+            next_hop = self.fibs[active_dut_index][dst_ip]
+            possible_exp_port_list = next_hop.get_next_hop_list()
+            if possible_exp_port_list == exp_port_list:
+                filtered_ports.append(port)
+        logging.info('ports={}'.format(ports))
+        logging.info('filtered_ports={}'.format(filtered_ports))
+        return filtered_ports
 
     def check_hash(self, hash_key):
         dst_ip = self.dst_ip_interval.get_random_ip()
-        next_hop = self.fib[dst_ip]
-        exp_port_list = self.fib[dst_ip].get_next_hop_list()
-        logging.info("exp_port_list: {}".format(exp_port_list))
-        if exp_port_list <= 1:
+        src_port, exp_port_list, next_hop = self.get_src_and_exp_ports(dst_ip)
+        logging.info("dst_ip={}, src_port={}, exp_port_list={}".format(dst_ip, src_port, exp_port_list))
+        if len(exp_port_list) <= 1:
             logging.warning("{} has only {} nexthop".format(dst_ip, exp_port_list))
             assert False
-        in_port = random.choice([port for port in self.in_ports if port not in exp_port_list])
 
         hit_count_map = {}
-        if hash_key == 'ingress-port': # The sample is too little for hash_key ingress-port, check it loose(just verify if the asic actually used the hash field as a load-balancing factor)
-            for in_port in [port for port in self.in_ports if port not in exp_port_list]:
-                logging.info("in_port: {}".format(in_port))
-                (matched_index, _) = self.check_ip_route(hash_key, in_port, dst_ip, exp_port_list)
+        if hash_key == 'ingress-port':
+            # Unenough samples for hash_key ingress-port, check it loosely
+            # Just verify if the asic actually use the hash field as a load-balancing factor
+            for ingress_port in self.get_ingress_ports(exp_port_list, dst_ip):
+                logging.info('Checking hash key {}, src_port={}, exp_ports={}, dst_ip={}'\
+                    .format(hash_key, ingress_port, exp_port_list, dst_ip))
+                (matched_index, _) = self.check_ip_route(hash_key, ingress_port, dst_ip, exp_port_list)
                 hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
             logging.info("hit count map: {}".format(hit_count_map))
             assert True if len(hit_count_map.keys()) == 1 else False
         else:
-            for _ in range(0, self.BALANCING_TEST_TIMES):
-                logging.info("in_port: {}".format(in_port))
-                (matched_index, _) = self.check_ip_route(hash_key, in_port, dst_ip, exp_port_list)
+            for _ in range(0, self.balancing_test_times*len(exp_port_list)):
+                logging.info('Checking hash key {}, src_port={}, exp_ports={}, dst_ip={}'\
+                    .format(hash_key, src_port, exp_port_list, dst_ip))
+                (matched_index, _) = self.check_ip_route(hash_key, src_port, dst_ip, exp_port_list)
                 hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
-            logging.info("hit count map: {}".format(hit_count_map))
+            logging.info("hash_key={}, hit count map: {}".format(hash_key, hit_count_map))
 
             self.check_balancing(next_hop.get_next_hop(), hit_count_map)
 
-    def check_ip_route(self, hash_key, in_port, dst_ip, dst_port_list):
+    def check_ip_route(self, hash_key, src_port, dst_ip, dst_port_list):
         if ip_network(unicode(dst_ip)).version == 4:
-            (matched_index, received) = self.check_ipv4_route(hash_key, in_port, dst_port_list)
+            (matched_index, received) = self.check_ipv4_route(hash_key, src_port, dst_port_list)
         else:
-            (matched_index, received) = self.check_ipv6_route(hash_key, in_port, dst_port_list)
+            (matched_index, received) = self.check_ipv6_route(hash_key, src_port, dst_port_list)
 
         assert received
 
         matched_port = dst_port_list[matched_index]
         logging.info("Received packet at " + str(matched_port))
+        time.sleep(0.02)
 
         return (matched_port, received)
 
@@ -113,11 +171,11 @@ class HashTest(BaseTest):
             if ip_proto not in skip_ports:
                 return ip_proto
 
-    def check_ipv4_route(self, hash_key, in_port, dst_port_list):
+    def check_ipv4_route(self, hash_key, src_port, dst_port_list):
         '''
         @summary: Check IPv4 route works.
         @param hash_key: hash key to build packet with.
-        @param in_port: index of port to use for sending packet to switch
+        @param src_port: index of port to use for sending packet to switch
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         '''
         base_mac = self.dataplane.get_mac(0, 0)
@@ -125,13 +183,18 @@ class HashTest(BaseTest):
         ip_dst = self.dst_ip_interval.get_random_ip() if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) if hash_key == 'src-mac' else base_mac
-        dst_mac = random.choice(self.dst_macs) if hash_key == 'dst-mac' else self.router_mac
+
+        src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else base_mac
+
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
+        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
+
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
 
         pkt = simple_tcp_packet(pktlen=100 if vlan_id == 0 else 104,
-                            eth_dst=dst_mac,
+                            eth_dst=router_mac,
                             eth_src=src_mac,
                             dl_vlan_enable=False if vlan_id == 0 else True,
                             vlan_vid=vlan_id,
@@ -142,7 +205,7 @@ class HashTest(BaseTest):
                             tcp_dport=dport,
                             ip_ttl=64)
         exp_pkt = simple_tcp_packet(
-                            eth_src=dst_mac,
+                            eth_src=exp_router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
                             tcp_sport=sport,
@@ -155,13 +218,25 @@ class HashTest(BaseTest):
         masked_exp_pkt = Mask(exp_pkt)
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
 
-        send_packet(self, in_port, pkt)
-        logging.info("Sent packet {} from port {} to {}".format(repr(pkt), str(in_port), str(ip_dst)))
+        send_packet(self, src_port, pkt)
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(pkt.src,
+                    pkt.dst,
+                    pkt['IP'].src,
+                    pkt['IP'].dst,
+                    sport,
+                    dport))
+        logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(exp_router_mac,
+                    'any',
+                    ip_src,
+                    ip_dst,
+                    sport,
+                    dport))
 
         return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
-    #---------------------------------------------------------------------
 
-    def check_ipv6_route(self, hash_key, in_port, dst_port_list):
+    def check_ipv6_route(self, hash_key, src_port, dst_port_list):
         '''
         @summary: Check IPv6 route works.
         @param hash_key: hash key to build packet with.
@@ -172,15 +247,20 @@ class HashTest(BaseTest):
         base_mac = self.dataplane.get_mac(0, 0)
         ip_src = self.src_ip_interval.get_random_ip() if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip() if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) if hash_key == 'src-mac' else base_mac
-        dst_mac = random.choice(self.dst_macs) if hash_key == 'dst-mac' else self.router_mac
+
+        src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else base_mac
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
+        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
+
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto(ipv6=True) if hash_key == "ip-proto" else None
 
         pkt = simple_tcpv6_packet(pktlen=100 if vlan_id == 0 else 104,
-                                eth_dst=dst_mac,
+                                eth_dst=router_mac,
                                 eth_src=src_mac,
                                 dl_vlan_enable=False if vlan_id == 0 else True,
                                 vlan_vid=vlan_id,
@@ -191,7 +271,7 @@ class HashTest(BaseTest):
                                 tcp_dport=dport,
                                 ipv6_hlim=64)
         exp_pkt = simple_tcpv6_packet(
-                                eth_src=dst_mac,
+                                eth_src=exp_router_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,
                                 tcp_sport=sport,
@@ -205,11 +285,24 @@ class HashTest(BaseTest):
         masked_exp_pkt = Mask(exp_pkt)
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
 
-        send_packet(self, in_port, pkt)
-        logging.info("Sent packet {} from port {} to {}".format(repr(pkt), str(in_port), str(ip_dst)))
+        send_packet(self, src_port, pkt)
+        logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(pkt.src,
+                    pkt.dst,
+                    pkt['IPv6'].src,
+                    pkt['IPv6'].dst,
+                    sport,
+                    dport))
+        logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
+            .format(exp_router_mac,
+                    'any',
+                    ip_src,
+                    ip_dst,
+                    sport,
+                    dport))
 
         return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
-    #---------------------------------------------------------------------
+
     def check_within_expected_range(self, actual, expected):
         '''
         @summary: Check if the actual number is within the accepted range of the expected number
@@ -220,7 +313,6 @@ class HashTest(BaseTest):
         percentage = (actual - expected) / float(expected)
         return (percentage, abs(percentage) <= self.balancing_range)
 
-    #---------------------------------------------------------------------
     def check_balancing(self, dest_port_list, port_hit_cnt):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
@@ -250,8 +342,6 @@ class HashTest(BaseTest):
                 result &= r
 
         assert result
-
-    #---------------------------------------------------------------------
 
     def runTest(self):
         """

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1106,15 +1106,14 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         mg_facts['minigraph_ptf_indices'] = mg_facts['minigraph_port_indices'].copy()
 
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
-        # multiple DUTs sharing a same PTF host. Therefore, the indeces from
-        # the minigraph facts are not always match up with PTF port indeces.
+        # multiple DUTs sharing a same PTF host. Therefore, the indices from
+        # the minigraph facts are not always match up with PTF port indices.
         try:
             dut_index = tbinfo['duts'].index(self.hostname)
-            map = tbinfo['topo']['ptf_map'][dut_index]
+            map = tbinfo['topo']['ptf_map'][str(dut_index)]
             if map:
-                for port, index in mg_facts['minigraph_ptf_indices'].items():
-                    if index in map:
-                        mg_facts['minigraph_ptf_indices'][port] = map[index]
+                for port, index in mg_facts['minigraph_port_indices'].items():
+                    mg_facts['minigraph_ptf_indices'][port] = map[str(index)]
         except (ValueError, KeyError):
             pass
 
@@ -2113,6 +2112,13 @@ class DutHosts(object):
             on that MultiAsicSonicHost
         """
         return getattr(self.nodes, attr)
+
+    def config_facts(self, *module_args, **complex_args):
+        result = {}
+        for node in self.nodes:
+            complex_args['host'] = node.hostname
+            result[node.hostname] = node.config_facts(*module_args, **complex_args)['ansible_facts']
+        return result
 
 
 class FanoutHost(object):

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -1,12 +1,21 @@
-import pytest
+import copy
 import time
 import json
 import logging
 import tempfile
+import random
+
+from collections import defaultdict
+from datetime import datetime
+
+import pytest
+import requests
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, change_mac_addresses   # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
-from datetime import datetime
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side
+from tests.common.dualtor.mux_simulator_control import mux_server_url
 
 logger = logging.getLogger(__name__)
 
@@ -24,33 +33,54 @@ DST_IPV6_RANGE = ['20D0:A800:0:01::', '20D0:A800:0:01::FFFF']
 VLANIDS = range(1032, 1279)
 VLANIP = '192.168.{}.1/24'
 PTF_QLEN = 2000
+DEFAULT_MUX_SERVER_PORT = 8080
 
-
-@pytest.fixture(scope="module")
-def config_facts(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    return duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 
 
 @pytest.fixture(scope='module')
-def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts, tbinfo):
-    duthost = duthosts[rand_one_dut_hostname]
+def config_facts(duthosts):
+    return duthosts.config_facts(source='running')
 
+
+@pytest.fixture(scope='module')
+def minigraph_facts(duthosts, tbinfo):
+    return duthosts.get_extended_minigraph_facts(tbinfo)
+
+
+def get_fib_info(duthost, cfg_facts, mg_facts):
+    """Get parsed FIB information from redis DB.
+
+    Args:
+        duthost (SonicHost): Object for interacting with DUT.
+        cfg_facts (dict): Configuration facts.
+        mg_facts (dict): Minigraph facts.
+
+    Returns:
+        dict: Map of prefix to PTF ports that are connected to DUT output ports.
+            {
+                '192.168.0.0/21': [],
+                '192.168.8.0/25': [[58 59] [62 63] [66 67] [70 71]],
+                '192.168.16.0/25': [[58 59] [62 63] [66 67] [70 71]],
+                ...
+                '20c0:c2e8:0:80::/64': [[58 59] [62 63] [66 67] [70 71]],
+                '20c1:998::/64': [[58 59] [62 63] [66 67] [70 71]],
+                ...
+            }
+    """
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-
     duthost.shell("redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(timestamp))
     duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
 
-    po = config_facts.get('PORTCHANNEL', {})
-    ports = config_facts.get('PORT', {})
+    po = cfg_facts.get('PORTCHANNEL', {})
+    ports = cfg_facts.get('PORT', {})
 
-    tmp_fib_info = tempfile.NamedTemporaryFile()
+    fib_info = {}
     with open("/tmp/fib/{}/tmp/fib.{}.txt".format(duthost.hostname, timestamp)) as fp:
         fib = json.load(fp)
         for k, v in fib.items():
             skip = False
+
             prefix = k.split(':', 1)[1]
             ifnames = v['value']['ifname'].split(',')
             nh = v['value']['nexthop']
@@ -65,84 +95,174 @@ def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts, tbinfo):
                     else:
                         logger.info("Route point to non front panel port {}:{}".format(k, v))
                         skip = True
+
             # skip direct attached subnet
             if nh == '0.0.0.0' or nh == '::' or nh == "":
                 skip = True
 
             if not skip:
-                tmp_fib_info.write("{}".format(prefix))
-                for op in oports:
-                    tmp_fib_info.write(" [{}]".format(" ".join(op)))
-                tmp_fib_info.write("\n")
+                fib_info[prefix] = oports
             else:
-                tmp_fib_info.write("{} []\n".format(prefix))
+                fib_info[prefix] = []
+    return fib_info
+
+
+def gen_fib_info_file(ptfhost, fib_info, filename):
+    tmp_fib_info = tempfile.NamedTemporaryFile()
+    for prefix, oports in fib_info.items():
+        tmp_fib_info.write(prefix)
+        if oports:
+            for op in oports:
+                tmp_fib_info.write(' [{}]'.format(' '.join(op)))
+        else:
+            tmp_fib_info.write(' []')
+        tmp_fib_info.write('\n')
     tmp_fib_info.flush()
-
-    ptfhost.copy(src=tmp_fib_info.name, dest="/root/fib_info.txt")
-
-
-def get_vlan_untag_ports(config_facts):
-    """
-    get all untag vlan ports
-    """
-    vlan_untag_ports = []
-    vlans = config_facts.get('VLAN_INTERFACE', {}).keys()
-    for vlan in vlans:
-        vlan_member_info = config_facts.get('VLAN_MEMBER', {}).get(vlan, {})
-        if vlan_member_info:
-            for port_name, tag_mode in vlan_member_info.items():
-                if tag_mode['tagging_mode'] == 'untagged':
-                    vlan_untag_ports.append(port_name)
-
-    return vlan_untag_ports
+    ptfhost.copy(src=tmp_fib_info.name, dest=filename)
 
 
-def get_router_interface_ports(config_facts, tbinfo):
-    """
-    get all physical ports associated with router interface (physical router interface, port channel router interface and vlan router interface)
-    """
+@pytest.fixture(scope='module')
+def fib_info_files(duthosts, ptfhost, config_facts, minigraph_facts):
+    files = []
+    for dut_index, duthost in enumerate(duthosts):
+        fib_info = get_fib_info(duthost, config_facts[duthost.hostname], minigraph_facts[duthost.hostname])
+        filename = '/root/fib_info_dut{}.txt'.format(dut_index)
+        gen_fib_info_file(ptfhost, fib_info, filename)
+        files.append(filename)
 
-    ports = config_facts.get('INTERFACE', {}).keys()
-    portchannels_member_ports = []
-    vlan_untag_ports = []
-    portchannels_name = config_facts.get('PORTCHANNEL_INTERFACE', {}).keys()
-    if portchannels_name:
-        for po_name in portchannels_name:
-            for port_name in config_facts.get('PORTCHANNEL', {})[po_name]['members']:
-                portchannels_member_ports.append(port_name)
-    if 't0' in tbinfo['topo']['name']:
-        vlan_untag_ports = get_vlan_untag_ports(config_facts)
+    return files
 
-    router_interface_ports = ports + portchannels_member_ports + vlan_untag_ports
 
-    return router_interface_ports
+@pytest.fixture(scope='module')
+def disabled_ptf_ports(tbinfo):
+    ports = set()
+    for ptf_map in tbinfo['topo']['ptf_map_disabled'].values():
+        for ptf_port_index in ptf_map.values():
+            ports.add(ptf_port_index)
+    return ports
+
+
+@pytest.fixture(scope='module')
+def vlan_ptf_ports(duthosts, config_facts, tbinfo):
+    ports = set()
+    for dut_index, duthost in enumerate(duthosts):
+        for vlan_members in config_facts[duthost.hostname].get('VLAN_MEMBER', {}).values():
+            for intf in vlan_members.keys():
+                dut_port_index = config_facts[duthost.hostname]['port_index_map'][intf]
+                ports.add(tbinfo['topo']['ptf_map'][str(dut_index)][str(dut_port_index)])
+    return ports
+
+
+@pytest.fixture(scope='module')
+def router_macs(duthosts):
+    mac_addresses = []
+    for duthost in duthosts:
+        mac_addresses.append(duthost.facts['router_mac'])
+    return mac_addresses
+
+
+# For dualtor
+@pytest.fixture(scope='module')
+def vlan_macs(duthosts, config_facts):
+    mac_addresses = []
+    for duthost in duthosts:
+        dut_vlan_mac = None
+        for vlan in config_facts[duthost.hostname].get('VLAN', {}).values():
+            if 'mac' in vlan:
+                dut_vlan_mac = vlan['mac']
+                break
+        if not dut_vlan_mac:
+            dut_vlan_mac = duthost.facts['router_mac']
+        mac_addresses.append(dut_vlan_mac)
+    return mac_addresses
+
+
+def set_mux_side(tbinfo, mux_server_url, side):
+    if 'dualtor' in tbinfo['topo']['name']:
+        res = requests.post(mux_server_url, json={"active_side": side})
+        pytest_assert(res.status_code==200, 'Failed to set active side: {}'.format(res.text))
+        return res.json()   # Response is new mux_status of all mux Y-cables.
+    return {}
+
+
+@pytest.fixture
+def set_mux_random(tbinfo, mux_server_url):
+    return set_mux_side(tbinfo, mux_server_url, 'random')
+
+
+@pytest.fixture
+def set_mux_same_side(tbinfo, mux_server_url):
+    return set_mux_side(tbinfo, mux_server_url, random.choice(['upper_tor', 'lower_tor']))
+
+
+@pytest.fixture
+def get_mux_status(tbinfo, mux_server_url):
+    if 'dualtor' in tbinfo['topo']['name']:
+        res = requests.get(mux_server_url)
+        pytest_assert(res.status_code==200, 'Failed to get mux status: {}'.format(res.text))
+        return res.json()
+    return {}
+
+
+@pytest.fixture
+def ptf_test_port_map(ptfhost, tbinfo, disabled_ptf_ports, vlan_ptf_ports, router_macs, vlan_macs, get_mux_status):
+    active_dut_map = {}
+    if get_mux_status:
+        for mux_status in get_mux_status.values():
+            active_dut_index = 0 if mux_status['active_side'] == 'upper_tor' else 1
+            active_dut_map[str(mux_status['port_index'])] = active_dut_index
+
+    logger.info('router_macs={}'.format(router_macs))
+    logger.info('vlan_macs={}'.format(vlan_macs))
+    logger.info('vlan_ptf_ports={}'.format(vlan_ptf_ports))
+    logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
+    logger.info('active_dut_map={}'.format(active_dut_map))
+
+    ports_map = {}
+    for ptf_port, dut_intf_map in tbinfo['topo']['ptf_dut_intf_map'].items():
+        if int(ptf_port) in disabled_ptf_ports:
+            continue
+
+        target_dut_index = None
+        target_mac = None
+        if int(ptf_port) in vlan_ptf_ports:    # PTF port connected to VLAN interface of DUT
+            if active_dut_map:  # dualtor topology
+                # If PTF port is connected to VLAN interface of dualToR DUTs, the PTF port index should be
+                # same as DUT port index. Base on this fact to find out dut index of active side.
+                target_dut_index = active_dut_map[ptf_port]
+                target_mac = vlan_macs[target_dut_index]
+
+        if not target_dut_index:
+            target_dut_index = int(dut_intf_map.keys()[0])
+        if not target_mac:
+            target_mac = router_macs[target_dut_index]
+        ports_map[ptf_port] = {'target_dut': target_dut_index, 'target_mac': target_mac}
+
+    ptfhost.copy(content=json.dumps(ports_map), dest=PTF_TEST_PORT_MAP)
+    return PTF_TEST_PORT_MAP
 
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, True, 1514)])
-def test_basic_fib(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ipv4, ipv6, mtu, config_facts, build_fib):
-    duthost = duthosts[rand_one_dut_hostname]
-
+def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu, fib_info_files, router_macs, set_mux_random, ptf_test_port_map):
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
     # do not test load balancing for vs platform as kernel 4.9
     # can only do load balance base on L3
-    if duthost.facts['asic_type'] in ["vs"]:
+    if duthosts[0].facts['asic_type'] in ["vs"]:
         test_balancing = False
     else:
         test_balancing = True
 
     logging.info("run ptf test")
-    testbed_type = tbinfo['topo']['name']
-    router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
     log_file = "/tmp/fib_test.FibTest.ipv4.{}.ipv6.{}.{}.log".format(ipv4, ipv6, timestamp)
     logging.info("PTF log file: %s" % log_file)
     ptf_runner(ptfhost,
                 "ptftests",
                 "fib_test.FibTest",
                 platform_dir="ptftests",
-                params={"testbed_type": testbed_type,
-                        "router_mac": router_mac,
-                        "fib_info": "/root/fib_info.txt",
+                params={"fib_info_files": fib_info_files[:2],  # Test at most 2 DUTs
+                        "ptf_test_port_map": ptf_test_port_map,
+                        "router_macs": router_macs,
                         "ipv4": ipv4,
                         "ipv6": ipv6,
                         "testbed_mtu": mtu,
@@ -152,14 +272,26 @@ def test_basic_fib(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ipv4, ipv6,
                 socket_recv_size=16384)
 
 
+def get_vlan_untag_ports(duthosts, config_facts):
+    """
+    get all untag vlan ports
+    """
+    vlan_untag_ports = {}
+    for duthost in duthosts:
+        ports = []
+        vlans = config_facts.get('VLAN_INTERFACE', {}).keys()
+        for vlan in vlans:
+            vlan_member_info = config_facts[duthost.hostname].get('VLAN_MEMBER', {}).get(vlan, {})
+            if vlan_member_info:
+                for port_name, tag_mode in vlan_member_info.items():
+                    if tag_mode['tagging_mode'] == 'untagged':
+                        ports.append(port_name)
+        vlan_untag_ports[duthost.hostname] = ports
+    return vlan_untag_ports
+
+
 @pytest.fixture(scope="module")
-def setup_hash(tbinfo, duthosts, rand_one_dut_hostname, config_facts):
-    duthost = duthosts[rand_one_dut_hostname]
-    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-
-    setup_info = {}
-
-    # TODO
+def hash_keys(duthost):
     hash_keys = HASH_KEYS[:]    # Copy from global var to avoid side effects of multiple iterations
     if 'dst-mac' in hash_keys:
         hash_keys.remove('dst-mac')
@@ -177,34 +309,46 @@ def setup_hash(tbinfo, duthosts, rand_one_dut_hostname, config_facts):
     if duthost.facts['asic_type'] in ["barefoot"]:
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
-    setup_info['hash_keys'] = hash_keys
 
-    setup_info['testbed_type'] = tbinfo['topo']['name']
-    setup_info['router_mac'] = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+    return hash_keys
 
-    vlan_untag_ports = get_vlan_untag_ports(config_facts)
-    in_ports_name = get_router_interface_ports(config_facts, tbinfo)
-    setup_info['in_ports'] = [config_facts.get('port_index_map', {})[p] for p in in_ports_name]
+
+def configure_vlan(duthost, ports):
+    for vlan in VLANIDS:
+        duthost.shell('config vlan add {}'.format(vlan))
+        for port in ports:
+            duthost.shell('config vlan member add {} {}'.format(vlan, port))
+        duthost.shell('config interface ip add Vlan{} '.format(vlan) + VLANIP.format(vlan%256))
+    time.sleep(5)
+
+
+def unconfigure_vlan(duthost, ports):
+    for vlan in VLANIDS:
+        for port in ports:
+            duthost.shell('config vlan member del {} {}'.format(vlan, port))
+        duthost.shell('config interface ip remove Vlan{} '.format(vlan) + VLANIP.format(vlan%256))
+        duthost.shell('config vlan del {}'.format(vlan))
+    time.sleep(5)
+
+
+@pytest.fixture
+def setup_vlan(tbinfo, duthosts, config_facts, hash_keys):
+
+    vlan_untag_ports = get_vlan_untag_ports(duthosts, config_facts)
+    need_to_clean_vlan = False
 
     # add some vlan for hash_key vlan-id test
-    if 't0' in setup_info['testbed_type'] and 'vlan-id' in hash_keys:
-        for vlan in VLANIDS:
-            duthost.shell('config vlan add {}'.format(vlan))
-            for port in vlan_untag_ports:
-                duthost.shell('config vlan member add {} {}'.format(vlan, port))
-            duthost.shell('config interface ip add Vlan{} '.format(vlan) + VLANIP.format(vlan%256))
-        time.sleep(5)
+    if tbinfo['topo']['type'] == 't0' and 'dualtor' not in tbinfo['topo']['name'] and 'vlan-id' in hash_keys:
+        for duthost in duthosts:
+            configure_vlan(duthost, vlan_untag_ports[duthost.hostname])
+        need_to_clean_vlan = True
 
-    yield setup_info
+    yield
 
     # remove added vlan
-    if 't0' in setup_info['testbed_type'] and 'vlan-id' in hash_keys:
-        for vlan in VLANIDS:
-            duthost.shell('config interface ip remove Vlan{} '.format(vlan) + VLANIP.format(vlan%256))
-            for port in vlan_untag_ports:
-                duthost.shell('config vlan member del {} {}'.format(vlan, port))
-            duthost.shell('config vlan del {}'.format(vlan))
-        time.sleep(5)
+    if need_to_clean_vlan:
+        for duthost in duthosts:
+            unconfigure_vlan(duthost, vlan_untag_ports[duthost.hostname])
 
 
 @pytest.fixture(params=["ipv4", "ipv6"])
@@ -212,14 +356,14 @@ def ipver(request):
     return request.param
 
 
-def test_hash(setup_hash, ptfhost, build_fib, ipver):
+def test_hash(fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, router_macs, set_mux_same_side, ptf_test_port_map):
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.HashTest.{}.{}.log".format(ipver, timestamp)
     logging.info("PTF log file: %s" % log_file)
     if ipver == "ipv4":
         src_ip_range = SRC_IP_RANGE
         dst_ip_range = DST_IP_RANGE
-    elif ipver == "ipv6":
+    else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
 
@@ -227,14 +371,13 @@ def test_hash(setup_hash, ptfhost, build_fib, ipver):
             "ptftests",
             "hash_test.HashTest",
             platform_dir="ptftests",
-            params={"testbed_type": setup_hash['testbed_type'],
-                    "router_mac": setup_hash['router_mac'],
-                    "fib_info": "/root/fib_info.txt",
+            params={"fib_info_files": fib_info_files[:2],   # Test at most 2 DUTs
+                    "ptf_test_port_map": ptf_test_port_map,
+                    "hash_keys": hash_keys,
                     "src_ip_range": ",".join(src_ip_range),
                     "dst_ip_range": ",".join(dst_ip_range),
-                    "in_ports": setup_hash['in_ports'],
-                    "vlan_ids": VLANIDS,
-                    "hash_keys": setup_hash['hash_keys']},
+                    "router_macs": router_macs,
+                    "vlan_ids": VLANIDS},
             log_file=log_file,
             qlen=PTF_QLEN,
             socket_recv_size=16384)

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -1,11 +1,9 @@
-import copy
 import time
 import json
 import logging
 import tempfile
 import random
 
-from collections import defaultdict
 from datetime import datetime
 
 import pytest


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Update the FIB test to support the DualToR topology.

#### How did you do it?
Changes:
* Improve the testbed.py to include more DUT to PTF port mapping information
* Run the basic FIB and FIB hash test on all DUTs.
* In the fib_test.py and hash_test.py PTF scripts, replace hard coded source ports with information passed from argument.
* In test scripts calling ptf_running, build a map `ptf_test_port_map` and dump it to `ptfhost`. Then pass the file location to PTF script as argument of `ptf_runner`. Keys of the map is enabled PTF port index (T0 topologies have disabled ports). Value is a diction with two keys: `target_dut` and `target_mac`. `target_dut` is index of the mux active side DUT in case of dualtor. For non-dualtor, the `target_dut` is always 0. `target_mac` is MAC address of the active side DUT. In case of dualtor, specifically it is the VLAN interface's MAC address if the PTF port is connected to VLAN port of DUT. Otherwise, it is just the router MAC.
* Previously, balancing test is executed based on the probability that a random number between 0 and 1 is smaller than 0.0001. The new approach is to always run balancing test once for a random IP range.
* A FIB info file is generated for each DUT and dumped to PTF container. Path of the FIB info files are passed to PTF scripts in a list.
* Increase wait time between packets sending from 0.01 to 0.02 second to avoid BGP flapping.
* Updated the test_bgp_speaker.py script to call the new fib_test.py PTF script accordingly.
* Added fixtures to toggle active side of all mux to same side. 
* In test_bgp_speaker.py script, always toggle active side of all mux to the currently selected DUT (by the `rand_one_hostname` fixture).
* In test_bgp_speaker.py script, removed calling of `collect_techsupport`. The reason is that the `collect_techsupport` fixture depends on the 'enum_dut_hostname` fixture. As a result, all test cases in this script will be parameterized by all the available DUTs. 
* Improve logging in PTF scripts.

#### How did you verify/test it?
Test run the script on t0, t1-lag, dualtor topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
