### PR TITLE
[dualtor] Add tunnel traffic utility

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -97,23 +97,31 @@ def map_hostname_to_tor_side(tbinfo, hostname):
         return None
 
 
+def get_t1_ptf_pc_ports(dut, tbinfo):
+    """Gets the PTF portchannel ports connected to the T1 switchs."""
+    config_facts = dut.get_running_config_facts()
+    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+
+    pc_ports = {}
+    for pc in config_facts['PORTCHANNEL'].keys():
+        pc_ports[pc] = []
+        for intf in config_facts["PORTCHANNEL"][pc]["members"]:
+            ptf_port_index = mg_facts["minigraph_ptf_indices"][intf]
+            intf_name = "eth{}".format(ptf_port_index)
+            pc_ports[pc].append(intf_name)
+
+    return pc_ports
+
+
 def get_t1_ptf_ports(dut, tbinfo):
     '''
     Gets the PTF ports connected to a given DUT for the first T1
     '''
-    config_facts = dut.get_running_config_facts()
-    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+    pc_ports = get_t1_ptf_pc_ports(dut, tbinfo)
 
     # Always choose the first portchannel
-    portchannel = sorted(config_facts['PORTCHANNEL'].keys())[0]
-    dut_portchannel_members = config_facts['PORTCHANNEL'][portchannel]['members']
-
-    ptf_portchannel_intfs = []
-
-    for intf in dut_portchannel_members:
-        member = mg_facts['minigraph_ptf_indices'][intf]
-        intf_name = 'eth{}'.format(member)
-        ptf_portchannel_intfs.append(intf_name)
+    portchannel = sorted(pc_ports.keys())[0]
+    ptf_portchannel_intfs = pc_ports[portchannel]
 
     logger.info("Using portchannel ports {} on PTF for DUT {}".format(ptf_portchannel_intfs, dut.hostname))
     return ptf_portchannel_intfs
@@ -157,7 +165,7 @@ def update_mux_configs_and_config_reload(dut, state):
     # Update mux_cable state and dump to a temp file
     mux_cable_config_json = json.loads(mux_cable_config)
     for _, config in mux_cable_config_json.items():
-            config['state'] = state
+        config['state'] = state
     mux_cable_config_json = {"MUX_CABLE": mux_cable_config_json}
     TMP_FILE = "/tmp/mux_config.json"
     with open(TMP_FILE, "w") as f:
@@ -188,6 +196,7 @@ def force_active_tor(dut, intf):
         for i in intf:
             cmds.append("config muxcable mode active {}".format(i))
     dut.shell_cmds(cmds=cmds)
