### PR TITLE
[voq] Neighbor and host IP forwarding test cases and helpers.

### DIFF
--- a/ansible/roles/test/files/ptftests/voq.py
+++ b/ansible/roles/test/files/ptftests/voq.py
@@ -84,12 +84,12 @@ class DataplaneTest(BaseTest):
 
         self.dataplane = ptf.dataplane_instance
         self.dataplane.flush()
-        if config["log_dir"] is None:
+        if config["log_dir"] is not None:
             filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
             self.dataplane.start_pcap(filename)
 
     def tearDown(self):
-        if config["log_dir"] is None:
+        if config["log_dir"] is not None:
             self.dataplane.stop_pcap()
         reset_filters()
         BaseTest.tearDown(self)

--- a/ansible/roles/test/files/ptftests/voq.py
+++ b/ansible/roles/test/files/ptftests/voq.py
@@ -1,0 +1,427 @@
+import os
+import ptf
+import ptf.packet as scapy
+import ptf.dataplane as dataplane
+from ptf.testutils import *
+from ptf.mask import Mask
+from ptf import config
+from ptf.base_tests import BaseTest
+import ptf.testutils as testutils
+from scapy.all import Ether
+from scapy.layers.l2 import Dot1Q
+from scapy.layers.inet6 import IPv6, ICMPv6ND_NA, ICMPv6NDOptDstLLAddr
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def make_ndp_grat_ndp_packet(pktlen=64,
+                             eth_dst='00:01:02:03:04:05',
+                             eth_src='00:06:07:08:09:0a',
+                             dl_vlan_enable=False,
+                             vlan_vid=0,
+                             vlan_pcp=0,
+                             ipv6_src='2001:db8:85a3::8a2e:370:7334',
+                             ipv6_dst='2001:db8:85a3::8a2e:370:7335',
+                             ipv6_tc=0,
+                             ipv6_ecn=None,
+                             ipv6_dscp=None,
+                             ipv6_hlim=255,
+                             ipv6_fl=0,
+                             ipv6_tgt='2001:db8:85a3::8a2e:370:7334',
+                             hw_tgt='00:06:07:08:09:0a', ):
+    """
+    Generates a simple NDP advertisement similar to PTF testutils simple_arp_packet.
+
+    Args:
+        pktlen: length of packet
+        eth_dst: etheret destination address.
+        eth_src: ethernet source address
+        dl_vlan_enable: True to add vlan header.
+        vlan_vid: vlan ID
+        vlan_pcp: vlan priority
+        ipv6_src: IPv6 source address
+        ipv6_dst: IPv6 destination address
+        ipv6_tc: IPv6 traffic class
+        ipv6_ecn: IPv6 traffic class ECN
+        ipv6_dscp: IPv6 traffic class DSCP
+        ipv6_hlim: IPv6 hop limit/ttl
+        ipv6_fl: IPv6 flow label
+        ipv6_tgt: ICMPv6 ND advertisement target address.
+        hw_tgt: IPv6 ND advertisement destination link-layer address.
+
+    Returns:
+        Crafted scapy packet for using with send_packet().
+    """
+
+    if MINSIZE > pktlen:
+        pktlen = MINSIZE
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
+
+    pkt = Ether(dst=eth_dst, src=eth_src)
+    if dl_vlan_enable or vlan_vid or vlan_pcp:
+        pkt /= Dot1Q(vlan=vlan_vid, prio=vlan_pcp)
+    pkt /= IPv6(src=ipv6_src, dst=ipv6_dst, fl=ipv6_fl, tc=ipv6_tc, hlim=ipv6_hlim)
+    pkt /= ICMPv6ND_NA(R=0, S=0, O=1, tgt=ipv6_tgt)
+    pkt /= ICMPv6NDOptDstLLAddr(lladdr=hw_tgt)
+    pkt /= ("D" * (pktlen - len(pkt)))
+
+    return pkt
+
+
+class DataplaneTest(BaseTest):
+    """
+    Base class for tests
+    """
+
+    def setUp(self):
+        BaseTest.setUp(self)
+
+        self.test_params = test_params_get()
+        logger.info("You specified the following test-params when invoking ptf:")
+        logger.info(self.test_params)
+
+        self.dataplane = ptf.dataplane_instance
+        self.dataplane.flush()
+        if config["log_dir"] is None:
+            filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
+            self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config["log_dir"] is None:
+            self.dataplane.stop_pcap()
+        reset_filters()
+        BaseTest.tearDown(self)
+
+
+class GARP(DataplaneTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = testutils.test_params_get()
+
+    def runTest(self):
+        """
+        For test_voq_nbr test_gratarp_macchange, sends an unsolicited ARP
+        """
+        pkt = simple_arp_packet(
+            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_src=self.test_params['vm_mac'],
+            arp_op=1,
+            ip_snd=self.test_params['vmip'],
+            ip_tgt=self.test_params['vmip'],
+            hw_snd=self.test_params['vm_mac'],
+            hw_tgt='ff:ff:ff:ff:ff:ff',
+        )
+
+        send_packet(self, self.test_params['port'], pkt)
+
+
+class GNDP(DataplaneTest):
+
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = testutils.test_params_get()
+
+    def runTest(self):
+        """
+        For test_voq_nbr test_gratarp_macchange, sends an unsolicited NDP
+        """
+        pkt = make_ndp_grat_ndp_packet(eth_dst='33:33:00:00:00:01',
+                                       eth_src=self.test_params['vm_mac'],
+                                       ipv6_src=self.test_params['vmip'],
+                                       ipv6_dst="ff02::1",
+                                       ipv6_tgt=self.test_params['vmip'],
+                                       hw_tgt=self.test_params['vm_mac'],
+                                       )
+
+        send_packet(self, self.test_params['port'], pkt)
+
+
+def build_ttl0_pkts(version, dst_mac, dst_ip, vm_mac, vm_ip, dut_lb):
+    """
+    Builds ttl0 packet to send and ICMP TTL exceeded packet to expect back.
+
+    Args:
+        version: 4 or 6 for
+        dst_mac: Destination MAC, of DUT port.
+        dst_ip: Destination IP, a farend VM interface.
+        vm_mac: Source MAC, of VM port that packets are sent out.
+        vm_ip: Source IP, of the VM port.
+        dut_lb: Loopback of DUT, source of the ICMP packets returned to the VM.
+
+    Returns:
+        3 packets, one with ttl0 to send, one as the ICMP expected packet, and one to check for TTL wrapping.
+
+    """
+    if version == 4:
+        send_pkt = simple_udp_packet(eth_dst=dst_mac,  # mac address of dut
+                                     eth_src=vm_mac,  # mac address of vm1
+                                     ip_src=str(vm_ip),
+                                     ip_dst=str(dst_ip),
+                                     ip_ttl=0,
+                                     pktlen=100)
+
+        exp_pkt255 = simple_udp_packet(eth_dst=dst_mac,  # mac address of dut
+                                       eth_src=vm_mac,  # mac address of vm1
+                                       ip_src=str(vm_ip),
+                                       ip_dst=str(dst_ip),
+                                       ip_ttl=255,
+                                       pktlen=100)
+        v4_pktsz = 128
+        exp_pkt = simple_icmp_packet(eth_dst=vm_mac,
+                                     # mac address of vm1
+                                     eth_src=dst_mac,  # mac address of dut
+                                     ip_src=dut_lb,
+                                     ip_dst=vm_ip,
+                                     ip_ttl=64,
+                                     icmp_code=0,
+                                     icmp_type=11,
+                                     pktlen=v4_pktsz,
+                                     )
+
+        masked_pkt = Mask(exp_pkt)
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "len")
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "id")
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_pkt.set_do_not_care_scapy(scapy.ICMP, "chksum")
+        masked_pkt.set_do_not_care(304, v4_pktsz * 8 - 304)  # ignore icmp data
+
+    else:
+        send_pkt = simple_udpv6_packet(eth_dst=dst_mac,  # mac address of dut
+                                       eth_src=vm_mac,  # mac address of vm1
+                                       ipv6_src=str(vm_ip),
+                                       ipv6_dst=str(dst_ip),
+                                       ipv6_hlim=0,
+                                       pktlen=100)
+
+        exp_pkt255 = simple_udpv6_packet(eth_dst=dst_mac,  # mac address of dut
+                                         eth_src=vm_mac,  # mac address of vm1
+                                         ipv6_src=str(vm_ip),
+                                         ipv6_dst=str(dst_ip),
+                                         ipv6_hlim=255,
+                                         pktlen=100)
+
+        v6_pktsz = 148
+        exp_pkt = simple_icmpv6_packet(eth_dst=vm_mac,  # mac address of vm1
+                                       eth_src=dst_mac,  # mac address of dut
+                                       ipv6_src=str(dut_lb),
+                                       ipv6_dst=str(vm_ip),
+                                       ipv6_hlim=64,
+                                       icmp_code=0,
+                                       icmp_type=3,
+                                       pktlen=v6_pktsz,
+                                       )
+        #
+        masked_pkt = Mask(exp_pkt)
+        masked_pkt.set_do_not_care_scapy(scapy.IPv6, "tc")
+        masked_pkt.set_do_not_care_scapy(scapy.IPv6, "fl")
+        masked_pkt.set_do_not_care_scapy(scapy.IPv6, "plen")
+        masked_pkt.set_do_not_care_scapy(scapy.ICMPv6Unknown, "cksum")
+        masked_pkt.set_do_not_care(456, v6_pktsz * 8 - 456)  # ignore icmp data
+
+    return send_pkt, masked_pkt, exp_pkt255
+
+
+class TTL0(DataplaneTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = testutils.test_params_get()
+
+    def runTest(self):
+        """
+        For test_voq_ipfwd - test_ipforwarding_ttl0, sends a ttl0 and verifies it is not forwarded and
+        time exceeded message is received.
+
+        """
+        vm_mac = self.test_params['vm_mac']
+        vm_ip = self.test_params['vm_ip']
+        dut_lb = self.test_params['dut_lb']
+        version = self.test_params['version']
+        dst_mac = self.test_params['dst_mac']
+        dst_ip = self.test_params['dst_ip']
+
+        src_port = self.test_params['src_port']
+        src_rx_ports = self.test_params['src_rx_ports']
+        dst_rx_ports = self.test_params['dst_rx_ports']
+
+        send_pkt, masked_pkt, exp_pkt255 = build_ttl0_pkts(version, dst_mac, dst_ip, vm_mac, vm_ip, dut_lb)
+        logger.info("sending packet to port %s", src_port)
+        send(self, src_port, send_pkt)
+        print("masked packet matched port: %s" % src_port)
+
+        result = dp_poll(self, device_number=0, exp_pkt=masked_pkt, timeout=2)
+        self.at_receive(result.packet, device_number=result.device, port_number=result.port)
+
+        print("Found %s ICMP ttl expired packets on ports: %s" % (result, str(src_rx_ports)))
+        logger.info("Found %s ICMP ttl expired packets on ports: %s" % (result, str(src_rx_ports)))
+        print("port: %s" % result.port)
+        if str(result.port) not in src_rx_ports:
+            self.fail("Port %s not in %s" % (result.port, src_rx_ports))
+
+        verify_no_packet_any(self, send_pkt, dst_rx_ports)
+        verify_no_packet_any(self, exp_pkt255, dst_rx_ports)
+        logger.info("Ran to completion.")
+
+
+class MtuTest(BaseTest):
+    """
+    For jumbo packet test in voq/test_voq_ipfwd.py
+
+    Test through multiple cards and ICMP to linecard host CPU.
+
+    Modified from mtu_test.py
+    """
+
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = test_params_get()
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.router_mac = self.test_params['router_mac_src_side']
+        self.router_mac_dst = self.test_params['router_mac_dst_side']
+        self.pktlen = self.test_params['pktlen']
+        self.src_host_ip = self.test_params.get('src_host_ip')
+        self.src_router_ip = self.test_params.get('src_router_ip')
+        self.dst_host_ip = self.test_params.get('dst_host_ip')
+        self.src_ptf_port_list = self.test_params.get('src_ptf_port_list')
+        self.dst_ptf_port_list = self.test_params.get('dst_ptf_port_list')
+        self.version = self.test_params.get('version')
+
+    def check_icmp_mtu(self):
+        """Check ICMP/Ping to DUT works for MAX MTU. """
+
+        ip_src = self.src_host_ip
+        ip_dst = self.src_router_ip
+        src_mac = self.dataplane.get_mac(0, self.src_ptf_port_list[0])
+        pktlen = self.pktlen
+
+        if self.version == 4:
+            pkt = simple_icmp_packet(pktlen=pktlen,
+                                     eth_dst=self.router_mac,
+                                     eth_src=src_mac,
+                                     ip_src=ip_src,
+                                     ip_dst=ip_dst,
+                                     ip_ttl=64)
+
+            exp_pkt = simple_icmp_packet(pktlen=pktlen,
+                                         eth_src=self.router_mac,
+                                         ip_src=ip_dst,
+                                         ip_dst=ip_src,
+                                         icmp_type=0)
+
+            masked_exp_pkt = Mask(exp_pkt)
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.ICMP, "chksum")
+
+        else:
+            pkt = simple_icmpv6_packet(pktlen=pktlen,
+                                       eth_dst=self.router_mac,
+                                       eth_src=src_mac,
+                                       ipv6_src=ip_src,
+                                       ipv6_dst=ip_dst,
+                                       ipv6_hlim=64,
+                                       icmp_code=0,
+                                       icmp_type=128)
+
+            exp_pkt = simple_icmpv6_packet(pktlen=pktlen,
+                                           eth_src=self.router_mac,
+                                           ipv6_src=ip_dst,
+                                           ipv6_dst=ip_src,
+                                           icmp_type=129,
+                                           icmp_code=0)
+
+            masked_exp_pkt = Mask(exp_pkt)
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "id")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "tc")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "fl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "plen")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.ICMPv6Unknown, "chksum")
+
+        src_port = self.src_ptf_port_list[0]
+        send_packet(self, src_port, pkt)
+        logging.info("Sending packet from port " + str(src_port) + " address " + ip_src)
+        logging.info("To MAC %s, dst_ip: %s", self.router_mac, ip_dst)
+        dst_port_list = self.src_ptf_port_list
+        logging.info("Expect packet on port: %s of len %s, eth: %s, ipsrc: %s, ipdst: %s",
+                     str(dst_port_list), pktlen, self.router_mac, ip_dst, ip_src)
+
+        (matched_index, received) = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+
+        assert received
+
+        matched_port = dst_port_list[matched_index]
+        logging.info("Received packet at " + str(matched_port))
+
+        return
+
+    def check_ip_mtu(self):
+        """Check unicast IP forwarding in DUT works for MAX MTU."""
+
+        ip_src = self.src_host_ip
+        ip_dst = self.dst_host_ip
+        src_mac = self.dataplane.get_mac(0, self.src_ptf_port_list[0])
+
+        if self.version == 4:
+            pkt = simple_ip_packet(pktlen=self.pktlen,
+                                   eth_dst=self.router_mac,
+                                   eth_src=src_mac,
+                                   ip_src=ip_src,
+                                   ip_dst=ip_dst,
+                                   ip_ttl=64)
+
+            exp_pkt = simple_ip_packet(pktlen=self.pktlen,
+                                       eth_src=self.router_mac_dst,
+                                       ip_src=ip_src,
+                                       ip_dst=ip_dst,
+                                       ip_ttl=63)
+
+            masked_exp_pkt = Mask(exp_pkt)
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        else:
+            pkt = simple_ipv6ip_packet(pktlen=self.pktlen,
+                                       eth_dst=self.router_mac,
+                                       eth_src=src_mac,
+                                       ipv6_src=ip_src,
+                                       ipv6_dst=ip_dst,
+                                       ipv6_hlim=64)
+
+            exp_pkt = simple_ipv6ip_packet(pktlen=self.pktlen,
+                                           eth_src=self.router_mac_dst,
+                                           ipv6_src=ip_src,
+                                           ipv6_dst=ip_dst,
+                                           ipv6_hlim=63)
+
+            masked_exp_pkt = Mask(exp_pkt)
+            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        src_port = self.src_ptf_port_list[0]
+        send_packet(self, src_port, pkt)
+        logging.info("Sending packet from port " + str(src_port) + " to " + ip_dst)
+
+        dst_port_list = self.dst_ptf_port_list
+        (matched_index, received) = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+
+        assert received
+
+        matched_port = dst_port_list[matched_index]
+        logging.info("Received packet at " + str(matched_port))
+
+        return
+
+    def runTest(self):
+        """
+        Send MAX MTU packet to and through DUT.
+        """
+        self.check_icmp_mtu()
+        self.check_ip_mtu()

--- a/ansible/roles/test/files/ptftests/voq.py
+++ b/ansible/roles/test/files/ptftests/voq.py
@@ -1,7 +1,6 @@
 import os
 import ptf
 import ptf.packet as scapy
-import ptf.dataplane as dataplane
 from ptf.testutils import *
 from ptf.mask import Mask
 from ptf import config

--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -144,7 +144,7 @@ class RedisCli(object):
 
     def get_keys(self, table):
         """
-        Executes a redis CLI get or hget and validates the response against a provided field.
+        Gets the list of keys in a table.
 
         Args:
             table: full name of the table for which to get the keys.

--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -1,6 +1,7 @@
 import logging
 import json
-from tests.common.devices import DEFAULT_NAMESPACE, SonicAsic
+from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.devices.sonic_asic import SonicAsic
 
 logger = logging.getLogger(__name__)
 

--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -316,7 +316,7 @@ class AsicDbCli(RedisCli):
 
     def get_hostif_table(self, refresh=False):
         """
-        Returns the a fresh hostif table if refresh is true, else returns the entry from cache.  Initializes instance
+        Returns a fresh hostif table if refresh is true, else returns the entry from cache.  Initializes instance
         table on first run.
 
         Args:

--- a/tests/voq/conftest.py
+++ b/tests/voq/conftest.py
@@ -1,4 +1,10 @@
 import pytest
+import logging
+
+from voq_helpers import get_eos_mac
+from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -21,7 +27,6 @@ def all_cfg_facts(duthosts):
     #   asic0_results['ansible_facts']
     # result = duthosts.config_facts(source='persistent', asic_index='all')
     # return result
-    # work around https://github.com/Azure/sonic-mgmt/issues/3020
     results = {}
     for node in duthosts.nodes:
         results[node.hostname] = node.config_facts(source='persistent', asic_index='all')
@@ -34,10 +39,46 @@ def bgp_redistribute_route_lo(duthosts, all_cfg_facts):
         for a_asic in a_host.asics:
             asic_asn = all_cfg_facts[a_host.hostname][a_asic.asic_index]['ansible_facts']['DEVICE_METADATA']['localhost']['bgp_asn']
             send_command = a_asic.get_docker_cmd(
-                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv4 unicast' -c 'redistribute connected'",
+                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv4 unicast' -c 'no redistribute connected route-map HIDE_INTERNAL' -c 'redistribute connected'",
                 "bgp")
             send_command_ipv6 = a_asic.get_docker_cmd(
-                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv6 unicast' -c 'redistribute connected'",
+                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv6 unicast' -c 'no redistribute connected route-map HIDE_INTERNAL' -c 'redistribute connected'",
                 "bgp")
             a_host.command(send_command)
             a_host.command(send_command_ipv6)
