### PR TITLE
Add option to copy minigraph to DUT

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -48,6 +48,11 @@
     - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
       when: inventory_hostname not in testbed_facts['duts']
 
+    - name: Set default num_asic
+      set_fact:
+        num_asics: 1
+      when: num_asics is not defined
+
     - name: Set default dut index
       set_fact:
         dut_index: "{{ testbed_facts['duts_map'][inventory_hostname]|int }}"
@@ -66,11 +71,11 @@
     delegate_to: localhost
 
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}"
+    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
-    port_alias: hwsku="{{ hwsku }}"
+    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 
@@ -230,6 +235,13 @@
         template: src=templates/minigraph_template.j2
                   dest=/etc/sonic/minigraph.xml
         become: true
+        when: copy|bool == false
+
+      - name: copy existing minigraph file for SONiC device
+        template: src=minigraph/{{ inventory_hostname }}.{{ topo }}.xml
+                  dest=/etc/sonic/minigraph.xml
+        become: true
+        when: copy|bool == true
 
       - name: Test if configlet script exist
         stat:
@@ -322,6 +334,12 @@
         register: docker_status
 
       - debug: msg={{ docker_status.stdout_lines }}
+
+      - name: start topology service for multi-asic platform
+        become: true
+        shell: systemctl start topology.service
+        when: num_asics > 1
+        ignore_errors: true
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -338,7 +338,7 @@
       - name: start topology service for multi-asic platform
         become: true
         shell: systemctl start topology.service
-        when: start_topo_service|bool == true
+        when: start_topo_service is defined and start_topo_service|bool == true
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -235,13 +235,13 @@
         template: src=templates/minigraph_template.j2
                   dest=/etc/sonic/minigraph.xml
         become: true
-        when: copy|bool == false
+        when: copy is not defined or copy is defined and copy|bool == false
 
       - name: copy existing minigraph file for SONiC device
         template: src=minigraph/{{ inventory_hostname }}.{{ topo }}.xml
                   dest=/etc/sonic/minigraph.xml
         become: true
-        when: copy|bool == true
+        when: copy is defined and copy|bool == true
 
       - name: Test if configlet script exist
         stat:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -338,8 +338,7 @@
       - name: start topology service for multi-asic platform
         become: true
         shell: systemctl start topology.service
-        when: num_asics > 1
-        ignore_errors: true
+        when: start_topo_service|bool == true
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -48,11 +48,6 @@
     - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
       when: inventory_hostname not in testbed_facts['duts']
 
-    - name: Set default num_asic
-      set_fact:
-        num_asics: 1
-      when: num_asics is not defined
-
     - name: Set default dut index
       set_fact:
         dut_index: "{{ testbed_facts['duts_map'][inventory_hostname]|int }}"
@@ -71,11 +66,11 @@
     delegate_to: localhost
 
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
+    port_alias: hwsku="{{ hwsku }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
-    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
+    port_alias: hwsku="{{ hwsku }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 
@@ -335,11 +330,6 @@
         register: docker_status
 
       - debug: msg={{ docker_status.stdout_lines }}
-
-      - name: start topology service for multi-asic platform
-        become: true
-        shell: systemctl start topology.service
-        when: start_topo_service is defined and start_topo_service|bool == true
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -158,6 +158,12 @@
     delegate_to: localhost
     when: local_minigraph is defined and local_minigraph|bool == true
 
+  - name: copy existing minigraph file for SONiC device
+    copy: src=minigraph/{{ inventory_hostname }}.{{ topo }}.xml
+          dest=/etc/sonic/minigraph.xml
+    become: true
+    when: copy is defined and copy|bool == true
+
   - block:
     - name: Init telemetry keys
       set_fact:
@@ -230,18 +236,13 @@
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true
         ignore_errors: true
+        when: copy is not defined or copy is defined and copy|bool == false
 
       - name: create new minigraph file for SONiC device
         template: src=templates/minigraph_template.j2
                   dest=/etc/sonic/minigraph.xml
         become: true
         when: copy is not defined or copy is defined and copy|bool == false
