### PR TITLE
[snmp] Added new snmp test case

### DIFF
--- a/docs/testplan/SNMP-v2mib-test-plan.md
+++ b/docs/testplan/SNMP-v2mib-test-plan.md
@@ -1,0 +1,29 @@
+# SNMP-v2mib test plan
+
+* [Overview](#Overview)
+   * [Scope](#Scope)
+   * [Testbed](#Testbed)
+* [Setup configuration](#Setup%20configuration)
+* [Test cases](#Test%20cases)
+
+## Overview
+The purpose is to test that SNMPv2-MIB objects are functioning properly on the SONIC switch DUT.
+
+### Scope
+The test is targeting a running SONIC system with fully functioning configuration. The purpose of the test is not to test specific API, but functional testing of SNMP on SONIC system.
+
+### Testbed
+The test will run on any testbeds.
+
+## Setup configuration
+This test requires no specific setup.
+
+## Test
+Retrieve facts for a device using SNMP, and compare it to system values.
+
+## Test cases
+### Test case test_snmp_v2mib
+#### Test steps
+* Retrieve facts for a device using SNMP
+* Get expected values for a device from system.
+* Compare that facts received by SNMP are equal to values received from system.

--- a/tests/snmp/test_snmp_v2mib.py
+++ b/tests/snmp/test_snmp_v2mib.py
@@ -1,0 +1,46 @@
+"""
+Test SNMPv2MIB in SONiC.
+"""
+
+import pytest
+from tests.common.helpers.assertions import pytest_assert # pylint: disable=import-error
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+
+def test_snmp_v2mib(duthosts, rand_one_dut_hostname, localhost, creds):
+    """
+    Verify SNMPv2-MIB objects are functioning properly
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    snmp_facts = localhost.snmp_facts(host=host_ip, version="v2c",
+                                      community=creds["snmp_rocommunity"])['ansible_facts']
+    dut_facts = duthost.setup()['ansible_facts']
+    debian_ver = duthost.shell('cat /etc/debian_version')['stdout']
+    cmd = 'docker exec snmp grep "sysContact" /etc/snmp/snmpd.conf'
+    sys_contact = " ".join(duthost.shell(cmd)['stdout'].split()[1:])
+    sys_location = duthost.shell("grep 'snmp_location' /etc/sonic/snmp.yml")['stdout'].split()[-1]
+
+    expected_res = {'kernel_version': dut_facts['ansible_kernel'],
+                    'hwsku': duthost.facts['hwsku'],
+                    'os_version': 'SONiC.{}'.format(duthost.os_version),
+                    'debian_version': '{} {}'.format(dut_facts['ansible_distribution'], debian_ver)}
+
+    #Verify that sysName, sysLocation and sysContact MIB objects functions properly
+    pytest_assert(snmp_facts['ansible_sysname'] == duthost.hostname,
+                  "Unexpected MIB result {}".format(snmp_facts['ansible_sysname']))
+    pytest_assert(snmp_facts['ansible_syslocation'] == sys_location,
+                  "Unexpected MIB result {}".format(snmp_facts['ansible_syslocation']))
+    pytest_assert(snmp_facts['ansible_syscontact'] == sys_contact,
+                  "Unexpected MIB result {}".format(snmp_facts['ansible_syscontact']))
+
+    #Verify that sysDescr MIB object functions properly
+    missed_values = []
+    for system_value in expected_res:
+        if expected_res[system_value] not in snmp_facts['ansible_sysdescr']:
+            missed_values.append(expected_res[system_value])
+    pytest_assert(not missed_values, "System values {} was not found in SNMP facts: {}"
+                  .format(missed_values, snmp_facts['ansible_sysdescr']))


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR implements a new test case `test_snmp_v2mib` according to the following test plan. 
Test should verify that SNMPv2-MIB objects are functioning properly.
Fixes # (issue)

#### Testplan:
* Retrieve facts for a device using SNMP
* Get expected values for a device from system
* Compare that facts received by SNMP are equal to values received from system
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to add a new test case for snmp.
#### How did you do it?

#### How did you verify/test it
Run test on t0 and t1 topo.
`snmp/test_snmp_v2mib.py::test_snmp_v2mib PASSED `
#### Any platform specific information?
```
SONiC.master.117-dirty-20210207.073945
Distribution: Debian 10.8
Kernel: 4.19.0-9-2-amd64
Build commit: 3cc55154
Build date: Sun Feb  7 07:55:17 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?
Supports any topo.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
