### PR TITLE
[pdu manager] introduce pdu manager

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -17,6 +17,7 @@ import sys
 sys.path.append("..")
 from tests.common.connections import ConsoleHost
 from tests.common.plugins.pdu_controller.snmp_pdu_controllers import get_pdu_controller
+from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory
 
 g_inv_mgr = None
 g_task_runner = None
@@ -53,12 +54,12 @@ def get_pdu_info(pdu_host):
         return g_pdu_dict[pdu_host]
 
     hosts = retrieve_hosts('all', pdu_host)
-    pdus=[]
+    pdus={}
     g_pdu_dict[pdu_host] = pdus
     for ph in pdu_host.split(','):
         if ph in hosts:
             pdu = hosts[ph]
-            pdus.append(pdu)
+            pdus[ph] = pdu
 
     return pdus
 
@@ -79,7 +80,7 @@ def action_list(parameters):
             data.append(dict(zip(header, (name, vars['ansible_host']))))
     else:
         for name, vars in hosts.items():
-            data.append((name, vars['ansible_host']))
+            data.append((name, vars['ansible_host'] if 'ansible_host' in vars else 'not_available'))
     show_data_output(header, data, parameters['json'])
 
 
@@ -146,35 +147,27 @@ def pdu_action_on_dut(host, attrs, action):
         ret['Summary'].append('PDU not found in inventory')
         return ret
 
-    for pdu_info in pdu_list:
-        pdu_host = pdu_info['ansible_host'] if pdu_info and 'ansible_host' in pdu_info else None
-        p_name = pdu_info['inventory_hostname'] if pdu_info and 'inventory_hostname' in pdu_info else None
-        if not pdu_host or not p_name:
-            ret['Summary'].append('No PDU IP or name')
-            continue
+    # TODO: fake graph data to force building pdu manager from inventory until
+    #       we add code to read and construct the conn_graph_facts
+    fake_graph = { 'device_pdu_info' : {}, 'device_pdu_links' : {} }
 
-        controller = get_pdu_controller(pdu_host, host, pdu_info)
+    pduman = pdu_manager_factory(host, pdu_list, fake_graph, pdu_list.values()[0])
 
-        if not controller:
-            ret['Summary'].append('Failed to communicate with controller {}'.format(p_name))
-            continue
+    if not pduman:
+        ret['Summary'].append('Failed to communicate with controller {}'.format(pdu_name))
+        return ret
 
-        status = controller.get_outlet_status()
-        if action == 'off':
-            for outlet in status:
-                controller.turn_off_outlet(outlet['outlet_id'])
-            status = controller.get_outlet_status()
-        elif action == 'on':
-            for outlet in status:
-                controller.turn_on_outlet(outlet['outlet_id'])
-            status = controller.get_outlet_status()
-        elif action != 'status':
-            ret['Summary'].append('Unsupported action {}.'.format(action))
-            continue
+    if action == 'off':
+        pduman.turn_off_outlet()
+    elif action == 'on':
+        pduman.turn_on_outlet()
+    elif action != 'status':
+        ret['Summary'].append('Unsupported action {}.'.format(action))
+        return ret
 
-        for outlet in status:
-            outlet.update({ 'PDU' : p_name, 'PDU_IP' : pdu_host })
-            ret['PDU status'].append(outlet)
+    status = pduman.get_outlet_status()
+    for outlet in status:
+        ret['PDU status'].append(outlet)
 
     return ret
 

--- a/ansible/devutils
+++ b/ansible/devutils
@@ -92,7 +92,8 @@ def action_ping(parameters):
         g_task_runner.submit_task(name + '|' + vars['ansible_host'], run_cmd, cmd=cmd)
     if parameters['json']:
         for name, result in g_task_runner.task_results():
-            data.append(dict(zip(header, (name.split('|')[0], name.split('|')[1], 'Success' if result['result'][0] == 0 else "Fail"))))
+            data.append(
+                dict(zip(header, (name.split('|')[0], name.split('|')[1], 'Success' if result['result'][0] == 0 else "Fail"))))
     else:
         for name, result in g_task_runner.task_results():
             data.append((name.split('|')[0], name.split('|')[1], 'Success' if result['result'][0] == 0 else "Fail"))
@@ -104,7 +105,8 @@ def action_ping(parameters):
                 g_task_runner.submit_task(name + '|' + vars['ansible_hostv6'], run_cmd, cmd=cmd)
         if parameters['json']:
             for name, result in g_task_runner.task_results():
-                data.append(dict(zip(header, (name.split('|')[0], name.split('|')[1], 'Success' if result['result'][0] == 0 else "Fail"))))
+                data.append(
+                    dict(zip(header, (name.split('|')[0], name.split('|')[1], 'Success' if result['result'][0] == 0 else "Fail"))))
         else:
             for name, result in g_task_runner.task_results():
                 data.append((name.split('|')[0], name.split('|')[1], 'Success' if result['result'][0] == 0 else "Fail"))