-
-      - name: copy existing minigraph file for SONiC device
-        template: src=minigraph/{{ inventory_hostname }}.{{ topo }}.xml
-                  dest=/etc/sonic/minigraph.xml
-        become: true
-        when: copy is defined and copy|bool == true
 
       - name: Test if configlet script exist
         stat:

--- a/ansible/lab
+++ b/ansible/lab
@@ -104,6 +104,7 @@ sonic_multi_asic:
   vars:
     hwsku: msft_multi_asic_vs
     iface_speed: 40000
+    num_asics: 4
   hosts:
     vlab-07:
       ansible_host: 10.250.0.109

--- a/ansible/lab
+++ b/ansible/lab
@@ -104,7 +104,7 @@ sonic_multi_asic:
   vars:
     hwsku: msft_multi_asic_vs
     iface_speed: 40000
-    num_asics: 4 
+    num_asics: 6
     start_topo_service: True
   hosts:
     vlab-07:

--- a/ansible/lab
+++ b/ansible/lab
@@ -104,8 +104,6 @@ sonic_multi_asic:
   vars:
     hwsku: msft_multi_asic_vs
     iface_speed: 40000
-    num_asics: 6
-    start_topo_service: True
   hosts:
     vlab-07:
       ansible_host: 10.250.0.109

--- a/ansible/lab
+++ b/ansible/lab
@@ -104,7 +104,8 @@ sonic_multi_asic:
   vars:
     hwsku: msft_multi_asic_vs
     iface_speed: 40000
-    num_asics: 4
+    num_asics: 4 
+    start_topo_service: True
   hosts:
     vlab-07:
       ansible_host: 10.250.0.109

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -403,7 +403,7 @@ function copy_minigraph
   shift
   shift
 
-  echo "Deploying minigraph '$topology'"
+  echo "Copying minigraph '$topology'"
 
   read_file $topology
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -394,7 +394,7 @@ function test_minigraph
   echo Done
 }
 
-function copy_load_minigraph
+function copy_minigraph
 {
   topology=$1
   inventory=$2
@@ -407,7 +407,7 @@ function copy_load_minigraph
 
   read_file $topology
 
-  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e deploy=true -e save=true -e copy=true $@
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e copy=true $@
 
   echo Done
 }
@@ -532,7 +532,7 @@ case "${subcmd}" in
                ;;
   test-mg)     test_minigraph $@
                ;;
-  copy-mg)     copy_load_minigraph $@
+  copy-mg)     copy_minigraph $@
                ;;
   create-master) start_k8s_vms $@
                  setup_k8s_vms $@


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
- For multi-asic VS platform, topology service has to be started before loading minigraph after boot up. This is required because some services(swss/syncd/teamd) are dependent on topology service.
- Add a new option to copy a generated minigraph in ansible/minigraph directory to DUT and load minigraph. 
This option will skip generating the minigraph from the templates and load a generated minigraph. This is done so that we can load an existing multi-asic minigraph while multi-asic minigraph generation is not in place.

#### How did you do it?
- Add a new option to copy generated minigraph with the name minigraph/DUT_NAME.TOPO.xml to DUT instead of creating minigraph from templates.
-  To copy the exiting minigraph (minigraph/DUT_NAME.TOPO.xml) to DUT:
./testbed-cli.sh -t vtestbed.csv -m veos_vtb copy-mg vms-kvm-t0 lab password.txt
To copy existing minigraph( minigraph/DUT_NAME.TOPO.xml ) to DUT and load minigraph:
./testbed-cli.sh -t vtestbed.csv -m veos_vtb copy-mg vms-kvm-t0 lab password.txt -e deploy=true -e save=true
To generate a new minigraph locally and load the generated minigraph to DUT:
./testbed-cli.sh -t vtestbed.csv -m veos_vtb geb-mg vms-kvm-t0 lab password.txt -e copy=true


#### How did you verify/test it?
- Single asic VS - No Change.
- Multi-asic VS - use a 4-asic vs image and bring up multi-asic VS testbed.
./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-multi-asic-t1-lag password.txt
- Copy minigraph and verify start of topology service and loading minigraph using:
./testbed-cli.sh -t vtestbed.csv -m veos_vtb copy-mg vms-kvm-multi-asic-t1-lag lab password.txt
- Verify that all internal and external interfaces are up and all internal and external BGP sessions are up.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
