### PR TITLE
[minigraph]: Make dual ToR lo2 IPs identical

### DIFF
--- a/ansible/vars/topo_dualtor-56.yml
+++ b/ansible/vars/topo_dualtor-56.yml
@@ -121,10 +121,10 @@ topology:
     loopback2:
       ipv4:
         - 10.1.0.36/32
-        - 10.1.0.37/32
+        - 10.1.0.36/32
       ipv6:
         - FC00:1::36/128
-        - FC00:1::37/128
+        - FC00:1::36/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_dualtor.yml
+++ b/ansible/vars/topo_dualtor.yml
@@ -73,10 +73,10 @@ topology:
     loopback2:
       ipv4:
         - 10.1.0.36/32
-        - 10.1.0.37/32
+        - 10.1.0.36/32
       ipv6:
         - FC00:1::36/128
-        - FC00:1::37/128
+        - FC00:1::36/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Dual ToR devices need the same Loopback2 IP to receive heartbeat replies on standby ports.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
