### PR TITLE
 Fix add-topo error RTNETLINK answers: No route to host

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -344,9 +344,8 @@ class VMTopology(object):
             if mgmt_ipv6_addr:
                 VMTopology.cmd("nsenter -t %s -n ip -6 addr flush dev %s" % (self.pid, int_if))
                 VMTopology.cmd("nsenter -t %s -n ip -6 addr add %s dev %s" % (self.pid, mgmt_ipv6_addr, int_if))
-            if mgmt_gw_v6:
+            if mgmt_ipv6_addr and mgmt_gw_v6:
                 VMTopology.cmd("nsenter -t %s -n ip -6 route flush default" % (self.pid))
-                VMTopology.cmd("nsenter -t %s -n ip -6 route add %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
                 VMTopology.cmd("nsenter -t %s -n ip -6 route add default via %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
 
         return

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -346,6 +346,7 @@ class VMTopology(object):
                 VMTopology.cmd("nsenter -t %s -n ip -6 addr add %s dev %s" % (self.pid, mgmt_ipv6_addr, int_if))
             if mgmt_gw_v6:
                 VMTopology.cmd("nsenter -t %s -n ip -6 route flush default" % (self.pid))
+                VMTopology.cmd("nsenter -t %s -n ip -6 route add %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
                 VMTopology.cmd("nsenter -t %s -n ip -6 route add default via %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
 
         return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix add-topo error `RTNETLINK answers: No route to host`.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`add-topo` is seen to be failing for some DUTs. This is due to the step where IPv6 default route is flushed and then a new default route is added.
```

TASK [vm_set : Bind topology t0-64 to VMs. base vm = VM0732] *********************************************************************************************************************************************************************
Wednesday 06 January 2021  18:38:50 +0000 (0:00:00.052)       0:01:58.327 *****
fatal: [STR-ACS-SERV-07]: FAILED! => {"changed": false, "msg": "ret_code=2, error message=RTNETLINK answers: No route to host\n. cmd=nsenter -t 50526 -n ip -6 route add default via 2a01:111:e210:b000::01 dev mgmt"}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************
STR-ACS-SERV-07            : ok=114  changed=4    unreachable=0    failed=1    skipped=96   rescued=0    ignored=0

Wednesday 06 January 2021  18:38:54 +0000 (0:00:04.176)       0:02:02.503 *****
===============================================================================
```
#### How did you do it?
Add route to gateway after flushing and before adding default route.

#### How did you verify/test it?
With fix, add-topo passes now:
```

TASK [vm_set : Bind topology t0-64 to VMs. base vm = VM0732] *********************************************************************************************************************************************************************
Wednesday 06 January 2021  18:46:49 +0000 (0:00:00.055)       0:01:53.674 *****
changed: [STR-ACS-SERV-07]
PLAY RECAP ***********************************************************************************************************************************************************************************************************************
STR-ACS-SERV-07            : ok=14   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0

Wednesday 06 January 2021  18:52:14 +0000 (0:00:04.211)       0:00:10.907 *****
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
