### PR TITLE
[test/cacl/function]: improve reliablibilty of cacl_function test

### DIFF
--- a/ansible/roles/test/files/helpers/config_service_acls.sh
+++ b/ansible/roles/test/files/helpers/config_service_acls.sh
@@ -75,6 +75,10 @@ EOF
 # Install the new service ACLs
 acl-loader update full /tmp/testacl.json
 
+# log control plane acl after install
+logger -t cacltest "added cacl test rules"
+iptables -nL | logger -t cacltest
+
 # Sleep to allow Ansible playbook ample time to attempt to connect and timeout
 sleep 60
 
@@ -83,3 +87,7 @@ rm -rf /tmp/testacl.json
 
 # IMPORTANT! Delete the ACLs we just added in order to restore connectivity
 acl-loader delete
+
+# log control plane acl after deletion
+logger -t cacltest "deleted cacl test rules"
+iptables -nL | logger -t cacltest


### PR DESCRIPTION

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix #2743 

#### How did you do it?
- increase the wait timeout for cacl to take effect after installation.
it appears the wait timeout is not large enough for cacl to take
effect.

- fix a bug when waiting for the SSH port to be stopped.

- add more logging function for debugging

#### How did you verify/test it?
run locally.

#### Any platform specific information?
kvm
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
