### PR TITLE
[crm] Ignore error messages for removing non-empty VLAN

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -49,6 +49,28 @@ RESTORE_CMDS = {"test_crm_route": [],
                 "wait": 0}
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution.
+
+    We don't have control over the order events are received by orchagent, so it is
+    possible that we attempt to remove the VLAN before its members are removed. This results
+    in error messages initially, but subsequent retries will succeed once the VLAN member is
+    removed.
+
+    Args:
+        rand_one_dut_hostname: Fixture to randomly pick a DUT from the testbed
+        loganalyzer: Loganalyzer utility fixture
+
+    """
+    ignoreRegex = [
+        ".*ERR swss#orchagent.*removeVlan: Failed to remove non-empty VLAN.*"
+    ]
+
+    if loganalyzer:  # Skip if loganalyzer is disabled
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
+
+
 def apply_acl_config(duthost, test_name, collector, entry_num=1):
     """ Create acl rule defined in config file. Return ACL table key. """
     base_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [crm] Ignore error messages for removing non-empty VLAN
Fixes https://github.com/Azure/sonic-mgmt/issues/2871

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We noticed in https://github.com/Azure/sonic-mgmt/issues/2871 that even though the CRM test queues up VLAN updates in sequential order, the member removal can still happen after the VLAN removal. As expected, orchagent emits a failure log and retries the VLAN removal later, but this can cause issues in the test.

#### How did you do it?
Added a loganalyzer exception for VLAN removal errors.

#### How did you verify/test it?
Re-ran the test on a DUT in the lab. Noted the error message in the syslog, but the test was still able to pass.

#### Any platform specific information?
n/a

#### Supported testbed topology if it's a new test case?
n/a

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
n/a