### PR TITLE
[swap_syncd] Improve log messages and clean-up docker code

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -1,150 +1,210 @@
-"""
-    docker contains utilities for interacting with Docker on the DUT.
-"""
+"""docker contains utilities for interacting with Docker on the duthost."""
 
 import collections
 import logging
-import os
 
 from tests.common import config_reload
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.errors import RunAnsibleModuleFail
 
-_LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
-_BASE_DIR = os.path.dirname(os.path.realpath(__file__))
-SONIC_DOCKER_REGISTRY = os.path.join(_BASE_DIR, "../../../ansible/vars/docker_registry.yml")
+_DockerRegistryInfo = collections.namedtuple("DockerRegistryInfo", "host username password")
 
-_DockerRegistryInfo = collections.namedtuple('DockerRegistryInfo', 'host username password')
+
 class DockerRegistryInfo(_DockerRegistryInfo):
-    """
-        DockerRegistryInfo holds all the data needed to access a remote Docker registry.
+    """DockerRegistryInfo holds all the data needed to access a remote Docker registry.
 
-        Attributes:
-            host (str): The remote host where the Docker registry is located.
-            username (str): The username used to access the registry.
-            password (str): The password used to access the registry.
+    `host` is a required attribute, `username` and `password` can be added if the target registry
+    requires authentication.
+
+    Attributes:
+        host (str): The remote host where the Docker registry is located.
+        username (str): The username used to access the registry.
+        password (str): The password used to access the registry.
     """
     pass
 
-def load_docker_registry_info(dut, creds):
-    """
-        Attempts to load Docker registry information.
 
-        This method will first search for the registry in the `secret_vars` section
-        of the Ansible inventory. If it's not found, then it will load the registry from
-        the `SONIC_DOCKER_REGISTRY` file.
+def load_docker_registry_info(duthost, creds):
+    """Attempts to load Docker registry information.
 
-        Args:
-            dut (SonicHost): The target device.
+    Args:
+        duthost (SonicHost): The target device.
+        creds (dict): Credentials used to access the docker registry.
 
-        Raises:
-            IOError: If the registry file cannot be read.
-            ValueError: If the registry information is missing from both the
-                Ansible inventory and the registry file.
+    Raises:
+        ValueError: If the registry information is missing from both the
+            Ansible inventory and the registry file.
 
-        Returns:
-            DockerRegistryInfo: The registry information that was loaded.
+    Returns:
+        DockerRegistryInfo: The registry information that was loaded.
     """
     host = creds.get("docker_registry_host")
     username = creds.get("docker_registry_username")
     password = creds.get("docker_registry_password")
 
     if not host:
-        error_message = "Missing registry hostname"
-        _LOGGER.error(error_message)
+        error_message = ("Could not find hostname for docker registry; "
+                         "please check that the `docker_registry_host` ansible variable is defined.")
+        logger.error(error_message)
         raise ValueError(error_message)
 
     return DockerRegistryInfo(host, username, password)
 
-def delete_container(dut, container_name):
+
+def delete_container(duthost, container_name):
+    """Attempts to delete the specified container from the duthost.
+
+    Args:
+        duthost (SonicHost): The target device.
+        container_name (str): The name of the container to delete.
     """
-        Attempts to delete the specified container from the DUT.
+    duthost.command("docker stop {}".format(container_name), module_ignore_errors=True)
+    duthost.command("docker rm {}".format(container_name), module_ignore_errors=True)
 
-        Args:
-            dut (SonicHost): The target device.
-            container_name (str): The name of the container to delete.
+
+def download_image(duthost, registry, image_name, image_version="latest"):
+    """Attempts to download the specified image from the registry.
+
+    Args:
+        duthost (SonicHost): The target device.
+        registry (DockerRegistryInfo): The registry from which to pull the image.
+        image_name (str): The name of the image to download.
+        image_version (str): The version of the image to download.
     """
