### PR TITLE
[pdu] address SENTRY4 PDU support issues

### DIFF
--- a/tests/common/plugins/psu_controller/snmp_psu_controllers.py
+++ b/tests/common/plugins/psu_controller/snmp_psu_controllers.py
@@ -72,8 +72,8 @@ class snmpPsuController(PsuControllerBase):
         EMERSON_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.476.1.42.3.8.50.20.1.100.1.1"
         # MIB OID for 'Sentry Switched PDU'
         SENTRY4_PORT_NAME_BASE_OID = "1.3.6.1.4.1.1718.4.1.8.2.1.3"
-        SENTRY4_PORT_STATUS_BASE_OID = "1.3.6.1.4.1.1718.4.1.8.3.1.1.1.1"
-        SENTRY4_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.1718.4.1.8.5.1.1.1.1"
+        SENTRY4_PORT_STATUS_BASE_OID = "1.3.6.1.4.1.1718.4.1.8.3.1.1"
+        SENTRY4_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.1718.4.1.8.5.1.2"
         self.STATUS_ON = "1"
         self.STATUS_OFF = "0"
         self.CONTROL_ON = "1"
@@ -151,6 +151,10 @@ class snmpPsuController(PsuControllerBase):
         """
         Dynamically update Oids based on the PDU lane ID
         """
+        if self.psuType == "SENTRY4":
+            # No need to update lane for SENTRY4
+            return
+
         self.pPORT_NAME_BASE_OID     = self.pPORT_NAME_BASE_OID[0: -1] + str(lane_id)
         self.pPORT_STATUS_BASE_OID   = self.pPORT_STATUS_BASE_OID[0: -1] + str(lane_id)
         self.pPORT_CONTROL_BASE_OID  = self.pPORT_CONTROL_BASE_OID[0: -1] + str(lane_id)


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PDU control cannot get PDU status on Sentry4 PDUs.

#### How did you do it?

- SENTRY4 PSU doesn't need to do lane updated.  The port/status/control OID is fixed.
- SENTRY4 PSU return port OID in the format of 1.1.port_ID.  therefore, removing the trailing '1.1' from status/control OID prefix.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Dummy test code like following:

```
def test_pdu(duthosts, enum_dut_hostname, psu_controller):
    dut = duthosts[enum_dut_hostname]
    status = psu_controller.get_psu_status()
    psutype = psu_controller.psuType
    ports = psu_controller.pdu_ports
    hname = psu_controller.hostname
    logger.warning('psu controller status: {}, type {}, ports {}, host {}'.format(status, psutype, ports, hname))
    psu_controller.turn_off_psu(0)
    status = psu_controller.get_psu_status()
    logger.warning('psu controller status: {}, type {}, ports {}, host {}'.format(status, psutype, ports, hname))
    psu_controller.turn_on_psu(0)
    status = psu_controller.get_psu_status()
    logger.warning('psu controller status: {}, type {}, ports {}, host {}'.format(status, psutype, ports, hname))

Output:
test_foo.py::test_pdu[str-7260cx3-acs-1]
------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------
07:48:59 WARNING test_foo.py:test_pdu:21: psu controller status: [{'psu_id': 0, 'psu_on': True}, {'psu_id': 1, 'psu_on': True}], type SENTRY4, ports ['.1.1.36', '.1.1.37'], host str-7260cx3-acs-1
07:48:59 WARNING test_foo.py:test_pdu:24: psu controller status: [{'psu_id': 0, 'psu_on': False}, {'psu_id': 1, 'psu_on': True}], type SENTRY4, ports ['.1.1.36', '.1.1.37'], host str-7260cx3-acs-1
07:49:00 WARNING test_foo.py:test_pdu:27: psu controller status: [{'psu_id': 0, 'psu_on': True}, {'psu_id': 1, 'psu_on': True}], type SENTRY4, ports ['.1.1.36', '.1.1.37'], host str-7260cx3-acs-1
PASSED                     
```