### PR TITLE
[Mellanox] Relax the margin in PGHeadroomWatermark test

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -161,10 +161,7 @@ class QosParamMellanox(object):
         wm_pg_headroom['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         wm_pg_headroom['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
         wm_pg_headroom['cell_size'] = self.cell_size
-        if self.asic_type == 'spc3':
-            wm_pg_headroom['pkts_num_margin'] = 3
-        else:
-            wm_pg_headroom['pkts_num_margin'] = 2
+        wm_pg_headroom['pkts_num_margin'] = 3
 
         wm_pg_shared_lossless = self.qos_params_mlnx['wm_pg_shared_lossless']
         wm_pg_shared_lossless['pkts_num_trig_pfc'] = pkts_num_dismiss_pfc


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Relax the margin in PGHeadroomWatermark test

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To relax the margin in the PGHeadroomWatermark test to tolerance the deviation better and make the test more stable.

#### How did you do it?

#### How did you verify/test it?
Run RPC test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
