### PR TITLE
Apply standard vxlan_port config on DUT before Vxlan test

### DIFF
--- a/tests/vxlan/templates/vxlan_switch.j2
+++ b/tests/vxlan/templates/vxlan_switch.j2
@@ -1,0 +1,9 @@
+{% set vxlan_port = 4789 %}
+[
+    {
+        "SWITCH_TABLE:switch": {
+            "vxlan_port": "{{ vxlan_port }}"
+        },
+        "OP": "SET"
+    }
+]

--- a/tests/vxlan/vnet_constants.py
+++ b/tests/vxlan/vnet_constants.py
@@ -9,6 +9,7 @@ DUT_VNET_CONF_JSON = "/tmp/vnet.conf.json"
 DUT_VNET_ROUTE_JSON = "/tmp/vnet.route.json"
 DUT_VNET_INTF_JSON = "/tmp/vnet.intf.json"
 DUT_VNET_NBR_JSON = "/tmp/vnet.nbr.json"
+DUT_VXLAN_PORT_JSON = "/tmp/vxlan_switch.json"
 TEMPLATE_DIR = "vxlan/templates"
 
 CLEANUP_KEY = "cleanup"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Set standard vxlan port on DUT before starting vxlan test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The default vxlan port needs to be changed to 4789
#### How did you do it?
Create a template file to generate config and then copy the config over to the DUT and apply it.
#### How did you verify/test it?
vxlan test now passes with this fix
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
