### PR TITLE
[advanced-reboot] improve logging and assertions

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -155,6 +155,7 @@ class ReloadTest(BaseTest):
         self.check_param('vnet', False, required=False)
         self.check_param('vnet_pkts', None, required=False)
         self.check_param('target_version', '', required=False)
+        self.check_param('bgp_v4_v6_time_diff', 40, required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -871,6 +871,7 @@ class ReloadTest(BaseTest):
 
         def wait_for_ssh_threads(signal):
             while any(thr.is_alive() for thr, _ in self.ssh_jobs) and not signal.is_set():
+                self.log('Waiting till SSH threads stop')
                 time.sleep(self.TIMEOUT)
 
             for thr, _ in self.ssh_jobs:
@@ -1147,8 +1148,10 @@ class ReloadTest(BaseTest):
         return stdout, stderr, return_code
 
     def peer_state_check(self, ip, queue):
-        ssh = Arista(ip, queue, self.test_params)
+        self.log('SSH thread for VM {} started'.format(ip))
+        ssh = Arista(ip, queue, self.test_params, log_cb=self.log)
         self.fails[ip], self.info[ip], self.cli_info[ip], self.logs_info[ip] = ssh.run()
+        self.log('SSH thread for VM {} finished'.format(ip))
 
     def wait_until_cpu_port_down(self, signal):
         while not signal.is_set():

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -35,9 +35,10 @@ import enum
 
 class Arista(object):
     DEBUG = False
-    def __init__(self, ip, queue, test_params, login='admin', password='123456'):
+    def __init__(self, ip, queue, test_params, log_cb=None, login='admin', password='123456'):
         self.ip = ip
         self.queue = queue
+        self.log_cb = log_cb
         self.login = login
         self.password = password
         self.conn = None
@@ -51,6 +52,10 @@ class Arista(object):
 
     def __del__(self):
         self.disconnect()
+
+    def log(self, msg):
+        if self.log_cb is not None:
+            self.log_cb('SSH thread VM={}: {}'.format(self.ip, msg))
 
     def connect(self):
         self.conn = paramiko.SSHClient()
@@ -117,6 +122,7 @@ class Arista(object):
         while not (quit_enabled and v4_routing_ok and v6_routing_ok):
             cmd = self.queue.get()
             if cmd == 'quit':
+                self.log('quit command received')
                 quit_enabled = True
                 continue
             cur_time = time.time()
@@ -159,20 +165,29 @@ class Arista(object):
 
         attempts = 60
         log_present = False
-        for _ in range(attempts):
+        log_data = {}
+        for attempt in range(attempts):
+            self.log('Collecting logs for attemt {}'.format(attempt))
             log_output = self.do_cmd("show log | begin %s" % log_first_line)
+            self.log('Log output "{}"'.format(log_output))
             log_lines = log_output.split("\r\n")[1:-1]
-            log_data = self.parse_logs(log_lines)
-            if (self.reboot_type == 'fast-reboot' and \
-                any(k.startswith('BGP') for k in log_data) and any(k.startswith('PortChannel') for k in log_data)) \
-                    or (self.reboot_type == 'warm-reboot' and any(k.startswith('BGP') for k in log_data)):
-                log_present = True
-                break
-            time.sleep(1) # wait until logs are populated
+            try:
+                log_data = self.parse_logs(log_lines)
+                if (self.reboot_type == 'fast-reboot' and \
+                    any(k.startswith('BGP') for k in log_data) and any(k.startswith('PortChannel') for k in log_data)) \
+                        or (self.reboot_type == 'warm-reboot' and any(k.startswith('BGP') for k in log_data)):
+                    log_present = True
+                    break
+                time.sleep(1) # wait until logs are populated
+            except Exception as err:
+                msg = 'Exception occured when parsing logs from VM: msg={} type={}'.format(err, type(err))
+                self.log(msg)
+                self.fails.add(msg)
 
         if not log_present:
             log_data['error'] = 'Incomplete output'
 
+        self.log('Disconnecting from VM')
         self.disconnect()
 
         # save data for troubleshooting
@@ -186,6 +201,7 @@ class Arista(object):
             with open("/tmp/%s.logging" % self.ip, "w") as fp:
                 fp.write("\n".join(log_lines))
 
+        self.log('Checking BGP GR peer status on VM')
         self.check_gr_peer_status(data)
         cli_data = {}
         cli_data['lacp']   = self.check_series_status(data, "lacp",         "LACP session")
@@ -193,15 +209,17 @@ class Arista(object):
         cli_data['bgp_v6'] = self.check_series_status(data, "bgp_route_v6", "BGP v6 routes")
         cli_data['po']     = self.check_change_time(samples, "po_changetime", "PortChannel interface")
 
-        route_timeout             = log_data['route_timeout']
-        cli_data['route_timeout'] = route_timeout
+        if 'route_timeout' in log_data:
+            route_timeout             = log_data['route_timeout']
+            cli_data['route_timeout'] = route_timeout
 
-        # {'10.0.0.38': [(0, '4200065100)')], 'fc00::2d': [(0, '4200065100)')]}
-        for nei in route_timeout.keys():
-            asn = route_timeout[nei][0][-1]
-            msg = 'BGP route GR timeout: neighbor %s (ASN %s' % (nei, asn)
-            self.fails.add(msg)
+            # {'10.0.0.38': [(0, '4200065100)')], 'fc00::2d': [(0, '4200065100)')]}
+            for nei in route_timeout.keys():
+                asn = route_timeout[nei][0][-1]
+                msg = 'BGP route GR timeout: neighbor %s (ASN %s' % (nei, asn)
+                self.fails.add(msg)
 
+        self.log('Finishing run()')
         return self.fails, self.info, cli_data, log_data
 
     def extract_from_logs(self, regexp, data):
@@ -248,24 +266,28 @@ class Arista(object):
         # first state is Idle, last state is Established
         for events in result_bgp.values():
             if len(events) > 1:
-                assert(events[0][1] != 'Established')
+                first_state = events[0][1]
+                assert first_state != 'Established', 'First BGP state should not be Established, it was {}'.format(first_state)
 
-            assert(events[-1][1] == 'Established')
+            last_state = events[-1][1]
+            assert last_state == 'Established', 'Last BGP state is not Established, it was {}'.format(last_state)
 
-        # verify BGP establishment time between v4 and v6 peer is not more than 20s
+        # verify BGP establishment time between v4 and v6 peer is not more than 40s
         if self.reboot_type == 'warm-reboot':
             estab_time = 0
             for ip in result_bgp:
                 if estab_time > 0:
                     diff = abs(result_bgp[ip][-1][0] - estab_time)
-                    assert(diff <= 20)
+                    assert diff <= 40, 'BGP establishement time between v4 and v6 peer is longer than 40 sec, it was {}'.format(diff)
                     break
                 estab_time = result_bgp[ip][-1][0]
 
         # first state is down, last state is up
         for events in result_if.values():
-            assert(events[0][1] == 'down')
-            assert(events[-1][1] == 'up')
+            first_state = events[0][1]
+            last_state = events[-1][1]
+            assert first_state == 'down', 'First PO state should be down, it was {}'.format(first_state)
+            assert last_state == 'up', 'Last PO state should be up, it was {}'.format(last_state)
 
         neigh_ipv4 = [neig_ip for neig_ip in result_bgp.keys() if '.' in neig_ip][0]
         for neig_ip in result_bgp.keys():

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -49,6 +49,7 @@ class Arista(object):
         self.info = set()
         self.min_bgp_gr_timeout = int(test_params['min_bgp_gr_timeout'])
         self.reboot_type = test_params['reboot_type']
+        self.bgp_v4_v6_time_diff = test_params['bgp_v4_v6_time_diff']
 
     def __del__(self):
         self.disconnect()
@@ -272,13 +273,14 @@ class Arista(object):
             last_state = events[-1][1]
             assert last_state == 'Established', 'Last BGP state is not Established, it was {}'.format(last_state)
 
-        # verify BGP establishment time between v4 and v6 peer is not more than 40s
+        # verify BGP establishment time between v4 and v6 peer is not more than self.bgp_v4_v6_time_diff
         if self.reboot_type == 'warm-reboot':
             estab_time = 0
             for ip in result_bgp:
                 if estab_time > 0:
                     diff = abs(result_bgp[ip][-1][0] - estab_time)
-                    assert diff <= 40, 'BGP establishement time between v4 and v6 peer is longer than 40 sec, it was {}'.format(diff)
+                    assert diff <= self.bgp_v4_v6_time_diff, \
+                        'BGP establishement time between v4 and v6 peer is longer than {} sec, it was {}'.format(self.bgp_v4_v6_time_diff, diff)
                     break
                 estab_time = result_bgp[ip][-1][0]
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -167,7 +167,7 @@ class Arista(object):
         log_present = False
         log_data = {}
         for attempt in range(attempts):
-            self.log('Collecting logs for attemt {}'.format(attempt))
+            self.log('Collecting logs for attempt {}'.format(attempt))
             log_output = self.do_cmd("show log | begin %s" % log_first_line)
             self.log('Log output "{}"'.format(log_output))
             log_lines = log_output.split("\r\n")[1:-1]

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -79,6 +79,7 @@ class AdvancedReboot:
         self.readyTimeout = self.request.config.getoption("--ready_timeout")
         self.replaceFastRebootScript = self.request.config.getoption("--replace_fast_reboot_script")
         self.postRebootCheckScript = self.request.config.getoption("--post_reboot_check_script")
+        self.bgpV4V6TimeDiff = self.request.config.getoption("--bgp_v4_v6_time_diff")
 
         # Set default reboot limit if it is not given
         if self.rebootLimit is None:
@@ -482,6 +483,7 @@ class AdvancedReboot:
                 "setup_fdb_before_test" : True,
                 "vnet" : self.vnet,
                 "vnet_pkts" : self.vnetPkts,
+                "bgp_v4_v6_time_diff": self.bgpV4V6TimeDiff
             },
             log_file=u'/tmp/advanced-reboot.ReloadTest.log',
             module_ignore_errors=self.moduleIgnoreErrors

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -91,3 +91,11 @@ def add_advanced_reboot_args(parser):
         default=None,
         help="Script for checking additional states on DUT"
     )
