### PR TITLE
[dualtor][tunnel] Add ipinip testcase

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -312,16 +312,23 @@ def apply_mux_cable_table_to_dut(duthosts, rand_one_dut_hostname, mock_server_ba
 
 
 @pytest.fixture(scope='module')
-def apply_mock_dual_tor_tables(apply_mux_cable_table_to_dut, apply_tunnel_table_to_dut, apply_peer_switch_table_to_dut):
+def apply_mock_dual_tor_tables(request, tbinfo):
     '''
     Wraps all table fixtures for convenience
     '''
-    logger.info("Done applying database tables for dual ToR mock")
+    if tbinfo["topo"]["name"] == "t0":
+        request.getfixturevalue("apply_mux_cable_table_to_dut")
+        request.getfixturevalue("apply_tunnel_table_to_dut")
+        request.getfixturevalue("apply_peer_switch_table_to_dut")
+        logger.info("Done applying database tables for dual ToR mock")
 
 
 @pytest.fixture(scope='module')
-def apply_mock_dual_tor_kernel_configs(apply_dual_tor_peer_switch_route, apply_dual_tor_neigh_entries):
+def apply_mock_dual_tor_kernel_configs(request, tbinfo):
     '''
     Wraps all kernel related (routes and neighbor entries) fixtures for convenience
     '''
-    logger.info("Done applying kernel configs for dual ToR mock")
+    if tbinfo["topo"]["name"] == "t0":
+        request.getfixturevalue("apply_dual_tor_peer_switch_route")
+        request.getfixturevalue("apply_dual_tor_neigh_entries")
+        logger.info("Done applying kernel configs for dual ToR mock")

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -139,7 +139,7 @@ def get_t1_active_ptf_ports(dut, tbinfo):
     ptf_portchannel_intfs = {}
     for k, v in config_facts['PORTCHANNEL'].items():
         if k in up_portchannels:
-            ptf_portchannel_intfs[k]  = []
+            ptf_portchannel_intfs[k] = []
             for member in v['members']:
                 ptf_portchannel_intfs[k].append(mg_facts['minigraph_ptf_indices'][member])
 
@@ -550,10 +550,10 @@ def check_tunnel_balance(ptfhost, active_tor_mac, standby_tor_mac, active_tor_ip
     log_file = "/tmp/ip_in_ip_tunnel_test.{}.log".format(timestamp)
     logging.info("PTF log file: %s" % log_file)
     ptf_runner(ptfhost,
-                "ptftests",
-                "ip_in_ip_tunnel_test.IpinIPTunnelTest",
-                platform_dir="ptftests",
-                params=params,
-                log_file=log_file,
-                qlen=2000,
-                socket_recv_size=16384)
+               "ptftests",
+               "ip_in_ip_tunnel_test.IpinIPTunnelTest",
+               platform_dir="ptftests",
+               params=params,
+               log_file=log_file,
+               qlen=2000,
+               socket_recv_size=16384)

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -2,6 +2,7 @@
 Utility functions can re-used in testing scripts.
 """
 import collections
+import ipaddress
 import logging
 import six
 import sys
@@ -316,3 +317,12 @@ def get_test_server_vars(inv_files, server, variable=None):
     else:
         logger.error("Unable to find test server host under group {}".format(server))
         return None
+
+
+def is_ipv4_address(ip_address):
+    """Check if ip address is ipv4."""
+    try:
+        ipaddress.IPv4Address(ip_address)
+        return True
+    except ipaddress.AddressValueError:
+        return False

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -1,0 +1,145 @@
+"""
+1. Send IPinIP packets from t1 to ToR.
+2. Check that for inner packet that has destination IP as active server IP, the packet
+is decapsulated and forwarded to server port.
+3. Check that for inner packet that has destination IP as standby server IP, the packet
+is not forwarded to server port or re-encapsulated to T1s.
+"""
+import logging
+import pytest
+import random
+
+from ptf import mask
+from ptf import testutils
+from scapy.all import Ether, IP
+from tests.common.dualtor.dual_tor_mock import *
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
+from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
+from tests.common.utilities import is_ipv4_address
+
+
+pytestmark = [
+    pytest.mark.topology("t0")
+]
+
+
+@pytest.fixture(scope="module")
+def tor(duthosts, rand_one_dut_hostname):
+    """Select a tor as test target."""
+    return duthosts[rand_one_dut_hostname]
+
+
+@pytest.fixture(scope="function")
+def test_interface(tor):
+    """Select a random interface to test."""
+    config_facts = tor.get_running_config_facts()
+    muxcable_table = config_facts["MUX_CABLE"]
+    iface = str(random.choice(muxcable_table.keys()))
+    server_ipv4 = muxcable_table[iface]["server_ipv4"]
+    logging.info("select DUT interface %s to test.", iface)
+    return iface, server_ipv4.split("/")[0]
+
+
+@pytest.fixture(scope="function")
+def build_encapsulated_packet(test_interface, ptfadapter, tor, tunnel_traffic_monitor):
+    """Build the encapsulated packet sent from T1 to ToR."""
+    _, server_ipv4 = test_interface
+    config_facts = tor.get_running_config_facts()
+    try:
+        peer_ipv4_address = [_["address_ipv4"] for _ in config_facts["PEER_SWITCH"].values()][0]
+    except IndexError:
+        raise ValueError("Failed to get peer ToR address from CONFIG_DB")
+
+    tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback0"]
+                        if is_ipv4_address(_.split("/")[0])][0]
+    tor_ipv4_address = tor_ipv4_address.split("/")[0]
+
+    inner_dscp = random.choice(range(0, 33))
+    inner_ttl = random.choice(range(3, 65))
+    inner_packet = testutils.simple_ip_packet(
+        ip_src="1.1.1.1",
+        ip_dst=server_ipv4,
+        ip_dscp=inner_dscp,
+        ip_ttl=inner_ttl
+    )[IP]
+    packet = testutils.simple_ipv4ip_packet(
+        eth_dst=tor.facts["router_mac"],
+        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        ip_src=peer_ipv4_address,
+        ip_dst=tor_ipv4_address,
+        ip_dscp=inner_dscp,
+        ip_ttl=255,
+        inner_frame=inner_packet
+    )
+    logging.info("the encapsulated packet to send:\n%s", tunnel_traffic_monitor._dump_show_str(packet))
+    return packet
+
+
+def get_ptf_server_intf_index(tor, tbinfo, iface):
+    """Get the index of ptf ToR-facing interface on ptf."""
+    mg_facts = tor.get_extended_minigraph_facts(tbinfo)
+    return mg_facts["minigraph_ptf_indices"][iface]
+
+
+def build_expected_packet_to_server(encapsulated_packet):
+    """Build packet expected to be received by server from the tunnel packet."""
+    inner_packet = encapsulated_packet[IP].payload[IP].copy()
+    # use dummy mac address that will be ignored in mask
+    inner_packet = Ether(src="aa:bb:cc:dd:ee:ff", dst="aa:bb:cc:dd:ee:ff") / inner_packet
+    exp_pkt = mask.Mask(inner_packet)
+    exp_pkt.set_do_not_care_scapy(Ether, "dst")
+    exp_pkt.set_do_not_care_scapy(Ether, "src")
+    exp_pkt.set_do_not_care_scapy(IP, "tos")
+    exp_pkt.set_do_not_care_scapy(IP, "ttl")
+    exp_pkt.set_do_not_care_scapy(IP, "chksum")
+    return exp_pkt
+
+
+def test_dualtor_ipinip_active_tor(
+    apply_mock_dual_tor_tables,
+    apply_mock_dual_tor_kernel_configs,
+    apply_active_state_to_orchagent,
+    build_encapsulated_packet, test_interface, ptfadapter,
+    tbinfo, tor, tunnel_traffic_monitor
+):
+    encapsulated_packet = build_encapsulated_packet
+    iface, _ = test_interface
+
+    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+    exp_pkt = build_expected_packet_to_server(encapsulated_packet)
+
+    ptfadapter.dataplane.flush()
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=1)
+    _, rec_pkt = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index])
+    rec_pkt = Ether(rec_pkt)
+    logging.info("received decap packet:\n%s", tunnel_traffic_monitor._dump_show_str(rec_pkt))
+    exp_ttl = encapsulated_packet[IP].payload[IP].ttl - 1
+    exp_tos = encapsulated_packet[IP].payload[IP].tos
+    if rec_pkt[IP].ttl != exp_ttl:
+        pytest.fail("the expected ttl should be %s" % exp_ttl)
+    if rec_pkt[IP].tos != exp_tos:
+        pytest.fail("the expected tos should be %s" % exp_tos)
+
+
+def test_dualtor_ipinip_standby_tor(
+    apply_mock_dual_tor_tables,
+    apply_mock_dual_tor_kernel_configs,
+    apply_standby_state_to_orchagent,
+    build_encapsulated_packet, test_interface, ptfadapter,
+    tbinfo, tor, tunnel_traffic_monitor
+):
+    encapsulated_packet = build_encapsulated_packet
+    iface, _ = test_interface
+
+    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+    exp_pkt = build_expected_packet_to_server(encapsulated_packet)
+
+    ptfadapter.dataplane.flush()
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    with tunnel_traffic_monitor(tor, existing=False):
+        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=1)
+
+    testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=[exp_ptf_port_index])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add two testcases:
1. `test_decap_active_tor`
Send encapsulated packet to the active tor, verify the packet is
decapsulated by the active tor and forwarded to the server.
2. `test_decap_standby_tor`
Send encapsulated packet to the standby tor, verify the packet is
neither decapsulated and forwarded to server or decapsulated and
re-encapsulated back to T1s.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes #2777

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Cover the testing scenario that aims to verify that encapsulated packet could be:
1. decapsulated by the active tor and forwarded to the server.
2. not decapsulated by the standby tor then either forwarded to the server or re-encapsulated back to T1s.

#### How did you do it?
1. Randomly choose a ToR from the testbed.
2. Randomly choose an interface on the target ToR and toggle it as `active` or `standby` 
3. Created encapsulated simulating tunnel traffic
The outer packet is from the other ToR to the testing target ToR.
The inner packet is to one of the servers.
4. Send the encapsulated packet to the target ToR from the ptf intercepted interface of T1s.
5. Do the verification
For `active` mode, the encapsulated packet should be decapped by the target ToR and forwarded to the server.
For `standby` mode, the encapsulated packet should not be either forwarded to the server or re-encapsulated back to T1s.

#### How did you verify/test it?
Run those two tests against dualtor testbeds.

#### Any platform specific information?
dualtor testbeds

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
