### PR TITLE
[test_show_bgp_summary] Change prefixReceivedCount key due to Frr Update

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -534,7 +534,7 @@ class TestVrfFib():
 
             for info in bgp_summary:
                 for peer, attr in bgp_summary[info]['peers'].iteritems():
-                    prefix_count = attr['prefixReceivedCount']
+                    prefix_count = attr['pfxRcd']
                     # skip ipv6 peers under 'ipv4Unicast' and compare only ipv4 peers under 'ipv4Unicast', and ipv6 peers under 'ipv6Unicast'
                     if info == "ipv4Unicast" and attr['idType'] == 'ipv6':
                         continue
@@ -886,7 +886,7 @@ class TestVrfLoopbackIntf():
             assert bgp_info['ipv4Unicast']['peers'][str(ptf_speaker_ip.ip)]['state'] == 'Established', \
                    "Bgp peer {} should be Established!".format(ptf_speaker_ip.ip)
             # Verify accepted prefixes of the dynamic neighbors are correct
-            assert bgp_info['ipv4Unicast']['peers'][str(ptf_speaker_ip.ip)]['prefixReceivedCount'] == 1
+            assert bgp_info['ipv4Unicast']['peers'][str(ptf_speaker_ip.ip)]['pfxRcd'] == 1
 
 
 class TestVrfWarmReboot():


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: On master Sonic test_show_bgp_summary fails with error ```KeyError: 'prefixReceivedCount```. This happens due to recent update of FRR up to version 7.5, after which key ```prefixReceivedCount``` have changed to ```pfxRcd```.  So in order to make test pass on Sonic master key should be changed to ```pfxRcd```. This wont affect released Sonic version, because it contains both keys. 

```
SONiC.master.113-dirty-20210203.033203

"peers":{
    "10.0.0.57":{
      "remoteAs":64600,
      "version":4,
      "msgRcvd":3329,
      "msgSent":6529,
      "tableVersion":0,
      "outq":0,
      "inq":0,
      "peerUptime":"00:06:14",
      "peerUptimeMsec":374000,
      "peerUptimeEstablishedEpoch":1611333401,
      "pfxRcd":6400,
      "pfxSnt":6401,
      "state":"Established",
      "connectionsEstablished":1,
      "connectionsDropped":0,
      "idType":"ipv4"
    },

SONiC.201911.208-dirty-20210122.060940

"peers":{
    "10.0.0.57":{
      "remoteAs":64600,
      "version":4,
      "msgRcvd":3550,
      "msgSent":4690,
      "tableVersion":0,
      "outq":0,
      "inq":0,
      "peerUptime":"03:11:32",
      "peerUptimeMsec":11492000,
      "peerUptimeEstablishedEpoch":1611316346,
      "prefixReceivedCount":6400,
      "pfxRcd":6400,
      "state":"Established",
      "connectionsEstablished":1,
      "connectionsDropped":0,
      "idType":"ipv4"
    },
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make test_show_bgp_summary backward compatible.
#### How did you do it?
Changed the prefixReceivedCount key.
#### How did you verify/test it?
Run test_show_bgp_summary on t0 topo
`vrf/test_vrf.py::TestVrfFib::test_show_bgp_summary PASSED`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.113-dirty-20210203.033203
Distribution: Debian 10.7
Kernel: 4.19.0-9-2-amd64
Build commit: f8ddc39a
Build date: Wed Feb  3 12:24:16 UTC 2021
Built by: johnar@worker-s453e80
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
