### PR TITLE
[ACL] Fix ACL rules are not ready yet when test cases are started in as5835_54t model

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -481,7 +481,7 @@ class BaseAclTest(object):
     def check_rule_counters(self, duthost):
         logger.info('Wait all rule counters are ready')
 
-        return wait_until(300, 2, self.check_rule_counters_internal, duthost)
+        return wait_until(60, 2, self.check_rule_counters_internal, duthost)
 
     def check_rule_counters_internal(self, duthost):
         res = duthost.command('aclshow -a')

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -18,6 +18,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_module
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
+from tests.common.utilities import wait_until
 from tests.conftest import duthost
 
 logger = logging.getLogger(__name__)
@@ -138,7 +139,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
     vlan_ports = []
 
     if topo == "t0":
-        vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname] 
+        vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
                       for ifname in mg_facts["minigraph_vlans"].values()[0]["members"]]
 
     setup_information = {
@@ -407,6 +408,9 @@ class BaseAclTest(object):
                 self.setup_rules(duthost, acl_table, ip_version)
 
             self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo)
+
+            assert self.check_rule_counters(duthost), "Rule counters should be ready!"
+
         except LogAnalyzerError as err:
             # Cleanup Config DB if rule creation failed
             logger.error("ACL table creation failed, attempting to clean-up...")
@@ -473,6 +477,21 @@ class BaseAclTest(object):
     def direction(self, request):
         """Parametrize test based on direction of traffic."""
         return request.param
+
+    def check_rule_counters(self, duthost):
+        logger.info('Wait all rule counters are ready')
+
+        return wait_until(300, 2, self.check_rule_counters_internal, duthost)
+
+    def check_rule_counters_internal(self, duthost):
+        res = duthost.command('aclshow -a')
+
+        num_of_lines = len(res['stdout'].split('\n'))
+
+        if num_of_lines <= 2 or 'N/A' in res['stdout']:
+            return False
+
+        return True
 
     def get_src_port(self, setup, direction):
         """Get a source port for the current test."""


### PR DESCRIPTION
### Description of PR

Add check code to ensure ACL rules are already written to hardware chip by check and wait until the output of `aclshow -a` command is OK.

Summary:

Fixes the failed test cases in `as5835_54t` model (or other models equipped with Broadcom chip), because of the rules are not set to Broadcom chip yet but the test case is already started to test. In this case, the first few test cases whose patterns like `test_unmatched_blocked` and `test_XXX_dropped` sometimes fail.

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach

#### What is the motivation for this PR?

Fix failed test cases in `as5835_54t` model.

#### How did you do it?

Check output of `aclshow -a` command and ensure that one or more rules are able to displayed and values of counters are not `N/A`.

#### How did you verify/test it?

Run the modified code in `as5835_54t` model to ensure that the problem is fixed.

#### Any platform specific information?

    Distribution: Debian 10.7
    Kernel: 4.19.0-6-2-amd64
    Build commit: 9b840957
    Build date: Thu Feb  4 12:09:29 UTC 2021
    Built by: ubuntu@ip-10-5-1-193
    
    Platform: x86_64-accton_as5835_54t-r0
    HwSKU: Accton-AS5835-54T
    ASIC: broadcom

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 

N/A