### PR TITLE
[port toggle] Clean up port toggle library and increase default timeouts

### DIFF
--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -1,145 +1,125 @@
-"""
-Tool used for shutdown/startup port on the DUT.
-"""
-
-import datetime
+"""Utility for shutting down/bringing up ports on the DUT."""
 import time
 import logging
 import pprint
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
+BASE_PORT_COUNT = 28.0  # default t0 topology has 28 ports to toggle
+
 
 def port_toggle(duthost, tbinfo, ports=None, wait_time_getter=None, wait_after_ports_up=60, watch=False):
-    """
-    Toggle ports on DUT.
+    """Toggle ports on the DUT.
 
     Args:
         duthost: DUT host object
+        tbinfo: Information about the testbed
         ports: Specify list of ports, None if toggle all ports
         wait_time_getter: A call back function to get port toggle wait time.
         wait_after_ports_up: Time to wait after interfaces become up
         watch: Logging system state
     """
-
     def __get_down_ports(expect_up=True):
-        """Check interface status and return the down ports in a set
-        """
-        ports_down = duthost.interface_facts(up_ports=ports)['ansible_facts']['ansible_interface_link_down_ports']
-        db_ports_down = duthost.show_interface(command='status', up_ports=ports)['ansible_facts']\
-            ['ansible_interface_link_down_ports']
+        """Check interface status and return the down ports in a set."""
+        ports_down = duthost.interface_facts(up_ports=ports)["ansible_facts"]["ansible_interface_link_down_ports"]
+        db_ports_down = duthost.show_interface(command="status", up_ports=ports)["ansible_facts"]\
+            ["ansible_interface_link_down_ports"]
         if expect_up:
             return set(ports_down) | set(db_ports_down)
         else:
             return set(ports_down) & set(db_ports_down)
 
-    if ports is None:
-        logger.debug('ports is None, toggling all minigraph ports')
+    if not ports:
+        logger.info("No ports specified, toggling all minigraph ports")
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        ports = mg_facts['minigraph_ports'].keys()
-    if not wait_time_getter:
-        wait_time_getter = get_port_toggle_wait_time
-    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports))
-    logger.info('toggling ports:\n%s', pprint.pformat(ports))
+        ports = mg_facts["minigraph_ports"].keys()
 
-    cmds_down = []
-    cmds_up = []
-    for port in ports:
-        cmds_down.append('config interface shutdown {}'.format(port))
-        cmds_up.append('config interface startup {}'.format(port))
+    if not wait_time_getter:
+        wait_time_getter = default_port_toggle_wait_time
+
+    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports))
+    logger.info("Toggling ports:\n%s", pprint.pformat(ports))
+
+    cmds_down = ["config interface shutdown {}".format(port) for port in ports]
+    cmds_up = ["config interface startup {}".format(port) for port in ports]
 
     shutdown_ok = False
-    shutdown_err_msg = ''
+    shutdown_err_msg = ""
     try:
         duthost.shell_cmds(cmds=cmds_down)
+
         if watch:
             time.sleep(1)
+            log_system_resources(duthost, logger)
 
-            # Watch memory status
-            memory_output = duthost.shell("show system-memory")["stdout"]
-            logger.info("Memory Status: %s", memory_output)
-
-            # Watch orchagent CPU utilization
-            orch_cpu = duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"]
-            logger.info("Orchagent CPU Util: %s", orch_cpu)
-
-            # Watch Redis Memory
-            redis_memory = duthost.shell("redis-cli info memory | grep used_memory_human")["stdout"]
-            logger.info("Redis Memory: %s", redis_memory)
-
-        logger.info('Wait for ports to become down.')
-        start_time = datetime.datetime.now()
-        while True:
-            down_ports = __get_down_ports(expect_up=False)
-            if len(down_ports) == len(ports):
-                shutdown_ok = True
-                break
-            time.sleep(5)
-            if (datetime.datetime.now() - start_time).seconds > port_down_wait_time:
-                break
+        logger.info("Wait for ports to go down")
+        shutdown_ok = wait_until(port_down_wait_time, 5, lambda: len(__get_down_ports(expect_up=False)) == len(ports))
 
         if not shutdown_ok:
-            shutdown_err_msg = 'Some ports did not go down as expected: {}'.format(str(set(ports) - set(down_ports)))
+            up_ports = __get_down_ports(expect_up=True)
+            shutdown_err_msg = "Some ports did not go down as expected: {}".format(str(up_ports))
     except Exception as e:
-        shutdown_err_msg = 'Shutdown ports failed with exception: {}'.format(repr(e))
+        shutdown_err_msg = "Shutdown ports failed with exception: {}".format(repr(e))
 
     startup_ok = False
-    startup_err_msg = ''
+    startup_err_msg = ""
     try:
         duthost.shell_cmds(cmds=cmds_up)
 
-        logger.info('Wait for ports to become up.')
-        start_time = datetime.datetime.now()
-        while True:
-            down_ports = __get_down_ports()
-            if len(down_ports) == 0:
-                startup_ok = True
-                break
-            time.sleep(5)
-            if (datetime.datetime.now() - start_time).seconds > port_up_wait_time:
-                break
+        logger.info("Wait for ports to come up")
+        startup_ok = wait_until(port_up_wait_time, 5, lambda: len(__get_down_ports()) == 0)
 
         if not startup_ok:
-            startup_err_msg = 'Some ports did not go up as expected: {}'.format(str(down_ports))
-
+            down_ports = __get_down_ports()
+            startup_err_msg = "Some ports did not come up as expected: {}".format(str(down_ports))
     except Exception as e:
-        startup_err_msg = 'Startup interfaces failed with exception: {}'.format(repr(e))
+        startup_err_msg = "Startup ports failed with exception: {}".format(repr(e))
 
     pytest_assert(shutdown_ok, shutdown_err_msg)
     pytest_assert(startup_ok, startup_err_msg)
 
-    logger.info('wait %d seconds for system to startup', wait_after_ports_up)
+    logger.info("Wait %d seconds for system to stabilize", wait_after_ports_up)
     time.sleep(wait_after_ports_up)
 
 
-def get_port_toggle_wait_time(duthost, port_count):
-    """
-    Port toggle wait time depends on many factors: port count, cpu type. This function allow user to customize port
-    toggle wait time according to DUT host information and port count.
-    :param duthost: DUT host object
-    :param port_count: total port count to be toggled
-    :return: port down wait time and port up wait time
-    """
-    port_down_wait_time, port_up_wait_time = 20, 60
-    asic_type = duthost.facts["asic_type"]
-    if asic_type == 'mellanox':
-        # default t0 topology has 28 ports to toggle
-        base_port_count = 28.0
-        if port_count <= base_port_count:
-            port_count_factor = 1
-        else:
-            port_count_factor = port_count / base_port_count
-        from .mellanox_data import get_chip_type
-        chip_type = get_chip_type(duthost)
-        if chip_type == 'spectrum1':
-            # spectrum based switch usually has less powerful cpu
-            port_down_wait_time = 40
-            port_up_wait_time = 70
-        else:
-            port_down_wait_time = 30
+def log_system_resources(duthost, logger):
+    # Watch memory status
+    memory_output = duthost.shell("show system-memory")["stdout"]
+    logger.info("Memory Status: %s", memory_output)
 
+    # Watch orchagent CPU utilization
+    orch_cpu = duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"]
+    logger.info("Orchagent CPU Util: %s", orch_cpu)
+
+    # Watch Redis Memory
+    redis_memory = duthost.shell("redis-cli info memory | grep used_memory_human")["stdout"]
+    logger.info("Redis Memory: %s", redis_memory)
+
+
+def default_port_toggle_wait_time(duthost, port_count):
+    """Get the default timeout for shutting down/starting up a set of ports.
+
+    Port toggle wait time can depend on many factors: port count, cpu type, etc. The callback allows
+    users to customize port toggle wait behavior based on DUT specs and port count.
+
+    Args:
+        duthost: DUT host object
+        port_count: total number of ports to toggle
+
+    Returns
+        (int, int): timeout for shutting down ports, and timeout for bringing up ports
+    """
+    port_down_wait_time, port_up_wait_time = 90, 180
+    asic_type = duthost.facts["asic_type"]
+
+    if asic_type == "mellanox":
+        if port_count <= BASE_PORT_COUNT:
+            port_count = 28.0
+
+        port_count_factor = port_count / BASE_PORT_COUNT
         port_down_wait_time = int(port_down_wait_time * port_count_factor)
         port_up_wait_time = int(port_up_wait_time * port_count_factor)
 

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -112,7 +112,7 @@ def default_port_toggle_wait_time(duthost, port_count):
     Returns
         (int, int): timeout for shutting down ports, and timeout for bringing up ports
     """
