### PR TITLE
[device map] fix device map creation issue and caching issue

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1136,7 +1136,8 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             map = tbinfo['topo']['ptf_map'][str(dut_index)]
             if map:
                 for port, index in mg_facts['minigraph_port_indices'].items():
-                    mg_facts['minigraph_ptf_indices'][port] = map[str(index)]
+                    if str(index) in map:
+                        mg_facts['minigraph_ptf_indices'][port] = map[str(index)]
         except (ValueError, KeyError):
             pass
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -195,9 +195,6 @@ export ANSIBLE_LIBRARY=$SONIC_MGMT_DIR/ansible/library/
 # workaround for issue https://github.com/Azure/sonic-mgmt/issues/1659
 export ANSIBLE_KEEP_REMOTE_FILES=1
 
-# clear cache from previous test runs
-rm -rf $SONIC_MGMT_DIR/tests/_cache
-
 # clear logs from previous test runs
 rm -rf $SONIC_MGMT_DIR/tests/logs
 mkdir -p  $SONIC_MGMT_DIR/tests/logs

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -14,6 +14,13 @@ pytestmark = [
     pytest.mark.disable_loganalyzer
 ]
 
+
+def test_cleanup_cache():
+    folder = '_cache'
+    if os.path.exists(folder):
+        os.system('rm -rf {}'.format(folder))
+
+
 def test_cleanup_testbed(duthosts, enum_dut_hostname, request, ptfhost):
     duthost = duthosts[enum_dut_hostname]
     deep_clean = request.config.getoption("--deep_clean")


### PR DESCRIPTION
### Description of PR
Summary:

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
lag_2 was failing on dualtor testbed with 3 tests. 3 particular lag always fail. Investigation shows that the cached ptf port map was not right.

#### How did you do it?
Device map creation could be aborted in the middle and leave map half updated if an extra interface was not defined in the
topology but show up in the minigraph.

And because we cache the host variables on the file system, the cache could prevent a correct map being generated.

Add a new pretest to remove cache. It would still be good to generate cache for each nightly test.

Remove cache removal from kvmtest.sh to leave it for pretest.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
Verified that the new pretest will remove _cache if exists.

Verified that newly generated port map for dualtor testbed is correct.

lag_2 passes with the change.