+
+
+@reset_ansible_local_tmp
+def _get_nbr_macs(nbrhosts, node=None, results=None):
+    vm = nbrhosts[node]
+    node_results = {}
+
+    for intf in vm['conf']['interfaces'].keys():
+        logger.info("Get MAC on vm %s for intf: %s", node, intf)
+        mac = get_eos_mac(vm, intf)
+        logger.info("Found MAC on vm %s for intf: %s, mac: %s", node, intf, mac['mac'])
+        node_results[intf] = mac['mac']
+
+    results[node] = node_results
+
+
+@pytest.fixture(scope="module")
+def nbr_macs(nbrhosts):
+    """
+    Fixture to get all the neighbor mac addresses in parallel.
+
+    Args:
+        nbrhosts:
+
+    Returns:
+        Dictionary of MAC addresses of neighbor VMS, dict[vm_name][interface_name] = "mac address"
+
+    """
+    results = {}
+    logger.debug("Get MACS for all neighbor hosts.")
+    parallel_run(_get_nbr_macs, [nbrhosts], results, nbrhosts.keys(), timeout=120)
+
+    for res in results['results']:
+        logger.info("parallel_results %s = %s", res, results['results'][res])
+
+    return results['results']

--- a/tests/voq/conftest.py
+++ b/tests/voq/conftest.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def chassis_facts(duthosts):
+    """
+    Fixture to add some items to host facts from inventory file.
+    """
+    for a_host in duthosts.nodes:
+
+        if len(duthosts.supervisor_nodes) > 0:
+            slot_num = a_host.command(
+                "python3 -c 'import platform_ndk.nokia_common; print(platform_ndk.nokia_common._get_my_slot())'")[
+                'stdout']
+            a_host.facts['slot_num'] = int(slot_num)
+
+
+@pytest.fixture(scope="module")
+def all_cfg_facts(duthosts):
+    # { 'ixr_vdk_boar10' : [ asic0_results, asic1_results ] }
+    #   asic0_results['ansible_facts']
+    # result = duthosts.config_facts(source='persistent', asic_index='all')
+    # return result
+    # work around https://github.com/Azure/sonic-mgmt/issues/3020
+    results = {}
+    for node in duthosts.nodes:
+        results[node.hostname] = node.config_facts(source='persistent', asic_index='all')
+    return results
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bgp_redistribute_route_lo(duthosts, all_cfg_facts):
+    for a_host in duthosts.frontend_nodes:
+        for a_asic in a_host.asics:
+            asic_asn = all_cfg_facts[a_host.hostname][a_asic.asic_index]['ansible_facts']['DEVICE_METADATA']['localhost']['bgp_asn']
+            send_command = a_asic.get_docker_cmd(
+                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv4 unicast' -c 'redistribute connected'",
+                "bgp")
+            send_command_ipv6 = a_asic.get_docker_cmd(
+                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv6 unicast' -c 'redistribute connected'",
+                "bgp")
+            a_host.command(send_command)
+            a_host.command(send_command_ipv6)

--- a/tests/voq/conftest.py
+++ b/tests/voq/conftest.py
@@ -82,11 +82,10 @@ def nbr_macs(nbrhosts):
         Dictionary of MAC addresses of neighbor VMS, dict[vm_name][interface_name] = "mac address"
 
     """
-    results = {}
     logger.debug("Get MACS for all neighbor hosts.")
-    parallel_run(_get_nbr_macs, [nbrhosts], results, nbrhosts.keys(), timeout=120)
+    results = parallel_run(_get_nbr_macs, [nbrhosts], {}, nbrhosts.keys(), timeout=120)
 
-    for res in results['results']:
-        logger.info("parallel_results %s = %s", res, results['results'][res])
+    for res in results:
+        logger.info("parallel_results %s = %s", res, results[res])
 
-    return results['results']
+    return results

--- a/tests/voq/conftest.py
+++ b/tests/voq/conftest.py
@@ -45,12 +45,12 @@ def bgp_redistribute_route_lo(duthosts, all_cfg_facts):
             asic_asn = all_cfg_facts[a_host.hostname][a_asic.asic_index]['ansible_facts']['DEVICE_METADATA']['localhost']['bgp_asn']
 
             send_command = a_asic.get_docker_cmd(
-               "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv4 unicast' -c 'no redistribute connected route-map HIDE_INTERNAL' -c 'redistribute connected'",
-               "bgp")
+                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv4 unicast' -c 'no redistribute connected route-map HIDE_INTERNAL' -c 'redistribute connected'",
+                "bgp")
 
             send_command_ipv6 = a_asic.get_docker_cmd(
-               "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv6 unicast' -c 'no redistribute connected route-map HIDE_INTERNAL' -c 'redistribute connected'",
-               "bgp")
+                "vtysh -c 'configure terminal' -c 'router bgp " + asic_asn + "' -c 'address-family ipv6 unicast' -c 'no redistribute connected route-map HIDE_INTERNAL' -c 'redistribute connected'",
+                "bgp")
 
             a_host.command(send_command)
             a_host.command(send_command_ipv6)

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -3,155 +3,102 @@ import json
 import logging
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
+
 from tests.common.helpers.redis import AsicDbCli, RedisKeyNotFound
-from voq_helpers import check_local_neighbor, check_voq_remote_neighbor, get_sonic_mac
-from voq_helpers import check_local_neighbor_asicdb, get_device_system_ports, get_inband_info, get_port_by_ip
+from voq_helpers import check_voq_remote_neighbor, get_sonic_mac
+from voq_helpers import check_local_neighbor_asicdb, get_device_system_ports, get_inband_info
 from voq_helpers import check_rif_on_sup, check_voq_neighbor_on_sup, find_system_port
-from tests.common.helpers.dut_utils import get_host_visible_vars
-from tests.common.utilities import get_inventory_files
-from tests.voq.voq_helpers import get_eos_mac, get_vm_with_ip
+from voq_helpers import check_one_neighbor_present
+
+logger = logging.getLogger(__name__)
+
 
 pytestmark = [
     pytest.mark.topology('t2')
 ]
 
-logger = logging.getLogger(__name__)
+
+class TestVoqSwitch(object):
+    SWITCH_ID_LIST = []
+
+    def test_voq_switch_create(self, duthosts, enum_frontend_dut_hostname, enum_asic_index, all_cfg_facts):
+        """Compare the config facts with the asic db for switch:
+        * Verify ASIC_DB get all system ports referenced in configDB created on all hosts and ASICs.
+        * Verify object creation and values of port attributes.
+        """
+        per_host = duthosts[enum_frontend_dut_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        dev_facts = cfg_facts['DEVICE_METADATA']['localhost']
+        asicdb = AsicDbCli(asic)
+
+        switchkey = asicdb.get_switch_key()
+        logger.info("Checking switch %s", switchkey)
+        check_list = {
+            "max_cores": "SAI_SWITCH_ATTR_MAX_SYSTEM_CORES",
+            "switch_id": "SAI_SWITCH_ATTR_SWITCH_ID"}
+        for k in check_list:
+            asicdb.get_and_check_key_value(switchkey, dev_facts[k], field=check_list[k])
+
+        pytest_assert(dev_facts["switch_id"] not in TestVoqSwitch.SWITCH_ID_LIST,
+                      "Switch ID: %s has been used more than once" % dev_facts["switch_id"])
+        TestVoqSwitch.SWITCH_ID_LIST.append(dev_facts["switch_id"])
+
+        asicdb.get_and_check_key_value(switchkey, "SAI_SWITCH_TYPE_VOQ", field="SAI_SWITCH_ATTR_TYPE")
 
 
-@pytest.fixture(scope="module", autouse=True)
-def chassis_facts(duthosts, request):
-    """
-    Fixture to add some items to host facts from inventory file.
-    """
-    for a_host in duthosts.nodes:
-
-        if len(duthosts.supervisor_nodes) > 0:
-            inv_files = get_inventory_files(request)
-            host_vars = get_host_visible_vars(inv_files, a_host.hostname)
-            pytest_assert('slot_num' in host_vars, 
-                          "Variable 'slot_num' not found in inventory for host {}".format (a_host.hostname))
-            slot_num = host_vars['slot_num'] 
-            a_host.facts['slot_num'] = int(slot_num)
-
-
-
-@reset_ansible_local_tmp
-def _get_nbr_macs(nbrhosts, node=None, results=None):
-    vm = nbrhosts[node]
-    node_results = {}
-
-    for intf in vm['conf']['interfaces'].keys():
-        logger.info("Get MAC on vm %s for intf: %s", node, intf)
-        mac = get_eos_mac(vm, intf)
-        logger.info("Found MAC on vm %s for intf: %s, mac: %s", node, intf, mac['mac'])
-        node_results[intf] = mac['mac']
-
-    results[node] = node_results
-
-
-@pytest.fixture(scope="module")
-def nbr_macs(nbrhosts):
-    """
-    Fixture to get all the neighbor mac addresses in parallel.
-
-    Args:
-        nbrhosts:
-
-    Returns:
-        Dictionary of MAC addresses of neighbor VMS, dict[vm_name][interface_name] = "mac address"
-
-    """
-    results = {}
-    logger.debug("Get MACS for all neighbor hosts.")
-    parallel_run(_get_nbr_macs, [nbrhosts], results, nbrhosts.keys(), timeout=120)
-
-    for res in results['results']:
-        logger.info("parallel_results %s = %s", res, results['results'][res])
-
-    return results['results']
-
-
-def test_voq_switch_create(duthosts):
-    """Compare the config facts with the asic db for switch:
-    * Verify ASIC_DB get all system ports referenced in configDB created on all hosts and ASICs.
-    * Verify object creation and values of port attributes.
-    """
-
-    switch_id_list = []
-    for per_host in duthosts.frontend_nodes:
-
-        for asic in per_host.asics:
-            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            dev_facts = cfg_facts['DEVICE_METADATA']['localhost']
-            asicdb = AsicDbCli(asic)
-
-            switchkey = asicdb.get_switch_key()
-            logger.info("Checking switch %s", switchkey)
-            check_list = {
-                "max_cores": "SAI_SWITCH_ATTR_MAX_SYSTEM_CORES",
-                "switch_id": "SAI_SWITCH_ATTR_SWITCH_ID"}
-            for k in check_list:
-                asicdb.get_and_check_key_value(switchkey, dev_facts[k], field=check_list[k])
-
-            pytest_assert(dev_facts["switch_id"] not in switch_id_list,
-                          "Switch ID: %s has been used more than once" % dev_facts["switch_id"])
-            switch_id_list.append(dev_facts["switch_id"])
-
-            asicdb.get_and_check_key_value(switchkey, "SAI_SWITCH_TYPE_VOQ", field="SAI_SWITCH_ATTR_TYPE")
-
-
-def test_voq_system_port_create(duthosts):
+def test_voq_system_port_create(duthosts, enum_frontend_dut_hostname, enum_asic_index, all_cfg_facts):
     """Compare the config facts with the asic db for system ports
 
     * Verify ASIC_DB get all system ports referenced in configDB created on all hosts and ASICs.
     * Verify object creation and values of port attributes.
 
     """
+    per_host = duthosts[enum_frontend_dut_hostname]
+    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
-    for per_host in duthosts.frontend_nodes:
+    logger.info("Checking system ports on host: %s, asic: %s", per_host.hostname, asic.asic_index)
 
-        for asic in per_host.asics:
-            logger.info("Checking system ports on host: %s, asic: %s", per_host.hostname, asic.asic_index)
-            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            dev_ports = get_device_system_ports(cfg_facts)
-            asicdb = AsicDbCli(asic)
-            keylist = asicdb.get_system_port_key_list()
-            pytest_assert(len(keylist) == len(dev_ports.keys()),
-                          "Found %d system port keys, %d entries in cfg_facts, not matching" % (
-                              len(keylist), len(dev_ports.keys())))
-            logger.info("Found %d system port keys, %d entries in cfg_facts, checking each.",
-                        len(keylist), len(dev_ports.keys()))
-            for portkey in keylist:
-                try:
-                    port_output = asicdb.hget_key_value(portkey, field="SAI_SYSTEM_PORT_ATTR_CONFIG_INFO")
-                except RedisKeyNotFound:
-                    # TODO: Need to check on behavior here.
-                    logger.warning("System port: %s had no SAI_SYSTEM_PORT_ATTR_CONFIG_INFO", portkey)
-                    continue
-                port_data = json.loads(port_output)
-                for cfg_port in dev_ports:
-                    if dev_ports[cfg_port]['system_port_id'] == port_data['port_id']:
-                        #             "switch_id": "0",
-                        #             "core_index": "1",
-                        #             "core_port_index": "6",
-                        #             "speed": "400000"
-                        pytest_assert(dev_ports[cfg_port]['switch_id'] == port_data[
-                            'attached_switch_id'], "switch IDs do not match for port: %s" % portkey)
-                        pytest_assert(dev_ports[cfg_port]['core_index'] == port_data[
-                            'attached_core_index'], "switch IDs do not match for port: %s" % portkey)
-                        pytest_assert(dev_ports[cfg_port]['core_port_index'] == port_data[
-                            'attached_core_port_index'], "switch IDs do not match for port: %s" % portkey)
-                        pytest_assert(dev_ports[cfg_port]['speed'] == port_data[
-                            'speed'], "switch IDs do not match for port: %s" % portkey)
-                        break
-                else:
-                    logger.error("Could not find config entry for portkey: %s" % portkey)
+    dev_ports = get_device_system_ports(cfg_facts)
+    asicdb = AsicDbCli(asic)
+    keylist = asicdb.get_system_port_key_list()
+    pytest_assert(len(keylist) == len(dev_ports.keys()),
+                  "Found %d system port keys, %d entries in cfg_facts, not matching" % (
+                      len(keylist), len(dev_ports.keys())))
+    logger.info("Found %d system port keys, %d entries in cfg_facts, checking each.",
+                len(keylist), len(dev_ports.keys()))
+    for portkey in keylist:
+        try:
+            port_output = asicdb.hget_key_value(portkey, field="SAI_SYSTEM_PORT_ATTR_CONFIG_INFO")
+        except RedisKeyNotFound:
+            # TODO: Need to check on behavior here.
+            logger.warning("System port: %s had no SAI_SYSTEM_PORT_ATTR_CONFIG_INFO", portkey)
+            continue
+        port_data = json.loads(port_output)
+        for cfg_port in dev_ports:
+            if dev_ports[cfg_port]['system_port_id'] == port_data['port_id']:
+                #             "switch_id": "0",
+                #             "core_index": "1",
+                #             "core_port_index": "6",
+                #             "speed": "400000"
+                pytest_assert(dev_ports[cfg_port]['switch_id'] == port_data[
+                    'attached_switch_id'], "switch IDs do not match for port: %s" % portkey)
+                pytest_assert(dev_ports[cfg_port]['core_index'] == port_data[
+                    'attached_core_index'], "switch IDs do not match for port: %s" % portkey)
+                pytest_assert(dev_ports[cfg_port]['core_port_index'] == port_data[
+                    'attached_core_port_index'], "switch IDs do not match for port: %s" % portkey)
+                pytest_assert(dev_ports[cfg_port]['speed'] == port_data[
+                    'speed'], "switch IDs do not match for port: %s" % portkey)
+                break
+        else:
+            logger.error("Could not find config entry for portkey: %s" % portkey)
 
-            logger.info("Host: %s, Asic: %s all ports match all parameters", per_host.hostname, asic.asic_index)
+    logger.info("Host: %s, Asic: %s all ports match all parameters", per_host.hostname, asic.asic_index)
 
 
-def test_voq_local_port_create(duthosts):
+def test_voq_local_port_create(duthosts, enum_frontend_dut_hostname, enum_asic_index, all_cfg_facts):
     """Compare the config facts with the asic db for local ports
 
     * Verify ASIC_DB has host interface information for all local ports on all cards and ASICs.
@@ -159,53 +106,53 @@ def test_voq_local_port_create(duthosts):
     * Verify interfaces exist in show interfaces on the linecard.
     """
 
-    for per_host in duthosts.frontend_nodes:
+    per_host = duthosts[enum_frontend_dut_hostname]
+    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
-        for asic in per_host.asics:
-            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            dev_ports = cfg_facts['PORT']
+    dev_ports = cfg_facts['PORT']
 
-            asicdb = AsicDbCli(asic)
+    asicdb = AsicDbCli(asic)
 
-            keylist = asicdb.get_hostif_list()
-            pytest_assert(len(keylist) == len(dev_ports.keys()),
-                          "Found %d hostif keys, %d entries in cfg_facts" % (len(keylist), len(dev_ports.keys())))
-            logger.info("Found %s ports to check on host:%s, asic: %s.", len(dev_ports.keys()), per_host.hostname,
-                        asic.asic_index)
+    keylist = asicdb.get_hostif_list()
+    pytest_assert(len(keylist) == len(dev_ports.keys()),
+                  "Found %d hostif keys, %d entries in cfg_facts" % (len(keylist), len(dev_ports.keys())))
+    logger.info("Found %s ports to check on host:%s, asic: %s.", len(dev_ports.keys()), per_host.hostname,
+                asic.asic_index)
 
-            show_intf = asic.show_interface(command="status")['ansible_facts']
-            for portkey in keylist:
-                port_name = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_NAME")
-                port_state = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_OPER_STATUS")
-                port_type = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_TYPE")
-                logger.info("Checking port: %s, state: %s", port_name, port_state)
-                # "SAI_HOSTIF_ATTR_NAME": "Ethernet0",
-                # "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x1000000000002",
-                # "SAI_HOSTIF_ATTR_OPER_STATUS": "false",
-                # "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV"
-                pytest_assert(port_type == "SAI_HOSTIF_TYPE_NETDEV", "Port %s is not type netdev" % portkey)
-                if port_state == "true":
-                    pytest_assert(show_intf['int_status'][port_name]['oper_state'] == "up",
-                                  "Show interface state is down when it should be up")
-                if port_state == "false":
-                    pytest_assert(show_intf['int_status'][port_name]['oper_state'] == "down",
-                                  "Show interface state is up when it should be down")
+    show_intf = asic.show_interface(command="status", include_internal_intfs=True)['ansible_facts']
+    for portkey in keylist:
+        port_name = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_NAME")
+        port_state = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_OPER_STATUS")
+        port_type = asicdb.hget_key_value(portkey, "SAI_HOSTIF_ATTR_TYPE")
+        logger.info("Checking port: %s, state: %s", port_name, port_state)
+        # "SAI_HOSTIF_ATTR_NAME": "Ethernet0",
+        # "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x1000000000002",
+        # "SAI_HOSTIF_ATTR_OPER_STATUS": "false",
+        # "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV"
+        pytest_assert(port_type == "SAI_HOSTIF_TYPE_NETDEV", "Port %s is not type netdev" % portkey)
+        if port_state == "true":
+            pytest_assert(show_intf['int_status'][port_name]['oper_state'] == "up",
+                          "Show interface state is down when it should be up")
+        if port_state == "false":
+            pytest_assert(show_intf['int_status'][port_name]['oper_state'] == "down",
+                          "Show interface state is up when it should be down")
 
-                if asic.namespace is None:
-                    cmd = "sudo ifconfig %s" % port_name
-                else:
-                    cmd = "sudo ip netns exec %s ifconfig %s" % (asic.namespace, port_name)
-                ifout = per_host.command(cmd)
-                assert "not found" not in ifout['stdout_lines'][0], "Interface %s not found" % port_name
-                if port_state == "true" and "RUNNING" in ifout['stdout_lines'][0]:
-                    logger.debug("Interface state is up and matches")
-                elif port_state == "false" and "RUNNING" not in ifout['stdout_lines'][0]:
-                    logger.debug("Interface state is down and matches")
-                else:
-                    raise AssertionError("Interface state does not match: %s %s", port_state, ifout['stdout_lines'][0])
+        if asic.namespace is None:
+            cmd = "sudo ifconfig %s" % port_name
+        else:
+            cmd = "sudo ip netns exec %s ifconfig %s" % (asic.namespace, port_name)
+        ifout = per_host.command(cmd)
+        assert "not found" not in ifout['stdout_lines'][0], "Interface %s not found" % port_name
+        if port_state == "true" and "RUNNING" in ifout['stdout_lines'][0]:
+            logger.debug("Interface state is up and matches")
+        elif port_state == "false" and "RUNNING" not in ifout['stdout_lines'][0]:
+            logger.debug("Interface state is down and matches")
+        else:
+            raise AssertionError("Interface state does not match: %s %s", port_state, ifout['stdout_lines'][0])
 
 
-def test_voq_interface_create(duthosts):
+def test_voq_interface_create(duthosts, enum_frontend_dut_hostname, enum_asic_index, all_cfg_facts):
     """
     Verify router interfaces are created on all line cards and present in Chassis App Db.
 
