### PR TITLE
[eos vm] enable ports by default

### DIFF
--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -63,6 +63,7 @@ interface {{ name }}
  description LOOPBACK
 {% else %}
  no switchport
+ no shutdown
 {% endif %}
 {% if name.startswith('Port-Channel') %}
  port-channel min-links 2
@@ -86,6 +87,7 @@ interface {{ name }}
 interface {{ bp_ifname }}
  description backplane
  no switchport
+ no shutdown
 {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
 {% endif %}

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -63,6 +63,7 @@ interface {{ name }}
  description LOOPBACK
 {% else %}
  no switchport
+ no shutdown
 {% endif %}
 {% if name.startswith('Port-Channel') %}
  port-channel min-links 1
@@ -86,6 +87,7 @@ interface {{ name }}
 interface {{ bp_ifname }}
  description backplane
  no switchport
+ no shutdown
 {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
 {% endif %}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -60,6 +60,7 @@ interface {{ name }}
  description LOOPBACK
 {% else %}
  no switchport
+ no shutdown
 {% endif %}
 {% if name.startswith('Port-Channel') %}
  port-channel min-links 1
@@ -83,6 +84,7 @@ interface {{ name }}
 interface {{ bp_ifname }}
  description backplane
  no switchport
+ no shutdown
 {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
 {% endif %}

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -59,6 +59,7 @@ interface {{ name }}
  description LOOPBACK
 {% else %}
  no switchport
+ no shutdown
 {% endif %}
 {% if name.startswith('Port-Channel') %}
  port-channel min-links 2
@@ -82,6 +83,7 @@ interface {{ name }}
 interface {{ bp_ifname }}
  description backplane
  no switchport
+ no shutdown
 {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
 {% endif %}

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -59,6 +59,7 @@ interface {{ name }}
  description LOOPBACK
 {% else %}
  no switchport
+ no shutdown
 {% endif %}
 {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
@@ -75,6 +76,7 @@ interface {{ name }}
 interface {{ bp_ifname }}
  description backplane
  no switchport
+ no shutdown
 {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
 {% endif %}


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Noticed an issue where if an interface on VM is disabled. Removing topology and add topology won't fix it.

#### How did you do it?
Add "no shutdown" to make sure these ports are enabled after topology redeploy.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Disable a port on VM, without fix, remove/add topology will leave the port disabled. with the fix, remove/add topology end up with a healthy system.