### PR TITLE
[sonic_upgrade] Clean up previous downloads before downloading new image

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -52,15 +52,18 @@ def download_new_sonic_image(module, new_image_url, save_as):
     global results
 
     # Clean-up previous downloads first
-    exec_command(module, cmd="rm -f {}".format(save_as), msg="clean up previously downloaded image")
+    exec_command(module,
+                 cmd="rm -f {}".format(save_as),
+                 msg="clean up previously downloaded image",
+                 ignore_error=True)
 
     exec_command(module,
-                cmd="curl -o {} {}".format(save_as, new_image_url),
-                msg="downloading new image")
+                 cmd="curl -o {} {}".format(save_as, new_image_url),
+                 msg="downloading new image")
 
     if path.exists(save_as):
-        _, out, _ = exec_command(module,cmd="sonic_installer binary_version %s" % save_as)
-        results['downloaded_image_version'] = out.rstrip('\n')
+        _, out, _ = exec_command(module, cmd="sonic_installer binary_version {}".format(save_as))
+        results["downloaded_image_version"] = out.rstrip('\n')
 
 
 def install_new_sonic_image(module, new_image_url, save_as=None):

--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -50,6 +50,10 @@ def reduce_installed_sonic_images(module, disk_used_pcent):
 
 def download_new_sonic_image(module, new_image_url, save_as):
     global results
+
+    # Clean-up previous downloads first
+    exec_command(module, cmd="rm -f {}".format(save_as), msg="clean up previously downloaded image")
+
     exec_command(module,
                 cmd="curl -o {} {}".format(save_as, new_image_url),
                 msg="downloading new image")


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [sonic_upgrade] Clean up previous downloads before downloading new image
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We notice that very occasionally the upgrade_sonic ansible job will timeout and leave the system in an unreachable state. While investigating this, we found that the `/host/downloaded-sonic-image` was still present, and removing this file seemed to fix the system. We suspect that the download could be getting interrupted/corrupted in some situations, and cleaning up from previous installations might help prevent this issue in the future.

#### How did you do it?
Added a step prior to downloading the new image to first delete any data previously present at the download location.

#### How did you verify/test it?
Ran `upgrade_sonic` locally and verified there was no regression.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
