### PR TITLE
DualToR link failure utilities and fixtures

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -170,7 +170,7 @@ def _shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None
     dut_intfs = natsorted(dut_intfs)
 
     full_dut_fanout_port_map = {}
-    for _, fanout_host in tor_fanouthosts.items():
+    for fanout_host in tor_fanouthosts.values():
         for encoded_dut_intf, fanout_intf in fanout_host.host_to_fanout_port_map.items():
             full_dut_fanout_port_map[encoded_dut_intf] = {
                 'fanout_host': fanout_host,
@@ -208,9 +208,7 @@ def shutdown_fanout_upper_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinf
 
     def shutdown(dut_intfs=None):
         logger.info('Shutdown fanout ports connected to upper_tor')
-        _down_intfs = _shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs)
-        for fanout_host, fanout_intf in _down_intfs:
-            down_intfs.append((fanout_host, fanout_intf))
+        down_intfs.extend(_shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs))
 
     yield shutdown
 
@@ -235,9 +233,7 @@ def shutdown_fanout_lower_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinf
 
     def shutdown(dut_intfs=None):
         logger.info('Shutdown fanout ports connected to lower_tor')
-        _down_intfs = _shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs)
-        for fanout_host, fanout_intf in _down_intfs:
-            down_intfs.append((fanout_host, fanout_intf))
+        down_intfs.extend(_shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs))
 
     yield shutdown
 
@@ -269,15 +265,11 @@ def shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, lower_tor_h
 
         if upper:
             logger.info('Shutdown fanout ports connected to upper_tor')
-            _down_intfs = _shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs)
-            for fanout_host, fanout_intf in _down_intfs:
-                down_intfs.append((fanout_host, fanout_intf))
+            down_intfs.extend(_shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs))
 
         if lower:
             logger.info('Shutdown fanout ports connected to lower_tor')
-            _down_intfs = _shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs)
-            for fanout_host, fanout_intf in _down_intfs:
-                down_intfs.append((fanout_host, fanout_intf))
+            down_intfs.extend(_shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs))
 
     yield shutdown
 
@@ -346,9 +338,7 @@ def shutdown_t1_upper_tor_intfs(upper_tor_host, nbrhosts, tbinfo):
 
     def shutdown(vm_names=None):
         logger.info('Shutdown T1 VM ports connected to upper_tor')
-        _down_intfs = _shutdown_t1_tor_intfs(upper_tor_host, nbrhosts, tbinfo, vm_names)
-        for eos_host, vm_intf in _down_intfs:
-            down_intfs.append((eos_host, vm_intf))
+        down_intfs.extend(_shutdown_t1_tor_intfs(upper_tor_host, nbrhosts, tbinfo, vm_names))
 
     yield shutdown
 
