### PR TITLE
[pretest] add a separator for internal pretests

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -164,3 +164,9 @@ def test_update_saithrift_ptf(request, ptfhost):
         pytest.skip("Download failed/error while installing python saithrift package")
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
     logging.info("Python saithrift package installed successfully")
+
+"""
+    Separator for internal pretests.
+    Please add public pretest above this comment and keep internal
+    pretests below this comment.
+"""


### PR DESCRIPTION
Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

Add separator for internal pretests. Without it ever time someone adds a pretest at the end of this file. Internal auto-rebasing
will fail. 

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
None-functional change.