### PR TITLE
[recovery] Bring up BGP when minigraph is reloaded

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 config_sources = ['config_db', 'minigraph']
 
 
-def config_reload(duthost, config_source='config_db', wait=120):
+def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True):
     """
     reload SONiC configuration
     :param duthost: DUT host object
@@ -25,6 +25,8 @@ def config_reload(duthost, config_source='config_db', wait=120):
 
     if config_source == 'minigraph':
         duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
+        if start_bgp:
+            duthost.shell('config bgp startup all')
         duthost.shell('config save -y')
 
     if config_source == 'config_db':

--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -8,6 +8,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.assertions import pytest_assert
 from datetime import datetime
 from tests.common.reboot import reboot
+from tests.common import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +33,8 @@ def cleanup_read_mac(duthosts, rand_one_dut_hostname, localhost):
     if backup_minigraph_exist:
         logger.info("Apply minigraph from backup")
         duthost.shell("mv /etc/sonic/minigraph.xml.backup /etc/sonic/minigraph.xml")
-        duthost.shell("config load_minigraph -y")
-        duthost.shell("config save -y")
+        config_reload(duthost, config_source='minigraph')
+
 
 class ReadMACMetadata():
     def __init__(self, request):
@@ -85,8 +86,7 @@ class ReadMACMetadata():
 
             if current_minigraph:
                 logger.info("Execute cli 'config load_minigraph -y' to apply new minigraph")
-                duthost.shell("config load_minigraph -y")
-                duthost.shell("config save -y")
+                config_reload(duthost, config_source='minigraph')
 
             logger.info("Remove old (not current) sonic image")
             duthost.reduce_and_add_sonic_images(disk_used_pcent = 1)


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [recovery] Bring up BGP when minigraph is reloaded

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
There are build flags that disable BGP by default in the minigraph, which can cause test issues if a default minigraph is loaded that does not have BGP enabled.

#### How did you do it?
I added a flag to enable BGP while loading the minigraph so that the testbed is restored to a usable state.

#### How did you verify/test it?
Re-ran a few tests that use load_minigraph to verify that BGP is up when the test completes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
