### PR TITLE
[pretest] Stop pfcwd on dual tor testbed

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -28,6 +28,13 @@ def pytest_addoption(parser):
     parser.addoption('--fake-storm', action='store', type=bool, default=True,
                      help='Fake storm for most ports instead of using pfc gen')
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_pfcwd_test_dualtor(tbinfo):
+    if 'dualtor' in tbinfo['topo']['name']:
+        pytest.skip("Pfcwd tests skipped on dual tor testbed")
+
+    yield
+
 @pytest.fixture(scope="module")
 def fake_storm(request, duthosts, rand_one_dut_hostname):
     """

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -29,7 +29,7 @@ PTF_PASS_RATIO_THRESH = 0.6
 MAX_TEST_INTFS_COUNT = 4
 
 @pytest.fixture(scope="module", autouse=True)
-def pfc_test_setup(duthosts, rand_one_dut_hostname):
+def pfc_test_setup(duthosts, rand_one_dut_hostname, tbinfo):
     """
     Generate configurations for the tests
 
@@ -73,7 +73,8 @@ def pfc_test_setup(duthosts, rand_one_dut_hostname):
                 }
 
     """ Enable DUT's PFC wd """
-    duthost.shell('sudo pfcwd start_default')
+    if 'dualtor' not in tbinfo['topo']['name']:
+        duthost.shell('sudo pfcwd start_default')
 
 def run_test(pfc_test_setup, fanouthosts, duthost, ptfhost, conn_graph_facts,
              fanout_info, traffic_params, pause_prio=None, queue_paused=True,

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -207,6 +207,16 @@ def test_inject_y_cable_simulator_client(duthosts, enum_dut_hostname, tbinfo):
     dut.shell('docker cp /tmp/y_cable_simulator_client.py pmon:/usr/lib/python3/dist-packages/')
     dut.shell('systemctl restart pmon')
 
+def test_stop_pfcwd(duthosts, enum_dut_hostname, tbinfo):
+    '''
+     Stop pfcwd on dual tor testbeds
+    '''
+    if 'dualtor' not in tbinfo['topo']['name']:
+        pytest.skip("Skip this test on non dualTOR testbeds")
+
+    dut = duthosts[enum_dut_hostname]
+    dut.command('pfcwd stop')
+
 """
     Separator for internal pretests.
     Please add public pretest above this comment and keep internal


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Stop pfcwd on dual tor testbeds to avoid the continuous log messages seen due to missing buffer templates
Feb 20 06:35:25.709727 str2-7050cx3-acs-06 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet4
Feb 20 06:35:25.709868 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet40
Feb 20 06:35:25.710021 str2-7050cx3-acs-06 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet40
Feb 20 06:35:25.710163 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet44

Added fixture to skip the pfcwd tests on dual tor and also ensure that pfcwd does not get started on dual tor testbeds in other testcases as well

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

