### PR TITLE
[minigraph]: Generate smart cables from server intfs

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -65,34 +65,6 @@
   - topo_facts: topo={{ topo }}
     delegate_to: localhost
 
-  - name: set default dualtor facts
-    set_fact:
-      dual_tor_facts: {}
-    when: "'dualtor' not in topo"
-    
-  - name: gather dual ToR information
-    dual_tor_facts: hostname="{{ inventory_hostname }}" testbed_facts="{{ testbed_facts }}" hostvars="{{ hostvars }}" vm_config="{{ vm_topo_config }}"
-    delegate_to: localhost
-    when: "'dualtor' in topo"
-
-  - name: generate y_cable simulator driver
-    include_tasks: dualtor/config_y_cable_simulator.yml
-    when: "'dualtor' in topo"
-    
-  - name: set default vm file path
-    set_fact:
-      vm_file: veos
-    when: vm_file is not defined
-
-  - set_fact:
-      VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
-      remote_dut: "{{ ansible_ssh_host }}"
-
-  - name: gather testbed VM informations
-    testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }} vm_file={{ vm_file }}
-    delegate_to: localhost
-    when: "VM_topo | bool"
-
   - name: find interface name mapping and individual interface speed if defined from dut
     port_alias: hwsku="{{ hwsku }}"
     when: deploy is defined and deploy|bool == true
@@ -111,6 +83,40 @@
       vlan_intfs: "{{ vlan_intfs|default([])}} + ['{{ port_alias[item] }}' ]"
     with_items: "{{ host_if_indexes }}"
     when: "('host_interfaces_by_dut' in vm_topo_config) and ('tor' in vm_topo_config['dut_type'] | lower)"
+
+  - name: set default dualtor facts
+    set_fact:
+      dual_tor_facts: {}
+    when: "'dualtor' not in topo"
+    
+  - name: gather dual ToR information
+    dual_tor_facts: 
+      hostname: "{{ inventory_hostname }}"
+      testbed_facts: "{{ testbed_facts }}"
+      hostvars: "{{ hostvars }}"
+      vm_config: "{{ vm_topo_config }}"
+      port_alias: "{{ port_alias }}"
+      vlan_intfs: "{{ vlan_intfs }}"
+    delegate_to: localhost
+    when: "'dualtor' in topo"
+
+  - name: generate y_cable simulator driver
+    include_tasks: dualtor/config_y_cable_simulator.yml
+    when: "'dualtor' in topo"
+
+  - name: set default vm file path
+    set_fact:
+      vm_file: veos
+    when: vm_file is not defined
+
+  - set_fact:
+      VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
+      remote_dut: "{{ ansible_ssh_host }}"
+
+  - name: gather testbed VM informations
+    testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }} vm_file={{ vm_file }}
+    delegate_to: localhost
+    when: "VM_topo | bool"
 
   - name: find all vlan configurations for T0 topology
     vlan_config:

--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -1,11 +1,13 @@
 from collections import defaultdict
 class DualTorParser:
 
-    def __init__(self, hostname, testbed_facts, host_vars, vm_config):
+    def __init__(self, hostname, testbed_facts, host_vars, vm_config, port_alias, vlan_intfs):
         self.hostname = hostname
         self.testbed_facts = testbed_facts
         self.host_vars = host_vars
         self.vm_config = vm_config
+        self.port_alias = port_alias
+        self.vlan_intfs = vlan_intfs
         self.dual_tor_facts = {}
 
     def parse_neighbor_tor(self):
@@ -49,10 +51,10 @@ class DualTorParser:
     def generate_cable_names(self):
         cables = []
 
-        dut_index = list(sorted(self.testbed_facts['duts'])).index(self.hostname)
-        for server_num in sorted(self.vm_config['host_interfaces_by_dut'][dut_index]):
-            name = '{}-Server{}-SC'.format(self.hostname, server_num + 1)
-            cables.append(name)
+        for server_num, dut_intf in enumerate(self.vlan_intfs):
+            name = '{}-Servers{}-SC'.format(self.hostname, server_num)
+            cable = {"hostname": name, "dut_intf": dut_intf}
+            cables.append(cable)
 
         self.dual_tor_facts['cables'] = cables
 
@@ -75,7 +77,9 @@ def main():
             hostname=dict(required=True, default=None, type='str'),
             testbed_facts=dict(required=True, default=None, type='dict'),
             hostvars=dict(required=True, default=None, type='dict'),
