### PR TITLE
[kvmtest] Clear cache before subsequent PR test runs

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -187,6 +187,10 @@ export ANSIBLE_LIBRARY=$SONIC_MGMT_DIR/ansible/library/
 # workaround for issue https://github.com/Azure/sonic-mgmt/issues/1659
 export ANSIBLE_KEEP_REMOTE_FILES=1
 
+# clear cache from previous test runs
+rm -rf $SONIC_MGMT_DIR/tests/_cache
+
+# clear logs from previous test runs
 rm -rf $SONIC_MGMT_DIR/tests/logs
 mkdir -p  $SONIC_MGMT_DIR/tests/logs
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [kvmtest] Clear cache before subsequent PR test runs

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We want to avoid regressions like the one described in https://github.com/Azure/sonic-mgmt/pull/2892 in the future. Also, this helps us prevent any weird, inconsistent behavior between PR tests.

#### How did you do it?
Added a line to remove the cache directory in the kvmtest script.

#### How did you verify/test it?
Re-ran the tests to verify they still run.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
