### PR TITLE
Create certificates for starting RESTAPI server

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -161,6 +161,8 @@
         dsmsroot_key_t: ""
         dsmsroot_cer_t: ""
         dir_path_t: ""
+        subject_server: ""
+        subject_client: ""
 
     - name: read server key
       set_fact:
@@ -187,10 +189,15 @@
         dir_path_t: "{{ telemetry_certs['dir_path'] }}"
       when: telemetry_certs['dir_path'] is defined
 
-    - name: read subject
+    - name: read server subject
       set_fact:
-        subject_t: "{{ telemetry_certs['subject'] }}"
-      when: telemetry_certs['subject'] is defined
+        subject_server: "{{ telemetry_certs['subject_server'] }}"
+      when: telemetry_certs['subject_server'] is defined
+    
+    - name: read client subject
+      set_fact:
+        subject_client: "{{ telemetry_certs['subject_client'] }}"
+      when: telemetry_certs['subject_client'] is defined
 
     - include_tasks: deploy_certs.yml
       vars:
@@ -199,7 +206,8 @@
         server_key: "{{ server_key_t }}"
         dsmsroot_cer: "{{ dsmsroot_cer_t }}"
         dsmsroot_key: "{{ dsmsroot_key_t }}"
-        subject: "{{ subject_t }}"
+        cert_subject: "{{ subject_server }}"
+        root_subject: "{{ subject_client }}"
     
     when: deploy is defined and deploy|bool == true
 
@@ -236,8 +244,7 @@
         dir_path: "{{ dir_path_t }}"
         server_crt: "{{ server_crt_t }}"
         server_key: "{{ server_key_t }}"
-        subject: "{{ subject_t }}"
-    
+        cert_subject: "{{ subject_t }}"
     when: deploy is defined and deploy|bool == true
 
   - block:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -221,6 +221,45 @@
     when: deploy is defined and deploy|bool == true
 
   - block:
+    - name: Init restapi keys
+      set_fact:
+        server_key: ""
+        server_crt: ""
+        root_cert: ""
+        dir_path: ""
+
+    - name: read server key
+      set_fact:
+        server_key: "{{ restapi_certs['server_key'] }}"
+      when: restapi_certs['server_key'] is defined
+
+    - name: read server crt
+      set_fact:
+        server_crt: "{{ restapi_certs['server_crt'] }}"
+      when: restapi_certs['server_crt'] is defined
+
+    - name: read root cert
+      set_fact:
+        root_cert: "{{ restapi_certs['root_cert'] }}"
+      when: restapi_certs['root_cert'] is defined
+
+    - name: read directory path
+      set_fact:
+        dir_path: "{{ restapi_certs['dir_path'] }}"
+      when: restapi_certs['dir_path'] is defined
+
+    - name: Generate server cert using openssl.
+      command: openssl req \
+          -x509 \
+          -sha256 \
+          -nodes \
+          -newkey rsa:2048 \
+          -keyout "{{ server_key }}"
+          -subj "/CN=sonic.restapi.test"
+          -out "{{ server_crt }}"
+      become: true
+
+  - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -266,6 +266,8 @@
           -out "{{ server_crt }}"
       become: true
 
+    when: deploy is defined and deploy|bool == true
+
   - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -248,6 +248,13 @@
         dir_path: "{{ restapi_certs['dir_path'] }}"
       when: restapi_certs['dir_path'] is defined
 
+    - name: Create restapi directory
+      file:
+        path: "{{ dir_path }}"
+        state: directory
+        mode: '0755'
+      become: true
+
     - name: Generate server cert using openssl.
       command: openssl req \
           -x509 \

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -156,116 +156,88 @@
   - block:
     - name: Init telemetry keys
       set_fact:
-        server_key: ""
-        server_cer: ""
-        dsmsroot_key: ""
-        dsmsroot_cer: ""
-        dir_path: ""
+        server_key_t: ""
+        server_cer_t: ""
+        dsmsroot_key_t: ""
+        dsmsroot_cer_t: ""
+        dir_path_t: ""
 
     - name: read server key
       set_fact:
-        server_key: "{{ telemetry_certs['server_key'] }}"
+        server_key_t: "{{ telemetry_certs['server_key'] }}"
       when: telemetry_certs['server_key'] is defined
 
     - name: read server cer
       set_fact:
-        server_cer: "{{ telemetry_certs['server_cer'] }}"
+        server_cer_t: "{{ telemetry_certs['server_cer'] }}"
       when: telemetry_certs['server_cer'] is defined
 
     - name: read dsmsroot key
       set_fact:
