### PR TITLE
[test_platform_info] Add check for return value of PsuController.get_psu_status as it could return empty list

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -132,8 +132,8 @@ def get_psu_num(dut):
     psu_num = 0
     try:
         psu_num = int(psu_num_out["stdout"])
-    except:
-        pytest_assert(False, "Unable to get the number of PSUs using command '%s'" % cmd_num_psu)
+    except Exception as e:
+        pytest_assert(False, "Unable to get the number of PSUs using command '{}' with exception {}".format(cmd_num_psu, repr(e)))
 
     return psu_num
 

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -10,6 +10,7 @@ import time
 
 import pytest
 
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
 from thermal_control_test_helper import *
@@ -154,7 +155,7 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
 
 def turn_all_psu_on(psu_ctrl):
     all_psu_status = psu_ctrl.get_psu_status()
-    assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
+    pytest_assert(all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status))
     for psu in all_psu_status:
         if not psu["psu_on"]:
             psu_ctrl.turn_on_psu(psu["psu_id"])
@@ -208,7 +209,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
 
     logging.info("Start testing turn off/on PSUs")
     all_psu_status = psu_ctrl.get_psu_status()
-    assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
+    pytest_assert(all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status))
     for psu in all_psu_status:
         psu_under_test = None
 
@@ -361,7 +362,7 @@ def test_thermal_control_psu_absence(duthosts, rand_one_dut_hostname, psu_contro
 
         logging.info('Shutdown first PSU and check thermal control result...')
         all_psu_status = psu_ctrl.get_psu_status()
-        assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
+        pytest_assert(all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status))
         psu = all_psu_status[0]
         turn_off_psu_and_check_thermal_control(duthost, psu_ctrl, psu, fan_mocker)
         psu_test_results.clear()

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -10,7 +10,7 @@ import time
 
 import pytest
 
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
 from thermal_control_test_helper import *
@@ -77,7 +77,7 @@ def stop_pmon_sensord_task(ans_host):
 
     sensord_running_status, sensord_pid = check_sensord_status(ans_host)
     if sensord_running_status:
-        assert False, "Failed to stop sensord task before test."
+        pytest_assert(False, "Failed to stop sensord task before test.")
     else:
         logging.info("sensord stopped successfully")
 
@@ -104,7 +104,7 @@ def psu_test_setup_teardown(duthosts, rand_one_dut_hostname):
         if sensord_running_status:
             logging.info("sensord task restarted, pid = {}".format(sensord_pid))
         else:
-            assert False, "Failed to restart sensord task after test."
+            pytest_assert(False, "Failed to restart sensord task after test.")
     else:
         logging.info("sensord is running, pid = {}".format(sensord_pid))
 
@@ -133,7 +133,7 @@ def get_psu_num(dut):
     try:
         psu_num = int(psu_num_out["stdout"])
     except:
-        assert False, "Unable to get the number of PSUs using command '%s'" % cmd_num_psu
+        pytest_assert(False, "Unable to get the number of PSUs using command '%s'" % cmd_num_psu)
 
     return psu_num
 
@@ -155,7 +155,7 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
 
 def turn_all_psu_on(psu_ctrl):
     all_psu_status = psu_ctrl.get_psu_status()
-    pytest_assert(all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status))
+    pytest_require(all_psu_status and len(all_psu_status) >= 2, 'Skip the test, cannot to get at least 2 PSU status: {}'.format(all_psu_status))
     for psu in all_psu_status:
         if not psu["psu_on"]:
             psu_ctrl.turn_on_psu(psu["psu_id"])
@@ -188,28 +188,25 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
     psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
 
     psu_num = get_psu_num(duthost)
