### PR TITLE
[acl] Add test cases for IPv6 dataplane ACLs

### DIFF
--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -1,0 +1,438 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "{{ acl_table_name }}": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::6/128"
+                                    }
+                                }
+                            },
+                            "2": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 2
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "3": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 3
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "40c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4621"
+                                    }
+                                }
+                            },
+                            "5": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 5
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 126
+                                    }
+                                }
+                            },
+                            "6": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 6
+                                },
+                                "transport": {
+                                    "config": {
+                                        "tcp-flags": ["TCP_ACK", "TCP_PSH", "TCP_FIN", "TCP_SYN"]
+                                    }
+                                }
+                            },
+                            "7": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 7
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "8": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 8
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "9": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 9
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4631"
+                                    }
+                                }
+                            },
+                            "10": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 10
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4656..4671"
+                                    }
+                                }
+                            },
+                            "11": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 11
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4640..4687"
+                                    }
+                                }
+                            },
+                            "12": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 12
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 58,
+                                        "source-ip-address": "60c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "13": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 13
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 17,
+                                        "source-ip-address": "60c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "14": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 14
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::3/128"
+                                    }
+                                }
+                            },
+                            "15": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 15
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "16": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 16
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "40c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "17": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 17
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4721"
+                                    }
+                                }
+                            },
+                            "18": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 18
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 127
+                                    }
+                                }
+                            },
+                            "19": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 19
+                                },
+                                "transport": {
+                                    "config": {
+                                        "tcp-flags": ["TCP_RST", "TCP_URG"]
+                                    }
+                                }
+                            },
+                            "20": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 20
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::7/128"
+                                    }
+                                }
+                            },
+                            "21": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 21
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::7/128"
+                                    }
+                                }
+                            },
+                            "22": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 22
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4731"
+                                    }
+                                }
+                            },
+                            "23": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 23
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4756..4771"
+                                    }
+                                }
+                            },
+                            "24": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 24
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4740..4787"
+                                    }
+                                }
+                            },
+                            "25": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 25
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 58,
+                                        "source-ip-address": "60c0:a800::2/128"
+                                    }
+                                }
+                            },
+                            "26": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 26
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 17,
+                                        "source-ip-address": "60c0:a800::2/128"
+                                    }
+                                }
+                            },
+                            "27": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 27
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "179"
+                                    }
+                                }
+                            },
+                            "28": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 28
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "179"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/acl/templates/acltb_v6_test_rules_part_1.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_1.j2
@@ -1,0 +1,135 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "{{ acl_table_name }}": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "70c0:a800::6/128"
+                                    }
+                                }
+                            },
+                            "2": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 2
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "25c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "3": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 3
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "27c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "5621"
+                                    }
+                                }
+                            },
+                            "13": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 13
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 17,
+                                        "source-ip-address": "70c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "14": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 14
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "70c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "27": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 27
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "179"
+                                    }
+                                }
+                            },
+                            "28": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 28
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "179"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -1,0 +1,438 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "{{ acl_table_name }}": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::6/128"
+                                    }
+                                }
+                            },
+                            "2": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 2
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "3": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 3
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "40c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4621"
+                                    }
+                                }
+                            },
+                            "5": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 5
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 126
+                                    }
+                                }
+                            },
+                            "6": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 6
+                                },
+                                "transport": {
+                                    "config": {
+                                        "tcp-flags": ["TCP_ACK", "TCP_PSH", "TCP_FIN", "TCP_SYN"]
+                                    }
+                                }
+                            },
+                            "7": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 7
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "8": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 8
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::4/128"
+                                    }
+                                }
+                            },
+                            "9": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 9
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4631"
+                                    }
+                                }
+                            },
+                            "10": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 10
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4656..4671"
+                                    }
+                                }
+                            },
+                            "11": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 11
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4640..4687"
+                                    }
+                                }
+                            },
+                            "12": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 12
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 58,
+                                        "source-ip-address": "60c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "13": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 13
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 17,
+                                        "source-ip-address": "60c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "14": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 14
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::3/128"
+                                    }
+                                }
+                            },
+                            "15": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 15
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "20c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "16": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 16
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "40c0:a800::8/128"
+                                    }
+                                }
+                            },
+                            "17": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 17
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4721"
+                                    }
+                                }
+                            },
+                            "18": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 18
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 127
+                                    }
+                                }
+                            },
+                            "19": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 19
+                                },
+                                "transport": {
+                                    "config": {
+                                        "tcp-flags": ["TCP_RST", "TCP_URG"]
+                                    }
+                                }
+                            },
+                            "20": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 20
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::7/128"
+                                    }
+                                }
+                            },
+                            "21": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 21
+                                },
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "60c0:a800::7/128"
+                                    }
+                                }
+                            },
+                            "22": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 22
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4731"
+                                    }
+                                }
+                            },
+                            "23": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 23
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "4756..4771"
+                                    }
+                                }
+                            },
+                            "24": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 24
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "4740..4787"
+                                    }
+                                }
+                            },
+                            "25": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 25
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 58,
+                                        "source-ip-address": "60c0:a800::2/128"
+                                    }
+                                }
+                            },
+                            "26": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 26
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": 17,
+                                        "source-ip-address": "60c0:a800::2/128"
+                                    }
+                                }
+                            },
+                            "27": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 27
+                                },
+                                "transport": {
+                                    "config": {
+                                        "source-port": "179"
+                                    }
+                                }
+                            },
+                            "28": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 28
+                                },
+                                "transport": {
+                                    "config": {
+                                        "destination-port": "179"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -34,19 +34,51 @@ FILES_DIR = os.path.join(BASE_DIR, "files")
 TEMPLATE_DIR = os.path.join(BASE_DIR, "templates")
 
 ACL_TABLE_TEMPLATE = "acltb_table.j2"
-ACL_RULES_FULL_TEMPLATE = "acltb_test_rules.j2"
-ACL_RULES_PART_TEMPLATES = tuple("acltb_test_rules_part_{}.j2".format(i) for i in xrange(1, 3))
 ACL_REMOVE_RULES_FILE = "acl_rules_del.json"
 
-DEFAULT_SRC_IP = "20.0.0.1"
+# TODO: We really shouldn't have two separate templates for v4 and v6, need to combine them somehow
+ACL_RULES_FULL_TEMPLATE = {
+    "ipv4": "acltb_test_rules.j2",
+    "ipv6": "acltb_v6_test_rules.j2"
+}
+ACL_RULES_PART_TEMPLATES = {
+    "ipv4": tuple("acltb_test_rules_part_{}.j2".format(i) for i in xrange(1, 3)),
+    "ipv6": tuple("acltb_v6_test_rules_part_{}.j2".format(i) for i in xrange(1, 3))
+}
 
-DOWNSTREAM_DST_IP = "192.168.0.2"
-DOWNSTREAM_IP_TO_ALLOW = "192.168.0.4"
-DOWNSTREAM_IP_TO_BLOCK = "192.168.0.8"
+DEFAULT_SRC_IP = {
+    "ipv4": "20.0.0.1",
+    "ipv6": "60c0:a800::5"
+}
 
-UPSTREAM_DST_IP = "192.168.128.1"
-UPSTREAM_IP_TO_ALLOW = "192.168.136.1"
-UPSTREAM_IP_TO_BLOCK = "192.168.144.1"
+
+# TODO: These routes don't match the VLAN interface from the T0 topology.
+# This needs to be addressed before we can enable the v6 tests for T0
+DOWNSTREAM_DST_IP = {
+    "ipv4": "192.168.0.2",
+    "ipv6": "20c0:a800::2"
+}
+DOWNSTREAM_IP_TO_ALLOW = {
+    "ipv4": "192.168.0.4",
+    "ipv6": "20c0:a800::4"
+}
+DOWNSTREAM_IP_TO_BLOCK = {
+    "ipv4": "192.168.0.8",
+    "ipv6": "20c0:a800::8"
+}
+
+UPSTREAM_DST_IP = {
+    "ipv4": "192.168.128.1",
+    "ipv6": "40c0:a800::2"
+}
+UPSTREAM_IP_TO_ALLOW = {
+    "ipv4": "192.168.136.1",
+    "ipv6": "40c0:a800::4"
+}
+UPSTREAM_IP_TO_BLOCK = {
+    "ipv4": "192.168.144.1",
+    "ipv6": "40c0:a800::8"
+}
 
 VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 
@@ -106,9 +138,8 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
     vlan_ports = []
 
     if topo == "t0":
-        vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
-                      for ifname
-                      in mg_facts["minigraph_vlans"].values()[0]["members"]]
+        vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname] 
+                      for ifname in mg_facts["minigraph_vlans"].values()[0]["members"]]
 
     setup_information = {
         "router_mac": duthost.facts["router_mac"],
@@ -130,8 +161,16 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
     duthost.command("rm -rf {}".format(DUT_TMP_DIR))
 
 
+@pytest.fixture(scope="module", params=["ipv4", "ipv6"])
+def ip_version(request, tbinfo):
+    if tbinfo["topo"]["type"] == "t0" and request.param == "ipv6":
+        pytest.skip("IPV6 ACL test not currently supported on t0 testbeds")
+
+    return request.param
+
+
 @pytest.fixture(scope="module")
-def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname):
+def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, ip_version):
     """Set up the ARP responder utility in the PTF container."""
     duthost = duthosts[rand_one_dut_hostname]
     if setup["topo"] != "t0":
