### PR TITLE
Modified FIB testcases to support T2 topology on multi-dut

### DIFF
--- a/ansible/roles/test/files/ptftests/fib.py
+++ b/ansible/roles/test/files/ptftests/fib.py
@@ -19,6 +19,7 @@ EXCLUDE_IPV4_PREFIXES = [
 EXCLUDE_IPV6_PREFIXES = [
         '::/128',               # Unspecified           RFC 4291
         '::1/128',              # Loopback              RFC 4291
+        'fc00::/8',             # Interface local address that can interfere in testing T2 topology (learnt via fabric)
         'fe80::/10',            # Link local            RFC 4291
         'ff00::/8'              # Multicast             RFC 4291
         ]

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -103,6 +103,7 @@ class FibTest(BaseTest):
         fib_info = self.test_params.get('fib_info', None)
         self.fib = fib.Fib(self.test_params['fib_info']) if fib_info is not None else None
         self.router_mac = self.test_params.get('router_mac', None)
+        self.exp_router_mac = self.test_params.get('exp_router_mac', None)
         self.pktlen = self.test_params.get('testbed_mtu', 1500)
 
         self.test_ipv4 = self.test_params.get('ipv4', True)
@@ -124,6 +125,8 @@ class FibTest(BaseTest):
             # Provide the list of all UP interfaces with index in sequence order starting from 0
             if self.test_params['testbed_type'] == 't1' or self.test_params['testbed_type'] == 't1-lag' or self.test_params['testbed_type'] == 't0-64-32':
                 self.src_ports = range(0, 32)
+            if self.test_params['testbed_type'] == 't2':
+                self.src_ports = range(32, 63)
             if self.test_params['testbed_type'] == 't1-64-lag' or self.test_params['testbed_type'] == 't1-64-lag-clet':
                 self.src_ports = [0, 1, 4, 5, 16, 17, 20, 21, 34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63]
             if self.test_params['testbed_type'] == 't0':
@@ -236,9 +239,12 @@ class FibTest(BaseTest):
                             ip_options=self.ip_options,
                             dl_vlan_enable=self.src_vid is not None,
                             vlan_vid=self.src_vid or 0)
+
+        exp_router_mac = self.exp_router_mac if self.exp_router_mac else self.router_mac
+
         exp_pkt = simple_tcp_packet(
                             self.pktlen,
-                            eth_src=self.router_mac,
+                            eth_src=exp_router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
                             tcp_sport=sport,
@@ -284,9 +290,12 @@ class FibTest(BaseTest):
                                 ipv6_hlim=self.ttl,
                                 dl_vlan_enable=self.src_vid is not None,
                                 vlan_vid=self.src_vid or 0)
+
+        exp_router_mac = self.exp_router_mac if self.exp_router_mac else self.router_mac
+
         exp_pkt = simple_tcpv6_packet(
                                 pktlen=self.pktlen,
-                                eth_src=self.router_mac,
+                                eth_src=exp_router_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,
                                 tcp_sport=sport,

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -54,6 +54,7 @@ class HashTest(BaseTest):
         self.vlan_ids = self.test_params.get('vlan_ids', [])
         self.hash_keys = self.test_params.get('hash_keys', ['src-ip', 'dst-ip', 'src-port', 'dst-port'])
         self.dst_macs = self.test_params.get('dst_macs', [])    # TODO
+        self.in_port_router_mac = self.test_params.get('in_port_router_mac', None)
 
         self.balancing_range = self.test_params.get('balancing_range', self.DEFAULT_BALANCING_RANGE)
 
@@ -130,8 +131,10 @@ class HashTest(BaseTest):
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
 
+        in_port_router_mac = self.in_port_router_mac if self.in_port_router_mac else dst_mac
+
         pkt = simple_tcp_packet(pktlen=100 if vlan_id == 0 else 104,
-                            eth_dst=dst_mac,
+                            eth_dst=in_port_router_mac,
                             eth_src=src_mac,
                             dl_vlan_enable=False if vlan_id == 0 else True,
                             vlan_vid=vlan_id,
@@ -179,8 +182,10 @@ class HashTest(BaseTest):
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto(ipv6=True) if hash_key == "ip-proto" else None
 
+        in_port_router_mac = self.in_port_router_mac if self.in_port_router_mac else dst_mac
+
         pkt = simple_tcpv6_packet(pktlen=100 if vlan_id == 0 else 104,
-                                eth_dst=dst_mac,
+                                eth_dst=in_port_router_mac,
                                 eth_src=src_mac,
                                 dl_vlan_enable=False if vlan_id == 0 else True,
                                 vlan_vid=vlan_id,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
- Modified FIB testcases to support T2 topology on Multi-dut
<!--

-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Needed FIB testcases to support T2 topology for multi-dut

#### How did you do it?
To run traffic across multiple line cards in case of VOQ, needed access to T3 and T2 line cards so removed 'rand_one_dut_hostname' . 
sending traffic from T1 to T3 line cards.
#### How did you verify/test it?
Ran testcases on VOQ testbed with T2 topology
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T2 
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
