### PR TITLE
Fix no '_loader' attribute issue of cached variable manager

### DIFF
--- a/tests/common/cache/facts_cache.py
+++ b/tests/common/cache/facts_cache.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 import os
-import pickle
+import cPickle as pickle
 import shutil
 import sys
 
@@ -111,7 +111,7 @@ class FactsCache(with_metaclass(Singleton, object)):
                     os.makedirs(cache_subfolder)
 
                 with open(facts_file, 'w') as f:
-                    pickle.dump(value, f)
+                    pickle.dump(value, f, pickle.HIGHEST_PROTOCOL)
                     self._cache[zone][key] = value
                     logger.info('Cached facts "{}.{}" to {}'.format(zone, key, facts_file))
                     return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Due the limitation of pickle, the variable manager objected loaded from pickle file does not
have the _loader and _hostvars attribute set. This could cause below exception when trying
to get host visible variables from cached variable manager:
```
    AttributeError: 'VariableManager' object has no attribute '_loader'
```
The cached inventory manager also has the similar issue.

#### How did you do it?
The fix is not to cache inventory manager and variable manager. This PR also replaced pickle
with cPickle which is faster.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
