### PR TITLE
[pfcwd] Disable fake storm on Mellanox platforms

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from .files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,22 @@ def pytest_addoption(parser):
                      help='PFC WD storm restore interval')
     parser.addoption('--fake-storm', action='store', type=bool, default=True,
                      help='Fake storm for most ports instead of using pfc gen')
+
+@pytest.fixture(scope="module")
+def fake_storm(request, duthosts, rand_one_dut_hostname):
+    """
+    Enable/disable fake storm based on platform and input parameters
+
+    Args:
+        request: pytest request object
+        duthosts: AnsibleHost instance for multi DUT
+        rand_one_dut_hostname: hostname of DUT
+
+    Returns:
+        fake_storm: False/True
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    return request.config.getoption('--fake-storm') if not isMellanoxDevice(duthost) else False
 
 @pytest.fixture(scope="module")
 def setup_pfc_test(duthosts, rand_one_dut_hostname, ptfhost, conn_graph_facts, tbinfo):

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -499,12 +499,13 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         logger.info("--- Verify PFCwd counters for port {} ---".format(port))
         self.stats.verify_pkt_cnts(self.pfc_wd['port_type'], self.pfc_wd['test_pkt_count'])
 
-    def test_pfcwd_actions(self, request, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, fanouthosts):
+    def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, fanouthosts):
         """
         PFCwd functional test
 
         Args:
             request(object) : pytest request object
+            fake_storm(fixture) : Module scoped fixture for enable/disable fake storm
             setup_pfc_test(fixture) : Module scoped autouse fixture for PFCwd
             fanout_graph_facts(fixture) : fanout graph info
             ptfhost(AnsibleHost) : ptf host instance
@@ -522,10 +523,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.neighbors = setup_info['neighbors']
         dut_facts = self.dut.facts
         self.peer_dev_list = dict()
-        self.fake_storm = request.config.getoption("--fake-storm")
+        self.fake_storm = fake_storm
+        self.storm_hndle = None
 
         for idx, port in enumerate(self.ports):
-             self.storm_hndle = None
              logger.info("")
              logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
              self.setup_test_params(port, setup_info['vlan'], init=not idx)

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -430,12 +430,13 @@ class TestPfcwdWb(SetupPfcwdFunc):
                         logger.info("--- Disabling fake storm on port {} queue {}".format(port, queue))
                         PfcCmd.set_storm_status(self.dut, self.oid_map[(port, queue)], "disabled")
 
-    def pfcwd_wb_helper(self, request, testcase_actions, setup_pfc_test, fanout_graph_facts, ptfhost,
+    def pfcwd_wb_helper(self, fake_storm, testcase_actions, setup_pfc_test, fanout_graph_facts, ptfhost,
                         duthost, localhost, fanouthosts):
         """
         Helper method that initializes the vars and starts the test execution
 
         Args:
+            fake_storm(bool): if fake storm is enabled or disabled
             testcase_actions(list): list of actions that the test will go through
             setup_pfc_test(fixture): module scoped autouse fixture
             fanout_graph_facts(fixture): fanout info
@@ -460,7 +461,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         storm_deferred = 0
         storm_restored = 0
         self.max_wait = 0
-        self.fake_storm = request.config.getoption("--fake-storm")
+        self.fake_storm = fake_storm
         self.oid_map = dict()
         self.storm_threads = []
 
@@ -519,11 +520,12 @@ class TestPfcwdWb(SetupPfcwdFunc):
         """
         yield request.param
 
-    def test_pfcwd_wb(self, request, testcase_action, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, localhost, fanouthosts):
+    def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, localhost, fanouthosts):
         """
         Tests PFCwd warm reboot with various testcase actions
 
         Args:
+            fake_storm(fixture): fake storm status
             testcase_action(fixture): testcase to execute (values: 'no_storm', 'storm', 'async_storm')
 
                 'no_storm' : PFCwd storm detection/restore before and after warm reboot
@@ -543,5 +545,5 @@ class TestPfcwdWb(SetupPfcwdFunc):
         """
         duthost = duthosts[rand_one_dut_hostname]
         logger.info("--- {} ---".format(TESTCASE_INFO[testcase_action]['desc']))
-        self.pfcwd_wb_helper(request, TESTCASE_INFO[testcase_action]['test_sequence'], setup_pfc_test,
+        self.pfcwd_wb_helper(fake_storm, TESTCASE_INFO[testcase_action]['test_sequence'], setup_pfc_test,
                              fanout_graph_facts, ptfhost, duthost, localhost, fanouthosts)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fake storm option was added to reduce the flakiness of test runs seen on some platforms due to actual pfc storm not large enough to trigger pfcwd. This is causing some failures on Mellanox platforms after warm reboot. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you do it?
Created a module scoped 'fake_storm' fixture and set its status to False for Mellanox platforms

#### How did you verify/test it?
Ran both the tests (test_pfcwd_function.py and test_pfcwd_warm_reboot.py) on Mellanox and non Mellanox platforms and they passed
Verified in the logs that pfc storm was always generated by the fanout for Mellanox platforms and for non Mellanox platforms only the 1st port had the storm generated by the fanout. Rest of the ports were using the fake storm
