### PR TITLE
[acl] Skip IPv6 dataacl tests on 201911 images

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -162,9 +162,12 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
 
 
 @pytest.fixture(scope="module", params=["ipv4", "ipv6"])
-def ip_version(request, tbinfo):
+def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
     if tbinfo["topo"]["type"] == "t0" and request.param == "ipv6":
         pytest.skip("IPV6 ACL test not currently supported on t0 testbeds")
+
+    if "201911" in duthosts[rand_one_dut_hostname].os_version and request.param == "ipv6":
+        pytest.skip("acl-loader does not handle IPV6 default drop rule correctly in 201911")
 
     return request.param
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [acl] Skip IPv6 dataacl tests on 201911 images
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In the 201911 branch `acl-loader` inserts an ETHERTYPE rule as the default rule for all dataplane ACL rules. This is not allowed for IPv6 ACLs, so the command fails, so the tests all fail due to loganalyzer errors.

#### How did you do it?
I added a skip for IPv6 dataacl tests against 201911 images (unless we eventually decide to backport support to the 201911 branch).

#### How did you verify/test it?
Re-ran tests against 201911 image, verified the tests are skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
