### PR TITLE
[test_snmp_phy_entity] Adjust test case to support any number of lanes

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -36,7 +36,9 @@ THERMAL_NAMING_RULE = {
     },
     "gearbox": {
         "name": "Gearbox {} Temp",
-        "temperature": "gearbox{}_temp_input"
+        "temperature": "gearbox{}_temp_input",
+        "high_threshold": "mlxsw-gearbox{}/temp_trip_hot",
+        "high_critical_threshold": "mlxsw-gearbox{}/temp_trip_crit"
     },
     "asic_ambient": {
         "name": "ASIC",
@@ -61,6 +63,11 @@ THERMAL_NAMING_RULE = {
 ASIC_THERMAL_RULE_201911 = {
     "name": "Ambient ASIC Temp",
     "temperature": "asic"
+}
+
+GEARBOX_THERMAL_RULE_201911 = {
+    "name": "Gearbox {} Temp",
+    "temperature": "gearbox{}_temp_input"
 }
 
 FAN_NAMING_RULE = {
@@ -543,6 +550,9 @@ class TemperatureData:
         if 'ASIC' in naming_rule['name']:
             if self.helper.is_201911():
                 naming_rule = ASIC_THERMAL_RULE_201911
+        if 'Gearbox' in naming_rule['name']:
+            if self.helper.is_201911():
+                naming_rule = GEARBOX_THERMAL_RULE_201911
 
         self.name = naming_rule['name']
         self.temperature_file = naming_rule['temperature']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test case hard coded 4 lanes for a transceiver, but there are cables have more than 4 lanes, so need to adjust the case to test cables which has any number of lanes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

The test case hard coded 4 lanes for a transceiver, but there are cables have more than 4 lanes, so need to adjust the case to test cables which has any number of lanes.

#### How did you do it?

Read lane data from redis and compare it with snmp output.

#### How did you verify/test it?

Manually run the test case

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
