### PR TITLE
[icmp responder]: Allow hardcoding of ICMP responder MAC

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -177,7 +177,11 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
     templ = Template(open(os.path.join(TEMPLATES_DIR, ICMP_RESPONDER_CONF_TEMPL)).read())
     ptf_indices = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_ptf_indices"]
     vlan_intfs = duthost.get_vlan_intfs()
+    vlan_table = duthost.get_running_config_facts()['VLAN']
+    vlan_name = list(vlan_table.keys())[0]
+    vlan_mac = vlan_table[vlan_name]['mac']
     icmp_responder_args = " ".join("-i eth%s" % ptf_indices[_] for _ in vlan_intfs)
+    icmp_responder_args += " " + "-m {}".format(vlan_mac)
     ptfhost.copy(
         content=templ.render(icmp_responder_args=icmp_responder_args),
         dest=os.path.join(SUPERVISOR_CONFIG_DIR, "icmp_responder.conf")
@@ -188,4 +192,4 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
     yield
 
     logging.debug("Stop running icmp_responder")
-    ptfhost.shell("supervisorctl stop icmp_responder")
+    # ptfhost.shell("supervisorctl stop icmp_responder")

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -192,4 +192,4 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
     yield
 
     logging.debug("Stop running icmp_responder")
-    # ptfhost.shell("supervisorctl stop icmp_responder")
+    ptfhost.shell("supervisorctl stop icmp_responder")

--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -6,7 +6,7 @@ from scapy.data import ETH_P_IP
 from select import select
 
 
-def respond_to_icmp_request(socket, request, src_mac=None):
+def respond_to_icmp_request(socket, request, dst_mac=None):
     """Respond to ICMP request."""
     reply = request.copy()
     reply[ICMP].type = 0
@@ -15,12 +15,12 @@ def respond_to_icmp_request(socket, request, src_mac=None):
     reply[IP].src, reply[IP].dst = request[IP].dst, request[IP].src
     reply[IP].chksum = None
 
-    if src_mac is None:
-        icmp_reply_source_mac = request[Ether].src
+    if dst_mac is None:
+        icmp_reply_dst_mac = request[Ether].src
     else:
-        icmp_reply_source_mac = src_mac
+        icmp_reply_dst_mac = dst_mac
 
-    reply[Ether].src, reply[Ether].dst = request[Ether].dst, icmp_reply_source_mac
+    reply[Ether].src, reply[Ether].dst = request[Ether].dst, icmp_reply_dst_mac
     socket.send(reply)
 
 
@@ -29,7 +29,7 @@ class ICMPSniffer(object):
 
     TYPE_ECHO_REQUEST = 8
 
-    def __init__(self, ifaces, request_handler=None, src_mac=None):
+    def __init__(self, ifaces, request_handler=None, dst_mac=None):
         """
         Init ICMP sniffer.
 
@@ -43,7 +43,7 @@ class ICMPSniffer(object):
             self.sniff_sockets.append(conf.L2socket(type=ETH_P_IP, iface=iface, filter="icmp"))
             self.iface_hwaddr[iface] = get_if_hwaddr(iface)
         self.request_handler = request_handler
-        self.src_mac = src_mac
+        self.dst_mac = dst_mac
 
     def __call__(self):
         try:
@@ -53,7 +53,7 @@ class ICMPSniffer(object):
                     packet = s.recv()
                     if packet is not None:
                         if packet[ICMP].type == self.TYPE_ECHO_REQUEST and self.request_handler:
-                            self.request_handler(s, packet, self.src_mac)
+                            self.request_handler(s, packet, self.dst_mac)
         finally:
             for s in self.sniff_sockets:
                 s.close()
@@ -62,10 +62,10 @@ class ICMPSniffer(object):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="ICMP responder")
     parser.add_argument("--intf", "-i", dest="ifaces", required=True, action="append", help="interface to listen for ICMP request")
-    parser.add_argument("--src_mac", "-m", dest="src_mac", required=False, action="store", help="The source MAC to use for ICMP replies")
+    parser.add_argument("--dst_mac", "-m", dest="dst_mac", required=False, action="store", help="The source MAC to use for ICMP replies")
     args = parser.parse_args()
     ifaces = args.ifaces
-    src_mac = args.src_mac
+    dst_mac = args.dst_mac
 
-    icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, src_mac=src_mac)
+    icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, dst_mac=dst_mac)
     icmp_sniffer()

--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -6,7 +6,7 @@ from scapy.data import ETH_P_IP
 from select import select
 
 
-def respond_to_icmp_request(socket, request):
+def respond_to_icmp_request(socket, request, src_mac=None):
     """Respond to ICMP request."""
     reply = request.copy()
     reply[ICMP].type = 0
@@ -14,7 +14,13 @@ def respond_to_icmp_request(socket, request):
     reply[ICMP].chksum = None
     reply[IP].src, reply[IP].dst = request[IP].dst, request[IP].src
     reply[IP].chksum = None
-    reply[Ether].src, reply[Ether].dst = request[Ether].dst, request[Ether].src
+
+    if src_mac is None:
+        icmp_reply_source_mac = request[Ether].src
+    else:
+        icmp_reply_source_mac = src_mac
+
+    reply[Ether].src, reply[Ether].dst = request[Ether].dst, icmp_reply_source_mac
     socket.send(reply)
 
 
@@ -23,7 +29,7 @@ class ICMPSniffer(object):
 
     TYPE_ECHO_REQUEST = 8
 
-    def __init__(self, ifaces, request_handler=None):
+    def __init__(self, ifaces, request_handler=None, src_mac=None):
         """
         Init ICMP sniffer.
 
@@ -37,6 +43,7 @@ class ICMPSniffer(object):
             self.sniff_sockets.append(conf.L2socket(type=ETH_P_IP, iface=iface, filter="icmp"))
             self.iface_hwaddr[iface] = get_if_hwaddr(iface)
         self.request_handler = request_handler
+        self.src_mac = src_mac
 
     def __call__(self):
         try:
@@ -46,7 +53,7 @@ class ICMPSniffer(object):
                     packet = s.recv()
                     if packet is not None:
                         if packet[ICMP].type == self.TYPE_ECHO_REQUEST and self.request_handler:
-                            self.request_handler(s, packet)
+                            self.request_handler(s, packet, self.src_mac)
         finally:
             for s in self.sniff_sockets:
                 s.close()
@@ -55,8 +62,10 @@ class ICMPSniffer(object):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="ICMP responder")
     parser.add_argument("--intf", "-i", dest="ifaces", required=True, action="append", help="interface to listen for ICMP request")