-    dut.command("docker stop {}".format(container_name))
-    dut.command("docker rm {}".format(container_name))
+    try:
+        if registry.username and registry.password:
+            duthost.command("docker login {} -u {} -p {}".format(registry.host, registry.username, registry.password))
+    except RunAnsibleModuleFail as e:
+        error_message = ("Could not login to Docker registry. Please verify that your DNS server is reachable, "
+                         "the specified registry is reachable, and your credentials are correct.")
+        logger.error(error_message)
+        logger.error("Error detail:\n{}".format(repr(e)))
+        raise RuntimeError(error_message)
 
-def download_image(dut, registry, image_name, image_version="latest"):
-    """
-        Attempts to download the specified image from the registry.
+    try:
+        duthost.command("docker pull {}/{}:{}".format(registry.host, image_name, image_version))
+    except RunAnsibleModuleFail as e:
+        error_message = ('Image "{}:{}" not found. Please verify that this image has been uploaded to the '
+                         "specified registry.".format(image_name, image_version))
+        logger.error(error_message)
+        logger.error("Error detail:\n{}".format(repr(e)))
+        raise RuntimeError(error_message)
 
-        Args:
-            dut (SonicHost): The target device.
-            registry (DockerRegistryInfo): The registry from which to pull the image.
-            image_name (str): The name of the image to download.
-            image_version (str): The version of the image to download.
-    """
 
