### PR TITLE
Implenemt playbook to recover vmhost server automatically

### DIFF
--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -27,43 +27,19 @@
     delay: 10
     ignore_errors: true
 
-  - name: Destroy vm {{ vm_name }} if it hangs
-    virt: name={{ vm_name }}
-          command=destroy
-          uri=qemu:///system
-    when: kickstart_output.kickstart_code != 0
-    become: yes
+  - name: Respin failed vm
+    include_tasks: respin_vm.yml
+    vars:
+      src_disk_image: "{{ home_path }}/{{ root_path }}/images/{{ hdd_image_filename }}"
+      disk_image: "{{ home_path }}/{{ root_path }}/disks/{{ vm_name }}_hdd.vmdk"
+      cdrom_image: "{{ home_path }}/{{ root_path }}/images/{{ cd_image_filename }}"
+    when: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != 0'
     ignore_errors: true
 
-  - name: Start vm again {{ vm_name }}
-    virt: name={{ vm_name }}
-          state=running
-          uri=qemu:///system
-    when: kickstart_output.kickstart_code != 0
-    become: yes
-    ignore_errors: true
-
-  - name: Wait until vm {{ vm_name }} is loaded
-    kickstart: telnet_port={{ serial_port }}
-              login={{ eos_default_login }}
-              password={{ eos_default_password }}
-              hostname={{ hostname }}
-              mgmt_ip="{{ mgmt_ip_address }}/{{ mgmt_prefixlen }}"
-              mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
-              new_login={{ eos_login }}
-              new_password={{ eos_password }}
-              new_root_password={{ eos_root_password }}
-    register: kickstart_output_final
-    until: '"kickstart_code" in kickstart_output_final and kickstart_output_final.kickstart_code == 0'
-    retries: 5
-    delay: 10
-    ignore_errors: true
-    when: kickstart_output.kickstart_code != 0
-
-  - name: Kickstart gives error again vm {{ vm_name }}
+  - name: Kickstart gives error after {{ respin_retry }} retries, vm {{ vm_name }}
     set_fact:
       kickstart_failed_vms: "{{ kickstart_failed_vms + [vm_name] }}"
-    when: '"kickstart_code" in kickstart_output_final and kickstart_output_final.kickstart_code != 0'
+    when: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != 0'
 
   - name: Set VM to autostart
     command: "virsh autostart {{ vm_name }}"

--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -36,7 +36,7 @@
     when: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != 0'
     ignore_errors: true
 
-  - name: Kickstart gives error after {{ respin_retry }} retries, vm {{ vm_name }}
+  - name: Kickstart gives error after respin vm {{ vm_name }}
     set_fact:
       kickstart_failed_vms: "{{ kickstart_failed_vms + [vm_name] }}"
     when: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != 0'

--- a/ansible/roles/vm_set/tasks/respin_vm.yml
+++ b/ansible/roles/vm_set/tasks/respin_vm.yml
@@ -1,0 +1,52 @@
+---
+# This playbook will respin a specific vm
+
+- name: Destroy VM {{ vm_name }}
+  virt: name={{ vm_name }}
+        state=destroyed
+        uri=qemu:///system
+  become: yes
+  ignore_errors: true
+
+- name: Undefine VM {{ vm_name }}
+  virt: name={{ vm_name }}
+        command=undefine
+        uri=qemu:///system
+  become: yes
+  ignore_errors: true
+
+- name: Remove arista disk image for {{ vm_name }}
+  file: path={{ disk_image }} state=absent
+
+- name: Copy arista disk image for {{ vm_name }}
+  copy: src={{ src_disk_image }} dest={{ disk_image }} remote_src=True
+
+- name: Define vm {{ vm_name }}
+  virt: name={{ vm_name }}
+        command=define
+        xml="{{ lookup('template', 'templates/arista.xml.j2') }}"
+        uri=qemu:///system
+  become: yes
+
+- name: Start vm {{ vm_name }}
+  virt: name={{ vm_name }}
+        state=running
+        uri=qemu:///system
+  become: yes
+  ignore_errors: true
+
+- name: Wait until vm {{ vm_name }} is loaded
+  kickstart: telnet_port={{ serial_port }}
+            login={{ eos_default_login }}
+            password={{ eos_default_password }}
+            hostname={{ hostname }}
+            mgmt_ip="{{ mgmt_ip_address }}/{{ mgmt_prefixlen }}"
+            mgmt_gw={{ vm_mgmt_gw | default(mgmt_gw) }}
+            new_login={{ eos_login }}
+            new_password={{ eos_password }}
+            new_root_password={{ eos_root_password }}
+  register: kickstart_output
+  until: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code == 0'
+  retries: 5
+  delay: 10
+  ignore_errors: true

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -42,7 +42,7 @@ function usage
   echo "To start VMs for specified topology on server: $0 start-topo-vms 'topo-name' ~/.password"
   echo "To stop all VMs on a server:  $0 stop-vms 'server-name' ~/.password"
   echo "To stop VMs for specified topology on server: $0 stop-topo-vms 'topo-name' ~/.password"
