### PR TITLE
Add default cred for vlab-04 in veos_vtb inventory

### DIFF
--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -91,6 +91,8 @@ all:
           type: kvm
           hwsku: Force10-S6000
           serial_port: 9002
+          ansible_password: password
+          ansible_user: admin
         vlab-05:
           ansible_host: 10.250.0.110
           ansible_hostv6: fec0::ffff:afa:a


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Somehow Ansible is not able to figure out correct credential for accessing vlab-04 in KVM testing. 

#### How did you do it?
This change is to add the default credentials for vlab-04 in the veos_vtb inventory file just like the other KVM sonic hosts.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