@@ -116,7 +118,8 @@ def action_ssh(parameters):
     hosts = parameters['hosts']
     for _, vars in hosts.items():
         client = SSHClient()
-        client.connect(hostname=vars['ansible_host'], username=vars['creds']['username'], passwords=vars['creds']['password'])
+        client.connect(hostname=vars['ansible_host'], username=vars[
+                       'creds']['username'], passwords=vars['creds']['password'])
         client.posix_shell()
 
 
@@ -125,17 +128,17 @@ def action_console(parameters):
     # Todo: Retrieve console vars from conn_graph_fact
     for _, vars in hosts.items():
         console_host = ConsoleHost(console_type=vars['console_type'],
-                                    console_host=vars['console_host'],
-                                    console_port=vars['console_port'],
-                                    sonic_username=vars['creds']['username'],
-                                    sonic_password=vars['creds']['password'],
-                                    console_username=vars['creds']['console_user'][vars['console_type']],
-                                    console_password=vars['creds']['console_password'][vars['console_type']])
+                                   console_host=vars['console_host'],
+                                   console_port=vars['console_port'],
+                                   sonic_username=vars['creds']['username'],
+                                   sonic_password=vars['creds']['password'],
+                                   console_username=vars['creds']['console_user'][vars['console_type']],
+                                   console_password=vars['creds']['console_password'][vars['console_type']])
         console_host.posix_shell()
 
 
 def pdu_action_on_dut(host, attrs, action):
-    ret = { 'Host' : host, 'PDU status' : [], 'Summary' : [], 'Action' : action }
+    ret = {'Host': host, 'PDU status': [], 'Summary': [], 'Action': action}
     pdu_name = attrs['pdu_host'] if 'pdu_host' in attrs else None
     if not pdu_name:
         ret['Summary'].append('DUT has no PDU configuration')
@@ -148,7 +151,7 @@ def pdu_action_on_dut(host, attrs, action):
 
     # TODO: fake graph data to force building pdu manager from inventory until
     #       we add code to read and construct the conn_graph_facts
-    fake_graph = { 'device_pdu_info' : {}, 'device_pdu_links' : {} }
+    fake_graph = {'device_pdu_info': {}, 'device_pdu_links': {}}
 
     pduman = pdu_manager_factory(host, pdu_list, fake_graph, pdu_list.values()[0])
 
@@ -174,7 +177,7 @@ def pdu_action_on_dut(host, attrs, action):
 def action_pdu(parameters, action):
     hosts = parameters['hosts']
     data = []
-    header = [ 'Host', 'Action', 'PDU status', 'Summary' ]
+    header = ['Host', 'Action', 'PDU status', 'Summary']
     for host, attrs in hosts.items():
         g_task_runner.submit_task(host, pdu_action_on_dut, host=host, attrs=attrs, action=action)
 
@@ -183,7 +186,7 @@ def action_pdu(parameters, action):
         if parameters['json']:
             data.append(status)
         else:
-            data.append([ status[x] for x in header ])
+            data.append([status[x] for x in header])
 
     return header, data
 
@@ -238,16 +241,19 @@ def parallel_run(parameters):
         for name, result in g_task_runner.task_results():
             print("task result for {} ===============>\n{}".format(name, str(result['result'][1])))
 
+
 def ssh_run_command(hostname, username, passwords, cmd):
     client = SSHClient()
     client.connect(hostname=hostname, username=username, passwords=passwords)
     return client.run_command(cmd)
+
 
 def validate_args(args):
     if args.action == 'run' and args.cmd == '':
         print("command is missing for run action")
         return False
     return True
+
 
 def main():
     parser = argparse.ArgumentParser(description='Device utilities')
@@ -267,7 +273,8 @@ def main():
                         type=str, required=False)
     parser.add_argument('-u', '--user', help='User: user account to login to host with, default admin',
                         type=str, required=False, default='admin')
