### PR TITLE
[conn_graph_facts] Enforce uniform return variable data type

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -13,13 +13,13 @@
 - name: build fanout startup config for Arista fanout leaf
   template: src=arista_7260_deploy.j2
             dest=/mnt/flash/startup-config
-  when: device_info.HwSku == "Arista-7260QX-64"
+  when: device_info[inventory_hostname]["HwSku"] == "Arista-7260QX-64"
   become: yes
 
 - name: build fanout startup config for 7060
   template: src=arista_7060_deploy.j2
             dest=/mnt/flash/startup-config
-  when: device_info.HwSku == "Arista-7060CX-32S"
+  when: device_info[inventory_hostname]["HwSku"] == "Arista-7060CX-32S"
   become: yes
 
 - name: reboot

--- a/ansible/roles/fanout/tasks/fanout_mlnx.yml
+++ b/ansible/roles/fanout/tasks/fanout_mlnx.yml
@@ -7,7 +7,7 @@
 ### playbook
 ################################################################################################
 - name: prepare fanout switch admin login info
-  set_fact: ansible_ssh_user={{ fanout_mlnx_user }} ansible_ssh_pass={{ fanout_mlnx_password }} peer_hwsku={{device_info['HwSku']}}
+  set_fact: ansible_ssh_user={{ fanout_mlnx_user }} ansible_ssh_pass={{ fanout_mlnx_password }} peer_hwsku={{device_info[inventory_hostname]['HwSku']}}
   tags: always
 
 ##########################################

--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,19 +1,19 @@
-- debug: msg="{{ device_info }}"
+- debug: msg="{{ device_info[inventory_hostname] }}"
 
 - name: prepare fanout switch admin login info
   set_fact: ansible_user={{ fanout_sonic_user }} ansible_password={{ fanout_sonic_password }}
 
 - name: find interface name mapping
-  port_alias: hwsku="{{ device_info["HwSku"] }}"
+  port_alias: hwsku="{{ device_info[inventory_hostname]["HwSku"] }}"
 
 - name: build fanout vlan config
-  fail: msg="SONiC fanout switch with HwSku {{ device_info.HwSku }} not supported"
-  when: device_info.HwSku != "Arista-7060CX-32S-C32"
+  fail: msg="SONiC fanout switch with HwSku {{ device_info[inventory_hostname]['HwSku'] }} not supported"
+  when: device_info[inventory_hostname]["HwSku"] != "Arista-7060CX-32S-C32"
 
 - name: build fanout startup config for Arista 7060 SONiC leaf fanout
   template: src=sonic_deploy_arista_7060.j2
             dest=/etc/sonic/vlan.json
-  when: device_info.HwSku == "Arista-7060CX-32S-C32"
+  when: device_info[inventory_hostname]["HwSku"] == "Arista-7060CX-32S-C32"
   become: yes
 
 - name: disable all copp rules

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -11,7 +11,7 @@
   delegate_to: localhost
   tags: always
 
-- set_fact: sw_type="{{ device_info['Type'] }}"
+- set_fact: sw_type="{{ device_info[inventory_hostname]['Type'] }}"
 
 - set_fact: os='eos'
   when: os is not defined

--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -25,8 +25,12 @@
   register: lab
 
 - set_fact:
-    dev_vlans: "{{ devinfo.ansible_facts.device_vlan_range|flatten(levels=1) }}"
     lab_devices: "{{ lab.ansible_facts.device_info }}"
+
+- name: Collect DUTs vlans
+  set_fact:
+    dev_vlans: "{{ dev_vlans|default([]) + item.value }}"
+  loop: "{{ devinfo['ansible_facts']['device_vlan_range'] | dict2items }}"
 
 - name: Find the root fanout switch
   set_fact:

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -15,7 +15,7 @@ ntp server vrf management {{ ntp_server }}
 {% endfor %}
 !
 spanning-tree mode none
-no spanning-tree vlan {{ device_vlan_range | list | join(',') }}
+no spanning-tree vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 !
 aaa authorization exec default local
 aaa root secret 0 {{ lab_admin_pass }}
@@ -23,7 +23,7 @@ aaa root secret 0 {{ lab_admin_pass }}
 username admin privilege 15 role network-admin secret 0 {{ lab_admin_pass }}
 username eapi privilege 15 secret 0 {{ lab_admin_pass }}
 !
-vlan {{ device_vlan_range | list | join(',') }}
+vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 !
 vrf definition management
    rd 1:1
@@ -31,10 +31,10 @@ vrf definition management
 {% for i in range(1,33) %}
 {% set intf =  'Ethernet' + i|string + '/1'  %}
 interface {{ intf }}
