### PR TITLE
Fix vxlan decap testcase failure in warmup due to DUT connection issue

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -10,9 +10,10 @@
 # 1. 'config_file' is a filename of a file which contains all necessary information to run the test. The file is populated by ansible. This parameter is mandatory.
 # 2. 'vxlan_enabled' is a boolean parameter. When the parameter is true the test will fail if vxlan test failing. When the parameter is false the test will not fail. By default this parameter is false.
 # 3. 'count' is an integer parameter. It defines how many packets are sent for each combination of ingress/egress interfaces. By default the parameter equal to 1
-# 4. 'dut_host' is the ip address of dut.
+# 4. 'dut_hostname' is the name of dut.
 # 5. 'sonic_admin_user': User name to login dut
 # 6. 'sonic_admin_password': Password for sonic_admin_user to login dut
+# 7. 'sonic_admin_alt_password': Alternate Password for sonic_admin_user to login dut
 
 import sys
 import os.path
@@ -170,9 +171,9 @@ class Vxlan(BaseTest):
             raise Exception("required parameter 'config_file' is not present")
         config = self.test_params['config_file']
 
-        if 'dut_host' not in self.test_params:
-            raise Exception("required parameter 'dut_host' is not present")
-        self.dut_host = self.test_params['dut_host']
+        if 'dut_hostname' not in self.test_params:
+            raise Exception("required parameter 'dut_hostname' is not present")
+        self.dut_hostname = self.test_params['dut_hostname']
 
         if 'sonic_admin_user' not in self.test_params:
             raise Exception("required parameter 'sonic_admin_user' is not present")
@@ -181,6 +182,10 @@ class Vxlan(BaseTest):
         if 'sonic_admin_password' not in self.test_params:
             raise Exception("required parameter 'sonic_admin_password' is not present")
         self.sonic_admin_password = self.test_params['sonic_admin_password']
+
+        if 'sonic_admin_alt_password' not in self.test_params:
+            raise Exception("required parameter 'sonic_admin_alt_password' is not present")
+        self.sonic_admin_alt_password = self.test_params['sonic_admin_alt_password']
 
         if not os.path.isfile(config):
             raise Exception("the config file %s doesn't exist" % config)
@@ -252,9 +257,10 @@ class Vxlan(BaseTest):
         time.sleep(10)
         self.dataplane.flush()
         self.dut_connection = DeviceConnection(
-            self.dut_host,
+            self.dut_hostname,
             self.sonic_admin_user,
-            password=self.sonic_admin_password
+            password=self.sonic_admin_password,
+            alt_password=self.sonic_admin_alt_password
         )
 
         return

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -149,6 +149,8 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
 def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost, creds):
     duthost = duthosts[rand_one_dut_hostname]
 
+    sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
+
     vxlan_enabled, scenario = vxlan_status
     logger.info("vxlan_enabled=%s, scenario=%s" % (vxlan_enabled, scenario))
     log_file = "/tmp/vxlan-decap.Vxlan.{}.{}.log".format(scenario, datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
@@ -161,6 +163,7 @@ def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfho
                         "count": COUNT,
                         "sonic_admin_user": creds.get('sonicadmin_user'),
                         "sonic_admin_password": creds.get('sonicadmin_password'),
-                        "dut_host": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']},
+                        "sonic_admin_alt_password": sonic_admin_alt_password,
+                        "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']},
                 qlen=10000,
                 log_file=log_file)


### PR DESCRIPTION
### Description of PR
When running testcase  "vxlan/test_vxlan_decap.py" keep seeing failure in WARMUP.
this is causing the test to fail at pre-test time and never had a chance to run the actual testcase.
Debugged through the test and noticed that the fdbshow and "show arp" never was able to get any output from the cmd issued.
Looked deeper and found that the dut connection was not done correctly which causes the test case logic to always timeout waiting for the MAC and show ARP output which eventually leads to testcase declaring WARMUP failure.

Summary:
Fixes # (https://github.com/Azure/sonic-buildimage/issues/6573)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Added many debug code within the test case to chase down the root cause.
Once fixed the DUT connection issue observed the fdbshow and show arp output started to come in and getting matched
by the rest of the test case logic and WARMUP stage passes...

