### PR TITLE
[platform api] Fix sfp index

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -115,14 +115,14 @@ class TestSfpApi(PlatformApiTestBase):
         self.candidate_sfp = []
         if self.skip_absent_sfp:
             # Skip absent SFP if option "--skip-absent-sfp" set to True 
-            for i in range(self.num_sfps):
+            for i in range(1, self.num_sfps + 1):
                 try:
                     if sfp.get_presence(platform_api_conn, i):
                         self.candidate_sfp.append(i)
                 except Exception:
                     pytest.fail("get_presence API is not supported, failed to compose present SFP list")
         else:
-            self.candidate_sfp = range(self.num_sfps)
+            self.candidate_sfp = range(1, self.num_sfps + 1)
     #
     # Helper functions
     #
@@ -133,7 +133,7 @@ class TestSfpApi(PlatformApiTestBase):
         if self.chassis_facts:
             expected_sfps = self.chassis_facts.get("sfps")
             if expected_sfps:
-                expected_value = expected_sfps[sfp_idx].get(key)
+                expected_value = expected_sfps[sfp_idx - 1].get(key)
 
         if self.expect(expected_value is not None,
                        "Unable to get expected value for '{}' from platform.json file for SFP {}".format(key, sfp_idx)):


### PR DESCRIPTION
Signed-off-by: Antonina Melnyk <antoninax.melnyk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Change sfp index from 0-based to 1-based

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
On practice chassis.get_sfp function accept a 1-based index as its argument. Before the fix, returned values were shifted by one.

#### How did you do it?
Change sfp index from 0-based to 1-based

#### How did you verify/test it?
Test is locally

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
