### PR TITLE
Initial voq chassis test cases and helpers

### DIFF
--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -1,0 +1,390 @@
+import logging
+
+
+class RedisCli(object):
+    """Base class for interface to RedisDb using redis-cli command.
+
+    Attributes:
+        host: a SonicHost or SonicAsic.  Commands will be run on this shell.
+        database: Redis database number.
+        pid: Port number of redis db.
+    """
+
+    def __init__(self, host, database=1, pid=6379):
+        """Initializes base class with defaults"""
+        self.host = host
+        self.database = database
+        self.pid = pid
+
+    def _cli_prefix(self):
+        """Builds opening of redis CLI command for other methods."""
+        # return "docker exec -i {docker} redis-cli -p {pid} --raw -n {db} ".format(
+        #     docker=self.docker, db=self.database, pid=self.pid)
+        return " -p {pid} --raw -n {db} ".format(db=self.database, pid=self.pid)
+
+    def _run_and_check(self, cmd):
+        """
+        Executes a redis CLI command and checks the output for empty string.
+
+        Args:
+            cmd: Full CLI command to run.
+
+        Returns:
+            Ansible CLI output dictionary with stdout and stdout_lines keys on success.
+            Empty dictionary on error.
+
+        """
+        result = self.host.run_redis_cli_cmd(cmd)
+
+        if len(result["stdout_lines"]) == 0:
+            logging.error("No command response: %s" % cmd)
+            return {}
+
+        return result
+
+    def _run_and_raise(self, cmd):
+        """
+        Executes a redis CLI command and checks the output for empty string.
+
+        Args:
+            cmd: Full CLI command to run.
+
+        Returns:
+            Ansible CLI output dictionary with stdout and stdout_lines keys on success.
+
+        Raises:
+            Exception: If the command had no output.
+
+        """
+        result = self.host.run_redis_cli_cmd(cmd)
+
+        if len(result["stdout_lines"]) == 0:
+            logging.error("No command response: %s" % cmd)
+            raise Exception("Command: %s returned no response." % cmd)
+
+        return result
+
+    def get_key_value(self, key):
+        """
+        Executes a redis CLI get command.
+
+        Args:
+            key: full name of the key to get.
+
+        Returns:
+            The corresponding value of the key.
+
+        Raises:
+            RedisKeyNotFound: If the key has no value or is not present.
+
+        """
+        cmd = self._cli_prefix() + "get " + key
+        result = self._run_and_check(cmd)
+        if result == {}:
+            raise RedisKeyNotFound("Key: %s not found in rediscmd: %s" % (key, cmd))
+        else:
+            return result['stdout']
+
+    def hget_key_value(self, key, field):
+        """
+        Executes a redis CLI hget command.
+
+        Args:
+            key: full name of the key to get.
+            field: Name of the hash field to get.
+
+        Returns:
+            The corresponding value of the key.
+
+        Raises:
+            RedisKeyNotFound: If the key or field has no value or is not present.
+
+        """
+        cmd = self._cli_prefix() + "hget {} {}".format(key, field)
+        result = self._run_and_check(cmd)
+        if result == {}:
+            raise RedisKeyNotFound("Key: %s, field: %s not found in rediscmd: %s" % (key, field, cmd))
+        else:
+            return result['stdout']
+
+    def get_and_check_key_value(self, key, value, field=None):
+        """
+        Executes a redis CLI get or hget and validates the response against a provided field.
+
+        Args:
+            key: full name of the key to get.
+            value: expected value to test against.
+            field: Optional; Name of the hash field to use with hget.
+
+        Returns:
+            True if the validation succeeds.
+
+        Raises:
+            RedisKeyNotFound: If the key or field has no value or is not present.
+            AssertionError: If the fetched value from redis does not match the provided value.
+
+        """
+        if field is None:
+            result = self.get_key_value(key)
+        else:
+            result = self.hget_key_value(key, field)
+
+        if str(result).lower() == str(value).lower():
+            logging.info("Value {val} matches output {out}".format(val=value, out=result))
+            return True
+        else:
+            raise AssertionError("redis value error: %s != %s key was: %s" % (result, value, key))
+
+
+class AsicDbCli(RedisCli):
+    """
+    Class to interface with the ASICDB on a host.
+
+    Attributes:
+        host: a SonicHost or SonicAsic.  Commands will be run on this shell.
+
+    """
+    ASIC_SWITCH_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH"
+    ASIC_SYSPORT_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_SYSTEM_PORT"
+    ASIC_PORT_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_PORT"
+    ASIC_HOSTIF_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"
+    ASIC_ROUTERINTF_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"
+    ASIC_NEIGH_ENTRY_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY"
+
+    def __init__(self, host):
+        """
+        Initializes a connection to the ASIC DB (database 1)
+        """
+        super(AsicDbCli, self).__init__(host, 1)
+        # cache this to improve speed
+        self.hostif_portidlist = []
+
+    def get_switch_key(self):
+        """Returns a list of keys in the switch table"""
+        cmd = self._cli_prefix() + "KEYS %s*" % AsicDbCli.ASIC_SWITCH_TABLE
+        return self._run_and_raise(cmd)["stdout_lines"][0]
+
+    def get_system_port_key_list(self):
+        """Returns a list of keys in the system port table"""
+        cmd = self._cli_prefix() + "KEYS %s*" % AsicDbCli.ASIC_SYSPORT_TABLE
+        return self._run_and_raise(cmd)["stdout_lines"]
+
+    def get_port_key_list(self):
+        """Returns a list of keys in the local port table"""
+        cmd = self._cli_prefix() + "KEYS %s*" % AsicDbCli.ASIC_PORT_TABLE
+        return self._run_and_raise(cmd)["stdout_lines"]
+
+    def get_hostif_list(self):
+        """Returns a list of keys in the host interface table"""
+        cmd = self._cli_prefix() + "KEYS %s:*" % AsicDbCli.ASIC_HOSTIF_TABLE
+        return self._run_and_raise(cmd)["stdout_lines"]
+
+    def get_router_if_list(self):
+        """Returns a list of keys in the router interface table"""
+        cmd = self._cli_prefix() + "KEYS %s:*" % AsicDbCli.ASIC_ROUTERINTF_TABLE
+        return self._run_and_raise(cmd)["stdout_lines"]
+
+    def get_neighbor_key_by_ip(self, ipaddr):
+        """Returns the key in the neighbor table that is for a specific IP neighbor
+
+        Args:
+            ipaddr: The IP address to search for in the neighbor table.
+
+        """
+        result = self._run_and_raise(self._cli_prefix() + "KEYS %s*%s*" % (AsicDbCli.ASIC_NEIGH_ENTRY_TABLE, ipaddr))
+        neighbor_key = None
+        match_str = '"ip":"%s"' % ipaddr
+        for key in result["stdout_lines"]:
+            if match_str in key:
+                neighbor_key = key
+                break
+
+        return neighbor_key
+
+    def get_neighbor_value(self, neighbor_key, field):
+        """
+        Returns a value of a field in the neighbor table.
+
+        Note:
+            The structure of the keys in this table cause the command() method to fail, so this function uses shell() to
+            retrieve the command output.
+
+        Args:
+            neighbor_key: The full key of the neighbor table.
+            field: The field to get in the neighbor hash table.
+        """
+        cmd = ["/usr/bin/redis-cli", "-n", "1", "HGET", neighbor_key, field]
+        if self.host.namespace is not None:
+            cmd = ["sudo", "ip", "netns", "exec"] + cmd
+        result = self.host.sonichost.shell(argv=cmd)
+        logging.debug("neigh result: %s", result['stdout'])
+        return result['stdout']
+
+    def get_hostif_portid_oidlist(self, refresh=False):
+        """
+        Returns a list of portids associated with the hostif entries on the asics.
+
+        Walks through the HOSTIF table getting each port ID from the cache and returns the list.  The list
+        is saved so it can be returned directly in subsequent calls.
+
+        Args:
+            refresh: Forces the redis DB to be requeried after the first time.
+
+
+        """
+        if self.hostif_portidlist != [] and refresh is False:
+            return self.hostif_portidlist
+
+        hostif_keylist = self.get_hostif_list()
+        return_list = []
+        for hostif_key in hostif_keylist:
+            hostif_portid = self.hget_key_value(hostif_key, 'SAI_HOSTIF_ATTR_OBJ_ID')
+            return_list.append(hostif_portid)
+        self.hostif_portidlist = return_list
+        return return_list
+
+    def find_hostif_by_portid(self, portid):
+        """
+        Returns an HOSTIF table key for the port specified.
+
+        Args:
+            portid: A port OID (oid:0x1000000000004)
+
+        Raises:
+            RedisKeyNotFound: If no hostif exists with the portid provided.
+        """
+        hostif_keylist = self.get_hostif_list()
+        for hostif_key in hostif_keylist:
+            hostif_portid = self.hget_key_value(hostif_key, 'SAI_HOSTIF_ATTR_OBJ_ID')
+            if hostif_portid == portid:
+                return hostif_key
+        else:
+            raise RedisKeyNotFound("Can't find hostif in asicdb with portid: %s", portid)
+
+    def get_rif_porttype(self, portid):
+        """
+        Determines whether a specific port OID referenced in a router interface entry is a local port or a system port.
+
+        Args:
+            portid: the port oid from SAI_ROUTER_INTERFACE_ATTR_PORT_ID (oid:0x6000000000c4d)
+
+        Returns:
+            "hostif" if the port ID has a host interface
+            "sysport" if it is a system port.
+            "port" if the port ID is in local port table but has no hostif
+            "other" if it is not found in any port table
+        """
+        # could be a localport
+        if "%s:%s" % (
+                AsicDbCli.ASIC_PORT_TABLE,
+                portid) in self.get_port_key_list() and portid in self.get_hostif_portid_oidlist():
+            return "hostif"
+        # could be a system port
+        elif "%s:%s" % (AsicDbCli.ASIC_SYSPORT_TABLE, portid) in self.get_system_port_key_list():
+            return "sysport"
+        # could be something else
+        elif "%s:%s" % (AsicDbCli.ASIC_PORT_TABLE, portid) in self.get_port_key_list():
+            return "port"
+        else:
+            return "other"
+
+
+class AppDbCli(RedisCli):
+    """
+    Class to interface with the APPDB on a host.
+
+    Attributes:
+        host: a SonicHost or SonicAsic.  Commands will be run on this shell.
+
+    """
+    APP_NEIGH_TABLE = "NEIGH_TABLE"
+
+    def __init__(self, host):
+        super(AppDbCli, self).__init__(host, 0)
+
+    def get_neighbor_key_by_ip(self, ipaddr):
+        """Returns the key in the neighbor table that is for a specific IP neighbor
+
+        Args:
+            ipaddr: The IP address to search for in the neighbor table.
+
+        """
+        result = self._run_and_raise(self._cli_prefix() + "KEYS %s:*%s*" % (AppDbCli.APP_NEIGH_TABLE, ipaddr))
+        neighbor_key = None
+        for key in result["stdout_lines"]:
+            if key.endswith(ipaddr):
+                neighbor_key = key
+                break
+
+        return neighbor_key
+
+
+class VoqDbCli(RedisCli):
+    """
+    Class to interface with the Chassis VOQ DB on a supervisor.
+
+    Attributes:
+        host: a SonicHost instance for a supervisor card.  Commands will be run on this shell.
+
+    """
+
+    def __init__(self, host):
+        """Initializes the class with the database parameters and finds the IP address of the database"""
+        super(VoqDbCli, self).__init__(host, 12, 6380)
+        output = host.command("grep chassis_db_address /etc/sonic/chassisdb.conf")
+        # chassis_db_address=10.0.0.16
+        self.ip = output['stdout'].split("=")[1]
+
+    def _cli_prefix(self):
+        """Builds opening of redis CLI command for other methods."""
+        return "-h {ip} -p {pid} --raw -n {db} ".format(
+            ip=self.ip, db=self.database, pid=self.pid)
+
+    def get_neighbor_key_by_ip(self, ipaddr):
+        """Returns the key in the neighbor table that is for a specific IP neighbor
+
+        Args:
+            ipaddr: The IP address to search for in the neighbor table.
+
+        """
+        cmd = self._cli_prefix() + 'KEYS "SYSTEM_NEIGH|*%s*"' % ipaddr
+        result = self._run_and_raise(cmd)
+        neighbor_key = None
+        for key in result["stdout_lines"]:
+            if key.endswith(ipaddr):
+                neighbor_key = key
+                break
+
+        return neighbor_key
+
+    def get_router_interface_id(self, slot, asic, port):
+        """Returns the router OID stored in the router interface table entry for the provided entry.
+
+        Args:
+            slot: slot of the router interface in either numeric or text. (3 or Slot3)
+            asic: ASIC number of the router interface in either numeric or text (0 or Asic0)
+            port: Full text of port (Ethernet17)
+
+
+        """
+        slot = str(slot)
+        if slot.isdigit():
+            slot_str = "Linecard" + slot
+        else:
+            slot_str = slot
+
+        asic = str(asic)
+        if asic.isdigit():
+            asic_str = "Asic" + asic
+        else:
+            asic_str = asic
+
+        key = "SYSTEM_INTERFACE|{}|{}|{}".format(slot_str, asic_str, port)
+        return self.hget_key_value(key, "rif_id")
+
+
+class RedisKeyNotFound(KeyError):
+    """
+    Raised when requested keys or fields are not found in the redis db.
+    """
+    pass