Before the fix:
```
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {
E               "changed": true,
E               "cmd": "ptf --test-dir ptftests vxlan-decap.Vxlan --platform-dir ptftests --qlen=10000 --platform remote -t 'vxlan_enabled=True;count=10;config_file='\"'\"'/tmp/vxlan_decap.json'\"'\"';sonic_admin_user=u'\"'\"'admin'\"'\"';dut_host=u'\"'\"'10.3.147.243'\"'\"';sonic_admin_password=u'\"'\"'password'\"'\"'' --relax --debug info --log-file /tmp/vxlan-decap.Vxlan.Enabled.2021-01-20-05:35:40.log",
E               "delta": "0:01:45.018798",
E               "end": "2021-01-20 06:05:36.721712",
E               "failed": true,
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "ptf --test-dir ptftests vxlan-decap.Vxlan --platform-dir ptftests --qlen=10000 --platform remote -t 'vxlan_enabled=True;count=10;config_file='\"'\"'/tmp/vxlan_decap.json'\"'\"';sonic_admin_user=u'\"'\"'admin'\"'\"';dut_host=u'\"'\"'10.3.147.243'\"'\"';sonic_admin_password=u'\"'\"'password'\"'\"'' --relax --debug info --log-file /tmp/vxlan-decap.Vxlan.Enabled.2021-01-20-05:35:40.log",
E                       "_uses_shell": true,
E                       "argv": null,
E                       "chdir": "/root",
E                       "creates": null,
E                       "executable": null,
E                       "removes": null,
E                       "stdin": null,
E                       "stdin_add_newline": true,
E                       "strip_empty_ends": true,
E                       "warn": true
E                   }
E               },
E               "msg": "non-zero return code",
E               "rc": 1,
E               "start": "2021-01-20 06:03:51.702914",
E               "stderr": "WARNING: No route found for IPv6 destination :: (no default route?)\n/usr/local/lib/python2.7/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.\n  from cryptography.hazmat.backends import default_backend\nvxlan-decap.Vxlan ... FAIL\n\n======================================================================\nFAIL: vxlan-decap.Vxlan\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"ptftests/vxlan-decap.py\", line 391, in runTest\n    self.warmup()\n  File \"ptftests/vxlan-decap.py\", line 328, in warmup\n    raise AssertionError(\"Warmup failed\")\nAssertionError: Warmup failed\n\n----------------------------------------------------------------------\nRan 1 test in 102.951s\n\nFAILED (failures=1)",
E               "stderr_lines": [
E                   "WARNING: No route found for IPv6 destination :: (no default route?)",
E                   "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.",
E                   "  from cryptography.hazmat.backends import default_backend",
E                   "vxlan-decap.Vxlan ... FAIL",
E                   "",
E                   "======================================================================",
E                   "FAIL: vxlan-decap.Vxlan",
E                   "----------------------------------------------------------------------",
E                   "Traceback (most recent call last):",
E                   "  File \"ptftests/vxlan-decap.py\", line 391, in runTest",
E                   "    self.warmup()",
E                   "  File \"ptftests/vxlan-decap.py\", line 328, in warmup",
E                   "    raise AssertionError(\"Warmup failed\")",
E                   "AssertionError: Warmup failed",
E                   "",
E                   "----------------------------------------------------------------------",
E                   "Ran 1 test in 102.951s",
E                   "",
E                   "FAILED (failures=1)"
E               ],
E               "stdout": "",
E               "stdout_lines": []
E           }
```

**Additional information you deem important (e.g. issue happens only occasionally):**

    **Output of `show version`:**
Any recent master image should reproduce with same result.  But a private BRCM SAI fix for syncd crash is required

```

After the fix is in place:

```
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 3 items

vxlan/test_vxlan_decap.py::test_vxlan_decap[NoVxLAN] PASSED              [ 33%]
vxlan/test_vxlan_decap.py::test_vxlan_decap[Enabled] PASSED              [ 66%]
vxlan/test_vxlan_decap.py::test_vxlan_decap[Removed] PASSED              [100%]

--- generated xml file: /var/src/Networking-acs-sonic-mgmt/tests/logs/tr.xml ---
========================== 3 passed in 370.04 seconds ==========================
```

#### Any platform specific information?
This fix is NOT platform dependent.