### PR TITLE
Add extra minigraph loopback IP interfaces for dual ToR

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -33,19 +33,26 @@ class DualTorParser:
         '''
         Parses the IPv4 and IPv6 loopback IPs for the DUTs
 
-        Similar to `parse_tor_position`, the ToR which comes first alphabetically is always assigned the first IP
+        Similar to `parse_tor_position`, the ToR which comes first in the testbed file is always assigned the first IP
         '''
 
         loopback_ips = defaultdict(dict)
+        addl_loopback_ips = defaultdict(dict)
 
-        ipv4_loopbacks = sorted(self.vm_config['DUT']['loopback']['ipv4'])
-        ipv6_loopbacks = sorted(self.vm_config['DUT']['loopback']['ipv6'])
+        for dut_num, dut in enumerate(self.testbed_facts['duts']):
+            loopback_ips[dut]['ipv4'] = self.vm_config['DUT']['loopback']['ipv4'][dut_num]
+            loopback_ips[dut]['ipv6'] = self.vm_config['DUT']['loopback']['ipv6'][dut_num] 
 
-        for i, dut in enumerate(sorted(self.testbed_facts['duts'])):
-            loopback_ips[dut]['ipv4'] = ipv4_loopbacks[i]
-            loopback_ips[dut]['ipv6'] = ipv6_loopbacks[i] 
+            for loopback_num in range(1, 3): # Generate two additional loopback IPs, Loopback1 and Loopback2
+                loopback_key = 'loopback{}'.format(loopback_num)
+                loopback_dict = {}
+                loopback_dict['ipv4'] = self.vm_config['DUT'][loopback_key]['ipv4'][dut_num]
+                loopback_dict['ipv6'] = self.vm_config['DUT'][loopback_key]['ipv6'][dut_num]
+                loopback_dict['host_ip_base_index'] = loopback_num * 2
+                addl_loopback_ips[dut][loopback_num] = loopback_dict
 
-        self.dual_tor_facts['loopback'] = loopback_ips     
+        self.dual_tor_facts['loopback'] = loopback_ips 
+        self.dual_tor_facts['addl_loopbacks'] = addl_loopback_ips
 
     def generate_cable_names(self):
         cables = []

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -18,6 +18,27 @@
           </a:Prefix>
           <a:PrefixStr>{{ lp_ipv6 }}</a:PrefixStr>
         </a:LoopbackIPInterface>
+      {%- if 'addl_loopbacks' in dual_tor_facts -%}
+      {%- for loopback_num in dual_tor_facts['addl_loopbacks'][inventory_hostname] -%}
+        {%- set loopback_facts = dual_tor_facts['addl_loopbacks'][inventory_hostname][loopback_num] -%}
+        <a:LoopbackIPInterface>
+          <Name>HostIP{{ loopback_facts['host_ip_base_index'] }}</Name>
+          <AttachTo>Loopback{{ loopback_num }}</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback_facts['ipv4'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback_facts['ipv4'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP{{ loopback_facts['host_ip_base_index'] + 1 }}</Name>
+          <AttachTo>Loopback{{ loopback_num }}</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback_facts['ipv6'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback_facts['ipv6'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      {%- endfor -%}
+      {%- endif -%}
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
         <a:ManagementIPInterface>

--- a/ansible/vars/topo_dualtor-56.yml
+++ b/ansible/vars/topo_dualtor-56.yml
@@ -111,6 +111,20 @@ topology:
       ipv6:
         - FC00:1::32/128
         - FC00:1::33/128
+    loopback1:
+      ipv4:
+        - 10.1.0.34/32
+        - 10.1.0.35/32
+      ipv6:
+        - FC00:1::34/128
+        - FC00:1::35/128
+    loopback2:
+      ipv4:
+        - 10.1.0.36/32
+        - 10.1.0.37/32
+      ipv6:
+        - FC00:1::36/128
+        - FC00:1::37/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_dualtor.yml
+++ b/ansible/vars/topo_dualtor.yml
@@ -63,6 +63,20 @@ topology:
       ipv6:
         - FC00:1::32/128
         - FC00:1::33/128
+    loopback1:
+      ipv4:
+        - 10.1.0.34/32
+        - 10.1.0.35/32
+      ipv6:
+        - FC00:1::34/128
+        - FC00:1::35/128
+    loopback2:
+      ipv4:
+        - 10.1.0.36/32
+        - 10.1.0.37/32
+      ipv6:
+        - FC00:1::36/128
+        - FC00:1::37/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION
* add extra loopback IPs to dual ToR topology files
* parse extra loopbacks in dual_tor_facts
* During DPG generation read extra loopbacks if available

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2920 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
New components supporting dual ToR feautures require up to 2 extra loopbacks (Loopback1 and Loopback2) to function correctly.

#### How did you do it?
Add 2 additional IPv4 and IPv6 loopback IPs per DUT

#### How did you verify/test it?
Deploy minigraph to dual ToR devices, verify extra loopbacks are parsed into config DB
Run `testmg.sh` script

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