--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -258,8 +258,8 @@ class AsicDbCli(RedisCli):
             hostif_portid = self.hget_key_value(hostif_key, 'SAI_HOSTIF_ATTR_OBJ_ID')
             if hostif_portid == portid:
                 return hostif_key
-        else:
-            raise RedisKeyNotFound("Can't find hostif in asicdb with portid: %s", portid)
+
+        raise RedisKeyNotFound("Can't find hostif in asicdb with portid: %s", portid)
 
     def get_rif_porttype(self, portid):
         """

--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -1,5 +1,7 @@
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 class RedisCli(object):
     """Base class for interface to RedisDb using redis-cli command.
@@ -37,7 +39,7 @@ class RedisCli(object):
         result = self.host.run_redis_cli_cmd(cmd)
 
         if len(result["stdout_lines"]) == 0:
-            logging.error("No command response: %s" % cmd)
+            logger.error("No command response: %s" % cmd)
             return {}
 
         return result
@@ -59,7 +61,7 @@ class RedisCli(object):
         result = self.host.run_redis_cli_cmd(cmd)
 
         if len(result["stdout_lines"]) == 0:
-            logging.error("No command response: %s" % cmd)
+            logger.error("No command response: %s" % cmd)
             raise Exception("Command: %s returned no response." % cmd)
 
         return result