-    parser.add_argument('-c', '--concurrency', help='Concurrency: the max concurrency for tasks that can run simultaneously, default 1',
+    parser.add_argument(
+        '-c', '--concurrency', help='Concurrency: the max concurrency for tasks that can run simultaneously, default 1',
                         type=int, required=False, default=1)
     parser.add_argument('-j', '--json', help='json output', action='store_true',
                         required=False, default=False)
@@ -275,26 +282,26 @@ def main():
     args = parser.parse_args()
     if not validate_args(args):
         return
-    build_global_vars(args.concurrency, args.inventory);
+    build_global_vars(args.concurrency, args.inventory)
     hosts = retrieve_hosts(args.group, args.limit)
-    actions = { 'list' : action_list,
-                'ping' : action_ping,
-                'ssh' : action_ssh,
-                'console' : action_console,
-                'run' : ssh_run_command,
-                'pdu_status' : action_pdu_status,
-                'pdu_off' : action_pdu_off,
-                'pdu_on' : action_pdu_on,
-                'pdu_reboot' : action_pdu_reboot,
-              }
-    parameters = { 'hosts' : hosts,
-                   'limit' : args.limit,
-                   'action' : actions[args.action],
-                   'user' : args.user,
-                   'ipv6' : args.ipv6,
-                   'cmd': args.cmd,
-                   'json' : args.json,
-                 }
+    actions = {'list': action_list,
+               'ping': action_ping,
+               'ssh': action_ssh,
+               'console': action_console,
+               'run': ssh_run_command,
+               'pdu_status': action_pdu_status,
+               'pdu_off': action_pdu_off,
+               'pdu_on': action_pdu_on,
+               'pdu_reboot': action_pdu_reboot,
+               }
+    parameters = {'hosts': hosts,
+                  'limit': args.limit,
+                  'action': actions[args.action],
+                  'user': args.user,
+                  'ipv6': args.ipv6,
+                  'cmd': args.cmd,
+                  'json': args.json,
+                  }
     action_dispatcher(parameters)
 
 

--- a/ansible/devutils
+++ b/ansible/devutils
@@ -53,7 +53,7 @@ def get_pdu_info(pdu_host):
         return g_pdu_dict[pdu_host]
 
     hosts = retrieve_hosts('all', pdu_host)
-    pdus={}
+    pdus = {}
     g_pdu_dict[pdu_host] = pdus
     for ph in pdu_host.split(','):
         if ph in hosts:
@@ -153,7 +153,7 @@ def pdu_action_on_dut(host, attrs, action):
     pduman = pdu_manager_factory(host, pdu_list, fake_graph, pdu_list.values()[0])
 
     if not pduman:
-        ret['Summary'].append('Failed to communicate with controller {}'.format(pdu_name))
+        ret['Summary'].append('Failed to communicate with PDU controller {}'.format(pdu_name))
         return ret
 
     if action == 'off':

--- a/ansible/devutils
+++ b/ansible/devutils
@@ -16,7 +16,6 @@ from devutil.task_runner import TaskRunner
 import sys
 sys.path.append("..")
 from tests.common.connections import ConsoleHost
-from tests.common.plugins.pdu_controller.snmp_pdu_controllers import get_pdu_controller
 from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory
 
 g_inv_mgr = None

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -1,23 +1,14 @@
 import logging
 
 import pytest
+from pdu_manager import pdu_manager_factory
 
 
-def pdu_controller_factory(controller_ip, controller_protocol, dut_hostname, pdu):
-    """
-    @summary: Factory function for creating PDU controller according to different management protocol.
-    @param controller_ip: IP address of the PDU controller host.
-    @param controller_protocol: Management protocol supported by the PDU controller host.
-    @param dut_hostname: Hostname of the DUT to be controlled by the PDU controller.
-    """
-    logging.info("Creating pdu controller object")
-    if controller_protocol == "snmp":
-        import snmp_pdu_controllers
-        return snmp_pdu_controllers.get_pdu_controller(controller_ip, dut_hostname, pdu)
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def pdu_controller(duthosts, rand_one_dut_hostname, pdu):
+def pdu_controller(duthosts, rand_one_dut_hostname, conn_graph_facts, pdu):
     """
     @summary: Fixture for controlling power supply to PSUs of DUT
     @param duthost: Fixture duthost defined in sonic-mgmt/tests/conftest.py
@@ -25,39 +16,18 @@ def pdu_controller(duthosts, rand_one_dut_hostname, pdu):
               controller_base.py.
     """
     duthost = duthosts[rand_one_dut_hostname]
-
-    logging.info("Creating pdu_controller fixture")
     inv_mgr = duthost.host.options["inventory_manager"]
-    pdu_host = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
-    if not pdu_host:
-        logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create pdu_controller" %
-                     duthost.hostname)
-        yield None
-        return
+    pdu_host_list = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
+    pdu_hosts = {}
+    for ph in pdu_host_list.split(','):
+        var_list = inv_mgr.get_host(ph).get_vars()
+        pdu_hosts[ph] = var_list
 
-    controller_vars = inv_mgr.get_host(pdu_host).get_vars()
-
-    controller_ip = controller_vars.get("ansible_host")
-    if not controller_ip:
-        logging.info("No 'ansible_host' is defined in inventory file for '%s'" % pdu_host)
-        logging.info("Unable to create pdu_controller for %s" % duthost.hostname)
-        yield None
-        return
-
-    controller_protocol = controller_vars.get("protocol")
-    if not controller_protocol:
-        logging.info("No protocol is defined in inventory file for '%s'. Try to use default 'snmp'" % pdu_host)
-        controller_protocol = "snmp"
-
-    controller = pdu_controller_factory(controller_ip, controller_protocol, duthost.hostname, pdu)
+    controller = pdu_manager_factory(duthost.hostname, pdu_hosts, conn_graph_facts, pdu)
 
     yield controller
 
-    logging.info("pdu_controller fixture teardown, ensure that all PDU outlets are turned on after test")
+    logger.info("pdu_controller fixture teardown, ensure that all PDU outlets are turned on after test")
     if controller:
