### PR TITLE
[test_reporting] Refactor parser and upload script to allow JSON files as input

### DIFF
--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -1,10 +1,8 @@
 import argparse
-import os
-import sys
 
 from junit_xml_parser import (
-    validate_junit_xml_file,
-    validate_junit_xml_archive,
+    validate_junit_json_file,
+    validate_junit_xml_path,
     parse_test_result
 )
 from report_data_storage import KustoConnector
@@ -24,23 +22,18 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
     parser.add_argument(
         "--external_id", "-e", type=str, help="An external tracking ID to append to the report.",
     )
+    parser.add_argument(
+        "--json", "-j", action="store_true", help="Load an existing test result JSON file from path_name.",
+    )
 
     args = parser.parse_args()
 
-    path = args.path_name
-
-    if not os.path.exists(path):
-        print(f"{path} not found")
-        sys.exit(1)
-
-    # FIXME: This interface is actually really clunky, should just have one method and check file
-    # v. dir internally. Fix in the next PR.
-    if os.path.isfile(path):
-        roots = [validate_junit_xml_file(path)]
+    if args.json:
+        test_result_json = validate_junit_json_file(args.path_name)
     else:
-        roots = validate_junit_xml_archive(path)
+        roots = validate_junit_xml_path(args.path_name)
+        test_result_json = parse_test_result(roots)
 
-    test_result_json = parse_test_result(roots)
     tracking_id = args.external_id if args.external_id else ""
 
     kusto_db = KustoConnector(args.db_name)


### PR DESCRIPTION
- Refactor junit_xml_parser to validate JSON test result files
- Refactor report_uploader to accept JSON files as input

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
It would be helpful to be able to use the junit_xml_parser to produce JSON files, so they can be saved/shared later, but also be able to re-use that JSON file in the test_report_uploader script without having to parse the XML files again.

#### How did you do it?
I added methods for validating the correctness of a given JSON test result file to the parser. Then, I added options so that a JSON file with test results already parsed can be passed into both the parser script and report_uploader script so that it can be used instead of an XML file/directory.

#### How did you verify/test it?
Verified that files output from the junit_xml_parser tool succesfully validate, and that removing fields from these files (like test names, timestamps, etc.) causes the files to fail to validate/upload.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
