### PR TITLE
[conn_graph] Fix the fanout connection parsing error

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -362,25 +362,28 @@ def main():
             if host_vlan:
                 device_vlan_range.append(host_vlan["VlanRange"])
                 device_vlan_list.append(host_vlan["VlanList"])
-                port_vlans = lab_graph.get_host_port_vlans(hostname)
-                device_vlan_map_list[hostname] = {}
+                if dev["Type"] == "FanoutLeaf":
+                    device_vlan_map_list[hostname] = host_vlan["VlanList"]
+                else:
+                    port_vlans = lab_graph.get_host_port_vlans(hostname)
+                    device_vlan_map_list[hostname] = {}
 
-                port_name_list_sorted = get_port_name_list(dev['HwSku'])
-                print_debug_msg(debug_fname,"For %s with hwsku %s, port_name_list is %s" % (hostname, dev['HwSku'], port_name_list_sorted))
-                for a_host_vlan in host_vlan["VlanList"]:
-                    # Get the corresponding port for this vlan from the port vlan list for this hostname
-                    found_port_for_vlan = False
-                    for a_port in port_vlans:
-                        if a_host_vlan in port_vlans[a_port]['vlanlist']:
-                            if a_port in port_name_list_sorted:
-                                port_index = port_name_list_sorted.index(a_port)
-                                device_vlan_map_list[hostname][port_index] = a_host_vlan
-                                found_port_for_vlan = True
-                                break
-                            else:
-                                module.fail_json(msg="Did not find port for %s in the ports based on hwsku '%s' for host %s" % (a_port, dev['HwSku'], hostname))
-                    if not found_port_for_vlan:
-                        module.fail_json(msg="Did not find corresponding link for vlan %d in %s for host %s" % (a_host_vlan, port_vlans, hostname))
+                    port_name_list_sorted = get_port_name_list(dev['HwSku'])
+                    print_debug_msg(debug_fname,"For %s with hwsku %s, port_name_list is %s" % (hostname, dev['HwSku'], port_name_list_sorted))
+                    for a_host_vlan in host_vlan["VlanList"]:
+                        # Get the corresponding port for this vlan from the port vlan list for this hostname
+                        found_port_for_vlan = False
+                        for a_port in port_vlans:
+                            if a_host_vlan in port_vlans[a_port]['vlanlist']:
+                                if a_port in port_name_list_sorted:
+                                    port_index = port_name_list_sorted.index(a_port)
+                                    device_vlan_map_list[hostname][port_index] = a_host_vlan
+                                    found_port_for_vlan = True
+                                    break
+                                else:
+                                    module.fail_json(msg="Did not find port for %s in the ports based on hwsku '%s' for host %s" % (a_port, dev['HwSku'], hostname))
+                        if not found_port_for_vlan:
+                            module.fail_json(msg="Did not find corresponding link for vlan %d in %s for host %s" % (a_host_vlan, port_vlans, hostname))
             device_port_vlans.append(lab_graph.get_host_port_vlans(hostname))
         results = {k: v for k, v in locals().items()
                    if (k.startswith("device_") and v)}

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -362,7 +362,7 @@ def main():
             if host_vlan:
                 device_vlan_range.append(host_vlan["VlanRange"])
                 device_vlan_list.append(host_vlan["VlanList"])
-                if dev["Type"] == "FanoutLeaf":
+                if dev["Type"].lower() != "devsonic":
                     device_vlan_map_list[hostname] = host_vlan["VlanList"]
                 else:
                     port_vlans = lab_graph.get_host_port_vlans(hostname)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fanout graph parsing was broken due to #2517 
Following errors were seen while running pfcwd tests
E           RunAnsibleModuleFail: run module conn_graph_facts failed, Ansible Results =>
E           {
E               "changed": false, 
E               "failed": true, 
E               "invocation": {
E                   "module_args": {
E                       "anchor": null, 
E                       "filename": "/var/nejo/Networking-acs-sonic-mgmt/tests/common/fixtures/../../../ansible/files/starlab_connection_graph.xml", 
E                       "filepath": null, 
E                       "host": "str-7260cx3-acs-fan-05", 
E                       "hosts": null
E                   }
E               }, 
E               "msg": "Did not find port for Ethernet23/1 in the ports based on hwsku 'Arista-7260CX3' for host str-7260cx3-acs-fan-05"
E           }

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you do it?
Parsing logic added in #2517 was for SONIC duts. Retained the old logic when dev type is FanoutLeaf

#### How did you verify/test it?
Ran one of the pfcwd tests and it passed