@@ -217,99 +164,99 @@ def test_voq_interface_create(duthosts):
     * Repeat with IPv4, IPv6, dual-stack.
 
     """
-    for per_host in duthosts.frontend_nodes:
-        logger.info("Check router interfaces on node: %s", per_host.hostname)
+    per_host = duthosts[enum_frontend_dut_hostname]
+    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+    logger.info("Check router interfaces on node: %s, asic: %d", per_host.hostname, asic.asic_index)
 
-        for asic in per_host.asics:
-            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            dev_intfs = cfg_facts['INTERFACE']
-            voq_intfs = cfg_facts['VOQ_INBAND_INTERFACE']
-            dev_sysports = get_device_system_ports(cfg_facts)
+    dev_intfs = cfg_facts['INTERFACE']
+    dev_sysports = get_device_system_ports(cfg_facts)
 
-            slot = per_host.facts['slot_num']
-            rif_ports_in_asicdb = []
+    slot = per_host.facts['slot_num']
+    rif_ports_in_asicdb = []
 
-            # intf_list = get_router_interface_list(dev_intfs)
-            asicdb = AsicDbCli(asic)
+    # intf_list = get_router_interface_list(dev_intfs)
+    asicdb = AsicDbCli(asic)
 
-            asicdb_intf_key_list = asicdb.get_router_if_list()
-            # Check each rif in the asicdb, if it is local port, check VOQ DB for correct RIF.
-            # If it is on system port, verify slot/asic/port and OID match a RIF in VoQDB
-            for rif in asicdb_intf_key_list:
-                rif_type = asicdb.hget_key_value(rif, "SAI_ROUTER_INTERFACE_ATTR_TYPE")
-                if rif_type != "SAI_ROUTER_INTERFACE_TYPE_PORT":
-                    logger.info("Skip this rif: %s, it is not on a port: %s", rif, rif_type)
-                    continue
-                else:
-                    portid = asicdb.hget_key_value(rif, "SAI_ROUTER_INTERFACE_ATTR_PORT_ID")
-                    logger.info("Process RIF %s, Find port with ID: %s", rif, portid)
+    asicdb_intf_key_list = asicdb.get_router_if_list()
+    # Check each rif in the asicdb, if it is local port, check VOQ DB for correct RIF.
+    # If it is on system port, verify slot/asic/port and OID match a RIF in VoQDB
+    for rif in asicdb_intf_key_list:
+        rif_type = asicdb.hget_key_value(rif, "SAI_ROUTER_INTERFACE_ATTR_TYPE")
+        if rif_type != "SAI_ROUTER_INTERFACE_TYPE_PORT":
+            logger.info("Skip this rif: %s, it is not on a port: %s", rif, rif_type)
+            continue
+        else:
+            portid = asicdb.hget_key_value(rif, "SAI_ROUTER_INTERFACE_ATTR_PORT_ID")
+            logger.info("Process RIF %s, Find port with ID: %s", rif, portid)
 
-                porttype = asicdb.get_rif_porttype(portid)
-                logger.info("RIF: %s is of type: %s", rif, porttype)
-                if porttype == 'hostif':
-                    # find the hostif entry to get the physical port the router interface is on.
-                    hostifkey = asicdb.find_hostif_by_portid(portid)
-                    hostif = asicdb.hget_key_value(hostifkey, 'SAI_HOSTIF_ATTR_NAME')
-                    logger.info("RIF: %s is on local port: %s", rif, hostif)
-                    rif_ports_in_asicdb.append(hostif)
-                    if hostif not in dev_intfs and hostif not in voq_intfs:
-                        pytest.fail("Port: %s has a router interface, but it isn't in configdb." % portid)
+        porttype = asicdb.get_rif_porttype(portid)
+        logger.info("RIF: %s is of type: %s", rif, porttype)
+        if porttype == 'hostif':
+            # find the hostif entry to get the physical port the router interface is on.
+            hostifkey = asicdb.find_hostif_by_portid(portid)
+            hostif = asicdb.hget_key_value(hostifkey, 'SAI_HOSTIF_ATTR_NAME')
+            logger.info("RIF: %s is on local port: %s", rif, hostif)
+            rif_ports_in_asicdb.append(hostif)
+            if hostif not in dev_intfs:
+                pytest.fail("Port: %s has a router interface, but it isn't in configdb." % portid)
 
-                    # check MTU and ethernet address
-                    asicdb.get_and_check_key_value(rif, cfg_facts['PORT'][hostif]['mtu'],
-                                                   field="SAI_ROUTER_INTERFACE_ATTR_MTU")
-                    intf_mac = get_sonic_mac(per_host, asic.asic_index, hostif)
-                    asicdb.get_and_check_key_value(rif, intf_mac, field="SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS")
+            # check MTU and ethernet address
+            asicdb.get_and_check_key_value(rif, cfg_facts['PORT'][hostif]['mtu'],
+                                           field="SAI_ROUTER_INTERFACE_ATTR_MTU")
+            intf_mac = get_sonic_mac(per_host, asic.asic_index, hostif)
+            asicdb.get_and_check_key_value(rif, intf_mac, field="SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS")
 
-                    sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
-                    sysport_info = find_system_port(dev_sysports, slot, asic.asic_index, hostif)
-                    for sup in duthosts.supervisor_nodes:
-                        check_rif_on_sup(sup, sup_rif, sysport_info['slot'], sysport_info['asic'], hostif)
+            sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
+            sysport_info = find_system_port(dev_sysports, slot, asic.asic_index, hostif)
+            for sup in duthosts.supervisor_nodes:
+                check_rif_on_sup(sup, sup_rif, sysport_info['slot'], sysport_info['asic'], hostif)
 
-                elif porttype == 'sysport':
-                    try:
-                        port_output = asicdb.hget_key_value("ASIC_STATE:SAI_OBJECT_TYPE_SYSTEM_PORT:" + portid,
-                                                            field="SAI_SYSTEM_PORT_ATTR_CONFIG_INFO")
-                    except RedisKeyNotFound:
-                        # not a hostif or system port, log error and continue
-                        logger.error("Did not find OID %s in local or system tables" % portid)
-                        continue
-                    port_data = json.loads(port_output)
-                    for cfg_port in dev_sysports:
-                        if dev_sysports[cfg_port]['system_port_id'] == port_data['port_id']:
-                            logger.info("RIF: %s is on remote port: %s", rif, cfg_port)
-                            break
-                    else:
-                        raise AssertionError("Did not find OID %s in local or system tables" % portid)
+        elif porttype == 'sysport':
+            try:
+                port_output = asicdb.hget_key_value("ASIC_STATE:SAI_OBJECT_TYPE_SYSTEM_PORT:" + portid,
+                                                    field="SAI_SYSTEM_PORT_ATTR_CONFIG_INFO")
+            except RedisKeyNotFound:
+                # not a hostif or system port, log error and continue
+                logger.error("Did not find OID %s in local or system tables" % portid)
+                continue
+            port_data = json.loads(port_output)
+            for cfg_port in dev_sysports:
+                if dev_sysports[cfg_port]['system_port_id'] == port_data['port_id']:
+                    logger.info("RIF: %s is on remote port: %s", rif, cfg_port)
+                    break
+            else:
+                raise AssertionError("Did not find OID %s in local or system tables" % portid)
 
-                    sys_slot, sys_asic, sys_port = cfg_port.split("|")
-                    sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
-                    for sup in duthosts.supervisor_nodes:
-                        check_rif_on_sup(sup, sup_rif, sys_slot, sys_asic, sys_port)
+            sys_slot, sys_asic, sys_port = cfg_port.split("|")
+            sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
+            for sup in duthosts.supervisor_nodes:
+                check_rif_on_sup(sup, sup_rif, sys_slot, sys_asic, sys_port)
 
-                elif porttype == 'port':
-                    # this is the RIF on the inband port.
-                    inband = get_inband_info(cfg_facts)
-                    logger.info("RIF: %s is on local port: %s", rif, inband['port'])
+        elif porttype == 'port':
+            # this is the RIF on the inband port.
+            inband = get_inband_info(cfg_facts)
+            logger.info("RIF: %s is on local port: %s", rif, inband['port'])
 
-                    # check MTU and ethernet address
-                    asicdb.get_and_check_key_value(rif, cfg_facts['PORT'][inband['port']]['mtu'],
-                                                   field="SAI_ROUTER_INTERFACE_ATTR_MTU")
-                    intf_mac = get_sonic_mac(per_host, asic.asic_index, inband['port'])
-                    asicdb.get_and_check_key_value(rif, intf_mac, field="SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS")
+            # check MTU and ethernet address
+            asicdb.get_and_check_key_value(rif, cfg_facts['PORT'][inband['port']]['mtu'],
+                                           field="SAI_ROUTER_INTERFACE_ATTR_MTU")
+            intf_mac = get_sonic_mac(per_host, asic.asic_index, inband['port'])
+            asicdb.get_and_check_key_value(rif, intf_mac, field="SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS")
 
-                    sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
-                    sysport_info = find_system_port(dev_sysports, slot, asic.asic_index, inband['port'])
-                    for sup in duthosts.supervisor_nodes:
-                        check_rif_on_sup(sup, sup_rif, sysport_info['slot'], sysport_info['asic'], inband['port'])
+            sup_rif = asicdb.hget_key_value("VIDTORID", "oid:" + rif.split(":")[3])
+            sysport_info = find_system_port(dev_sysports, slot, asic.asic_index, inband['port'])
+            for sup in duthosts.supervisor_nodes:
+                check_rif_on_sup(sup, sup_rif, sysport_info['slot'], sysport_info['asic'], inband['port'])
 
-            # Verify each RIF in config had a corresponding local port RIF in the asicDB.
-            for rif in dev_intfs:
-                pytest_assert(rif in rif_ports_in_asicdb, "Interface %s is in configdb.json but not in asicdb" % rif)
-            logger.info("Interfaces %s are present in configdb.json and asicdb" % str(dev_intfs.keys()))
+    # Verify each RIF in config had a corresponding local port RIF in the asicDB.
+    for rif in dev_intfs:
+        pytest_assert(rif in rif_ports_in_asicdb, "Interface %s is in configdb.json but not in asicdb" % rif)
+    logger.info("Interfaces %s are present in configdb.json and asicdb" % str(dev_intfs.keys()))
 
 
-def test_voq_neighbor_create(duthosts, nbrhosts, nbr_macs):
+def test_voq_neighbor_create(duthosts, enum_frontend_dut_hostname, enum_asic_index, nbrhosts,
+                             all_cfg_facts):
     """
     Verify neighbor entries are created on linecards for local and remote VMS.
 
@@ -342,66 +289,19 @@ def test_voq_neighbor_create(duthosts, nbrhosts, nbr_macs):
     * Repeat with IPv4, IPv6, dual-stack.
 
     """
+    per_host = duthosts[enum_frontend_dut_hostname]
+    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
-    for per_host in duthosts.frontend_nodes:
+    logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
+    neighs = cfg_facts['BGP_NEIGHBOR']
 
-        for asic in per_host.asics:
-            logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
-            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            dev_sysports = get_device_system_ports(cfg_facts)
-            neighs = cfg_facts['BGP_NEIGHBOR']
-            inband_info = get_inband_info(cfg_facts)
-
-            # Check each neighbor in table
-            for neighbor in neighs:
-                local_ip = neighs[neighbor]['local_addr']
-                if local_ip == inband_info['ipv4_addr'] or local_ip == inband_info['ipv6_addr']:
-                    # skip inband neighbors
-                    continue
-
-                # Check neighbor on local linecard
-                local_port = get_port_by_ip(cfg_facts, local_ip)
-                show_intf = asic.show_interface(command="status")['ansible_facts']
-                if local_port is None:
-                    logger.error("Did not find port for this neighbor %s, must skip", local_ip)
-                    continue
-                elif "portchannel" in local_port.lower():
-                    # TODO: LAG support
-                    logger.info("Port channel is not supported yet by this test, skip port: %s", local_port)
-                    continue
-                if show_intf['int_status'][local_port]['oper_state'] == "down":
-                    logger.error("Port is down, must skip interface: %s, IP: %s", local_port, local_ip)
-                    continue
-                nbr_vm = get_vm_with_ip(neighbor, nbrhosts)
-                neigh_mac = nbr_macs[nbr_vm['vm']][nbr_vm['port']]
-                #neigh_mac = get_neighbor_mac(neighbor, nbrhosts, nbrhosts_facts)
-                if neigh_mac is None:
-                    logger.error("Could not find neighbor MAC, must skip.  IP: %s, port: %s", local_ip, local_port)
-
-                local_dict = check_local_neighbor(per_host, asic, neighbor, neigh_mac, local_port)
-                logger.info("Local_dict: %s", local_dict)
-
-                # Check the same neighbor entry on the supervisor nodes
-                sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
-                for sup in duthosts.supervisor_nodes:
-                    check_voq_neighbor_on_sup(sup, sysport_info['slot'], sysport_info['asic'], local_port,
-                                              neighbor, local_dict['encap_index'], neigh_mac)
-
-                # Check the neighbor entry on each remote linecard
-                for rem_host in duthosts.frontend_nodes:
-
-                    for rem_asic in rem_host.asics:
-                        if rem_host == per_host and rem_asic == asic:
-                            # skip remote check on local host
-                            continue
-                        rem_cfg_facts = rem_asic.config_facts(source="persistent")['ansible_facts']
-                        remote_inband_info = get_inband_info(rem_cfg_facts)
-                        remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
-                        check_voq_remote_neighbor(rem_host, rem_asic, neighbor, neigh_mac, remote_inband_info['port'],
-                                                  local_dict['encap_index'], remote_inband_mac)
+    # Check each neighbor in table
+    for neighbor in neighs:
+        check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
 
 
-def test_voq_inband_port_create(duthosts):
+def test_voq_inband_port_create(duthosts, enum_frontend_dut_hostname, enum_asic_index, all_cfg_facts):
     """
     Test inband port creation.
 