@@ -142,7 +181,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname):
 
         return  # Don't fall through to t0 case
 
-    addr_list = [DOWNSTREAM_DST_IP, DOWNSTREAM_IP_TO_ALLOW, DOWNSTREAM_IP_TO_BLOCK]
+    addr_list = [DOWNSTREAM_DST_IP[ip_version], DOWNSTREAM_IP_TO_ALLOW[ip_version], DOWNSTREAM_IP_TO_BLOCK[ip_version]]
 
     vlan_host_map = defaultdict(dict)
     for i in range(len(addr_list)):
@@ -160,8 +199,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname):
     ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
 
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": "-e"})
-    ptfhost.template(src="templates/arp_responder.conf.j2",
-                     dest="/etc/supervisor/conf.d/arp_responder.conf")
+    ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 
     ptfhost.shell("supervisorctl reread && supervisorctl update")
     ptfhost.shell("supervisorctl restart arp_responder")
@@ -207,7 +245,7 @@ def stage(request, duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="module")
-def acl_table_config(duthosts, rand_one_dut_hostname, setup, stage):
+def acl_table_config(duthosts, rand_one_dut_hostname, setup, stage, ip_version):
     """Generate ACL table configuration files and deploy them to the DUT.
 
     Args:
@@ -221,24 +259,20 @@ def acl_table_config(duthosts, rand_one_dut_hostname, setup, stage):
 
     """
     duthost = duthosts[rand_one_dut_hostname]
