### PR TITLE
[pretest] Add support to update python saithrift package on ptf

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,8 @@ def pytest_addoption(parser):
     ########################
     parser.addoption("--deep_clean", action="store_true", default=False,
                      help="Deep clean DUT before tests (remove old logs, cores, dumps)")
+    parser.addoption("--py_saithrift_url", action="store", default=None, type=str,
+                     help="Specify the url of the saithrift package to be installed on the ptf (should be http://<serverip>/path/python-saithrift_0.9.4_amd64.deb")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -149,3 +149,18 @@ def test_collect_testbed_prio(duthosts, tbinfo):
                 json.dump({ tbname : prio_info[i]}, yf, indent=4)
         except IOError as e:
             logger.warning('Unable to create file {}: {}'.format(filepath, e))
+
+def test_update_saithrift_ptf(request, ptfhost):
+    '''
+    Install the correct python saithrift package on the ptf
+    '''
+    py_saithrift_url = request.config.getoption("--py_saithrift_url")
+    if not py_saithrift_url:
+        pytest.skip("No URL specified for python saithrift package")
+    pkg_name = py_saithrift_url.split("/")[-1]
+    ptfhost.shell("rm -f {}".format(pkg_name))
+    result = ptfhost.get_url(url=py_saithrift_url, dest="/root", module_ignore_errors=True)
+    if result["failed"] != False or "OK" not in result["msg"]:
+        pytest.skip("Download failed/error while installing python saithrift package")
+    ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
+    logging.info("Python saithrift package installed successfully")


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Some tests like qos_sai are dependent on the python saithrift package installed on the ptf. This PR adds support to install the correct python saithrift package based on the image version being tested prior to the test run

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you do it?
Added --py_saithrift_url option in conftest.py
Changes in test_pretest to install the package if the url is present and valid. In case of missing url or download error, the testcase is skipped

#### How did you verify/test it?
Tested without specifying --py_saithrift_url and testcase was skipped
Tested with incorrect url and testcase was skipped
Tested with valid url and package was installed on ptf