-        outlet_status = controller.get_outlet_status()
-        if outlet_status:
-            for outlet in outlet_status:
-                if not outlet["outlet_on"]:
-                    controller.turn_on_outlet(outlet["outlet_id"])
+        controller.turn_on_outlet()
         controller.close()

--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -77,13 +77,13 @@ class PduManager():
 
         controller = None
         pdu_ip = psu_peer['ManagementIp']
-        dup_ctrl = False
+        shared_pdu = False
         for pdu in self.controllers:
             if psu_name in pdu:
                 logger.warning('PSU {} already has a pdu definition'.format(psu_name))
                 return
             if pdu_ip == pdu['host']:
-                dup_ctrl = True
+                shared_pdu = True # Sharing controller with another outlet
                 controller = pdu['controller']
 
         outlets = []
@@ -96,7 +96,7 @@ class PduManager():
               }
         next_index = len(self.controllers)
         self.controllers.append(pdu)
-        if not dup_ctrl:
+        if not shared_pdu:
             controller = get_pdu_controller(pdu_ip, self.dut_hostname, pdu_vars)
             if not controller:
                 logger.warning('Failed creating pdu controller: {}'.format(psu_peer))

--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -23,7 +23,9 @@ from snmp_pdu_controllers import get_pdu_controller
 
 logger = logging.getLogger(__name__)
 
+
 class PduManager():
+
     def __init__(self, dut_hostname):
         """
             dut_hostname is the target DUT host name. The dut
@@ -47,12 +49,10 @@ class PduManager():
         """
         self.controllers = []
 
-
     def _update_outlets(self, outlets, pdu_index):
         for outlet in outlets:
             outlet['pdu_index'] = pdu_index
             outlet['pdu_name'] = self.controllers[pdu_index]['psu_peer']['peerdevice']
-
 
     def add_controller(self, psu_name, psu_peer, pdu_vars):
         """
@@ -83,17 +83,17 @@ class PduManager():
                 logger.warning('PSU {} already has a pdu definition'.format(psu_name))
                 return
             if pdu_ip == pdu['host']:
-                shared_pdu = True # Sharing controller with another outlet
+                shared_pdu = True  # Sharing controller with another outlet
                 controller = pdu['controller']
 
         outlets = []
         pdu = {
-                'psu_name' : psu_name,
-                'host' : pdu_ip,
-                'controller' : controller,
-                'outlets' : outlets,
-                'psu_peer' : psu_peer,
-              }
+            'psu_name': psu_name,
+                'host': pdu_ip,
+                'controller': controller,
+                'outlets': outlets,
+                'psu_peer': psu_peer,
+        }
         next_index = len(self.controllers)
         self.controllers.append(pdu)
         if not shared_pdu:
@@ -106,11 +106,9 @@ class PduManager():
             pdu['outlets'] = outlets
             pdu['controller'] = controller
 
-
     def _get_pdu_controller(self, pdu_index):
         pdu = self.controllers[pdu_index]
         return pdu['controller']
-
 
     def turn_on_outlet(self, outlet=None):
         """
@@ -131,7 +129,6 @@ class PduManager():
 
         return ret
 
-
     def turn_off_outlet(self, outlet=None):
         """
             Turnning off an outlet. The outlet contains enough information
@@ -150,7 +147,6 @@ class PduManager():
                     ret = ret and rc
 
         return ret
-
 
     def get_outlet_status(self, outlet=None):
         """
@@ -174,7 +170,6 @@ class PduManager():
                     status = status + outlets
 
         return status
-
 
     def close(self):
         for controller in self.controllers:
@@ -227,17 +222,18 @@ def _build_pdu_manager_from_inventory(pduman, dut_hostname, pdu_hosts, pdu_vars)
 
         controller_protocol = var_list.get("protocol")
         if not controller_protocol:
-            logger.info('No protocol is defined in inventory file for "{}". Try to use default "snmp"'.format(pdu_hosts))
+            logger.info(
+                'No protocol is defined in inventory file for "{}". Try to use default "snmp"'.format(pdu_hosts))
             controller_protocol = 'snmp'
 
         psu_peer = {
-                        'peerdevice'   : ph,
-                        'HwSku'        : 'unknown',
-                        'Protocol'     : controller_protocol,
-                        'ManagementIp' : controller_ip,
-                        'Type'         : 'Pdu',
-                        'peerport'     : 'probing',
-                   }
+            'peerdevice': ph,
+                        'HwSku': 'unknown',
+                        'Protocol': controller_protocol,
+                        'ManagementIp': controller_ip,
+                        'Type': 'Pdu',
+                        'peerport': 'probing',
+        }
         pduman.add_controller(ph, psu_peer, pdu_vars)
 
     return len(pduman.controllers) > 0
@@ -260,5 +256,3 @@ def pdu_manager_factory(dut_hostname, pdu_hosts, conn_graph_facts, pdu_vars):
         return pduman
 
     return None
-
-

