### PR TITLE
[ci] Fix ownership of workspace directory before checking out sonic-mgmt

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -9,6 +9,11 @@ parameters:
   type: string
 
 steps:
+- script: |
+    username=$(id -un)
+    sudo chown -R ${username}.${username} .
+  displayName: 'Cleanup'
+
 - checkout: self
   clean: true
   displayName: 'checkout sonic-mgmt repo'


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [ci] Fix ownership of workspace directory before checking out sonic-mgmt
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`t1-lag` tests are failing on the PR right now because `git clean` cannot delete certain files.

#### How did you do it?
Update the ownership of the files in the workspace before proceeding with the rest of the pipeline.

#### How did you verify/test it?
Check PR result.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