-    if registry.username and registry.password:
-        dut.command("docker login {} -u {} -p {}".format(registry.host, registry.username, registry.password))
+def tag_image(duthost, tag, image_name, image_version="latest"):
+    """Applies the specified tag to a Docker image on the duthost.
 
-    dut.command("docker pull {}/{}:{}".format(registry.host, image_name, image_version))
-
-def tag_image(dut, tag, image_name, image_version="latest"):
-    """
-        Applies the specified tag to a Docker image on the DUT.
-
-        Args:
-            dut (SonicHost): The target device.
-            tag (str): The tag to apply to the target image.
-            image_name (str): The name of the image to tag.
-            image_version (str): The version of the image to tag.
-    """
-
-    dut.command("docker tag {}:{} {}".format(image_name, image_version, tag))
-
-def swap_syncd(dut, creds):
-    """
-        Replaces the running syncd container with the RPC version of it.
-
-        This will download a new Docker image to the DUT and restart the swss service.
-
-        Args:
-            dut (SonicHost): The target device.
+    Args:
+        duthost (SonicHost): The target device.
+        tag (str): The tag to apply to the target image.
+        image_name (str): The name of the image to tag.
+        image_version (str): The version of the image to tag.
     """
 
-    if is_broadcom_device(dut):
-        vendor_id = "brcm"
-    elif is_mellanox_device(dut):
-        vendor_id = "mlnx"
-    else:
-        error_message = "\"{}\" is not currently supported".format(dut.facts["asic_type"])
-        _LOGGER.error(error_message)
-        raise ValueError(error_message)
+    duthost.command("docker tag {}:{} {}".format(image_name, image_version, tag))
+
+
+def swap_syncd(duthost, creds):
+    """Replaces the running syncd container with the RPC version of it.
+
+    This will download a new Docker image to the duthost and restart the swss service.
+
+    Args:
+        duthost (SonicHost): The target device.
+        creds (dict): Credentials used to access the docker registry.
+    """
+    vendor_id = _get_vendor_id(duthost)
 
     docker_syncd_name = "docker-syncd-{}".format(vendor_id)
     docker_rpc_image = docker_syncd_name + "-rpc"
 
-    dut.command("config bgp shutdown all")  # Force image download to go through mgmt network
-    dut.command("systemctl stop swss")
-    delete_container(dut, "syncd")
+    duthost.command("config bgp shutdown all")  # Force image download to go through mgmt network
+    duthost.command("systemctl stop swss", module_ignore_errors=True)
+    delete_container(duthost, "syncd")
 
     # Set sysctl RCVBUF parameter for tests
-    dut.command("sysctl -w net.core.rmem_max=609430500")
+    duthost.command("sysctl -w net.core.rmem_max=609430500")
 
     # Set sysctl SENDBUF parameter for tests
-    dut.command("sysctl -w net.core.wmem_max=609430500")
+    duthost.command("sysctl -w net.core.wmem_max=609430500")
 
     # TODO: Getting the base image version should be a common utility
-    output = dut.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
+    output = duthost.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
     sonic_version = output["stdout_lines"][0].strip()
 
+    _perform_swap_syncd_shutdown_check(duthost)
+
+    registry = load_docker_registry_info(duthost, creds)
+    download_image(duthost, registry, docker_rpc_image, sonic_version)
+
+    tag_image(
+        duthost,
+        "{}:latest".format(docker_syncd_name),
+        "{}/{}".format(registry.host, docker_rpc_image),
+        sonic_version
+    )
+
+    logger.info("Reloading config and restarting swss...")
+    config_reload(duthost)
+
+    _perform_syncd_liveness_check(duthost)
+
+
+def restore_default_syncd(duthost, creds):
+    """Replaces the running syncd with the default syncd that comes with the image.
+
+    This will restart the swss service.
+
+    Args:
+        duthost (SonicHost): The target device.
+        creds (dict): Credentials used to access the docker registry.
+    """
+    vendor_id = _get_vendor_id(duthost)
+
+    docker_syncd_name = "docker-syncd-{}".format(vendor_id)
+
+    duthost.command("systemctl stop swss", module_ignore_errors=True)
+    delete_container(duthost, "syncd")
+
+    # TODO: Getting the base image version should be a common utility
+    output = duthost.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
+    sonic_version = output["stdout_lines"][0].strip()
+
+    tag_image(
+        duthost,
+        "{}:latest".format(docker_syncd_name),
+        docker_syncd_name,
+        sonic_version
+    )
+
+    logger.info("Reloading config and restarting swss...")
+    config_reload(duthost)
+
+    # Remove the RPC image from the duthost
+    docker_rpc_image = docker_syncd_name + "-rpc"
+    registry = load_docker_registry_info(duthost, creds)
+    duthost.command(
+        "docker rmi {}/{}:{}".format(registry.host, docker_rpc_image, sonic_version),
+        module_ignore_errors=True
+    )
+
+
+def _perform_swap_syncd_shutdown_check(duthost):
     def ready_for_swap():
-        syncd_status = dut.command("docker ps -f name=syncd")["stdout_lines"]
+        syncd_status = duthost.command("docker ps -f name=syncd")["stdout_lines"]
         if len(syncd_status) > 1:
             return False
 
-        swss_status = dut.command("docker ps -f name=swss")["stdout_lines"]
+        swss_status = duthost.command("docker ps -f name=swss")["stdout_lines"]
         if len(swss_status) > 1:
             return False
 
-        bgp_summary = dut.command("show ip bgp summary")["stdout_lines"]
+        bgp_summary = duthost.command("show ip bgp summary")["stdout_lines"]
         idle_count = 0
         expected_idle_count = 0
         for line in bgp_summary:
@@ -157,57 +217,42 @@ def swap_syncd(dut, creds):
 
         return idle_count == expected_idle_count
 
-    pytest_assert(wait_until(30, 3, ready_for_swap), "Docker and/or BGP failed to shut down")
+    shutdown_check = wait_until(30, 3, ready_for_swap)
 
-    registry = load_docker_registry_info(dut, creds)
-    download_image(dut, registry, docker_rpc_image, sonic_version)
+    logging.info("syncd status:\n%s", duthost.command("docker ps -f name=syncd", module_ignore_errors=True)["stdout"])
+    logging.info("swss status:\n%s", duthost.command("docker ps -f name=swss", module_ignore_errors=True)["stdout"])
+    logging.info("bgp status:\n%s", duthost.command("show ip bgp summary", module_ignore_errors=True)["stdout"])
 
-    tag_image(dut,
-              "{}:latest".format(docker_syncd_name),
-              "{}/{}".format(registry.host, docker_rpc_image),
-              sonic_version)
-
-    _LOGGER.info("Reloading config and restarting swss...")
-    config_reload(dut)
+    pytest_assert(shutdown_check, "Docker and/or BGP failed to shut down in 30s")
 
 
-def restore_default_syncd(dut, creds):
-    """
-        Replaces the running syncd with the default syncd that comes with the image.
+def _perform_syncd_liveness_check(duthost):
+    def check_liveness():
+        syncd_status = duthost.command(
+            "docker exec syncd supervisorctl status syncd",
+            module_ignore_errors=True
+        )["stdout"]
 