@@ -417,51 +317,51 @@ def test_voq_inband_port_create(duthosts):
 
 
     """
-    for per_host in duthosts.frontend_nodes:
-        if per_host.get_facts()['asic_type'] == 'vs':
-            pytest.skip("Inband port currently not supported on a VS chassis")
+    per_host = duthosts[enum_frontend_dut_hostname]
+    if per_host.get_facts()['asic_type'] == 'vs':
+        pytest.skip("Inband port currently not supported on a VS chassis")
+    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+    dev_sysports = get_device_system_ports(cfg_facts)
+    inband_info = get_inband_info(cfg_facts)
+    inband_mac = get_sonic_mac(per_host, asic.asic_index, inband_info['port'])
 
-        for asic in per_host.asics:
-            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            dev_sysports = get_device_system_ports(cfg_facts)
-            inband_info = get_inband_info(cfg_facts)
-            inband_mac = get_sonic_mac(per_host, asic.asic_index, inband_info['port'])
+    inband_ips = []
+    if 'ipv6_addr' in inband_info:
+        inband_ips.append(inband_info['ipv6_addr'])
+    if 'ipv4_addr' in inband_info:
+        inband_ips.append(inband_info['ipv4_addr'])
 
-            inband_ips = []
-            if 'ipv6_addr' in inband_info:
-                inband_ips.append(inband_info['ipv6_addr'])
-            if 'ipv4_addr' in inband_info:
-                inband_ips.append(inband_info['ipv4_addr'])
+    for neighbor_ip in inband_ips:
 
-            for neighbor_ip in inband_ips:
+        host = per_host
+        neighbor_mac = inband_mac
+        interface = inband_info['port']
 
-                host = per_host
-                neighbor_mac = inband_mac
-                interface = inband_info['port']
+        logger.info("Check local neighbor on host %s, asic %s for %s/%s via port: %s", host.hostname,
+                    str(asic.asic_index),
+                    neighbor_ip, neighbor_mac, interface)
 
-                logger.info("Check local neighbor on host %s, asic %s for %s/%s via port: %s", host.hostname,
-                            str(asic.asic_index),
-                            neighbor_ip, neighbor_mac, interface)
+        asic_dict = check_local_neighbor_asicdb(asic, neighbor_ip, neighbor_mac)
+        encap_idx = asic_dict['encap_index']
 
-                asic_dict = check_local_neighbor_asicdb(asic, neighbor_ip, neighbor_mac)
-                encap_idx = asic_dict['encap_index']
+        # Check the inband neighbor entry on the supervisor nodes
+        sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, interface)
+        for sup in duthosts.supervisor_nodes:
+            check_voq_neighbor_on_sup(sup, sysport_info['slot'], sysport_info['asic'], interface, neighbor_ip,
+                                      encap_idx, inband_mac)
 
-                # Check the inband neighbor entry on the supervisor nodes
-                sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, interface)
-                for sup in duthosts.supervisor_nodes:
-                    check_voq_neighbor_on_sup(sup, sysport_info['slot'], sysport_info['asic'], interface, neighbor_ip,
-                                              encap_idx, inband_mac)
+        # Check the neighbor entry on each remote linecard
+        for rem_host in duthosts.frontend_nodes:
 
-                # Check the neighbor entry on each remote linecard
-                for rem_host in duthosts.frontend_nodes:
+            for rem_asic in rem_host.asics:
+                if rem_host == per_host and rem_asic == asic:
+                    # skip remote check on local host
+                    continue
+                rem_cfg_facts = all_cfg_facts[rem_host.hostname][rem_asic.asic_index]['ansible_facts']
+                remote_inband_info = get_inband_info(rem_cfg_facts)
+                remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
+                check_voq_remote_neighbor(rem_host, rem_asic, neighbor_ip, inband_mac,
+                                          remote_inband_info['port'],
+                                          encap_idx, remote_inband_mac)
 
-                    for rem_asic in rem_host.asics:
-                        if rem_host == per_host and rem_asic == asic:
-                            # skip remote check on local host
-                            continue
-                        rem_cfg_facts = rem_asic.config_facts(source="persistent")['ansible_facts']
-                        remote_inband_info = get_inband_info(rem_cfg_facts)
-                        remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
-                        check_voq_remote_neighbor(rem_host, rem_asic, neighbor_ip, inband_mac,
-                                                  remote_inband_info['port'],
-                                                  encap_idx, remote_inband_mac)

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -376,4 +376,3 @@ def test_voq_inband_port_create(duthosts, enum_frontend_dut_hostname, enum_asic_
                 check_voq_remote_neighbor(rem_host, rem_asic, neighbor_ip, inband_mac,
                                           remote_inband_info['port'],
                                           encap_idx, remote_inband_mac)
-

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -1,0 +1,1292 @@
+import logging
+import pytest
+import random
+import ipaddress
+import json
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.errors import RunAnsibleModuleFail
+
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+
+from tests.common.utilities import wait_until
+from tests.common.helpers.parallel import parallel_run
+from tests.common.platform.device_utils import fanout_switch_port_lookup
+
+from ptf.testutils import simple_udp_packet, simple_icmp_packet, simple_udpv6_packet, simple_icmpv6_packet
+from ptf.testutils import send, dp_poll, verify_no_packet_any
+from ptf.mask import Mask
+import ptf.packet as scapy
+
+from test_voq_nbr import LinkFlap
+
+from voq_helpers import sonic_ping
+from voq_helpers import eos_ping
+from voq_helpers import get_inband_info
+from voq_helpers import get_vm_with_ip
+from voq_helpers import asic_cmd
+from voq_helpers import get_port_by_ip
+from voq_helpers import get_sonic_mac
+from voq_helpers import get_eos_mac
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2'),
+    pytest.mark.sanity_check(check_items=["-monit"], allow_recover=False),
+    pytest.mark.disable_loganalyzer
+]
+
+LOG_PING = True
+DEFAULT_EOS_TTL = 64
+DEFAULT_SONIC_TTL = 64
+
+
+# Analyze logs at the beginning and end of all tests in the module, instead of each test.
+@pytest.fixture(scope="module", autouse=True)
+def loganalyzer(duthosts, request):
+    analyzers = {}
+    markers = {}
+    # Analyze all the duts
+    for duthost in duthosts:
+        # Force rotate logs
+        try:
+            duthost.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+        except RunAnsibleModuleFail as e:
+            logging.warning("logrotate is failed. Command returned:\n"
+                            "Stdout: {}\n"
+                            "Stderr: {}\n"
+                            "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
+
+        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
+        logging.info("Add start marker into DUT syslog")
+        marker = loganalyzer.init()
+        logging.info("Load config and analyze log")
+        # Read existed common regular expressions located with legacy loganalyzer module
+        loganalyzer.load_common_config()
+        analyzers[duthost.hostname] = loganalyzer
+        markers[duthost.hostname] = marker
+
+    yield analyzers
+
+    for dut_hostname, dut_analyzer in analyzers.items():
+        dut_analyzer.analyze(markers[dut_hostname])
+
+
+def _get_nbr_macs(nbrhosts, node=None, results=None):
+    vm = nbrhosts[node]
+    node_results = {}
+
+    for intf in vm['conf']['interfaces'].keys():
+        logger.info("Get MAC on vm %s for intf: %s", node, intf)
+        mac = get_eos_mac(vm, intf)
+        logger.info("Found MAC on vm %s for intf: %s, mac: %s", node, intf, mac['mac'])
+        node_results[intf] = mac['mac']
+
+    results[node] = node_results
+
+
+@pytest.fixture(scope="module")
+def nbr_macs(nbrhosts):
+    """
+    Fixture to get all the neighbor mac addresses in parallel.
+
+    Args:
+        nbrhosts:
+
+    Returns:
+
+    """
+    results = {}
+
+    parallel_run(_get_nbr_macs, [nbrhosts], results, nbrhosts.keys(), timeout=120)
+
+    for res in results['results']:
+        logger.info("parallel_results %s = %s", res, results['results'][res])
+
+    return results['results']
+
+
+def log_port_info(ports):
+    """
+    Dumps the picked ports to the log file.
+
+    Args:
+        ports: Output of pick_ports.
+
+    """
+    port_dict_to_print = {}
+    for a_port_name, a_port in ports.items():
+        port_dict_to_print[a_port_name] = {}
+        for a_fld_name in a_port:
+            if a_fld_name == 'dut':
+                port_dict_to_print[a_port_name]['dut'] = a_port['dut'].hostname
+            elif a_fld_name == 'asic':
+                port_dict_to_print[a_port_name]['asic'] = a_port['asic'].asic_index
+            elif isinstance(a_port[a_fld_name], ipaddress.IPv4Address) or isinstance(a_port[a_fld_name],
+                                                                                     ipaddress.IPv6Address):
+                port_dict_to_print[a_port_name][a_fld_name] = "%s" % a_port[a_fld_name]
+            else:
+                port_dict_to_print[a_port_name][a_fld_name] = a_port[a_fld_name]
+
+    logger.info("Ports picked are:\n%s" % json.dumps(port_dict_to_print, indent=4))
+
+
+def get_info_for_a_port(cfg_facts, iface_list, version, dut, asic_index, nbrhosts):
+    """
+    Picks a port from the interface list and gets all the required data for a port to test
+    with, IP, portnames, attached VMs, etc.
+
+    Args:
+        cfg_facts: config facts fot the asic.
+        iface_list: Interface list for the ASIC.
+        version: 4 or 6 for IP version.
+        dut: Duthost instance the port is on.
+        asic_index: Asic index the port is on (0, 1, etc).
+        nbrhosts: nbrhosts fixture.
+
+    Returns:
+
+    """
+    rtn_dict = {}
+    port = random.choice(iface_list)
+    rtn_dict['port'] = port
+    rtn_dict['my_ip'] = get_ip_address(cfg_facts, port, version)
+    rtn_dict['dut'] = dut
+    rtn_dict['asic'] = dut.asics[asic_index]
+
+    # Get nbr VM info from the configured facts
+    nbr_in_cfg = cfg_facts['BGP_NEIGHBOR']
+    nbr_ip = [n for n in nbr_in_cfg if ipaddress.ip_address(nbr_in_cfg[n]['local_addr']) == rtn_dict['my_ip']][0]
+    nbr_dict = get_vm_with_ip(nbr_ip, nbrhosts)
+    rtn_dict['nbr_ip'] = nbr_ip
+    rtn_dict['nbr_vm'] = nbr_dict['vm']
+    rtn_dict['nbr_port'] = nbr_dict['port']
+    rtn_dict['nbr_lb'] = ipaddress.ip_interface(
+        unicode(nbrhosts[nbr_dict['vm']]['conf']['interfaces']['Loopback0']['ipv%s' % version])).ip
+
+    # Get my lbk addresses
+    lbs = cfg_facts['LOOPBACK_INTERFACE']['Loopback0'].keys()
+    for lb in lbs:
+        lbintf = ipaddress.ip_interface(lb)
+        if lbintf.ip.version == version:
+            rtn_dict['my_lb_ip'] = lbintf.ip
+
+    # Get the inband interface ip
+    inband_ips = get_inband_info(cfg_facts)
+    rtn_dict['inband'] = inband_ips['ipv%s_addr' % version]
+
+    return rtn_dict
+
+
+def pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a="ethernet", version=4):
+    """
+    Selects ports to test by sampling the interface and port channel lists.
+
+    Args:
+        duthosts: The duthosts fixture.
+        all_cfg_facts: The config_facts for all the duts.
+        nbrhosts: The nbrhosts fixture.
+        port_type_a: ethernet or portchannel, the port type for the main test port.
+        version: 4 or 6, the IP version to test.
+
+    Returns:
+        intfs_to_test: A merged dictionary of ethernet and portchannel interfaces to test
+            portA - interface of type port_type_A on first frontend node in an asic.
+            portB - interface on first frontend node in the same asic as portA - preferably of type different than
+                    port_type_A.
+            portC - interface on any asic other than portA asic in the chassis of type port_type_A - preferably on
+                    another frontend node.
+            portD - interface on any asic other than portA asic in the chassis of type different than port_type_A -
+                    preferably on another frontend node.
+
+        if we can't find portA we will skip the test.
+        if we can't find any portB, portC, or portD, then their respective dictionary will be None, and the ping tests
+             to that port would be ignored.
+        intfs_to_test: A list of the chosen interfaces names.
+
+    """
+    intfs_to_test = {}
+    # Lets find portA and portB in the first frontend node
+    dutA = duthosts.frontend_nodes[0]
+
+    for a_asic_index, a_asic_cfg in enumerate(all_cfg_facts[dutA.hostname]):
+        cfg_facts = a_asic_cfg['ansible_facts']
+        cfgd_intfs = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
+        cfgd_pos = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
+        eths = [intf for intf in cfgd_intfs if "ethernet" in intf.lower()]
+        pos = [intf for intf in cfgd_pos if "portchannel" in intf.lower()]
+        if port_type_a == "ethernet":
+            if len(eths) != 0:
+                intfs_to_test['portA'] = get_info_for_a_port(cfg_facts, eths, version, dutA, a_asic_index, nbrhosts)
+                # We have one ethernet interface, lets check for a pos interface for portB
+                if len(pos) != 0:
+                    intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, pos, version, dutA, a_asic_index, nbrhosts)
+                else:
+                    # No pos interfaces, let see if we have other ethernet ports in this asic
+                    if len(eths) != 1:
+                        # We have more than 1 eth interface, pick it for port B
+                        intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, eths, version, dutA, a_asic_index,
+                                                                     nbrhosts)
+        else:
+            # port type is portchannel
+            if len(pos) != 0:
+                intfs_to_test['portA'] = get_info_for_a_port(cfg_facts, pos, version, dutA, a_asic_index, nbrhosts)
+                # We have one pc interface, lets check for a eth interface for portB
+                if len(eths) != 0:
+                    intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, eths, version, dutA, a_asic_index, nbrhosts)
+                else:
+                    # No eth interfaces, let see if we have other pc ports in this asic
+                    if len(pos) != 1:
+                        # We have more than 1 pc interface, pick it for port B
+                        intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, pos, version, dutA, a_asic_index,
+                                                                     nbrhosts)
+
+        if 'portA' in intfs_to_test:
+            break
+
+    if len(duthosts.frontend_nodes) == 1:
+        # We are dealing with a single card, lets find the portC and portD in other asic on the same card
+        other_duts = [dutA]
+    else:
+        other_duts = duthosts.frontend_nodes[1:]
+
+    # Lets try to find portC and portD on other asics/linecards.
+    for a_dut in other_duts:
+        for a_asic_index, a_asic_cfg in enumerate(all_cfg_facts[a_dut.hostname]):
+            if a_dut == dutA and a_asic_index == intfs_to_test['portA']['asic']:
+                # Ignore the asic we used for portA
+                continue
+            cfg_facts = a_asic_cfg['ansible_facts']
+            cfgd_intfs = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
+            cfgd_pos = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
+            eths = [intf for intf in cfgd_intfs if "ethernet" in intf.lower()]
+            pos = [intf for intf in cfgd_pos if "portchannel" in intf.lower()]
+            if len(eths) != 0:
+                if port_type_a == "ethernet":
+                    intfs_to_test['portC'] = get_info_for_a_port(cfg_facts, eths, version, a_dut, a_asic_index,
+                                                                 nbrhosts)
+                else:
+                    intfs_to_test['portD'] = get_info_for_a_port(cfg_facts, eths, version, a_dut, a_asic_index,
+                                                                 nbrhosts)
+
+            if len(pos) != 0:
+                if port_type_a == "ethernet":
+                    intfs_to_test['portD'] = get_info_for_a_port(cfg_facts, pos, version, a_dut, a_asic_index, nbrhosts)
+                else:
+                    intfs_to_test['portC'] = get_info_for_a_port(cfg_facts, pos, version, a_dut, a_asic_index, nbrhosts)
+
+            if 'portC' in intfs_to_test and 'portD' in intfs_to_test:
+                # We have found both portC and portD - no need to check other asics
+                break
+
+        if 'portC' in intfs_to_test and 'portD' in intfs_to_test:
+            # We have found both portC and portD - no need to check other DUTs
+            break
+    log_port_info(intfs_to_test)
+    return intfs_to_test
+
+
+def get_ip_address(cfg_facts, port, ipver):
+    """
+    Gets the IP address of a port.
+
+    Args:
+        cfg_facts: Config facts for an asic.
+        port: Port name.
+        ipver: IP version, 4 or 6.
+
+    Returns:
+        an ipaddress.IPAddress() for the port.
+
+    """
+
+    intfs = {}
+    intfs.update(cfg_facts['INTERFACE'])
+    if "PORTCHANNEL_INTERFACE" in cfg_facts:
+        intfs.update(cfg_facts['PORTCHANNEL_INTERFACE'])
+
+    addresses = intfs[port]
+    for address in addresses:
+        intf = ipaddress.ip_interface(address)
+        if intf.ip.version == ipver:
+            return intf.ip
+
+
+def check_packet(function, ports, dst_port, src_port, dev=None, dst_ip_fld='my_ip', ttl=64, size=64, src_ip_fld='my_ip',
+                 ttl_change=1):
+    """
+    Calls a ping function and verifies the output and whether TTL was decremented on the RX packet.
+
+    Args:
+        function: Traffic function to call, sonic_ping or eos_ping.
+        ports: pick_ports output.
+        dst_port: entry in pick_ports of destination port ("portD")
+        src_port: entry in pick_ports of source port ("portA")
+        dev: Device to run function on, and EosHost or SonicAsic.
+        dst_ip_fld: Entry in pick_ports dictionary to use as IP destination.
+        ttl: Initial TTL.
+        size: Initial packet ICMP data size.
+        src_ip_fld: Entry in pick_ports dictionary to use as IP source.
+        ttl_change: Expected TTL change.
+
+    Raises:
+        pytest.Failed if the checks failed.
+
+    """
+    if dst_port in ports and src_port in ports:
+        if not dev:
+            dev = ports[src_port]['asic']
+        src_ip = ports[src_port][src_ip_fld]
+        dst_ip = ports[dst_port][dst_ip_fld]
+
+        if ttl > ttl_change:
+            out = function(dev, dst_ip, count=1, size=size, ttl=ttl, interface=src_ip, verbose=LOG_PING)
+            for response in out['parsed']:
+                logger.info("response: %s", response)
+                pytest_assert(response['ttl'] == str(DEFAULT_EOS_TTL - ttl_change),
+                              "TTL did not change by: %d, %s => %s, %s != %s" % (
+                                  ttl_change, src_ip, dst_ip, response['ttl'], str(DEFAULT_EOS_TTL - ttl_change)))
+        else:
+            logger.info("Testing a TTL 0 scenario, packet should be lost: %d, %s => %s" % (ttl_change, src_ip, dst_ip))
+            with pytest.raises((AssertionError, RunAnsibleModuleFail)) as exc:
+                function(dev, dst_ip, count=1, size=size, ttl=ttl, interface=src_ip, verbose=LOG_PING)
+
+            logger.info("Raised exception: %s, value: %s", str(exc), str(exc.value))
+            if isinstance(exc.type, AssertionError):
+                logging.info("exc.value = %s ... entry0 %s", exc.value, exc.value[0][0])
+                pytest_assert(exc.value[0][0]['ttl_exceed'] is True, "Packet with ttl 1 should not have arrived")
+
+
+class TestTableValidation(object):
+    """
+    Verify the kernel route table is correct based on the topology.
+
+    Test Steps
+
+    * Verify routes for local addresses on both line cards are directly connected.
+    * Verify routes for local inband interfaces are directly connected.
+    * Verify BGP established between line cards.
+    * Verify routes of remote linecard inband interfaces are connected via local linecard inband interface.
+    * Verify IP interface addresses on remote network ports have a next hop of their inband IP. On linecard 1,
+      route 10.0.0.64/31 next hop is 133.133.133.5.
+    * Verify all learned prefixes from neighbors have their neighbors as next hop.
+    * Repeat for IPv4 only, IPv6 only, dual-stack.
+    """
+
+    def test_host_route_table_local_addr(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                         all_cfg_facts):
+        """
+        Verify routes for local addresses on both line cards are directly connected.
+
+        Args:
+            duthosts: duthosts fixture
+            enum_rand_one_per_hwsku_frontend_hostname: linecard enum fixture.
+            enum_asic_index: asic enum fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+
+        """
+
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        ipv4_routes = asic_cmd(asic, "ip -4 route")["stdout_lines"]
+        ipv6_routes = asic_cmd(asic, "ip -6 route")["stdout_lines"]
+
+        intfs = {}
+        intfs.update(cfg_facts['INTERFACE'])
+        if "PORTCHANNEL_INTERFACE" in cfg_facts:
+            intfs.update(cfg_facts['PORTCHANNEL_INTERFACE'])
+
+        for port in intfs:
+            for address in intfs[port]:
+                ip_intf = ipaddress.ip_interface(address)
+                logger.info("Network %s v%s, is connected via: %s", str(ip_intf.network), ip_intf.network.version, port)
+                if ip_intf.network.version == 6:
+                    routes = ipv6_routes
+                else:
+                    routes = ipv4_routes
+
+                for route in routes:
+                    if route.startswith("{} dev {} proto kernel".format(str(ip_intf.network), port)):
+                        logger.info("Matched route for %s", str(ip_intf.network))
+                        break
+                else:
+                    pytest.fail("Did not find route for: %s" % str(ip_intf.network))
+
+    def test_host_route_table_inband_addr(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                          all_cfg_facts):
+        """
+        Verify routes for local inband interfaces are directly connected. Verify routes of remote linecard inband
+        interfaces are connected via local linecard inband interface.
+
+        Args:
+            duthosts: duthosts fixture
+            enum_rand_one_per_hwsku_frontend_hostname: linecard enum fixture.
+            enum_asic_index: asic enum fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+
+
+        """
+
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        ipv4_routes = asic_cmd(asic, "ip -4 route")["stdout_lines"]
+        ipv6_routes = asic_cmd(asic, "ip -6 route")["stdout_lines"]
+
+        intf = cfg_facts['VOQ_INBAND_INTERFACE']
+        for port in intf:
+            for address in cfg_facts['BGP_INTERNAL_NEIGHBOR'].keys():
+                ip_intf = ipaddress.ip_interface(address)
+                logger.info("Network %s v%s, is connected via: %s", str(ip_intf.network), ip_intf.network.version, port)
+                if ip_intf.network.version == 6:
+                    routes = ipv6_routes
+                else:
+                    routes = ipv4_routes
+
+                for route in routes:
+                    if route.startswith("{} dev {}".format(str(ip_intf.ip), port)):
+                        logger.info("Matched route for %s", str(ip_intf.ip))
+                        break
+                else:
+                    pytest.fail("Did not find route for: %s" % str(ip_intf.ip))
+
+    def test_host_route_table_bgp(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                  all_cfg_facts):
+        """
+        Verify BGP established between line cards.
+
+        Args:
+            duthosts: duthosts fixture
+            enum_rand_one_per_hwsku_frontend_hostname: linecard enum fixture.
+            enum_asic_index: asic enum fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+
+
+        """
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        bgp_facts = per_host.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
+
+        for address in cfg_facts['BGP_INTERNAL_NEIGHBOR'].keys():
+            pytest_assert(bgp_facts['bgp_neighbors'][address]['state'] == "established",
+                          "BGP internal neighbor: %s is not established: %s" % (
+                              address, bgp_facts['bgp_neighbors'][address]['state']))
+
+    def test_host_route_table_remote_interface_addr(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                                    enum_asic_index, all_cfg_facts):
+        """
+        Verify IP interface addresses on remote network ports have a next hop of their inband IP.
+        On linecard 1, route 10.0.0.64/31 next hop is 133.133.133.5.
+
+        Args:
+            duthosts: duthosts fixture
+            enum_rand_one_per_hwsku_frontend_hostname: linecard enum fixture.
+            enum_asic_index: asic enum fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+
+
+        """
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        ipv4_routes = asic_cmd(asic, "ip -4 route")["stdout_lines"]
+        ipv6_routes = asic_cmd(asic, "ip -6 route")["stdout_lines"]
+
+        inband = get_inband_info(cfg_facts)
+        for rem_host in duthosts.frontend_nodes:
+            for rem_asic in rem_host.asics:
+                if rem_host == per_host and rem_asic == asic:
+                    # skip remote check on local host
+                    continue
+
+                rem_cfg_facts = all_cfg_facts[rem_host.hostname][rem_asic.asic_index]['ansible_facts']
+                rem_inband_info = get_inband_info(rem_cfg_facts)
+                rem_intfs = {}
+                rem_intfs.update(rem_cfg_facts['INTERFACE'])
+                if "PORTCHANNEL_INTERFACE" in rem_cfg_facts:
+                    rem_intfs.update(rem_cfg_facts['PORTCHANNEL_INTERFACE'])
+
+                for port in rem_intfs:
+                    for address in rem_intfs[port]:
+
+                        ip_intf = ipaddress.ip_interface(address)
+                        logger.info("Network %s v%s, is connected via: %s, on host: %s", str(ip_intf.network),
+                                    ip_intf.network.version, inband['port'], per_host.hostname)
+                        if ip_intf.network.version == 6:
+                            routes = ipv6_routes
+                            inband_ip = rem_inband_info['ipv6_addr']
+                        else:
+                            routes = ipv4_routes
+                            inband_ip = rem_inband_info['ipv4_addr']
+
+                        for route in routes:
+                            if route.startswith(
+                                    "{} via {} dev {}".format(str(ip_intf.network), inband_ip, inband['port'])):
+                                logger.info("Matched route for %s", str(ip_intf.network))
+                                break
+                        else:
+                            pytest.fail("Did not find route for: %s" % str(ip_intf.network))
+
+    def test_host_route_table_nbr_lb_addr(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                          all_cfg_facts, nbrhosts):
+        """
+        Verify all learned prefixes from neighbors have their neighbors as next hop.
+
+        Args:
+            duthosts: duthosts fixture
+            enum_rand_one_per_hwsku_frontend_hostname: linecard enum fixture.
+            enum_asic_index: asic enum fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+            nbrhosts: nbrhosts fixture.
+
+        """
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        ipv4_routes = asic_cmd(asic, "ip -4 route")["stdout_lines"]
+        ipv6_routes = asic_cmd(asic, "ip -6 route")["stdout_lines"]
+
+        # get attached neighbors
+        neighs = cfg_facts['BGP_NEIGHBOR']
+        for neighbor in neighs:
+            local_ip = neighs[neighbor]['local_addr']
+
+            local_port = get_port_by_ip(cfg_facts, local_ip)
+            nbr = get_vm_with_ip(neighbor, nbrhosts)
+            nbr_vm = nbr['vm']
+
+            neigh_ip = ipaddress.ip_address(neighbor)
+            lbip = ipaddress.ip_interface(
+                unicode(nbrhosts[nbr_vm]['conf']['interfaces']['Loopback0']['ipv%s' % neigh_ip.version]))
+            logger.info("Verify loopback0 ip: %s is connected via ip: %s port: %s", str(lbip), str(neigh_ip),
+                        local_port)
+
+            if lbip.ip.version == 6:
+                routes = ipv6_routes
+            else:
+                routes = ipv4_routes
+
+            for route in routes:
+                if route.startswith("{} via {} dev {} proto bgp".format(str(lbip.ip), str(neigh_ip), local_port)):
+                    logger.info("Matched route for %s", str(lbip.ip))
+                    break
+            else:
+                pytest.fail("Did not find route for: %s" % str(lbip.ip))
+
+
+class TestVoqIPFwd(object):
+
+    @pytest.mark.parametrize('ttl, size', [(2, 1500), (255, 1500), (128, 64), (128, 9000)])
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["portchannel", "ethernet"])
+    def test_voq_local_interface_ping(self, duthosts, nbrhosts, all_cfg_facts, ttl, size, version, porttype):
+        """
+        Verify Host IP forwarding for IPv4 and IPv6 for various packet sizes and ttls to local line card interfaces.
+
+        Test Steps
+
+        * On linecard 1, send ping from:
+            * DUT IP interface A to DUT IP Interface B. (10.0.0.0 to 10.0.0.2)
+            * DUT IP interface A to DUT IP Interface D. (10.0.0.0 to 10.0.0.64)
+        * On linecard 2, send ping from:
+            * DUT IP interface D to DUT IP Interface A.
+        * Repeat for TTL 0,1,2,255
+        * Repeat for 64, 1500, 9100B packets
+        * Repeat for IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            nbrhosts: The nbrhosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            ttl: TTL of transmitted packet.
+            size: ICMP data size
+            version: IP version.
+            porttype: Test port type, ethernet or portchannel
+
+        """
+        logger.info(
+            "Pinging local interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl, size=size))
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+
+        check_packet(sonic_ping, ports, 'portB', 'portA', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portC', 'portA', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', size=size, ttl=ttl, ttl_change=1)
+
+        if 'portC' in ports:
+            check_packet(sonic_ping, ports, 'portA', 'portC', size=size, ttl=ttl, ttl_change=1)
+        else:
+            check_packet(sonic_ping, ports, 'portA', 'portD', size=size, ttl=ttl, ttl_change=1)
+
+    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (255, 1456), (1, 1456)])
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_voq_local_neighbor_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts):
+        """
+        Verify Host IP forwarding for IPv4 and IPv6 for various packet sizes and ttls to neighbor addresses.
+
+        Test Steps
+
+        * On linecard 1, send ping from:
+            * DUT IP Interface on port A to directly connected neighbor address. (10.0.0.0 to 10.0.0.1)
+            * DUT IP Interface A to neighbor address on port B. (10.0.0.0 to 10.0.0.3)
+            * DUT IP Interface A to neighbor address on port D. (10.0.0.0 to 10.0.0.65)
+        * On linecard 2, send ping from:
+            * DUT IP interface D to neighbor address on port A. (10.0.0.64 to 10.0.0.1)
+        * On Router 01T3, send ping from:
+            * Router IP interface to DUT address on port A. (10.0.0.1 to 10.0.0.0)
+            * Router IP interface to DUT address on port D. (10.0.0.1 to 10.0.0.64)
+        * Repeat for TTL 0,1,2,255
+        * Repeat for 64, 1500, 9100B packets
+        * Repeat for IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            nbrhosts: The nbrhosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            ttl: TTL of transmitted packet.
+            size: ICMP data size
+            version: IP version.
+            porttype: Test port type, ethernet or portchannel
+
+        """
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+        logger.info(
+            "Pinging local interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl, size=size))
+        check_packet(sonic_ping, ports, 'portA', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portB', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portC', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=1)
+
+        vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+
+        if 'portC' in ports:
+            check_packet(sonic_ping, ports, 'portA', 'portC', dev=ports['portC']['asic'], dst_ip_fld='nbr_ip',
+                         size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portC', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_ip',
+                         dev=vm_host_to_A, size=size, ttl=ttl)
+        else:
+            check_packet(sonic_ping, ports, 'portA', 'portD', dev=ports['portD']['asic'], dst_ip_fld='nbr_ip',
+                         size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_ip',
+                         dev=vm_host_to_A, size=size, ttl=ttl)
+
+        check_packet(eos_ping, ports, 'portA', 'portA', src_ip_fld='nbr_ip', dst_ip_fld='my_ip',
+                     dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
+
+    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (255, 1456), (1, 1456)])
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_voq_neighbor_lb_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts):
+        """
+        Verify Host IP forwarding for IPv4 and IPv6 for various packet sizes and ttls to learned route addresses.
+
+        Test Steps
+
+        * On linecard 1, send ping from:
+            * DUT IP Interface A to routed loopback address from router 01T3. (10.0.0.0 to 100.1.0.1)
+            * DUT IP Interface A to routed loopback address from router 02T3. (10.0.0.0 to 100.1.0.2)
+            * DUT IP Interface A to routed loopback address from router 01T1. (10.0.0.0 to 100.1.0.33)
+        * On linecard 2, send ping from:
+            * DUT IP interface D to routed loopback address from router 01T3. (200.0.0.1 to 100.1.0.1)
+        * On Router 01T3, send ping from:
+            * Router loopback interface to DUT address on port A. (100.1.0.1 to 10.0.0.0)
+            * Router loopback interface to DUT address on port D. (100.1.0.1 to 10.0.0.64)
+        * Repeat for TTL 0,1,2,255
+        * Repeat for 64, 1500, 9100B packets
+        * Repeat for IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            nbrhosts: The nbrhosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            ttl: TTL of transmitted packet.
+            size: ICMP data size
+            version: IP version.
+            porttype: Test port type, ethernet or portchannel
+
+        """
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+        logger.info("Pinging neighbor interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl,
+                                                                                                 size=size))
+
+        check_packet(sonic_ping, ports, 'portA', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portB', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portC', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=1)
+
+        vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+
+        if 'portC' in ports:
+            check_packet(sonic_ping, ports, 'portA', 'portC', dst_ip_fld='nbr_lb', dev=ports['portC']['asic'],
+                         size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portC', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=1)
+        else:
+            check_packet(sonic_ping, ports, 'portA', 'portD', dst_ip_fld='nbr_lb', dev=ports['portD']['asic'],
+                         size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=1)
+
+    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (255, 1456), (1, 1456)])
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_voq_inband_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts):
+        """
+        Verify IP connectivity over inband interfaces.
+
+        * On linecard 1 send ping from:
+            * Inband interface F0 to inband interface F1 (133.133.133.1 to 133.133.133.5)
+            * Inband interface F0 to interface D (133.133.133.1 to 10.0.0.64)
+            * Inband interface F0 to neighbor on port A (133.133.133.1 to 10.0.0.1)
+            * Inband interface F0 to neighbor on port D (133.133.133.1 to 10.0.0.65)
+            * Inband interface F0 to routed loopback from router 01T3 (133.133.133.1 to 100.1.0.1)
+            * Inband interface F0 to routed loopback from router 01T1 (133.133.133.1 to 100.1.0.33)
+        * On linecard 2, send ping from:
+            * Inband interface F1 to inband interface F0 (133.133.133.5 to 133.133.133.1)
+            * Inband interface F1 to interface D (133.133.133.5 to 10.0.0.64)
+            * Inband interface F1 to neighbor on port A (133.133.133.5 to 10.0.0.1)
+            * Inband interface F1 to neighbor on port D (133.133.133.5 to 10.0.0.65)
+            * Inband interface F1 to routed loopback from router 01T3 (133.133.133.5 to 100.1.0.1)
+            * Inband interface F1 to routed loopback from router 01T1 (133.133.133.5 to 100.1.0.33)
+        * On Router 01T3, send ping from:
+            * Router loopback interface to DUT inband address on linecard 1. (100.1.0.1 to 133.133.133.1)
+            * Router loopback interface to DUT inband address on linecard 2. (100.1.0.1 to 133.133.133.5)
+        * Repeat for TTL 0,1,2,255
+        * Repeat for 64, 1500, 9100B packets
+        * Repeat for IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            nbrhosts: The nbrhosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            ttl: TTL of transmitted packet.
+            size: ICMP data size
+            version: IP version.
+            porttype: Test port type, ethernet or portchannel
+
+        """
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+        logger.info("Pinging neighbor interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl,
+                                                                                                 size=size))
+        remote_port = 'portD'
+        if 'portC' in ports:
+            remote_port = 'portC'
+
+        check_packet(sonic_ping, ports, remote_port, 'portA', src_ip_fld='inband', dst_ip_fld='inband', size=size,
+                     ttl=ttl)
+
+        check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portB', 'portA', src_ip_fld='inband', size=size, ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size, ttl=ttl,
+                     ttl_change=0)
+        check_packet(sonic_ping, ports, 'portB', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size, ttl=ttl,
+                     ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size, ttl=ttl,
+                     ttl_change=0)
+        check_packet(sonic_ping, ports, 'portB', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size, ttl=ttl,
+                     ttl_change=0)
+
+        check_packet(sonic_ping, ports, 'portC', 'portA', src_ip_fld='inband', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', src_ip_fld='inband', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portC', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size, ttl=ttl,
+                     ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size, ttl=ttl,
+                     ttl_change=1)
+        check_packet(sonic_ping, ports, 'portC', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size, ttl=ttl,
+                     ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size, ttl=ttl,
+                     ttl_change=1)
+
+        check_packet(sonic_ping, ports, 'portA', remote_port, src_ip_fld='inband', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portB', remote_port, src_ip_fld='inband', size=size, ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portA', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portB', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portA', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portB', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=1)
+
+        ttl_chg_port_C = 0
+        if ports[remote_port]['asic'] != ports['portC']['asic']:
+            ttl_chg_port_C = 1
+        ttl_chg_port_D = 0
+        if ports[remote_port]['asic'] != ports['portD']['asic']:
+            ttl_chg_port_D = 1
+
+        check_packet(sonic_ping, ports, 'portC', remote_port, src_ip_fld='inband', size=size, ttl=ttl,
+                     ttl_change=ttl_chg_port_C)
+        check_packet(sonic_ping, ports, 'portD', remote_port, src_ip_fld='inband', size=size, ttl=ttl,
+                     ttl_change=ttl_chg_port_D)
+        check_packet(sonic_ping, ports, 'portC', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=ttl_chg_port_C)
+        check_packet(sonic_ping, ports, 'portD', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=ttl_chg_port_D)
+        check_packet(sonic_ping, ports, 'portC', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=ttl_chg_port_C)
+        check_packet(sonic_ping, ports, 'portD', remote_port, src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=ttl_chg_port_D)
+
+        vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+        check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='inband', src_ip_fld='nbr_lb',
+                     dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
+        check_packet(eos_ping, ports, remote_port, 'portA', dst_ip_fld='inband', src_ip_fld='nbr_lb',
+                     dev=vm_host_to_A, size=size, ttl=ttl)
+
+    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (1, 1456), (255, 1456)])
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_voq_dut_lb_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts):
+        """
+        Verify IP Connectivity to DUT loopback addresses.
+
+        Test Steps
+
+        * On linecard 1 send ping from:
+            * Loopback to IP interface of port D (11.1.0.1 to 10.0.0.64)
+            * Loopback to neighbor on port D (11.1.0.1 to 10.0.0.65)
+            * Loopback to routed loopback address (11.1.0.1 to 100.1.0.1)
+            * Loopback to routed loopback address (11.1.0.1 to 100.1.0.33)
+        * On Router 01T3, send ping from:
+            * Router loopback interface to DUT loopback address on linecard 1. (100.1.0.1 to 11.1.0.1)
+            * Router loopback interface to DUT loopback address on linecard 2. (100.1.0.1 to 11.1.0.2)
+        * Repeat for TTL 0,1,2,255
+        * Repeat for 64, 1500, 9100B packets
+        * Repeat for IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            nbrhosts: The nbrhosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            ttl: TTL of transmitted packet.
+            size: ICMP data size
+            version: IP version.
+            porttype: Test port type, ethernet or portchannel
+
+        """
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+        logger.info("Pinging neighbor interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl,
+                                                                                                 size=size))
+        # these don't decrement ttl
+        check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size, ttl=ttl,
+                     ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portB', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size, ttl=ttl,
+                     ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portB', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=0)
+        check_packet(sonic_ping, ports, 'portA', 'portB', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=0)
+
+        # these do decrement ttl
+        check_packet(sonic_ping, ports, 'portC', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size, ttl=ttl,
+                     ttl_change=1)
+        check_packet(sonic_ping, ports, 'portC', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portC', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size, ttl=ttl,
+                     ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
+                     ttl=ttl, ttl_change=1)
+        check_packet(sonic_ping, ports, 'portD', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_lb', size=size,
+                     ttl=ttl, ttl_change=1)
+
+        vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+        check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                     dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
+        if 'portC' in ports:
+            check_packet(eos_ping, ports, 'portC', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=1)
+        else:
+            check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=1)
+
+    @pytest.mark.parametrize('ttl, size', [(2, 64), (128, 64), (255, 1456)])
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_voq_end_to_end_ping(self, duthosts, all_cfg_facts, ttl, size, version, porttype, nbrhosts):
+        """
+        Verify IP Connectivity to DUT loopback addresses.
+
+        Test Steps
+
+        * On Router 1, send ping from:
+            * End to end port A to B, ports on same linecard.  (100.1.0.1 to 100.1.0.2)
+            * End to end port A to D, ports across multiple linecards. (100.1.0.1 to 100.1.0.33)
+        * Repeat for TTL 0,1,2,255
+        * Repeat for 64, 1500, 9100B packets
+        * Repeat for IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            nbrhosts: The nbrhosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            ttl: TTL of transmitted packet.
+            size: ICMP data size
+            version: IP version.
+            porttype: Test port type, ethernet or portchannel
+
+        """
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+        logger.info("Pinging neighbor interfaces for ip: {ipv}, ttl: {ttl}, size: {size}".format(ipv=version, ttl=ttl,
+                                                                                                 size=size))
+        vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+        check_packet(eos_ping, ports, 'portB', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb', dev=vm_host_to_A,
+                     size=size, ttl=ttl, ttl_change=0)
+        check_packet(eos_ping, ports, 'portC', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb', dev=vm_host_to_A,
+                     size=size, ttl=ttl)
+        check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb', dev=vm_host_to_A,
+                     size=size, ttl=ttl)
+
+
+def build_ttl0_pkts(ports, nbr_macs, version, dst_mac, dst_ip):
+    """
+    Builds ttl0 packet to send and ICMP TTL exceeded packet to expect back.
+
+    Args:
+        ports: ports structure from pick_ports
+        nbr_macs: nbr_macs fixture
+        version: IP version, 4 or 6
+        dst_mac: Destination MAC, of DUT port.
+        dst_ip: Destination IP, a farend VM interface.
+
+    Returns:
+        3 packets, one with ttl0 to send, one as the ICMP expected packet, and one to check for TTL wrapping.
+
+    """
+    if version == 4:
+        send_pkt = simple_udp_packet(eth_dst=dst_mac,  # mac address of dut
+                                     eth_src=nbr_macs[ports['portA']['nbr_vm']][ports['portA']['nbr_port']],
+                                     # mac address of vm1
+                                     ip_src=str(ports['portA']['nbr_lb']),
+                                     ip_dst=str(dst_ip),
+                                     ip_ttl=0,
+                                     pktlen=100)
+
+        exp_pkt255 = simple_udp_packet(eth_dst=dst_mac,  # mac address of dut
+                                       eth_src=nbr_macs[ports['portA']['nbr_vm']][ports['portA']['nbr_port']],
+                                       # mac address of vm1
+                                       ip_src=str(ports['portA']['nbr_lb']),
+                                       ip_dst=str(dst_ip),
+                                       ip_ttl=255,
+                                       pktlen=100)
+        V4_PKTSZ = 128
+        exp_pkt = simple_icmp_packet(eth_dst=nbr_macs[ports['portA']['nbr_vm']][ports['portA']['nbr_port']],
+                                     # mac address of vm1
+                                     eth_src=dst_mac,  # mac address of dut
+                                     ip_src=str(ports['portA']['my_lb_ip']),
+                                     ip_dst=str(ports['portA']['nbr_lb']),
+                                     ip_ttl=64,
+                                     icmp_code=0,
+                                     icmp_type=11,
+                                     pktlen=V4_PKTSZ,
+                                     )
+
+        masked_pkt = Mask(exp_pkt)
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "len")
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "id")
+        masked_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_pkt.set_do_not_care_scapy(scapy.ICMP, "chksum")
+        masked_pkt.set_do_not_care(304, V4_PKTSZ * 8 - 304)  # ignore icmp data
+
+    else:
+        send_pkt = simple_udpv6_packet(eth_dst=dst_mac,  # mac address of dut
+                                       eth_src=nbr_macs[ports['portA']['nbr_vm']][ports['portA']['nbr_port']],
+                                       # mac address of vm1
+                                       ipv6_src=str(ports['portA']['nbr_lb']),
+                                       ipv6_dst=str(dst_ip),
+                                       ipv6_hlim=0,
+                                       pktlen=100)
+
+        exp_pkt255 = simple_udpv6_packet(eth_dst=dst_mac,  # mac address of dut
+                                         eth_src=nbr_macs[ports['portA']['nbr_vm']][ports['portA']['nbr_port']],
+                                         # mac address of vm1
+                                         ipv6_src=str(ports['portA']['nbr_lb']),
+                                         ipv6_dst=str(dst_ip),
+                                         ipv6_hlim=255,
+                                         pktlen=100)
+
+        V6_PKTSZ = 148
+        exp_pkt = simple_icmpv6_packet(eth_dst=nbr_macs[ports['portA']['nbr_vm']][ports['portA']['nbr_port']],
+                                       # mac address of vm1
+                                       eth_src=dst_mac,  # mac address of dut
+                                       ipv6_src=str(ports['portA']['my_lb_ip']),
+                                       ipv6_dst=str(ports['portA']['nbr_lb']),
+                                       ipv6_hlim=64,
+                                       icmp_code=0,
+                                       icmp_type=3,
+                                       pktlen=V6_PKTSZ,
+                                       )
+
+        masked_pkt = Mask(exp_pkt)
+        masked_pkt.set_do_not_care_scapy(scapy.IPv6, "tc")
+        masked_pkt.set_do_not_care_scapy(scapy.IPv6, "fl")
+        masked_pkt.set_do_not_care_scapy(scapy.IPv6, "plen")
+        masked_pkt.set_do_not_care_scapy(scapy.ICMPv6Unknown, "cksum")
+        masked_pkt.set_do_not_care(456, V6_PKTSZ * 8 - 456)  # ignore icmp data
+
+    return send_pkt, masked_pkt, exp_pkt255
+
+
+class TestVoqIPFwdTTL0(object):
+
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_ipforwarding_ttl0(self, duthosts, all_cfg_facts, tbinfo, ptfadapter, version, porttype, nbrhosts,
+                               nbr_macs):
+        """
+        Verifies that TTL0 packets are dropped and that ICMP time expired message is received
+
+        Args:
+            duthosts: The duthosts fixture
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            tbinfo: The tbinfo fixture.
+            ptfadapter: The ptfadapter fixture
+            version: IP version, 4 or 6
+            porttype: Port type to test, ethernet or portchannel.
+            nbrhosts: The nbrhosts fixture.
+            nbr_macs: The nbr_macs fixture
+
+        """
+
+        devices = {}
+        for k, v in tbinfo['topo']['properties']['topology']['VMs'].items():
+            devices[k] = {'vlans': v['vlans']}
+
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+
+        for dst_rtr, dst_ip in [(ports['portB']['nbr_vm'], ports['portB']['nbr_lb']),
+                                (ports['portD']['nbr_vm'], ports['portD']['nbr_lb'])]:  # (self.rtrD['vm'], self.lbD.ip)
+            logger.info("Send TTL 0 packet from %s => %s", ports['portA']['nbr_lb'], str(dst_ip))
+            # 0.1@1 = dut_index.dut_port@ptfport
+            src_port = devices[ports['portA']['nbr_vm']]['vlans'][0].split("@")[1]
+
+            src_rx_ports = []
+            for item in devices[ports['portA']['nbr_vm']]['vlans']:
+                src_rx_ports.append(item.split("@")[1])
+            logger.info("PTF source ports: %s", src_rx_ports)
+
+            dst_rx_ports = []
+            for item in devices[dst_rtr]['vlans']:
+                dst_rx_ports.append(item.split("@")[1])
+            logger.info("PTF destination ports: %s", dst_rx_ports)
+
+            dst_mac = get_sonic_mac(ports['portA']['dut'], ports['portA']['asic'].asic_index, ports['portA']['port'])
+
+            send_pkt, masked_pkt, exp_pkt255 = build_ttl0_pkts(ports, nbr_macs, version, dst_mac, dst_ip)
+
+            send(ptfadapter, src_port, send_pkt)
+            logger.info("masked packet matched port: %s", src_port)
+
+            result = dp_poll(ptfadapter, device_number=0, exp_pkt=masked_pkt, timeout=2)
+            ptfadapter.at_receive(result.packet, device_number=result.device, port_number=result.port)
+
+            logger.info("Found %s ICMP ttl expired packets on ports: %s", result, str(src_rx_ports))
+            logger.info("port: %s", result.port)
+            pytest_assert(str(result.port) in src_rx_ports, "Port %s not in %s" % (result.port, src_rx_ports))
+
+            verify_no_packet_any(ptfadapter, send_pkt, dst_rx_ports)
+            verify_no_packet_any(ptfadapter, exp_pkt255, dst_rx_ports)
+
+
+def bgp_established(host, asic):
+    """
+    Helper function to poll for BGP state.
+
+    Args:
+        host: Instance of duthost.
+        asic: Instance of SonicAsic.
+
+    Returns:
+        True if all neighbors are established, False if not.
+
+    """
+    if host.facts['num_asic'] > 1:
+        bgp_facts = host.bgp_facts(instance_id=asic.asic_index)['ansible_facts']
+    else:
+        bgp_facts = host.bgp_facts()['ansible_facts']
+    for k, v in bgp_facts['bgp_neighbors'].items():
+        if v['state'] != 'established':
+            logger.info("Neighbor %s not established yet: %s", k, v['state'])
+            return False
+    return True
+
+
+class TestFPLinkFlap(LinkFlap):
+
+    @pytest.mark.parametrize('version', [4, 6])
+    @pytest.mark.parametrize('porttype', ["ethernet", "portchannel"])
+    def test_front_panel_linkflap_port(self, duthosts, all_cfg_facts,
+                                       fanouthosts, porttype, version, nbrhosts):
+        """
+        Traffic to Sonic host interfaces recovers after the front panel port flaps.
+
+        Test Steps
+
+        * Admin down interface on fanout connected to DUT port A to cause LOS on DUT.
+        * On linecard 1 verify ping is successful from:
+            * DUT IP Interface B to DUT Interface D
+            * DUT Neighbor IP B to DUT Neighbor IP D
+        * On Router 02T3, verify ping is successful from Router Interface to DUT IP Interface B and D.
+        * On linecard 1, verify ping fails from:
+            * DUT IP Interface A to DUT IP interface B and D.
+            * DUT IP Interface A to attached neighbor.
+        * On Router 01T3, verify ping fails to all DUT addresses.
+        * On fanout switch, admin up the downed interface.
+        * Validate all traffic flows are correct as in test cases 2-7.
+        * Retry traffic with TTL 0,1,2,255
+        * Retry traffic with 64, 1500, 9100B packets
+        * Retry traffic with IPv6
+
+        Args:
+            duthosts: The duthosts fixture.
+            all_cfg_facts: The all_cfg_facts fixture from voq/conftest.py
+            fanouthosts: The fanouthosts fixture.
+            version: IP version, 4 or 6
+            porttype: Port type to test, ethernet or portchannel.
+            nbrhosts: The nbrhosts fixture.
+
+        """
+        pytest_assert(fanouthosts != {}, "Fanouthosts fixture did not return anything, this test case has no hope.")
+        logger.info("Fanouthosts: %s", fanouthosts)
+
+        ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+        cfg_facts = all_cfg_facts[ports['portA']['dut'].hostname][ports['portA']['asic'].asic_index]['ansible_facts']
+
+        if "portchannel" in ports['portA']['port'].lower():
+            pc_cfg = cfg_facts['PORTCHANNEL_MEMBER']
+            pc_members = pc_cfg[ports['portA']['port']]
+            logger.info("Portchannel members %s: %s", ports['portA']['port'], pc_members.keys())
+            portbounce_list = pc_members.keys()
+        else:
+            portbounce_list = [ports['portA']['port']]
+
+        for lport in portbounce_list:
+            logger.info("Lookup ports for %s, %s", ports['portA']['dut'].hostname, lport)
+            fanout, fanport = fanout_switch_port_lookup(fanouthosts, ports['portA']['dut'].hostname, lport)
+            logger.info("bring down fanout port: %s, host: %s", fanport, fanout.host.hostname)
+            self.linkflap_down(fanout, fanport, ports['portA']['dut'], lport)
+
+        try:
+            logger.info("=" * 80)
+            logger.info("Link down validations")
+            logger.info("-" * 80)
+
+            check_packet(sonic_ping, ports, "portD", "portB", dst_ip_fld='my_ip', src_ip_fld='my_ip',
+                         dev=ports['portA']['asic'], size=256, ttl=2,
+                         ttl_change=1)
+            check_packet(eos_ping, ports, 'portB', 'portB', dst_ip_fld='my_ip', src_ip_fld='nbr_ip',
+                         dev=nbrhosts[ports["portB"]['nbr_vm']]['host'], size=256, ttl=2, ttl_change=0)
+            check_packet(eos_ping, ports, 'portD', 'portB', dst_ip_fld='my_ip', src_ip_fld='nbr_ip',
+                         dev=nbrhosts[ports["portB"]['nbr_vm']]['host'], size=256, ttl=2)
+
+            check_packet(sonic_ping, ports, "portB", "portA", dst_ip_fld='my_ip', src_ip_fld='my_ip',
+                         dev=ports['portA']['asic'], size=256, ttl=2,
+                         ttl_change=0)
+
+            with pytest.raises(AssertionError):
+                sonic_ping(ports['portA']['asic'], ports['portD']['my_ip'], size=256, ttl=2,
+                           interface=ports['portA']['my_ip'], verbose=True)
+            with pytest.raises(AssertionError):
+                sonic_ping(ports['portA']['asic'], ports['portA']['nbr_ip'], size=256, ttl=2,
+                           interface=ports['portA']['my_ip'], verbose=True)
+            with pytest.raises(AssertionError):
+                eos_ping(nbrhosts[ports['portA']['nbr_vm']]['host'], ports['portA']['my_ip'], size=256, ttl=2,
+                         verbose=True)
+            with pytest.raises(AssertionError):
+                eos_ping(nbrhosts[ports['portA']['nbr_vm']]['host'], ports['portD']['my_ip'], size=256, ttl=2,
+                         verbose=True)
+
+        finally:
+            for lport in portbounce_list:
+                fanout, fanport = fanout_switch_port_lookup(fanouthosts, ports['portA']['dut'].hostname, lport)
+                self.linkflap_up(fanout, fanport, ports['portA']['dut'], lport)
+
+        # Validate from port A and neighbor A that everything is good after port is up.
+
+        # need bgp to establish
+        wait_until(200, 20, bgp_established, ports['portA']['dut'], ports['portA']['asic'])
+
+        routes = asic_cmd(ports['portA']['asic'], "ip -%d route" % version)["stdout_lines"]
+        for route in routes:
+            logger.info("R: %s", route)
+        bgp = asic_cmd(ports['portA']['asic'], "show ip bgp summary")["stdout_lines"]
+        for route in bgp:
+            logger.info("B: %s", route)
+
+        logger.info("=" * 80)
+        logger.info("Link up validations")
+        logger.info("-" * 80)
+
+        for ttl, size in [(2, 64), (128, 64), (1, 1450)]:
+            # local interfaces
+            check_packet(sonic_ping, ports, 'portB', 'portA', size=size, ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portC', 'portA', size=size, ttl=ttl, ttl_change=1)
+            check_packet(sonic_ping, ports, 'portD', 'portA', size=size, ttl=ttl, ttl_change=1)
+            # local neighbors
+            check_packet(sonic_ping, ports, 'portA', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portB', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portC', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=1)
+            check_packet(sonic_ping, ports, 'portD', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=1)
+
+            vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+
+            check_packet(sonic_ping, ports, 'portA', 'portD', dev=ports['portD']['asic'], dst_ip_fld='nbr_ip',
+                         size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_ip',
+                         dev=vm_host_to_A, size=size, ttl=ttl)
+
+            # loopbacks
+            check_packet(sonic_ping, ports, 'portA', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portB', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portC', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=1)
+            check_packet(sonic_ping, ports, 'portD', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=1)
+
+            vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+
+            check_packet(sonic_ping, ports, 'portA', 'portD', dst_ip_fld='nbr_lb', dev=ports['portD']['asic'],
+                         size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=1)
+
+            # inband
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', size=size, ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_ip', size=size,
+                         ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', dst_ip_fld='nbr_lb', size=size,
+                         ttl=ttl, ttl_change=0)
+
+            # DUT loopback
+            # these don't decrement ttl
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size,
+                         ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
+                         ttl=ttl, ttl_change=0)
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_lb', size=size,
+                         ttl=ttl, ttl_change=0)
+
+            vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+            check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
+
+            # end to end
+            vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+            check_packet(eos_ping, ports, 'portB', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
+            check_packet(eos_ping, ports, 'portC', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl)
+            check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                         dev=vm_host_to_A, size=size, ttl=ttl)

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -163,6 +163,13 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a="ethernet", versio
     """
     Selects ports to test by sampling the interface and port channel lists.
 
