### PR TITLE
Converting legacy platform tests for a T2 chassis, adding validation of values to tests, and refactor test_sfp into smaller tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,8 +658,8 @@ def generate_params_supervisor_hostname(request):
         # Expecting only a single supervisor node
         if is_supervisor_node(inv_files, dut):
             return [dut]
-    pytest.fail("Test selected require a supervisor node, " +
-                "none of the DUTs '{}' in testbed '{}' are a supervisor node".format(duts, tbname))
+    # If there are no supervisor cards in a multi-dut tesbed, we are dealing with all pizza box in the testbed, pick the first DUT
+    return [duts[0]]
 
 def generate_param_asic_index(request, dut_indices, param_type):
     _, tbinfo = get_tbinfo(request)

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -81,7 +81,7 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
 
     actual_fields_values = set(summary_dict.values())
     diff_fields_values = expected_fields_values.difference(actual_fields_values)
-    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() == None)),
+    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() is None)),
                   "Unexpected value of fields, actual=%s, expected=%s on host '%s'" % (
                         str(actual_fields_values), str(expected_fields_values), duthost.hostname))
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -81,9 +81,8 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
 
     actual_fields_values = set(summary_dict.values())
     diff_fields_values = expected_fields_values.difference(actual_fields_values)
-    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() is None)),
-                  "Unexpected value of fields, actual=%s, expected=%s on host '%s'" % (
-                        str(actual_fields_values), str(expected_fields_values), duthost.hostname))
+    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() == None)),
+                  "Unexpected value of fields, actual={}, expected={} on host '{}'".format(actual_fields_values, expected_fields_values, duthost.hostname))
 
 
 def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
@@ -120,7 +119,6 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
             "0x2B": "Mellanox"
             "0xFE": "0xFBA1E964"
     """
-    
     if 'syseeprom_info' in dut_vars:
         expected_syseeprom_info_dict = dut_vars['syseeprom_info']
 
@@ -153,8 +151,8 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
             "CRC-32"]
 
         utility_cmd = "sudo python -c \"import imp; \
-            m = imp.load_source('eeprom', '/usr/share/sonic/device/%s/plugins/eeprom.py'); \
-            t = m.board('board', '', '', ''); e = t.read_eeprom(); t.decode_eeprom(e)\"" % duthost.facts["platform"]
+            m = imp.load_source('eeprom', '/usr/share/sonic/device/{}/plugins/eeprom.py'); \
+            t = m.board('board', '', '', ''); e = t.read_eeprom(); t.decode_eeprom(e)\"".format(duthost.facts["platform"])
 
         utility_cmd_output = duthost.command(utility_cmd)
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -102,9 +102,9 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
     Gather expected data from a inventory file instead if 'syseeprom_info' is defined in the inventory
     # Sample inventory with syseeprom:
     
-    str- msn2700-01:
+    str-msn2700-01:
         ansible_host: 10.251.0.188
-        model: MSN2700 - CS2FO
+        model: MSN2700-CS2FO
         serial: MT1234X56789
         base_mac: 24:8a:07:12:34:56
         syseeprom_info:
@@ -120,6 +120,7 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
             "0x2B": "Mellanox"
             "0xFE": "0xFBA1E964"
     """
+    
     if 'syseeprom_info' in dut_vars:
         expected_syseeprom_info_dict = dut_vars['syseeprom_info']
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -18,6 +18,7 @@ import util
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
+from tests.common.utilities import get_inventory_files, get_host_visible_vars
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
@@ -30,15 +31,20 @@ CMD_SHOW_PLATFORM = "show platform"
 THERMAL_CONTROL_TEST_WAIT_TIME = 65
 THERMAL_CONTROL_TEST_CHECK_INTERVAL = 5
 
+@pytest.fixture(scope='module')
+def dut_vars(duthosts, enum_rand_one_per_hwsku_hostname, request):
+    inv_files = get_inventory_files(request)
+    dut_vars = get_host_visible_vars(inv_files, enum_rand_one_per_hwsku_hostname)
+    yield dut_vars
 
-def test_show_platform_summary(duthosts, rand_one_dut_hostname):
+def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
     """
     @summary: Verify output of `show platform summary`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "summary"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info("Verifying output of '{}' on '{}'...".format(cmd, duthost.hostname))
     summary_output_lines = duthost.command(cmd)["stdout_lines"]
     summary_dict = util.parse_colon_speparated_lines(summary_output_lines)
     expected_fields = set(["Platform", "HwSKU", "ASIC"])
@@ -46,26 +52,90 @@ def test_show_platform_summary(duthosts, rand_one_dut_hostname):
     new_field = set(["ASIC Count"])
 
     missing_fields = expected_fields - actual_fields
-    pytest_assert(len(missing_fields) == 0, "Output missing fields: {}".format(repr(missing_fields)))
+    pytest_assert(len(missing_fields) == 0, "Output missing fields: {} on '{}'".format(repr(missing_fields), duthost.hostname))
 
     unexpected_fields = actual_fields - expected_fields
-    pytest_assert(((unexpected_fields == new_field) or len(unexpected_fields) == 0), "Unexpected fields in output: {}".format(repr(unexpected_fields)))
+    pytest_assert(((unexpected_fields == new_field) or len(unexpected_fields) == 0),
+                  "Unexpected fields in output: {}  on '{}'".format(repr(unexpected_fields), duthost.hostname))
 
-    # TODO: Test values against platform-specific expected data instead of testing for missing values
+    # Testing for missing values
     for key in expected_fields:
-        pytest_assert(summary_dict[key], "Missing value for '{}'".format(key))
+        pytest_assert(summary_dict[key], "Missing value for '{}' on '{}'".format(key, duthost.hostname))
+
+    # Testings values against values defined in the inventory if present in the inventory.
+    #    hwsku based on 'hwsku' or 'sonic_hwsku' inventory variable.
+    #    platform based on 'sonic_hw_platform'  inventory variable.
+    #    asic based on 'asic_type'  inventory variable.
+    #    num_asic on 'num_asics' inventory variable
+    expected_hwsku = dut_vars['hwsku'] if 'hwsku' in dut_vars else None
+    if not expected_hwsku:
+        # Lets try 'sonic_hwsku' as well
+        expected_hwsku = dut_vars['sonic_hwsku'] if 'sonic_hwsku' in dut_vars else None
+    expected_platform = dut_vars['sonic_hw_platform'] if 'sonic_hw_platform' in dut_vars else None
+    expected_asic = dut_vars['asic_type'] if 'asic_type' in dut_vars else None
+    expected_num_asic = str(dut_vars['num_asics']) if 'num_asics' in dut_vars else None
+
+    expected_fields_values = {expected_platform, expected_hwsku, expected_asic}
+    if len(unexpected_fields) != 0:
+        expected_fields_values.add(expected_num_asic)
+
+    actual_fields_values = set(summary_dict.values())
+    diff_fields_values = expected_fields_values.difference(actual_fields_values)
+    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() == None)),
+                  "Unexpected value of fields, actual=%s, expected=%s on host '%s'" % (
+                        str(actual_fields_values), str(expected_fields_values), duthost.hostname))
 
 
-def test_show_platform_syseeprom(duthosts, rand_one_dut_hostname):
+def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
     """
     @summary: Verify output of `show platform syseeprom`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "syseeprom"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
