### PR TITLE
[wr_arp] add timeout to thread join

### DIFF
--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -271,7 +271,11 @@ class ArpTest(BaseTest):
 
         self.assertTrue(time.time() < self.stop_at, "warm-reboot took to long")
 
-        test_port_thr.join()
+        test_port_thr.join(timeout=self.how_long)
+        if test_port_thr.isAlive():
+            self.log("Timed out wating for warm reboot")
+            self.req_dut('quit')
+            self.assertTrue(False, "Timed out waiting for warm reboot")
 
         uptime_after = self.req_dut('uptime')
         if uptime_after.startswith('error'):

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -273,7 +273,7 @@ class ArpTest(BaseTest):
 
         test_port_thr.join(timeout=self.how_long)
         if test_port_thr.isAlive():
-            self.log("Timed out wating for warm reboot")
+            self.log("Timed out waiting for warm reboot")
             self.req_dut('quit')
             self.assertTrue(False, "Timed out waiting for warm reboot")
 


### PR DESCRIPTION
### Description of PR
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
test_wr_arp.py got stuck in nightly test until the test was aborted. This is because paramiko didn't return shell command return code from exec_command() call. So if there were error and warm-reboot didn't proceed, the command will return as success. Without return code, we cannot solely rely on stderr to judge if the command failed or not (because we could ignored the error and proceeded).

#### How did you do it?
When warm reboot fails to reboot the dut and test failed to detect the failure. The thread.join() would fail and the test will stuck
indefinitely.

Add a timeout to join and check if the thread quit after join returns.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
While warm reboot fails, with the fix, the thread join will timeout and give properly error information:

E                   "======================================================================", 
E                   "FAIL: wr_arp.ArpTest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"ptftests/wr_arp.py\", line 278, in runTest", 
E                   "    self.assertTrue(False, \"Timed out waiting for warm reboot\")", 
E                   "AssertionError: Timed out waiting for warm reboot", 
E                   "", 
E                   "----------------------------------------------------------------------", 
E                   "Ran 1 test in 384.692s", 
E                   "", 
E                   "FAILED (failures=1)"