### PR TITLE
[qos] Ignore sdk messages during port pause

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -530,6 +530,9 @@ class QosSaiBase:
 
                 ".*ERR monit.*'bgp\|bgpmon' status failed.*'/usr/bin/python.* /usr/local/bin/bgpmon' is not running.*",
                 ".*ERR monit.*bgp\|fpmsyncd.*status failed.*NoSuchProcess process no longer exists.*",
+                ".*WARNING syncd#SDK:.*check_attribs_metadata: Not implemented attribute.*",
+                ".*WARNING syncd#SDK:.*sai_set_attribute: Failed attribs check, key:Switch ID.*",
+                ".*WARNING syncd#SDK:.*check_rate: Set max rate to 0.*"
             ]
             loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Adding few messages from SDK seen on Mellanox devices during port pause to the loganalyzer ignore list

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Ran the qos sai test that were failing earlier because of loganalyzer failures and they passed
