### PR TITLE
[cache] ignore cache attribute error

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -227,7 +227,10 @@ def get_host_visible_vars(inv_files, hostname, variable=None):
             logger.error("Unable to find host {} in {}".format(hostname, str(inv_files)))
             return None
 
-        host_visible_vars = vm.get_vars(host=host)
+        try:
+            host_visible_vars = vm.get_vars(host=host)
+        except AttributeError:
+            host_visible_vars = {}
         cache.write(hostname, 'host_visible_vars', {'inv_files': inv_files, 'vars': host_visible_vars})
 
     if variable:


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When building variable cache the first time, there will be an attribute error.

#### How did you do it?
Catch and ignore the initial cache error.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run test against a DUT doesn't have cache built (or remove the cache). Without the fix, there would be an exception. With the fix, the test proceeds.

__________________________________________________________ ERROR at setup of test_disable_rsyslog_rate_limit[str-7260cx3-acs-1] __________________________________________________________

enhance_inventory = None, ansible_adhoc = <function init_host_mgr at 0x7ff6a1944350>
tbinfo = {'comment': 'yingxie', 'conf-name': 'vms7-t0-7260-1', 'duts': ['str-7260cx3-acs-1'], 'duts_map': {'str-7260cx3-acs-1': 0}, ...}

    @pytest.fixture(name="duthosts", scope="session")
    def fixture_duthosts(enhance_inventory, ansible_adhoc, tbinfo):
        """
        @summary: fixture to get DUT hosts defined in testbed.
        @param ansible_adhoc: Fixture provided by the pytest-ansible package.
            Source of the various device objects. It is
            mandatory argument for the class constructors.
        @param tbinfo: fixture provides information about testbed.
        """
>       return DutHosts(ansible_adhoc, tbinfo)

ansible_adhoc = <function init_host_mgr at 0x7ff6a1944350>
enhance_inventory = None
tbinfo     = {'comment': 'yingxie', 'conf-name': 'vms7-t0-7260-1', 'duts': ['str-7260cx3-acs-1'], 'duts_map': {'str-7260cx3-acs-1': 0}, ...}

conftest.py:226:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
common/devices.py:1947: in __init__
    self.supervisor_nodes = self._Nodes([node for node in self.nodes if node.is_supervisor_node()])
common/devices.py:363: in is_supervisor_node
    return is_supervisor_node(inv_files, self.hostname)
common/helpers/dut_utils.py:14: in is_supervisor_node
    node_type = get_host_visible_vars(inv_files, hostname, variable='type')
common/utilities.py:230: in get_host_visible_vars
    host_visible_vars = vm.get_vars(host=host)
/usr/local/lib/python2.7/dist-packages/ansible/vars/manager.py:171: in get_vars
    include_delegate_to=include_delegate_to,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ansible.vars.manager.VariableManager object at 0x7ff6a0538c50>, play = None, host = str-7260cx3-acs-1, task = None, include_hostvars = True, include_delegate_to = True

    def _get_magic_variables(self, play, host, task, include_hostvars, include_delegate_to):
        '''
        Returns a dictionary of so-called "magic" variables in Ansible,
        which are special variables we set internally for use.
        '''
    
        variables = {}
>       variables['playbook_dir'] = os.path.abspath(self._loader.get_basedir())
E       AttributeError: 'VariableManager' object has no attribute '_loader'

host       = str-7260cx3-acs-1
include_delegate_to = True
include_hostvars = True
play       = None
self       = <ansible.vars.manager.VariableManager object at 0x7ff6a0538c50>
task       = None
variables  = {}

/usr/local/lib/python2.7/dist-packages/ansible/vars/manager.py:435: AttributeError