### PR TITLE
Parse platform.json, hwsku.json for generate minigraph

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -178,14 +178,14 @@ class SonicPortAliasMap():
         aliasmap = {}
         portspeed = {}
 
-        # if platform.json and hwsku.json are exist, than get portmap from hwsku
+        # if platform.json and hwsku.json exist, than get portmap from hwsku
         platform_file = self.get_platform_path()
         hwsku_file = self.get_hwsku_path()
         if platform_file and hwsku_file:
             self.get_portmap_from_platform_hwsku(platform_file, hwsku_file, aliases, portmap, aliasmap, portspeed)
             return (aliases, portmap, aliasmap, portspeed)
 
-        # platform.json or hwsku.json is not exist so get portmap from port_config.ini
+        # platform.json or hwsku.json does not exist so get portmap from port_config.ini
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
             raise Exception("Something wrong when trying to find the portmap file, either the hwsku is not available or file location is not correct")

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -4,9 +4,12 @@ import re
 import os
 import traceback
 import subprocess
+import json
+import ast
 from operator import itemgetter
 from itertools import groupby
 from collections import defaultdict
+from collections import OrderedDict
 
 try:
     from sonic_py_common import multi_asic  
@@ -49,6 +52,8 @@ RETURN = '''
 FILE_PATH = '/usr/share/sonic/device'
 PORTMAP_FILE = 'port_config.ini'
 ALLOWED_HEADER = ['name', 'lanes', 'alias', 'index', 'asic_port_name', 'role', 'speed']
+PLATFORM_FILE = 'platform.json'
+HWSKU_FILE = 'hwsku.json'
 
 MACHINE_CONF = '/host/machine.conf'
 ONIE_PLATFORM_KEY = 'onie_platform'
@@ -89,11 +94,98 @@ class SonicPortAliasMap():
             return portconfig
         return None
 
+    def get_platform_path(self):
+        platform = self.get_platform_type()
+        if platform is None:
+            return None
+        platform_path = os.path.join(FILE_PATH, platform, PLATFORM_FILE)
+        if os.path.exists(platform_path):
+            return platform_path
+        return None
+
+    def get_hwsku_path(self):
+        platform = self.get_platform_type()
+        if platform is None:
+            return None
+        hwsku_path = os.path.join(FILE_PATH, platform, self.hwsku, HWSKU_FILE)
+        if os.path.exists(hwsku_path):
+            return hwsku_path
+        return None
+
+    def get_portmap_from_platform_hwsku(self, platform_file, hwsku_file, aliases, portmap, aliasmap, portspeed):
+        decoder = json.JSONDecoder(object_pairs_hook=OrderedDict)
+        brkout_pattern = r'(\d{1,3})x(\d{1,3}G)(\[\d{1,3}G\])?(\((\d{1,3})\))?'
+        with open(platform_file) as f:
+            data = json.load(f, object_pairs_hook=OrderedDict)
+            platform_dict = decoder.decode(json.dumps(data))
+        with open(hwsku_file) as f:
+            data = json.load(f)
+            hwsku_dict = ast.literal_eval(json.dumps(data))
+        for interface in platform_dict["interfaces"]:
+            if interface not in hwsku_dict["interfaces"]:
+                raise Exception("interface {} not in hwsku dict".format(interface))
+            alias_at_lanes = platform_dict["interfaces"][interface]['alias_at_lanes']
+            lanes = platform_dict["interfaces"][interface]['lanes']
+            breakout_mode = hwsku_dict["interfaces"][interface]["default_brkout_mode"]
+
+            # Asymmetric breakout mode
+            if re.search("\+", breakout_mode) is not None:
+                breakout_parts = breakout_mode.split("+")
+                match_list = [re.match(brkout_pattern, i).groups() for i in breakout_parts]
+            # Symmetric breakout mode
+            else:
+                match_list = [re.match(brkout_pattern, breakout_mode).groups()]
+
+            offset = 0
+            parent_intf_id = int(re.search("Ethernet(\d+)", interface).group(1))
+            for k in match_list:
+                if k is None:
+                    continue
+                num_lane_used, speed, assigned_lane = k[0], k[1], k[4]
+
+                if assigned_lane is None:
+                    assigned_lane = len(lanes.split(","))
+                parent_intf_id = int(offset)+int(parent_intf_id)
+
+                alias_start = 0 + offset
+                step = int(assigned_lane)//int(num_lane_used)
+                for i in range(0, int(assigned_lane), step):
+                    intf_name = "Ethernet" + str(parent_intf_id)
+                    alias = alias_at_lanes.split(",")[alias_start]
+                    aliases.append(alias)
+                    portmap[intf_name] = alias
+                    aliasmap[alias] = intf_name
+                    if speed:
+                        speed_pat = re.search("^((\d+)G|\d+)$", speed.upper())
+                        if speed_pat is None:
+                            raise Exception('{} speed is not Supported...'.format(speed))
+                        speed_G, speed_orig = speed_pat.group(2), speed_pat.group(1)
+                        if speed_G:
+                            portspeed[intf_name] = str(int(speed_G)*1000)
+                        else:
+                            portspeed[intf_name] = speed_orig
+                    else:
+                        raise Exception('Regex return for speed is None...')
+
+                    parent_intf_id += step
+                    alias_start += step
+                parent_intf_id = 0
+                offset = int(assigned_lane) + int(offset)
+
     def get_portmap(self, asic_id=None):
         aliases = []
         portmap = {}
         aliasmap = {}
         portspeed = {}
+
+        # if platform.json and hwsku.json are exist, than get portmap from hwsku
+        platform_file = self.get_platform_path()
+        hwsku_file = self.get_hwsku_path()
+        if platform_file and hwsku_file:
+            self.get_portmap_from_platform_hwsku(platform_file, hwsku_file, aliases, portmap, aliasmap, portspeed)
+            return (aliases, portmap, aliasmap, portspeed)
+
+        # platform.json or hwsku.json is not exist so get portmap from port_config.ini
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
             raise Exception("Something wrong when trying to find the portmap file, either the hwsku is not available or file location is not correct")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

After transition from port_config.ini to platform.json, hwsku.json, we can`t fully deprecate and remove port_config.ini cause of port_mgmt/ansible use port_config.ini for generate minigraph. So currently we have configuration(platform.json, hwsku.json) using by sonic for configure ports and configuration(port_config.ini) using by sonic_mgmt for generate minigraph. So changes in platform.json and hwsku.json will not affect minigraph because of port_config.ini so we have configuration mismatch.
PR add functionality to sonic_mgmt for parse platform.json and hwsku.json and use this configuration for generation minigraph.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
- fully deprecate and remove port_config.ini
- avoid mismatch configurations between port_config.ini and platform.json, hwsku.json

#### How did you do it?
Add functionality for parsing platform.json, hwsku.json and use this configuration for generate minigraph.

#### How did you verify/test it?
Compare generated minigraph/config_db configurations with platform.json, hwsku.json.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
