### PR TITLE
[vlan] Update test_vlan

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -118,6 +118,19 @@ def setup_vlan(ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, vlan_ports_
             duthost.command('config vlan add {}'.format(vlan['vlan_id']))
             duthost.command("config interface ip add Vlan{} {}".format(vlan['vlan_id'], vlan['ip'].upper()))
 
+        # Delete untagged vlans from interfaces to avoid error message
+        # when adding untagged vlan to interface that already have one
+        if 'master' in duthost.os_version or '202012' in duthost.os_version:
+            logger.info("Delete untagged vlans from interfaces")
+            for vlan_port in vlan_ports_list:
+                vlan_members = cfg_facts.get('VLAN_MEMBER', {})
+                vlan_name, vid = vlan_members.keys()[0], vlan_members.keys()[0].replace("Vlan", '')
+                try:
+                    if vlan_members[vlan_name][vlan_port['dev']]['tagging_mode'] == 'untagged':
+                        duthost.command("config vlan member del {} {}".format(vid, vlan_port['dev']))
+                except KeyError:
+                    continue
+
         logger.info("Add members to Vlans")
         for vlan_port in vlan_ports_list:
             for permit_vlanid in vlan_port['permit_vlanid'].keys():
@@ -424,7 +437,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
 
     src_mac = ptfadapter.dataplane.get_mac(0, src_port)
     dst_mac = ptfadapter.dataplane.get_mac(0, dst_port)
-    
+
     transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
 
@@ -441,7 +454,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     else:
         pytest.fail("Expected packet was not received")
 
-    logger.info ("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))  
+    logger.info ("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))
 
     testutils.send(ptfadapter, dst_port, return_transmit_untagged_pkt)
 

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -120,7 +120,7 @@ def setup_vlan(ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, vlan_ports_
 
         # Delete untagged vlans from interfaces to avoid error message
         # when adding untagged vlan to interface that already have one
-        if 'master' in duthost.os_version or '202012' in duthost.os_version:
+        if '201911' not in duthost.os_version:
             logger.info("Delete untagged vlans from interfaces")
             for vlan_port in vlan_ports_list:
                 vlan_members = cfg_facts.get('VLAN_MEMBER', {})


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_vlan fails due to recent PR in sonic-utilities - [1382](https://github.com/Azure/sonic-utilities/pull/1382). When test tries to add untagged vlan for a interface that already have one untagged vlan, it receives error message `Error: Ethernet8 is already untagged member!` . So in order to make test pass, we need to delete vlan from interfaces before adding new ones.
This change is needed for master and 202012 Sonic images. On teardown there is config reload, therefore after test execution, default settings will be restored.

```
vlan/test_vlan.py::test_vlan_tc1_send_untagged ERROR
vlan/test_vlan.py::test_vlan_tc2_send_tagged ERROR
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid ERROR
vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast ERROR
vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast ERROR

E           RunAnsibleModuleFail: run module command failed, Ansible Results =>
E           {
E               "changed": true, 
E               "cmd": [
E                   "supervisorctl", 
E                   "stop", 
E                   "arp_responder"
E               ], 
E               "delta": "0:00:00.309234", 
E               "end": "2021-02-10 01:32:43.918828", 
E               "failed": true, 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "supervisorctl stop arp_responder", 
E                       "_uses_shell": false, 
E                       "argv": null, 
E                       "chdir": null, 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2021-02-10 01:32:43.609594", 
E               "stderr": "", 
E               "stderr_lines": [], 
E               "stdout": "arp_responder: ERROR (no such process)", 
E               "stdout_lines": [
E                   "arp_responder: ERROR (no such process)"
E               ]
E           }
```

```
show vlan config
Name VID Member Mode
-------- ----- ---------- --------
Vlan200 200 Ethernet8 tagged
Vlan1000 1000 Ethernet4 untagged
Vlan1000 1000 Ethernet8 untagged
Vlan1000 1000 Ethernet12 untagged
Vlan1000 1000 Ethernet16 untagged
Vlan1000 1000 Ethernet20 untagged
Vlan1000 1000 Ethernet24 untagged
Vlan1000 1000 Ethernet28 untagged
Vlan1000 1000 Ethernet32 untagged
Vlan1000 1000 Ethernet36 untagged
Vlan1000 1000 Ethernet40 untagged
Vlan1000 1000 Ethernet44 untagged
Vlan1000 1000 Ethernet48 untagged
Vlan1000 1000 Ethernet52 untagged
Vlan1000 1000 Ethernet56 untagged
Vlan1000 1000 Ethernet60 untagged
Vlan1000 1000 Ethernet64 untagged
Vlan1000 1000 Ethernet68 untagged
Vlan1000 1000 Ethernet72 untagged
Vlan1000 1000 Ethernet76 untagged
Vlan1000 1000 Ethernet80 untagged
Vlan1000 1000 Ethernet84 untagged
Vlan1000 1000 Ethernet88 untagged
Vlan1000 1000 Ethernet92 untagged
Vlan1000 1000 Ethernet96 untagged

sudo config vlan member add --untagged 100 Ethernet8
Error: Ethernet8 is already untagged member!
```
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make test_vlan passed 
#### How did you do it?
Delete untagged vlan if interfaces already have one. 
#### How did you verify/test it?
Run test on t0 topo on master, 201911 and 202012 images. 
```
vlan/test_vlan.py::test_vlan_tc1_send_untagged PASSED
vlan/test_vlan.py::test_vlan_tc2_send_tagged PASSED
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid PASSED
vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast PASSED
vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast PASSED
```
#### Any platform specific information?
```
SONiC.master.119-dirty-20210209.083357
Build commit: 1d99d14e
Build date: Tue Feb  9 08:49:25 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