-    syseeprom_output = duthost.command(cmd)["stdout"]
-    # TODO: Gather expected data from a platform-specific data file instead of this method
+    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
+    syseeprom_cmd = duthost.command(cmd)
+    syseeprom_output = syseeprom_cmd["stdout"]
+    syseeprom_output_lines = syseeprom_cmd["stdout_lines"]
+
+    """
+    Gather expected data from a inventory file instead if 'syseeprom_info' is defined in the inventory
+    # Sample inventory with syseeprom:
+    
+    str- msn2700-01:
+        ansible_host: 10.251.0.188
+        model: MSN2700 - CS2FO
+        serial: MT1234X56789
+        base_mac: 24:8a:07:12:34:56
+        syseeprom_info:
+            "0x21": "MSN2700"
+            "0x22": "MSN2700-CS2FO"
+            "0x23": "MT1234X56789"
+            "0x24": "24:8a:07:12:34:56"
+            "0x25": "12/07/2016"
+            "0x26": "0"
+            "0x28": "x86_64-mlnx_x86-r0"
+            "0x29": "2016.11-5.1.0008-9600"
+            "0x2A": "128"
+            "0x2B": "Mellanox"
+            "0xFE": "0xFBA1E964"
+    """
+    if 'syseeprom_info' in dut_vars:
+        expected_syseeprom_info_dict = dut_vars['syseeprom_info']
+
+        parsed_syseeprom = {}
+        # Can't use util.get_fields as the values go beyond the last set of '---' in the hearder line.
+        regex_int = re.compile(r'([\S\s]+)(0x[A-F0-9]+)\s+([\d]+)\s+([\S\s]*)')
+        for line in syseeprom_output_lines[6:]:
+            t1 = regex_int.match(line)
+            if t1:
+                parsed_syseeprom[t1.group(2).strip()] = t1.group(4).strip()
+
+        for field in expected_syseeprom_info_dict:
+            pytest_assert(field in parsed_syseeprom, "Expected field '{}' not present in syseeprom on '{}'".format(field, duthost.hostname))
+            pytest_assert(parsed_syseeprom[field] == expected_syseeprom_info_dict[field],
+                          "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
+                          format(field, parsed_syseeprom[field], expected_syseeprom_info_dict[field], duthost.hostname))
 
     if duthost.facts["asic_type"] in ["mellanox"]:
         expected_fields = [
@@ -88,29 +158,34 @@ def test_show_platform_syseeprom(duthosts, rand_one_dut_hostname):
         utility_cmd_output = duthost.command(utility_cmd)
 
         for field in expected_fields:
-            pytest_assert(syseeprom_output.find(field) >= 0, "Expected field '{}' was not found".format(field))
-            pytest_assert(utility_cmd_output["stdout"].find(field) >= 0, "Expected field '{}' was not found".format(field))
+            pytest_assert(syseeprom_output.find(field) >= 0, "Expected field '{}' was not found on '{}'".format(field, duthost.hostname))
+            pytest_assert(utility_cmd_output["stdout"].find(field) >= 0, "Expected field '{}' was not found on '{}'".format(field, duthost.hostname))
 
         for line in utility_cmd_output["stdout_lines"]:
-            pytest_assert(line in syseeprom_output, "Line '{}' was not found in output".format(line))
+            pytest_assert(line in syseeprom_output, "Line '{}' was not found in output on '{}'".format(line, duthost.hostname))
 
-
-def test_show_platform_psustatus(duthosts, rand_one_dut_hostname):
+def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     """
     @summary: Verify output of `show platform psustatus`
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    logging.info("Check pmon daemon status")
-    assert check_pmon_daemon_status(duthost), "Not all pmon daemons running."
-
+    duthost = duthosts[enum_supervisor_dut_hostname]
+    logging.info("Check pmon daemon status on dut '{}'".format(duthost.hostname))
+    assert check_pmon_daemon_status(duthost), "Not all pmon daemons running on '{}'".format(duthost.hostname)
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
     psu_status_output_lines = duthost.command(cmd)["stdout_lines"]
     psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
+
+    # Check that all psus are showing valid status and also at-least one PSU is OK.
+    num_psu_ok = 0
     for line in psu_status_output_lines[2:]:
-        pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output: '{}'".format(line))
-        # TODO: Compare against expected platform-specific output
+        psu_match = psu_line_pattern.match(line)
+        pytest_assert(psu_match, "Unexpected PSU status output: '{}' on '{}'".format(line, duthost.hostname))
+        psu_status = psu_match.group(1)
+        if psu_status == "OK":
+            num_psu_ok += 1
+    pytest_assert(num_psu_ok > 0, " No PSU's are displayed with OK status on '{}'".format(duthost.hostname))
 
 
 def verify_show_platform_fan_output(duthost, raw_output_lines):
@@ -123,108 +198,123 @@ def verify_show_platform_fan_output(duthost, raw_output_lines):
         NUM_EXPECTED_COLS = 8
     else:
         NUM_EXPECTED_COLS = 6
-
-    pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output")
+    fans = {}
+    pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output on '{}'".format(duthost.hostname))
     if len(raw_output_lines) == 1:
-        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Fan Not detected", "Unexpected fan status output")
+        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Fan Not detected", "Unexpected fan status output on '{}'".format(duthost.hostname))
     else:
-        pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output if any fan is detected")
+        pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output if any fan is detected on '{}'".format(duthost.hostname))
         second_line = raw_output_lines[1]
         field_ranges = util.get_field_range(second_line)
-        pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns".format(NUM_EXPECTED_COLS))
+        field_names = util.get_fields(raw_output_lines[0], field_ranges)
+        pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns on '{}'".format(NUM_EXPECTED_COLS, duthost.hostname))
 
+        fan_num = 0
+        for line in raw_output_lines[2:]:
+            field_values = util.get_fields(line, field_ranges)
+            fans['fan' + str(fan_num)] = {}
+            for field_index, a_field in enumerate(field_names):
+                fans['fan' + str(fan_num)][a_field] = field_values[field_index]
+            fan_num += 1
 
-def test_show_platform_fan(duthosts, rand_one_dut_hostname):
+    return fans
+
+def test_show_platform_fan(duthosts, enum_supervisor_dut_hostname):
     """
     @summary: Verify output of `show platform fan`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "fan"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
     fan_status_output_lines = duthost.command(cmd)["stdout_lines"]
-    verify_show_platform_fan_output(duthost, fan_status_output_lines)
+    fans = verify_show_platform_fan_output(duthost, fan_status_output_lines)
 
-    # TODO: Test values against platform-specific expected data
+    # Check that all fans are showing valid status and also at-least one PSU is OK.
+    num_fan_ok = 0
+    for a_fan in fans.values():
+        if a_fan['Status'] == "OK":
+            num_fan_ok += 1
+    pytest_assert(num_fan_ok > 0, " No Fans are displayed with OK status on '{}'".format(duthost.hostname))
 
 
-def verify_show_platform_temperature_output(raw_output_lines):
+def verify_show_platform_temperature_output(raw_output_lines, hostname):
     """
     @summary: Verify output of `show platform temperature`. Expected output is
               "Thermal Not detected" or a table of thermal status data with 8 columns.
     """
     NUM_EXPECTED_COLS = 8
 
-    pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output")
+    pytest_assert(len(raw_output_lines) > 0, "There must be at least one line of output on '{}'".format(hostname))
     if len(raw_output_lines) == 1:
-        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Thermal Not detected", "Unexpected thermal status output")
+        pytest_assert(raw_output_lines[0].encode('utf-8').strip() == "Thermal Not detected", "Unexpected thermal status output on '{}'".format(hostname))
     else:
-        pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output if any thermal is detected")
+        pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output if any thermal is detected on '{}'".format(hostname))
         second_line = raw_output_lines[1]
         field_ranges = util.get_field_range(second_line)
-        pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns".format(NUM_EXPECTED_COLS))
+        pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns on '{}'".format(NUM_EXPECTED_COLS, hostname))
 
 
-def test_show_platform_temperature(duthosts, rand_one_dut_hostname):
+def test_show_platform_temperature(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     @summary: Verify output of `show platform temperature`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "temperature"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info("Verifying output of '{}' on '{}'...".format(cmd, duthost.hostname))
     temperature_output_lines = duthost.command(cmd)["stdout_lines"]
-    verify_show_platform_temperature_output(temperature_output_lines)
+    verify_show_platform_temperature_output(temperature_output_lines, duthost.hostname)
 
     # TODO: Test values against platform-specific expected data
 
 
-def test_show_platform_ssdhealth(duthosts, rand_one_dut_hostname):
+def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
     """
     @summary: Verify output of `show platform ssdhealth`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "ssdhealth"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info("Verifying output of '{}' on ''{}'...".format(cmd, duthost.hostname))
     ssdhealth_output_lines = duthost.command(cmd)["stdout_lines"]
     ssdhealth_dict = util.parse_colon_speparated_lines(ssdhealth_output_lines)
     expected_fields = set(["Device Model", "Health", "Temperature"])
     actual_fields = set(ssdhealth_dict.keys())
 
     missing_fields = expected_fields - actual_fields
-    pytest_assert(len(missing_fields) == 0, "Output missing fields: {}".format(repr(missing_fields)))
+    pytest_assert(len(missing_fields) == 0, "Output missing fields: {} on '{}'".format(repr(missing_fields), duthost.hostname))
 
     unexpected_fields = actual_fields - expected_fields
-    pytest_assert(len(unexpected_fields) == 0, "Unexpected fields in output: {}".format(repr(unexpected_fields)))
+    pytest_assert(len(unexpected_fields) == 0, "Unexpected fields in output: {} on '{}'".format(repr(unexpected_fields), duthost.hostname))
 
     # TODO: Test values against platform-specific expected data instead of testing for missing values
     for key in expected_fields:
-        pytest_assert(ssdhealth_dict[key], "Missing value for '{}'".format(key))
+        pytest_assert(ssdhealth_dict[key], "Missing value for '{}' on '{}'".format(key, duthost.hostname))
 
 
-def verify_show_platform_firmware_status_output(raw_output_lines):
+def verify_show_platform_firmware_status_output(raw_output_lines, hostname):
     """
     @summary: Verify output of `show platform firmware status`. Expected output is
               a table of firmware data conaining 5 columns.
     """
     NUM_EXPECTED_COLS = 5
 
-    pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output")
+    pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output on '{}'".format(hostname))
     second_line = raw_output_lines[1]
     field_ranges = util.get_field_range(second_line)
-    pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns".format(NUM_EXPECTED_COLS))
+    pytest_assert(len(field_ranges) == NUM_EXPECTED_COLS, "Output should consist of {} columns on '{}'".format(NUM_EXPECTED_COLS, hostname))
 
 
-def test_show_platform_firmware_status(duthosts, rand_one_dut_hostname):
+def test_show_platform_firmware_status(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     @summary: Verify output of `show platform firmware status`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "firmware", "status"])
 
-    logging.info("Verifying output of '{}' ...".format(cmd))
+    logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
     firmware_output_lines = duthost.command(cmd)["stdout_lines"]
-    verify_show_platform_firmware_status_output(firmware_output_lines)
+    verify_show_platform_firmware_status_output(firmware_output_lines, duthost.hostname)
 
     # TODO: Test values against platform-specific expected data

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -81,7 +81,7 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
 
     actual_fields_values = set(summary_dict.values())
     diff_fields_values = expected_fields_values.difference(actual_fields_values)
-    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() == None)),
+    pytest_assert((len(diff_fields_values) == 0 or (len(diff_fields_values) == 1 and diff_fields_values.pop() is None)),
                   "Unexpected value of fields, actual={}, expected={} on host '{}'".format(actual_fields_values, expected_fields_values, duthost.hostname))
 
 

--- a/tests/platform_tests/sfp/conftest.py
+++ b/tests/platform_tests/sfp/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import logging
+import os
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+
+ans_host = None
+
+
+def teardown_module():
+    logging.info("remove script to retrieve port mapping")
+    file_path = os.path.join('/usr/share/sonic/device', ans_host.facts['platform'], 'plugins/getportmap.py')
+    ans_host.file(path=file_path, state='absent')
+
+
+@pytest.fixture(autouse=True)
+def disable_analyzer_for_mellanox(duthost):
+    if duthost.facts["asic_type"] in ["mellanox"]:
+        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_cfg')
+        loganalyzer.load_common_config()
+
+        loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
+        marker = loganalyzer.init()
+    yield
+
+    if duthost.facts["asic_type"] in ["mellanox"]:
+        loganalyzer.analyze(marker)

--- a/tests/platform_tests/sfp/test_sfpshow.py
+++ b/tests/platform_tests/sfp/test_sfpshow.py
@@ -1,0 +1,56 @@
+"""
+Check SFP status using sfpshow.
+
+This script covers test case 'Check SFP status and configure SFP' in the SONiC platform test plan:
+https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
+"""
+
+import logging
+import pytest
+
+from util import parse_eeprom
+from util import parse_output
+from util import get_dev_conn
+
+cmd_sfp_presence = "sudo sfpshow presence"
+cmd_sfp_eeprom = "sudo sfpshow eeprom"
+
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
+]
+
+
+def test_check_sfp_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+    """
+    @summary: Check SFP presence using 'sfputil show presence'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+
+    logging.info("Check output of '%s'" % cmd_sfp_presence)
+    sfp_presence = duthost.command(cmd_sfp_presence)
+    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
+    for intf in dev_conn:
+        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+
+
+def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+    """
+    @summary: Check SFP presence using 'sfputil show presence'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+
+    logging.info("Check output of '%s'" % cmd_sfp_eeprom)
+    sfp_eeprom = duthost.command(cmd_sfp_eeprom)
+    parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
+    for intf in dev_conn:
+        assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
+        assert parsed_eeprom[intf] == "SFP EEPROM detected"

--- a/tests/platform_tests/sfp/test_sfpshow.py
+++ b/tests/platform_tests/sfp/test_sfpshow.py
@@ -31,11 +31,11 @@ def test_check_sfp_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
-    logging.info("Check output of '%s'" % cmd_sfp_presence)
+    logging.info("Check output of '{}'".format(cmd_sfp_presence))
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 
@@ -48,7 +48,7 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
-    logging.info("Check output of '%s'" % cmd_sfp_eeprom)
+    logging.info("Check output of '{}'".format(cmd_sfp_eeprom))
     sfp_eeprom = duthost.command(cmd_sfp_eeprom)
     parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
     for intf in dev_conn:

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -1,102 +1,40 @@
 """
-Check SFP status and configure SFP
+Check SFP status and configure SFP using sfputil.
 
 This script covers test case 'Check SFP status and configure SFP' in the SONiC platform test plan:
 https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
+
 import logging
-import re
-import os
 import time
 import copy
 
 import pytest
 
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from tests.common.platform.interface_utils import get_port_map
+from util import parse_eeprom
+from util import parse_output
+from util import get_dev_conn
 
-ans_host = None
-
-def teardown_module():
-    logging.info("remove script to retrieve port mapping")
-    file_path = os.path.join('/usr/share/sonic/device', ans_host.facts['platform'], 'plugins/getportmap.py')
-    ans_host.file(path=file_path, state='absent')
+cmd_sfp_presence = "sudo sfputil show presence"
+cmd_sfp_eeprom = "sudo sfputil show eeprom"
+cmd_sfp_reset = "sudo sfputil reset"
+cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
+cmd_sfp_set_lpmode = "sudo sfputil lpmode"
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
 ]
 
-def parse_output(output_lines):
-    """
-    @summary: For parsing command output. The output lines should have format 'key value'.
-    @param output_lines: Command output lines
-    @return: Returns result in a dictionary
-    """
-    res = {}
-    for line in output_lines:
-        fields = line.split()
-        if len(fields) != 2:
-            continue
-        res[fields[0]] = fields[1]
-    return res
 
-
-def parse_eeprom(output_lines):
+def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
     """
-    @summary: Parse the SFP eeprom information from command output
-    @param output_lines: Command output lines
-    @return: Returns result in a dictionary
-    """
-    res = {}
-    for line in output_lines:
-        if re.match(r"^Ethernet\d+: .*", line):
-            fields = line.split(":")
-            res[fields[0]] = fields[1].strip()
-    return res
-
-def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
-    """
-    @summary: Check SFP status and configure SFP
-
-    This case is to use the sfputil tool and show command to check SFP status and configure SFP. Currently the
-    only configuration is to reset SFP. Commands to be tested:
-    * sfputil show presence
-    * show interface transceiver presence
-    * sfputil show eeprom
-    * show interface transceiver eeprom
-    * sfputil reset <interface name>
+    @summary: Check SFP presence using 'sfputil show presence'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_cfg')
-        loganalyzer.load_common_config()
-
-        loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
-        marker = loganalyzer.init()
-
-    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
-
-    # Get the interface pertaining to that asic
-    portmap = get_port_map(duthost, enum_frontend_asic_index)
-    logging.info("Got portmap {}".format(portmap))
-
-    if enum_frontend_asic_index is not None:
-        # Check if the interfaces of this AISC is present in conn_graph_facts
-        dev_conn = {k:v for k, v in portmap.items() if k in conn_graph_facts["device_conn"][duthost.hostname]}
-        logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, dev_conn))
-
-    cmd_sfpshow_presence = "sudo sfpshow presence"
-    cmd_sfpshow_eeprom = "sudo sfpshow eeprom"
-    cmd_sfp_presence = "sudo sfputil show presence"
-    cmd_sfp_eeprom = "sudo sfputil show eeprom"
-    cmd_sfp_reset = "sudo sfputil reset"
-    cmd_xcvr_presence = "show interface transceiver presence"
-    cmd_xcvr_eeprom = "show interface transceiver eeprom"
-
     global ans_host
     ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
     logging.info("Check output of '%s'" % cmd_sfp_presence)
     sfp_presence = duthost.command(cmd_sfp_presence)
@@ -105,12 +43,14 @@ def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_fr
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
-    logging.info("Check output of '%s'" % cmd_xcvr_presence)
-    xcvr_presence = duthost.command(cmd_xcvr_presence)
-    parsed_presence = parse_output(xcvr_presence["stdout_lines"][2:])
-    for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_xcvr_presence
-        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+    """
+    @summary: Check SFP presence using 'sfputil show presence'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
     logging.info("Check output of '%s'" % cmd_sfp_eeprom)
     sfp_eeprom = duthost.command(cmd_sfp_eeprom)
@@ -119,28 +59,15 @@ def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_fr
         assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
-    logging.info("Check output of '%s'" % cmd_xcvr_eeprom)
-    xcvr_eeprom = duthost.command(cmd_xcvr_eeprom)
-    parsed_eeprom = parse_eeprom(xcvr_eeprom["stdout_lines"])
-    for intf in dev_conn:
-        assert intf in parsed_eeprom, "Interface is not in output of '%s'" % cmd_xcvr_eeprom
-        assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
-    logging.info("Check output of '%s'" % cmd_sfpshow_presence)
-    sfp_presence = duthost.command(cmd_sfpshow_presence)
-    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-    for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfpshow_presence
-        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
-
-    logging.info("Check output of '%s'" % cmd_sfpshow_eeprom)
-    sfp_eeprom = duthost.command(cmd_sfpshow_eeprom)
-    parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
-    for intf in dev_conn:
-        assert intf in parsed_eeprom, "Interface is not in output of 'sfpshow eeprom'"
-        assert parsed_eeprom[intf] == "SFP EEPROM detected"
-
-    logging.info("Test '%s <interface name>'" % cmd_sfp_reset)
+def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
+    """
+    @summary: Check SFP presence using 'sfputil show presence'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
     tested_physical_ports = set()
     for intf in dev_conn:
         phy_intf = portmap[intf][0]
@@ -163,22 +90,13 @@ def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_fr
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
-    namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    # TODO Remove this logic when minigraph facts supports namespace in multi_asic
-    up_ports = mg_facts["minigraph_ports"]
-    if enum_frontend_asic_index is not None:
-        # Check if the interfaces of this AISC is present in conn_graph_facts
-        up_ports = {k:v for k, v in portmap.items() if k in mg_facts["minigraph_ports"]}
-    intf_facts = duthost.interface_facts(namespace=namespace, up_ports=up_ports)["ansible_facts"]
+    intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
 
-    if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer.analyze(marker)
 
-
-def test_check_sfp_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, conn_graph_facts, tbinfo):
+def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
     """
     @summary: Check SFP low power mode
 
@@ -189,28 +107,9 @@ def test_check_sfp_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hos
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.get_asic(enum_frontend_asic_index)
-    if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_lpm')
-        loganalyzer.load_common_config()
-
-        loganalyzer.ignore_regex.append("Eeprom query failed")
-        marker = loganalyzer.init()
-
-    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
 
     # Get the interface pertaining to that asic
-    portmap = get_port_map(duthost, enum_frontend_asic_index)
-    logging.info("Got portmap {}".format(portmap))
-
-    if enum_frontend_asic_index is not None:
-        # Check if the interfaces of this AISC is present in conn_graph_facts
-        dev_conn = {k:v for k, v in portmap.items() if k in conn_graph_facts["device_conn"][duthost.hostname]}
-        logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, dev_conn))
-
-    cmd_sfp_presence = "sudo sfputil show presence"
-    cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
-    cmd_sfp_set_lpmode = "sudo sfputil lpmode"
-
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
     global ans_host
     ans_host = duthost
 