--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -1,0 +1,264 @@
+"""
+    PduManager is intended to solve the issue where DUT connects to
+    multiple PDU controllers.
+
+    It also intended to hide the dependency on the fake outlet_id,
+    and reference outlet buy outlet dictionary directly. With this,
+    we could enable different way to identify outlet, e.g. with the
+    outlet number from graph.
+
+    It also intended to create a smooth transition from defining
+    PDU in inventory to defining PDU in connection graph. Data in
+    graph is preferred, but if graph data is missing, existing
+    inventory data will be used.
+
+    PDU manager implements the same base PDU controller APIs and
+    collect status from and distribute operations to individual PDU
+    controllers.
+"""
+
+import logging
+import copy
+from snmp_pdu_controllers import get_pdu_controller
+
+logger = logging.getLogger(__name__)
+
+class PduManager():
+    def __init__(self, dut_hostname):
+        """
+            dut_hostname is the target DUT host name. The dut
+            defines which PDU(s) and outlet(s) it connected to.
+
+            It is NOT the PDU host name. PDU host name is defined
+            either in graph or in inventory and associated with
+            the DUT.
+        """
+        self.dut_hostname = dut_hostname
+        """
+            controlers is an array of controller dictionaries with
+            following information:
+            {
+                'psu_name'   : name of the PSU on DUT,
+                'host'       : controller_IP_address,
+                'controller' : controller instance,
+                'outlets'    : cached outlet status,
+                'psu_peer'   : psu peer information,
+            }
+        """
+        self.controllers = []
+
+
+    def _update_outlets(self, outlets, pdu_index):
+        for outlet in outlets:
+            outlet['pdu_index'] = pdu_index
+            outlet['pdu_name'] = self.controllers[pdu_index]['psu_peer']['peerdevice']
+
+
+    def add_controller(self, psu_name, psu_peer, pdu_vars):
+        """
+            Add a controller to be managed.
+            Sampel psu_peer:
+            {
+                "peerdevice": "pdu-107",
+                "HwSku": "Sentry",
+                "Protocol": "snmp",
+                "ManagementIp": "10.0.0.107",
+                "Type": "Pdu",
+                "peerport": "39"
+            }
+        """
+        if 'Protocol' not in psu_peer or 'ManagementIp' not in psu_peer:
+            logger.info('psu_peer {} missing critical inforamtion'.format(psu_peer))
+            return
+
+        if psu_peer['Protocol'] != 'snmp':
+            logger.warning('Controller protocol {} is not supported'.format(protocol))
+            return
+
+        controller = None
+        pdu_ip = psu_peer['ManagementIp']
+        dup_ctrl = False
+        for pdu in self.controllers:
+            if psu_name in pdu:
+                logger.warning('PSU {} already has a pdu definition'.format(psu_name))
+                return
+            if pdu_ip == pdu['host']:
+                dup_ctrl = True
+                controller = pdu['controller']
+
+        outlets = []
+        pdu = {
+                'psu_name' : psu_name,
+                'host' : pdu_ip,
+                'controller' : controller,
+                'outlets' : outlets,
+                'psu_peer' : psu_peer,
+              }
+        next_index = len(self.controllers)
+        self.controllers.append(pdu)
+        if not dup_ctrl:
+            controller = get_pdu_controller(pdu_ip, self.dut_hostname, pdu_vars)
+            if not controller:
+                logger.warning('Failed creating pdu controller: {}'.format(psu_peer))
+                return
+            outlets = controller.get_outlet_status()
+            self._update_outlets(outlets, next_index)
+            pdu['outlets'] = outlets
+            pdu['controller'] = controller
+
+
+    def _get_pdu_controller(self, pdu_index):
+        pdu = self.controllers[pdu_index]
+        return pdu['controller']
+
+
+    def turn_on_outlet(self, outlet=None):
+        """
+            Turnning on an outlet. The outlet contains enough information
+            to identify the pdu controller + outlet ID.
+            when outlet is None, all outlets will be turned off.
+        """
+        if outlet is not None:
+            controller = self._get_pdu_controller(outlet['pdu_index'])
+            return controller.turn_on_outlet(outlet['outlet_id'])
+        else:
+            # turn on all outlets
+            ret = True
+            for controller in self.controllers:
+                for outlet in controller['outlets']:
+                    rc = controller['controller'].turn_on_outlet(outlet['outlet_id'])
+                    ret = ret and rc
+
+        return ret
+
+
+    def turn_off_outlet(self, outlet=None):
+        """
+            Turnning off an outlet. The outlet contains enough information
+            to identify the pdu controller + outlet ID.
+            when outlet is None, all outlets will be turned off.
+        """
+        if outlet is not None:
+            controller = self._get_pdu_controller(outlet['pdu_index'])
+            return controller.turn_off_outlet(outlet['outlet_id'])
+        else:
+            # turn on all outlets
+            ret = True
+            for controller in self.controllers:
+                for outlet in controller['outlets']:
+                    rc = controller['controller'].turn_off_outlet(outlet['outlet_id'])
+                    ret = ret and rc
+
+        return ret
+
+
+    def get_outlet_status(self, outlet=None):
+        """
+            Getting outlet status. The outlet contains enough information
+            to identify the pdu controller + outlet ID.
+            when outlet is None, status of all outlets will be returned.
+        """
+        status = []
+        if outlet is not None:
+            pdu_index = outlet['pdu_index']
+            controller = self._get_pdu_controller(pdu_index)
+            outlets = controller.get_outlet_status(outlet['outlet_id'])
+            self._update_outlets(outlets, pdu_index)
+            status = status + outlets
+        else:
+            # collect all status
+            for pdu_index, controller in enumerate(self.controllers):
+                if len(controller['outlets']) > 0:
+                    outlets = controller['controller'].get_outlet_status()
+                    self._update_outlets(outlets, pdu_index)
+                    status = status + outlets
+
+        return status
+
+
+    def close(self):
+        for controller in self.controllers:
+            if len(controller['outlets']) > 0:
+                controller['controller'].close()
+
+
+def _merge_dev_link(devs, links):
+    ret = copy.deepcopy(devs)
+    for host, info in links.items():
+        if host not in ret:
+            ret[host] = {}
+
+        for key, val in info.items():
+            if key not in ret[host]:
+                ret[host][key] = {}
+            ret[host][key].update(val)
+
+    return ret
+
+
+def _build_pdu_manager_from_graph(pduman, dut_hostname, conn_graph_facts, pdu_vars):
+    logger.info('Creating pdu manager from graph information')
+    pdu_devs = conn_graph_facts['device_pdu_info']
+    pdu_links = conn_graph_facts['device_pdu_links']
+    pdu_info = _merge_dev_link(pdu_devs, pdu_links)
+    if dut_hostname not in pdu_info or not pdu_info[dut_hostname]:
+        # No PDU information in graph
+        logger.info('PDU informatin for {} is not found in graph'.format(dut_hostname))
+        return False
+
+    for psu_name, psu_peer in pdu_info[dut_hostname].items():
+        pduman.add_controller(psu_name, psu_peer, pdu_vars)
+
+    return len(pduman.controllers) > 0
+
+
+def _build_pdu_manager_from_inventory(pduman, dut_hostname, pdu_hosts, pdu_vars):
+    logger.info('Creating pdu manager from inventory information')
+    if not pdu_hosts:
+        logger.info('Do not have sufficient PDU information to create PDU manager for host {}'.format(dut_hostname))
+        return False
+
+    for ph, var_list in pdu_hosts.items():
+        controller_ip = var_list.get("ansible_host")
+        if not controller_ip:
+            logger.info('No "ansible_host" is defined in inventory file for "{}"'.format(pdu_hosts))
+            logger.info('Unable to create pdu_controller for {}'.format(dut_hostname))
+            continue
+
+        controller_protocol = var_list.get("protocol")
+        if not controller_protocol:
+            logger.info('No protocol is defined in inventory file for "{}". Try to use default "snmp"'.format(pdu_hosts))
+            controller_protocol = 'snmp'
+
+        psu_peer = {
+                        'peerdevice'   : ph,
+                        'HwSku'        : 'unknown',
+                        'Protocol'     : controller_protocol,
+                        'ManagementIp' : controller_ip,
+                        'Type'         : 'Pdu',
+                        'peerport'     : 'probing',
+                   }
+        pduman.add_controller(ph, psu_peer, pdu_vars)
+
+    return len(pduman.controllers) > 0
+
+
+def pdu_manager_factory(dut_hostname, pdu_hosts, conn_graph_facts, pdu_vars):
+    """
+    @summary: Factory function for creating PDU manager instance.
+    @param dut_hostname: DUT host name.
+    @param pdu_hosts: comma separated PDU host names.
+    @param conn_graph_facts: connection graph facts.
+    @param pdu_vars: pdu community strings
+    """
+    logger.info('Creating pdu manager object')
+    pduman = PduManager(dut_hostname)
+    if _build_pdu_manager_from_graph(pduman, dut_hostname, conn_graph_facts, pdu_vars):
+        return pduman
+
+    if _build_pdu_manager_from_inventory(pduman, dut_hostname, pdu_hosts, pdu_vars):
+        return pduman
+
+    return None
+
+

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -118,7 +118,7 @@ class snmpPduController(PduControllerBase):
         This method depends on this configuration to find out the PDU ports connected to PSUs of specific DUT.
         """
         if not self.pduType:
-            logging.info('PDU type is unknown')
+            logging.info('PDU type is unknown: pdu_ip {} dut {}'.format(self.controller, self.hostname))
             return
 
         max_lane = 5
@@ -149,7 +149,7 @@ class snmpPduController(PduControllerBase):
                     self.map_host_to_lane(lane_id)
                     break
         else:
-            logging.error("{} device is not attached to any of PDU port".format(self.hostname.lower()))
+            logging.error("{} device is not attached to any outlet of PDU {}".format(self.hostname.lower(), self.controller))
 
     def map_host_to_lane(self, lane_id):
         """
