### PR TITLE
[sanity test] enable sanity check against 201811 images

### DIFF
--- a/ansible/library/show_ip_interface.py
+++ b/ansible/library/show_ip_interface.py
@@ -54,6 +54,12 @@ class ShowIpInterfaceModule(object):
             "(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|N\/A)\s*"   # peer IPv4
         )
 
+        regex_old = re.compile(
+            "\s*(\S+)\s+"                                    # interface name
+            "(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\/(\d{1,2})\s*" # IPv4
+            "(up|down)\/(up|down)\s*"                        # oper/admin state
+        )
+
         self.ip_int = {}
         try:
             rc, self.out, err = self.module.run_command(
@@ -64,6 +70,7 @@ class ShowIpInterfaceModule(object):
             for line in self.out.split("\n"):
                 line = line.strip()
                 m = re.match(regex_int, line)
+                om = re.match(regex_old, line)
                 if m:
                     self.ip_int[m.group(1)] = {}
                     self.ip_int[m.group(1)]["ipv4"] = m.group(2)
@@ -72,6 +79,12 @@ class ShowIpInterfaceModule(object):
                     self.ip_int[m.group(1)]["oper_state"] = m.group(5)
                     self.ip_int[m.group(1)]["bgp_neighbor"] = m.group(6)
                     self.ip_int[m.group(1)]["peer_ipv4"] = m.group(7)
+                elif om:
+                    self.ip_int[om.group(1)] = {}
+                    self.ip_int[om.group(1)]["ipv4"] = om.group(2)
+                    self.ip_int[om.group(1)]["prefix_len"] = om.group(3)
+                    self.ip_int[om.group(1)]["admin"] = om.group(4)
+                    self.ip_int[om.group(1)]["oper_state"] = om.group(5)
             self.facts['ip_interfaces'] = self.ip_int
         except Exception as e:
             self.module.fail_json(msg=str(e))

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -441,11 +441,17 @@ class SonicHost(AnsibleHostBase):
         critical_process_list = []
         succeeded = True
 
+
         file_content = self.shell("docker exec {} bash -c '[ -f /etc/supervisor/critical_processes ] \
                 && cat /etc/supervisor/critical_processes'".format(container_name), module_ignore_errors=True)
         for line in file_content["stdout_lines"]:
             line_info = line.strip().split(':')
             if len(line_info) != 2:
+                if '201811' in self._os_version and len(line_info) == 1:
+                    identifier_value = line_info[0].strip()
+                    critical_process_list.append(identifier_value)
+                    continue
+
                 succeeded = False
                 break
 
@@ -1685,6 +1691,10 @@ class SonicAsic(object):
 
     def get_ip_route_info(self, dstip):
         return self.sonichost.get_ip_route_info(dstip, self.cli_ns_option)
+
+    @property
+    def os_version(self):
+        return self.sonichost.os_version
 
 class MultiAsicSonicHost(object):
     """ This class represents a Multi-asic SonicHost It has two attributes:

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -45,7 +45,7 @@ def check_services(dut):
 
 def _find_down_phy_ports(dut, phy_interfaces):
     down_phy_ports = []
-    intf_facts = dut.show_interface(command='status', include_internal_intfs=True)['ansible_facts']['int_status']
+    intf_facts = dut.show_interface(command='status', include_internal_intfs=('201811' not in dut.os_version))['ansible_facts']['int_status']
     for intf in phy_interfaces:
         try:
             if intf_facts[intf]['oper_state'] == 'down':


### PR DESCRIPTION
Summary:
enable sanity check against 201811 images

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To enable sanity check when testing upgrade path from 201811 to an newer branch.

#### How did you do it?
- This change is needed for upgrade path test when source image is from 201811 branch.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test_pretest.py::test_update_testbed_metadata, without the change, sanity check fails. With the change, test passes.