### PR TITLE
Fix inaccurate flows in response of updating mux status

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.md
+++ b/ansible/roles/vm_set/files/mux_simulator.md
@@ -21,7 +21,7 @@ On SONiC DUT side, script [y_cable_simulator_client.py](https://github.com/Azure
 ## Configuration
 The default TCP port that the mux simulator will be listening on is configurable by variable `mux_simulator_port` in [https://github.com/Azure/sonic-mgmt/blob/master/ansible/group_vars/all/variables](https://github.com/Azure/sonic-mgmt/blob/master/ansible/group_vars/all/variables).
 
-The mux simulator would be deployed to test server as a systemd server `mux-simulator` during `testbed-cli.sh add-topo`.
+The mux simulator would be deployed to test server as a systemd service `mux-simulator` during `testbed-cli.sh add-topo`.
 ```
 azure@str2-acs-serv-17:~$ sudo systemctl status mux-simulator
 ● mux-simulator.service - mux simulator
@@ -118,14 +118,14 @@ The APIs using json for data exchange.
 }
 ```
 
-### GET /mux/<vm_set>/<port_index>
+### GET `/mux/<vm_set>/<port_index>`
 
 * `vm_set`: Value of column `group_name` in `testbed.csv` of current testbed.
 * `port_index`: Index of DUT front panel port. Starting from `0`.
 
 Response: `mux_status`
 
-### POST /mux/<vm_set>/<port_index>
+### POST `/mux/<vm_set>/<port_index>`
 Post json data format:
 ```
 {
@@ -140,10 +140,10 @@ Post json data format:
 
 Response: `mux_status`
 
-### GET /mux/<vm_set>
+### GET `/mux/<vm_set>`
 Response: `all_mux_status`
 
-### POST /mux/<vm_set>
+### POST `/mux/<vm_set>`
 
 Post json data format:
 ```
@@ -155,7 +155,7 @@ Set active side for all bridges of specified vm_set.
 
 Response: `all_mux_status`
 
-### POST /mux/<vm_set>/<port_index>/<action>
+### POST `/mux/<vm_set>/<port_index>/<action>`
 
 * `action`: one of: `output`, `drop`.
 

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -288,7 +288,6 @@ def set_active_side(vm_set, port_index, new_active_side):
     # Need to toggle active side anyway
     flows = get_flows(vm_set, port_index)
     active_port = get_active_port(flows)
-    nic_port = mux_status['ports']['nic']
     if new_active_side == 'toggle':
         new_active_side = 'tor_a' if mux_status['active_side'] == 'tor_b' else 'tor_b'
 
@@ -494,7 +493,6 @@ def update_flow_action_to_nic(mux_status, action):
         in_port,
         action_desc)
     run_cmd(cmdline)
-    flow = {in_port: [{'action': action, 'out_port': out_port}]}
     new_flows = get_flows(mux_status['vm_set'], mux_status['port_index'])
     mux_status['flows'] = new_flows
     return mux_status

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -294,8 +294,16 @@ def set_active_side(vm_set, port_index, new_active_side):
 
     new_active_port = mux_status['ports'][new_active_side]
     run_cmd('ovs-ofctl --names del-flows mbr-{}-{} in_port="{}"'.format(vm_set, port_index, active_port))
-    run_cmd('ovs-ofctl --names add-flow  mbr-{}-{} in_port="{}",actions=output:"{}"'
-        .format(vm_set, port_index, new_active_port, nic_port))
+    actions = []
+    for action in flows[active_port]:
+        action_desc = action['action']
+        if action['out_port']:
+            action_desc += ':"{}"'.format(action['out_port'])
+        actions.append(action_desc)
+    run_cmd('ovs-ofctl --names add-flow  mbr-{}-{} in_port="{}",actions={}'
+        .format(vm_set, port_index, new_active_port, ','.join(actions)))
+    new_flows = get_flows(vm_set, port_index)
+    mux_status['flows'] = new_flows
     mux_status['active_side'] = new_active_side
     mux_status['active_port'] = new_active_port
     return mux_status
@@ -487,7 +495,8 @@ def update_flow_action_to_nic(mux_status, action):
         action_desc)
     run_cmd(cmdline)
     flow = {in_port: [{'action': action, 'out_port': out_port}]}
-    mux_status['flows'].update(flow)
+    new_flows = get_flows(mux_status['vm_set'], mux_status['port_index'])
+    mux_status['flows'] = new_flows
     return mux_status
 
 
@@ -526,8 +535,8 @@ def update_flow_action_to_tor(mux_status, action, tor_ports):
         nic_port,
         action_desc)
     run_cmd(cmdline)
-    flow = {nic_port: [{'action': 'output', 'out_port': port} for port in output_tor_ports]}
-    mux_status['flows'].update(flow)
+    new_flows = get_flows(mux_status['vm_set'], mux_status['port_index'])
+    mux_status['flows'] = new_flows
     return mux_status
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The mux simulator has two issues with updating active side and flow action.

1. An updated mux status is returned if call the HTTP API to change active side
   or flow behavior. However, the flows information in returned mux status is
   inaccurate.
2. If the action to "nic" port is "drop", then the new action will always be
   "output" if switched active side. It would be better to keep the original
   action.

#### How did you do it?
Changes:
1. Always get latest flow status using "ovs-ofctl" command after changed active
   side or flow action.
2. Always keep the original flow action after changed active side.
3. Fix issues in documentation:
  * Quote URLs to ensure correct rendering of markdown.
  * Fix typo.
 
#### How did you verify/test it?
Test the APIs using tool like postman.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