-    if psu_num < 2:
-        pytest.skip("At least 2 PSUs required for rest of the testing in this case")
+    pytest_require(psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
 
     logging.info("Create PSU controller for testing")
     psu_ctrl = psu_controller
-    if psu_ctrl is None:
-        pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
+    pytest_require(psu_ctrl, "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
 
     logging.info("To avoid DUT being shutdown, need to turn on PSUs that are not powered")
     turn_all_psu_on(psu_ctrl)
 
     logging.info("Initialize test results")
     psu_test_results = {}
-    if not check_all_psu_on(duthost, psu_test_results):
-        pytest.skip("Some PSU are still down, skip rest of the testing in this case")
+    pytest_require(check_all_psu_on(duthost, psu_test_results), "Some PSU are still down, skip rest of the testing in this case")
 
-    assert len(psu_test_results.keys()) == psu_num, \
-        "In consistent PSU number output by '%s' and '%s'" % (CMD_PLATFORM_PSUSTATUS, "sudo psuutil numpsus")
+    pytest_assert(len(psu_test_results.keys()) == psu_num, \
+        "In consistent PSU number output by '%s' and '%s'" % (CMD_PLATFORM_PSUSTATUS, "sudo psuutil numpsus"))
 
     logging.info("Start testing turn off/on PSUs")
     all_psu_status = psu_ctrl.get_psu_status()
-    pytest_assert(all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status))
+    pytest_require(all_psu_status and len(all_psu_status) >= 2, 'Skip the test, cannot get at least 2 PSU status: {}'.format(all_psu_status))
     for psu in all_psu_status:
         psu_under_test = None
 
@@ -219,12 +216,12 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
-            assert psu_line_pattern.match(line), "Unexpected PSU status output"
+            pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output")
             fields = line.split()
             if fields[2] != "OK":
                 psu_under_test = fields[1]
             check_vendor_specific_psustatus(duthost, line)
-        assert psu_under_test is not None, "No PSU is turned off"
+        pytest_assert(psu_under_test is not None, "No PSU is turned off")
 
         logging.info("Turn on PSU %s" % str(psu["psu_id"]))
         psu_ctrl.turn_on_psu(psu["psu_id"])
@@ -232,16 +229,16 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
-            assert psu_line_pattern.match(line), "Unexpected PSU status output"
+            pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output")
             fields = line.split()
             if fields[1] == psu_under_test:
-                assert fields[2] == "OK", "Unexpected PSU status after turned it on"
+                pytest_assert(fields[2] == "OK", "Unexpected PSU status after turned it on")
             check_vendor_specific_psustatus(duthost, line)
 
         psu_test_results[psu_under_test] = True
 
     for psu in psu_test_results:
-        assert psu_test_results[psu], "Test psu status of PSU %s failed" % psu
+        pytest_assert(psu_test_results[psu], "Test psu status of PSU %s failed" % psu)
 
 
 @pytest.mark.disable_loganalyzer
@@ -255,15 +252,14 @@ def test_show_platform_fanstatus_mocked(duthosts, rand_one_dut_hostname, mocker_
     with ThermalPolicyFileContext(duthost, THERMAL_POLICY_INVALID_FORMAT_FILE):
         # Mock data and check
         mocker = mocker_factory(duthost, 'FanStatusMocker')
-        if mocker is None:
-            pytest.skip("No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
+        pytest_require(mocker, "No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
 
         logging.info('Mock FAN status data...')
         mocker.mock_data()
         logging.info('Wait and check actual data with mocked FAN status data...')
         result = check_cli_output_with_mocker(duthost, mocker, CMD_PLATFORM_FANSTATUS, THERMAL_CONTROL_TEST_WAIT_TIME, 2)
 
-        assert result, 'FAN mock data mismatch'
+        pytest_assert(result, 'FAN mock data mismatch')
 
 
 @pytest.mark.disable_loganalyzer
@@ -275,15 +271,14 @@ def test_show_platform_temperature_mocked(duthosts, rand_one_dut_hostname, mocke
     duthost = duthosts[rand_one_dut_hostname]
     # Mock data and check
     mocker = mocker_factory(duthost, 'ThermalStatusMocker')
-    if mocker is None:
-        pytest.skip("No ThermalStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
+    pytest_require(mocker, "No ThermalStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
 
     logging.info('Mock Thermal status data...')
     mocker.mock_data()
     logging.info('Wait and check actual data with mocked Thermal status data...')
     result = check_cli_output_with_mocker(duthost, mocker, CMD_PLATFORM_TEMPER, THERMAL_CONTROL_TEST_WAIT_TIME)
 
-    assert result, 'Thermal mock data mismatch'
+    pytest_assert(result, 'Thermal mock data mismatch')
 
 
 @pytest.mark.disable_loganalyzer
@@ -328,26 +323,24 @@ def test_thermal_control_psu_absence(duthosts, rand_one_dut_hostname, psu_contro
     """
     duthost = duthosts[rand_one_dut_hostname]
     psu_num = get_psu_num(duthost)
-    if psu_num < 2:
-        pytest.skip("At least 2 PSUs required for rest of the testing in this case")
+    
+    pytest_require(psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
 
     logging.info("Create PSU controller for testing")
     psu_ctrl = psu_controller
-    if psu_ctrl is None:
-        pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
+
+    pytest_require(psu_ctrl, "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
 
     logging.info("To avoid DUT being shutdown, need to turn on PSUs that are not powered")
     turn_all_psu_on(psu_ctrl)
 
     logging.info("Initialize test results")
     psu_test_results = {}
-    if not check_all_psu_on(duthost, psu_test_results):
-        pytest.skip("Some PSU are still down, skip rest of the testing in this case")
+    pytest_require(check_all_psu_on(duthost, psu_test_results), "Some PSU are still down, skip rest of the testing in this case")
 
     with ThermalPolicyFileContext(duthost, THERMAL_POLICY_VALID_FILE):
         fan_mocker = mocker_factory(duthost, 'FanStatusMocker')
-        if fan_mocker is None:
-            pytest.skip("No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
+        pytest_require(fan_mocker, "No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
 
         restart_thermal_control_daemon(duthost)
         logging.info('Wait and check all FAN speed turn to 60%...')
@@ -355,32 +348,30 @@ def test_thermal_control_psu_absence(duthosts, rand_one_dut_hostname, psu_contro
                                  THERMAL_CONTROL_TEST_CHECK_INTERVAL,
                                  fan_mocker.check_all_fan_speed,
                                  60)
-        if not wait_result:
-             pytest.skip("FAN speed is not 60%, there might be abnormal in FAN/PSU, skip rest of the testing in this case")
+
+        pytest_require(wait_result, "FAN speed is not 60%, there might be abnormal in FAN/PSU, skip rest of the testing in this case")
 
         check_thermal_algorithm_status(duthost, mocker_factory, False)
 
         logging.info('Shutdown first PSU and check thermal control result...')
         all_psu_status = psu_ctrl.get_psu_status()
-        pytest_assert(all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status))
+        pytest_require(all_psu_status and len(all_psu_status) >= 2, 'Skip the test, cannot get at least 2 PSU status: {}'.format(all_psu_status))
         psu = all_psu_status[0]
         turn_off_psu_and_check_thermal_control(duthost, psu_ctrl, psu, fan_mocker)
         psu_test_results.clear()
-        if not check_all_psu_on(duthost, psu_test_results):
-            pytest.skip("Some PSU are still down, skip rest of the testing in this case")
+        pytest_require(check_all_psu_on(duthost, psu_test_results), "Some PSU are still down, skip rest of the testing in this case")
 
         logging.info('Shutdown second PSU and check thermal control result...')
         psu = all_psu_status[1]
         turn_off_psu_and_check_thermal_control(duthost, psu_ctrl, psu, fan_mocker)
         psu_test_results.clear()
-        if not check_all_psu_on(duthost, psu_test_results):
-            pytest.skip("Some PSU are still down, skip rest of the testing in this case")
+        pytest_require(check_all_psu_on(duthost, psu_test_results), "Some PSU are still down, skip rest of the testing in this case")
 
         logging.info('Wait and check all FAN speed turn to 65%...')
-        assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
-                          THERMAL_CONTROL_TEST_CHECK_INTERVAL,
-                          fan_mocker.check_all_fan_speed,
-                          65), 'FAN speed not change to 65% according to policy'
+        pytest_assert(wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
+                                 THERMAL_CONTROL_TEST_CHECK_INTERVAL,
+                                 fan_mocker.check_all_fan_speed,
+                                 65), 'FAN speed not change to 65% according to policy')
 
 
 def turn_off_psu_and_check_thermal_control(dut, psu_ctrl, psu, mocker):
@@ -396,17 +387,17 @@ def turn_off_psu_and_check_thermal_control(dut, psu_ctrl, psu, mocker):
     psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
     cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
     for line in cli_psu_status["stdout_lines"][2:]:
-        assert psu_line_pattern.match(line), "Unexpected PSU status output"
+        pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output")
         fields = line.split()
         if fields[2] != "OK":
             psu_under_test = fields[1]
 
-    assert psu_under_test is not None, "No PSU is turned off"
+    pytest_assert(psu_under_test is not None, "No PSU is turned off")
     logging.info('Wait and check all FAN speed turn to 100%...')
-    assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
-                      THERMAL_CONTROL_TEST_CHECK_INTERVAL,
-                      mocker.check_all_fan_speed,
-                      100), 'FAN speed not turn to 100% after PSU off'
+    pytest_assert(wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
+                             THERMAL_CONTROL_TEST_CHECK_INTERVAL,
+                             mocker.check_all_fan_speed,
+                             100), 'FAN speed not turn to 100% after PSU off')
 
     psu_ctrl.turn_on_psu(psu["psu_id"])
     time.sleep(5)
@@ -423,8 +414,7 @@ def test_thermal_control_fan_status(duthosts, rand_one_dut_hostname, mocker_fact
 
     with ThermalPolicyFileContext(duthost, THERMAL_POLICY_VALID_FILE):
         fan_mocker = mocker_factory(duthost, 'FanStatusMocker')
-        if fan_mocker is None:
-            pytest.skip("No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
+        pytest_require(fan_mocker, "No FanStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
 
         logging.info('Mock FAN status data...')
         fan_mocker.mock_data()  # make data random

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -154,11 +154,11 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
 
 def turn_all_psu_on(psu_ctrl):
     all_psu_status = psu_ctrl.get_psu_status()
-    if all_psu_status:
-        for psu in all_psu_status:
-            if not psu["psu_on"]:
-                psu_ctrl.turn_on_psu(psu["psu_id"])
-                time.sleep(5)
+    assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
+    for psu in all_psu_status:
+        if not psu["psu_on"]:
+            psu_ctrl.turn_on_psu(psu["psu_id"])
+            time.sleep(5)
 
 
 def check_all_psu_on(dut, psu_test_results):
@@ -208,6 +208,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, ps
 
     logging.info("Start testing turn off/on PSUs")
     all_psu_status = psu_ctrl.get_psu_status()
+    assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
     for psu in all_psu_status:
         psu_under_test = None
 
@@ -360,6 +361,7 @@ def test_thermal_control_psu_absence(duthosts, rand_one_dut_hostname, psu_contro
 
         logging.info('Shutdown first PSU and check thermal control result...')
         all_psu_status = psu_ctrl.get_psu_status()
+        assert all_psu_status and len(all_psu_status) >= 2, 'Failed to get at least 2 PSU status: {}'.format(all_psu_status)
         psu = all_psu_status[0]
         turn_off_psu_and_check_thermal_control(duthost, psu_ctrl, psu, fan_mocker)
         psu_test_results.clear()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add check for return value of PsuController.get_psu_status as it could return empty list

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

PsuController.get_psu_status could return empty list. If we continue the test, it might mislead test case results reviewer because test case could failed at other place if `get_psu_status ` return empty.

#### How did you do it?

Add an assertion after get_psu_status

#### How did you verify/test it?

Manual test

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
