### PR TITLE
Adjust 'test_snmp_phy_entity' test case to support any number of lanes

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import re
 import time
 
 from tests.common.utilities import wait_until
@@ -74,20 +75,12 @@ PSU_SENSOR_INFO = {
     'voltage': ('Voltage', 4, SENSOR_TYPE_VOLTAGE),
 }
 
-XCVR_SENSOR_OID_LIST = [SENSOR_TYPE_TEMP,
-                        SENSOR_TYPE_PORT_TX_POWER + 1,
-                        SENSOR_TYPE_PORT_TX_POWER + 2,
-                        SENSOR_TYPE_PORT_TX_POWER + 3,
-                        SENSOR_TYPE_PORT_TX_POWER + 4,
-                        SENSOR_TYPE_PORT_RX_POWER + 1,
-                        SENSOR_TYPE_PORT_RX_POWER + 2,
-                        SENSOR_TYPE_PORT_RX_POWER + 3,
-                        SENSOR_TYPE_PORT_RX_POWER + 4,
-                        SENSOR_TYPE_PORT_TX_BIAS + 1,
-                        SENSOR_TYPE_PORT_TX_BIAS + 2,
-                        SENSOR_TYPE_PORT_TX_BIAS + 3,
-                        SENSOR_TYPE_PORT_TX_BIAS + 4,
-                        SENSOR_TYPE_VOLTAGE]
+XCVR_SENSOR_PATTERN = {
+    'temperature': {'sort_factor': 0, 'oid_base': SENSOR_TYPE_TEMP, 'extract_line_number': False},
+    'voltage': {'sort_factor': 9000, 'oid_base': SENSOR_TYPE_VOLTAGE, 'extract_line_number': False},
+    'tx(\d+)power': {'sort_factor': 1000, 'oid_base': SENSOR_TYPE_PORT_TX_POWER, 'extract_line_number': True},
+    'rx(\d+)power': {'sort_factor': 2000, 'oid_base': SENSOR_TYPE_PORT_RX_POWER, 'extract_line_number': True},
+    'tx(\d+)bias': {'sort_factor': 3000, 'oid_base': SENSOR_TYPE_PORT_TX_BIAS, 'extract_line_number': True}}
 
 # Constants
 CHASSIS_KEY = 'chassis 1'
@@ -371,18 +364,21 @@ def test_transceiver_info(duthost, snmp_physical_entity_info):
         assert transceiver_snmp_fact['entPhysModelName'] == transceiver_info['model']
         assert transceiver_snmp_fact['entPhysIsFRU'] == REPLACEABLE if transceiver_info[
                                                                            'is_replaceable'] == 'True' else NOT_REPLACEABLE
-        _check_transceiver_dom_sensor_info(transceiver_snmp_fact['oid'], snmp_physical_entity_info)
+        _check_transceiver_dom_sensor_info(duthost, name, transceiver_snmp_fact['oid'], snmp_physical_entity_info)
 
 
-def _check_transceiver_dom_sensor_info(transceiver_oid, snmp_physical_entity_info):
+def _check_transceiver_dom_sensor_info(duthost, name, transceiver_oid, snmp_physical_entity_info):
     """
     Check transceiver DOM sensor information in physical entity mib
+    :param duthost: DUT host object
+    :param name: Transceiver name
     :param transceiver_oid: Transceiver oid
     :param snmp_physical_entity_info: Physical entity information from snmp fact
     :return:
     """
-    for index, sensor_oid_offset in enumerate(XCVR_SENSOR_OID_LIST):
-        expect_oid = transceiver_oid + sensor_oid_offset
+    sensor_data_list = _get_transceiver_sensor_data(duthost, name)
+    for index, sensor_data in enumerate(sensor_data_list):
+        expect_oid = transceiver_oid + sensor_data.oid_offset
         assert expect_oid in snmp_physical_entity_info, 'Cannot find port sensor in physical entity mib'
         sensor_snmp_fact = snmp_physical_entity_info[expect_oid]
         assert sensor_snmp_fact['entPhysDescr'] is not None