-{% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
+{% if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
 {%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 100gfull
@@ -42,14 +42,14 @@ interface {{ intf }}
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 50gfull
@@ -57,9 +57,9 @@ interface {{ intf }}
    no shutdown
 {% set intf =  'Ethernet' + i|string + '/3'  %}
 interface {{ intf }}
-{%         if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
+{%         if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 50gfull
@@ -72,10 +72,10 @@ interface {{ intf }}
 {#        Not valid speed value #}
    shutdown
 {%     endif %}
-{% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %}
+{% elif intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport mode trunk
-   switchport trunk allowed vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    spanning-tree portfast
    speed force 40gfull
    no shutdown
@@ -87,7 +87,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
  no shutdown
 !
 # LACP packets pass through
@@ -95,8 +95,8 @@ mac address-table reserved forward 0180.c200.0002
 # LLDP packets pass through
 mac address-table reserved forward 0180.c200.000e
 !
-ip route 0.0.0.0/0 {{ device_info["ManagementGw"] }}
-ip route vrf management 0.0.0.0/0 {{ device_info["ManagementGw"] }}
+ip route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
+ip route vrf management 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
 !
 ip routing
 no ip routing vrf management

--- a/ansible/roles/fanout/templates/arista_7260_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260_deploy.j2
@@ -18,7 +18,7 @@ ntp server vrf management {{ ntp_server }}
 {% endfor %}
 !
 spanning-tree mode none
-no spanning-tree vlan {{ device_vlan_range | list | join(',') }}
+no spanning-tree vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 !
 aaa authorization exec default local
 aaa root secret 0 {{ lab_admin_pass }}
@@ -26,7 +26,7 @@ aaa root secret 0 {{ lab_admin_pass }}
 username admin privilege 15 role network-admin secret 0 {{ lab_admin_pass }}
 username eapi privilege 15 secret 0 {{ lab_admin_pass }}
 !
-vlan {{ device_vlan_range | list | join(',') }}
+vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 !
 vrf definition management
    rd 1:1
@@ -34,17 +34,17 @@ vrf definition management
 {% for i in range(1,65) %}
 {% set intf =  'Ethernet' + i|string  %}
 interface {{ intf }}
-{% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+{% if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
    no shutdown
-{% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %}
-   description {{ device_conn[intf]['peerdevice'] }}-{{ device_conn[intf]['peerport'] }}
+{% elif intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport mode trunk
-   switchport trunk allowed vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    no shutdown
 {% else %}
    shutdown
@@ -54,7 +54,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
  no shutdown
 !
 # LACP packets pass through
@@ -62,8 +62,8 @@ mac address-table reserved forward 0180.c200.0002
 # LLDP packets pass through
 mac address-table reserved forward 0180.c200.000e
 !
-ip route 0.0.0.0/0 {{ device_info["ManagementGw"] }}
-ip route vrf management 0.0.0.0/0 {{ device_info["ManagementGw"] }}
+ip route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
+ip route vrf management 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
 !
 ip routing
 no ip routing vrf management

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -15,7 +15,7 @@ ntp server vrf management {{ ntp_server }}
 {% endfor %}
 !
 spanning-tree mode none
-no spanning-tree vlan {{ device_vlan_range | list | join(',') }}
+no spanning-tree vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 !
 !
 aaa authorization exec default local
@@ -24,18 +24,18 @@ aaa root secret 0 {{ lab_admin_pass }}
 username admin privilege 15 role network-admin secret 0 {{ lab_admin_pass }}
 username eapi privilege 15 secret 0 {{ lab_admin_pass }}
 !
-vlan {{ device_vlan_range | list | join(',') }}
+vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 !
 vrf definition management
    rd 1:1
 !
 {% for i in range(1,65) %}
 {% set intf =  'Ethernet' + i|string + '/1'  %}
-{% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
+{% if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
 {%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
    interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 100gfull
@@ -44,7 +44,7 @@ vrf definition management
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
    interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
@@ -54,7 +54,7 @@ vrf definition management
 {%             set subintf = 'Ethernet' + i|string + '/' + sub|string %}
    interface {{ subintf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 10gfull
@@ -64,7 +64,7 @@ vrf definition management
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 50gfull
@@ -73,9 +73,9 @@ interface {{ intf }}
 !
 {% set intf =  'Ethernet' + i|string + '/3'  %}
 interface {{ intf }}
-{%         if intf in device_port_vlans and device_port_vlans[intf]['mode'] != "Trunk" %}
+{%         if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 50gfull
@@ -88,11 +88,11 @@ interface {{ intf }}
 {#        Not valid speed value #}
    shutdown
 {%     endif %}
-{% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %}
+{% elif intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
    interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport mode trunk
-   switchport trunk allowed vlan {{ device_port_vlans[intf]['vlanids'] }}
+   switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    spanning-tree portfast
 {%       if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
             speed forced 100gfull
@@ -110,7 +110,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
  no shutdown
 !
 # LACP packets pass through
@@ -118,8 +118,8 @@ mac address-table reserved forward 0180.c200.0002
 # LLDP packets pass through
 mac address-table reserved forward 0180.c200.000e
 !
-ip route 0.0.0.0/0 {{ device_info["ManagementGw"] }}
-ip route vrf management 0.0.0.0/0 {{ device_info["ManagementGw"] }}
+ip route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
+ip route vrf management 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
 !
 ip routing
 no ip routing vrf management

--- a/ansible/roles/fanout/templates/force10_s6100_deploy.j2
+++ b/ansible/roles/fanout/templates/force10_s6100_deploy.j2
@@ -22,18 +22,18 @@ mac-address-table aging-time 10
 interface {{ intf }}
  no ip address
  switchport
-{% if intf in device_port_vlans and device_port_vlans[intf]['mode'] != 'Trunk' %}
+{% if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != 'Trunk' %}
  description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
  vlan-stack access
  no shutdown
- interface Vlan {{ device_port_vlans[intf]['vlanids'] }}
+ interface Vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
  vlan-stack compatible
  member {{ intf }}
-{% elif intf in device_port_vlans and device_port_vlans[intf]['mode'] == 'Trunk' %} 
+{% elif intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %} 
  description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
  vlan-stack trunk 
  no shutdown
-{% for vlanid in  device_port_vlans[intf]['vlanlist']  %}
+{% for vlanid in  device_port_vlans[inventory_hostname][intf]['vlanlist']  %}
  interface Vlan {{ vlanid }}
  vlan-stack compatible
  member {{ intf }}
@@ -47,12 +47,12 @@ interface {{ intf }}
 {% endfor %}
 !
 interface ManagementEthernet 1/1
- ip address {{ device_info["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
  no shutdown
 !
 interface Vlan 1
 !
-management route 0.0.0.0/0 {{ device_info["ManagementGw"] }} 
+management route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }} 
 !
 ip ssh server enable
 !

--- a/ansible/roles/fanout/templates/sonic_deploy.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy.j2
@@ -2,7 +2,7 @@
 
 "DEVICE_METADATA": {
     "localhost": {
-        "hwsku": "{{ device_info["HwSku"] }}",
+        "hwsku": "{{ device_info[inventory_hostname]["HwSku"] }}",
         "hostname": "{{ inventory_hostname }}"
     }
 },
@@ -19,7 +19,7 @@
 },
 
 "VLAN": {
-{% for vlanid in device_vlan_list | unique %}
+{% for vlanid in device_vlan_list[inventory_hostname] | unique %}
     "Vlan{{ vlanid }}": {
         "vlanid": "{{ vlanid }}"
     }{% if not loop.last %},{% endif %}
@@ -28,15 +28,15 @@
 
 {% set ns = {'firstPrinted': False} %}
 "VLAN_MEMBER": {
-{% for alias in device_port_vlans %}
-{% if device_port_vlans[alias]['mode'] == 'Access' %}
+{% for alias in device_port_vlans[inventory_hostname] %}
+{% if device_port_vlans[inventory_hostname][alias]['mode'] == 'Access' %}
 {% if ns.firstPrinted %},{% endif %}
-    "Vlan{{ device_port_vlans[alias]['vlanids'] }}|{{ alias }}": {
+    "Vlan{{ device_port_vlans[inventory_hostname][alias]['vlanids'] }}|{{ alias }}": {
         "tagging_mode" : "untagged"
     }
 {% if ns.update({'firstPrinted': True}) %} {% endif %}
-{% elif device_port_vlans[alias]['mode'] == 'Trunk' %}
-  {% for vlanid in device_port_vlans[alias]['vlanlist'] %}
+{% elif device_port_vlans[inventory_hostname][alias]['mode'] == 'Trunk' %}
+  {% for vlanid in device_port_vlans[inventory_hostname][alias]['vlanlist'] %}
 {% if ns.firstPrinted %},{% endif %}
     "Vlan{{ vlanid }}|{{ alias }}": {
         "tagging_mode" : "tagged"
@@ -48,8 +48,8 @@
 },
 
 "MGMT_INTERFACE": {
-    "eth0|{{ device_info["ManagementIp"] }}": {
-        "gwaddr": "{{ device_info["ManagementGw"] }}"
+    "eth0|{{ device_info[inventory_hostname]["ManagementIp"] }}": {
+        "gwaddr": "{{ device_info[inventory_hostname]["ManagementGw"] }}"
     }
 }
 

--- a/ansible/roles/fanout/templates/sonic_deploy_arista_7060.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_arista_7060.j2
@@ -2,13 +2,13 @@
 
 "DEVICE_METADATA": {
     "localhost": {
-        "hwsku": "{{ device_info["HwSku"] }}",
+        "hwsku": "{{ device_info[inventory_hostname]["HwSku"] }}",
         "hostname": "{{ inventory_hostname }}"
     }
 },
 
 "PORT": {
-{% for alias in device_conn %}
+{% for alias in device_conn[inventory_hostname] %}
     "{{ alias }}": {
         "admin_status": "up",
         "speed": "100000",
@@ -18,7 +18,7 @@
 },
 
 "VLAN": {
-{% for vlanid in device_vlan_list | unique %}
+{% for vlanid in device_vlan_list[inventory_hostname] | unique %}
     "Vlan{{ vlanid }}": {
         "vlanid": "{{ vlanid }}"
     }{% if not loop.last %},{% endif %}
@@ -27,15 +27,15 @@
 
 {% set ns = {'firstPrinted': False} %}
 "VLAN_MEMBER": {
-{% for alias in device_port_vlans %}
-{% if device_port_vlans[alias]['mode'] == 'Access' %}
+{% for alias in device_port_vlans[inventory_hostname] %}
+{% if device_port_vlans[inventory_hostname][alias]['mode'] == 'Access' %}
 {% if ns.firstPrinted %},{% endif %}
-    "Vlan{{ device_port_vlans[alias]['vlanids'] }}|{{ alias }}": {
+    "Vlan{{ device_port_vlans[inventory_hostname][alias]['vlanids'] }}|{{ alias }}": {
         "tagging_mode" : "untagged"
     }
 {% if ns.update({'firstPrinted': True}) %} {% endif %}
-{% elif device_port_vlans[alias]['mode'] == 'Trunk' %}
-  {% for vlanid in device_port_vlans[alias]['vlanlist'] %}
+{% elif device_port_vlans[inventory_hostname][alias]['mode'] == 'Trunk' %}
+  {% for vlanid in device_port_vlans[inventory_hostname][alias]['vlanlist'] %}
 {% if ns.firstPrinted %},{% endif %}
     "Vlan{{ vlanid }}|{{ alias }}": {
         "tagging_mode" : "tagged"
@@ -47,8 +47,8 @@
 },
 
 "MGMT_INTERFACE": {
-    "eth0|{{ device_info["ManagementIp"] }}": {
-        "gwaddr": "{{ device_info["ManagementGw"] }}"
+    "eth0|{{ device_info[inventory_hostname]["ManagementIp"] }}": {
+        "gwaddr": "{{ device_info[inventory_hostname]["ManagementGw"] }}"
     }
 },
 
@@ -65,7 +65,7 @@
 },
 
 "QUEUE": {
-{% for alias in device_conn %}
+{% for alias in device_conn[inventory_hostname] %}
     "{{ alias }}|0": {
         "scheduler": "[SCHEDULER|scheduler.0]"
     },
@@ -93,7 +93,7 @@
 },
 
 "BUFFER_QUEUE": {
-{% for alias in device_conn %}
+{% for alias in device_conn[inventory_hostname] %}
     "{{ alias }}|0-2": {
         "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
     },
@@ -107,7 +107,7 @@
 },
 
 "BUFFER_PG": {
-{% for alias in device_conn %}
+{% for alias in device_conn[inventory_hostname] %}
     "{{ alias }}|0": {
         "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
     },
@@ -119,7 +119,7 @@
 
 "CABLE_LENGTH": {
     "AZURE": {
-{% for alias in device_conn %}
+{% for alias in device_conn[inventory_hostname] %}
     "{{ alias }}": "300m"{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
+++ b/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
@@ -25,7 +25,7 @@ class FanoutHandler(BaseFanoutHandler):
         fanout_facts = self.ansible_localhost.conn_graph_facts(host=self.fanout_host, filename=LAB_CONNECTION_GRAPH)["ansible_facts"]
 
         self.fanout_trunk_port = None
-        for iface, iface_info in fanout_facts["device_port_vlans"].items():
+        for iface, iface_info in fanout_facts["device_port_vlans"][self.fanout_hosts].items():
             if iface_info["mode"] == "Trunk":
                 self.fanout_trunk_port = iface[iface.find("/") + 1:]
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Make all the returns from `conn_graph_facts` of type `dict`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Enforce uniform returns for `conn_graph_facts` for both single and multi-DUTs.

#### How did you do it?
Make them all dictionary.

#### How did you verify/test it?
Run add_topo/remove_topo.
Run Pytest.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
