### PR TITLE
[Mellanox] Test case should be marked as failure if cannot get PSU fan speed

### DIFF
--- a/tests/platform_tests/mellanox/test_thermal_control.py
+++ b/tests/platform_tests/mellanox/test_thermal_control.py
@@ -129,8 +129,7 @@ def get_psu_speed(dut, index):
     index = index + 1
     psu_speed_path = PSU_SPEED_PATH.format(index)
     file_stat = dut.stat(path=psu_speed_path)
-    if not file_stat["stat"]["exists"]:
-        return None
+    assert file_stat["stat"]["exists"], 'Failed to get PSU speed file due to {} does not exist'.format(psu_speed_path)
 
     cmd_output = dut.command('cat {}'.format(psu_speed_path))
     try:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test case should be marked as failure if cannot get PSU fan speed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Test case should be marked as failure if cannot get PSU fan speed because it usually means that there is an issue with the sysfs. 

#### How did you do it?

If PSU speed sysfs does not exist, assert false.

#### How did you verify/test it?

Manually run the test case

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