-        This will restart the swss service.
+        return "RUNNING" in syncd_status
 
-        Args:
-            dut (SonicHost): The target device.
-    """
+    liveness_check = wait_until(10, 1, check_liveness)
 
-    if is_broadcom_device(dut):
+    logging.info(
+        "syncd status:\n%s",
+        duthost.command("docker exec syncd supervisorctl status syncd", module_ignore_errors=True)["stdout"]
+    )
+
+    pytest_assert(liveness_check, "syncd crashed after swap_syncd")
+
+
+def _get_vendor_id(duthost):
+    if is_broadcom_device(duthost):
         vendor_id = "brcm"
-    elif is_mellanox_device(dut):
+    elif is_mellanox_device(duthost):
         vendor_id = "mlnx"
     else:
-        error_message = "\"{}\" is not currently supported".format(dut.facts["asic_type"])
-        _LOGGER.error(error_message)
+        error_message = '"{}" does not currently support swap_syncd'.format(duthost.facts["asic_type"])
+        logger.error(error_message)
         raise ValueError(error_message)
 
-    docker_syncd_name = "docker-syncd-{}".format(vendor_id)
-
-    dut.command("systemctl stop swss")
-    delete_container(dut, "syncd")
-
-    # TODO: Getting the base image version should be a common utility
-    output = dut.command("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version")
-    sonic_version = output["stdout_lines"][0].strip()
-
-    tag_image(dut,
-              "{}:latest".format(docker_syncd_name),
-              docker_syncd_name,
-              sonic_version)
-
-    _LOGGER.info("Reloading config and restarting swss...")
-    config_reload(dut)
-
-    # Remove the RPC image from the DUT
-    docker_rpc_image = docker_syncd_name + "-rpc"
-    registry = load_docker_registry_info(dut, creds)
-    dut.command("docker rmi {}/{}:{}".format(registry.host, docker_rpc_image, sonic_version))
+    return vendor_id

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -350,13 +350,14 @@ class QosSaiBase:
         """
         duthost = duthosts[rand_one_dut_hostname]
         swapSyncd = request.config.getoption("--qos_swap_syncd")
-        if swapSyncd:
-            docker.swap_syncd(duthost, creds)
+        try:
+            if swapSyncd:
+                docker.swap_syncd(duthost, creds)
 
-        yield
-
-        if swapSyncd:
-            docker.restore_default_syncd(duthost, creds)
+            yield
+        finally:
+            if swapSyncd:
+                docker.restore_default_syncd(duthost, creds)
 
     @pytest.fixture(scope='class', autouse=True)
     def dutConfig(self, request, duthosts, rand_one_dut_hostname, tbinfo):


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [swap_syncd] Improve log messages and clean-up docker code
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
While looking into https://github.com/Azure/sonic-mgmt/issues/2910, we discovered the root cause was _actually_ that swap_syncd left the device in a crashed state. The test did not pick this up.

#### How did you do it?
So, to make it easier to find similar docker RPC regressions in the future, we should check the state of `syncd` when the swap_syncd is done.

In addition, the exceptions Ansible throws are very verbose and it's generally not easy to tell how/why swap_syncd failed. So, I also made the log messages more specific and added debugging recommendations.

#### How did you verify/test it?
Ran the `qos_sai` tests in the following scenarios:
- Bad nameserver
- Docker image version does not exist
- Bad RPC docker/RPC docker causes crash
- The healthy case/working case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
