### PR TITLE
Use pytest.fail() for vlan non-broadcast tests

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -385,7 +385,7 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
         logger.info ("One Way Tagged Packet Transmission Works")
         logger.info ("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
     else:
-        test.fail("Expected packet was not received")
+        pytest.fail("Expected packet was not received")
 
     logger.info ("Tagged packet to be sent from port {} to port {}".format(dst_port, src_port))
 
@@ -398,7 +398,7 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
         logger.info ("Two Way Tagged Packet Transmission Works")
         logger.info ("Tagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
     else:
-        test.fail("Expected packet was not received")
+        pytest.fail("Expected packet was not received")
 
 @pytest.mark.bsl
 def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
@@ -438,7 +438,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
         logger.info ("One Way Untagged Packet Transmission Works")
         logger.info ("Untagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
     else:
-        test.fail("Expected packet was not received")
+        pytest.fail("Expected packet was not received")
 
     logger.info ("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))  
 
@@ -452,4 +452,4 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
         logger.info ("Two Way Untagged Packet Transmission Works")
         logger.info ("Untagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
     else:
-        test.fail("Expected packet was not received")
+        pytest.fail("Expected packet was not received")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use correct fail method for vlan non-broadcast tests, added in [#2663](https://github.com/Azure/sonic-mgmt/pull/2663)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`test_vlan_tc4_tagged_non_broadcast` and `test_vlan_tc5_untagged_non_broadcast` fail with incorrect error message if we do not receive expected packet.
**Expected result:**
```
        if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
            logger.info ("One Way Tagged Packet Transmission Works")
            logger.info ("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
        else:
>           test.fail("Expected packet was not received")
E           Failed: Expected packet was not received
```
**Actual result:**
```
        if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
            logger.info ("One Way Tagged Packet Transmission Works")
            logger.info ("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
        else:
>           test.fail("Expected packet was not received")
E           NameError: global name 'test' is not defined
```
#### How did you do it?
Use `pytest.fail()` instead of `test.fail()`
#### How did you verify/test it?
Run test_vlan.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