-    stage_to_name_map = {
-        "ingress": "DATA_INGRESS_TEST",
-        "egress": "DATA_EGRESS_TEST"
-    }
 
-    acl_table_name = stage_to_name_map[stage]
+    acl_table_name = "DATA_{}_{}_TEST".format(stage.upper(), ip_version.upper())
 
     acl_table_vars = {
         "acl_table_name": acl_table_name,
         "acl_table_ports": setup["acl_table_ports"],
         "acl_table_stage": stage,
-        "acl_table_type": "L3"
+        "acl_table_type": "L3" if ip_version == "ipv4" else "L3V6"
     }
 
     logger.info("ACL table configuration:\n{}".format(pprint.pformat(acl_table_vars)))
 
     acl_table_config_file = "acl_table_{}.json".format(acl_table_name)
-    acl_table_config_path = os.path.join(DUT_TMP_DIR,  acl_table_config_file)
+    acl_table_config_path = os.path.join(DUT_TMP_DIR, acl_table_config_file)
 
     logger.info("Generating DUT config for ACL table \"{}\"".format(acl_table_name))
     duthost.host.options["variable_manager"].extra_vars.update(acl_table_vars)
@@ -309,7 +343,7 @@ class BaseAclTest(object):
     ACL_COUNTERS_UPDATE_INTERVAL_SECS = 10
 
     @abstractmethod
-    def setup_rules(self, dut, acl_table):
+    def setup_rules(self, dut, acl_table, ip_version):
         """Setup ACL rules for testing.
 
         Args:
@@ -348,7 +382,7 @@ class BaseAclTest(object):
         dut.command("config acl update full {}".format(remove_rules_dut_path))
 
     @pytest.fixture(scope="class", autouse=True)
-    def acl_rules(self, duthosts, rand_one_dut_hostname, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo):
+    def acl_rules(self, duthosts, rand_one_dut_hostname, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo, ip_version):
         """Setup/teardown ACL rules for the current set of tests.
 
         Args:
@@ -367,7 +401,7 @@ class BaseAclTest(object):
         try:
             loganalyzer.expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
             with loganalyzer:
