### PR TITLE
[everflow] Fix mirror session parsing on 201911 images

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -608,6 +608,12 @@ class BaseEverflowTest(object):
                       "Test mirror session {} not found".format(mirror_session["session_name"]))
 
         lines = mirror_output["stdout_lines"]
+
+        if "201911" in duthost.os_version:
+            # Because this line is not in the output in 201911, we need to add it so that the
+            # parser is consistent between 201911 and future versions.
+            lines = ["ERSPAN Sessions"] + lines
+
         sessions = self._parse_mirror_session_running_config(lines)
 
         session = [x for x in sessions["ERSPAN Sessions"]["data"] if x["Name"] == mirror_session["session_name"]]


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [everflow] Fix mirror session parsing on 201911 images
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
https://github.com/Azure/sonic-mgmt/pull/2708 changed the method for parsing mirror sessions to account for changes in the master branch. However, it is not backwards compatible w/ the 201911 image.

#### How did you do it?
I appended some extra input to the mirror session output so that the format would match the master branch.

#### How did you verify/test it?
Re-ran the everflow IPV6 tests against 201911 and master image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
