### PR TITLE
[Platform API] Test against Python 3 platform API if available on DuT

### DIFF
--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -4,7 +4,6 @@ import json
 import os
 import sys
 import syslog
-from io import BytesIO
 
 # TODO: Clean this up once we no longer need to support Python 2
 if sys.version_info.major == 3:
@@ -94,10 +93,7 @@ class PlatformAPITestService(BaseHTTPRequestHandler):
         except NotImplementedError as e:
             syslog.syslog(syslog.LOG_WARNING, "API '{}' not implemented".format(api))
 
-        response = BytesIO()
-        response.write(json.dumps({'res': res}, default=obj_serialize).encode('ascii'))
-
-        self.wfile.write(response.getvalue())
+        self.wfile.write(json.dumps({'res': res}, default=obj_serialize).encode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -20,13 +20,17 @@ def start_platform_api_service(duthost, localhost):
                              timeout=5,
                              module_ignore_errors=True)
     if 'exception' in res:
+        # TODO: Remove this check once we no longer need to support Python 2
+        res = duthost.command('docker exec -i pmon python3 -c "import sonic_platform"', module_ignore_errors=True)
+        py3_platform_api_available = not res['failed']
+
         supervisor_conf = [
-            "[program:platform_api_server]",
-            "command=/usr/bin/python /opt/platform_api_server.py --port {}".format(SERVER_PORT),
-            "autostart=True",
-            "autorestart=True",
-            "stdout_logfile=syslog",
-            "stderr_logfile=syslog",
+            '[program:platform_api_server]',
+            'command=/usr/bin/python{} /opt/platform_api_server.py --port {}'.format('3' if py3_platform_api_available else '2', SERVER_PORT),
+            'autostart=True',
+            'autorestart=True',
+            'stdout_logfile=syslog',
+            'stderr_logfile=syslog',
         ]
         dest_path = os.path.join(os.sep, 'tmp', 'platform_api_server.conf')
         pmon_path = os.path.join(os.sep, 'etc', 'supervisor', 'conf.d', 'platform_api_server.conf')


### PR DESCRIPTION
### Description of PR
Test against Python 3 platform API if available on DuT. If not available, test against the Python 2 platform API

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

SONiC is migrating from Python 2 to Python 3. As vendors provide Python 3 versions of their sonic-platform package, we should begin testing against the Python 3 version of the package, rather than the Python 2 package.

#### How did you do it?

1. Make platform_api_server.py HTTP server compliant with both Python 2 and Python 3
2. In related conftest.py, run `docker exec -i pmon python3 -c "import sonic_platform"` on the DuT to determine if a Python 3 sonic-platform package is installed. If it is, we will run platform_api_server.py on the DuT using Python 3, otherwise we will run it using Python 2.
- Also remove unnecessary BytesIO module, and simply convert response to bytes using `str.encode('utf-8')`, which works with both Python 2 and 3.

#### How did you verify/test it?
1. Run platform API tests on a DuT which has a Python 3 platform API installed, make sure tests succeed.
2. Run platform API tests on a DuT which only has a Python 2 platform API, make sure tests succeed and no regressions.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
