### PR TITLE
[test_vlan] Set unique MAC addresses for ptf interfaces

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -13,6 +13,7 @@ import pprint
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Set unique MAC addresses on ptf interfaces during test_vlan

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR #2663 added non-broadcast tests.
By default, we have same MAC addresses on ptf interfaces eth0-eth28. Tests send ICMP packets with specified source and destination MACs. Since we have same MAC for eth0-eth28, if more than one of them is in the same VLAN, fdb table on DUT will have only one entry for this MAC/VLAN. Packet will be forwarded to the port, specified in fdb, which may be different from expected port. In this case test fails due to packet not arriving to expected port.
#### How did you do it?
Set unique MAC addresses for ptf interfaces by adding `import change_mac_addresses` to test.
#### How did you verify/test it?
Run test_vlan.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
