### PR TITLE
[Platform tests] Added support of several lanes on one PDU

### DIFF
--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -132,17 +132,18 @@ class snmpPsuController(PsuControllerBase):
                 )
             if errorIndication:
                 logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
-            for varBinds in varTable:
-                for oid, val in varBinds:
-                    current_oid = oid.prettyPrint()
-                    current_val = val.prettyPrint()
-                    if self.hostname.lower()  in current_val.lower():
-                        host_matched = True
-                        # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
-                        self.pdu_ports.append(current_oid.replace(pdu_port_base, ''))
-            if host_matched:
-                self.map_host_to_lane(lane_id)
-                break
+            else:
+                for varBinds in varTable:
+                    for oid, val in varBinds:
+                        current_oid = oid.prettyPrint()
+                        current_val = val.prettyPrint()
+                        if self.hostname.lower()  in current_val.lower():
+                            host_matched = True
+                            # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
+                            self.pdu_ports.append(current_oid.replace(pdu_port_base, ''))
+                if host_matched:
+                    self.map_host_to_lane(lane_id)
+                    break
         else:
             logging.error("{} device is not attached to any of PDU port".format(self.hostname.lower()))
 

--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -117,22 +117,45 @@ class snmpPsuController(PsuControllerBase):
         The PDU ports connected to DUT must have hostname of DUT configured in port name/description.
         This method depends on this configuration to find out the PDU ports connected to PSUs of specific DUT.
         """
+        max_lane = 5
+        host_matched = False
         cmdGen = cmdgen.CommandGenerator()
         snmp_auth = cmdgen.CommunityData(self.snmp_rocommunity)
-        errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
-            snmp_auth,
-            cmdgen.UdpTransportTarget((self.controller, 161)),
-            cmdgen.MibVariable(self.pPORT_NAME_BASE_OID,),
-            )
-        if errorIndication:
-            logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
-        for varBinds in varTable:
-            for oid, val in varBinds:
-                current_oid = oid.prettyPrint()
-                current_val = val.prettyPrint()
-                if self.hostname.lower()  in current_val.lower():
-                    # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
-                    self.pdu_ports.append(current_oid.replace(self.PORT_NAME_BASE_OID, ''))
+
+        for lane_id in range(1, max_lane + 1):
+            pdu_port_base = self.PORT_NAME_BASE_OID[0: -1] + str(lane_id)
+
+            errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
+                snmp_auth,
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                cmdgen.MibVariable("." + pdu_port_base,),
+                )
+            if errorIndication:
+                logging.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
+            for varBinds in varTable:
+                for oid, val in varBinds:
+                    current_oid = oid.prettyPrint()
+                    current_val = val.prettyPrint()
+                    if self.hostname.lower()  in current_val.lower():
+                        host_matched = True
+                        # Remove the preceding PORT_NAME_BASE_OID, remaining string is the PDU port ID
+                        self.pdu_ports.append(current_oid.replace(pdu_port_base, ''))
+            if host_matched:
+                self.map_host_to_lane(lane_id)
+                break
+        else:
+            logging.error("{} device is not attached to any of PDU port".format(self.hostname.lower()))
+
+    def map_host_to_lane(self, lane_id):
+        """
+        Dynamically update Oids based on the PDU lane ID
+        """
+        self.pPORT_NAME_BASE_OID     = self.pPORT_NAME_BASE_OID[0: -1] + str(lane_id)
+        self.pPORT_STATUS_BASE_OID   = self.pPORT_STATUS_BASE_OID[0: -1] + str(lane_id)
+        self.pPORT_CONTROL_BASE_OID  = self.pPORT_CONTROL_BASE_OID[0: -1] + str(lane_id)
+        self.PORT_NAME_BASE_OID      = self.PORT_NAME_BASE_OID[0: -1] + str(lane_id)
+        self.PORT_STATUS_BASE_OID    = self.PORT_STATUS_BASE_OID[0: -1] + str(lane_id)
+        self.PORT_CONTROL_BASE_OID   = self.PORT_CONTROL_BASE_OID[0: -1] + str(lane_id)
 
     def __init__(self, hostname, controller, pdu):
         logging.info("Initializing " + self.__class__.__name__)


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Added support of several lanes on one PDU
Fixes # (improvement)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In file "snmp_psu_controllers.py" are defined different OIDs for PDU control, as result it fills in those variables:
self.pPORT_NAME_BASE_OID
self.pPORT_STATUS_BASE_OID
self.pPORT_CONTROL_BASE_OID
self.PORT_NAME_BASE_OID
self.PORT_STATUS_BASE_OID
self.PORT_CONTROL_BASE_OID

However there is hardcode just to use first('1') lane (slot). It means that if there will be used PDU which supports several lanes and switch will be connected to the outlet located in second or other lane, test will not be able to perform PSU turn on/off.

#### How did you do it?
Updated logic in 'snmp_psu_controllers.py' file, to figure out which lane is used for current switch and on the fly update the following variables:
self.pPORT_NAME_BASE_OID
self.pPORT_STATUS_BASE_OID
self.pPORT_CONTROL_BASE_OID
self.PORT_NAME_BASE_OID
self.PORT_STATUS_BASE_OID
self.PORT_CONTROL_BASE_OID

#### How did you verify/test it?
Tested on the local setups with PDU which supports 1 and more lanes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