@@ -130,7 +132,7 @@ class RedisCli(object):
             result = self.hget_key_value(key, field)
 
         if str(result).lower() == str(value).lower():
-            logging.info("Value {val} matches output {out}".format(val=value, out=result))
+            logger.info("Value {val} matches output {out}".format(val=value, out=result))
             return True
         else:
             raise AssertionError("redis value error: %s != %s key was: %s" % (result, value, key))
@@ -217,7 +219,7 @@ class AsicDbCli(RedisCli):
         if self.host.namespace is not None:
             cmd = ["sudo", "ip", "netns", "exec"] + cmd
         result = self.host.sonichost.shell(argv=cmd)
-        logging.debug("neigh result: %s", result['stdout'])
+        logger.debug("neigh result: %s", result['stdout'])
         return result['stdout']
 
     def get_hostif_portid_oidlist(self, refresh=False):

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -1,0 +1,434 @@
+"""Test initialization of VoQ objects, switch, system ports, router interfaces, neighbors, inband port."""
+import json
+import logging
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+
+from tests.common.helpers.redis import AsicDbCli, RedisKeyNotFound
+from tests.common.errors import RunAnsibleModuleFail
+from voq_helpers import check_local_neighbor, check_voq_remote_neighbor, get_sonic_mac, get_neighbor_mac
+from voq_helpers import check_local_neighbor_asicdb, get_device_system_ports, get_inband_info, get_port_by_ip
+from voq_helpers import check_rif_on_sup, check_voq_neighbor_on_sup, find_system_port
+
+pytestmark = [
+    pytest.mark.topology('t2')
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def chassis_facts(duthosts):
+    """
+    Fixture to add some items to host facts from inventory file.
+    """
+    for a_host in duthosts.nodes:
+
+        if len(duthosts.supervisor_nodes) > 0:
+            out = a_host.command("cat /etc/sonic/card_details.json")
+            card_details = json.loads(out['stdout'])
+            if 'slot_num' in card_details:
+                a_host.facts['slot_num'] = card_details['slot_num']
+
+
+@pytest.fixture(scope="module")
+def nbrhosts_facts(nbrhosts):
+    nbrhosts_facts = {}
+    for a_vm in nbrhosts:
+        try:
+            vm_facts = nbrhosts[a_vm]['host'].eos_facts()
+        except RunAnsibleModuleFail:
+            logging.error("VM: %s is down, skipping config fetching.", a_vm)
+            continue
+        logging.debug("vm facts: {}".format(json.dumps(vm_facts, indent=4)))
+        nbrhosts_facts[a_vm] = vm_facts
+    return nbrhosts_facts
+
+
+def test_voq_switch_create(duthosts):
+    """Compare the config facts with the asic db for switch:
+    * Verify ASIC_DB get all system ports referenced in configDB created on all hosts and ASICs.
+    * Verify object creation and values of port attributes.
+    """
+
+    switch_id_list = []
+    for per_host in duthosts.frontend_nodes:
+
+        for asic in per_host.asics:
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            dev_facts = cfg_facts['DEVICE_METADATA']['localhost']
+            asicdb = AsicDbCli(asic)
+
+            switchkey = asicdb.get_switch_key()
+            logging.info("Checking switch %s", switchkey)
+            check_list = {
+                "max_cores": "SAI_SWITCH_ATTR_MAX_SYSTEM_CORES",
+                "switch_id": "SAI_SWITCH_ATTR_SWITCH_ID"}
+            for k in check_list:
+                asicdb.get_and_check_key_value(switchkey, dev_facts[k], field=check_list[k])
+
+            pytest_assert(dev_facts["switch_id"] not in switch_id_list,
+                          "Switch ID: %s has been used more than once" % dev_facts["switch_id"])
+            switch_id_list.append(dev_facts["switch_id"])
+
+            asicdb.get_and_check_key_value(switchkey, "SAI_SWITCH_TYPE_VOQ", field="SAI_SWITCH_ATTR_TYPE")
+
+
+def test_voq_system_port_create(duthosts):
+    """Compare the config facts with the asic db for system ports
+
+    * Verify ASIC_DB get all system ports referenced in configDB created on all hosts and ASICs.
+    * Verify object creation and values of port attributes.
+
+    """
+
+    for per_host in duthosts.frontend_nodes:
+
+        for asic in per_host.asics:
+            logging.info("Checking system ports on host: %s, asic: %s", per_host.hostname, asic.asic_index)
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            dev_ports = get_device_system_ports(cfg_facts)
+            asicdb = AsicDbCli(asic)
+            keylist = asicdb.get_system_port_key_list()
+            pytest_assert(len(keylist) == len(dev_ports.keys()),
+                          "Found %d system port keys, %d entries in cfg_facts, not matching" % (
+                              len(keylist), len(dev_ports.keys())))
+            logging.info("Found %d system port keys, %d entries in cfg_facts, checking each.",
+                         len(keylist), len(dev_ports.keys()))
+            for portkey in keylist:
+                try:
+                    port_output = asicdb.hget_key_value(portkey, field="SAI_SYSTEM_PORT_ATTR_CONFIG_INFO")
+                except RedisKeyNotFound:
+                    # TODO: Need to check on behavior here.
+                    logging.warning("System port: %s had no SAI_SYSTEM_PORT_ATTR_CONFIG_INFO", portkey)
+                    continue
+                port_data = json.loads(port_output)
+                for cfg_port in dev_ports:
+                    if dev_ports[cfg_port]['system_port_id'] == port_data['port_id']:
+                        #             "switch_id": "0",
+                        #             "core_index": "1",
+                        #             "core_port_index": "6",
+                        #             "speed": "400000"
+                        pytest_assert(dev_ports[cfg_port]['switch_id'] == port_data[
+                            'attached_switch_id'], "switch IDs do not match for port: %s" % portkey)
+                        pytest_assert(dev_ports[cfg_port]['core_index'] == port_data[
+                            'attached_core_index'], "switch IDs do not match for port: %s" % portkey)
+                        pytest_assert(dev_ports[cfg_port]['core_port_index'] == port_data[
+                            'attached_core_port_index'], "switch IDs do not match for port: %s" % portkey)
+                        pytest_assert(dev_ports[cfg_port]['speed'] == port_data[
+                            'speed'], "switch IDs do not match for port: %s" % portkey)
+                        break
+                else:
+                    logging.error("Could not find config entry for portkey: %s" % portkey)
+
+            logging.info("Host: %s, Asic: %s all ports match all parameters", per_host.hostname, asic.asic_index)
+
+
+def test_voq_local_port_create(duthosts):
+    """Compare the config facts with the asic db for local ports
+
+    * Verify ASIC_DB has host interface information for all local ports on all cards and ASICs.
+    * Verify host interfaces exist on host CLI (ifconfig).
+    * Verify interfaces exist in show interfaces on the linecard.
+    """
+
+    for per_host in duthosts.frontend_nodes:
+
+        for asic in per_host.asics:
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            dev_ports = cfg_facts['PORT']
+
+            asicdb = AsicDbCli(asic)
+
+            keylist = asicdb.get_hostif_list()
+            pytest_assert(len(keylist) == len(dev_ports.keys()),
+                          "Found %d hostif keys, %d entries in cfg_facts" % (len(keylist), len(dev_ports.keys())))
+            logging.info("Found %s ports to check on host:%s, asic: %s.", len(dev_ports.keys()), per_host.hostname,
+                         asic.asic_index)
+
+            show_intf = asic.show_interface(command="status")['ansible_facts']
+            for portkey in keylist:
+                port_name = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_NAME")
+                port_state = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_OPER_STATUS")
+                port_type = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_TYPE")
+                logging.info("Checking port: %s, state: %s", port_name, port_state)
+                # "SAI_HOSTIF_ATTR_NAME": "Ethernet0",
+                # "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x1000000000002",
+                # "SAI_HOSTIF_ATTR_OPER_STATUS": "false",
+                # "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV"
+                pytest_assert(port_type == "SAI_HOSTIF_TYPE_NETDEV", "Port %s is not type netdev" % portkey)
+                if port_state == "true":
+                    pytest_assert(show_intf['int_status'][port_name]['oper_state'] == "up",
+                                  "Show interface state is down when it should be up")
+                if port_state == "false":
+                    pytest_assert(show_intf['int_status'][port_name]['oper_state'] == "down",
+                                  "Show interface state is up when it should be down")
+
+                if asic.namespace is None:
+                    cmd = "sudo ifconfig %s" % port_name
+                else:
+                    cmd = "sudo ip netns exec %s ifconfig %s" % (asic.namespace, port_name)
+                ifout = per_host.command(cmd)
+                assert "not found" not in ifout['stdout_lines'][0], "Interface %s not found" % port_name
+                if port_state == "true" and "RUNNING" in ifout['stdout_lines'][0]:
+                    logging.debug("Interface state is up and matches")
+                elif port_state == "false" and "RUNNING" not in ifout['stdout_lines'][0]:
+                    logging.debug("Interface state is down and matches")
+                else:
+                    raise AssertionError("Interface state does not match: %s %s", port_state, ifout['stdout_lines'][0])
+
+
+def test_voq_interface_create(duthosts):
+    """
+    Verify router interfaces are created on all line cards and present in Chassis App Db.
+
+    * Verify router interface creation on local ports in ASIC DB.
+    * PORT_ID should match system port table and traced back to config_db.json, mac and MTU should match as well.
+    * Verify SYSTEM_INTERFACE table in Chassis AppDb (redis-dump -h <ip> -p 6380 -d 12 on supervisor).
+    * Verify creation interfaces with different MTUs in configdb.json.
+    * Verify creation of different subnet masks in configdb.json.
+    * Repeat with IPv4, IPv6, dual-stack.
+
+    """
+    for per_host in duthosts.frontend_nodes:
+        logging.info("Check router interfaces on node: %s", per_host.hostname)
+
+        for asic in per_host.asics:
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            dev_intfs = cfg_facts['INTERFACE']
+            dev_sysports = get_device_system_ports(cfg_facts)
+
+            slot = per_host.facts['slot_num']
+            rif_ports_in_asicdb = []
+
+            # intf_list = get_router_interface_list(dev_intfs)
+            asicdb = AsicDbCli(asic)
+
+            asicdb_intf_key_list = asicdb.get_router_if_list()
+            # Check each rif in the asicdb, if it is local port, check VOQ DB for correct RIF.
+            # If it is on system port, verify slot/asic/port and OID match a RIF in VoQDB
+            for rif in asicdb_intf_key_list:
+                rif_type = asicdb.hget_key_value(rif, "SAI_ROUTER_INTERFACE_ATTR_TYPE")
+                if rif_type != "SAI_ROUTER_INTERFACE_TYPE_PORT":
+                    logging.info("Skip this rif: %s, it is not on a port: %s", rif, rif_type)
+                    continue
+                else:
+                    portid = asicdb.hget_key_value(rif, "SAI_ROUTER_INTERFACE_ATTR_PORT_ID")
+                    logging.info("Process RIF %s, Find port with ID: %s", rif, portid)
+
+                porttype = asicdb.get_rif_porttype(portid)
+                logging.info("RIF: %s is of type: %s", rif, porttype)
+                if porttype == 'hostif':
+                    # find the hostif entry to get the physical port the router interface is on.
+                    hostifkey = asicdb.find_hostif_by_portid(portid)
+                    hostif = asicdb.hget_key_value(hostifkey, 'SAI_HOSTIF_ATTR_NAME')
+                    logging.info("RIF: %s is on local port: %s", rif, hostif)
+                    rif_ports_in_asicdb.append(hostif)
+                    if hostif not in dev_intfs:
+                        pytest.fail("Port: %s has a router interface, but it isn't in configdb." % portid)
+
+                    # check MTU and ethernet address
+                    asicdb.get_and_check_key_value(rif, cfg_facts['PORT'][hostif]['mtu'],
+                                                   field="SAI_ROUTER_INTERFACE_ATTR_MTU")
+                    intf_mac = get_sonic_mac(per_host, asic.asic_index, hostif)
+                    asicdb.get_and_check_key_value(rif, intf_mac, field="SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS")
+
+                    sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
+                    sysport_info = find_system_port(dev_sysports, slot, asic.asic_index, hostif)
+                    for sup in duthosts.supervisor_nodes:
+                        check_rif_on_sup(sup, sup_rif, sysport_info['slot'], sysport_info['asic'], hostif)
+
+                elif porttype == 'sysport':
+                    try:
+                        port_output = asicdb.hget_key_value("ASIC_STATE:SAI_OBJECT_TYPE_SYSTEM_PORT:" + portid,
+                                                            field="SAI_SYSTEM_PORT_ATTR_CONFIG_INFO")
+                    except RedisKeyNotFound:
+                        # not a hostif or system port, log error and continue
+                        logging.error("Did not find OID %s in local or system tables" % portid)
+                        continue
+                    port_data = json.loads(port_output)
+                    for cfg_port in dev_sysports:
+                        if dev_sysports[cfg_port]['system_port_id'] == port_data['port_id']:
+                            logging.info("RIF: %s is on remote port: %s", rif, cfg_port)
+                            break
+                    else:
+                        raise AssertionError("Did not find OID %s in local or system tables" % portid)
+
+                    sys_slot, sys_asic, sys_port = cfg_port.split("|")
+                    sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
+                    for sup in duthosts.supervisor_nodes:
+                        check_rif_on_sup(sup, sup_rif, sys_slot, sys_asic, sys_port)
+
+                elif porttype == 'port':
+                    # this is the RIF on the inband port.
+                    inband = get_inband_info(cfg_facts)
+                    logging.info("RIF: %s is on local port: %s", rif, inband['port'])
+
+                    # check MTU and ethernet address
+                    asicdb.get_and_check_key_value(rif, cfg_facts['PORT'][inband['port']]['mtu'],
+                                                   field="SAI_ROUTER_INTERFACE_ATTR_MTU")
+                    intf_mac = get_sonic_mac(per_host, asic.asic_index, inband['port'])
+                    asicdb.get_and_check_key_value(rif, intf_mac, field="SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS")
+
+                    sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
+                    sysport_info = find_system_port(dev_sysports, slot, asic.asic_index, hostif)
+                    for sup in duthosts.supervisor_nodes:
+                        check_rif_on_sup(sup, sup_rif, sysport_info['slot'], sysport_info['asic'], inband['port'])
+
+            # Verify each RIF in config had a corresponding local port RIF in the asicDB.
+            for rif in dev_intfs:
+                pytest_assert(rif in rif_ports_in_asicdb, "Interface %s is in configdb.json but not in asicdb" % rif)
+            logging.info("Interfaces %s are present in configdb.json and asicdb" % str(dev_intfs.keys()))
+
+
+def test_voq_neighbor_create(duthosts, nbrhosts, nbrhosts_facts):
+    """
+    Verify neighbor entries are created on linecards for local and remote VMS.
+
+    For local neighbors:
+    * ARP/NDP should be resolved when BGP to adjacent VMs is established.
+    * On local linecard, verify ASIC DB entries.
+        * MAC address matches MAC of neighbor VM.
+        * Router interface OID matches back to the correct interface and port the neighbor was learned on.
+    * On local linecard, verify show arp/ndp, ip neigh commands.
+        * MAC address matches MAC of neighbor VM.
+    * On local linecard. verify neighbor table in appDB.
+        * MAC address matches MAC of neighbor VM.
+    * On supervisor card, verify SYSTEM_NEIGH table in Chassis AppDB (redis-dump -h <ip> -p 6380 -d 12 on supervisor).
+        * Verify encap index and MAC address match between ASICDB the Chassis AppDB
+    * Repeat with IPv4, IPv6, dual-stack.
+
+    For remote neighbors:
+    * When local neighbors are established as in the Local Neighbor testcase, corresponding entries will be established
+      on all other line cards.  On each remote card, verify:
+    * Verify ASIC DB entries on remote linecards.
+        * Verify impose index=True in ASIC DB.
+        * Verify MAC address in ASIC DB is the remote neighbor mac.
+        * Verify encap index for ASIC DB entry matches Chassis App DB.
+        * Verify router interface OID matches the interface the neighbor was learned on.
+    * Verify on linecard CLI, show arp/ndp, ip neigh commands.
+        * For inband port, MAC should be inband port mac in kernel table and LC appDb.
+        * For inband vlan mode, MAC will be remote ASIC mac in kernel table and LC appdb.
+    * Verify neighbor table in linecard appdb.
+    * Verify static route is installed in kernel routing table with /32 (or /128 for IPv6) for neighbor entry.
+    * Repeat with IPv4, IPv6, dual-stack.
+
+    """
+
+    for per_host in duthosts.frontend_nodes:
+
+        for asic in per_host.asics:
+            logging.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            dev_sysports = get_device_system_ports(cfg_facts)
+            neighs = cfg_facts['BGP_NEIGHBOR']
+            inband_info = get_inband_info(cfg_facts)
+
+            # Check each neighbor in table
+            for neighbor in neighs:
+                local_ip = neighs[neighbor]['local_addr']
+                if local_ip == inband_info['ipv4_addr'] or local_ip == inband_info['ipv6_addr']:
+                    # skip inband neighbors
+                    continue
+
+                # Check neighbor on local linecard
+                local_port = get_port_by_ip(cfg_facts, local_ip)
+                show_intf = asic.show_interface(command="status")['ansible_facts']
+                if local_port is None:
+                    logging.error("Did not find port for this neighbor %s, must skip", local_ip)
+                    continue
+                elif "portchannel" in local_port.lower():
+                    # TODO: LAG support
+                    logging.info("Port channel is not supported yet by this test, skip port: %s", local_port)
+                    continue
+                if show_intf['int_status'][local_port]['oper_state'] == "down":
+                    logging.error("Port is down, must skip interface: %s, IP: %s", local_port, local_ip)
+                    continue
+
+                neigh_mac = get_neighbor_mac(neighbor, nbrhosts, nbrhosts_facts)
+                if neigh_mac is None:
+                    logging.error("Could not find neighbor MAC, must skip.  IP: %s, port: %s", local_ip, local_port)
+
+                local_dict = check_local_neighbor(per_host, asic, neighbor, neigh_mac, local_port)
+                logging.info("Local_dict: %s", local_dict)
+
+                # Check the same neighbor entry on the supervisor nodes
+                sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
+                for sup in duthosts.supervisor_nodes:
+                    check_voq_neighbor_on_sup(sup, sysport_info['slot'], sysport_info['asic'], local_port,
+                                              neighbor, local_dict['encap_index'], neigh_mac)
+
+                # Check the neighbor entry on each remote linecard
+                for rem_host in duthosts.frontend_nodes:
+
+                    for rem_asic in rem_host.asics:
+                        if rem_host == per_host and rem_asic == asic:
+                            # skip remote check on local host
+                            continue
+                        rem_cfg_facts = rem_asic.config_facts(source="persistent")['ansible_facts']
+                        remote_inband_info = get_inband_info(rem_cfg_facts)
+                        remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
+                        check_voq_remote_neighbor(rem_host, rem_asic, neighbor, neigh_mac, remote_inband_info['port'],
+                                                  local_dict['encap_index'], remote_inband_mac)
+
+
+def test_voq_inband_port_create(duthosts):
+    """
+    Test inband port creation.
+
+    These steps are covered by previous test cases:
+        * On each linecard, verify inband ports are present in ASICDB.
+        * On each linecard, verify inband router interfaces are present in ASICDB
+        * On supervisor card, verify inband router interfaces are present in Chassis App DB
+
+    This test function will cover:
+        * On each linecard, verify permanent neighbors for all inband ports.
+        * On each linecard, verify kernel routes for all inband ports.
+        * Repeat with IPv4, IPv6, dual-stack.
+
+
+    """
+    for per_host in duthosts.frontend_nodes:
+
+        for asic in per_host.asics:
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            dev_sysports = get_device_system_ports(cfg_facts)
+            inband_info = get_inband_info(cfg_facts)
+            inband_mac = get_sonic_mac(per_host, asic.asic_index, inband_info['port'])
+
+            inband_ips = []
+            if 'ipv6_addr' in inband_info:
+                inband_ips.append(inband_info['ipv6_addr'])
+            if 'ipv4_addr' in inband_info:
+                inband_ips.append(inband_info['ipv4_addr'])
+
+            for neighbor_ip in inband_ips:
+
+                host = per_host
+                neighbor_mac = inband_mac
+                interface = inband_info['port']
+
+                logging.info("Check local neighbor on host %s, asic %s for %s/%s via port: %s", host.hostname,
+                             str(asic.asic_index),
+                             neighbor_ip, neighbor_mac, interface)
+
+                asic_dict = check_local_neighbor_asicdb(asic, neighbor_ip, neighbor_mac)
+                encap_idx = asic_dict['encap_index']
+
+                # Check the inband neighbor entry on the supervisor nodes
+                sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, interface)
+                for sup in duthosts.supervisor_nodes:
+                    check_voq_neighbor_on_sup(sup, sysport_info['slot'], sysport_info['asic'], interface, neighbor_ip,
+                                              encap_idx, inband_mac)
+
+                # Check the neighbor entry on each remote linecard
+                for rem_host in duthosts.frontend_nodes:
+
+                    for rem_asic in rem_host.asics:
+                        if rem_host == per_host and rem_asic == asic:
+                            # skip remote check on local host
+                            continue
+                        rem_cfg_facts = rem_asic.config_facts(source="persistent")['ansible_facts']
+                        remote_inband_info = get_inband_info(rem_cfg_facts)
+                        remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
+                        check_voq_remote_neighbor(rem_host, rem_asic, neighbor_ip, inband_mac,
+                                                  remote_inband_info['port'],
+                                                  encap_idx, remote_inband_mac)

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -1,0 +1,477 @@
+import json
+import logging
+import re
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.redis import AsicDbCli, AppDbCli, VoqDbCli
+
+
+def check_host_arp_table(host, neighbor_ip, neighbor_mac, interface, state):
+    """
+    Validates the ARP table of a host by running ip neigh for a single neighbor.
+
+    Args:
+        host: instance of SonicHost to run the arp show.
+        neighbor_ip: IP address of the neighbor to verify.
+        neighbor_mac: MAC address expected in the show command output.
+        interface: Port expected in the show command output.
+        state: ARP entry state expected in the show command output.
+
+    """
+    arptable = host.switch_arptable()['ansible_facts']
+    logging.debug("ARP: %s", arptable)
+    if ':' in neighbor_ip:
+        table = arptable['arptable']['v6']
+    else:
+        table = arptable['arptable']['v4']
+    pytest_assert(neighbor_ip in table, "IP %s not in arp list: %s" % (neighbor_ip, table.keys()))
+    pytest_assert(table[neighbor_ip]['macaddress'] == neighbor_mac,
+                  "table MAC %s does not match neighbor mac: %s" % (table[neighbor_ip]['macaddress'], neighbor_mac))
+    pytest_assert(table[neighbor_ip]['interface'] == interface,
+                  "table interface %s does not match interface: %s" % (table[neighbor_ip]['interface'], interface))
+    pytest_assert(table[neighbor_ip]['state'].lower() == state.lower(),
+                  "table state %s is not %s" % (table[neighbor_ip]['state'].lower(), state.lower()))
+
+
+def check_local_neighbor_asicdb(asic, neighbor_ip, neighbor_mac):
+    """
+    Verifies the neighbor information of a sonic host in the asicdb for a locally attached neighbor.
+
+    Args:
+        asic: The SonicAsic instance to be checked.
+        neighbor_ip: The IP address of the neighbor.
+        neighbor_mac: The MAC address of the neighbor.
+
+    Returns:
+        A dictionary with the encap ID from the ASIC neighbor table.
+
+    Raises:
+        Pytest Failed exception when assertions fail.
+
+    """
+    asicdb = AsicDbCli(asic)
+    neighbor_key = asicdb.get_neighbor_key_by_ip(neighbor_ip)
+    pytest_assert(neighbor_key is not None, "Did not find neighbor in asictable for IP: %s" % neighbor_ip)
+    asic_mac = asicdb.get_neighbor_value(neighbor_key, 'SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS')
+    pytest_assert(asic_mac.lower() == neighbor_mac.lower(),
+                  "MAC does not match in asicDB, asic %s, device %s" % (asic_mac.lower(), neighbor_mac.lower()))
+    encap_idx = asicdb.get_neighbor_value(neighbor_key, 'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX')
+    return {"encap_index": encap_idx}
+
+
+def check_local_neighbor(host, asic, neighbor_ip, neighbor_mac, interface):
+    """
+    Verifies the neighbor information of a sonic host for a locally attached neighbor.
+
+    The ASIC DB, APP DB, and host ARP table are checked.
+
+    Args:
+        host: Instance of SonicHost to check.
+        asic: Instance of SonicAsic to check.
+        neighbor_ip: IP address if the neighbor to check.
+        neighbor_mac: Expected ethernet MAC address of the neighbor.
+        interface: Expected interface the neighbor was learned on.
+
+    Returns:
+        A dictionary with the key into the LC APP DB neighbor table and the encap ID from the ASIC DB neighbor table.
+        {'encap_index': u'1074790408',
+         'neighbor_key': u'NEIGH_TABLE:Ethernet10:2064:103::1'}
+
+    Raises:
+        Pytest Failed exception when assertions fail.
+
+    """
+    logging.info("Check local neighbor on host %s, asic %s for %s/%s via port: %s", host.hostname, str(asic.asic_index),
+                 neighbor_ip, neighbor_mac, interface)
+
+    # verify asic db
+    asic_dict = check_local_neighbor_asicdb(asic, neighbor_ip, neighbor_mac)
+
+    # verify LC appdb
+    appdb = AppDbCli(asic)
+    neighbor_key = appdb.get_neighbor_key_by_ip(neighbor_ip)
+    appdb.get_and_check_key_value(neighbor_key, neighbor_mac, field="neigh")
+    pytest_assert(":{}:".format(interface) in neighbor_key, "Port for %s does not match" % neighbor_key)
+
+    # verify linux arp table
+    check_host_arp_table(host, neighbor_ip, neighbor_mac, interface, 'REACHABLE')
+
+    return {'neighbor_key': neighbor_key, 'encap_index': asic_dict['encap_index']}
+
+
+def check_bgp_kernel_route(host, asicnum, prefix, ipver, interface, present=True):
+    """
+    Checks the kernel route is installed from the bgp container.
+
+    Args:
+        host: sonic duthost instance to check.
+        asicnum: asic index to check.
+        prefix: IP address plus mask to check in routing table.
+        ipver: ip or ipv6.
+        interface: Attached interface for the neighbor route.
+        present: Optional; Check whether route is installed or removed.
+
+    Raises:
+        Pytest Failed exception when assertions fail.
+
+    """
+    docker = "bgp"
+    if host.facts["num_asic"] > 1:
+        docker = "bgp" + str(asicnum)
+
+    output = host.command("docker exec " + docker + " vtysh -c \"show {} route {} json\"".format(ipver, prefix))
+    parsed = json.loads(output["stdout"])
+    if present is True:
+        pytest_assert(prefix in parsed.keys(), "Prefix: %s not in route list: %s" % (prefix, parsed.keys()))
+        pytest_assert(parsed[prefix][0]['protocol'] == "kernel", "Prefix: %s not kernel route" % prefix)
+        pytest_assert(parsed[prefix][0]['nexthops'][0]['directlyConnected'] is True,
+                      "Prefix: %s not directly connected" % prefix)
+        pytest_assert(parsed[prefix][0]['nexthops'][0]['active'] is True, "Prefix: %s not active" % prefix)
+        pytest_assert(parsed[prefix][0]['nexthops'][0]['interfaceName'] == interface,
+                      "Prefix: %s out interface is not correct" % prefix)
+        logging.info("Route %s is present in remote neighbor: %s/%s", prefix, host.hostname, str(asicnum))
+
+
+def check_host_kernel_route(host, asicnum, ipaddr, ipver, interface, present=True):
+    """
+    Checks the kernel route on the host OS.
+
+    Args:
+        host: sonic duthost instance to check.
+        asicnum: asic index to check.
+        ipaddr: IP address to check in routing table.
+        ipver: ip or ipv6.
+        interface: Attached interface for the neighbor route.
+        present: Optional; Check whether route is installed or removed.
+
+    Raises:
+        Pytest Failed exception when assertions fail.
+
+    """
+    ver = "-4" if ipver == "ip" else "-6"
+    if host.facts["num_asic"] == 1:
+        cmd = "ip {} route show exact {}".format(ver, ipaddr)
+    else:
+        cmd = "ip netns exec asic{} ip {} route show exact {}".format(asicnum, ver, ipaddr)
+    logging.debug("Kernel rt cmd: %s", cmd)
+    output = host.command(cmd)['stdout']
+    if present is True:
+        logging.info("host ip route output: %s", output)
+        pytest_assert(output.startswith(ipaddr), "Address: %s not in netstat output list: %s" % (ipaddr, output))
+        pytest_assert("dev %s" % interface in output, "Interface is not %s: %s" % (interface, output))
+
+
+def check_neighbor_kernel_route(host, asicnum, ipaddr, interface, present=True):
+    """
+    Verifies if a neighbor kernel route is installed or not.
+
+    Checks BGP docker and linux kernel route tables.
+
+    Args:
+        host: sonic duthost instance to check.
+        asicnum: asic index to check.
+        ipaddr: IP address to check in routing table.  Mask will be applied by this function.
+        interface: Attached interface for the neighbor route.
+        present: Optional; Check whether route is installed or removed.
+    """
+    if ":" in ipaddr:
+        ipver = "ipv6"
+        prefix = ipaddr + "/128"
+    else:
+        ipver = "ip"
+        prefix = ipaddr + "/32"
+    check_bgp_kernel_route(host, asicnum, prefix, ipver, interface, present)
+    check_host_kernel_route(host, asicnum, ipaddr, ipver, interface, present)
+
+
+def check_voq_remote_neighbor(host, asic, neighbor_ip, neighbor_mac, interface, encap_idx, inband_mac):
+    """
+    Verifies the neighbor information of a neighbor learned on a different host.
+
+    The ASIC DB, APP DB, and host ARP table are checked. The host kernal route is verified.  The encap ID from the
+    local neighbor is provided as a parameter and verified that it is imposed.
+
+    Args:
+        host: Instance of SonicHost to check.
+        asic: Instance of SonicAsic to check.
+        neighbor_ip: IP address if the neighbor to check.
+        neighbor_mac: Expected ethernet MAC address of the neighbor.
+        interface: Expected interface the neighbor was learned on.
+        encap_idx: The encap index from the SONIC host the neighbor is directly attached to.
+        inband_mac: The MAC of the inband port of the remote host.
+
+    Raises:
+        Pytest Failed exception when assertions fail.
+    """
+    logging.info("Check remote neighbor on host %s, asic: %s for %s/%s via port: %s", host.hostname,
+                 str(asic.asic_index), neighbor_ip, neighbor_mac, interface)
+
+    # asic db
+    asicdb = AsicDbCli(asic)
+    neighbor_key = asicdb.get_neighbor_key_by_ip(neighbor_ip)
+    pytest_assert(neighbor_key is not None, "Did not find neighbor in asic table for IP: %s" % neighbor_ip)
+    pytest_assert(asicdb.get_neighbor_value(neighbor_key,
+                                            'SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS').lower() == neighbor_mac.lower(),
+                  "MAC does not match in asicDB")
+    pytest_assert(asicdb.get_neighbor_value(neighbor_key,
+                                            'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX') == encap_idx,
+                  "Encap index does not match in asicDB")
+    pytest_assert(asicdb.get_neighbor_value(neighbor_key,
+                                            'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX') == "true",
+                  "Encap impose is not true in asicDB")
+    pytest_assert(asicdb.get_neighbor_value(neighbor_key,
+                                            'SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL') == "false",
+                  "is local is not false in asicDB")
+
+    # LC app db
+    appdb = AppDbCli(asic)
+    neighbor_key = appdb.get_neighbor_key_by_ip(neighbor_ip)
+    pytest_assert(":{}:".format(interface) in neighbor_key, "Port for %s does not match" % neighbor_key)
+    appdb.get_and_check_key_value(neighbor_key, inband_mac, field="neigh")
+
+    # verify linux arp table
+    check_host_arp_table(host, neighbor_ip, inband_mac, interface, 'PERMANENT')
+
+    # verify linux route entry
+    check_neighbor_kernel_route(host, asic.asic_index, neighbor_ip, interface)
+
+
+def check_rif_on_sup(sup, rif, slot, asic, port):
+    """
+    Checks the router interface entry on the supervisor card.
+
+    Args:
+        sup: duthost for the supervisor card
+        rif: OID of the router interface to check for.
+        slot: The slot number the router interface is on.
+        asic: The asic number the asic is on, or 0 if a single asic card.
+        port: the name of the port (Ethernet1)
+
+    """
+    voqdb = VoqDbCli(sup)
+
+    rif_oid = voqdb.get_router_interface_id(slot, asic, port)
+
+    if rif_oid == rif:
+        logging.info("RIF on sup: %s = %s", rif_oid, rif)
+    elif rif_oid[-10:-1] == rif[-10:-1]:
+        logging.warning("RIF on sup is a partial match: %s != %s", rif_oid, rif)
+    else:
+        logging.error("RIF on sup does not match: %s != %s" % (rif_oid, rif))
+
+
+def check_voq_neighbor_on_sup(sup, slot, asic, port, neighbor, encap_index, mac):
+    """
+     Checks the neighbor entry on the supervisor card.
+
+     Args:
+         sup: duthost for the supervisor card
+         slot: The slot the router interface is on, as in system port table (Slot2).
+         asic: The asic the router interface is on, as in the system port table (Asic0) .
+         port: the name of the port (Ethernet1)
+         neighbor: The IP of the neighbor
+         encap_index: The encap ID of the neighbor from the local asic db
+         mac: The MAC address of the neighbor
+
+    Raises:
+        Pytest Failed exception when assertions fail.
+
+    """
+    voqdb = VoqDbCli(sup)
+    neigh_key = voqdb.get_neighbor_key_by_ip(neighbor)
+    logging.info("Neigh key: %s, slotnum: %s", neigh_key, slot)
+    pytest_assert("|%s|" % slot in neigh_key,
+                  "Slot for %s does not match %s" % (neigh_key, slot))
+    pytest_assert("|%s:" % port in neigh_key,
+                  "Port for %s does not match %s" % (neigh_key, port))
+    pytest_assert("|%s|" % asic in neigh_key,
+                  "Asic for %s does not match %s" % (neigh_key, asic))
+
+    voqdb.get_and_check_key_value(neigh_key, mac, field="neigh")
+    voqdb.get_and_check_key_value(neigh_key, encap_index, field="encap_index")
+
+
+def get_neighbor_mac(neigh_ip, nbrhosts, nbrhosts_facts):
+    """
+    Gets the MAC address of a neighbor IP on an EOS host.
+
+    We need to get the MAC of the VM out of the linux shell, not from the EOS CLI.  The MAC used for punt/inject
+    on the EOS seems to be the linux one.  Find the interface name on the VM that is associated with the IP address,
+    then look on the linux OS shell for the MAC address of that interface.
+
+    Args:
+        neigh_ip: The IP address of the neighbor.
+        nbrhosts: dictionary provided by the nbrhosts fixture.
+
+    Returns:
+        A string with the MAC address.
+    """
+    nbr_vm = ""
+    nbr_intf = ""
+    # for a_vm in nbrhosts:
+    #     vm_cfg_facts = nbrhosts[a_vm]['host'].eos_facts()
+    #     logging.debug("vm facts: {}".format(json.dumps(vm_cfg_facts, indent=4)))
+    #     intfs = vm_cfg_facts['ansible_facts']['ansible_net_interfaces']
+    for a_vm in nbrhosts_facts:
+
+        intfs = nbrhosts_facts[a_vm]['ansible_facts']['ansible_net_interfaces']
+        for intf in intfs:
+            if intfs[intf]['ipv4'] != {} and intfs[intf]['ipv4']['address'] == neigh_ip:
+                nbr_vm = a_vm
+                nbr_intf = intf
+                break
+            if 'ipv6' in intfs[intf] and intfs[intf]['ipv6']['address'].lower() == neigh_ip.lower():
+                nbr_vm = a_vm
+                nbr_intf = intf
+                break
+        if nbr_vm != "":
+            break
+    else:
+        logging.error("Could not find port for neighbor IP: %s", neigh_ip)
+        logging.info("vm facts: {}".format(json.dumps(nbrhosts_facts, indent=4)))
+        return None
+    # convert Ethernet1 to eth1
+    shell_intf = "eth" + nbr_intf[-1]
+    nbrhosts[nbr_vm]['host'].eos_command(commands=["enable"])
+    output = nbrhosts[nbr_vm]['host'].eos_command(commands=["bash ip addr show dev %s" % shell_intf])
+    # 8: Ethernet0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 ...
+    #     link/ether a6:69:05:fd:da:5f brd ff:ff:ff:ff:ff:ff
+    mac = output['stdout_lines'][0][1].split()[1]
+    logging.info("mac: %s", mac)
+    return mac
+
+
+def get_sonic_mac(host, asicnum, port):
+    """Gets the MAC address of an SONIC port.
+
+    Args:
+        host: a duthost instance
+        asicnum: The asic number to run on, or empty string.
+        port: The name of the port to get the MAC
+
+    Returns:
+        A string with the MAC address.
+    """
+    if host.facts["num_asic"] == 1:
+        cmd = "sudo ip link show {}".format(port)
+    else:
+        ns = "asic" + str(asicnum)
+        cmd = "sudo ip netns exec {} ip link show {}".format(ns, port)
+    output = host.command(cmd)
+    mac = output['stdout_lines'][1].split()[1]
+    logging.info("host: %s, asic: %d, port: %s, mac: %s", host.hostname, asicnum, port, mac)
+    return mac
+
+
+def get_device_system_ports(cfg_facts):
+    """Returns the system ports from the config facts as a single dictionary, instead of a nested dictionary.
+
+    The ansible module for config facts automatically makes a 2 level nested dictionary when the keys are in the form
+    of part1|part2|part3 or part1|part2.  The first dictionary is keyed as "part1" and the nested dictionary is the
+    remainder of the key with the value.  This function returns a flat dictionary with the keys restored to their values
+    from the files.
+
+   Args:
+        cfg_facts: The "ansible_facts" output from the duthost "config_facts" module.
+
+    Returns:
+        The system port config facts in a single layer dictionary.
+
+    """
+
+    sys_port_slot_dict = cfg_facts['SYSTEM_PORT']
+    merge_dict = {}
+    for slot in sys_port_slot_dict:
+        for port in sys_port_slot_dict[slot]:
+            merge_dict[slot + "|" + port] = sys_port_slot_dict[slot][port]
+    return merge_dict
+
+
+def get_inband_info(cfg_facts):
+    """
+    Returns the inband port and IP addresses present in the configdb.json.
+
+   Args:
+        cfg_facts: The "ansible_facts" output from the duthost "config_facts" module.
+
+    Returns:
+        A dictionary with the inband port and IP addresses.
+    """
+
+    intf = cfg_facts['VOQ_INBAND_INTERFACE']
+    ret = {}
+    for a_intf in intf:
+        for addrs in intf[a_intf]:
+            ret['port'] = a_intf
+            intf_ip = addrs.split('/')
+            if ':' in intf_ip[0]:
+                ret['ipv6_addr'] = intf_ip[0]
+                ret['ipv6_mask'] = intf_ip[1]
+            elif ':' not in intf_ip[0]:
+                ret['ipv4_addr'] = intf_ip[0]
+                ret['ipv4_mask'] = intf_ip[1]
+    return ret
+
+
+def get_port_by_ip(cfg_facts, ipaddr):
+    """
+    Returns the port which has a given IP address from the dut config.
+
+    Args:
+        cfg_facts: The "ansible_facts" output from the duthost "config_facts" module.
+        ipaddr: The IP address to search for.
+
+    Returns:
+        A string with the port name or None if not found.  ("Ethernet12")
+
+    """
+    if ':' in ipaddr:
+        iptype = "ipv6"
+    else:
+        iptype = "ipv4"
+
+    intf = {}
+    intf.update(cfg_facts['INTERFACE'])
+    if "PORTCHANNEL_INTERFACE" in cfg_facts:
+        intf.update(cfg_facts['PORTCHANNEL_INTERFACE'])
+    for a_intf in intf:
+        for addrs in intf[a_intf]:
+            intf_ip = addrs.split('/')
+            if iptype == 'ipv6' and ':' in intf_ip[0] and intf_ip[0].lower() == ipaddr.lower():
+                return a_intf
+            elif iptype == 'ipv4' and ':' not in intf_ip[0] and intf_ip[0] == ipaddr:
+                return a_intf
+
+    raise Exception("Dod not find port for IP %s" % ipaddr)
+
+
+def find_system_port(dev_sysports, slot, asic_index, hostif):
+    """
+    System key string can be arbitrary text with slot, asic, and port, so try to find the match
+    and return the correct string.  ex.  "Slot1|asic3|Ethernet12" or "Linecard4|Asic1|Portchannel23"
+
+    Args:
+        dev_sysports: dictionary from config_facts with all of the system ports on the system.
+        slot: The slot number of the system port to find.
+        asic_index: The asic number of ths system port to find.
+        hostif: The interface of the system port to find.
+
+    Returns:
+        A dictionary with the system port text strings.
+
+    Raises:
+        KeyError if the system port can't be found in the dictionary.
+
+    """
+
+    sys_re = re.compile(r'([a-zA-Z]+{})\|([a-zA-Z]+{})\|{}'.format(slot, asic_index, hostif))
+    sys_info = {}
+
+    for sysport in dev_sysports:
+        match = sys_re.match(sysport)
+        if match:
+            sys_info['slot'] = match.group(1)
+            sys_info['asic'] = match.group(2)
+            sys_info['key'] = sysport
+            return sys_info
+    else:
+        raise KeyError("Could not find system port for {}/{}/{}".format(slot, asic_index, hostif))

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -473,5 +473,5 @@ def find_system_port(dev_sysports, slot, asic_index, hostif):
             sys_info['asic'] = match.group(2)
             sys_info['key'] = sysport
             return sys_info
