### PR TITLE
[minigraph]: Generate servers for dualtor minigraphs

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -70,9 +70,12 @@
       </Device>
 {% endif %}
 {% if 'cables' in dual_tor_facts %}
-{% set server_base_address = (vlan_configs.values() | list)[0]['prefix'] %}
-{% set server_base_address = server_base_address | ipaddr('network') %}
-{% set server_base_address = '.'.join(server_base_address.split('.')[:-1]) + '.{}' %}
+{% set server_base_address_v4 = (vlan_configs.values() | list)[0]['prefix'] %}
+{% set server_base_address_v4 = server_base_address_v4 | ipaddr('network') %}
+{% set server_base_address_v4 = '.'.join(server_base_address_v4.split('.')[:-1]) + '.{}' %}
+{% set server_base_address_v6 = (vlan_configs.values() | list)[0]['prefix_v6'] %}
+{% set server_base_address_v6 = server_base_address_v6 | ipaddr('network') %}
+{% set server_base_address_v6 = ':'.join(server_base_address_v6.split(':')[:-1]) + ':{}' %}
 {% for cable in dual_tor_facts['cables'] %}
       <Device i:type="SmartCable">
         <ElementType>SmartCable</ElementType>
@@ -94,8 +97,11 @@
       <Device i:type="Server">
         <ElementType>Server</ElementType>
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>{{ server_base_address.format(loop.index + 1) }}/26</d5p1:IPPrefix>
+          <d5p1:IPPrefix>{{ server_base_address_v4.format(loop.index + 1) }}/26</d5p1:IPPrefix>
         </Address> 
+        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>{{ server_base_address_v6.format(loop.index + 1) }}/96</d5p1:IPPrefix>
+        </AddressV6>
         <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
         </ManagementAddress>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -70,6 +70,9 @@
       </Device>
 {% endif %}
 {% if 'cables' in dual_tor_facts %}
+{% set server_base_address = (vlan_configs.values() | list)[0]['prefix'] %}
+{% set server_base_address = server_base_address | ipaddr('network') %}
+{% set server_base_address = '.'.join(server_base_address.split('.')[:-1]) + '.{}' %}
 {% for cable in dual_tor_facts['cables'] %}
       <Device i:type="SmartCable">
         <ElementType>SmartCable</ElementType>
@@ -87,6 +90,16 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true" />
         <Hostname>cable</Hostname>
+      </Device>
+      <Device i:type="Server">
+        <ElementType>Server</ElementType>
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>{{ server_base_address.format(loop.index + 1) }}/26</d5p1:IPPrefix>
+        </Address> 
+        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
+        </ManagementAddress>
+        <Hostname>Server{{ loop.index }}</Hostname>
       </Device>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Current minigraph generation does not include servers in the PNG section, which is needed for dual ToR operation.
#### How did you do it?
For each smart cable generated, also generate one server with a loopback in the same subnet as the DUT VLAN.

Example:

```
<Device i:type="Server">
  <ElementType>Server</ElementType>
  <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
    <d5p1:IPPrefix>192.168.0.2/26</d5p1:IPPrefix>
  </Address>
  <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
    <d5p1:IPPrefix>fc02:1000::2/96</d5p1:IPPrefix>
  </AddressV6> 
  <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
    <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
  </ManagementAddress>
  <Hostname>Server1</Hostname>
</Device>
```
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
