### PR TITLE
Fix incorrect minigraph_ptf_indices in minigraph facts.

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1133,10 +1133,14 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         # the minigraph facts are not always match up with PTF port indices.
         try:
             dut_index = tbinfo['duts'].index(self.hostname)
-            map = tbinfo['topo']['ptf_map'][str(dut_index)]
-            if map:
+            port_map = tbinfo['topo']['ptf_map'][str(dut_index)]
+
+            if port_map:
                 for port, index in mg_facts['minigraph_port_indices'].items():
-                    mg_facts['minigraph_ptf_indices'][port] = map[str(index)]
+                    try:
+                        mg_facts['minigraph_ptf_indices'][port] = port_map[str(index)]
+                    except (KeyError):
+                        pass
         except (ValueError, KeyError):
             pass
 
@@ -1891,7 +1895,7 @@ class SonicAsic(object):
 
     def interface_facts(self, *module_args, **complex_args):
         """Wrapper for the interface_facts ansible module.
-        
+
         Args:
             module_args: other ansible module args passed from the caller
             complex_args: other ansible keyword args

--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1131,18 +1131,14 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         # Fix the ptf port index for multi-dut testbeds. These testbeds have
         # multiple DUTs sharing a same PTF host. Therefore, the indices from
         # the minigraph facts are not always match up with PTF port indices.
-        try:
-            dut_index = tbinfo['duts'].index(self.hostname)
-            port_map = tbinfo['topo']['ptf_map'][str(dut_index)]
+        dut_index = tbinfo['duts'].index(self.hostname)
+        port_map = tbinfo['topo']['ptf_map'].get(str(dut_index), None)
 
-            if port_map:
-                for port, index in mg_facts['minigraph_port_indices'].items():
-                    try:
-                        mg_facts['minigraph_ptf_indices'][port] = port_map[str(index)]
-                    except (KeyError):
-                        pass
-        except (ValueError, KeyError):
-            pass
+        if port_map:
+            for port, index in mg_facts['minigraph_port_indices'].items():
+                # There may be more interfaces on DUT than port_map, so the check is necessary
+                if str(index) in port_map:
+                    mg_facts['minigraph_ptf_indices'][port] = port_map[str(index)]
 
         return mg_facts
 


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The ptf port indices for dualtor testbed is incorrect due to a bug in ```get_extended_minigraph_facts```. This commit address the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix bug in ```get_extended_minigraph_facts```, which cause incorrect ptf port indices on dualtor testbed.

#### How did you do it?
Add a ```try - except``` to catch ```KeyError``` in for loop.

#### How did you verify/test it?
Verified on dualtor testbed, and confirmed the ptf port indice is correct after this update.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