-        dsmsroot_key: "{{ telemetry_certs['dsmsroot_key'] }}"
+        dsmsroot_key_t: "{{ telemetry_certs['dsmsroot_key'] }}"
       when: telemetry_certs['dsmsroot_key'] is defined
 
     - name: read dsmsroot cer
       set_fact:
-        dsmsroot_cer: "{{ telemetry_certs['dsmsroot_cer'] }}"
+        dsmsroot_cer_t: "{{ telemetry_certs['dsmsroot_cer'] }}"
       when: telemetry_certs['dsmsroot_cer'] is defined
 
     - name: read directory path
       set_fact:
-        dir_path: "{{ telemetry_certs['dir_path'] }}"
+        dir_path_t: "{{ telemetry_certs['dir_path'] }}"
       when: telemetry_certs['dir_path'] is defined
 
-    - name: Create telemetry directory
-      file:
-        path: "{{ dir_path }}"
-        state: directory
-        mode: '0755'
-      become: true
+    - name: read subject
+      set_fact:
+        subject_t: "{{ telemetry_certs['subject'] }}"
+      when: telemetry_certs['subject'] is defined
 
-    # {{ server_cer }}/ streamingtelemetryserver.cer need to be copied on PTFDocker and renamed as dsmsroot.cer
-    - name: Generate server cert using openssl.
-      command: openssl req \
-          -x509 \
-          -sha256 \
-          -nodes \
-          -newkey rsa:2048 \
-          -keyout "{{ server_key }}"
-          -subj "/CN=ndastreamingservertest"
-          -out "{{ server_cer }}"
-      become: true
-
-    # {{ dsmsroot_cer }}/ dsmsroot.cer need to be copied on PTFDocker and renamed as streamingtelemetryclient.cer
-    # {{ dsms_key }}/ dsmsroot.key need to be copied and renamed as streamingtelemetryclient.key
-    - name: Generate dsmsroot cert using openssl.
-      command: openssl req \
-          -x509 \
-          -sha256 \
-          -nodes \
-          -newkey rsa:2048 \
-          -keyout "{{ dsmsroot_key }}"
-          -subj "/CN=ndastreamingclienttest"
-          -out "{{ dsmsroot_cer }}"
-      become: true
+    - include_tasks: deploy_certs.yml
+      vars:
+        dir_path: "{{ dir_path_t }}"
+        server_crt: "{{ server_cer_t }}"
+        server_key: "{{ server_key_t }}"
+        dsmsroot_cer: "{{ dsmsroot_cer_t }}"
+        dsmsroot_key: "{{ dsmsroot_key_t }}"
+        subject: "{{ subject_t }}"
+    
     when: deploy is defined and deploy|bool == true
 
   - block:
     - name: Init restapi keys
       set_fact:
-        server_key: ""
-        server_crt: ""
-        root_cert: ""
-        dir_path: ""
+        server_key_t: ""
+        server_crt_t: ""
+        dir_path_t: ""
+        subject_t: ""
 
     - name: read server key
       set_fact:
-        server_key: "{{ restapi_certs['server_key'] }}"
+        server_key_t: "{{ restapi_certs['server_key'] }}"
       when: restapi_certs['server_key'] is defined
 
     - name: read server crt
       set_fact:
-        server_crt: "{{ restapi_certs['server_crt'] }}"
+        server_crt_t: "{{ restapi_certs['server_crt'] }}"
       when: restapi_certs['server_crt'] is defined
 
-    - name: read root cert
+    - name: read subject
       set_fact:
-        root_cert: "{{ restapi_certs['root_cert'] }}"
-      when: restapi_certs['root_cert'] is defined
+        subject_t: "{{ restapi_certs['subject'] }}"
+      when: restapi_certs['subject'] is defined
 
     - name: read directory path
       set_fact:
-        dir_path: "{{ restapi_certs['dir_path'] }}"
+        dir_path_t: "{{ restapi_certs['dir_path'] }}"
       when: restapi_certs['dir_path'] is defined
 
-    - name: Create restapi directory
-      file:
-        path: "{{ dir_path }}"
-        state: directory
-        mode: '0755'
-      become: true
-
-    - name: Generate server cert using openssl.
-      command: openssl req \
-          -x509 \
-          -sha256 \
-          -nodes \
-          -newkey rsa:2048 \
-          -keyout "{{ server_key }}"
-          -subj "/CN=sonic.restapi.test"
-          -out "{{ server_crt }}"
-      become: true
-
+    - include_tasks: deploy_certs.yml
+      vars:
+        dir_path: "{{ dir_path_t }}"
+        server_crt: "{{ server_crt_t }}"
+        server_key: "{{ server_key_t }}"
+        subject: "{{ subject_t }}"
+    
     when: deploy is defined and deploy|bool == true
 
   - block:

