### PR TITLE
Add playbook step for configuring 7260 eos fanout

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_eos.yml
+++ b/ansible/roles/fanout/tasks/fanout_eos.yml
@@ -22,6 +22,12 @@
   when: device_info[inventory_hostname]["HwSku"] == "Arista-7060CX-32S"
   become: yes
 
+- name: build fanout startup config for 7260cx3
+  template: src=arista_7260cx3_deploy.j2
+            dest=/mnt/flash/startup-config
+  when: device_info[inventory_hostname]["HwSku"] == "Arista-7260CX3"
+  become: yes
+
 - name: reboot
   shell: sleep 2 && shutdown -r now "Reboot"
   async: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add playbook step for configuring 7260 eos fanout
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To support configuring 7260 EOS fanout in the testbed.

#### How did you do it?
Added ansible step for the 7260 HWSku.

#### How did you verify/test it?
Tested with fanout deployment playbook.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