-            vm_config=dict(required=True, default=None, type='dict')
+            vm_config=dict(required=True, default=None, type='dict'),
+            port_alias=dict(required=True, default=None, type='list'),
+            vlan_intfs=dict(required=True, default=None, type='list')
         ),
         supports_check_mode=True
     )
@@ -85,8 +89,10 @@ def main():
     testbed_facts = m_args['testbed_facts']
     host_vars = m_args['hostvars']
     vm_config = m_args['vm_config']
+    port_alias = m_args['port_alias']
+    vlan_intfs = m_args['vlan_intfs']
     try:
-        dual_tor_parser = DualTorParser(hostname, testbed_facts, host_vars, vm_config)
+        dual_tor_parser = DualTorParser(hostname, testbed_facts, host_vars, vm_config, port_alias, vlan_intfs)
         module.exit_json(ansible_facts={'dual_tor_facts': dual_tor_parser.get_dual_tor_facts()})
     except Exception as e:
         module.fail_json(msg=traceback.format_exc())

--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -49,8 +49,9 @@ class DualTorParser:
     def generate_cable_names(self):
         cables = []
 
-        for vm in sorted(self.vm_config['vm'].keys()):
-            name = '{}-{}-SC'.format(self.hostname, vm)
+        dut_index = list(sorted(self.testbed_facts['duts'])).index(self.hostname)
+        for server_num in sorted(self.vm_config['host_interfaces_by_dut'][dut_index]):
+            name = '{}-Server{}-SC'.format(self.hostname, server_num + 1)
             cables.append(name)
 
         self.dual_tor_facts['cables'] = cables

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -92,7 +92,7 @@
           <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
         </ManagementAddressV6>
         <SerialNumber i:nil="true" />
-        <Hostname>cable</Hostname>
+        <Hostname>{{ cable }}</Hostname>
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -11,16 +11,6 @@
         <StartDevice>{{ inventory_hostname }}</StartDevice>
         <StartPort>{{ port_alias[dut_intfs[if_index]] }}</StartPort>
       </DeviceLinkBase>
-{% if 'dualtor' in topo %}
-{% set cable_position = 'U' if inventory_hostname == dual_tor_facts['positions']['upper'] else 'L' %}
-      <DeviceLinkBase>
-        <ElementType>LogicalLink</ElementType>
-        <EndDevice>{{ inventory_hostname }}</EndDevice>
-        <EndPort>{{ port_alias[dut_intfs[if_index]] }}</EndPort>
-        <StartDevice>{{ dual_tor_facts['cables'][index] }}</StartDevice>
-        <StartPort>{{ cable_position }}</StartPort>
-      </DeviceLinkBase>
-{% endif %}
 {% endfor %}
 {% endfor %}
 {% if vm_topo_config['host_interfaces_by_dut'][dut_index|int] | length > 0 %}
@@ -33,6 +23,18 @@
         <StartPort>eth0</StartPort>
       </DeviceLinkBase>
 {% endfor %}
+{% if 'dualtor' in topo %}
+{% set cable_position = 'U' if inventory_hostname == dual_tor_facts['positions']['upper'] else 'L' %}
+{% for cable in dual_tor_facts['cables'] %}
+      <DeviceLinkBase>
+        <ElementType>LogicalLink</ElementType>
+        <EndDevice>{{ inventory_hostname }}</EndDevice>
+        <EndPort>{{ cable['dut_intf'] }}</EndPort>
+        <StartDevice>{{ cable['hostname'] }}</StartDevice>
+        <StartPort>{{ cable_position }}</StartPort>
+      </DeviceLinkBase>
+{% endfor %}
+{% endif %}
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>
@@ -92,7 +94,7 @@
           <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
         </ManagementAddressV6>
         <SerialNumber i:nil="true" />
-        <Hostname>{{ cable }}</Hostname>
+        <Hostname>{{ cable['hostname'] }}</Hostname>
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>
@@ -105,7 +107,7 @@
         <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
         </ManagementAddress>
-        <Hostname>Server{{ loop.index }}</Hostname>
+        <Hostname>Servers{{ loop.index - 1 }}</Hostname>
       </Device>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Previous smart cable generation was incorrectly using T1 interfaces

#### How did you do it?
Use server interfaces to generate smart cable interfaces

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