@@ -198,7 +198,7 @@ class snmpPduController(PduControllerBase):
         @return: Return true if successfully execute the command for turning on power. Otherwise return False.
         """
         if not self.pduType:
-            logging.error('Unable to turn on: PDU type is unknown')
+            logging.error('Unable to turn on: PDU type is unknown: pdu_ip {} dut {}'.format(self.controller, self.hostname))
             return False
 
         port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[rfc1902.Integer(outlet)]
@@ -231,7 +231,7 @@ class snmpPduController(PduControllerBase):
         @return: Return true if successfully execute the command for turning off power. Otherwise return False.
         """
         if not self.pduType:
-            logging.error('Unable to turn off: PDU type is unknown')
+            logging.error('Unable to turn off: PDU type is unknown: pdu_ip {} dut {}'.format(self.controller, self.hostname))
             return False
 
         port_oid = self.pPORT_CONTROL_BASE_OID + self.pdu_ports[rfc1902.Integer(outlet)]
@@ -268,7 +268,7 @@ class snmpPduController(PduControllerBase):
         """
         results = []
         if not self.pduType:
-            logging.error('Unable to retrieve status: PDU type is unknown')
+            logging.error('Unable to retrieve status: PDU type is unknown: pdu_ip {} dut {}'.format(self.controller, self.hostname))
             return results
 
         cmdGen = cmdgen.CommandGenerator()

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -158,7 +158,7 @@ def turn_all_outlets_on(pdu_ctrl):
     pytest_require(all_outlet_status and len(all_outlet_status) >= 2, 'Skip the test, cannot to get at least 2 outlet status: {}'.format(all_outlet_status))
     for outlet in all_outlet_status:
         if not outlet["outlet_on"]:
-            pdu_ctrl.turn_on_outlet(outlet["outlet_id"])
+            pdu_ctrl.turn_on_outlet(outlet)
             time.sleep(5)
 
 
@@ -210,8 +210,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, pd
     for outlet in all_outlet_status:
         psu_under_test = None
 
-        logging.info("Turn off outlet %s" % str(outlet["outlet_id"]))
-        pdu_ctrl.turn_off_outlet(outlet["outlet_id"])
+        logging.info("Turn off outlet {}".format(outlet))
+        pdu_ctrl.turn_off_outlet(outlet)
         time.sleep(5)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
@@ -223,8 +223,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, pd
             check_vendor_specific_psustatus(duthost, line)
         pytest_assert(psu_under_test is not None, "No PSU is turned off")
 
-        logging.info("Turn on outlet %s" % str(outlet["outlet_id"]))
-        pdu_ctrl.turn_on_outlet(outlet["outlet_id"])
+        logging.info("Turn on outlet {}".format(outlet))
+        pdu_ctrl.turn_on_outlet(outlet)
         time.sleep(5)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
@@ -378,7 +378,7 @@ def turn_off_outlet_and_check_thermal_control(dut, pdu_ctrl, outlet, mocker):
               control policy file.
     """
     logging.info("Turn off outlet %s" % str(outlet["psu_id"]))