@@ -397,6 +393,36 @@ def _check_transceiver_dom_sensor_info(transceiver_oid, snmp_physical_entity_inf
         assert sensor_snmp_fact['entPhysMfgName'] == ''
         assert sensor_snmp_fact['entPhysModelName'] == ''
         assert sensor_snmp_fact['entPhysIsFRU'] == NOT_REPLACEABLE
+
+
+class SensorData(object):
+    def __init__(self, key, value, sort_factor, oid_offset):
+        self.key = key
+        self.value = value
+        self.sort_factor = sort_factor
+        self.oid_offset = oid_offset
+
+
+def _get_transceiver_sensor_data(duthost, name):
+    key = XCVR_DOM_KEY_TEMPLATE.format(name)
+    sensor_info = redis_hgetall(duthost, STATE_DB, key)
+    sensor_data_list = []
+    for field, value in sensor_info.items():
+        for pattern, data in XCVR_SENSOR_PATTERN.items():
+            match_result = re.match(pattern, field)
+            if match_result:
+                if data['extract_line_number']:
+                    lane_number = int(match_result.group(1))
+                    sort_factor = data['sort_factor'] + lane_number
+                    oid_offset = data['oid_base'] + lane_number
+                else:
+                    sort_factor = data['sort_factor']
+                    oid_offset = data['oid_base']
+                sensor_data_list.append(SensorData(field, value, sort_factor, oid_offset))
+                break
+
+    sensor_data_list = sorted(sensor_data_list, key=lambda x: x.sort_factor)
+    return sensor_data_list
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import pytest
 import re
@@ -75,6 +76,7 @@ PSU_SENSOR_INFO = {
     'voltage': ('Voltage', 4, SENSOR_TYPE_VOLTAGE),
 }
 
+# The sort factor values are got from https://github.com/Azure/sonic-snmpagent/blob/dfde06e2f5d70e23882af6c0f1af4ae43ec2fa43/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py#L18
 XCVR_SENSOR_PATTERN = {
     'temperature': {'sort_factor': 0, 'oid_base': SENSOR_TYPE_TEMP, 'extract_line_number': False},
     'voltage': {'sort_factor': 9000, 'oid_base': SENSOR_TYPE_VOLTAGE, 'extract_line_number': False},
@@ -567,7 +569,7 @@ def redis_hgetall(duthost, db_id, key):
     if not content:
         return {}
 
-    return eval(content)
+    return ast.literal_eval(content)
 
 
 def is_null_str(value):

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -561,40 +561,13 @@ def redis_hgetall(duthost, db_id, key):
     :param key: Redis Key
     :return: A dictionary, key is field name, value is field value
     """
-    result = {}
-    """
-    Why we don't directly use HGETALL here? Because there are fields whose value contains line break.
-    And "sonic-db-cli XXX HGETALL XXX" may return something like:
-    
-    key1
-    value1
-    key2
-    part_of_value2
-                       part_of_value2
-                       part_of_value2
-    key3
-    value3
-    
-    Although we can still parse this kind of output to a dictionary, but the code will be very weird and not robust. 
-    So we use a solution here:
-        1. Get all field names of the table
-        2. Use HGET to get values for each fields
-    This solution is slower but more clear. 
-    """
-    cmd = 'sonic-db-cli {} HKEYS \"{}\"'.format(db_id, key)
+    cmd = 'sonic-db-cli {} HGETALL \"{}\"'.format(db_id, key)
     output = duthost.shell(cmd)
     content = output['stdout'].strip()
     if not content:
-        return result
+        return {}
 
-    field_names = content.split('\n')
-    for field_name in field_names:
-        field_name = field_name.strip()
-        cmd = 'sonic-db-cli {} HGET \"{}\" \"{}\"'.format(db_id, key, field_name)
-        output = duthost.shell(cmd)['stdout'].strip()
-        result[field_name] = output
-
-    return result
+    return eval(content)
 
 
 def is_null_str(value):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adjust test case to any type of lanes per cable and not fixed hard coded value of 4 lanes due to recent support of QSFP-DD. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Adjust the test case to support cables which has any number of lanes.

#### How did you do it?

Read lane data from redis and compare it with snmp output.

#### How did you verify/test it?

Manually run the test case

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