+
+    parser.addoption(
+        "--bgp_v4_v6_time_diff",
+        action="store",
+        type=int,
+        default=40,
+        help="Time difference (in sec) between BGP V4 and V6 establishment time"
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This commit includes 3 improvements/changes:
* Logs from SSH VM thread for better debugging
* Improved assertion handling, added reasonable messages on
assertions. This fixes the issue when SSH thread fails
with AssertionError in parse_logs() leaving "fails" dict
empty and making the main thread fail with KeyError when
it tries to get failures for a particular VM in the dict.
This double failure produces unreadable test log and confuses
when analyzing issues.
* Relaxed a condition for BGP v4 vs v6 establishement time
difference assertion. Originally it was set to 20 sec and
a special patch in sonic-quagga was made for that, but not
for frr. Also, the reasonability for this check is questionable.
This is discussed seperately
Azure#2610.
For now, increased the time difference threshold to 40 sec

Summary: [advanced-reboot] improve logging and assertions
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/**improvement**)

### Approach
Improved logging and exception handling on SSH threads.
Also, increased diff time between v4 and v6 establishment time to 40s - Discussion about in Azure#2610.

#### What is the motivation for this PR?

Fix a failure that looks like this:

```
E               "stderr_lines": [
E                   "WARNING: No route found for IPv6 destination :: (no default route?)", 
E                   "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.", 
E                   "  from cryptography.hazmat.backends import default_backend", 
E                   "advanced-reboot.ReloadTest ... FAIL", 
E                   "", 
E                   "======================================================================", 
E                   "FAIL: advanced-reboot.ReloadTest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"ptftests/advanced-reboot.py\", line 1079, in runTest", 
E                   "    self.handle_post_reboot_test_reports()", 
E                   "  File \"ptftests/advanced-reboot.py\", line 1048, in handle_post_reboot_test_reports", 
E                   "    self.assertTrue(is_good, errors)", 
E                   "AssertionError: ", 
E                   "", 
E                   "Something went wrong. Please check output below:", 
E                   "", 
E                   "FAILED:dut:Control plane didn't come up within warm up timeout", 
E                   "FAILED:dut:DUT is not ready for test", 
E                   "", 
E                   "", 
E                   "----------------------------------------------------------------------", 
E                   "Ran 1 test in 337.861s", 
E                   "", 
E                   "FAILED (failures=1)"
E               ], 
```

To more reasonable errors like this:

```
2021-02-18 10:41:40 : ==================================================
2021-02-18 10:41:40 : Report:
2021-02-18 10:41:40 : ==================================================
2021-02-18 10:41:40 : LACP/BGP were down for (extracted from cli):
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 :     10.213.84.181 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)
2021-02-18 10:41:40 :     10.213.84.182 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)
2021-02-18 10:41:40 :     10.213.84.183 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)
2021-02-18 10:41:40 :     10.213.84.184 - lacp:   0.000 (0) po_events: (1) bgp v4:   0.000 (0) bgp v6:   0.000 (0)
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Extracted from VM logs:
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Extracted log info from 10.213.84.181
2021-02-18 10:41:40 :     Incomplete output
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Extracted log info from 10.213.84.182
2021-02-18 10:41:40 :     Incomplete output
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Extracted log info from 10.213.84.183
2021-02-18 10:41:40 :     Incomplete output
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Extracted log info from 10.213.84.184
2021-02-18 10:41:40 :     Incomplete output
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Summary:
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Longest downtime period was 0:00:00
2021-02-18 10:41:40 : Reboot time was 0:00:00
2021-02-18 10:41:40 : Expected downtime is less then 0:00:30
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Additional info:
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : INFO:10.213.84.184:PortChannel interface state changed 1 times
2021-02-18 10:41:40 : INFO:10.213.84.181:PortChannel interface state changed 1 times
2021-02-18 10:41:40 : INFO:10.213.84.183:PortChannel interface state changed 1 times
2021-02-18 10:41:40 : INFO:10.213.84.182:PortChannel interface state changed 1 times
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : Fails:
2021-02-18 10:41:40 : --------------------------------------------------
2021-02-18 10:41:40 : FAILED:10.213.84.184:Exception occured when parsing logs from VM: msg=BGP establishement time between v4 and v6 peer is longer than 20 sec, it was 22 type=<type 'exceptions.AssertionError'>
2021-02-18 10:41:40 : FAILED:10.213.84.181:Exception occured when parsing logs from VM: msg=BGP establishement time between v4 and v6 peer is longer than 20 sec, it was 24 type=<type 'exceptions.AssertionError'>
2021-02-18 10:41:40 : FAILED:10.213.84.183:Exception occured when parsing logs from VM: msg=BGP establishement time between v4 and v6 peer is longer than 20 sec, it was 23 type=<type 'exceptions.AssertionError'>
2021-02-18 10:41:40 : FAILED:10.213.84.182:Exception occured when parsing logs from VM: msg=BGP establishement time between v4 and v6 peer is longer than 20 sec, it was 23 type=<type 'exceptions.AssertionError'>
2021-02-18 10:41:40 : ==================================================
2021-02-18 10:41:40 : Disabling arp_responder
```

#### How did you do it?

Described above.

#### How did you verify/test it?

Ran warm-reboot and fast-reboot tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