+
 
 def _get_tor_fanouthosts(tor_host, fanouthosts):
     """Helper function to get the fanout host objects that the current tor_host connected to.

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -1,0 +1,131 @@
+"""Tunnel traffic verification utilities."""
+import ipaddress
+import logging
+import operator
+import pytest
+import sys
+
+from io import BytesIO
+from ptf import mask, testutils
+from scapy.all import IP, Ether
+from tests.common.dualtor import dual_tor_utils
+
+
+@pytest.fixture(scope="function")
+def tunnel_traffic_monitor(ptfadapter, tbinfo):
+
+    class TunnelTrafficMonitor(object):
+        """Monit tunnel traffic from standby ToR to active ToR."""
+
+        @staticmethod
+        def _get_t1_ptf_port_indexes(dut, tbinfo):
+            """Get the port indexes of those ptf port connecting to T1 switches."""
+            pc_ports = dual_tor_utils.get_t1_ptf_pc_ports(dut, tbinfo)
+            return [int(_.strip("eth")) for _ in reduce(operator.add, pc_ports.values(), [])]
+
+        @staticmethod
+        def _find_ipv4_lo_addr(config_facts):
+            """Find the ipv4 Loopback0 address."""
+            for addr in config_facts["LOOPBACK_INTERFACE"]["Loopback0"]:
+                if isinstance(ipaddress.ip_network(addr), ipaddress.IPv4Network):
+                    return addr.split("/")[0]
+
+        @staticmethod
+        def _build_tunnel_packet(out_src_ip, out_dst_ip):
+            """Build the expected tunnel packet."""
+            exp_pkt = testutils.simple_ip_packet(
+                ip_src=out_src_ip,
+                ip_dst=out_dst_ip,
+                pktlen=20
+            )
+            exp_pkt = mask.Mask(exp_pkt)
+            exp_pkt.set_do_not_care_scapy(Ether, "dst")
+            exp_pkt.set_do_not_care_scapy(Ether, "src")
+            exp_pkt.set_do_not_care_scapy(IP, "ihl")
+            exp_pkt.set_do_not_care_scapy(IP, "tos")
+            exp_pkt.set_do_not_care_scapy(IP, "len")
+            exp_pkt.set_do_not_care_scapy(IP, "id")
+            exp_pkt.set_do_not_care_scapy(IP, "flags")
+            exp_pkt.set_do_not_care_scapy(IP, "frag")
+            exp_pkt.set_do_not_care_scapy(IP, "ttl")
+            exp_pkt.set_do_not_care_scapy(IP, "proto")
+            exp_pkt.set_do_not_care_scapy(IP, "chksum")
+            exp_pkt.set_ignore_extra_bytes()
+            return exp_pkt
+
+        @staticmethod
+        def _dump_show_str(packet):
+            """Dump packet show output to string."""
+            _stdout, sys.stdout = sys.stdout, BytesIO()
+            try:
+                packet.show()
+                return sys.stdout.getvalue()
+            finally:
+                sys.stdout = _stdout
+
+        @staticmethod
+        def _check_ttl(packet):
+            """Check ttl field in the packet."""
+            outer_ttl, inner_ttl = packet[IP].ttl, packet[IP].payload[IP].ttl
+            logging.debug("Outer packet TTL: %s, inner packet TTL: %s", outer_ttl, inner_ttl)
+            if outer_ttl != inner_ttl:
+                raise ValueError("Outer packet TTL not same as inner packet TTL.")
+
+        @staticmethod
+        def _check_tos(packet):
+            """Check ToS field in the packet."""
+
+            def _disassemble_ip_tos(tos):
+                return tos >> 2, tos & 0x3
+
+            outer_tos, inner_tos = packet[IP].tos, packet[IP].payload[IP].tos
+            outer_dscp, outer_ecn = _disassemble_ip_tos(outer_tos)
+            inner_dscp, inner_ecn = _disassemble_ip_tos(inner_tos)
+            logging.debug("Outer packet DSCP: {0:06b}, inner packet DSCP: {1:06b}".format(outer_dscp, inner_dscp))
+            logging.debug("Outer packet ECN: {0:02b}, inner packet ECN: {0:02b}".format(outer_ecn, inner_ecn))
+            if outer_dscp != inner_ecn:
+                raise ValueError("Outer packet DSCP not same as inner packet DSCP.")
+            if outer_ecn != inner_ecn:
+                raise ValueError("Outer packet ECN not same as inner packet ECN")
+
+        def __init__(self, active_tor, standby_tor):
+            """
+            Init the tunnel traffic monitor.
+
+            @param active_tor: active ToR that decaps the tunnel traffic.
+            @param standby_tor: standby ToR that does the encap.
+            """
+            self.active_tor = active_tor
+            self.standby_tor = standby_tor
+            self.listen_ports = sorted(self._get_t1_ptf_port_indexes(standby_tor, tbinfo))
+            self.ptfadapter = ptfadapter
+            active_tor_cfg_facts = self.active_tor.config_facts(
+                host=self.active_tor.hostname, source="persistent"
+            )["ansible_facts"]
+            standby_tor_cfg_facts = self.standby_tor.config_facts(
+                host=self.standby_tor.hostname, source="persistent"
+            )["ansible_facts"]
+            self.active_tor_lo_addr = self._find_ipv4_lo_addr(active_tor_cfg_facts)
+            self.standby_tor_lo_addr = self._find_ipv4_lo_addr(standby_tor_cfg_facts)
+            self.exp_pkt = self._build_tunnel_packet(self.standby_tor_lo_addr, self.active_tor_lo_addr)
+
+        def __enter__(self):
+            self.ptfadapter.dataplane.flush()
+
+        def __exit__(self, *exc_info):
+            if exc_info[0]:
+                return
+
+            port_index, rec_pkt = testutils.verify_packet_any_port(
+                ptfadapter,
+                self.exp_pkt,
+                ports=self.listen_ports
+            )
+            rec_pkt = Ether(rec_pkt)
+            rec_port = self.listen_ports[port_index]
+            logging.debug("Receive encap packet from PTF interface %s", "eth%s" % rec_port)
+            logging.debug("Encapsulated packet:\n%s", self._dump_show_str(rec_pkt))
+            self._check_ttl(rec_pkt)
+            self._check_tos(rec_pkt)
+
+    return TunnelTrafficMonitor


### PR DESCRIPTION
Add tunnel traffic check utility to verify that the tunnel IPinIP packet
that the fields(TTL, DSCP, and ECN) from the outer IP header are set
properly based on the TUNNEL mode.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2816

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add tunnel traffic check utility.

#### How did you do it?
Add fixture `tunnel_traffic_monitor` that returns a context manager that could support verifying traffic with the following usage:
```python
    with tunnel_traffic_monitor(upper_tor, lower_tor):
        testutils.send(ptfadapter, int(t1_lower_tor_intfs[0].strip('eth')), packet, count=1)
``` 

#### How did you verify/test it?
Sample test:
```python
import pdb
import pytest
import ptf.testutils as testutils
from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
from tests.common.dualtor.dual_tor_utils import *


pytestmark = [
    pytest.mark.topology("any"),
]


TARGET_SERVER = "192.168.0.3/21"
DUT_PORT = "Ethernet8"


@pytest.fixture(scope='function')
def setup_intf(duthosts, ptfhost, tbinfo):
    mg_facts = duthosts[0].get_extended_minigraph_facts(tbinfo)
    ptf_port_index = mg_facts["minigraph_ptf_indices"][DUT_PORT]
    ptf_port = "eth%s" % ptf_port_index
    ptfhost.shell("ifconfig %s %s" % (ptf_port, TARGET_SERVER))
    yield ptf_port_index, ptf_port
    ptfhost.shell('ifconfig %s 0.0.0.0' % ptf_port)


def test_tunnel(duthosts, ptfadapter, setup_intf, t1_lower_tor_intfs, tunnel_traffic_monitor):
    # assume upper_tor is active
    upper_tor, lower_tor = duthosts[0], duthosts[1]
    lower_tor_cfg_facts = lower_tor.config_facts(host=upper_tor.hostname, source="persistent")["ansible_facts"]

    ptf_port_index, _ = setup_intf

    router_mac = lower_tor_cfg_facts["DEVICE_METADATA"]["localhost"]["mac"]

    packet = testutils.simple_ip_packet(
        eth_dst=router_mac,
        eth_src=ptfadapter.dataplane.get_mac(0, ptf_port_index),
        ip_src="1.1.1.1",
        ip_dst=TARGET_SERVER.split("/")[0],
        ip_dscp=15,
        ip_ttl=50,
        ip_ecn=2
    )
    with tunnel_traffic_monitor(upper_tor, lower_tor):
        testutils.send(ptfadapter, int(t1_lower_tor_intfs[0].strip('eth')), packet, count=1)

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
