### PR TITLE
[sflow] Disable Loganalyzer on reboot test cases.

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -388,6 +388,7 @@ class TestAgentId():
 
 # ------------------------------------------------------------------------------
 
+@pytest.mark.disable_loganalyzer
 class TestReboot():
 
     def testRebootSflowEnable(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):


### PR DESCRIPTION
### Description of PR

Summary:
Sflow test case passed, but Loganalyzer detects a lot of error message of other component
after switch reboot causes the test case teardown fail.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Reboot test cases failed because Loganalyzer detects a lot of error message of other component
after switch reboot.

#### How did you do it?
Disable Loganalyzer on reboot test cases.

#### How did you verify/test it?
Execution the sflow pytest and it's show passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
No.