-                self.setup_rules(duthost, acl_table)
+                self.setup_rules(duthost, acl_table, ip_version)
 
             self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo)
         except LogAnalyzerError as err:
@@ -446,239 +480,288 @@ class BaseAclTest(object):
         """Get the set of possible destination ports for the current test."""
         return setup["upstream_port_ids"] if direction == "downlink->uplink" else setup["downstream_port_ids"]
 
-    def get_dst_ip(self, direction):
+    def get_dst_ip(self, direction, ip_version):
         """Get the default destination IP for the current test."""
-        return UPSTREAM_DST_IP if direction == "downlink->uplink" else DOWNSTREAM_DST_IP
+        return UPSTREAM_DST_IP[ip_version] if direction == "downlink->uplink" else DOWNSTREAM_DST_IP[ip_version]
 
-    def tcp_packet(self, setup, direction, ptfadapter):
+    def tcp_packet(self, setup, direction, ptfadapter, ip_version, src_ip=None, dst_ip=None, proto=None, sport=0x4321, dport=0x51, flags=None):
         """Generate a TCP packet for testing."""
-        return testutils.simple_tcp_packet(
-            eth_dst=setup["router_mac"],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
-            ip_dst=self.get_dst_ip(direction),
-            ip_src=DEFAULT_SRC_IP,
-            tcp_sport=0x4321,
-            tcp_dport=0x51,
-            ip_ttl=64
-        )
+        src_ip = src_ip or DEFAULT_SRC_IP[ip_version]
+        dst_ip = dst_ip or self.get_dst_ip(direction, ip_version)
 
-    def udp_packet(self, setup, direction, ptfadapter):
+        if ip_version == "ipv4":
+            pkt = testutils.simple_tcp_packet(
+                eth_dst=setup["router_mac"],
+                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                ip_dst=dst_ip,
+                ip_src=src_ip,
+                tcp_sport=sport,
+                tcp_dport=dport,
+                ip_ttl=64
+            )
+
+            if proto:
+                pkt["IP"].proto = proto
+        else:
+            pkt = testutils.simple_tcpv6_packet(
+                eth_dst=setup["router_mac"],
+                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                ipv6_dst=dst_ip,
+                ipv6_src=src_ip,
+                tcp_sport=sport,
+                tcp_dport=dport,
+                ipv6_hlim=64
+            )
+
+            if proto:
+                pkt["IPv6"].nh = proto
+
+        if flags:
+            pkt["TCP"].flags = flags
+
+        return pkt
+
+    def udp_packet(self, setup, direction, ptfadapter, ip_version, src_ip=None, dst_ip=None, sport=1234, dport=80):
         """Generate a UDP packet for testing."""
-        return testutils.simple_udp_packet(
-            eth_dst=setup["router_mac"],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
-            ip_dst=self.get_dst_ip(direction),
-            ip_src=DEFAULT_SRC_IP,
-            udp_sport=1234,
-            udp_dport=80,
-            ip_ttl=64
-        )
+        src_ip = src_ip or DEFAULT_SRC_IP[ip_version]
+        dst_ip = dst_ip or self.get_dst_ip(direction, ip_version)
 
-    def icmp_packet(self, setup, direction, ptfadapter):
+        if ip_version == "ipv4":
+            return testutils.simple_udp_packet(
+                eth_dst=setup["router_mac"],
+                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                ip_dst=dst_ip,
+                ip_src=src_ip,
+                udp_sport=sport,
+                udp_dport=dport,
+                ip_ttl=64
+            )
+        else:
+            return testutils.simple_udpv6_packet(
+                eth_dst=setup["router_mac"],
+                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                ipv6_dst=dst_ip,
+                ipv6_src=src_ip,
+                udp_sport=sport,
+                udp_dport=dport,
+                ipv6_hlim=64
+            )
+
+    def icmp_packet(self, setup, direction, ptfadapter, ip_version, src_ip=None, dst_ip=None):
         """Generate an ICMP packet for testing."""
-        return testutils.simple_icmp_packet(
-            eth_dst=setup["router_mac"],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
-            ip_dst=self.get_dst_ip(direction),
-            ip_src=DEFAULT_SRC_IP,
-            icmp_type=8,
-            icmp_code=0,
-            ip_ttl=64,
-        )
+        src_ip = src_ip or DEFAULT_SRC_IP[ip_version]
+        dst_ip = dst_ip or self.get_dst_ip(direction, ip_version)
 
