### PR TITLE
Added test case to verify ebtables rules.

### DIFF
--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -30,8 +30,7 @@ def test_ebtables_application(duthosts, rand_one_dut_hostname):
 
     stdout = duthost.shell("sudo ebtables -L FORWARD")["stdout"]
     ebtables_rules = stdout.strip().split("\n")
-
-    actual_ebtables_rules = [rule.strip() for rule in ebtables_rules if rule.startswith('-')]
+    actual_ebtables_rules = [rule.strip().replace("0806","ARP") for rule in ebtables_rules if rule.startswith('-')]
 
     # Ensure all expected ebtables rules are present on the DuT
     missing_ebtables_rules = set(expected_ebtables_rules) - set(actual_ebtables_rules)

--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -1,0 +1,42 @@
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
+    pytest.mark.topology('any')
+]
+
+def generate_expected_rules(duthost):
+    ebtables_rules = []
+    # Default policies
+    ebtables_rules.append("-d BGA -j DROP")
+    ebtables_rules.append("-p ARP -j DROP")
+    ebtables_rules.append("-p 802_1Q --vlan-encap ARP -j DROP")
+    return ebtables_rules
+
+
+def test_ebtables_application(duthosts, rand_one_dut_hostname):
+    """
+    Test case to ensure ebtables rules are applied are corectly on DUT during init
+
+    This is done by generating our own set of expected ebtables
+    rules based on the DuT's configuration and comparing them against the
+    actual ebtables rules on the DuT.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    expected_ebtables_rules = generate_expected_rules(duthost)
+
+    stdout = duthost.shell("sudo ebtables -L FORWARD")["stdout"]
+    ebtables_rules = stdout.strip().split("\n")
+
+    actual_ebtables_rules = [rule.strip() for rule in ebtables_rules if rule.startswith('-')]
+
+    # Ensure all expected ebtables rules are present on the DuT
+    missing_ebtables_rules = set(expected_ebtables_rules) - set(actual_ebtables_rules)
+    pytest_assert(len(missing_ebtables_rules) == 0, "Missing expected ebtables rules: {}".format(repr(missing_ebtables_rules)))
+
+    # Ensure there are no unexpected ebtables rules present on the DuT
+    unexpected_ebtables_rules = set(actual_ebtables_rules) - set(expected_ebtables_rules)
+    pytest_assert(len(unexpected_ebtables_rules) == 0, "Unexpected ebtables rules: {}".format(repr(unexpected_ebtables_rules)))

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -100,6 +100,7 @@ test_t0() {
     bgp/test_bgp_fact.py \
     bgp/test_bgp_gr_helper.py \
     bgp/test_bgp_speaker.py \
+    cacl/test_ebtables_application.py \
     cacl/test_cacl_application.py \
     cacl/test_cacl_function.py \
     dhcp_relay/test_dhcp_relay.py \


### PR DESCRIPTION
What/Why I did:
- Added testcase to verify ebtable rules. To verify changes done as part of https://github.com/Azure/sonic-buildimage/pull/6542
- Added to T0 kvmtest.sh
- Will be enhance for multi-asic in another PR.

How I Verified:
`adosi@624e49377782:/var/src/Networking-acs-sonic-mgmt/tests$ ANSIBLE_KEEP_REMOTE_FILES=1 py.test --inventory "../ansible/str,../ansible/veos" --host-pattern str-s6000-on-2 --module-path "../ansible/library/" --testbed vms13-5-t1-lag  --testbed_file "../ansible/testbed.csv" --log-cli-level info   -ra -vvv "cacl/test_ebtables_application.py" --skip_sanity`
