### PR TITLE
Fix interface_check failure in test_cont_warm_reboot

### DIFF
--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -95,7 +95,7 @@ class ContinuousReboot:
         @param reboot_kwargs: The argument used by reboot_helper
         """
         logging.info("Run %s reboot on DUT" % self.reboot_type)
-        #self.run_reboot_testcase()
+        self.run_reboot_testcase()
         # Wait until uptime reaches allowed value
         self.wait_until_uptime()
         # Perform additional post-reboot health-check


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `test_cont_warm_reboot` that has started failing after the recent restructuring done in https://github.com/Azure/sonic-mgmt/pull/2883/files#

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
`test_cont_warm_reboot` is failing with:
```
=================================== FAILURES ===================================
____________________________ test_continuous_reboot ____________________________
Fixture "check_interfaces" called directly. Fixtures are not meant to be called directly,
but are created automatically when test functions request them as parameters.
```
This error is due to recent refactoring which made `check_interfaces` a fixture (previously a method).

#### What is the motivation for this PR?

#### How did you do it?
Added changes to access fixture on demand, and perform the interface status validation.

#### How did you verify/test it?
Tested on a KVM switch and the test passed. With interface made manually down, following error is gracefully generated  avoiding a test crash:
```
{
    "up_time": "2043.0s", 
    "test_duration": "93.658068s", 
    "image": "SONiC-OS-202012.15-03b26d43", 
    "result": false, 
    "is_new_image": false, 
    "test_id": 1, 
    "checks": {
        "check_interfaces_and_transceivers": "Interface check failed, not all interfaces are up. Failed: [{'check_item': 'interfaces', 'failed': True, 'host': 'vlab-01', 'down_ports': [u'Ethernet4']}]", 
        "verify_no_coredumps": true, 
        "check_reboot_type": true, 
        "verify_image": true, 
        "check_neighbors": true, 
        "check_services": true
    }
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
