### PR TITLE
[Docs] Fix the platform option for building docker-ptf.gz

### DIFF
--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -64,7 +64,7 @@ The PTF docker container is used to send and receive data plane packets to the D
     ```
     git clone --recursive https://github.com/Azure/sonic-buildimage.git
     cd sonic-buildimage
-    make configure PLATFORM=generic ;#takes about 1 hour or more
+    make configure PLATFORM=vs ;#takes about 1 hour or more
     make target/docker-ptf.gz
     ```
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the platform option for building docker-ptf.gz

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When I try to build target/docker-ptf.gz according to the document, it will show "No rule to make target 'target/docker-ptf.gz".
#### How did you do it?
According to https://github.com/Azure/sonic-buildimage/pull/6540, the platform option to build docker-ptf.gz should change to vs.
#### How did you verify/test it?
After changed the platform option to vs, target/docker-ptf.gz can be successfully built.

