### PR TITLE
Warm upgrade and continuous warm reboot modifications for KVM

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -125,7 +125,7 @@ def main():
     try:
         work_around_for_slow_disks(module)
         reduce_installed_sonic_images(module, disk_used_pcent)
-        if new_image_url:
+        if new_image_url or save_as:
             install_new_sonic_image(module, new_image_url, save_as)
     except:
         err = str(sys.exc_info())

--- a/tests/platform_tests/args/cont_warm_reboot_args.py
+++ b/tests/platform_tests/args/cont_warm_reboot_args.py
@@ -38,3 +38,10 @@ def add_cont_warm_reboot_args(parser):
         default="current",
         help="Comma separated list of images to be installed during continuous reboot test",
     )
+
+    parser.addoption(
+        "--skip_image_install",
+        type=bool,
+        default=False,
+        help="Skip image installation and run test on installed image in DUT",
+    )

--- a/tests/platform_tests/args/cont_warm_reboot_args.py
+++ b/tests/platform_tests/args/cont_warm_reboot_args.py
@@ -39,9 +39,3 @@ def add_cont_warm_reboot_args(parser):
         help="Comma separated list of images to be installed during continuous reboot test",
     )
 
-    parser.addoption(
-        "--skip_image_install",
-        type=bool,
-        default=False,
-        help="Skip image installation and run test on installed image in DUT",
-    )

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -59,7 +59,6 @@ class ContinuousReboot:
         self.continuous_reboot_delay = request.config.getoption("--continuous_reboot_delay")
         self.reboot_type = request.config.getoption("--reboot_type")
         self.image_location = request.config.getoption("--image_location")
-        self.skip_image_install = request.config.getoption("--skip_image_install")
         self.image_list = request.config.getoption("--image_list")
         self.current_image = self.duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
         self.test_report = dict()

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -13,7 +13,6 @@ from tests.common.reboot import get_reboot_cause
 from tests.common.platform.transceiver_utils import parse_transceiver_info
 from tests.common.plugins.sanity_check import checks
 from tests.common.fixtures.advanced_reboot import AdvancedReboot
-from tests.common.reboot import reboot
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -160,8 +160,11 @@ class ContinuousReboot:
         if result["failed"]:
             raise ContinuousRebootError("Interface check failed, not all interfaces are up")
 
+        # Skip this step for virtual testbed - KVM testbed has transeivers marked as "Not present"
+        # and the DB returns an "empty array" for "keys TRANSCEIVER_INFO*"
         if self.duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
             return
+
         logging.info("Check whether transceiver information of all ports are in redis")
         xcvr_info = self.duthost.command("redis-cli -n 6 keys TRANSCEIVER_INFO*")
         parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -138,7 +138,7 @@ def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds, tbinfo):
 def get_reboot_type(duthost):
     next_os_version = duthost.shell('sonic_installer list | grep Next | cut -f2 -d " "')['stdout']
     current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
-    
+ 
     # warm-reboot has to be forced for an upgrade from 201811 to 201811+ to bypass ASIC config changed error
     if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201811' not in next_os_version:
         reboot_type = "warm-reboot -f"

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -140,7 +140,8 @@ def get_reboot_type(duthost):
     current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
 
     # warm-reboot has to be forced for an upgrade from 201811 to 201911 to bypass ASIC config changed error
-    if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201911' in next_os_version:
+    if 'SONiC-OS-201811' in current_os_version and \
+                    ('SONiC-OS-201911' in next_os_version or 'SONiC-OS-202012' in next_os_version):
         reboot_type = "warm-reboot -f"
     else:
         reboot_type = "warm-reboot"

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -138,10 +138,9 @@ def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds, tbinfo):
 def get_reboot_type(duthost):
     next_os_version = duthost.shell('sonic_installer list | grep Next | cut -f2 -d " "')['stdout']
     current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
-
-    # warm-reboot has to be forced for an upgrade from 201811 to 201911 to bypass ASIC config changed error
-    if 'SONiC-OS-201811' in current_os_version and \
-                    ('SONiC-OS-201911' in next_os_version or 'SONiC-OS-202012' in next_os_version):
+    
+    # warm-reboot has to be forced for an upgrade from 201811 to 201811+ to bypass ASIC config changed error
+    if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201811' not in next_os_version:
         reboot_type = "warm-reboot -f"
     else:
         reboot_type = "warm-reboot"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach

1. Enable continuous warm reboot for KVM.
2. Add new option to skip image installation for continuous warm reboot.
3. Check 202012 image type to decide warm-reboot command. 

#### What is the motivation for this PR?
Warm upgrade support for KVM and 202012 images.

#### How did you do it?

#### How did you verify/test it?
Tested on KVM switch - warm-upgrade (201811 to 202012) and continuous warm reboot (202012 to 202012).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