-    port_down_wait_time, port_up_wait_time = 90, 180
+    port_down_wait_time, port_up_wait_time = 120, 180
     asic_type = duthost.facts["asic_type"]
 
     if asic_type == "mellanox":

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -117,7 +117,7 @@ def default_port_toggle_wait_time(duthost, port_count):
 
     if asic_type == "mellanox":
         if port_count <= BASE_PORT_COUNT:
-            port_count = 28.0
+            port_count = BASE_PORT_COUNT
 
         port_count_factor = port_count / BASE_PORT_COUNT
         port_down_wait_time = int(port_down_wait_time * port_count_factor)


### PR DESCRIPTION
- Increase port up/down timeouts to 120/180s respectively to increase stability
- Clean up doc comments
- Refactor code to use wait_until utility

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [port toggle] Clean up port toggle library and increase default timeouts
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We see some flakiness in the ACL port toggle tests and link flap tests because we keep running into timeouts while shutting all ports/bringing up all ports.

#### How did you do it?
I significantly bumped up the timeouts for port shutdown/startup for all devices. `wait_until` will finish early on faster platforms, so we would rather use a more conservative timeout across the board than try to optimize for each different type of device.

I also went through and refactored the code to use `wait_until` instead of a custom solution, and cleaned up the doc comments for consistency.

#### How did you verify/test it?
Re-ran the test on multiple different platforms + OS versions, all look stable now.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
