### PR TITLE
[multi-asic] fix for multi-asic and include check for BGP_INTERNAL_NEIGHBORS in config_db

### DIFF
--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -18,16 +18,21 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     config_facts = duthost.config_facts(host=duthost.hostname, source="running",namespace=namespace)['ansible_facts']
 
+    sonic_db_cmd = "sonic-db-cli {}".format("-n " + namespace if namespace else "")
     for k, v in bgp_facts['bgp_neighbors'].items():
         # Verify bgp sessions are established
         assert v['state'] == 'established'
         # Verify local ASNs in bgp sessions
         assert v['local AS'] == int(config_facts['DEVICE_METADATA']['localhost']['bgp_asn'].decode("utf-8"))
         # Check bgpmon functionality by validate STATE DB contains this neighbor as well
-        state_fact = duthost.shell('sonic-db-cli STATE_DB HGET "NEIGH_STATE_TABLE|{}" "state"'.format(k), module_ignore_errors=False)['stdout_lines']
+        state_fact = duthost.shell('{} STATE_DB HGET "NEIGH_STATE_TABLE|{}" "state"'.format(sonic_db_cmd, k), module_ignore_errors=False)['stdout_lines']
         assert state_fact[0] == "Established"
 
-    for k, v in config_facts['BGP_NEIGHBOR'].items():
+    # In multi-asic, would have 'BGP_INTERNAL_NEIGHBORS' and possibly no 'BGP_NEIGHBOR' (ebgp) neighbors. 
+    nbrs_in_cfg_facts = {}
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_NEIGHBOR', {}))
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_INTERNAL_NEIGHBOR', {}))
+    for k, v in nbrs_in_cfg_facts.items():
         # Compare the bgp neighbors name with config db bgp neighbors name
         assert v['name'] == bgp_facts['bgp_neighbors'][k]['description']
         # Compare the bgp neighbors ASN with config db


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In a multi-asic system:
  - Have 'BGP_INTERNAL_NEIGHBORS' in config_db that should be checked as well.
  - Could have no 'BGP_NEIGHBORS' in config_db - no eBGP neighbors.
  - sonic-db-cli command needs to include  '-n <asic_namespace>'
  
#### How did you do it?

- If multi-asic, then add '-n <asic_namespace>' to the sonic-db-cli command being sent
- Included BGP_NEIGHBOR and BGP_INTERNAL_NEIGHBORS in validation against config_db.json.

#### How did you verify/test it?
Ran test against single asic and multi-asic DUT w/ and w/out BGP_INTERNAL_NEIGHBORS and BGP_NEIGHBORS

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
