### PR TITLE
Remove dependency of deprecated fib plugin for test_dir_bcast.py

### DIFF
--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -8,7 +8,7 @@ pytestmark = [
     pytest.mark.topology('t0')
 ]
 
-def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, fib):
+def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     support_testbed_types = frozenset(['t0', 't0-16', 't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116'])
     testbed_type = tbinfo['topo']['name']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In PR #2741, the fib plugin for announcing routes have been deprecated.
Announcing routes is done together with add-topo. The test_dir_bcast.py
script dependent on the fib plugin was missed in PR #2741.

#### How did you do it?
Since the routes have already been announced during add-topo, there
is no need to do that for test_dir_bcast.py again. To fix the issue, we can
simply removes the dependency of the fib plugin for test_dir_bcast.py.

#### How did you verify/test it?
Test run test_dir_bcast.py on T0 topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
