### PR TITLE
[kvmtest]: add multipath relex and bbr to t1-lag kvmtest

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -151,6 +151,9 @@ test_t1_lag() {
     monit/test_monit_status.py \
     test_interfaces.py \
     bgp/test_bgp_fact.py \
+    bgp/test_bgp_multipath_relax.py \
+    bgp/test_bgp_bbr.py \
+    bgp/test_bgp_bounce.py \
     lldp/test_lldp.py \
     route/test_default_route.py \
     platform_tests/test_cpu_memory_usage.py \


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
add multipath relex and bbr to t1-lag kvmtest

#### How did you do it?

#### How did you verify/test it?
run test with latest master image locally

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