@@ -369,18 +359,16 @@ def shutdown_t1_lower_tor_intfs(lower_tor_host, nbrhosts, tbinfo):
     Yields:
         function: A function for shutting down specified T1 VMs interfaces connected to lower_tor_host.
     """
-    down_ports = []
+    down_intfs = []
 
     def shutdown(vm_names=None):
         logger.info('Shutdown T1 VM ports connected to lower_tor')
-        _down_ports = _shutdown_t1_tor_intfs(lower_tor_host, nbrhosts, tbinfo, vm_names)
-        for eos_host, vm_intf in _down_ports:
-            down_ports.append((eos_host, vm_intf))
+        down_intfs.extend(_shutdown_t1_tor_intfs(lower_tor_host, nbrhosts, tbinfo, vm_names))
 
     yield shutdown
 
     logger.info('Recover T1 VM ports connected to lower_tor')
-    for eos_host, vm_intf in down_ports:
+    for eos_host, vm_intf in down_intfs:
         eos_host.no_shutdown(vm_intf)
 
 
@@ -405,15 +393,11 @@ def shutdown_t1_tor_intfs(upper_tor_host, lower_tor_host, nbrhosts, tbinfo):
 
         if upper:
             logger.info('Shutdown T1 VM ports connected to upper_tor')
-            _down_intfs = _shutdown_t1_tor_intfs(upper_tor_host, nbrhosts, tbinfo, vm_names)
-            for eos_host, vm_intf in _down_intfs:
-                down_intfs.append((eos_host, vm_intf))
+            down_intfs.extend(_shutdown_t1_tor_intfs(upper_tor_host, nbrhosts, tbinfo, vm_names))
 
         if lower:
             logger.info('Shutdown T1 VM ports connected to lower_tor')
-            _down_intfs = _shutdown_t1_tor_intfs(lower_tor_host, nbrhosts, tbinfo, vm_names)
-            for eos_host, vm_intf in _down_intfs:
-                down_intfs.append((eos_host, vm_intf))
+            down_intfs.extend(_shutdown_t1_tor_intfs(lower_tor_host, nbrhosts, tbinfo, vm_names))
 
     yield shutdown
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1,12 +1,18 @@
 import logging
 import pytest
 
+from natsort import natsorted
+
+from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.dut_ports import encode_dut_port_name
+
 logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope='session')
 def tor_mux_intf(duthosts):
     '''
-    Returns the server-facing interface on the ToR to be used for testing 
+    Returns the server-facing interface on the ToR to be used for testing
     '''
     # The same ports on both ToRs should be connected to the same PTF port
     dut = duthosts[0]
@@ -87,4 +93,244 @@ def get_t1_ptf_ports(dut, tbinfo):
         ptf_portchannel_intfs.append(intf_name)
 
     logger.info("Using portchannel ports {} on PTF for DUT {}".format(ptf_portchannel_intfs, dut.hostname))
-    return ptf_portchannel_intfs 
+    return ptf_portchannel_intfs
+
+
+def _get_tor_fanouthosts(tor_host, fanouthosts):
+    """Helper function to get the fanout host objects that the current tor_host connected to.
+
+    Args:
+        tor_host (object): Host object for the ToR DUT.
+        fanouthosts (dict): Key is fanout hostname, value is fanout host object.
+
+    Returns:
+        dict: Key is fanout hostname, value is fanout host object.
+    """
+    hosts = {}
+    for fanout_hostname, fanout_host in fanouthosts.items():
+        if tor_host.hostname in fanout_host.dut_hostnames:
+            hosts[fanout_hostname] = fanout_host
+    if not hosts:
+        pt_assert('Failed to get fanout for tor_host "{}"'.format(tor_host.hostname))
+    return hosts
+
+
+@pytest.fixture(scope='module')
+def upper_tor_fanouthosts(upper_tor_host, fanouthosts):
+    """Fixture to get the fanout hosts that the upper_tor_host connected to.
+
+    Args:
+        upper_tor_host (object): Host object for upper_tor.
+        fanouthosts (dict): Key is fanout hostname, value is fanout host object.
+
+    Returns:
+        dict: Key is fanout hostname, value is fanout host object.
+    """
+    return _get_tor_fanouthosts(upper_tor_host, fanouthosts)
+
+
+@pytest.fixture(scope='module')
+def lower_tor_fanouthosts(lower_tor_host, fanouthosts):
+    """Fixture to get the fanout hosts that the lower_tor_host connected to.
+
+    Args:
+        lower_tor_host (object): Host object for lower_tor.
+        fanouthosts (dict): Key is fanout hostname, value is fanout host object.
+
+    Returns:
+        dict: Key is fanout hostname, value is fanout host object.
+    """
+    return _get_tor_fanouthosts(lower_tor_host, fanouthosts)
+
+
+def shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None):
+    """Helper function for shutting down fanout interfaces that are connected to specified DUT interfaces.
+
+    Args:
+        tor_host (object): Host object for the ToR DUT.
+        tor_fanouthosts (dict): Key is fanout hostname, value is fanout host object.
+        tbinfo (dict): Testbed info from the tbinfo fixture.
+        dut_intfs (list, optional): List of DUT interface names, for example: ['Ethernet0', 'Ethernet4']. All the
+            fanout interfaces that are connected to the specified DUT interfaces will be shutdown. If dut_intfs is not
+            specified, the function will shutdown all the fanout interfaces that are connected to the tor_host DUT.
+            Defaults to None.
+
+    Returns:
+        list of tuple: Return a list of tuple. Each tuple has two items. The first item is the host object for fanout.
+            The second item is the fanout interface that has been shutdown. The returned list makes it easy to recover
+            the interfaces.
+    """
+    down_intfs = []
+
+    if not dut_intfs:
+        # If no interface is specified, shutdown all ports
+        mg_facts = tor_host.get_extended_minigraph_facts(tbinfo)
+        dut_intfs = mg_facts['minigraph_ports'].keys()
+
+    dut_intfs = natsorted(dut_intfs)
+
+    full_dut_fanout_port_map = {}
+    for _, fanout_host in tor_fanouthosts.items():
+        for encoded_dut_intf, fanout_intf in fanout_host.host_to_fanout_port_map.items():
+            full_dut_fanout_port_map[encoded_dut_intf] = {
+                'fanout_host': fanout_host,
+                'fanout_intf': fanout_intf
+            }
+
+    logger.debug('full_dut_fanout_port_map: {}'.format(full_dut_fanout_port_map))
+
+    for dut_intf in dut_intfs:
+        encoded_dut_intf = encode_dut_port_name(tor_host.hostname, dut_intf)
+        if encoded_dut_intf in full_dut_fanout_port_map:
+            fanout_host = full_dut_fanout_port_map[encoded_dut_intf]['fanout_host']
+            fanout_intf = full_dut_fanout_port_map[encoded_dut_intf]['fanout_intf']
+            fanout_host.shutdown(fanout_intf)
+            down_intfs.append((fanout_host, fanout_intf))
+        else:
+            logger.error('No dut intf "{}" in full_dut_fanout_port_map'.format(encoded_dut_intf))
+
+    return down_intfs
+
+
+@pytest.fixture
+def shutdown_fanout_upper_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo):
+    """Fixture for shutting down fanout interfaces connected to specified upper_tor interfaces.
+
+    Args:
+        upper_tor_host (object): Host object for upper_tor.
+        upper_tor_fanouthosts (dict): Key is fanout hostname, value is fanout host object.
+        tbinfo (dict): Testbed info from the tbinfo fixture.
+
+    Yields:
+        function: A function for shutting down fanout interfaces connected to specified upper_tor interfaces
+    """
+    down_intfs = []
+
+    def shutdown(dut_intfs=None):
+        _down_intfs = shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs)
+        for fanout_host, fanout_intf in _down_intfs:
+            down_intfs.append((fanout_host, fanout_intf))
+
+    yield shutdown
+
+    for fanout_host, fanout_intf in down_intfs:
+        fanout_host.no_shutdown(fanout_intf)
+
+
+@pytest.fixture
+def shutdown_fanout_lower_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo):
+    """Fixture for shutting down fanout interfaces connected to specified lower_tor interfaces.
+
+    Args:
+        lower_tor_host (object): Host object for lower_tor.
+        lower_tor_fanouthosts (dict): Key is fanout hostname, value is fanout host object.
+        tbinfo (dict): Testbed info from the tbinfo fixture.
+
+    Yields:
+        function: A function for shutting down fanout interfaces connected to specified lower_tor interfaces
+    """
+    down_intfs = []
+
+    def shutdown(dut_intfs=None):
+        _down_intfs = shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs)
+        for fanout_host, fanout_intf in _down_intfs:
+            down_intfs.append((fanout_host, fanout_intf))
+
+    yield shutdown
+
+    for fanout_host, fanout_intf in down_intfs:
+        fanout_host.no_shutdown(fanout_intf)
+
+
+def shutdown_t1_tor_intfs(tor_host, nbrhosts, tbinfo, vm_names=None):
+    """Function for shutting down specified T1 VMs' interfaces that are connected to the tor_host.
+
+    Args:
+        tor_host (object): Host object for the ToR DUT.
+        nbrhosts (dict): Dict returned by the nbrhosts fixture.
+        tbinfo (dict): Testbed info from the tbinfo fixture.
+        vm_names (list, optional): List of VM names, for example: ['ARISTA01T1', 'ARISTA02T1']. All the interfaces
+            connected to tor_host on the specified VMs will be shutdown. If vm_names is None, shutdown will be performed
+            on all the T1 VMs of tor_host.
+            Defaults to None.
+
+    Returns:
+        list of tuple: Return a list of tuple. Each tuple has two items. The first item is the host object for VM.
+            The second item is the VM interface that has been shutdown. The returned list makes it easy to recover
+            the interfaces.
+    """
+    down_intfs = []
+
+    tor_index = tbinfo['duts_map'][tor_host.hostname]
+
+    if not vm_names:
+        target_vms = nbrhosts
+    else:
+        target_vms = {}
+        for vm_name in vm_names:
+            if vm_name in nbrhosts:
+                target_vms[vm_name] = nbrhosts[vm_name]
+            else:
+                logger.error('Unknown vm_name: "{}"'.format(vm_name))
+
+    for vm_name in natsorted(target_vms.keys()):
+        eos_host = target_vms[vm_name]['host']
+        vm_intfs = tbinfo['topo']['properties']['configuration'][vm_name]['interfaces']
+        for vm_intf in natsorted(vm_intfs.keys()):
+            intf_detail = vm_intfs[vm_intf]
+            if 'dut_index' in intf_detail:
+                if intf_detail['dut_index'] == tor_index:
+                    eos_host.shutdown(vm_intf)
+                    down_intfs.append((eos_host, vm_intf))
+
+    return down_intfs
+
+
+@pytest.fixture
+def shutdown_t1_upper_tor_intfs(upper_tor_host, nbrhosts, tbinfo):
+    """Function for shutting down specified T1 VMs' interfaces that are connected to the upper_tor_host.
+
+    Args:
+        upper_tor_host (object): Host object for upper_tor.
+        nbrhosts (dict): Dict returned by the nbrhosts fixture.
+        tbinfo (dict): Testbed info from the tbinfo fixture.
+
+    Yields:
+        function: A function for shutting down specified T1 VMs interfaces connected to upper_tor_host.
+    """
+    down_intfs = []
+
+    def shutdown(vm_names=None):
+        _down_intfs = shutdown_t1_tor_intfs(upper_tor_host, nbrhosts, tbinfo, vm_names)
+        for eos_host, vm_intf in _down_intfs:
+            down_intfs.append((eos_host, vm_intf))
+
+    yield shutdown
+
+    for eos_host, vm_intf in down_intfs:
+        eos_host.no_shutdown(vm_intf)
+
+
+@pytest.fixture
+def shutdown_t1_lower_tor_intfs(lower_tor_host, nbrhosts, tbinfo):
+    """Function for shutting down specified T1 VMs' interfaces that are connected to the lower_tor_host.
+
+    Args:
+        lower_tor_host (object): Host object for lower_tor.
+        nbrhosts (dict): Dict returned by the nbrhosts fixture.
+        tbinfo (dict): Testbed info from the tbinfo fixture.
+
+    Yields:
+        function: A function for shutting down specified T1 VMs interfaces connected to lower_tor_host.
+    """
+    down_ports = []
+
+    def shutdown(vm_names=None):
+        _down_ports = shutdown_t1_tor_intfs(lower_tor_host, nbrhosts, tbinfo, vm_names)
+        for eos_host, vm_intf in _down_ports:
+            down_ports.append((eos_host, vm_intf))
+
+    yield shutdown
+
+    for eos_host, vm_intf in down_ports:
+        eos_host.no_shutdown(vm_intf)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,7 +245,7 @@ def k8smasters(ansible_adhoc, request):
     """
     Shortcut fixture for getting Kubernetes master hosts
     """
-    k8s_master_ansible_group = request.config.getoption("--kube_master") 
+    k8s_master_ansible_group = request.config.getoption("--kube_master")
     master_vms = {}
     inv_files = request.config.getoption("ansible_inventory")
     for inv_file in inv_files:
@@ -256,7 +256,7 @@ def k8smasters(ansible_adhoc, request):
         for hostname, attributes in k8sinventory[k8s_master_ansible_group]['hosts'].items():
             if 'haproxy' in attributes:
                 is_haproxy = True
-            else: 
+            else:
                 is_haproxy = False
             master_vms[hostname] = {'host': K8sMasterHost(ansible_adhoc,
                                                                hostname,
@@ -331,8 +331,11 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
                                         network_password,
                                         shell_user=shell_user,
                                         shell_passwd=shell_password)
+                    fanout.dut_hostnames = [dut_host]
                     fanout_hosts[fanout_host] = fanout
                 fanout.add_port_map(encode_dut_port_name(dut_host, dut_port), fanout_port)
+                if dut_host not in fanout.dut_hostnames:
+                    fanout.dut_hostnames.append(dut_host)
     except:
         pass
     return fanout_hosts
@@ -766,10 +769,10 @@ def generate_priority_lists(request, prio_scope):
             info = json.load(yf)
     except IOError as e:
         return empty
-    
+
     if tbname not in info:
         return empty
-    
+
     dut_prio = info[tbname]
     ret = []
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2756

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to add link failure utilities and fixtures for dualToR  testing:
* Shutdown the link between the fanout and the upper ToR
* Shutdown the link between the fanout and the lower ToR
* Shutdown the link between the upper ToR and the T1
* Shutdown the link between the lower ToR and the T1

#### How did you do it?
Added new functions and fixtures in tests.common/dualtor/dual_tor_utils.py. Fixtures added:
* upper_tor_fanouthosts
* lower_tor_fanouthosts
* shutdown_fanout_upper_tor_intfs
* shutdown_fanout_lower_tor_intfs
* shutdown_fanout_tor_intfs
* shutdown_t1_upper_tor_intfs
* shutdown_t1_lower_tor_intfs
* shutdown_t1_tor_intfs

#### How did you verify/test it?
Test run a script like below:
```
import logging
import logging

from tests.common.dualtor.dual_tor_utils import upper_tor_host
from tests.common.dualtor.dual_tor_utils import lower_tor_host
from tests.common.dualtor.dual_tor_utils import upper_tor_fanouthosts
from tests.common.dualtor.dual_tor_utils import lower_tor_fanouthosts

from tests.common.dualtor.dual_tor_utils import shutdown_fanout_upper_tor_intfs
from tests.common.dualtor.dual_tor_utils import shutdown_fanout_lower_tor_intfs
from tests.common.dualtor.dual_tor_utils import shutdown_fanout_tor_intfs
from tests.common.dualtor.dual_tor_utils import shutdown_t1_upper_tor_intfs
from tests.common.dualtor.dual_tor_utils import shutdown_t1_lower_tor_intfs
from tests.common.dualtor.dual_tor_utils import shutdown_t1_tor_intfs


logger = logging.getLogger(__name__)


def test_case1(shutdown_fanout_upper_tor_intfs):
    dut_intfs = ['Ethernet0', 'Ethernet4', 'Ethernet5']
    shutdown_fanout_upper_tor_intfs(dut_intfs=dut_intfs)


def test_case2(shutdown_fanout_lower_tor_intfs):
    dut_intfs = ['Ethernet0', 'Ethernet4', 'Ethernet5']
    shutdown_fanout_lower_tor_intfs(dut_intfs=dut_intfs)


def test_case3(shutdown_fanout_upper_tor_intfs):
    shutdown_fanout_upper_tor_intfs()


def test_case4(shutdown_fanout_lower_tor_intfs):
    shutdown_fanout_lower_tor_intfs()


def test_case5(shutdown_fanout_tor_intfs):
    dut_intfs = ['Ethernet0', 'Ethernet4', 'Ethernet5']
    shutdown_fanout_tor_intfs(dut_intfs=dut_intfs)


def test_case6(shutdown_fanout_tor_intfs):
    dut_intfs = ['Ethernet0', 'Ethernet4', 'Ethernet5']
    shutdown_fanout_tor_intfs(dut_intfs=dut_intfs, upper=True)


def test_case7(shutdown_fanout_tor_intfs):
    dut_intfs = ['Ethernet0', 'Ethernet4', 'Ethernet5']
    shutdown_fanout_tor_intfs(dut_intfs=dut_intfs, lower=True)


def test_case8(shutdown_fanout_tor_intfs):
    dut_intfs = ['Ethernet0', 'Ethernet4', 'Ethernet5']
    shutdown_fanout_tor_intfs(dut_intfs=dut_intfs, upper=True, lower=True)


def test_case9(shutdown_fanout_tor_intfs):
    shutdown_fanout_tor_intfs()


def test_case10(shutdown_fanout_tor_intfs):
    shutdown_fanout_tor_intfs(upper=True)


def test_case11(shutdown_fanout_tor_intfs):
    shutdown_fanout_tor_intfs(lower=True)


def test_case12(shutdown_fanout_tor_intfs):
    shutdown_fanout_tor_intfs(upper=True, lower=True)


def test_case13(shutdown_t1_upper_tor_intfs):
    vm_names = ['ARISTA01T1', 'WHATEVER']
    shutdown_t1_upper_tor_intfs(vm_names=vm_names)


def test_case14(shutdown_t1_lower_tor_intfs):
    vm_names = ['ARISTA01T1', 'WHATEVER']
    shutdown_t1_lower_tor_intfs(vm_names=vm_names)


def test_case15(shutdown_t1_upper_tor_intfs):
    shutdown_t1_upper_tor_intfs()


def test_case16(shutdown_t1_lower_tor_intfs):
    shutdown_t1_lower_tor_intfs()


def test_case17(shutdown_t1_tor_intfs):
    vm_names = ['ARISTA01T1', 'WHATEVER']
    shutdown_t1_tor_intfs(vm_names=vm_names)


def test_case18(shutdown_t1_tor_intfs):
    vm_names = ['ARISTA01T1', 'WHATEVER']
    shutdown_t1_tor_intfs(vm_names=vm_names, upper=True)


def test_case19(shutdown_t1_tor_intfs):
    vm_names = ['ARISTA01T1', 'WHATEVER']
    shutdown_t1_tor_intfs(vm_names=vm_names, lower=True)


def test_case20(shutdown_t1_tor_intfs):
    vm_names = ['ARISTA01T1', 'WHATEVER']
    shutdown_t1_tor_intfs(vm_names=vm_names, upper=True, lower=True)


def test_case21(shutdown_t1_tor_intfs):
    shutdown_t1_tor_intfs()


def test_case22(shutdown_t1_tor_intfs):
    shutdown_t1_tor_intfs(upper=True)


def test_case23(shutdown_t1_tor_intfs):
    shutdown_t1_tor_intfs(lower=True)


def test_case24(shutdown_t1_tor_intfs):
    shutdown_t1_tor_intfs(upper=True, lower=True)
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Specific for dualtor topology.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
