### PR TITLE
[sflow]Remove workaround patch on setup phase because CLI command has been fixed.

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -89,7 +89,6 @@ def config_dut_ports(duthost, ports, vlan):
    # Even though port is deleted from vlan , the port shows its master as Bridge upon assigning ip address.
    # Hence config reload is done as workaround. ##FIXME
     for i in range(len(ports)):
-        duthost.command('config vlan member add %s %s' %(vlan,ports[i]))
         duthost.command('config vlan member del %s %s' %(vlan,ports[i]))
         duthost.command('config interface ip add %s %s/24' %(ports[i],var['dut_intf_ips'][i]))
     duthost.command('config save -y')


### PR DESCRIPTION
### Description of PR

Summary:
The work around patch should be remove because the CLI command "config vlan member del" has been fixed in [PR #1038](https://github.com/Azure/sonic-utilities/pull/1038).

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Sflow test always failed causes VLAN 1000 already has this VLAN member, should not add again.

#### How did you do it?
Remove the workaround patch for add VLAN member.

#### How did you verify/test it?
- Check the CLI command has been fixed this issue which mentioned in [issue 2665](https://github.com/Azure/sonic-buildimage/issues/2665). 
- Execution the sflow pytest and it's show passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
No.