+                          ---------- DUT ----------
+                          |--- LC1 ---|--- LC2 ---|
+    VM01T3   -------------|A          |          C|------------- VM02T1
+                          |         F0|F1         |
+    VM02T3   -------------|B     LB1  |   LB2    D|------------- VM01T1
+                          |-----------|-----------|
+
     Args:
         duthosts: The duthosts fixture.
         all_cfg_facts: The config_facts for all the duts.

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -89,7 +89,7 @@ def log_port_info(ports):
             elif fld_name == 'asic':
                 port_dict_to_print[port_name]['asic'] = port['asic'].asic_index
             elif isinstance(port[fld_name], ipaddress.IPv4Address) or isinstance(port[fld_name],
-                                                                                     ipaddress.IPv6Address):
+                                                                                 ipaddress.IPv6Address):
                 port_dict_to_print[port_name][fld_name] = "%s" % port[fld_name]
             else:
                 port_dict_to_print[port_name][fld_name] = port[fld_name]
@@ -585,7 +585,7 @@ class TestTableValidation(object):
 
 class TestVoqIPFwd(object):
 
-    @pytest.mark.parametrize('ttl, size', [(2, 1500), (255, 1500), (128, 64), (128,9000)])
+    @pytest.mark.parametrize('ttl, size', [(2, 1500), (255, 1500), (128, 64), (128, 9000)])
     @pytest.mark.parametrize('version', [4, 6])
     @pytest.mark.parametrize('porttype', ["portchannel", "ethernet"])
     def test_voq_local_interface_ping(self, duthosts, nbrhosts, all_cfg_facts, ttl, size, version, porttype):

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -1,0 +1,878 @@
+"""Test neighbor lifecycle on VoQ chassis."""
+import logging
+import pytest
+import time
+import random
+from scapy.all import Ether
+from scapy.layers.l2 import Dot1Q
+from scapy.layers.inet6 import IPv6, ICMPv6ND_NA, ICMPv6NDOptDstLLAddr
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+from tests.common.helpers.parallel import parallel_run
+from tests.common.helpers.parallel import reset_ansible_local_tmp
+
+from voq_helpers import get_neighbor_info
+from voq_helpers import get_port_by_ip
+from voq_helpers import check_all_neighbors_present, check_one_neighbor_present
+from voq_helpers import asic_cmd, sonic_ping
+from voq_helpers import check_neighbor_is_gone
+
+from ptf.testutils import simple_arp_packet, send_packet, ip_make_tos, MINSIZE
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2')
+]
+
+NEW_MAC = "00:01:94:00:00:01"
+
+
+@pytest.fixture(scope="module")
+def setup(duthosts, nbrhosts, all_cfg_facts):
+    """
+    Setup fixture to disable all neighbors on DUT and VMs.
+
+    Args:
+        duthosts: Duthosts fixture
+        nbrhosts: Nbrhosts fixture
+        all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+
+    """
+
+    @reset_ansible_local_tmp
+    def disable_dut_bgp_neighs(cfg_facts, node=None, results=None):
+        """Target function do disable BGP neighbors on sonic DUTs.
+
+        Args:
+            cfg_facts: instance of fixture from voq/conftest.py
+            node (object, optional): A value item of the dict type fixture 'nbrhosts'. Defaults to None.
+            results (Proxy to shared dict, optional): An instance of multiprocessing.Manager().dict(). Proxy to a dict
+                shared by all processes for returning execution results. Defaults to None
+        """
+        if node is None or results is None:
+            logger.error('Missing kwarg "node" or "results"')
+            return
+
+        node_results = []
+        for asic in node.asics:
+            asic_cfg_facts = cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
+            logger.info('disable neighbors {} on dut host {}'.format(asic_cfg_facts['BGP_NEIGHBOR'], node.hostname))
+
+            for neighbor in asic_cfg_facts['BGP_NEIGHBOR']:
+                logger.info(
+                    "Shut down neighbor: {} on host {} asic {}".format(neighbor, node.hostname, asic.asic_index))
+
+                node_results.append(node.command("sudo config bgp shutdown neighbor {}".format(neighbor)))
+
+        results[node['host'].hostname] = node_results
+
+    parallel_run(disable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=120)
+
+    # disable bgp neighbors on vms
+    @reset_ansible_local_tmp
+    def disable_nbr_bgp_neighs(node=None, results=None):
+        """Target function to disable bgp neighbors on VMS.
+
+        Args:
+            node (object, optional): A value item of the dict type fixture 'nbrhosts'. Defaults to None.
+            results (Proxy to shared dict, optional): An instance of multiprocessing.Manager().dict(). Proxy to a dict
+                shared by all processes for returning execution results. Defaults to None.
+        """
+        if node is None or results is None:
+            logger.error('Missing kwarg "node" or "results"')
+            return
+
+        node_results = []
+        logger.info(
+            'disable neighbors {} on neighbor host {}'.format(node['conf']['bgp']['peers'], node['host'].hostname))
+        for peer in node['conf']['bgp']['peers']:
+            for neighbor in node['conf']['bgp']['peers'][peer]:
+                node_results.append(node['host'].eos_config(
+                    lines=["neighbor %s shutdown" % neighbor],
+                    parents=['router bgp {}'.format(node['conf']['bgp']['asn'])],
+                    module_ignore_errors=True)
+                )
+                if ":" in neighbor:
+                    node_results.append(node['host'].eos_config(
+                        lines=["ipv6 route ::/0 %s " % neighbor],
+                        module_ignore_errors=True)
+                    )
+                else:
+                    node_results.append(node['host'].eos_config(
+                        lines=["ip route 0.0.0.0/0 %s " % neighbor],
+                        module_ignore_errors=True)
+                    )
+
+        results[node['host'].hostname] = node_results
+
+    parallel_run(disable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=120)
+
+    yield
+
+    # cleanup
+
+    # restore neighbors on duts
+    @reset_ansible_local_tmp
+    def enable_dut_bgp_neighs(cfg_facts, node=None, results=None):
+        """Target function to enable BGP neighbors on the sonic hosts..
+
+        Args:
+            cfg_facts: Instance of all_cfg_facts fixture from voq/conftest.py
+            node (object, optional): A value item of the dict type fixture 'nbrhosts'. Defaults to None.
+            results (Proxy to shared dict, optional): An instance of multiprocessing.Manager().dict(). Proxy to a dict
+                shared by all processes for returning execution results. Defaults to None.
+        """
+        if node is None or results is None:
+            logger.error('Missing kwarg "node" or "results"')
+            return
+
+        node_results = []
+        for asic in node.asics:
+            asic_cfg_facts = cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
+            logger.info('enable neighbors {} on dut host {}'.format(asic_cfg_facts['BGP_NEIGHBOR'], node.hostname))
+            asnum = asic_cfg_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+
+            for neighbor in asic_cfg_facts['BGP_NEIGHBOR']:
+                logger.info(
+                    "Startup neighbor: {} on host {} asic {}".format(neighbor, node.hostname, asic.asic_index))
+
+                node_results.append(node.command("sudo config bgp startup neighbor {}".format(neighbor)))
+                node_results.append(node.command(
+                    "docker exec bgp vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
+                        asnum, neighbor)))
+
+        results[node['host'].hostname] = node_results
+
+    parallel_run(enable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=120)
+
+    # restore neighbors on vms
+    @reset_ansible_local_tmp
+    def enable_nbr_bgp_neighs(node=None, results=None):
+        """Target function to enable BGP neighbors on VMs.
+
+        Args:
+            node (object, optional): A value item of the dict type fixture 'nbrhosts'. Defaults to None.
+            results (Proxy to shared dict, optional): An instance of multiprocessing.Manager().dict(). Proxy to a dict
+                shared by all processes for returning execution results. Defaults to None.
+        """
+        if node is None or results is None:
+            logger.error('Missing kwarg "node" or "results"')
+            return
+
+        node_results = []
+        logger.info(
+            'enable neighbors {} on neighbor host {}'.format(node['conf']['bgp']['peers'], node['host'].hostname))
+        for peer in node['conf']['bgp']['peers']:
+            for neighbor in node['conf']['bgp']['peers'][peer]:
+                node_results.append(node['host'].eos_config(
+                    lines=["no neighbor %s shutdown" % neighbor],
+                    parents=['router bgp {}'.format(node['conf']['bgp']['asn'])],
+                    module_ignore_errors=True)
+                )
+                if ":" in neighbor:
+                    node_results.append(node['host'].eos_config(
+                        lines=["no ipv6 route ::/0 %s " % neighbor],
+                        module_ignore_errors=True)
+                    )
+                else:
+                    node_results.append(node['host'].eos_config(
+                        lines=["no ip route 0.0.0.0/0 %s " % neighbor],
+                        module_ignore_errors=True)
+                    )
+
+        results[node['host'].hostname] = node_results
+
+    parallel_run(enable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=120)
+
+
+def ping_all_dut_local_nbrs(duthosts):
+    """
+    Pings all neighbors locally attached to each frontend node on the DUT.
+
+    Args:
+        duthosts: An instance of the duthosts fixture.
+
+    """
+    logger.info("Pinging neighbors to establish ARP")
+    for per_host in duthosts.frontend_nodes:
+        for asic in per_host.asics:
+            cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
+            neighs = cfg_facts['BGP_NEIGHBOR']
+            for neighbor in neighs:
+                sonic_ping(asic, neighbor)
+
+
+def ping_all_neighbors(duthosts, neighbors):
+    """
+    Pings all neighbors in the neighbor list from all frontend hosts on the DUT..
+
+    Args:
+        duthosts: An instance of the duthosts fixture.
+        neighbors: A list of neighbor IP addresses.
+
+    """
+    for per_host in duthosts.frontend_nodes:
+        for asic in per_host.asics:
+            for neighbor in neighbors:
+                logger.info("Ping %s from %s/%s", neighbor, per_host.hostname, asic.asic_index)
+                sonic_ping(asic, neighbor)
+
+
+@pytest.fixture()
+def established_arp(duthosts):
+    """
+    Fixture to establish ARP to all neighbors at start of test.
+
+    Args:
+        duthosts: Instance of duthosts fixture.
+    """
+    ping_all_dut_local_nbrs(duthosts)
+
+
+@pytest.fixture()
+def cleared_arp(duthosts):
+    """
+    Fixture to clear ARP an NDP on all neighbors at start of test.
+
+    Args:
+        duthosts: Instance of duthosts fixture.
+    """
+    for per_host in duthosts.frontend_nodes:
+        for asic in per_host.asics:
+            asic_cmd(asic, "sonic-clear arp")
+            asic_cmd(asic, "sonic-clear ndp")
+
+
+def test_neighbor_clear_all(duthosts, setup, nbrhosts, all_cfg_facts, established_arp):
+    """
+    Verify tables, databases, and kernel routes are correctly deleted when the entire neighbor table is cleared.
+
+    Test Steps
+    * On local linecard:
+        * Issue `sonic-clear arp` command. and verify all addresses are removed and kernel routes are deleted on
+          all hosts and ASICs.
+        * Verify ARP/NDP entries are removed from CLI.
+        * Verify table entries in ASIC, AppDb are removed for all cleared addresses.
+    * On Supervisor card:
+        * Verify Chassis App DB entry are removed for only the cleared address.  Entries for addresses on other line
+        cards should still be present.
+    * On remote linecards:
+        * Verify table entries in ASICDB, APPDB, and host ARP table are removed for cleared addresses.
+        * Verify kernel routes for cleared address are deleted.
+    * Send full mesh traffic and verify relearn and DB.
+
+    Args:
+        duthosts: duthosts fixture.
+        setup: setup fixture for this module.
+        nbrhosts: nbrhosts fixture.
+        all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+        established_arp: Fixture to establish ARP to all neighbors.
+
+    """
+    all_neighbors = []
+
+    for per_host in duthosts.frontend_nodes:
+        for asic in per_host.asics:
+            asic_cmd(asic, "sonic-clear arp")
+            asic_cmd(asic, "sonic-clear ndp")
+            time.sleep(1)
+
+            cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+            neighs = cfg_facts['BGP_NEIGHBOR']
+
+            for neighbor in neighs:
+                all_neighbors.append(neighbor)
+                check_neighbor_is_gone(duthosts, all_cfg_facts, per_host, asic, neighbor)
+
+    # relearn and check
+    logger.info("Relearn neighbors on all nodes")
+    ping_all_dut_local_nbrs(duthosts)
+    ping_all_neighbors(duthosts, all_neighbors)
+    check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts)
+
+
+def test_neighbor_clear_one(duthosts, setup, nbrhosts, all_cfg_facts, established_arp):
+    """
+    Verify tables, databases, and kernel routes are correctly deleted when a single neighbor adjacency is cleared.
+
+    Test Steps
+    * On local linecard:
+        * Clear single address with command:  `ip neigh flush to "addr"`.
+        * Verify ARP/NDP entry removed from CLI.
+        * Verify table entries in ASIC, AppDb are removed for only the cleared address.
+    * On Supervisor card:
+        * Verify Chassis App DB entry are removed for only the cleared address.
+    * On remote linecards:
+        * Verify table entries in ASICDB, APPDB, and host ARP table are removed.
+        * Verify kernel route for cleared address is deleted.
+    * Restart traffic, verify relearn.
+
+    Args:
+        duthosts: duthosts fixture.
+        setup: setup fixture for this module.
+        nbrhosts: nbrhosts fixture.
+        all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+        established_arp: Fixture to establish ARP to all neighbors.
+
+    """
+    all_neighbors = []
+    for per_host in duthosts.frontend_nodes:
+
+        for asic in per_host.asics:
+            cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+            neighs = cfg_facts['BGP_NEIGHBOR']
+
+            for neighbor in neighs:
+                logger.info(
+                    "Flushing neighbor: {} on host {}/{}".format(neighbor, per_host.hostname, asic.asic_index))
+                asic_cmd(asic, "ip neigh flush to %s" % neighbor)
+                all_neighbors.append(neighbor)
+                check_neighbor_is_gone(duthosts, all_cfg_facts, per_host, asic, neighbor)
+
+    # relearn and check
+    logger.info("Relearn neighbors on all nodes")
+    ping_all_dut_local_nbrs(duthosts)
+    logger.info("Check neighbor relearn on all nodes.")
+    check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts)
+
+
+def change_mac(nbr, intf, mac):
+    """
+    Change the mac of a CEOS interface on the linux host OS.
+
+    Args:
+        nbr: Instance of the neighbor host.
+        intf: Interface to change in linux interface format. (ethX)
+        mac: New MAC address
+
+
+    """
+    nbr['host'].command("sudo ifconfig {} down".format(intf))
+    nbr['host'].command("sudo ifconfig {} hw ether {}".format(intf, mac))
+    nbr['host'].command("sudo ifconfig {} up".format(intf))
+
+
+def change_mac_ptf(ptfhost, intf, mac):
+    """
+    Change the mac of an interface on the PTF.
+
+    Args:
+        ptfhost: ptfhost fixture.
+        intf: Interface to change in linux interface format. (ethX)
+        mac: New MAC address
+
+    """
+    ptfhost.shell("ifconfig {} down".format(intf))
+    ptfhost.shell("ifconfig {} hw ether {}".format(intf, mac))
+    ptfhost.shell("ifconfig {} up".format(intf))
+
+
+def check_arptable_mac(host, neighbor, mac, checkstate=True):
+    arptable = host.switch_arptable()['ansible_facts']
+
+    if ':' in neighbor:
+        table = arptable['arptable']['v6']
+    else:
+        table = arptable['arptable']['v4']
+
+    logger.info("Poll neighbor: %s, mac: %s, state: %s", neighbor, table[neighbor]['macaddress'],
+                table[neighbor]['state'])
+    if checkstate:
+        return table[neighbor]['macaddress'] == mac and table[neighbor]['state'].lower() == "reachable"
+    else:
+        return table[neighbor]['macaddress'] == mac
+
+
+def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                setup, nbrhosts, established_arp, all_cfg_facts):
+    """
+    Verify tables, databases, and kernel routes are correctly updated when the MAC address of a neighbor changes
+    and is updated via request/reply exchange.
+
+    Test Steps
+    * Change the MAC address on a remote host that is already present in the ARP table.
+    * Without clearing the entry in the DUT, allow the existing entry to time out and the new reply to have the new MAC
+      address.
+    * On local linecard:
+        * Verify table entries in local ASIC, APP, and host ARP table are updated with new MAC.
+    * On supervisor card:
+        * Verify Chassis App DB entry is correct for with the updated MAC address.
+    * On remote linecards:
+        * Verify table entries in remote hosts/ASICs in APPDB, and host ARP table are still present with inband MAC
+          address
+        * Verify ASIC DB is updated with new MAC.
+        * Verify kernel route in remote hosts are still present to inband port.
+    * Verify that packets can be sent from local and remote linecards to the learned address.
+
+    Args:
+        duthosts: duthosts fixture.
+        enum_rand_one_per_hwsku_frontend_hostname: frontend iteration fixture.
+        enum_asic_index: asic iteration fixture.
+        setup: setup fixture for this module.
+        nbrhosts: nbrhosts fixture.
+        all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+        established_arp: Fixture to establish ARP to all neighbors.
+    """
+
+    per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+    neighs = cfg_facts['BGP_NEIGHBOR']
+
+    for neighbor in neighs:
+        local_ip = neighs[neighbor]['local_addr']
+
+        # Check neighbor on local linecard
+        local_port = get_port_by_ip(cfg_facts, local_ip)
+        if "portchannel" in local_port.lower():
+            logger.warning("Skip portchannel, MAC change doesn't seem supported on CEOS docker.")
+            continue
+
+        nbrinfo = get_neighbor_info(neighbor, nbrhosts)
+        original_mac = nbrinfo['mac']
+        logger.info("*" * 60)
+        logger.info("Verify initial neighbor: %s, port %s", neighbor, local_port)
+        pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac, checkstate=False),
+                      "MAC {} didn't change in ARP table".format(original_mac))
+        sonic_ping(asic, neighbor, verbose=True)
+        pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac),
+                      "MAC {} didn't change in ARP table".format(original_mac))
+        check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
+
+        try:
+            logger.info("Changing ethernet mac on neighbor: %s, port %s, vm %s", neighbor,
+                        nbrinfo['shell_intf'], nbrinfo['vm'])
+
+            change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], NEW_MAC)
+            if ":" in neighbor:
+                logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
+                asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, NEW_MAC, checkstate=False),
+                          "MAC {} didn't change in ARP table".format(NEW_MAC))
+
+            sonic_ping(asic, neighbor, verbose=True)
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, NEW_MAC),
+                          "MAC {} didn't change in ARP table".format(NEW_MAC))
+            logger.info("Verify neighbor after mac change: %s, port %s", neighbor, local_port)
+            check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
+            logger.info("Ping neighbor: %s from all line cards", neighbor)
+            ping_all_neighbors(duthosts, [neighbor])
+        finally:
+            logger.info("-" * 60)
+            logger.info("Will Restore ethernet mac on neighbor: %s, port %s, vm %s", neighbor,
+                        nbrinfo['shell_intf'], nbrinfo['vm'])
+            change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], original_mac)
+            if ":" in neighbor:
+                logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
+                asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac, checkstate=False),
+                          "MAC {} didn't change in ARP table".format(original_mac))
+            sonic_ping(asic, neighbor, verbose=True)
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac),
+                          "MAC {} didn't change in ARP table".format(original_mac))
+
+        check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
+        ping_all_neighbors(duthosts, [neighbor])
+
+
+class LinkFlap(object):
+
+    def check_intf_status(self, dut, dut_intf, exp_status):
+        """
+        Helper to poll on interface oper status
+
+        Args:
+            dut: Instance of duthost.
+            dut_intf: Interface to poll.
+            exp_status: Expected status (up or down)
+
+        Returns:
+            True if interface matches expected status, False otherwise.
+
+        """
+        status = dut.show_interface(command='status', interfaces=[dut_intf])['ansible_facts']['int_status']
+        logging.info("status: %s", status)
+        return status[dut_intf]['oper_state'] == exp_status
+
+    def linkflap_down(self, fanout, fanport, dut, dut_intf):
+        """
+        Brings down an interface on a fanout and polls the DUT for the interface to be operationally down.
+
+        Args:
+            fanout: Instance of fanouthost.
+            fanport: Port on the fanout to bring down.
+            dut: Instance of duthost.
+            dut_intf: DUT interface that connects to fanout port.
+
+        Raises:
+            pytest.Failed of DUT interface does not go down.
+
+        """
+        logger.info("Bring down link: %s/%s <-> %s/%s", fanout.hostname, fanport, dut.hostname, dut_intf)
+        fanout.shutdown(fanport)
+        pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'down'),
+                      "dut port {} didn't go down as expected".format(dut_intf))
+
+    def linkflap_up(self, fanout, fanport, dut, dut_intf):
+        """
+        Brings up an interface on a fanout and polls the DUT for the interface to be operationally up.
+
+        Args:
+            fanout: Instance of fanouthost.
+            fanport: Port on the fanout to bring down.
+            dut: Instance of duthost.
+            dut_intf: DUT interface that connects to fanout port.
+
+        Raises:
+            pytest.Failed of DUT interface does not go up.
+
+        """
+        logger.info("Bring up link: %s/%s <-> %s/%s", fanout.hostname, fanport, dut.hostname, dut_intf)
+        fanout.no_shutdown(fanport)
+        pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'up'),
+                      "dut port {} didn't go down as expected".format(dut_intf))
+
+    def localport_admindown(self, dut, dut_intf):
+        """
+        Admins down a port on the DUT and polls for oper status to be down.
+
+        Args:
+            dut: Instance of duthost.
+            dut_intf: Port to admin down.
+
+        Raises:
+            pytest.Failed of DUT interface does not go down.
+
+        """
+        logger.info("Admin down port %s/%s", dut.hostname, dut_intf)
+        dut.shutdown(dut_intf)
+        pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'down'),
+                      "dut port {} didn't go down as expected".format(dut_intf))
+
+    def localport_adminup(self, dut, dut_intf):
+        """
+        Admins up a port on the DUT and polls for oper status to be up.
+
+        Args:
+            dut: Instance of duthost.
+            dut_intf: Port to admin up.
+
+        Raises:
+            pytest.Failed of DUT interface does not go up.
+
+        """
+        logger.info("Admin up port %s/%s", dut.hostname, dut_intf)
+        dut.no_shutdown(dut_intf)
+        pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'up'),
+                      "dut port {} didn't go up as expected".format(dut_intf))
+
+
+def pick_ports(cfg_facts):
+    """
+    Selects ports to bounce by sampling the interface and port channel lists.
+
+    Args:
+        cfg_facts: The ansible_facts for the asic.
+
+    Returns:
+        intfs: A merged dictionary of ethernet and portchannel interfaces.
+        intfs_to_test: A list of the chosen interfaces names.
+
+    """
+    intfs = {}
+    intfs.update(cfg_facts['INTERFACE'])
+    if "PORTCHANNEL_INTERFACE" in cfg_facts:
+        intfs.update(cfg_facts['PORTCHANNEL_INTERFACE'])
+
+    eths = [intf for intf in intfs if "ethernet" in intf.lower()]
+    pos = [intf for intf in intfs if "portchannel" in intf.lower()]
+
+    intfs_to_test = []
+    if len(eths) > 0:
+        intfs_to_test.extend(random.sample(eths, 1))
+
+    if len(pos) > 0:
+        intfs_to_test.extend(random.sample(pos, 1))
+
+    return intfs, intfs_to_test
+
+
+class TestNeighborLinkFlap(LinkFlap):
+
+    def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                        all_cfg_facts,
+                                        setup, nbrhosts, established_arp):
+        """
+        Verify tables, databases, and kernel routes are correctly deleted when the DUT port is admin down/up.
+
+        Test Steps
+
+        * Admin down interface on DUT.
+        * On local linecard:
+            * Verify ARP/NDP entries are removed from CLI for neighbors on down port.
+            * Verify table entries in ASIC, AppDb are removed for addresses on down port.
+        * On Supervisor card:
+            * Verify Chassis App DB entry are removed for only the cleared address.  Entries for addresses on other
+            line cards should still be present.
+        * On remote linecards:
+            * Verify table entries in ASICDB, APPDB, and host ARP table are removed for cleared addresses.
+            * Verify kernel routes for cleared address are deleted.
+        * Admin interface up, verify recreation after restarting traffic.
+
+        Args:
+            duthosts: duthosts fixture.
+            enum_rand_one_per_hwsku_frontend_hostname: frontend iteration fixture.
+            enum_asic_index: asic iteration fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+            setup: setup fixture for this module.
+            nbrhosts: nbrhosts fixture.
+            established_arp: Fixture to establish ARP to all neighbors.
+
+        """
+
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        neighs = cfg_facts['BGP_NEIGHBOR']
+
+        intfs, intfs_to_test = pick_ports(cfg_facts)
+
+        logger.info("Will test interfaces: %s", intfs_to_test)
+
+        for intf in intfs_to_test:
+            local_ips = [i.split("/")[0] for i in intfs[intf].keys()]  # [u'2064:100::2/64', u'100.0.0.2/24']
+            neighbors = [n for n in neighs if neighs[n]['local_addr'] in local_ips]
+            logger.info("Testing neighbors: %s on intf: %s", neighbors, intf)
+            self.localport_admindown(per_host, intf)
+            try:
+                for neighbor in neighbors:
+                    check_neighbor_is_gone(duthosts, all_cfg_facts, per_host, asic, neighbor)
+            finally:
+                self.localport_adminup(per_host, intf)
+
+            for neighbor in neighbors:
+                sonic_ping(asic, neighbor)
+                check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
+
+
+def make_ndp_grat_ndp_packet(pktlen=64,
+                             eth_dst='00:01:02:03:04:05',
+                             eth_src='00:06:07:08:09:0a',
+                             dl_vlan_enable=False,
+                             vlan_vid=0,
+                             vlan_pcp=0,
+                             ipv6_src='2001:db8:85a3::8a2e:370:7334',
+                             ipv6_dst='2001:db8:85a3::8a2e:370:7335',
+                             ipv6_tc=0,
+                             ipv6_ecn=None,
+                             ipv6_dscp=None,
+                             ipv6_hlim=64,
+                             ipv6_fl=0,
+                             ipv6_tgt='2001:db8:85a3::8a2e:370:7334',
+                             hw_tgt='00:06:07:08:09:0a', ):
+    """
+    Generates a simple NDP advertisement similar to PTF testutils simple_arp_packet.
+
+    Args:
+        pktlen: length of packet
+        eth_dst: etheret destination address.
+        eth_src: ethernet source address
+        dl_vlan_enable: True to add vlan header.
+        vlan_vid: vlan ID
+        vlan_pcp: vlan priority
+        ipv6_src: IPv6 source address
+        ipv6_dst: IPv6 destination address
+        ipv6_tc: IPv6 traffic class
+        ipv6_ecn: IPv6 traffic class ECN
+        ipv6_dscp: IPv6 traffic class DSCP
+        ipv6_hlim: IPv6 hop limit/ttl
+        ipv6_fl: IPv6 flow label
+        ipv6_tgt: ICMPv6 ND advertisement target address.
+        hw_tgt: IPv6 ND advertisement destination link-layer address.
+
+    Returns:
+        Crafted scapy packet for using with send_packet().
+    """
+
+    if MINSIZE > pktlen:
+        pktlen = MINSIZE
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
+
+    pkt = Ether(dst=eth_dst, src=eth_src)
+    if dl_vlan_enable or vlan_vid or vlan_pcp:
+        pkt /= Dot1Q(vlan=vlan_vid, prio=vlan_pcp)
+    pkt /= IPv6(src=ipv6_src, dst=ipv6_dst, fl=ipv6_fl, tc=ipv6_tc, hlim=ipv6_hlim)
+    pkt /= ICMPv6ND_NA(R=0, S=0, O=1, tgt=ipv6_tgt)
+    pkt /= ICMPv6NDOptDstLLAddr(lladdr=hw_tgt)
+    pkt /= ("D" * (pktlen - len(pkt)))
+
+    return pkt
+
+
+class TestGratArp(object):
+    ADDR_OFFSET = 100
+
+    def send_grat_arp(self, vm_mac, vmip, port):
+        """
+        Sends a unsolicited ARP packet.
+
+        Args:
+            vm_mac: Target MAC on the VM to send in packet.
+            vmip: Target IP on the VM to send in ARP packet.
+            port: PTF port number
+
+        """
+        logger.info("Send GRAT ARP on port: %s, hwsnd=%s, hwtgt: bcast, ipsnd=iptgt=%s", port, vm_mac, vmip)
+        pkt = simple_arp_packet(
+            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_src=vm_mac,
+            arp_op=1,
+            ip_snd=vmip,
+            ip_tgt=vmip,
+            hw_snd=vm_mac,
+            hw_tgt='ff:ff:ff:ff:ff:ff',
+        )
+
+        send_packet(self.ptfadapter, port, pkt)
+
+    def send_grat_ndp(self, vm_mac, vmip, port):
+        """
+        Sends an IPv6 Neighbor Advertisement packet.
+
+        Args:
+            vm_mac: Target MAC on the VM to send in packet.
+            vmip: Target IP on the VM to send in NDP packet.
+            port: PTF port number
+
+        """
+        logger.info("Send GRAT NDP on port: %s, hwsnd=%s, hwtgt: bcast, ipsnd=iptgt=%s", port, vm_mac, vmip)
+        pkt = make_ndp_grat_ndp_packet(eth_dst='33:33:00:00:00:01',
+                                       eth_src=vm_mac,
+                                       ipv6_src=vmip,
+                                       ipv6_dst="ff02::1",
+                                       ipv6_tgt=vmip,
+                                       hw_tgt=vm_mac,
+                                       )
+        send_packet(self.ptfadapter, port, pkt)
+        time.sleep(0.500)
+        send_packet(self.ptfadapter, port, pkt)
+
+    def send_grat_pkt(self, vm_mac, vmip, port):
+        """
+        Send a unsolicited ARP or NDP packet.
+
+        Args:
+            vm_mac: Target MAC on the VM to send in packet.
+            vmip: Target IP on the VM to send in ARP packet.
+            port: PTF port number
+
+        """
+        if ":" in vmip:
+            self.send_grat_ndp(vm_mac, vmip, port)
+        else:
+            self.send_grat_arp(vm_mac, vmip, port)
+        logger.info("Grat packet sent.")
+
+    def test_gratarp_macchange(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                               ptfadapter, tbinfo, nbrhosts,
+                               setup, established_arp, all_cfg_facts):
+        """
+        Verify tables, databases, and kernel routes are correctly updated when a unsolicited ARP packet changes
+        the MAC address of learned neighbor.
+
+        Test Steps
+
+        * Send unsolicited ARP packet into DUT for an IP known by DUT with a different MAC address for the neighbor.
+        * Change the MAC address of the neighbor VM.
+        * On local linecard:
+            * Verify table entries in local ASIC, APP, and host ARP table are updated with new MAC.
+        * On supervisor card:
+            * Verify Chassis App DB entry is correct for with the updated MAC address.
+        * On remote linecards:
+            * Verify table entries in remote hosts/ASICs in APPDB, and host ARP table are still present with inband MAC
+              address
+            * Verify ASIC DB is updated with new MAC.
+            * Verify kernel route in remote hosts are still present to inband port.
+        * Verify that packets can be sent from local and remote linecards to learned address.
+
+        Args:
+            duthosts: The duthosts fixture
+            enum_rand_one_per_hwsku_frontend_hostname: frontend enumeration fixture
+            enum_asic_index: asic enumeration fixture
+            ptfadapter: The ptfadapter fixure.
+            tbinfo: The tbinfo fixture
+            nbrhosts: The nbrhosts fixture.
+            setup: The setup fixture from this module.
+            established_arp: The established_arp fixture from this module.
+            all_cfg_facts: The all_cfg_facts fixture from voq/contest.py
+
+
+        """
+        self.ptfadapter = ptfadapter
+        devices = {}
+        for k, v in tbinfo['topo']['properties']['topology']['VMs'].items():
+            devices[k] = {'vlans': v['vlans']}
+        logger.info("devices: %s", devices)
+
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+        asic = duthost.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[duthost.hostname][asic.asic_index]['ansible_facts']
+
+        neighs = cfg_facts['BGP_NEIGHBOR']
+        for neighbor in neighs:
+            if ":" in neighbor:
+                # TODO: Fix IPV6 packet transmission.
+                continue
+            local_ip = neighs[neighbor]['local_addr']
+
+            local_port = get_port_by_ip(cfg_facts, local_ip)
+            if "portchannel" in local_port.lower():
+                logger.info("Skip portchannel, MAC change doesn't seem supported on CEOS docker.")
+                continue
+            else:
+                inject_port = local_port
+
+            nbrinfo = get_neighbor_info(neighbor, nbrhosts)
+
+            # 0.1@1 = dut_index.dut_port@ptfport
+            tb_port = devices[nbrinfo['vm']]['vlans'][0].split("@")[1]
+            logging.info("%s port %s is on ptf port: %s", duthost.hostname, inject_port, tb_port)
+
+            original_mac = nbrinfo['mac']
+
+            logger.info("*" * 60)
+            logger.info("Verify initial neighbor: %s, port %s", neighbor, local_port)
+            sonic_ping(asic, neighbor)
+            pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, original_mac),
+                          "MAC {} didn't change in ARP table".format(original_mac))
+
+            check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
+
+            try:
+                change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], NEW_MAC)
+                self.send_grat_pkt(NEW_MAC, neighbor, int(tb_port))
+
+                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, NEW_MAC, checkstate=False),
+                              "MAC {} didn't change in ARP table".format(NEW_MAC))
+                sonic_ping(asic, neighbor)
+                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, NEW_MAC, checkstate=True),
+                              "MAC {} didn't change in ARP table".format(NEW_MAC))
+                check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
+                ping_all_neighbors(duthosts, [neighbor])
+            finally:
+                logger.info("Will Restore ethernet mac on neighbor: %s, port %s, vm %s", neighbor,
+                            nbrinfo['shell_intf'], nbrinfo['vm'])
+                change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], original_mac)
+                sonic_ping(asic, neighbor)
+                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, original_mac),
+                              "MAC {} didn't change in ARP table".format(original_mac))
+            sonic_ping(asic, neighbor)
+            check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
+            ping_all_neighbors(duthosts, [neighbor])

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -68,7 +68,7 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
 
                 node_results.append(node.command("sudo config bgp shutdown neighbor {}".format(neighbor)))
 
