### PR TITLE
[kvmtest]: add -e option to exit on any error

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -27,21 +27,25 @@ EOF
 inventory="veos_vtb"
 testbed_file="vtestbed.csv"
 refresh_dut=true
+exit_on_error=""
 SONIC_MGMT_DIR=/data/sonic-mgmt
 
-while getopts "ni:t:d:" opt; do
+while getopts "d:ei:nt:" opt; do
   case $opt in
-    n)
-      refresh_dut=""
+    d)
+      SONIC_MGMT_DIR=$OPTARG
       ;;
     i)
       inventory=$OPTARG
       ;;
+    e)
+      exit_on_error=true
+      ;;
+    n)
+      refresh_dut=""
+      ;;
     t)
       testbed_file=$OPTARG
-      ;;
-    d)
-      SONIC_MGMT_DIR=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -60,6 +64,22 @@ fi
 tbname=$1
 dut=$2
 
+RUNTEST_CLI_COMMON_OPTS="\
+-i $inventory \
+-d $dut \
+-n $tbname \
+-f $testbed_file \
+-k debug \
+-l warning \
+-m individual \
+-q 1 \
+-a False \
+-O \
+-r"
+
+if [ -n "$exit_on_error" ]; then
+    RUNTEST_CLI_COMMON_OPTS="$RUNTEST_CLI_COMMON_OPTS -E"
+fi
 
 if [ -f /data/pkey.txt ]; then
     pushd $HOME
@@ -85,20 +105,7 @@ popd
 export ANSIBLE_LIBRARY=$SONIC_MGMT_DIR/ansible/library/
 
 # workaround for issue https://github.com/Azure/sonic-mgmt/issues/1659
-export export ANSIBLE_KEEP_REMOTE_FILES=1
-
-PYTEST_CLI_COMMON_OPTS="\
--i $inventory \
--d $dut \
--n $tbname \
--f $testbed_file \
--k debug \
--l warning \
--m individual \
--q 1 \
--a False \
--O \
--r"
+export ANSIBLE_KEEP_REMOTE_FILES=1
 
 pushd $SONIC_MGMT_DIR/tests
 rm -rf logs
@@ -140,7 +147,7 @@ iface_namingmode/test_iface_namingmode.py \
 platform_tests/test_cpu_memory_usage.py \
 bgp/test_bgpmon.py"
 
-./run_tests.sh $PYTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
+./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
 popd
 
 # Create and deploy two vlan configuration (two_vlan_a) to the virtual switch
@@ -154,5 +161,5 @@ tgname=2vlans
 tests="dhcp_relay/test_dhcp_relay.py"
 
 pushd $SONIC_MGMT_DIR/tests
-./run_tests.sh $PYTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
+./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
 popd

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -10,6 +10,7 @@ function show_help_and_exit()
     echo "    -c <testcases> : specify test cases to execute (default: none, executed all matched)"
     echo "    -d <dut name>  : specify DUT name (default: DUT name associated with testbed in testbed file)"
     echo "    -e <parameters>: specify extra parameter(s) (default: none)"
+    echo "    -E             : exit for any error (default: False)"
     echo "    -f <tb file>   : specify testbed file (default testbed.csv)"
     echo "    -i <inventory> : specify inventory name"
     echo "    -k <file log>  : specify file log level: error|warning|info|debug (default debug)"
@@ -258,7 +259,7 @@ function run_individual_tests()
 setup_environment
 
 
-while getopts "h?a:b:c:d:e:f:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
+while getopts "h?a:b:c:d:e:Ef:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -278,6 +279,9 @@ while getopts "h?a:b:c:d:e:f:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
             ;;
         e )
             EXTRA_PARAMETERS="${EXTRA_PARAMETERS} ${OPTARG}"
+            ;;
+        E )
+            set -e
             ;;
         f )
             TESTBED_FILE=${OPTARG}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
use -e to exit tests on any error. not enabled by default

#### How did you do it?
add -e option to kvmtest
add -E option to run_tests

#### How did you verify/test it?
use kvmtest to verify

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
