### PR TITLE
[dualtor]: Send GARP to start linkmgrd heartbeat

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -475,7 +475,7 @@ def shutdown_t1_tor_intfs(upper_tor_host, lower_tor_host, nbrhosts, tbinfo):
         eos_host.no_shutdown(vm_intf)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def start_linkmgrd_heartbeat(ptfadapter, duthost, tbinfo):
     '''
     Send a GARP from from PTF->ToR from each PTF port connected to a mux cable

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -4,7 +4,6 @@ import json
 import ptf.testutils as testutils
 
 from ipaddress import ip_interface
-from jinja2 import Template
 from natsort import natsorted
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -478,9 +478,9 @@ def shutdown_t1_tor_intfs(upper_tor_host, lower_tor_host, nbrhosts, tbinfo):
 @pytest.fixture(scope='module', autouse=True)
 def start_linkmgrd_heartbeat(ptfadapter, duthost, tbinfo):
     '''
-    Send a GARP with the PTF MAC to the DUT for each port configured with a mux cable
+    Send a GARP from from PTF->ToR from each PTF port connected to a mux cable
 
-    Linkmgrd will not start sending heartbeats until the PTF MAC is present in the DUT neighbor table
+    This is needed since linkmgrd will not start sending heartbeats until the PTF MAC is learned in the DUT neighbor table
     '''
     garp_pkts = {}
 
@@ -495,6 +495,7 @@ def start_linkmgrd_heartbeat(ptfadapter, duthost, tbinfo):
         garp_pkt = testutils.simple_arp_packet(eth_src=ptf_mac,
                                                hw_snd=ptf_mac,
                                                ip_snd=str(server_ip.ip),
+                                               ip_tgt=str(server_ip.ip), # Re-use server IP as target IP, since it is within the subnet of the VLAN IP
                                                arp_op=2)
         garp_pkts[ptf_port_index] = garp_pkt
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Some mechanism is needed to allow the DUT to learn server/PTF MACs, similar to how they are learned in production environment. Without this, linkmgrd will not start sending heartbeats

#### How did you do it?
On each PTF port connected to a mux cable, send a GARP packet from the PTF to the DUT

#### How did you verify/test it?
Ran on dual ToR testbed, verified that linkmgrd started sending heartbeats after the PTF MAC was learned

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
