### PR TITLE
[nat] skip nat test when image doesn't have nat feature enabled

### DIFF
--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -151,6 +151,10 @@ def apply_global_nat_config(duthost):
     after test run cleanup DUT's NAT configration
     :param duthost: DUT host object
     """
+    status = duthost.get_feature_status()
+    if 'nat' not in status:
+        pytest.skip('nat feature is not enabled with image version {}'.format(duthost.os_version))
+
     nat_global_config(duthost)
     yield
     # reload config on teardown

--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -151,7 +151,7 @@ def apply_global_nat_config(duthost):
     after test run cleanup DUT's NAT configration
     :param duthost: DUT host object
     """
-    status = duthost.get_feature_status()
+    status, _ = duthost.get_feature_status()
     if 'nat' not in status:
         pytest.skip('nat feature is not enabled with image version {}'.format(duthost.os_version))
 


### PR DESCRIPTION
Summary:
skip nat test when image doesn't have nat feature enabled

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
nat tests are failing when executed against image doesn't have feature enabled.

#### How did you do it?
check feature table and skip the test when feature not enabled.

#### How did you verify/test it?
run nat test against an image that doesn't have nat feature enabled.