### PR TITLE
Fix neighbor health check failure for dualToR

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -66,10 +66,11 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, enum_dut_hostname)
         dut_type = dev_meta["localhost"]["type"]
 
     for k, v in nei_meta.items():
-        if 'SmartCable' == v['type'] or dut_type == v['type']:
+        if v['type'] in ['SmartCable', 'Server'] or dut_type == v['type']:
             # Smart cable doesn't respond to snmp, it doesn't have BGP session either.
             # DualToR has the peer ToR listed in device as well. If the device type
             # is the same as testing DUT, then it is the peer.
+            # The server neighbors need to be skipped too.
             continue
 
         failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'])


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR #2792 introduced neighbor with type 'Server' into 'DEVICE_NEIGHBOR_METADATA' of config DB.
The 'Server' neighbors should be skipped in neighbor health check.

#### How did you do it?
Skip checking neighbor with type 'Server'.

#### How did you verify/test it?
Test run the test_nbr_health.py script on dualtor. Test passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