-    pdu_ctrl.turn_off_outlet(outlet["outlet_id"])
+    pdu_ctrl.turn_off_outlet(outlet)
     time.sleep(5)
 
     psu_under_test = None
@@ -397,7 +397,7 @@ def turn_off_outlet_and_check_thermal_control(dut, pdu_ctrl, outlet, mocker):
                              mocker.check_all_fan_speed,
                              100), 'FAN speed not turn to 100% after PSU off')
 
-    pdu_ctrl.turn_on_outlet(outlet["outlet_id"])
+    pdu_ctrl.turn_on_outlet(outlet)
     time.sleep(5)
 
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -161,12 +161,12 @@ def _power_off_reboot_helper(kwargs):
 
     for outlet in all_outlets:
         logging.debug("turning off {}".format(outlet))
-        pdu_ctrl.turn_off_outlet(outlet["outlet_id"])
+        pdu_ctrl.turn_off_outlet(outlet)
     time.sleep(delay_time)
     logging.info("Power on {}".format(power_on_seq))
     for outlet in power_on_seq:
         logging.debug("turning on {}".format(outlet))
-        pdu_ctrl.turn_on_outlet(outlet["outlet_id"])
+        pdu_ctrl.turn_on_outlet(outlet)
 
 
 def test_power_off_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list, pdu_controller, power_off_delay):

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -444,20 +444,20 @@ def test_turn_off_pdu_and_check_psu_info(duthost, localhost, creds, pdu_controll
         pytest.skip('At least 2 outlets required for rest of the testing in this case')
 
     # turn on all PSU
-    for item in outlet_status:
-        if not item['outlet_on']:
-            pdu_controller.turn_on_outlet(item["outlet_id"])
+    for outlet in outlet_status:
+        if not outlet['outlet_on']:
+            pdu_controller.turn_on_outlet(outlet)
     time.sleep(5)
 
     outlet_status = pdu_controller.get_outlet_status()
-    for item in outlet_status:
-        if not item['outlet_on']:
+    for outlet in outlet_status:
+        if not outlet['outlet_on']:
             pytest.skip('Not all outlet are powered on, skip rest of the testing in this case')
 
     # turn off the first PSU
-    first_outlet_id = outlet_status[0]['outlet_id']
-    pdu_controller.turn_off_outlet(first_outlet_id)
-    assert wait_until(30, 5, check_outlet_status, pdu_controller, first_outlet_id, False)
+    first_outlet = outlet_status[0]
+    pdu_controller.turn_off_outlet(first_outlet)
+    assert wait_until(30, 5, check_outlet_status, pdu_controller, first_outlet, False)
     # wait for psud update the database
     assert wait_until(120, 20, _check_psu_status_after_power_off, duthost, localhost, creds)
 
@@ -581,13 +581,13 @@ def is_null_str(value):
     return not value or value == str(None) or value == 'N/A'
 
 
-def check_outlet_status(pdu_controller, outlet_id, expect_status):
+def check_outlet_status(pdu_controller, outlet, expect_status):
     """
     Check if a given PSU is at expect status
     :param pdu_controller: PDU controller
-    :param outlet_id: outlet id
+    :param outlet: PDU outlet
     :param expect_status: Expect bool status, True means on, False means off
     :return: True if a given PSU is at expect status
     """
-    status = pdu_controller.get_outlet_status(outlet_id)
+    status = pdu_controller.get_outlet_status(outlet)
     return 'outlet_on' in status[0] and status[0]['outlet_on'] == expect_status


### PR DESCRIPTION
### Description of PR
Introducing pdu manager.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The existing PDU controller implementation cannot handle if DUT connects to 2 different PDUs. The outlet_id was an index in return list, when there is more than one controller, the index will collide. Existing client code uses the outlet_id to access specific outlet. Which will not work in multi-PDU scenario.

#### How did you do it?
1. Introduce PDU manager to separate the client from the implementation  of pdu controllers.
2. Change client to toggle outlet with the whole outlet dictionary, so that client don't have to rely on the value of outlet_id.
3. PDU manager manages all PDU controllers associated with a DUT.
4. Change devutils to use PDU manager instead of invoking controller directly.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
```
yinxi@681acf730601:/var/src/sonic-mgmt/ansible$ ./devutils -i str -g sonic -a pdu_status -l str-7260cx3-acs-1                                                                             +-------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| Host              | Action   | PDU status                                                                                                                                                 | Summary   |
+===================+==========+============================================================================================================================================================+===========+
| str-7260cx3-acs-1 | status   | [{'outlet_on': True, 'pdu_index': 0, 'outlet_id': 0, 'pdu_name': u'pdu-107'}, {'outlet_on': True, 'pdu_index': 0, 'outlet_id': 1, 'pdu_name': u'pdu-107'}] | []        |
+-------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+

yinxi@681acf730601:/var/src/sonic-mgmt/tests$ ./run_tests.sh -n vms7-t0-7260-1 -i /var/src/sonic-mgmt/ansible/str,/var/src/sonic-mgmt/ansible/veos -u -m group -p /tmp/logs-01 -e --skip_sanity -c "snmp/test_snmp_phy_entity.py platform_tests/test_platform_info.py"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 14 items                                                                                                                                                                       

platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus[ignore_particular_error_log0] PASSED                                                                [  7%]
platform_tests/test_platform_info.py::test_show_platform_fanstatus_mocked SKIPPED                                                                                                  [ 14%]
platform_tests/test_platform_info.py::test_show_platform_temperature_mocked[ignore_particular_error_log0] SKIPPED                                                                  [ 21%]
platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_json PASSED                                                                                         [ 28%]
platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_json PASSED                                                                                          [ 35%]
platform_tests/test_platform_info.py::test_thermal_control_psu_absence[ignore_particular_error_log0] SKIPPED                                                                       [ 42%]
platform_tests/test_platform_info.py::test_thermal_control_psu_absence[ignore_particular_error_log0] ERROR                                                                         [ 42%]
platform_tests/test_platform_info.py::test_thermal_control_fan_status SKIPPED                                                                                                      [ 50%]
snmp/test_snmp_phy_entity.py::test_fan_drawer_info PASSED                                                                                                                          [ 57%]
snmp/test_snmp_phy_entity.py::test_fan_info PASSED                                                                                                                                 [ 64%]
snmp/test_snmp_phy_entity.py::test_psu_info PASSED                                                                                                                                 [ 71%]
snmp/test_snmp_phy_entity.py::test_thermal_info PASSED                                                                                                                             [ 78%]
snmp/test_snmp_phy_entity.py::test_transceiver_info PASSED                                                                                                                         [ 85%]
snmp/test_snmp_phy_entity.py::test_turn_off_pdu_and_check_psu_info PASSED                                                                                                          [ 92%]
snmp/test_snmp_phy_entity.py::test_remove_insert_fan_and_check_fan_info SKIPPED                                                                                                    [100%]
```