### PR TITLE
Upgrade path error fix - handle the cleanup only case without image URL

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -50,17 +50,16 @@ def reduce_installed_sonic_images(module, disk_used_pcent):
 
 def download_new_sonic_image(module, new_image_url, save_as):
     global results
-    if new_image_url:
-        exec_command(module,
-                    cmd="curl -o {} {}".format(save_as, new_image_url),
-                    msg="downloading new image")
+    exec_command(module,
+                cmd="curl -o {} {}".format(save_as, new_image_url),
+                msg="downloading new image")
+
     if path.exists(save_as):
         _, out, _ = exec_command(module,cmd="sonic_installer binary_version %s" % save_as)
         results['downloaded_image_version'] = out.rstrip('\n')
 
 
 def install_new_sonic_image(module, new_image_url, save_as=None):
-
     if not save_as:
         avail = get_disk_free_size(module, "/host")
         save_as = "/host/downloaded-sonic-image" if avail >= 2000 else "/tmp/tmpfs/downloaded-sonic-image"
@@ -126,7 +125,8 @@ def main():
     try:
         work_around_for_slow_disks(module)
         reduce_installed_sonic_images(module, disk_used_pcent)
-        install_new_sonic_image(module, new_image_url, save_as)
+        if new_image_url:
+            install_new_sonic_image(module, new_image_url, save_as)
     except:
         err = str(sys.exc_info())
         module.fail_json(msg="Error: %s" % err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix bug introduced by https://github.com/Azure/sonic-mgmt/pull/2661 where if `new_image_url` is not provided, the installation logic still proceeds.
This leads to error in the Ansible module in upgrade_sonic.yml step for removing old sonic images.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added the check for no image URL. And do not execute installation logic if URL is `None`.

#### How did you verify/test it?
Tested on a physical lab device, and the Ansible execution of `upgrade_sonic.yml` passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
