### PR TITLE
[dhcp_relay]: ignore rsyslog sendto error messages

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -21,8 +21,8 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
     if loganalyzer:
         ignoreRegex = [
             ".*ERR snmp#snmp-subagent.*",
-            ".*ERR rsyslogd: omfwd: socket (\d+): error (\d+) sending via udp: Network is unreachable.*",
-            ".*ERR rsyslogd: omfwd/udp: socket (\d+): sendto\(\) error: Network is unreachable.*"
+            ".*ERR rsyslogd: omfwd: socket (\d+): error (\d+) sending via udp: Network is (unreachable|down).*",
+            ".*ERR rsyslogd: omfwd/udp: socket (\d+): sendto\(\) error: Network is (unreachable|down).*"
         ]
         loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -21,6 +21,8 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
     if loganalyzer:
         ignoreRegex = [
             ".*ERR snmp#snmp-subagent.*",
+            ".*ERR rsyslogd: omfwd: socket (\d+): error (\d+) sending via udp: Network is unreachable.*",
+            ".*ERR rsyslogd: omfwd/udp: socket (\d+): sendto\(\) error: Network is unreachable.*"
         ]
         loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
make dhcp relay test more robust

#### How did you do it?
add two rsyslog error message to ignore

#### How did you verify/test it?

in dhcp relay test, all uplinks are shutdown which could cause
the rsyslog throw sendto() error due to network unreachable.

example: https://dev.azure.com/mssonic/build/_build/results?buildId=3238&view=logs&j=551384a3-3c3d-5d98-9a93-ab579ce10658&t=dcc0ef7a-c27d-5084-36c2-e0f4d142c187

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