-        results[node['host'].hostname] = node_results
+        results[node.hostname] = node_results
 
     parallel_run(disable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=120)
 
@@ -168,7 +168,7 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
                     "docker exec bgp vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
                         asnum, neighbor)))
 
-        results[node['host'].hostname] = node_results
+        results[node.hostname] = node_results
 
     parallel_run(enable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=120)
 
@@ -298,7 +298,7 @@ def poll_neighbor_table_delete(duthosts, neighs, delay=1, poll_time=180):
                     else:
                         node_cleared = True
 
-    logger.info("Neighbor poll ends after %s seconds", str(time.time()-t0))
+    logger.info("Neighbor poll ends after %s seconds", str(time.time() - t0))
 
 
 def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
@@ -795,7 +795,7 @@ class TestNeighborLinkFlap(LinkFlap):
 
             for neighbor in neighbors:
                 pytest_assert(wait_until(60, 2, check_arptable_state, per_host, neighbor, "REACHABLE"),
-                              "STATE for neighbor %s did not change to reachable".format(neighbor))
+                              "STATE for neighbor {} did not change to reachable".format(neighbor))
 
             dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighbors, nbrhosts, all_cfg_facts, nbr_macs)
 

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -439,28 +439,6 @@ def get_inband_info(cfg_facts):
     return ret
 
 
