### PR TITLE
[TACACS] Test that 'sudo pcieutil check' works for read-only user

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -59,6 +59,7 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'sudo decode-syseeprom',
             'sudo generate_dump',
             'sudo lldpshow',
+            'sudo pcieutil check',
             # 'sudo psuutil *',
             'sudo sonic-installer list',
             # 'sudo sfputil show *',


### PR DESCRIPTION

Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Ensure all read-only commands which require `sudo` can be run by a read-only user

#### How did you do it?

Add `sudo pcieutil check` to list of commands to be tested with a read-only user

#### How did you verify/test it?

Test should fail until https://github.com/Azure/sonic-buildimage/pull/6682 is merged, then it should pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