--- a/ansible/deploy_certs.yml
+++ b/ansible/deploy_certs.yml
@@ -1,0 +1,29 @@
+- name: Create directory
+  file:
+    path: "{{ dir_path }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Generate server cert using openssl.
+  command: openssl req \
+      -x509 \
+      -sha256 \
+      -nodes \
+      -newkey rsa:2048 \
+      -keyout "{{ server_key }}"
+      -subj "/CN={{ subject }}"
+      -out "{{ server_crt }}"
+  become: true
+
+- name: Generate dsmsroot cert using openssl.
+  command: openssl req \
+      -x509 \
+      -sha256 \
+      -nodes \
+      -newkey rsa:2048 \
+      -keyout "{{ dsmsroot_key }}"
+      -subj "/CN={{ subject }}"
+      -out "{{ dsmsroot_cer }}"
+  become: true
+  when: dsmsroot_cer is defined and dsmsroot_key is defined

--- a/ansible/deploy_certs.yml
+++ b/ansible/deploy_certs.yml
@@ -12,7 +12,7 @@
       -nodes \
       -newkey rsa:2048 \
       -keyout "{{ server_key }}"
-      -subj "/CN={{ subject }}"
+      -subj "/CN={{ cert_subject }}"
       -out "{{ server_crt }}"
   become: true
 
@@ -23,7 +23,7 @@
       -nodes \
       -newkey rsa:2048 \
       -keyout "{{ dsmsroot_key }}"
-      -subj "/CN={{ subject }}"
+      -subj "/CN={{ root_subject }}"
       -out "{{ dsmsroot_cer }}"
   become: true
   when: dsmsroot_cer is defined and dsmsroot_key is defined

--- a/ansible/group_vars/all/restapi_certs.yml
+++ b/ansible/group_vars/all/restapi_certs.yml
@@ -1,0 +1,7 @@
+# Configure restapi server certificates
+
+restapi_certs:
+    server_key: "/etc/sonic/credentials/restapiserver.key"
+    server_crt: "/etc/sonic/credentials/restapiserver.crt"
+    root_cert: "/etc/sonic/telemetry/AME_ROOT_CERTIFICATE.pem"
+    dir_path: "/etc/sonic/credentials"

--- a/ansible/group_vars/all/restapi_certs.yml
+++ b/ansible/group_vars/all/restapi_certs.yml
@@ -3,5 +3,5 @@
 restapi_certs:
     server_key: "/etc/sonic/credentials/restapiserver.key"
     server_crt: "/etc/sonic/credentials/restapiserver.crt"
-    root_cert: "/etc/sonic/telemetry/AME_ROOT_CERTIFICATE.pem"
+    subject: "client.restapi.test"
     dir_path: "/etc/sonic/credentials"

--- a/ansible/group_vars/all/telemetry_certs.yml
+++ b/ansible/group_vars/all/telemetry_certs.yml
@@ -7,4 +7,5 @@ telemetry_certs:
     dsmsroot_key: "/etc/sonic/telemetry/dsmsroot.key"
     dsmsroot_csr: "/etc/sonic/telemetry/dsmsroot.csr"
     dsmsroot_cer: "/etc/sonic/telemetry/dsmsroot.cer"
+    subject: "ndastreamingclienttest"
     dir_path: "/etc/sonic/telemetry"

--- a/ansible/group_vars/all/telemetry_certs.yml
+++ b/ansible/group_vars/all/telemetry_certs.yml
@@ -7,5 +7,6 @@ telemetry_certs:
     dsmsroot_key: "/etc/sonic/telemetry/dsmsroot.key"
     dsmsroot_csr: "/etc/sonic/telemetry/dsmsroot.csr"
     dsmsroot_cer: "/etc/sonic/telemetry/dsmsroot.cer"
-    subject: "ndastreamingclienttest"
+    subject_client: "ndastreamingclienttest"
+    subject_server: "ndastreamingservertest"
     dir_path: "/etc/sonic/telemetry"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

RESTAPI server requires server certificates to be present in order to start. Without RESTAPI server starting, monit will complain that restapi is not running. Therefore, creating and deploying dummy certificates to start RESTAPI server, will prevent sanity checks from failing.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [*] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
RESTAPI server requires server certificates to be present in order to start. Without RESTAPI server starting, monit will complain that restapi is not running. Therefore, creating and deploying dummy certificates to start RESTAPI server, will prevent sanity checks from failing.
#### How did you do it?
In the config_sonic_basedon_testbed.yml, I added the openssl logic to create certificates on the DUT in the correct location.
#### How did you verify/test it?
New certificates were creates in /etc/sonic/credentials and restapi server started as expected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