-def get_vm_with_ip(neigh_ip, nbrhosts):
-    """
-    Finds the EOS VM and port with a specific IP Address.
-
-    Args:
-        neigh_ip: IP address to find.
-        nbrhosts: nbrhosts fixture.
-
-    Returns:
-        A dictionary with the vm index for nbrhosts, and port name.
-    """
-    for a_vm in nbrhosts:
-        for port, a_intf in nbrhosts[a_vm]['conf']['interfaces'].iteritems():
-            if 'ipv4' in a_intf and a_intf['ipv4'].split("/")[0] == neigh_ip:
-                return {"vm": a_vm, "port": port}
-            if 'ipv6' in a_intf and a_intf['ipv6'].split("/")[0].lower() == neigh_ip.lower():
-                return {"vm": a_vm, "port": port}
-    logger.error("Could not find vm connected to neighbor IP: %s", neigh_ip)
-    logger.info("nbrhosts: {}".format(json.dumps(nbrhosts, indent=4)))
-    return None
-
-
 def get_port_by_ip(cfg_facts, ipaddr):
     """
     Returns the port which has a given IP address from the dut config.
@@ -755,7 +733,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
 
         # supervisor checks
         for entry in voq_dump:
-            matchstr = ':%s' % neighbor
+            matchstr = '|%s' % neighbor
             if entry.endswith(matchstr):
 
                 if "portchannel" in local_port.lower():
@@ -768,7 +746,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
                 logger.debug("Neigh key: %s, slotnum: %s", entry, slotname)
                 pytest_assert("|%s|" % slotname in entry,
                               "Slot for %s does not match %s" % (entry, slotname))
-                pytest_assert("|%s:" % local_port in entry,
+                pytest_assert("|%s|" % local_port in entry,
                               "Port for %s does not match %s" % (entry, local_port))
                 pytest_assert("|%s|" % asicname in entry,
                               "Asic for %s does not match %s" % (entry, asicname))
@@ -781,7 +759,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
                                                                          voq_dump[entry]['value']['encap_index'].lower()))
                 break
         else:
-            logger.error("Neighbor: %s on slot: %s, asic: %s not present in voq", neighbor, sysport_info['slot'])
+            logger.error("Neighbor: %s on slot: %s, asic: %s not present in voq", neighbor, sysport_info['slot'], sysport_info['asic'])
             fail_cnt += 1
 
         logger.info("Local %s/%s and chassisdb neighbor validation of %s is successful",
@@ -1206,4 +1184,3 @@ def eos_ping(eos, ipaddr, count=2, timeout=3, interface=None, size=None, ttl=Non
         raise AssertionError("Ping failed: %s" % output['parsed'])
 
     return output
-

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -433,7 +433,7 @@ def get_inband_info(cfg_facts):
                 if ':' in intf_ip[0]:
                     ret['ipv6_addr'] = intf_ip[0]
                     ret['ipv6_mask'] = intf_ip[1]
-                elif ':' not in intf_ip[0]:
+                else:
                     ret['ipv4_addr'] = intf_ip[0]
                     ret['ipv4_mask'] = intf_ip[1]
     return ret

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -281,13 +281,12 @@ def check_voq_remote_neighbor(host, asic, neighbor_ip, neighbor_mac, interface, 
     check_neighbor_kernel_route(host, asic.asic_index, neighbor_ip, interface)
 
 
-def check_rif_on_sup(sup, rif, slot, asic, port):
+def check_rif_on_sup(sup, slot, asic, port):
     """
     Checks the router interface entry on the supervisor card.
 
     Args:
         sup: duthost for the supervisor card