-    def expected_mask_routed_packet(self, pkt):
+        if ip_version == "ipv4":
+            return testutils.simple_icmp_packet(
+                eth_dst=setup["router_mac"],
+                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                ip_dst=dst_ip,
+                ip_src=src_ip,
+                icmp_type=8,
+                icmp_code=0,
+                ip_ttl=64,
+            )
+        else:
+            return testutils.simple_icmpv6_packet(
+                eth_dst=setup["router_mac"],
+                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                ipv6_dst=dst_ip,
+                ipv6_src=src_ip,
+                icmp_type=8,
+                icmp_code=0,
+                ipv6_hlim=64,
+            )
+
+    def expected_mask_routed_packet(self, pkt, ip_version):
         """Generate the expected mask for a routed packet."""
         exp_pkt = pkt.copy()
-        exp_pkt["IP"].ttl -= 1
+
+        if ip_version == "ipv4":
+            exp_pkt["IP"].ttl -= 1
+        else:
+            exp_pkt["IPv6"].hlim -= 1
+
         exp_pkt = mask.Mask(exp_pkt)
         exp_pkt.set_do_not_care_scapy(packet.Ether, "dst")
         exp_pkt.set_do_not_care_scapy(packet.Ether, "src")
-        exp_pkt.set_do_not_care_scapy(packet.IP, "chksum")
+
+        if ip_version == "ipv4":
+            exp_pkt.set_do_not_care_scapy(packet.IP, "chksum")
+
         return exp_pkt
 
-    def test_unmatched_blocked(self, setup, direction, ptfadapter):
+    def test_unmatched_blocked(self, setup, direction, ptfadapter, ip_version):
         """Verify that unmatched packets are dropped."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
 
-    def test_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward a packet on source IP."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.2"
+        src_ip = "20.0.0.2" if ip_version == "ipv4" else "60c0:a800::6"
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(1)
 
-    def test_rules_priority_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_rules_priority_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we respect rule priorites in the forwarding case."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.7"
+        src_ip = "20.0.0.7" if ip_version == "ipv4" else "60c0:a800::7"
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(20)
 
-    def test_rules_priority_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_rules_priority_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we respect rule priorites in the drop case."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.3"
+        src_ip = "20.0.0.3" if ip_version == "ipv4" else "60c0:a800::4"
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(7)
 
-    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward a packet on destination IP."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].dst = DOWNSTREAM_IP_TO_ALLOW if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW
+        dst_ip = DOWNSTREAM_IP_TO_ALLOW[ip_version] if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW[ip_version]
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(2 if direction == "uplink->downlink" else 3)
 
-    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop a packet on destination IP."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].dst = DOWNSTREAM_IP_TO_BLOCK if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK
+        dst_ip = DOWNSTREAM_IP_TO_BLOCK[ip_version] if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK[ip_version]
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(15 if direction == "uplink->downlink" else 16)
 
-    def test_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop a packet on source IP."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.6"
+        src_ip = "20.0.0.6" if ip_version == "ipv4" else "60c0:a800::3"
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(14)
 
-    def test_udp_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_udp_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward a UDP packet on source IP."""
-        pkt = self.udp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.4"
+        src_ip = "20.0.0.4" if ip_version == "ipv4" else "60c0:a800::8"
+        pkt = self.udp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(13)
 
-    def test_udp_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_udp_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop a UDP packet on source IP."""
-        pkt = self.udp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.8"
+        src_ip = "20.0.0.8" if ip_version == "ipv4" else "60c0:a800::2"
+        pkt = self.udp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(26)
 
-    def test_icmp_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_icmp_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop an ICMP packet on source IP."""
-        pkt = self.icmp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.8"
+        src_ip = "20.0.0.8" if ip_version == "ipv4" else "60c0:a800::2"
+        pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(25)
 