@@ -303,6 +202,3 @@ def test_check_sfp_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hos
     intf_facts = duthost.interface_facts(namespace=namespace, up_ports=up_ports)["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
         "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
-
-    if duthost.facts["asic_type"] in ["mellanox"]:
-        loganalyzer.analyze(marker)

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -36,11 +36,11 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
     ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
-    logging.info("Check output of '%s'" % cmd_sfp_presence)
+    logging.info("Check output of '{}'".format(cmd_sfp_presence))
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
@@ -52,7 +52,7 @@ def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
-    logging.info("Check output of '%s'" % cmd_sfp_eeprom)
+    logging.info("Check output of '{}'".format(cmd_sfp_eeprom))
     sfp_eeprom = duthost.command(cmd_sfp_eeprom)
     parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
     for intf in dev_conn:
@@ -76,8 +76,8 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
             continue
         tested_physical_ports.add(phy_intf)
         logging.info("resetting {} physical interface {}".format(intf, phy_intf))
-        reset_result = duthost.command("%s %s" % (cmd_sfp_reset, intf))
-        assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
+        reset_result = duthost.command("{} {}".format(cmd_sfp_reset, intf))
+        assert reset_result["rc"] == 0, "'{} {}' failed".format(cmd_sfp_reset, intf)
         time.sleep(5)
     logging.info("Wait some time for SFP to fully recover after reset")
     time.sleep(60)
@@ -86,14 +86,14 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
-        "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
+        "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])
 
 
 def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
@@ -113,12 +113,12 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     global ans_host
     ans_host = duthost
 
-    logging.info("Check output of '%s'" % cmd_sfp_show_lpmode)
+    logging.info("Check output of '{}'".format(cmd_sfp_show_lpmode))
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
     original_lpmode = copy.deepcopy(parsed_lpmode)
     for intf in dev_conn:
-        assert intf in parsed_lpmode, "Interface is not in output of '%s'" % cmd_sfp_show_lpmode
+        assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
@@ -146,8 +146,8 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
         tested_physical_ports.add(phy_intf)
         logging.info("setting {} physical interface {}".format(intf, phy_intf))
         new_lpmode = "off" if original_lpmode[intf].lower() == "on" else "on"
-        lpmode_set_result = duthost.command("%s %s %s" % (cmd_sfp_set_lpmode, new_lpmode, intf))
-        assert lpmode_set_result["rc"] == 0, "'%s %s %s' failed" % (cmd_sfp_set_lpmode, new_lpmode, intf)
+        lpmode_set_result = duthost.command("{} {} {}".format(cmd_sfp_set_lpmode, new_lpmode, intf))
+        assert lpmode_set_result["rc"] == 0, "'{} {} {}' failed".format(cmd_sfp_set_lpmode, new_lpmode, intf)
     time.sleep(10)
 
     if len(tested_physical_ports) == 0:
@@ -157,7 +157,7 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_lpmode, "Interface is not in output of '%s'" % cmd_sfp_show_lpmode
+        assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Try to change SFP lpmode")
@@ -173,22 +173,22 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
         tested_physical_ports.add(phy_intf)
         logging.info("restoring {} physical interface {}".format(intf, phy_intf))
         new_lpmode = original_lpmode[intf].lower()
-        lpmode_set_result = duthost.command("%s %s %s" % (cmd_sfp_set_lpmode, new_lpmode, intf))
-        assert lpmode_set_result["rc"] == 0, "'%s %s %s' failed" % (cmd_sfp_set_lpmode, new_lpmode, intf)
+        lpmode_set_result = duthost.command("{} {} {}".format(cmd_sfp_set_lpmode, new_lpmode, intf))
+        assert lpmode_set_result["rc"] == 0, "'{} {} {}' failed".format(cmd_sfp_set_lpmode, new_lpmode, intf)
     time.sleep(10)
 
     logging.info("Check SFP lower power mode again after changing SFP lpmode")
     lpmode_show = duthost.command(cmd_sfp_show_lpmode)
     parsed_lpmode = parse_output(lpmode_show["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_lpmode, "Interface is not in output of '%s'" % cmd_sfp_show_lpmode
+        assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
         assert parsed_lpmode[intf].lower() == "on" or parsed_lpmode[intf].lower() == "off", "Unexpected SFP lpmode"
 
     logging.info("Check sfp presence again after setting lpmode")
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check interface status")
@@ -201,4 +201,4 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
         up_ports = {k:v for k, v in portmap.items() if k in mg_facts["minigraph_ports"]}
     intf_facts = duthost.interface_facts(namespace=namespace, up_ports=up_ports)["ansible_facts"]
     assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
-        "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
+        "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -1,0 +1,55 @@
+"""
+Check SFP status using 'show interface transciever'.
+
+This script covers test case 'Check SFP status and configure SFP' in the SONiC platform test plan:
+https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
+"""
+
+import logging
+import pytest
+
+from util import parse_eeprom
+from util import parse_output
+from util import get_dev_conn
+
+cmd_sfp_presence = "show interface transceiver presence"
+cmd_sfp_eeprom = "show interface transceiver eeprom"
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
+]
+
+
+def test_check_sfp_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+    """
+    @summary: Check SFP presence using 'sfputil show presence'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+
+    logging.info("Check output of '%s'" % cmd_sfp_presence)
+    sfp_presence = duthost.command(cmd_sfp_presence)
+    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
+    for intf in dev_conn:
+        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+
+
+def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+    """
+    @summary: Check SFP presence using 'sfputil show presence'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ans_host
+    ans_host = duthost
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+
+    logging.info("Check output of '%s'" % cmd_sfp_eeprom)
+    sfp_eeprom = duthost.command(cmd_sfp_eeprom)
+    parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
+    for intf in dev_conn:
+        assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
+        assert parsed_eeprom[intf] == "SFP EEPROM detected"

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -30,11 +30,11 @@ def test_check_sfp_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
-    logging.info("Check output of '%s'" % cmd_sfp_presence)
+    logging.info("Check output of '{}'".format(cmd_sfp_presence))
     sfp_presence = duthost.command(cmd_sfp_presence)
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
     for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+        assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 
@@ -47,7 +47,7 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     ans_host = duthost
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
-    logging.info("Check output of '%s'" % cmd_sfp_eeprom)
+    logging.info("Check output of '{}'".format(cmd_sfp_eeprom))
     sfp_eeprom = duthost.command(cmd_sfp_eeprom)
     parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
     for intf in dev_conn:

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -1,0 +1,47 @@
+import re
+import logging
+from tests.common.platform.interface_utils import get_port_map
+
+
+def parse_output(output_lines):
+    """
+    @summary: For parsing command output. The output lines should have format 'key value'.
+    @param output_lines: Command output lines
+    @return: Returns result in a dictionary
+    """
+    res = {}
+    for line in output_lines:
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        res[fields[0]] = fields[1]
+    return res
+
+
+def parse_eeprom(output_lines):
+    """
+    @summary: Parse the SFP eeprom information from command output
+    @param output_lines: Command output lines
+    @return: Returns result in a dictionary
+    """
+    res = {}
+    for line in output_lines:
+        if re.match(r"^Ethernet\d+: .*", line):
+            fields = line.split(":")
+            res[fields[0]] = fields[1].strip()
+    return res
+
+
+def get_dev_conn(duthost, conn_graph_facts, asic_index):
+    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
+
+    # Get the interface pertaining to that asic
+    portmap = get_port_map(duthost, asic_index)
+    logging.info("Got portmap {}".format(portmap))
+
+    if asic_index is not None:
+        # Check if the interfaces of this AISC is present in conn_graph_facts
+        dev_conn = {k: v for k, v in portmap.items() if k in conn_graph_facts["device_conn"][duthost.hostname]}
+        logging.info("ASIC {} interface_list {}".format(asic_index, dev_conn))
+
+    return portmap, dev_conn

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -66,7 +66,7 @@ def supports_sfputil_on_dut(duthost):
     sfputil_file_path = os.path.join("/usr/share/sonic/device", duthost.facts['platform'], "plugins/spfutil.py")
     try:
         duthost.shell("cat {}".format(sfputil_file_path))["stdout_lines"]
-    except:
+    except Exception:
         supports_sfputil = False
 
 def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -17,11 +17,14 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.platform.interface_utils import get_port_map
 
 ans_host = None
+port_mapping = None
+supports_sfputil = True
 
 def teardown_module():
-    logging.info("remove script to retrieve port mapping")
-    file_path = os.path.join('/usr/share/sonic/device', ans_host.facts['platform'], 'plugins/getportmap.py')
-    ans_host.file(path=file_path, state='absent')
+    if supports_sfputil:
+        logging.info("remove script to retrieve port mapping")
+        file_path = os.path.join('/usr/share/sonic/device', ans_host.facts['platform'], 'plugins/getportmap.py')
+        ans_host.file(path=file_path, state='absent')
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -56,7 +59,17 @@ def parse_eeprom(output_lines):
             res[fields[0]] = fields[1].strip()
     return res
 
-def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
+def supports_sfputil_on_dut(duthost):
+    # check if duthost supports sfputils by checking the file in /usr/share/sonic/device/<platform>/plugins/sfputil.py
+    global supports_sfputil
+    supports_sfputil = True
+    sfputil_file_path = os.path.join("/usr/share/sonic/device", duthost.facts['platform'], "plugins/spfutil.py")
+    try:
+        duthost.shell("cat {}".format(sfputil_file_path))["stdout_lines"]
+    except:
+        supports_sfputil = False
+
+def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
     """
     @summary: Check SFP status and configure SFP
 
@@ -68,7 +81,10 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, enu
     * show interface transceiver eeprom
     * sfputil reset <interface name>
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    global supports_sfputil
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    supports_sfputil_on_dut(duthost)
+
     if duthost.facts["asic_type"] in ["mellanox"]:
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_cfg')
         loganalyzer.load_common_config()
@@ -93,15 +109,13 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, enu
     cmd_xcvr_presence = "show interface transceiver presence"
     cmd_xcvr_eeprom = "show interface transceiver eeprom"
 
-    global ans_host
-    ans_host = duthost
-
-    logging.info("Check output of '%s'" % cmd_sfp_presence)
-    sfp_presence = duthost.command(cmd_sfp_presence)
-    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-    for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
-        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+    if supports_sfputil:
+        logging.info("Check output of '%s'" % cmd_sfp_presence)
+        sfp_presence = duthost.command(cmd_sfp_presence)
+        parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
+        for intf in dev_conn:
+            assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+            assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
     logging.info("Check output of '%s'" % cmd_xcvr_presence)
     xcvr_presence = duthost.command(cmd_xcvr_presence)
@@ -110,12 +124,13 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, enu
         assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_xcvr_presence
         assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
-    logging.info("Check output of '%s'" % cmd_sfp_eeprom)
-    sfp_eeprom = duthost.command(cmd_sfp_eeprom)
-    parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
-    for intf in dev_conn:
-        assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
-        assert parsed_eeprom[intf] == "SFP EEPROM detected"
+    if supports_sfputil:
+        logging.info("Check output of '%s'" % cmd_sfp_eeprom)
+        sfp_eeprom = duthost.command(cmd_sfp_eeprom)
+        parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
+        for intf in dev_conn:
+            assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
+            assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
     logging.info("Check output of '%s'" % cmd_xcvr_eeprom)
     xcvr_eeprom = duthost.command(cmd_xcvr_eeprom)
@@ -124,45 +139,43 @@ def test_check_sfp_status_and_configure_sfp(duthosts, rand_one_dut_hostname, enu
         assert intf in parsed_eeprom, "Interface is not in output of '%s'" % cmd_xcvr_eeprom
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
-    logging.info("Test '%s <interface name>'" % cmd_sfp_reset)
-    tested_physical_ports = set()
-    for intf in dev_conn:
-        phy_intf = portmap[intf][0]
-        if phy_intf in tested_physical_ports:
-            logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
-            continue
-        tested_physical_ports.add(phy_intf)
-        logging.info("resetting {} physical interface {}".format(intf, phy_intf))
-        reset_result = duthost.command("%s %s" % (cmd_sfp_reset, intf))
-        assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
-        time.sleep(5)
-    logging.info("Wait some time for SFP to fully recover after reset")
-    time.sleep(60)
 
-    logging.info("Check sfp presence again after reset")
-    sfp_presence = duthost.command(cmd_sfp_presence)
-    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
-    for intf in dev_conn:
-        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
-        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+    if supports_sfputil:
+        portmap = get_port_map(duthost)
+        logging.info("Got portmap {}".format(portmap))
+        logging.info("Test '%s <interface name>'" % cmd_sfp_reset)
+        tested_physical_ports = set()
+        for intf in dev_conn:
+            phy_intf = portmap[intf][0]
+            if phy_intf in tested_physical_ports:
+                logging.info("skip tested SFPs {} to avoid repeating operating physical interface {}".format(intf, phy_intf))
+                continue
+            tested_physical_ports.add(phy_intf)
+            logging.info("resetting {} physical interface {}".format(intf, phy_intf))
+            reset_result = duthost.command("%s %s" % (cmd_sfp_reset, intf))
+            assert reset_result["rc"] == 0, "'%s %s' failed" % (cmd_sfp_reset, intf)
+            time.sleep(5)
+        logging.info("Wait some time for SFP to fully recover after reset")
+        time.sleep(60)
 
-    logging.info("Check interface status")
-    namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    # TODO Remove this logic when minigraph facts supports namespace in multi_asic
-    up_ports = mg_facts["minigraph_ports"]
-    if enum_frontend_asic_index is not None:
-        # Check if the interfaces of this AISC is present in conn_graph_facts
-        up_ports = {k:v for k, v in portmap.items() if k in mg_facts["minigraph_ports"]}
-    intf_facts = duthost.interface_facts(namespace=namespace, up_ports=up_ports)["ansible_facts"]
-    assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
-        "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
+        logging.info("Check sfp presence again after reset")
+        sfp_presence = duthost.command(cmd_sfp_presence)
+        parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
+        for intf in dev_conn:
+            assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfp_presence
+            assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+
+        logging.info("Check interface status")
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        intf_facts = duthost.interface_facts(up_ports=mg_facts["minigraph_ports"])["ansible_facts"]
+        assert len(intf_facts["ansible_interface_link_down_ports"]) == 0, \
+            "Some interfaces are down: %s" % str(intf_facts["ansible_interface_link_down_ports"])
 
     if duthost.facts["asic_type"] in ["mellanox"]:
         loganalyzer.analyze(marker)
 
 
-def test_check_sfp_low_power_mode(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo):
+def test_check_sfp_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, conn_graph_facts, tbinfo):
     """
     @summary: Check SFP low power mode
 
@@ -171,8 +184,14 @@ def test_check_sfp_low_power_mode(duthosts, rand_one_dut_hostname, enum_frontend
     * sfputil lpmode off
     * sfputil lpmode on
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    global supports_sfputil
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    supports_sfputil_on_dut(duthost)
     asichost = duthost.get_asic(enum_frontend_asic_index)
+
+    if not supports_sfputil:
+        pytest.skip("sfputil not supported on platform %s" % duthost.facts['platform'])
+
     if duthost.facts["asic_type"] in ["mellanox"]:
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='sfp_lpm')
         loganalyzer.load_common_config()

--- a/tests/platform_tests/test_sfp.py
+++ b/tests/platform_tests/test_sfp.py
@@ -87,6 +87,8 @@ def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_fr
         dev_conn = {k:v for k, v in portmap.items() if k in conn_graph_facts["device_conn"][duthost.hostname]}
         logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, dev_conn))
 
