### PR TITLE
[test_platform_info] Avoid thermal policy affect test case test_show_platform_fanstatus_mocked

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -245,23 +245,25 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
 
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_SHOW_PLATFORM_FAN], indirect=True)
-def test_show_platform_fanstatus_mocked(duthosts, rand_one_dut_hostname, mocker_factory, ignore_particular_error_log):
+def test_show_platform_fanstatus_mocked(duthosts, rand_one_dut_hostname, mocker_factory):
     """
     @summary: Check output of 'show platform fan'.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    # Mock data and check
-    mocker = mocker_factory(duthost, 'FanStatusMocker')
-    if mocker is None:
-        pytest.skip("No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
 
-    logging.info('Mock FAN status data...')
-    mocker.mock_data()
-    logging.info('Wait and check actual data with mocked FAN status data...')
-    result = check_cli_output_with_mocker(duthost, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
+    # Load an invalid thermal control configuration file here to avoid thermal policy affect the test result
+    with ThermalPolicyFileContext(duthost, THERMAL_POLICY_INVALID_FORMAT_FILE):
+        # Mock data and check
+        mocker = mocker_factory(duthost, 'FanStatusMocker')
+        if mocker is None:
+            pytest.skip("No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
 
-    assert result, 'FAN mock data mismatch'
+        logging.info('Mock FAN status data...')
+        mocker.mock_data()
+        logging.info('Wait and check actual data with mocked FAN status data...')
+        result = check_cli_output_with_mocker(duthost, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
+
+        assert result, 'FAN mock data mismatch'
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -44,8 +44,6 @@ LOG_EXPECT_INSUFFICIENT_FAN_NUM_CLEAR_RE = '.*Insufficient number of working fan
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP = ['.*ERR pmon#thermalctld.*int\(\) argument must be a string or a number.*',
                                      '.*ERR pmon#thermalctld.*invalid literal for int\(\) with base 10.*']
 
-SKIP_ERROR_LOG_SHOW_PLATFORM_FAN = SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP + ['.*ERR pmon#thermalctld.*Failed to get cooling level.*No such file or directory.*']
-
 SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*']
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue test_show_platform_fanstatus_mocked could failed dur to affect by thermal policy,

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

The test step of test_show_platform_fanstatus_mocked is like:

1. Mock fan data and record the expected data
2. Wait thermalctld to read the mocked data
3. Check the expected data with actual data

However, during the wait, thermal policy might take effect which could cause the check failure. This PR is to fix the issue.

#### How did you do it?

Load an invalid thermal control configuration file so that the thermal policy won't work, and it will not affect the `show platform fan` command.

#### How did you verify/test it?

Manually run the test case

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
