### PR TITLE
Fix root fanout connect issue caused by default "no switchport" configuration

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260_connect.j2
+++ b/ansible/roles/fanout/templates/arista_7260_connect.j2
@@ -10,6 +10,7 @@ vlan {{ dev_vlans | list | join(',') }}
 {% set peer_port = root_conn[intf]['peerport'] %}
 {% if peer_dev in lab_devices and 'Fanout' not in lab_devices[peer_dev]['Type'] and not deploy_leaf %}
  interface {{ intf }}
+  switchport
   switchport trunk allowed vlan remove {{ dev_vlans | list | join(',') }}
 {% if peer_dev == server and peer_port == server_port %}
   switchport mode trunk
@@ -19,6 +20,7 @@ vlan {{ dev_vlans | list | join(',') }}
 {% endif %}
 {% if peer_dev in lab_devices and 'Fanout' in lab_devices[peer_dev]['Type']  and deploy_leaf %}
  interface {{ intf }}
+  switchport
   switchport trunk allowed vlan remove {{ dev_vlans | list | join(',') }}
 {% if peer_dev == leaf_name %}
   description {{ peer_dev }}-{{ peer_port }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If root fanout switch interface has default "no switchport" configuration, the subsequent interface config commands like "switchport mode trunk" and "switchport trunk allowed vlan" commands are not able to override this "no switchport" configuration. Subsequently, the interface will remain in "routed" mode, not the expected "trunk" mode.

#### How did you do it?
The fix is to always issue "switchport" command while configuring interfaces between root fanout and leaf fanout or test server.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
