### PR TITLE
Fix 'fanout_graph_facts'

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -15,10 +15,10 @@ def fanout_graph_facts(localhost, duthosts, rand_one_dut_hostname, conn_graph_fa
     duthost = duthosts[rand_one_dut_hostname]
     facts = dict()
     dev_conn = conn_graph_facts.get('device_conn', {})
-    for intf, val in dev_conn[duthost.hostname].items():
+    for _, val in dev_conn[duthost.hostname].items():
         fanout = val["peerdevice"]
         if fanout not in facts:
-            facts[fanout] = get_graph_facts(duthost, localhost, fanout)
+            facts[fanout] = {k: v[fanout] for k, v in get_graph_facts(duthost, localhost, fanout).items()}
     return facts
 
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix the issue introduced by the return type change of
`conn_graph_facts` from list to dictionary.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Recent change from `conn_graph_facts` makes the returns from nested list to dictinaries.
Like:
```
'device_info': {u'str-7260cx3-64-17': {u'ManagementIp': u'10.3.146.148/23', u'HwSku': u'Arista-7260CX3', u'Type': u'FanoutLeaf', u'mgmtip': u'10.3.146.148', u'ManagementGw': u'10.3.146.1'}}
```

#### How did you do it?
Let's get the values out of the dictionaries like:
```
'device_info':  {u'ManagementIp': u'10.3.146.148/23', u'HwSku': u'Arista-7260CX3', u'Type': u'FanoutLeaf', u'mgmtip': u'10.3.146.148', u'ManagementGw': u'10.3.146.1'}
```

#### How did you verify/test it?
Run pfcwd testcases.
```
pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy PASSED                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
