### PR TITLE
Modify  test_ro_user_allowed_command and `test_ro_user_banned_command  to check common SONiC CLI commands

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -80,10 +80,16 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             # 'sudo psuutil *',
             # 'sudo sfputil show *',
             'sudo ip netns identify 1',
+            'sudo ipintutil'
     ]
         # Run as readonly use the commands allowed indirectly based on sudoers file
     commands_indirect = [
             'show version',
+            'show interface status',
+            'show interface portchannel',
+            'show ip bgp summary',
+            'show ip interface',
+            'show lldp table'
     ]
 
     for command in commands_direct + commands_indirect:
@@ -105,6 +111,8 @@ def test_ro_user_banned_command(localhost, duthosts, rand_one_dut_hostname, cred
     # Run as readonly use the commands allowed by sudoers file
     commands = [
             'sudo shutdown',
+            # all commands under the config tree
+            'sudo config'
     ]
 
     for command in commands:

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -80,7 +80,10 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             # 'sudo psuutil *',
             # 'sudo sfputil show *',
             'sudo ip netns identify 1',
-            'sudo ipintutil'
+            'sudo ipintutil',
+            'sudo ipintutil -a ipv6',
+            'sudo ipintutil -n asic0 -d all',
+            'sudo ipintutil -n asic0 -d all -a ipv6'
     ]
         # Run as readonly use the commands allowed indirectly based on sudoers file
     commands_indirect = [
@@ -89,6 +92,7 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'show interface portchannel',
             'show ip bgp summary',
             'show ip interface',
+            'show ipv6 interface',
             'show lldp table'
     ]
 


### PR DESCRIPTION

Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add the most commonly used CLI commands in the tests `test_ro_user_allowed_command` and `test_ro_user_banned_command` 

#### How did you verify/test it?
Logs from the tests.
```

arlakshm@61e163aff932:/data/sonic-mgmt/tests$ ./run_tests.sh -n vms-kvm-t0 -d vlab01 -c tacacs/test_ro_user.py::test_ro_user_banned_command  -l INFO -f vtestbed.csv -i veos_vtb -u -e '--skip_sanity'
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
========================================================================== test session starts ==========================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, repeat-0.8.0, metadata-1.10.0, html-1.22.1, ansible-2.2.2
collected 1 item

tacacs/test_ro_user.py::test_ro_user_banned_command
---------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------23:30:17 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
23:30:17 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
23:30:20 INFO conftest.py:generate_params_dut_hostname:697: DUTs in testbed 'vms-kvm-t0' are: ['vlab-01']
23:30:20 INFO conftest.py:creds:371: dut vlab-01 belongs to groups [u'lab', u'sonic', 'fanout']
23:30:20 INFO conftest.py:creds:383: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
23:30:20 INFO conftest.py:creds:383: skip empty var file ../ansible/group_vars/all/env.yml
23:30:22 INFO __init__.py:sanity_check:80: Prepare pre-test sanity check
23:30:22 INFO __init__.py:sanity_check:90: Found marker: m.name=disable_loganalyzer, m.args=(), m.kwargs={}
23:30:22 INFO __init__.py:sanity_check:90: Found marker: m.name=topology, m.args=('any',), m.kwargs={}
23:30:22 INFO __init__.py:sanity_check:90: Found marker: m.name=device_type, m.args=('vs',), m.kwargs={}
23:30:22 INFO __init__.py:sanity_check:114: Skip sanity check according to command line argument or configuration of test script.
23:31:11 INFO __init__.py:loganalyzer:17: Log analyzer is disabled
----------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------23:31:13 INFO test_ro_user.py:ssh_remote_ban_run:29: check command "sudo shutdown" rc=1
23:31:14 INFO test_ro_user.py:ssh_remote_ban_run:29: check command "sudo config" rc=1
PASSED                                                                                                                                                            [100%]

arlakshm@61e163aff932:/data/sonic-mgmt/tests$ ./run_tests.sh -n vms-kvm-t0 -d vlab01 -c tacacs/test_ro_user.py::test_ro_user_allowed_command  -l INFO -f vtestbed.csv -i veos_vtb -u -e '--skip_sanity'                                                                                                                                           === Running tests in groups ===                                                                                                                                          /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.                                                                                    from cryptography.exceptions import InvalidSignature                                                                                                                   ========================================================================== test session starts ==========================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, repeat-0.8.0, metadata-1.10.0, html-1.22.1, ansible-2.2.2
collected 1 item

tacacs/test_ro_user.py::test_ro_user_allowed_command
---------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------23:35:57 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
23:35:57 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
23:36:00 INFO conftest.py:generate_params_dut_hostname:697: DUTs in testbed 'vms-kvm-t0' are: ['vlab-01']
23:36:00 INFO conftest.py:creds:371: dut vlab-01 belongs to groups [u'lab', u'sonic', 'fanout']
23:36:00 INFO conftest.py:creds:383: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
23:36:00 INFO conftest.py:creds:383: skip empty var file ../ansible/group_vars/all/env.yml
23:36:02 INFO __init__.py:sanity_check:80: Prepare pre-test sanity check
23:36:02 INFO __init__.py:sanity_check:90: Found marker: m.name=disable_loganalyzer, m.args=(), m.kwargs={}
23:36:02 INFO __init__.py:sanity_check:90: Found marker: m.name=topology, m.args=('any',), m.kwargs={}
23:36:02 INFO __init__.py:sanity_check:90: Found marker: m.name=device_type, m.args=('vs',), m.kwargs={}
23:36:02 INFO __init__.py:sanity_check:114: Skip sanity check according to command line argument or configuration of test script.
23:36:51 INFO __init__.py:loganalyzer:17: Log analyzer is disabled
----------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------23:36:53 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo cat /var/log/syslog" rc=0
23:36:55 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo cat /var/log/syslog.1" rc=0
23:36:56 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo cat /var/log/syslog.2.gz" rc=1
23:36:57 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo brctl show" rc=0
23:36:59 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo docker exec snmp cat /etc/snmp/snmpd.conf" rc=0
23:37:00 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo docker images --format "table {% raw %}{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}{% endraw
%}"" rc=0
23:37:02 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo docker ps" rc=0
23:37:03 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo docker ps -a" rc=0
23:37:05 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo lldpctl" rc=0
23:37:06 INFO test_ro_user.py:ssh_remote_allow_run:23: check command ""sudo vtysh -c 'show ip bgp su'"" rc=0
23:37:08 INFO test_ro_user.py:ssh_remote_allow_run:23: check command ""sudo vtysh -n 0 -c 'show ip bgp su'"" rc=0
23:37:10 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo decode-syseeprom" rc=0
23:38:25 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo generate_dump" rc=0
23:38:27 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo lldpshow" rc=0
23:38:29 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo pcieutil check" rc=0
23:38:30 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo ip netns identify 1" rc=0
23:38:32 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo ipintutil" rc=0
23:38:34 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "show version" rc=0
23:38:36 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "show interface status" rc=0
23:38:38 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "show interface portchannel" rc=0
23:38:40 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "show ip bgp summary" rc=0
23:38:43 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "show ip interface" rc=0
23:38:46 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "show lldp table" rc=0
23:38:47 INFO test_ro_user.py:ssh_remote_allow_run:23: check command "sudo sonic-installer list" rc=0
PASSED                                                                                                                                                            [100%]

-------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ---------------------------------------------------------====================================================================== 1 passed in 194.62 seconds =======================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
