### PR TITLE
[test_traffic_shift] Changed path key due to FRR update

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -108,7 +108,7 @@ def parse_rib(host, ip_ver):
     for ip, nexthops in route_data['routes'].iteritems():
         aspath = set()
         for nexthop in nexthops:
-            aspath.add(nexthop['aspath'])
+            aspath.add(nexthop['path'])
         routes[ip] = aspath
     return routes
 


### PR DESCRIPTION
Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After FRR update to FRR 7.5, output of vtysh -c "show bgp ipv4 json" does not contain key "aspath":
`
{
    "valid":true,
    "bestpath":true,
    "pathFrom":"external",
    "prefix":"100.1.0.32",
    "prefixLen":32,
    "network":"100.1.0.32\/32",
    "weight":0,
    "peerId":"10.0.0.63",
    "path":"64016",
    "origin":"IGP",
    "nexthops":[
      {
        "ip":"10.0.0.63",
        "afi":"ipv4",
        "used":true
      }
    ]
}
`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [+] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test test_traffic_shift failed with error:
`no key "aspath"`
#### How did you do it?
Changed key from "aspath" to "path"
#### How did you verify/test it?
Run test test_traffic_shift; test passed

TC will be backward compatible with oldest versions of FRR as in output it has 2 keys with values:
`"aspath": "64600 65534 64799 65515", "path": "64600 65534 64799 65515"`

#### Any platform specific information?
SONiC Software Version: SONiC.master.91-dirty-20210111.022412
Distribution: Debian 10.7
Kernel: 4.19.0-9-2-amd64
Build date: Mon Jan 11 10:22:26 UTC 2021

Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