-    else:
-        raise KeyError("Could not find system port for {}/{}/{}".format(slot, asic_index, hostif))
+
+    raise KeyError("Could not find system port for {}/{}/{}".format(slot, asic_index, hostif))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
New test cases for VoQ system covering the first section of the distributed VoQ architecture test plan. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Implement automated tests to cover "System Initialization" section of the [Distributed VoQ Architecture](https://github.com/tcusto/sonic-mgmt/blob/master/docs/testplan/Distributed-VoQ-Arch-test-plan.md) test plan.

#### How did you do it?

There are new tests in test_voq_init.py for verifying the VoQ switch, system and local ports, router interfaces on local and system ports, and neighbors.  The switch and port tests run on each linecard in a VoQ chassis system and verify the T2 configuration has made it correctly to the ASIC DB.  The router interface test also verifies the Chassis App DB on the supervisor card.  The neighbor tests verify that local neighbor creation is propagated from the local linecard to the Chassis App DB on the supervisor and into ASIC and APP DBs on remote linecards.

Inband ports are also tested in the port and router interface test, and there is a separate test case for inband neighbors establishment.

There is a voq_helpers.py containing verification and utility functions that will be shared with future VoQ test scripts.  It contains routines for checking local and remote neighbors databases, checking kernel routes for remote neighbors, checking ARP tables, and other shared validations.

Lastly, in common/helpers/redis.py are classes for accessing the ASIC, APP, and Chassis APP DBs via the CLI.  There are methods for getting keys from various tables and calling get or hget on keys.  All of the redis db interactions that the tests perform are centralized here.

#### How did you verify/test it?
Ran the new tests against a chassis with T2 topology configured.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T2

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
