### PR TITLE
Fix issue: there could be more than 2 thermalctld processes

### DIFF
--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -259,7 +259,10 @@ def restart_thermal_control_daemon(dut):
     find_thermalctld_pid_cmd = 'docker exec -i pmon bash -c \'pgrep -f thermalctld\' | sort'
     output = dut.shell(find_thermalctld_pid_cmd)
     assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
-    assert len(output["stdout_lines"]) == 2, "There should be 2 thermalctld process"
+    # Usually there should be 2 thermalctld processes, but there is chance that
+    # sonic platform API might use subprocess which creates extra thermalctld process,
+    # so we check here thermalcltd must have at least 2 processes
+    assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
     pid_0 = int(output["stdout_lines"][0].strip())
     pid_1 = int(output["stdout_lines"][1].strip())
     # find and kill the parent process

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -260,8 +260,10 @@ def restart_thermal_control_daemon(dut):
     output = dut.shell(find_thermalctld_pid_cmd)
     assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
     # Usually there should be 2 thermalctld processes, but there is chance that
-    # sonic platform API might use subprocess which creates extra thermalctld process,
-    # so we check here thermalcltd must have at least 2 processes
+    # sonic platform API might use subprocess which creates extra thermalctld process.
+    # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may 
+    # use subprocess to call ethtool to do initialization.
+    # So we check here thermalcltd must have at least 2 processes.
     assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
     pid_0 = int(output["stdout_lines"][0].strip())
     pid_1 = int(output["stdout_lines"][1].strip())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue `There should be 2 thermalctld process`. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Usually there should be 2 thermalctld processes, but there is chance that sonic platform API might use subprocess which creates extra thermalctld process, so we need check thermalcltd must have 2 or more processes

#### How did you do it?

assert that there should be more than 2 thermalctld processes

#### How did you verify/test it?

Manually run the regression

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
