### PR TITLE
[Platform API] Ignore iptables delete failure in stop_platform_api_service fixture

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -69,7 +69,7 @@ def stop_platform_api_service(duthost):
         duthost.command('docker exec -i pmon supervisorctl update')
 
         # Delete the iptables rule we added
-        # We ignore errors here because after a watchdog test, the device will have power-cycled and will
+        # We ignore errors here because after a watchdog test, the DuT will have power-cycled and will
         # no longer have the rule we added in the start_platform_api_service fixture
         duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
 

--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -69,7 +69,9 @@ def stop_platform_api_service(duthost):
         duthost.command('docker exec -i pmon supervisorctl update')
 
         # Delete the iptables rule we added
-        duthost.command(IPTABLES_DELETE_RULE_CMD)
+        # We ignore errors here because after a watchdog test, the device will have power-cycled and will
+        # no longer have the rule we added in the start_platform_api_service fixture
+        duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
 
 @pytest.fixture(scope='function')
 def platform_api_conn(duthost, start_platform_api_service):


### PR DESCRIPTION
Summary:
Fixes # https://github.com/Azure/sonic-mgmt/issues/1940

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

During the watchdog test, the DuT will have power-cycled and will no longer have the iptables rule we added in the start_platform_api_service fixture. Therefore, we should ignore errors when attempting to delete the rule.

#### How did you do it?

Add `module_ignore_errors=True` parameter to `duthost.command()` call

#### How did you verify/test it?

Perform a watchdog test, ensure the iptables delete command failure doesn't cause the test to fail

#### Any platform specific information?

No.
