### PR TITLE
Use consistent dualToR terms 'upper_tor' and 'lower_tor'

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.md
+++ b/ansible/roles/vm_set/files/mux_simulator.md
@@ -71,7 +71,7 @@ The APIs using json for data exchange.
 ```
 {
   "active_port": "enp59s0f1.3216",
-  "active_side": "tor_a",
+  "active_side": "upper_tor",
   "bridge": "mbr-vms17-8-0",
   "flows": {
     "enp59s0f1.3216": [
@@ -94,8 +94,8 @@ The APIs using json for data exchange.
   "port_index": "0",
   "ports": {
     "nic": "muxy-vms17-8-0",
-    "tor_a": "enp59s0f1.3216",
-    "tor_b": "enp59s0f1.3272"
+    "upper_tor": "enp59s0f1.3216",
+    "lower_tor": "enp59s0f1.3272"
   },
   "vm_set": "vms17-8"
 }
@@ -129,14 +129,14 @@ Response: `mux_status`
 Post json data format:
 ```
 {
-    "active_side": "tor_a|tor_b|toggle|random"
+    "active_side": "upper_tor|lower_tor|toggle|random"
 }
 ```
 
-* "tor_a": set active side to "tor_a".
-* "tor_b": set active side to "tor_b".
+* "upper_tor": set active side to "upper_tor".
+* "lower_tor": set active side to "lower_tor".
 * "toggle": toggle active side.
-* "random": Randomly set active side to one of "tor_a" and "tor_b".
+* "random": Randomly set active side to one of "upper_tor" and "lower_tor".
 
 Response: `mux_status`
 
@@ -148,7 +148,7 @@ Response: `all_mux_status`
 Post json data format:
 ```
 {
-    "active_side": "tor_a|tor_b|toggle|random"
+    "active_side": "upper_tor|lower_tor|toggle|random"
 }
 ```
 Set active side for all bridges of specified vm_set.
@@ -162,11 +162,11 @@ Response: `all_mux_status`
 Post json data format:
 ```
 {
-    "out_ports": ["nic", "tor_a", "tor_b"],
+    "out_ports": ["nic", "upper_tor", "lower_tor"],
 }
 ```
 
-* `out_ports` is a list. It can contain single or multiple items from: `nic`, `tor_a`, `tor_b`.
+* `out_ports` is a list. It can contain single or multiple items from: `nic`, `upper_tor`, `lower_tor`.
 
 This API is to set specified out ports to `output` or `drop`.
 

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -22,6 +22,11 @@ from flask import Flask, request, jsonify
 app = Flask(__name__)
 
 
+TOR_A = 'upper_tor'
+TOR_B = 'lower_tor'
+NIC = 'nic'
+
+
 logging.basicConfig(
     filename='/tmp/mux_simulator.log',
     level=logging.INFO,
@@ -110,10 +115,10 @@ def get_mux_connections(vm_set, port_index):
                 "port_index": 0,
                 "ports": {
                     "nic": "muxy-vms17-8-0",
-                    "tor_a": "enp59s0f1.3216",
-                    "tor_b": "enp59s0f1.3272"
+                    "upper_tor": "enp59s0f1.3216",
+                    "lower_tor": "enp59s0f1.3272"
                 },
-                "active_side": "tor_a"
+                "active_side": "upper_tor"
             }
     """
     cmdline = 'ovs-ofctl --names show mbr-{}-{}'.format(vm_set, port_index)
@@ -125,9 +130,9 @@ def get_mux_connections(vm_set, port_index):
     mux_status = defaultdict(dict)
     mux_status['vm_set'] = vm_set
     mux_status['port_index'] = port_index
-    mux_status['ports']['nic'] = parsed[0][1]
-    mux_status['ports']['tor_a'] = parsed[1][1]
-    mux_status['ports']['tor_b'] = parsed[2][1]
+    mux_status['ports'][NIC] = parsed[0][1]
+    mux_status['ports'][TOR_A] = parsed[1][1]
+    mux_status['ports'][TOR_B] = parsed[2][1]
     mux_status['bridge'] = parsed[3][1]
     return mux_status
 
@@ -222,10 +227,10 @@ def get_mux_status(vm_set, port_index):
                 "port_index": 0,
                 "ports": {
                     "nic": "muxy-vms17-8-0",
-                    "tor_a": "enp59s0f1.3216",
-                    "tor_b": "enp59s0f1.3272"
+                    "upper_tor": "enp59s0f1.3216",
+                    "lower_tor": "enp59s0f1.3272"
                 },
-                "active_side": "tor_a",
+                "active_side": "upper_tor",
                 "active_port": "enp59s0f1.3216",
                 "flows": {
                     "muxy-vms17-8-0":
@@ -269,9 +274,9 @@ def set_active_side(vm_set, port_index, new_active_side):
     Args:
         vm_set (string): The vm_set of test setup.
         port_index (int or string): Index of the port.
-        new_active_side (string): One of: 'tor_a', 'tor_b', 'toggle', 'random'. If new_active_side is 'toggle',
-            always toggled the active side. If new_active_side is 'random', randomly choose new side from 'tor_a'
-            and 'tor_b'.
+        new_active_side (string): One of: 'upper_tor', 'lower_tor', 'toggle', 'random'. If new_active_side is 'toggle',
+            always toggled the active side. If new_active_side is 'random', randomly choose new side from 'upper_tor'
+            and 'lower_tor'.
 
     Returns:
         dict: Return the new full mux status in a dictionary.
@@ -279,7 +284,7 @@ def set_active_side(vm_set, port_index, new_active_side):
     mux_status = get_mux_status(vm_set, port_index)
 
     if new_active_side == 'random':
-        new_active_side = random.choice(['tor_a', 'tor_b'])
+        new_active_side = random.choice([TOR_A, TOR_B])
 
     if mux_status['active_side'] == new_active_side:
         # Current active side is same as new active side, no need to change.
@@ -289,7 +294,7 @@ def set_active_side(vm_set, port_index, new_active_side):
     flows = get_flows(vm_set, port_index)
     active_port = get_active_port(flows)
     if new_active_side == 'toggle':
-        new_active_side = 'tor_a' if mux_status['active_side'] == 'tor_b' else 'tor_b'
+        new_active_side = TOR_A if mux_status['active_side'] == TOR_B else TOR_B
 
     new_active_port = mux_status['ports'][new_active_side]
     run_cmd('ovs-ofctl --names del-flows mbr-{}-{} in_port="{}"'.format(vm_set, port_index, active_port))
@@ -336,9 +341,9 @@ def _validate_posted_data(data):
     Returns:
         tuple: Return the result in a tuple. The first item is either True or False. The second item is extra message.
     """
-    if 'active_side' in data and data['active_side'] in ['tor_a', 'tor_b', 'toggle', 'random']:
+    if 'active_side' in data and data['active_side'] in [TOR_A, TOR_B, 'toggle', 'random']:
         return True, ''
-    return False, 'Bad posted data, expected: {"active_side": "tor_a|tor_b|toggle|random"}'
+    return False, 'Bad posted data, expected: {"active_side": "upper_tor|lower_tor|toggle|random"}'
 
 
 @app.route('/mux/<vm_set>/<port_index>', methods=['GET', 'POST'])
@@ -426,8 +431,8 @@ def all_mux_status(vm_set):
 
     For GET request, return detailed status of all the mux Y cables belong to the specified vm_set.
     For POST request, update mux active side according to poseted data. Posted data format:
-        {"active_side": "tor_a|tor_b|random"}
-    The value of "active_side" must be one of "tor_a", "tor_b", "toggle" or "random".
+        {"active_side": "upper_tor|upper_tor|random"}
+    The value of "active_side" must be one of "upper_tor", "lower_tor", "toggle" or "random".
 
     Args:
         vm_set (string): The vm_set of test setup.
@@ -460,12 +465,12 @@ def _validate_out_ports(data):
     Args:
         data (dict): Posted json data. Expected:
                 {"out_ports": [<port>, <port>, ...]}
-            where <port> could be "nic", "tor_a" or "tor_b".
+            where <port> could be "nic", "upper_tor" or "lower_tor".
 
     Returns:
         tuple: Return the result in a tuple. The first item is either True or False. The second item is extra message.
     """
-    supported_out_ports = ['nic', 'tor_a', 'tor_b']
+    supported_out_ports = [NIC, TOR_A, TOR_B]
     try:
         assert 'out_ports' in data, 'Missing "out_ports" field'
         for port in data['out_ports']:
@@ -486,7 +491,7 @@ def update_flow_action_to_nic(mux_status, action):
         dict: The new mux status.
     """
     in_port = mux_status['active_port']
-    out_port = mux_status['ports']['nic'] if action == 'output' else None
+    out_port = mux_status['ports'][NIC] if action == 'output' else None
     action_desc = '{}:"{}"'.format(action, out_port) if out_port else action
     cmdline = 'ovs-ofctl --name mod-flows {} \'in_port="{}" actions={}\''.format(
         mux_status['bridge'],
@@ -499,17 +504,17 @@ def update_flow_action_to_nic(mux_status, action):
 
 
 def update_flow_action_to_tor(mux_status, action, tor_ports):
-    """Update the action for the flow to "tor_a" and/or "tor_b".
+    """Update the action for the flow to "upper_tor" and/or "lower_tor".
 
     Args:
         mux_status (dict): Current mux status.
         action (string): The action to be applied to flow. Either "output" or "drop".
-        tor_ports (list): A list like ["tor_a", "tor_b"].
+        tor_ports (list): A list like ["upper_tor", "lower_tor"].
 
     Returns:
         dict: The new mux status.
     """
-    nic_port = mux_status['ports']['nic']       # muxy-<vm_set>-<port_index>
+    nic_port = mux_status['ports'][NIC]       # muxy-<vm_set>-<port_index>
     old_output_tor_ports = set([item['out_port'] \
         for item in mux_status['flows'][nic_port] if item['action'] == 'output'])
 
@@ -547,7 +552,7 @@ def update_flow_action(vm_set, port_index, action, data):
         action (string): The action to be applied to flow. Either "output" or "drop".
         data (dict): Posted json data. Expected:
                 {"out_ports": [<port>, <port>, ...]}
-            where <port> could be "nic", "tor_a" or "tor_b".
+            where <port> could be "nic", "upper_tor" or "lower_tor".
 
     Returns:
         dict: The new mux status.
@@ -555,9 +560,9 @@ def update_flow_action(vm_set, port_index, action, data):
     mux_status = get_mux_status(vm_set, port_index)
     tor_ports = []
     for out_port in data['out_ports']:
-        if out_port == 'nic':
+        if out_port == NIC:
             mux_status = update_flow_action_to_nic(mux_status, action)
-        elif out_port == 'tor_a' or out_port == 'tor_b':
+        elif out_port == TOR_A or out_port == TOR_B:
             tor_ports.append(out_port)
     if tor_ports:
         mux_status = update_flow_action_to_tor(mux_status, action, tor_ports)

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -7,8 +7,8 @@ from tests.common import utilities
 
 logger = logging.getLogger(__name__)
 
-TOR_A = "upper_tor"
-TOR_B = "lower_tor"
+UPPER_TOR = "upper_tor"
+LOWER_TOR = "lower_tor"
 NIC = "nic"
 
 DROP = "drop"
@@ -149,7 +149,7 @@ def toggle_simulator_port_to_upper_tor(mux_server_url, physical_port):
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
     """
-    _simulator_port_toggle_to(mux_server_url, physical_port, TOR_A)
+    _simulator_port_toggle_to(mux_server_url, physical_port, UPPER_TOR)
 
 def toggle_simulator_port_to_lower_tor(mux_server_url, physical_port):
     """
@@ -158,7 +158,7 @@ def toggle_simulator_port_to_lower_tor(mux_server_url, physical_port):
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
     """
-    _simulator_port_toggle_to(mux_server_url, physical_port, TOR_B)
+    _simulator_port_toggle_to(mux_server_url, physical_port, LOWER_TOR)
 
 def recover_all_directions(mux_server_url, physical_port):
     """
@@ -170,7 +170,7 @@ def recover_all_directions(mux_server_url, physical_port):
         None.
     """
     server_url = _url(mux_server_url, physical_port, OUTPUT)
-    data = {"out_ports": [TOR_A, TOR_B, NIC]}
+    data = {"out_ports": [UPPER_TOR, LOWER_TOR, NIC]}
     pytest_assert(_post(server_url, data), "Failed to set output on all directions")
 
 def check_simulator_read_side(mux_server_url, physical_port):
@@ -189,9 +189,9 @@ def check_simulator_read_side(mux_server_url, physical_port):
     if not res:
         return -1
     active_side = res["active_side"]
-    if active_side == TOR_A:
+    if active_side == UPPER_TOR:
         return 1
-    elif active_side == TOR_B:
+    elif active_side == LOWER_TOR:
         return 2
     else:
         return -1
@@ -202,7 +202,7 @@ def toggle_all_simulator_ports_to_upper_tor(mux_server_url):
     A module level fixture to toggle all ports to upper_tor
     """
     server_url = _url(mux_server_url)
-    data = {"active_side": TOR_A}
+    data = {"active_side": UPPER_TOR}
     pytest_assert(_post(server_url, data), "Failed to toggle all ports to upper_tor")
 
 @pytest.fixture(scope='module')
@@ -211,7 +211,7 @@ def toggle_all_simulator_ports_to_lower_tor(mux_server_url):
     A module level fixture to toggle all ports to lower_tor
     """
     server_url = _url(mux_server_url)
-    data = {"active_side": TOR_B}
+    data = {"active_side": LOWER_TOR}
     pytest_assert(_post(server_url, data), "Failed to toggle all ports to upper_tor")
 
 @pytest.fixture(scope='module')

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -7,8 +7,8 @@ from tests.common import utilities
 
 logger = logging.getLogger(__name__)
 
-TOR_A = "tor_a"
-TOR_B = "tor_b"
+TOR_A = "upper_tor"
+TOR_B = "lower_tor"
 NIC = "nic"
 
 DROP = "drop"
@@ -81,7 +81,7 @@ def _post(server_url, data):
 
     Args:
         server_url: a str, the full address of mux server, like http://10.0.0.64:8080/mux/vms17-8[/1/drop|output]
-        data: data to post {"out_ports": ["nic", "tor_a", "tor_b"]}
+        data: data to post {"out_ports": ["nic", "upper_tor", "lower_tor"]}
     Returns:
         True if succeed. False otherwise
     """
@@ -108,7 +108,7 @@ def set_drop(mux_server_url, physical_port, directions):
     Args:
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
-        directions: a list, may contain "tor_a", "tor_b", "nic"
+        directions: a list, may contain "upper_tor", "lower_tor", "nic"
     Returns:
         None.
     """
@@ -122,7 +122,7 @@ def set_output(mux_server_url, physical_port, directions):
     Args:
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
-        directions: a list, may contain "tor_a", "tor_b", "nic"
+        directions: a list, may contain "upper_tor", "lower_tor", "nic"
     Returns:
         None.
     """
@@ -136,24 +136,24 @@ def _simulator_port_toggle_to(mux_server_url, physical_port, target):
     Args:
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
-        target: "tor_a" or "tor_b"
+        target: "upper_tor" or "lower_tor"
     """
     server_url = _url(mux_server_url, physical_port)
     data = {"active_side": target}
     pytest_assert(_post(server_url, data), "Failed to toggle to {} on port {}".format(target, physical_port))
 
-def toggle_simulator_port_to_tor_a(mux_server_url, physical_port):
+def toggle_simulator_port_to_upper_tor(mux_server_url, physical_port):
     """
-    Function to toggle a given y_cable ports to tor_a
+    Function to toggle a given y_cable ports to upper_tor
     Args:
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
     """
     _simulator_port_toggle_to(mux_server_url, physical_port, TOR_A)
 
-def toggle_simulator_port_to_tor_b(mux_server_url, physical_port):
+def toggle_simulator_port_to_lower_tor(mux_server_url, physical_port):
     """
-    Function to toggle a given y_cable ports to tor_b
+    Function to toggle a given y_cable ports to lower_tor
     Args:
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
@@ -180,8 +180,8 @@ def check_simulator_read_side(mux_server_url, physical_port):
         mux_server_url: a str, the address of mux server
         physical_port: physical port on switch, an integer starting from 1
     Returns:
-        1 if TOR_A is active
-        2 if TOR_B is active
+        1 if upper_tor is active
+        2 if lower_tor is active
         -1 for exception or inconstient status
     """
     server_url = _url(mux_server_url, physical_port)
@@ -197,29 +197,29 @@ def check_simulator_read_side(mux_server_url, physical_port):
         return -1
 
 @pytest.fixture(scope='module')
-def toggle_all_simulator_ports_to_tor_a(mux_server_url):
+def toggle_all_simulator_ports_to_upper_tor(mux_server_url):
     """
-    A module level fixture to toggle all ports to tor_a
+    A module level fixture to toggle all ports to upper_tor
     """
     server_url = _url(mux_server_url)
     data = {"active_side": TOR_A}
-    pytest_assert(_post(server_url, data), "Failed to toggle all ports to TOR A")
+    pytest_assert(_post(server_url, data), "Failed to toggle all ports to upper_tor")
 
 @pytest.fixture(scope='module')
-def toggle_all_simulator_ports_to_tor_b(mux_server_url):
+def toggle_all_simulator_ports_to_lower_tor(mux_server_url):
     """
-    A module level fixture to toggle all ports to tor_b
+    A module level fixture to toggle all ports to lower_tor
     """
     server_url = _url(mux_server_url)
     data = {"active_side": TOR_B}
-    pytest_assert(_post(server_url, data), "Failed to toggle all ports to TOR A")
+    pytest_assert(_post(server_url, data), "Failed to toggle all ports to upper_tor")
 
 @pytest.fixture(scope='module')
 def toggle_all_simulator_ports_to_another_side(mux_server_url):
     """
     A module level fixture to toggle all ports to another side
-    For example, if the current active side for a certain port is tor_a,
-    then it will be toggled to tor_b.
+    For example, if the current active side for a certain port is upper_tor,
+    then it will be toggled to lower_tor.
     """
     server_url = _url(mux_server_url)
     data = {"active_side": "toggle"}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The mux simulator server and client code uses term "tor_a" and "tor_b" refering the
upper ToR and lower ToR. To be consistent across documentations and other codes,
this change updated them to "upper_tor" and "lower_tor".

#### How did you do it?
In mux simulator server, client and documentation:
* updated term "tor_a" to "upper_tor".
* updated term "tor_b" to "lower_tor".

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