+    parser.add_argument("--src_mac", "-m", dest="src_mac", required=False, action="store", help="The source MAC to use for ICMP replies")
     args = parser.parse_args()
     ifaces = args.ifaces
+    src_mac = args.src_mac
 
-    icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request)
+    icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, src_mac=src_mac)
     icmp_sniffer()

--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -62,7 +62,7 @@ class ICMPSniffer(object):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="ICMP responder")
     parser.add_argument("--intf", "-i", dest="ifaces", required=True, action="append", help="interface to listen for ICMP request")
-    parser.add_argument("--dst_mac", "-m", dest="dst_mac", required=False, action="store", help="The source MAC to use for ICMP replies")
+    parser.add_argument("--dst_mac", "-m", dest="dst_mac", required=False, action="store", help="The destination MAC to use for ICMP echo replies")
     args = parser.parse_args()
     ifaces = args.ifaces
     dst_mac = args.dst_mac


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ICMP responder needs to reply to linkmgrd heartbeats using VLAN MAC as the source MAC. Currently, linkmgrd sends the heartbeat with the interface MAC instead of the VLAN MAC, and ICMP responder simply re-uses the interface MAC.

This change allows ICMP responder to always reply with the VLAN MAC.

#### How did you do it?
When deploying ICMP responder, read the VLAN MAC from the DUT and pass it as a CLI option to ICMP responder.

#### How did you verify/test it?
Ran ICMP responder with the MAC option, verified that response packets were sent with the correct MAC 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
