### PR TITLE
[dualtor] Update mux simulator control utility

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -37,7 +37,7 @@ def mux_server_url(request, tbinfo):
     return "http://{}:{}/mux/{}".format(ip, port, vmset_name)
 
 @pytest.fixture
-def url(mux_server_url, duthost, tbinfo):
+def url(mux_server_url, duthost):
     """
     A helper function is returned to make fixture accept arguments
     """
@@ -158,7 +158,7 @@ def set_output(url):
 @pytest.fixture
 def toggle_simulator_port_to_upper_tor(url):
     """
-    Returns _toggle_simulator_port_to_upper_tor to make fixture accpet arguments
+    Returns _toggle_simulator_port_to_upper_tor to make fixture accept arguments
     """
     def _toggle_simulator_port_to_upper_tor(interface_name):
         """
@@ -222,7 +222,7 @@ def check_simulator_read_side(url):
         Returns:
             1 if upper_tor is active
             2 if lower_tor is active
-            -1 for exception or inconstient status
+            -1 for exception or inconsistent status
         """
         server_url = url(interface_name)
         res = _get(server_url)

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -314,11 +314,14 @@ def toggle_all_simulator_ports_to_random_side(mux_server_url):
     _toggle_all_simulator_ports(mux_server_url, RANDOM)
 
 @pytest.fixture
-def simulator_server_down(set_drop):
+def simulator_server_down(set_drop, set_output):
     """
     A fixture to set drop on a given mux cable
     """
-    def _helper(interface_name):
+    tmp_list = []
+    def _drop_helper(interface_name):
+        tmp_list.append(interface_name)
         set_drop(interface_name, [UPPER_TOR, LOWER_TOR])
 
-    return _helper
+    yield _drop_helper
+    set_output(tmp_list[0], [UPPER_TOR, LOWER_TOR])


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to update mux simulator control utility.

1. Refactor helper function into function level fixture
2. Change argument physical_port to interface_name
3. Add a new fixture simulator_server_down to simulate server down scenario.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to update mux simulator control utility.

#### How did you do it?
Please refer to code.

#### How did you verify/test it?
Verified with a demo script.
```
def test_demo_1(toggle_simulator_port_to_upper_tor, toggle_simulator_port_to_lower_tor, check_simulator_read_side, upper_tor_host, lower_tor_host, get_active_torhost):
    toggle_simulator_port_to_lower_tor("Ethernet0")
    assert check_simulator_read_side("Ethernet0") == 2
    assert get_active_torhost("Ethernet0") == lower_tor_host
 
    toggle_simulator_port_to_upper_tor("Ethernet0")
    assert check_simulator_read_side("Ethernet0") == 1
    assert get_active_torhost("Ethernet0") == upper_tor_host
    assert True
 
def test_demo_2(simulator_server_down, recover_all_directions):
    simulator_server_down("Ethernet0")
    recover_all_directions("Ethernet0")
```

#### Any platform specific information?
Dualtor testbed specific.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
