### PR TITLE
[pdu] flatten the PDU status data

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -153,27 +153,28 @@ def pdu_action_on_dut(host, attrs, action):
             ret['Summary'].append('No PDU IP or name')
             continue
 
-        rec = { 'PDU' : p_name, 'PDU_IP' : pdu_host, 'status' : [] }
-        ret['PDU status'].append(rec)
-
         controller = get_pdu_controller(pdu_host, host, pdu_info)
 
         if not controller:
             ret['Summary'].append('Failed to communicate with controller {}'.format(p_name))
             continue
 
-        rec['status'] = controller.get_outlet_status()
+        status = controller.get_outlet_status()
         if action == 'off':
-            for outlet in rec['status']:
+            for outlet in status:
                 controller.turn_off_outlet(outlet['outlet_id'])
-            rec['status'] = controller.get_outlet_status()
+            status = controller.get_outlet_status()
         elif action == 'on':
-            for outlet in rec['status']:
+            for outlet in status:
                 controller.turn_on_outlet(outlet['outlet_id'])
-            rec['status'] = controller.get_outlet_status()
+            status = controller.get_outlet_status()
         elif action != 'status':
             ret['Summary'].append('Unsupported action {}.'.format(action))
             continue
+
+        for outlet in status:
+            outlet.update({ 'PDU' : p_name, 'PDU_IP' : pdu_host })
+            ret['PDU status'].append(outlet)
 
     return ret
 


### PR DESCRIPTION
### Description of PR
Summary:

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
devutils returns pdu status is too deep.

#### How did you do it?
Flatten the PDU status data so that if we have 2 outlets from different PDUs, the return data structure will be the same as 2 outlets from a single PDU.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
```
yinxi@681acf730601:/var/src/sonic-mgmt/ansible$ ./devutils -i str -g sonic -a pdu_status -l str-7260cx3-acs-1  
+-------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| Host              | Action   | PDU status                                                                                                                                                             | Summary   |
+===================+==========+========================================================================================================================================================================+===========+
| str-7260cx3-acs-1 | status   | [{'outlet_on': True, 'PDU_IP': u'10.3.155.107', 'PDU': u'pdu-107', 'outlet_id': 0}, {'outlet_on': True, 'PDU_IP': u'10.3.155.107', 'PDU': u'pdu-107', 'outlet_id': 1}] | []        |
+-------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
yinxi@681acf730601:/var/src/sonic-mgmt/ansible$ ./devutils -i str -g sonic -a pdu_status -l str-7260cx3-acs-1 -j
[
    {
        "Action": "status",
        "Host": "str-7260cx3-acs-1",
        "PDU status": [
            {
                "outlet_on": true,
                "PDU_IP": "10.3.155.107",
                "PDU": "pdu-107",
                "outlet_id": 0
            },
            {
                "outlet_on": true,
                "PDU_IP": "10.3.155.107",
                "PDU": "pdu-107",
                "outlet_id": 1
            }
        ],
        "Summary": []
    }
]
```