-        rif: OID of the router interface to check for.
         slot: The slot number the router interface is on.
         asic: The asic number the asic is on, or 0 if a single asic card.
         port: the name of the port (Ethernet1)
@@ -726,7 +725,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
                     fail_cnt += 1
                 else:
                     logger.debug("Asic neighbor macs for %s match: %s == %s", neighbor, neigh_mac.lower(),
-                                asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS'].lower())
+                                 asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS'].lower())
                 encaps[neighbor] = asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX']
                 break
         else:
@@ -743,7 +742,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
                     fail_cnt += 1
                 else:
                     logger.debug("App neighbor macs for %s match: %s == %s", neighbor, neigh_mac.lower(),
-                                app_dump[entry]['value']['neigh'].lower())
+                                 app_dump[entry]['value']['neigh'].lower())
 
                 pytest_assert(":{}:".format(local_port) in entry, "Port for %s does not match" % entry)
                 break
@@ -863,7 +862,7 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
                     fail_cnt += 1
                 else:
                     logger.debug("Asic neighbor macs for %s match: %s == %s", neighbor, neigh_mac.lower(),
-                                asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS'].lower())
+                                 asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS'].lower())
 
                 if encap_id != asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX']:
                     logger.error("Asic neighbor encap for %s do not match: %s != %s", neighbor, encap_id,
@@ -871,7 +870,7 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
                     fail_cnt += 1
                 else:
                     logger.debug("Asic neighbor encap for %s match: %s == %s", neighbor, encap_id,
-                                asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX'])
+                                 asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX'])
 
                 pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX'] == "true",
                               "Encap impose is not true in asicDB")
@@ -893,7 +892,7 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
                     fail_cnt += 1
                 else:
                     logger.debug("App neighbor macs for %s match: %s == %s", neighbor, remote_inband_mac.lower(),
-                                app_dump[entry]['value']['neigh'].lower())
+                                 app_dump[entry]['value']['neigh'].lower())
 
                 pytest_assert(":{}:".format(remote_inband_info['port']) in entry, "Port for %s does not match" % entry)
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Implement neighbor and forwarding tests from Distributed VoQ test plan.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Implement automated tests to cover the neighbor lifecycle and host IP forwarding sections of the [Distributed VoQ Testplan](https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/Distributed-VoQ-Arch-test-plan.md)

#### How did you do it?

Two new test scripts were added, test_voq_nbr.py, and test_voq_ipfwd.py.  Additional helpers were added to support these tests, and neighbor validation code was moved from test_voq_init.py to the helper library for code sharing.

test_voq_nbr.py includes tests for clearing the ARP and NDP tables, all at once, and one entry at a time.  It also includes tests for MAC address change of the VM with and without unsolicited ARP.  Port admin down test is present, and link flap will be added in a future PR.  The test script also uses a shared setup fixture to bring down BGP neighbors so the ARP entries aren't immediately relearned after an action, to give the test time to do verifications.  The neighbors are brought back up at the end of the script.

test_voq_ipfwd.py implements the "Host IP Forwarding" section of the VoQ test plan.  It includes the table validation, link flap and the various positive and negative tests described in the test plan.  Not all ports in the T2 topology are tested, there is a function to select 4 ports to use a traffic endpoints and the primary test port is a parameter to all of the test functions.

voq_helpers.py and redis.py were extended to handle neighbor deletes from redis and the Sonic ARP/route tables.  Shared fixtures were relocated to conftest.py and the nbrhosts_facts fixture from test_voq_init.py was eliminated, as it was unnecessary.

The existing test_voq_init.py script was updated to use the enum_frontend_dut_hostname fixture for the tests, which eliminate the loops in the tests.  The neighbor validation code for test_voq_neighbor_create was moved to voq_helpers so it could be shared with the test_voq_nbr.py script.


#### How did you verify/test it?
Ran against a chassis with a T2 topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T2

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