-  echo "To cleanup *all* vms and docker: $0 cleanup_vmhost 'server-name' ~/.password"
+  echo "To cleanup *all* vms and docker: $0 cleanup-vmhost 'server-name' ~/.password"
   echo "To deploy a topology on a server: $0 add-topo 'topo-name' ~/.password"
   echo "    Optional argument for add-topo:"
   echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -42,6 +42,7 @@ function usage
   echo "To start VMs for specified topology on server: $0 start-topo-vms 'topo-name' ~/.password"
   echo "To stop all VMs on a server:  $0 stop-vms 'server-name' ~/.password"
   echo "To stop VMs for specified topology on server: $0 stop-topo-vms 'topo-name' ~/.password"
+  echo "To cleanup *all* vms and docker: $0 cleanup_vmhost 'server-name' ~/.password"
   echo "To deploy a topology on a server: $0 add-topo 'topo-name' ~/.password"
   echo "    Optional argument for add-topo:"
   echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"
@@ -441,6 +442,18 @@ function stop_k8s_vms
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_stop_k8s_VMs.yml --vault-password-file="${passwd}" -l "${server}" -e k8s="true" $@
 }
 
+function cleanup_vmhost
+{
+  server=$1
+  passwd=$2
+  shift
+  shift
+  echo "Cleaning vm_host server '${server}'"
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile -e VM_num="$vm_num" testbed_cleanup.yml \
+      --vault-password-file="${passwd}" -l "${server}" $@
+}
+
 vmfile=veos
 tbfile=testbed.csv
 vm_type=veos
@@ -512,6 +525,8 @@ case "${subcmd}" in
   deploy-mg)   deploy_minigraph $@
                ;;
   test-mg)     test_minigraph $@
+               ;;
+  cleanup-vmhost) cleanup_vmhost $@
                ;;
   create-master) start_k8s_vms $@
                  setup_k8s_vms $@

--- a/ansible/testbed_cleanup.yml
+++ b/ansible/testbed_cleanup.yml
@@ -1,0 +1,17 @@
+---
+# This playbook will cleanup a vm_host, including removing all veos, containers and net bridges.
+
+- hosts: servers:&vm_host
+  gather_facts: no
+  tasks:
+    - name: run apt update and upgrade
+      include_tasks: update_reboot.yml
+
+    - name: run apt update and upgrade again
+      include_tasks: update_reboot.yml
+      when:  '"0 upgraded" not in apt_update_res.stdout'
+      with_items: '{{ range(0,3)|list }}'
+
+    - name: run cleanup script
+      shell: bash /home/azure/veos-vm/cleanup.sh
+      become: yes

--- a/ansible/update_reboot.yml
+++ b/ansible/update_reboot.yml
@@ -1,0 +1,13 @@
+---
+# This playbook will update the apt cache, and do a reboot if cache was updates.
+
+- name: update apt cache
+  apt: update_cache=yes upgrade=yes
+  environment: "{{ proxy_env | default({}) }}"
+  register: apt_update_res
+  become: true
+
+- name: reboot vm_host
+  reboot: reboot_timeout=600
+  when: '"0 upgraded" not in apt_update_res.stdout'
+

--- a/ansible/update_reboot.yml
+++ b/ansible/update_reboot.yml
@@ -10,4 +10,5 @@
 - name: reboot vm_host
   reboot: reboot_timeout=600
   when: '"0 upgraded" not in apt_update_res.stdout'
+  become: true
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This commit introduced several playbook to recover vmhost server automatically.
It's extremely time consuming to redeploy all testbeds on a host server if the server is down or rebooted. This PR adds a new option in ```testbed-cli.sh``` to do a cleanup of host server, and adds a respin of vm that failed to start. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to add new playbooks to support auto testbed recovery.

#### How did you do it?
1. Add a respin playbook to respin failed VMs
2. Add a cleanup playbook to cleanup host servers.

#### How did you verify/test it?
Verified in starlab.
```
$ ./recover_server.py --testbed-servers server_16 --testbed testbed.csv --vm-file veos --inventory str2 --passfile password.txt
INFO - LOG PATH: /tmp/recover_server_2021-01-19_07-19-44
INFO - Start running task server_16_cleanup_vmhost
INFO - Finish running task server_16_cleanup_vmhost
INFO - Start running task vms16-dual-t0-7050-2_start_topo_vms
INFO - Finish running task vms16-dual-t0-7050-2_start_topo_vms
INFO - Start running task vms16-dual-t0-7050-2_add_topo
INFO - Finish running task vms16-dual-t0-7050-2_add_topo
INFO - Start running task vms16-dual-t0-7050-2_deloy_mg
INFO - Finish running task vms16-dual-t0-7050-2_deloy_mg

============= server_16 recovery summary =============

Server server_16 recovery result:
server_16             start-topo-vms    add-topo    deploy-mg
--------------------  ----------------  ----------  -----------
vms16-dual-t0-7050-2  passed            passed      passed

======================================================

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