-    def test_icmp_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_icmp_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward an ICMP packet on source IP."""
-        pkt = self.icmp_packet(setup, direction, ptfadapter)
-        pkt["IP"].src = "20.0.0.4"
+        src_ip = "20.0.0.4" if ip_version == "ipv4" else "60c0:a800::8"
+        pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(12)
 
-    def test_l4_dport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_dport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on L4 destination port."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].dport = 0x1217
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x1217)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(5)
 
-    def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on L4 source port."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].sport = 0x120D
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x120D)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(4)
 
-    def test_l4_dport_range_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_dport_range_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on a range of L4 destination ports."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].dport = 0x123B
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x123B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(11)
 
-    def test_l4_sport_range_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_sport_range_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on a range of L4 source ports."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].sport = 0x123A
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x123A)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(10)
 
-    def test_l4_dport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_dport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on a range of L4 destination ports."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].dport = 0x127B
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x127B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(22)
 
-    def test_l4_sport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_sport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on a range of L4 source ports."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].sport = 0x1271
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(17)
 
-    def test_ip_proto_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_ip_proto_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on the IP protocol."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].proto = 0x7E
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, proto=0x7E)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(5)
 
-    def test_tcp_flags_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_tcp_flags_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on the TCP flags."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].flags = 0x1B
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x1B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(6)
 
-    def test_l4_dport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_dport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on L4 destination port."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].dport = 0x127B
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x127B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(22)
 
-    def test_l4_sport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_l4_sport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on L4 source port."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].sport = 0x1271
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(10)
 
-    def test_ip_proto_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_ip_proto_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on the IP protocol."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["IP"].proto = 0x7F
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, proto=0x7F)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(18)
 
-    def test_tcp_flags_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check):
+    def test_tcp_flags_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on the TCP flags."""
-        pkt = self.tcp_packet(setup, direction, ptfadapter)
-        pkt["TCP"].flags = 0x24
+        pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x24)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(5)
 
-    def _verify_acl_traffic(self, setup, direction, ptfadapter, pkt, dropped):
-        exp_pkt = self.expected_mask_routed_packet(pkt)
+    def _verify_acl_traffic(self, setup, direction, ptfadapter, pkt, dropped, ip_version):
+        exp_pkt = self.expected_mask_routed_packet(pkt, ip_version)
 
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, self.get_src_port(setup, direction), pkt)
@@ -692,7 +775,7 @@ class BaseAclTest(object):
 class TestBasicAcl(BaseAclTest):
     """Test Basic functionality of ACL rules (i.e. setup with full update on a running device)."""
 
-    def setup_rules(self, dut, acl_table):
+    def setup_rules(self, dut, acl_table, ip_version):
         """Setup ACL rules for testing.
 
         Args:
@@ -704,7 +787,7 @@ class TestBasicAcl(BaseAclTest):
         dut_conf_file_path = os.path.join(DUT_TMP_DIR, "acl_rules_{}.json".format(table_name))
 
         logger.info("Generating basic ACL rules config for ACL table \"{}\"".format(table_name))
-        dut.template(src=os.path.join(TEMPLATE_DIR, ACL_RULES_FULL_TEMPLATE),
+        dut.template(src=os.path.join(TEMPLATE_DIR, ACL_RULES_FULL_TEMPLATE[ip_version]),
                      dest=dut_conf_file_path)
 
         logger.info("Applying ACL rules config \"{}\"".format(dut_conf_file_path))
@@ -718,7 +801,7 @@ class TestIncrementalAcl(BaseAclTest):
     multiple parts.
     """
 
-    def setup_rules(self, dut, acl_table):
+    def setup_rules(self, dut, acl_table, ip_version):
         """Setup ACL rules for testing.
 
         Args:
@@ -731,7 +814,7 @@ class TestIncrementalAcl(BaseAclTest):
         logger.info("Generating incremental ACL rules config for ACL table \"{}\""
                     .format(table_name))
 
-        for part, config_file in enumerate(ACL_RULES_PART_TEMPLATES):
+        for part, config_file in enumerate(ACL_RULES_PART_TEMPLATES[ip_version]):
             dut_conf_file_path = os.path.join(DUT_TMP_DIR, "acl_rules_{}_part_{}.json".format(table_name, part))
             dut.template(src=os.path.join(TEMPLATE_DIR, config_file), dest=dut_conf_file_path)
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add test cases for IPv6 dataplane ACLs
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We currently don't have test coverage for IPv6 dataplane ACLs, beyond mirror ACL rules.

#### How did you do it?
Extended the ACL tests to cover IPv6 traffic as well

#### How did you verify/test it?
Ran the tests locally on t1 devices to verify the functionality was working, and ran on t0 devices to verify the tests were skipped.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
currently `t1` only, `t0` needs some work to function properly

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
