### PR TITLE
[icmp_responder]: Fix crash on non ICMP packets

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -178,7 +178,7 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, ICMP_RESPONDER_PY), dest=OPT_DIR)
 
-    logging.debug("Start running icmp_responder")
+    logging.info("Start running icmp_responder")
     templ = Template(open(os.path.join(TEMPLATES_DIR, ICMP_RESPONDER_CONF_TEMPL)).read())
     ptf_indices = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_ptf_indices"]
     vlan_intfs = duthost.get_vlan_intfs()
@@ -196,7 +196,7 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
 
     yield
 
-    logging.debug("Stop running icmp_responder")
+    logging.info("Stop running icmp_responder")
     ptfhost.shell("supervisorctl stop icmp_responder")
 
 

--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -52,7 +52,7 @@ class ICMPSniffer(object):
                 for s in sel[0]:
                     packet = s.recv()
                     if packet is not None:
-                        if packet[ICMP].type == self.TYPE_ECHO_REQUEST and self.request_handler:
+                        if ICMP in packet and packet[ICMP].type == self.TYPE_ECHO_REQUEST and self.request_handler:
                             self.request_handler(s, packet, self.dst_mac)
         finally:
             for s in self.sniff_sockets:


### PR DESCRIPTION
* Check if packet is ICMP before trying to access ICMP layer
* Change ICMP responder start/stop log level

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3006 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ICMP responder crashes when attempting to handle non ICMP packets, causing dual ToR testbed to switch the active ToR

#### How did you do it?
Check that each packet contains an ICMP layer before trying to access the ICMP layer

Also raise the log level for ICMP responder start/stop messages from debug to info

#### How did you verify/test it?
Run the new ICMP responder for several, confirm that it stays up the whole time and does not restart. Check the ICMP error log, confirm that no error messages are printed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
