### PR TITLE
[dual tor]: Assign upper/lower designations based on testbed file

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -27,7 +27,6 @@ class DualTorParser:
 
         The upper ToR is always the first ToR listed in the testbed file
         '''
-        upper_tor, lower_tor = self.testbed_facts['duts']
         self.dual_tor_facts['positions'] = {'upper': self.testbed_facts['duts'][0], 'lower': self.testbed_facts['duts'][1]}
 
     def parse_loopback_ips(self):

--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -25,10 +25,10 @@ class DualTorParser:
         '''
         Determines the position ('U' for upper and 'L' for lower) of the ToR.
 
-        The upper ToR is always the first ToR alphabetically by hostname
+        The upper ToR is always the first ToR listed in the testbed file
         '''
-        upper_tor, lower_tor = sorted(self.testbed_facts['duts'])
-        self.dual_tor_facts['positions'] = {'upper': upper_tor, 'lower': lower_tor}
+        upper_tor, lower_tor = self.testbed_facts['duts']
+        self.dual_tor_facts['positions'] = {'upper': self.testbed_facts['duts'][0], 'lower': self.testbed_facts['duts'][1]}
 
     def parse_loopback_ips(self):
         '''

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -61,7 +61,7 @@ def lower_tor_host(duthosts):
     '''
     Gets the host object for the lower ToR
 
-    Uses the convention that the second ToR listed in the testbed file is teh lower ToR
+    Uses the convention that the second ToR listed in the testbed file is the lower ToR
     '''
     dut = duthosts[1]
     logger.info("Using {} as lower ToR".format(dut.hostname))

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -49,9 +49,9 @@ def upper_tor_host(duthosts):
     '''
     Gets the host object for the upper ToR
 
-    Uses the convention that the first ToR alphabetically by hostname is the upper ToR
+    Uses the convention that the first ToR listed in the testbed file is the upper ToR
     '''
-    dut = sorted(duthosts, key=lambda dut: dut.hostname)[0]
+    dut = duthosts[0]
     logger.info("Using {} as upper ToR".format(dut.hostname))
     return dut
 
@@ -61,9 +61,9 @@ def lower_tor_host(duthosts):
     '''
     Gets the host object for the lower ToR
 
-    Uses the convention that the first ToR alphabetically by hostname is the upper ToR
+    Uses the convention that the second ToR listed in the testbed file is teh lower ToR
     '''
-    dut = sorted(duthosts, key=lambda dut: dut.hostname)[-1]
+    dut = duthosts[1]
     logger.info("Using {} as lower ToR".format(dut.hostname))
     return dut
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Apply convention of using testbed file to determine upper/lower designation for dual ToR testbeds

#### How did you do it?
Use the first listed ToR as upper, second as lower.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