+    cmd_sfpshow_presence = "sudo sfpshow presence"
+    cmd_sfpshow_eeprom = "sudo sfpshow eeprom"
     cmd_sfp_presence = "sudo sfputil show presence"
     cmd_sfp_eeprom = "sudo sfputil show eeprom"
     cmd_sfp_reset = "sudo sfputil reset"
@@ -122,6 +124,20 @@ def test_check_sfp_status_and_configure_sfp(duthosts, enum_rand_one_per_hwsku_fr
     parsed_eeprom = parse_eeprom(xcvr_eeprom["stdout_lines"])
     for intf in dev_conn:
         assert intf in parsed_eeprom, "Interface is not in output of '%s'" % cmd_xcvr_eeprom
+        assert parsed_eeprom[intf] == "SFP EEPROM detected"
+
+    logging.info("Check output of '%s'" % cmd_sfpshow_presence)
+    sfp_presence = duthost.command(cmd_sfpshow_presence)
+    parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
+    for intf in dev_conn:
+        assert intf in parsed_presence, "Interface is not in output of '%s'" % cmd_sfpshow_presence
+        assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
+
+    logging.info("Check output of '%s'" % cmd_sfpshow_eeprom)
+    sfp_eeprom = duthost.command(cmd_sfpshow_eeprom)
+    parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
+    for intf in dev_conn:
+        assert intf in parsed_eeprom, "Interface is not in output of 'sfpshow eeprom'"
         assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
     logging.info("Test '%s <interface name>'" % cmd_sfp_reset)

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -16,11 +16,11 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_xcvr_info_in_db(duthosts, rand_one_dut_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
+def test_xcvr_info_in_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     @summary: This test case is to verify that xcvrd works as expected by checking transceiver information in DB
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logging.info("Check transceiver status")
     all_interfaces = conn_graph_facts["device_conn"][duthost.hostname]
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Need to run the legacy platform tests against a T2 chassis. However, some of the tests would run only on supervisor card, while others would run only on frontend nodes (linecards).

So, need to convert these tests to use the enum_* fixtures for dut selection, rather than rand_one_dut_hostname.

Also, we need to add some validation of the commands based on some variables that are defined in the inventory file - similar to the new PMON API validation.
#### How did you do it?
The following modifications are made to some of the legacy platform tests:
- conftest.py:
    - Some of the platform tests run only on a supervisor card for a chassis. So, needed to change rand_one_dut_hostname to enum_dut_supervisor_hostname. However, in a multi-dut testbed that has no supervisor card (like DualTor), we would raise an exception that no supervisor card is present. Instead, we will now just return the first dut in the testbed.
    - Modified generate_params_supervisor_hostname function for this behavior.
- test_xcvr_info_in_db.py:
    - Use enum_rand_one_per_hwsku_frontend_hostname to run test against frontend node instead of rand_one_dut_hostname that could give us a supervisor card.

- test_sfp:
    - Broke into 3 smaller test for the 3 modules being tested
        - sfpshow
        - sfputil
        - show interface transceiver
    - These tests were added as a directory 'sfp' under platform_tests
    - In these tests:
       - Use enum_rand_one_per_hwsku_frontend_hostname to run test against frontend node instead of rand_one_dut_hostname
       - Added validation of 'sfpshow presence' and 'sfpshow eeprom'.

- test_show_platform.py:
    - Use enum_rand_one_per_hwsku_frontend_hostname to run tests against frontend node instead of rand_one_dut_hostname
    - test_show_platform_summary:
       - Added validation of fields in 'show platform summary' based on values in the inventory if defined.
          - hwsku - based on 'hwsku' variable in the inventory
          - platform - based on 'sonic_hw_platform' variable in the inventory
          - asic - based on 'asic_type' variable in the inventory
          - asic count - based on 'num_asics' variable in the inventory
    - test_show_syseeprom:
       - Validate values against 'syseeprom_info' dictionary if defined in the inventory
    - test_show_platform_psustatus:
       - Validate that atleast one of the PSU's shows status as OK.
    - test_show_platform_fan:
       - Validate that atleast one of the fans shows status as OK.
#### How did you verify/test it?
Validated the modified tests against a chassis and also a pizza box.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
