### PR TITLE
[multi-asic][minigraph]: Add changes to support minigraph generation for multi-asic

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -48,6 +48,11 @@
     - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
       when: inventory_hostname not in testbed_facts['duts']
 
+    - name: Set default num_asic
+      set_fact:
+        num_asics: 1
+      when: num_asics is not defined
+
     - name: Set default dut index
       set_fact:
         dut_index: "{{ testbed_facts['duts_map'][inventory_hostname]|int }}"
@@ -66,11 +71,11 @@
     delegate_to: localhost
 
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}"
+    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
-    port_alias: hwsku="{{ hwsku }}"
+    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 
@@ -148,11 +153,11 @@
   # create map of VM to asic interface names
   - name: find all interface asic names
     set_fact:
-      vm_asic_ifnames: "{{ vm_asic_ifnames | default({}) | combine({item.0.name: vm_asic_ifnames[item.0.name]|default([]) + [ asic_ifnames[item.1]] }) }}"
+      vm_asic_ifnames: "{{ vm_asic_ifnames | default({}) | combine({item.0.name: vm_asic_ifnames[item.0.name]|default([]) + [ front_panel_asic_ifnames[item.1]] }) }}"
     with_subelements:
       - "{{ interface_to_vms }}"
       - "ports"
-    when: asic_ifnames != [] 
+    when: front_panel_asic_ifnames != [] 
 
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2
@@ -356,6 +361,11 @@
         register: docker_status
 
       - debug: msg={{ docker_status.stdout_lines }}
+
+      - name: start topology service for multi-asic platform
+        become: true
+        shell: systemctl start topology.service
+        when: start_topo_service is defined and start_topo_service|bool == true
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -62,7 +62,7 @@
       when: "testbed_facts['vm_base'] != ''"
     when: testbed_name is defined
 
-  - topo_facts: topo={{ topo }}
+  - topo_facts: topo={{ topo }} hwsku={{ hwsku }}
     delegate_to: localhost
 
   - name: find interface name mapping and individual interface speed if defined from dut
@@ -144,6 +144,15 @@
     with_subelements:
       - "{{ interface_to_vms }}"
       - "ports"
+
+  # create map of VM to asic interface names
+  - name: find all interface asic names
+    set_fact:
+      vm_asic_ifnames: "{{ vm_asic_ifnames | default({}) | combine({item.0.name: vm_asic_ifnames[item.0.name]|default([]) + [ asic_ifnames[item.1]] }) }}"
+    with_subelements:
+      - "{{ interface_to_vms }}"
+      - "ports"
+    when: asic_ifnames != [] 
 
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -95,9 +95,9 @@ class SonicPortAliasMap():
         aliasmap = {}
         portspeed = {}
         # Front end interface asic names
-        asicifnames = []
+        front_panel_asic_ifnames = []
         # All asic names
-        asicnames = []
+        asic_if_names = []
 
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
@@ -144,12 +144,12 @@ class SonicPortAliasMap():
                             portspeed[alias] = mapping[speed_index]
                         if (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
-                            asicifnames.append(asicifname)
+                            front_panel_asic_ifnames.append(asicifname)
                     if (asic_name_index != -1) and (len(mapping) > asic_name_index):
-                        asicname = mapping[asic_name_index]
-                        asicnames.append(asicname)
+                        asicifname = mapping[asic_name_index]
+                        asic_if_names.append(asicifname)
 
-        return (aliases, portmap, aliasmap, portspeed, asicifnames, asicnames)
+        return (aliases, portmap, aliasmap, portspeed, front_panel_asic_ifnames, asic_if_names)
 
 def main():
     module = AnsibleModule(
@@ -166,10 +166,10 @@ def main():
         aliasmap = {}
         portspeed = {}
         allmap = SonicPortAliasMap(m_args['hwsku'])
-        # Front end interface asic names
-        asicifnames = []
+        # ASIC interface names of front panel interfaces 
+        front_panel_asic_ifnames = []
         # { asic_name: [ asic interfaces] }
-        asicnames = {}
+        asic_if_names = {}
 
         # When this script is invoked on sonic-mgmt docker, num_asic 
         # parameter is passed.
@@ -185,7 +185,7 @@ def main():
         for asic_id in range(num_asic):
             if num_asic == 1:
                 asic_id = None
-            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, asicifnames_asic, asicnames_asic) = allmap.get_portmap(asic_id)
+            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, asicifnames_asic) = allmap.get_portmap(asic_id)
             if aliases_asic is not None:
                 aliases.extend(aliases_asic)
             if portmap_asic is not None:
@@ -194,17 +194,17 @@ def main():
                 aliasmap.update(aliasmap_asic)
             if portspeed_asic is not None:
                 portspeed.update(portspeed_asic)
+            if front_panel_asic is not None:
+                front_panel_asic_ifnames.extend(front_panel_asic)
             if asicifnames_asic is not None:
-                asicifnames.extend(asicifnames_asic)
-            if asicnames_asic is not None:
                 asic = 'ASIC' + str(asic_id)
-                asicnames[asic] = asicnames_asic
+                asic_if_names[asic] = asicifnames_asic
         module.exit_json(ansible_facts={'port_alias': aliases,
                                         'port_name_map': portmap,
                                         'port_alias_map': aliasmap,
                                         'port_speed': portspeed,
-                                        'asic_ifnames': asicifnames,
-                                        'asic_names': asicnames})
+                                        'front_panel_asic_ifnames': front_panel_asic_ifnames,
+                                        'asic_if_names': asic_if_names})
     except (IOError, OSError), e:
         fail_msg = "IO error" + str(e)
         module.fail_json(msg=fail_msg)

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -94,6 +94,11 @@ class SonicPortAliasMap():
         portmap = {}
         aliasmap = {}
         portspeed = {}
+        # Front end interface asic names
+        asicifnames = []
+        # All asic names
+        asicnames = []
+
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
             raise Exception("Something wrong when trying to find the portmap file, either the hwsku is not available or file location is not correct")
@@ -102,6 +107,7 @@ class SonicPortAliasMap():
         alias_index = -1
         speed_index = -1
         role_index = -1
+        asic_name_index = -1
         while len(lines) != 0:
             line = lines.pop(0)
             if re.match('^#', line):
@@ -115,6 +121,8 @@ class SonicPortAliasMap():
                             speed_index = index
                         if 'role' in text:
                             role_index = index
+                        if 'asic_port_name' in text:
+                            asic_name_index = index
             else:
                 #added support to parse recycle port
                 if re.match('^Ethernet', line) or re.match('^Inband', line):
@@ -134,8 +142,14 @@ class SonicPortAliasMap():
                         aliasmap[alias] = name
                         if (speed_index != -1) and (len(mapping) > speed_index):
                             portspeed[alias] = mapping[speed_index]
+                        if (asic_name_index != -1) and (len(mapping) > asic_name_index):
+                            asicifname = mapping[asic_name_index]
+                            asicifnames.append(asicifname)
+                    if (asic_name_index != -1) and (len(mapping) > asic_name_index):
+                        asicname = mapping[asic_name_index]
+                        asicnames.append(asicname)
 
-        return (aliases, portmap, aliasmap, portspeed)
+        return (aliases, portmap, aliasmap, portspeed, asicifnames, asicnames)
 
 def main():
     module = AnsibleModule(
@@ -152,6 +166,11 @@ def main():
         aliasmap = {}
         portspeed = {}
         allmap = SonicPortAliasMap(m_args['hwsku'])
+        # Front end interface asic names
+        asicifnames = []
+        # { asic_name: [ asic interfaces] }
+        asicnames = {}
+
         # When this script is invoked on sonic-mgmt docker, num_asic 
         # parameter is passed.
         if m_args['num_asic'] is not None:
@@ -166,7 +185,7 @@ def main():
         for asic_id in range(num_asic):
             if num_asic == 1:
                 asic_id = None
-            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic) = allmap.get_portmap(asic_id)
+            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, asicifnames_asic, asicnames_asic) = allmap.get_portmap(asic_id)
             if aliases_asic is not None:
                 aliases.extend(aliases_asic)
             if portmap_asic is not None:
@@ -175,10 +194,17 @@ def main():
                 aliasmap.update(aliasmap_asic)
             if portspeed_asic is not None:
                 portspeed.update(portspeed_asic)
+            if asicifnames_asic is not None:
+                asicifnames.extend(asicifnames_asic)
+            if asicnames_asic is not None:
+                asic = 'ASIC' + str(asic_id)
+                asicnames[asic] = asicnames_asic
         module.exit_json(ansible_facts={'port_alias': aliases,
                                         'port_name_map': portmap,
                                         'port_alias_map': aliasmap,
-                                        'port_speed': portspeed})
+                                        'port_speed': portspeed,
+                                        'asic_ifnames': asicifnames,
+                                        'asic_names': asicnames})
     except (IOError, OSError), e:
         fail_msg = "IO error" + str(e)
         module.fail_json(msg=fail_msg)

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -76,10 +76,16 @@ class ParseTestbedTopoinfo():
             vmconfig[vm]['intfs'] = [[] for i in range(dut_num)]
             if 'properties' in vmconfig[vm]:
                 vmconfig[vm]['properties']=topo_definition['configuration'][vm]['properties']
-            vmconfig[vm]['interface_indexes'] = [[] for i in range(dut_num)]
-            for vlan in topo_definition['topology'][type][vm]['vlans']:
-                (dut_index, vlan_index, _) = parse_vm_vlan_port(vlan)
-                vmconfig[vm]['interface_indexes'][dut_index].append(vlan_index)
+            if type == 'VMs':
+                vmconfig[vm]['interface_indexes'] = [[] for i in range(dut_num)]
+                for vlan in topo_definition['topology'][type][vm]['vlans']:
+                    (dut_index, vlan_index, _) = parse_vm_vlan_port(vlan)
+                    vmconfig[vm]['interface_indexes'][dut_index].append(vlan_index)
+            if type == 'NEIGH_ASIC':
+                vmconfig[vm]['asic_intfs'] = [[] for i in range(dut_num)]
+                dut_index = 0
+                for asic_intf in topo_definition['topology'][type][vm]['asic_intfs']:
+                    vmconfig[vm]['asic_intfs'][dut_index].append(asic_intf)
         
             # physical interface
             for intf in topo_definition['configuration'][vm]['interfaces']:

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -182,7 +182,6 @@ class ParseTestbedTopoinfo():
             dut_asn = topo_definition['configuration_properties']['common']['dut_asn']
             vm_topo_config['dut_asn'] = dut_asn
             vm_topo_config['dut_type'] = topo_definition['configuration_properties']['common']['dut_type']
-            vmconfig = dict()
             vm_topo_config['vm'] = self.parse_topo_defintion(topo_definition, po_map, dut_num, 'VMs')
 
         for asic in asic_definition:
@@ -194,7 +193,6 @@ class ParseTestbedTopoinfo():
             for lo4096 in asic_definition[asic]['configuration_properties']['common']['Loopback4096']:
                 asic_topo_config[asic]['Loopback4096'].append(lo4096)
 
-            asicconfig = dict()
             asic_topo_config[asic]['asic'] = self.parse_topo_defintion(asic_definition[asic], po_map_asic, 1, 'ASICs')
 
         vm_topo_config['host_interfaces_by_dut'] = [[] for i in range(dut_num)]

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -66,8 +66,86 @@ class ParseTestbedTopoinfo():
     '''
     def __init__(self):
         self.vm_topo_config = {}
+        self.asic_topo_config = {}
 
-    def get_topo_config(self, topo_name):
+    def parse_topo_defintion(self, topo_definition, po_map, dut_num, type='VMs'):
+        dut_asn = topo_definition['configuration_properties']['common']['dut_asn']
+        vmconfig = dict()
+        for vm in topo_definition['topology'][type]:
+            vmconfig[vm] = dict()
+            vmconfig[vm]['intfs'] = [[] for i in range(dut_num)]
+            if 'properties' in vmconfig[vm]:
+                vmconfig[vm]['properties']=topo_definition['configuration'][vm]['properties']
+            vmconfig[vm]['interface_indexes'] = [[] for i in range(dut_num)]
+            for vlan in topo_definition['topology'][type][vm]['vlans']:
+                (dut_index, vlan_index, _) = parse_vm_vlan_port(vlan)
+                vmconfig[vm]['interface_indexes'][dut_index].append(vlan_index)
+        
+            # physical interface
+            for intf in topo_definition['configuration'][vm]['interfaces']:
+                if (type == 'VMs' and 'Ethernet' in intf) or \
+                   (type == 'ASICs' and re.match("Eth(\d+)-", intf)):
+                    dut_index = 0
+                    if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
+                        dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
+                    if 'lacp' in topo_definition['configuration'][vm]['interfaces'][intf]:
+                        po_map[topo_definition['configuration'][vm]['interfaces'][intf]['lacp']] = dut_index
+        
+                    vmconfig[vm]['intfs'][dut_index].append(intf)
+        
+            # ip interface
+            vmconfig[vm]['ip_intf'] = [None] * dut_num
+            vmconfig[vm]['peer_ipv4'] = [None] * dut_num
+            vmconfig[vm]['ipv4mask'] = [None] * dut_num
+            vmconfig[vm]['peer_ipv6'] = [None] * dut_num
+            vmconfig[vm]['ipv6mask'] = [None] * dut_num
+        
+        
+            for intf in topo_definition['configuration'][vm]['interfaces']:
+                dut_index = 0
+                if (type == 'VMs' and 'Ethernet' in intf) or \
+                   (type == 'ASICs' and re.match("Eth(\d+)-", intf)):
+                    if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
+                        dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
+                elif 'Port-Channel' in intf:
+                    m = re.search("(\d+)", intf)
+                    dut_index = po_map[int(m.group(1))]
+        
+                if 'ipv4' in topo_definition['configuration'][vm]['interfaces'][intf] and ('loopback' not in intf.lower()):
+                    (peer_ipv4, ipv4_mask) = topo_definition['configuration'][vm]['interfaces'][intf]['ipv4'].split('/')
+                    vmconfig[vm]['peer_ipv4'][dut_index] = peer_ipv4
+                    vmconfig[vm]['ipv4mask'][dut_index] = ipv4_mask
+                    vmconfig[vm]['ip_intf'][dut_index] = intf
+                if 'ipv6' in topo_definition['configuration'][vm]['interfaces'][intf] and ('loopback' not in intf.lower()):
+                    (ipv6_addr, ipv6_mask) = topo_definition['configuration'][vm]['interfaces'][intf]['ipv6'].split('/')
+                    vmconfig[vm]['peer_ipv6'][dut_index] = ipv6_addr.upper()
+                    vmconfig[vm]['ipv6mask'][dut_index] = ipv6_mask
+                    vmconfig[vm]['ip_intf'][dut_index] = intf
+        
+            # bgp
+            vmconfig[vm]['bgp_ipv4'] = [None] * dut_num
+            vmconfig[vm]['bgp_ipv6'] = [None] * dut_num
+            vmconfig[vm]['bgp_asn'] = topo_definition['configuration'][vm]['bgp']['asn']
+            for ipstr in topo_definition['configuration'][vm]['bgp']['peers'][dut_asn]:
+                ip = ipaddress.ip_address(ipstr.decode('utf8'))
+                for dut_index in range(0, dut_num):
+                    if ip.version == 4:
+                        # Each VM might not be connected to all the DUT's, so check if this VM is a peer to DUT at dut_index
+                        if vmconfig[vm]['peer_ipv4'][dut_index]:
+                            ipsubnet_str = vmconfig[vm]['peer_ipv4'][dut_index]+'/'+vmconfig[vm]['ipv4mask'][dut_index]
+                            ipsubnet = ipaddress.ip_interface(ipsubnet_str.decode('utf8'))
+                            if ip in ipsubnet.network:
+                                vmconfig[vm]['bgp_ipv4'][dut_index] = ipstr.upper()
+                    elif ip.version == 6:
+                        # Each VM might not be connected to all the DUT's, so check if this VM is a peer to DUT at dut_index
+                        if vmconfig[vm]['peer_ipv6'][dut_index]:
+                            ipsubnet_str = vmconfig[vm]['peer_ipv6'][dut_index]+'/'+vmconfig[vm]['ipv6mask'][dut_index]
+                            ipsubnet = ipaddress.ip_interface(ipsubnet_str.decode('utf8'))
+                            if ip in ipsubnet.network:
+                                vmconfig[vm]['bgp_ipv6'][dut_index] = ipstr.upper()
+        return vmconfig
+
+    def get_topo_config(self, topo_name, hwsku):
         CLET_SUFFIX = "-clet"
 
         if 'ptf32' in topo_name:
@@ -76,7 +154,9 @@ class ParseTestbedTopoinfo():
             topo_name = 't1-64'
         topo_name = re.sub(CLET_SUFFIX + "$", "", topo_name)
         topo_filename = 'vars/topo_' + topo_name + '.yml'
+        asic_topo_filename = 'vars/topo_' + hwsku + '.yml'
         vm_topo_config = dict()
+        asic_topo_config = dict()
         po_map = [None] * 16   # maximum 16 port channel interfaces
 
         ### read topology definition
@@ -85,6 +165,12 @@ class ParseTestbedTopoinfo():
         else:
             with open(topo_filename) as f:
                 topo_definition = yaml.load(f)
+
+        if not os.path.isfile(asic_topo_filename):
+            asic_definition = {}
+        else:
+            with open(asic_topo_filename) as f:
+                asic_definition = yaml.load(f)
 
         ### parse topo file specified in vars/ to reverse as dut config
         dut_num = 1
@@ -97,77 +183,19 @@ class ParseTestbedTopoinfo():
             vm_topo_config['dut_asn'] = dut_asn
             vm_topo_config['dut_type'] = topo_definition['configuration_properties']['common']['dut_type']
             vmconfig = dict()
-            for vm in topo_definition['topology']['VMs']:
-                vmconfig[vm] = dict()
-                vmconfig[vm]['intfs'] = [[] for i in range(dut_num)]
-                vmconfig[vm]['properties']=topo_definition['configuration'][vm]['properties']
-                vmconfig[vm]['interface_indexes'] = [[] for i in range(dut_num)]
-                for vlan in topo_definition['topology']['VMs'][vm]['vlans']:
-                    (dut_index, vlan_index, _) = parse_vm_vlan_port(vlan)
-                    vmconfig[vm]['interface_indexes'][dut_index].append(vlan_index)
+            vm_topo_config['vm'] = self.parse_topo_defintion(topo_definition, po_map, dut_num, 'VMs')
 
-                # physical interface
-                for intf in topo_definition['configuration'][vm]['interfaces']:
-                    if 'Ethernet' in intf:
-                        dut_index = 0
-                        if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
-                            dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
-                        if 'lacp' in topo_definition['configuration'][vm]['interfaces'][intf]:
-                            po_map[topo_definition['configuration'][vm]['interfaces'][intf]['lacp']] = dut_index
+        for asic in asic_definition:
+            po_map_asic = [None] * 16   # maximum 16 port channel interfaces
+            asic_topo_config[asic] = dict()
+            asic_topo_config[asic]['dut_asn'] = asic_definition[asic]['configuration_properties']['common']['dut_asn']
+            asic_topo_config[asic]['asic_type'] = asic_definition[asic]['configuration_properties']['common']['asic_type']
+            asic_topo_config[asic]['Loopback4096'] = []
+            for lo4096 in asic_definition[asic]['configuration_properties']['common']['Loopback4096']:
+                asic_topo_config[asic]['Loopback4096'].append(lo4096)
 
-                        vmconfig[vm]['intfs'][dut_index].append(intf)
-
-                # ip interface
-                vmconfig[vm]['ip_intf'] = [None] * dut_num
-                vmconfig[vm]['peer_ipv4'] = [None] * dut_num
-                vmconfig[vm]['ipv4mask'] = [None] * dut_num
-                vmconfig[vm]['peer_ipv6'] = [None] * dut_num
-                vmconfig[vm]['ipv6mask'] = [None] * dut_num
-
-
-                for intf in topo_definition['configuration'][vm]['interfaces']:
-                    dut_index = 0
-                    if 'Ethernet' in intf:
-                        if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
-                            dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
-                    elif 'Port-Channel' in intf:
-                        m = re.search("(\d+)", intf)
-                        dut_index = po_map[int(m.group(1))]
-
-                    if 'ipv4' in topo_definition['configuration'][vm]['interfaces'][intf] and ('loopback' not in intf.lower()):
-                        (peer_ipv4, ipv4_mask) = topo_definition['configuration'][vm]['interfaces'][intf]['ipv4'].split('/')
-                        vmconfig[vm]['peer_ipv4'][dut_index] = peer_ipv4
-                        vmconfig[vm]['ipv4mask'][dut_index] = ipv4_mask
-                        vmconfig[vm]['ip_intf'][dut_index] = intf
-                    if 'ipv6' in topo_definition['configuration'][vm]['interfaces'][intf] and ('loopback' not in intf.lower()):
-                        (ipv6_addr, ipv6_mask) = topo_definition['configuration'][vm]['interfaces'][intf]['ipv6'].split('/')
-                        vmconfig[vm]['peer_ipv6'][dut_index] = ipv6_addr.upper()
-                        vmconfig[vm]['ipv6mask'][dut_index] = ipv6_mask
-                        vmconfig[vm]['ip_intf'][dut_index] = intf
-
-                # bgp
-                vmconfig[vm]['bgp_ipv4'] = [None] * dut_num
-                vmconfig[vm]['bgp_ipv6'] = [None] * dut_num
-                vmconfig[vm]['bgp_asn'] = topo_definition['configuration'][vm]['bgp']['asn']
-                for ipstr in topo_definition['configuration'][vm]['bgp']['peers'][dut_asn]:
-                    ip = ipaddress.ip_address(ipstr.decode('utf8'))
-                    for dut_index in range(0, dut_num):
-                        if ip.version == 4:
-                            # Each VM might not be connected to all the DUT's, so check if this VM is a peer to DUT at dut_index
-                            if vmconfig[vm]['peer_ipv4'][dut_index]:
-                                ipsubnet_str = vmconfig[vm]['peer_ipv4'][dut_index]+'/'+vmconfig[vm]['ipv4mask'][dut_index]
-                                ipsubnet = ipaddress.ip_interface(ipsubnet_str.decode('utf8'))
-                                if ip in ipsubnet.network:
-                                    vmconfig[vm]['bgp_ipv4'][dut_index] = ipstr.upper()
-                        elif ip.version == 6:
-                            # Each VM might not be connected to all the DUT's, so check if this VM is a peer to DUT at dut_index
-                            if vmconfig[vm]['peer_ipv6'][dut_index]:
-                                ipsubnet_str = vmconfig[vm]['peer_ipv6'][dut_index]+'/'+vmconfig[vm]['ipv6mask'][dut_index]
-                                ipsubnet = ipaddress.ip_interface(ipsubnet_str.decode('utf8'))
-                                if ip in ipsubnet.network:
-                                    vmconfig[vm]['bgp_ipv6'][dut_index] = ipstr.upper()
-
-            vm_topo_config['vm'] = vmconfig
+            asicconfig = dict()
+            asic_topo_config[asic]['asic'] = self.parse_topo_defintion(asic_definition[asic], po_map_asic, 1, 'ASICs')
 
         vm_topo_config['host_interfaces_by_dut'] = [[] for i in range(dut_num)]
         if 'host_interfaces' in topo_definition['topology']:
@@ -191,22 +219,26 @@ class ParseTestbedTopoinfo():
             vm_topo_config['DUT'] = {}
 
         self.vm_topo_config = vm_topo_config
-        return vm_topo_config
+        self.asic_topo_config = asic_topo_config
+        return vm_topo_config, asic_topo_config
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
             topo=dict(required=True, default=None),
+            hwsku=dict(required=True, default=None),
         ),
         supports_check_mode=True
     )
     m_args = module.params
     topo_name = m_args['topo']
+    hwsku = m_args['hwsku']
     try:
         topoinfo = ParseTestbedTopoinfo()
-        vm_topo_config = topoinfo.get_topo_config(topo_name)
-        module.exit_json(ansible_facts={'vm_topo_config': vm_topo_config})
+        vm_topo_config, asic_topo_config = topoinfo.get_topo_config(topo_name, hwsku)
+        module.exit_json(ansible_facts={'vm_topo_config': vm_topo_config,
+                                        'asic_topo_config': asic_topo_config})
     except (IOError, OSError):
         module.fail_json(msg="Can not find topo file for %s" % topo_name)
     except Exception as e:

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -84,7 +84,7 @@ class ParseTestbedTopoinfo():
             # physical interface
             for intf in topo_definition['configuration'][vm]['interfaces']:
                 if (type == 'VMs' and 'Ethernet' in intf) or \
-                   (type == 'ASICs' and re.match("Eth(\d+)-", intf)):
+                   (type == 'NEIGH_ASIC' and re.match("Eth(\d+)-", intf)):
                     dut_index = 0
                     if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
                         dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
@@ -104,7 +104,7 @@ class ParseTestbedTopoinfo():
             for intf in topo_definition['configuration'][vm]['interfaces']:
                 dut_index = 0
                 if (type == 'VMs' and 'Ethernet' in intf) or \
-                   (type == 'ASICs' and re.match("Eth(\d+)-", intf)):
+                   (type == 'NEIGH_ASIC' and re.match("Eth(\d+)-", intf)):
                     if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
                         dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
                 elif 'Port-Channel' in intf:
@@ -193,7 +193,7 @@ class ParseTestbedTopoinfo():
             for lo4096 in asic_definition[asic]['configuration_properties']['common']['Loopback4096']:
                 asic_topo_config[asic]['Loopback4096'].append(lo4096)
 
-            asic_topo_config[asic]['asic'] = self.parse_topo_defintion(asic_definition[asic], po_map_asic, 1, 'ASICs')
+            asic_topo_config[asic]['neigh_asic'] = self.parse_topo_defintion(asic_definition[asic], po_map_asic, 1, 'NEIGH_ASIC')
 
         vm_topo_config['host_interfaces_by_dut'] = [[] for i in range(dut_num)]
         if 'host_interfaces' in topo_definition['topology']:

--- a/ansible/vars/topo_msft_four_asic_vs.yml
+++ b/ansible/vars/topo_msft_four_asic_vs.yml
@@ -2,13 +2,13 @@ ASIC0:
   topology:
     NEIGH_ASIC:
       ASIC2:
-        vlans:
-          - 4
-          - 5
+        asic_intfs:
+          - Eth4-ASIC0
+          - Eth5-ASIC0
       ASIC3:
-        vlans:
-          - 6
-          - 7
+        asic_intfs:
+          - Eth6-ASIC0
+          - Eth7-ASIC0
   configuration_properties:
     common:
       dut_asn: 65100
@@ -51,13 +51,13 @@ ASIC1:
   topology:
     NEIGH_ASIC:
       ASIC2:
-        vlans:
-          - 4
-          - 5
+        asic_intfs:
+          - Eth4-ASIC1
+          - Eth5-ASIC1
       ASIC3:
-        vlans:
-          - 6
-          - 7
+        asic_intfs:
+          - Eth6-ASIC1
+          - Eth7-ASIC1
   configuration_properties:
     common:
       dut_asn: 65100
@@ -100,13 +100,13 @@ ASIC2:
   topology:
     NEIGH_ASIC:
       ASIC0:
-        vlans:
-          - 0
-          - 1
+        asic_intfs:
+          - Eth0-ASIC2
+          - Eth1-ASIC2
       ASIC1:
-        vlans:
-          - 2
-          - 3
+        asic_intfs:
+          - Eth2-ASIC2
+          - Eth3-ASIC2
   configuration_properties:
     common:
       dut_asn: 65100
@@ -149,13 +149,13 @@ ASIC3:
   topology:
     NEIGH_ASIC:
       ASIC0:
-        vlans:
-          - 0
-          - 1
+        asic_intfs:
+          - Eth0-ASIC3
+          - Eth1-ASIC3
       ASIC1:
-        vlans:
-          - 2
-          - 3
+        asic_intfs:
+          - Eth2-ASIC3
+          - Eth3-ASIC3
   configuration_properties:
     common:
       dut_asn: 65100

--- a/ansible/vars/topo_msft_four_asic_vs.yml
+++ b/ansible/vars/topo_msft_four_asic_vs.yml
@@ -1,6 +1,6 @@
 ASIC0:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC2:
         vlans:
           - 4
@@ -49,7 +49,7 @@ ASIC0:
           ipv6: 2603:10e2:400:1::5/126
 ASIC1:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC2:
         vlans:
           - 4
@@ -98,7 +98,7 @@ ASIC1:
           ipv6: 2603:10e2:400:1::d/126
 ASIC2:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC0:
         vlans:
           - 0
@@ -147,7 +147,7 @@ ASIC2:
           ipv6: 2603:10e2:400:1::a/126
 ASIC3:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC0:
         vlans:
           - 0

--- a/ansible/vars/topo_msft_four_asic_vs.yml
+++ b/ansible/vars/topo_msft_four_asic_vs.yml
@@ -1,0 +1,197 @@
+ASIC0:
+  topology:
+    ASICs:
+      ASIC2:
+        vlans:
+          - 4
+          - 5
+      ASIC3:
+        vlans:
+          - 6
+          - 7
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: FrontEnd 
+      Loopback4096:
+        - 8.0.0.0/32
+        - 2603:10e2:400::/128
+  configuration:
+    ASIC2:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.1
+          - 2603:10e2:400:1::2
+      interfaces:
+        Eth0-ASIC2:
+          lacp: 1
+        Eth1-ASIC2:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.0/31
+          ipv6: 2603:10e2:400:1::1/126
+    ASIC3:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.3
+          - 2603:10e2:400:1::6
+      interfaces:
+        Eth0-ASIC3:
+          lacp: 2
+        Eth1-ASIC3:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.2/31
+          ipv6: 2603:10e2:400:1::5/126
+ASIC1:
+  topology:
+    ASICs:
+      ASIC2:
+        vlans:
+          - 4
+          - 5
+      ASIC3:
+        vlans:
+          - 6
+          - 7
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: FrontEnd
+      Loopback4096:
+        - 8.0.0.1/32
+        - 2603:10e2:400::1/128
+  configuration:
+    ASIC2:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.5
+          - 2603:10e2:400:1::a
+      interfaces:
+        Eth2-ASIC2:
+          lacp: 1
+        Eth3-ASIC2:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.4/31
+          ipv6: 2603:10e2:400:1::9/126
+    ASIC3:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.7
+          - 2603:10e2:400:1::e
+      interfaces:
+        Eth2-ASIC3:
+          lacp: 2
+        Eth3-ASIC3:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.6/31
+          ipv6: 2603:10e2:400:1::d/126
+ASIC2:
+  topology:
+    ASICs:
+      ASIC0:
+        vlans:
+          - 0
+          - 1
+      ASIC1:
+        vlans:
+          - 2
+          - 3
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: BackEnd
+      Loopback4096:
+        - 8.0.0.2/32
+        - 2603:10e2:400::2/128
+  configuration:
+    ASIC0:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.0
+          - 2603:10e2:400:1::1
+      interfaces:
+        Eth4-ASIC0:
+          lacp: 1
+        Eth5-ASIC0:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.1/31
+          ipv6: 2603:10e2:400:1::2/126
+    ASIC1:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.4
+          - 2603:10e2:400:1::9
+      interfaces:
+        Eth4-ASIC1:
+          lacp: 2
+        Eth5-ASIC1:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.5/31
+          ipv6: 2603:10e2:400:1::a/126
+ASIC3:
+  topology:
+    ASICs:
+      ASIC0:
+        vlans:
+          - 0
+          - 1
+      ASIC1:
+        vlans:
+          - 2
+          - 3
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: BackEnd
+      Loopback4096:
+        - 8.0.0.3/32
+        - 2603:10e2:400::3/128
+  
+  configuration:
+    ASIC0:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.2
+          - 2603:10e2:400:1::5
+      interfaces:
+        Eth6-ASIC0:
+          lacp: 1
+        Eth7-ASIC0:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.3/31
+          ipv6: 2603:10e2:400:1::6/126
+    ASIC1:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.6
+          - 2603:10e2:400:1::d
+      interfaces:
+        Eth6-ASIC1:
+          lacp: 2
+        Eth7-ASIC1:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.7/31
+          ipv6: 2603:10e2:400:1::e/126

--- a/ansible/vars/topo_msft_multi_asic_vs.yml
+++ b/ansible/vars/topo_msft_multi_asic_vs.yml
@@ -2,25 +2,25 @@ ASIC0:
   topology:
     NEIGH_ASIC:
       ASIC4:
-        vlans:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
-          - 23
+        asic_intfs:
+          - Eth16-ASIC0
+          - Eth17-ASIC0
+          - Eth18-ASIC0
+          - Eth19-ASIC0
+          - Eth20-ASIC0
+          - Eth21-ASIC0
+          - Eth22-ASIC0
+          - Eth23-ASIC0
       ASIC5:
-        vlans:
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
+        asic_intfs:
+          - Eth24-ASIC0
+          - Eth25-ASIC0
+          - Eth26-ASIC0
+          - Eth27-ASIC0
+          - Eth28-ASIC0
+          - Eth29-ASIC0
+          - Eth30-ASIC0
+          - Eth31-ASIC0
   configuration_properties:
     common:
       dut_asn: 65100
@@ -87,25 +87,25 @@ ASIC1:
   topology:
     NEIGH_ASIC:
       ASIC4:
-        vlans:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
-          - 23
+        asic_intfs:
+          - Eth16-ASIC1
+          - Eth17-ASIC1
+          - Eth18-ASIC1
+          - Eth19-ASIC1
+          - Eth20-ASIC1
+          - Eth21-ASIC1
+          - Eth22-ASIC1
+          - Eth23-ASIC1
       ASIC5:
-        vlans:
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
+        asic_intfs:
+          - Eth24-ASIC1
+          - Eth25-ASIC1
+          - Eth26-ASIC1
+          - Eth27-ASIC1
+          - Eth28-ASIC1
+          - Eth29-ASIC1
+          - Eth30-ASIC1
+          - Eth31-ASIC1
   configuration_properties:
     common:
       dut_asn: 65100
@@ -172,25 +172,25 @@ ASIC2:
   topology:
     NEIGH_ASIC:
       ASIC4:
-        vlans:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
-          - 23
+        asic_intfs:
+          - Eth16-ASIC2
+          - Eth17-ASIC2
+          - Eth18-ASIC2
+          - Eth19-ASIC2
+          - Eth20-ASIC2
+          - Eth21-ASIC2
+          - Eth22-ASIC2
+          - Eth23-ASIC2
       ASIC5:
-        vlans:
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
+        asic_intfs:
+          - Eth24-ASIC2
+          - Eth25-ASIC2
+          - Eth26-ASIC2
+          - Eth27-ASIC2
+          - Eth28-ASIC2
+          - Eth29-ASIC2
+          - Eth30-ASIC2
+          - Eth31-ASIC2
   configuration_properties:
     common:
       dut_asn: 65100
@@ -257,25 +257,25 @@ ASIC3:
   topology:
     NEIGH_ASIC:
       ASIC4:
-        vlans:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
-          - 23
+        asic_intfs:
+          - Eth16-ASIC3
+          - Eth17-ASIC3
+          - Eth18-ASIC3
+          - Eth19-ASIC3
+          - Eth20-ASIC3
+          - Eth21-ASIC3
+          - Eth22-ASIC3
+          - Eth23-ASIC3
       ASIC5:
-        vlans:
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
+        asic_intfs:
+          - Eth24-ASIC3
+          - Eth25-ASIC3
+          - Eth26-ASIC3
+          - Eth27-ASIC3
+          - Eth28-ASIC3
+          - Eth29-ASIC3
+          - Eth30-ASIC3
+          - Eth31-ASIC3
   configuration_properties:
     common:
       dut_asn: 65100
@@ -342,45 +342,45 @@ ASIC4:
   topology:
     NEIGH_ASIC:
       ASIC0:
-        vlans:
-          - 0
-          - 1
-          - 2
-          - 3
-          - 4
-          - 5
-          - 6
-          - 7
+        asic_intfs:
+          - Eth0-ASIC4
+          - Eth1-ASIC4
+          - Eth2-ASIC4
+          - Eth3-ASIC4
+          - Eth4-ASIC4
+          - Eth5-ASIC4
+          - Eth6-ASIC4
+          - Eth7-ASIC4
       ASIC1:
-        vlans:
-          - 8
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
+        asic_intfs:
+          - Eth8-ASIC4
+          - Eth9-ASIC4
+          - Eth10-ASIC4
+          - Eth11-ASIC4
+          - Eth12-ASIC4
+          - Eth13-ASIC4
+          - Eth14-ASIC4
+          - Eth15
       ASIC2:
-        vlans:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
-          - 23
+        asic_intfs:
+          - Eth16-ASIC4
+          - Eth17-ASIC4
+          - Eth18-ASIC4
+          - Eth19-ASIC4
+          - Eth20-ASIC4
+          - Eth21-ASIC4
+          - Eth22-ASIC4
+          - Eth23-ASIC4
       ASIC3:
-        vlans:
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
+        asic_intfs:
+          - Eth24-ASIC4
+          - Eth25-ASIC4
+          - Eth26-ASIC4
+          - Eth27-ASIC4
+          - Eth28-ASIC4
+          - Eth29-ASIC4
+          - Eth30-ASIC4
+          - Eth31-ASIC4
   configuration_properties:
     common:
       dut_asn: 65100
@@ -501,45 +501,45 @@ ASIC5:
   topology:
     NEIGH_ASIC:
       ASIC0:
-        vlans:
-          - 0
-          - 1
-          - 2
-          - 3
-          - 4
-          - 5
-          - 6
-          - 7
+        asic_intfs:
+          - Eth0-ASIC5
+          - Eth1-ASIC5
+          - Eth2-ASIC5
+          - Eth3-ASIC5
+          - Eth4-ASIC5
+          - Eth5-ASIC5
+          - Eth6-ASIC5
+          - Eth7-ASIC5
       ASIC1:
-        vlans:
-          - 8
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
+        asic_intfs:
+          - Eth8-ASIC5
+          - Eth9-ASIC5
+          - Eth10-ASIC5
+          - Eth11-ASIC5
+          - Eth12-ASIC5
+          - Eth13-ASIC5
+          - Eth14-ASIC5
+          - Eth15-ASIC5
       ASIC2:
-        vlans:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
-          - 23
+        asic_intfs:
+          - Eth16-ASIC5
+          - Eth17-ASIC5
+          - Eth18-ASIC5
+          - Eth19-ASIC5
+          - Eth20-ASIC5
+          - Eth21-ASIC5
+          - Eth22-ASIC5
+          - Eth23-ASIC5
       ASIC3:
-        vlans:
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
+        asic_intfs:
+          - Eth24-ASIC5
+          - Eth25-ASIC5
+          - Eth26-ASIC5
+          - Eth27-ASIC5
+          - Eth28-ASIC5
+          - Eth29-ASIC5
+          - Eth30-ASIC5
+          - Eth31-ASIC5
   configuration_properties:
     common:
       dut_asn: 65100

--- a/ansible/vars/topo_msft_multi_asic_vs.yml
+++ b/ansible/vars/topo_msft_multi_asic_vs.yml
@@ -1,6 +1,6 @@
 ASIC0:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC4:
         vlans:
           - 16
@@ -85,7 +85,7 @@ ASIC0:
           ipv6: 2603:10e2:400:1::5/126
 ASIC1:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC4:
         vlans:
           - 16
@@ -170,7 +170,7 @@ ASIC1:
           ipv6: 2603:10e2:400:1::d/126
 ASIC2:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC4:
         vlans:
           - 16
@@ -255,7 +255,7 @@ ASIC2:
           ipv6: 2603:10e2:400:1::15/126
 ASIC3:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC4:
         vlans:
           - 16
@@ -340,7 +340,7 @@ ASIC3:
           ipv6: 2603:10e2:400:1::1d/126
 ASIC4:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC0:
         vlans:
           - 0
@@ -499,7 +499,7 @@ ASIC4:
           ipv6: 2603:10e2:400:1::1a/126
 ASIC5:
   topology:
-    ASICs:
+    NEIGH_ASIC:
       ASIC0:
         vlans:
           - 0

--- a/ansible/vars/topo_msft_multi_asic_vs.yml
+++ b/ansible/vars/topo_msft_multi_asic_vs.yml
@@ -1,0 +1,659 @@
+ASIC0:
+  topology:
+    ASICs:
+      ASIC4:
+        vlans:
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+      ASIC5:
+        vlans:
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: FrontEnd 
+      Loopback4096:
+        - 8.0.0.0/32
+        - 2603:10e2:400::/128
+  configuration:
+    ASIC4:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.1
+          - 2603:10e2:400:1::2
+      interfaces:
+        Eth0-ASIC4:
+          lacp: 1
+        Eth1-ASIC4:
+          lacp: 1
+        Eth2-ASIC4:
+          lacp: 1
+        Eth3-ASIC4:
+          lacp: 1
+        Eth4-ASIC4:
+          lacp: 1
+        Eth5-ASIC4:
+          lacp: 1
+        Eth6-ASIC4:
+          lacp: 1
+        Eth7-ASIC4:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.0/31
+          ipv6: 2603:10e2:400:1::1/126
+    ASIC5:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.3
+          - 2603:10e2:400:1::6
+      interfaces:
+        Eth0-ASIC5:
+          lacp: 2
+        Eth1-ASIC5:
+          lacp: 2
+        Eth2-ASIC5:
+          lacp: 2
+        Eth3-ASIC5:
+          lacp: 2
+        Eth4-ASIC5:
+          lacp: 2
+        Eth5-ASIC5:
+          lacp: 2
+        Eth6-ASIC5:
+          lacp: 2
+        Eth7-ASIC5:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.2/31
+          ipv6: 2603:10e2:400:1::5/126
+ASIC1:
+  topology:
+    ASICs:
+      ASIC4:
+        vlans:
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+      ASIC5:
+        vlans:
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: FrontEnd
+      Loopback4096:
+        - 8.0.0.1/32
+        - 2603:10e2:400::1/128
+  configuration:
+    ASIC4:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.5
+          - 2603:10e2:400:1::a
+      interfaces:
+        Eth8-ASIC4:
+          lacp: 1
+        Eth9-ASIC4:
+          lacp: 1
+        Eth10-ASIC4:
+          lacp: 1
+        Eth11-ASIC4:
+          lacp: 1
+        Eth12-ASIC4:
+          lacp: 1
+        Eth13-ASIC4:
+          lacp: 1
+        Eth14-ASIC4:
+          lacp: 1
+        Eth15-ASIC4:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.4/31
+          ipv6: 2603:10e2:400:1::9/126
+    ASIC5:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.7
+          - 2603:10e2:400:1::e
+      interfaces:
+        Eth8-ASIC5:
+          lacp: 2
+        Eth9-ASIC5:
+          lacp: 2
+        Eth10-ASIC5:
+          lacp: 2
+        Eth11-ASIC5:
+          lacp: 2
+        Eth12-ASIC5:
+          lacp: 2
+        Eth13-ASIC5:
+          lacp: 2
+        Eth14-ASIC5:
+          lacp: 2
+        Eth15-ASIC5:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.6/31
+          ipv6: 2603:10e2:400:1::d/126
+ASIC2:
+  topology:
+    ASICs:
+      ASIC4:
+        vlans:
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+      ASIC5:
+        vlans:
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: FrontEnd
+      Loopback4096:
+        - 8.0.0.2/32
+        - 2603:10e2:400::2/128
+  configuration:
+    ASIC4:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.9
+          - 2603:10e2:400:1::11
+      interfaces:
+        Eth24-ASIC4:
+          lacp: 1
+        Eth25-ASIC4:
+          lacp: 1
+        Eth26-ASIC4:
+          lacp: 1
+        Eth27-ASIC4:
+          lacp: 1
+        Eth28-ASIC4:
+          lacp: 1
+        Eth29-ASIC4:
+          lacp: 1
+        Eth30-ASIC4:
+          lacp: 1
+        Eth31-ASIC4:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.8/31
+          ipv6: 2603:10e2:400:1::12/126
+    ASIC5:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.11
+          - 2603:10e2:400:1::16
+      interfaces:
+        Eth24-ASIC5:
+          lacp: 2
+        Eth25-ASIC5:
+          lacp: 2
+        Eth26-ASIC5:
+          lacp: 2
+        Eth27-ASIC5:
+          lacp: 2
+        Eth28-ASIC5:
+          lacp: 2
+        Eth29-ASIC5:
+          lacp: 2
+        Eth30-ASIC5:
+          lacp: 2
+        Eth31-ASIC5:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.10/31
+          ipv6: 2603:10e2:400:1::15/126
+ASIC3:
+  topology:
+    ASICs:
+      ASIC4:
+        vlans:
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+      ASIC5:
+        vlans:
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: FrontEnd
+      Loopback4096:
+        - 8.0.0.3/32
+        - 2603:10e2:400::3/128
+  configuration:
+    ASIC4:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.13
+          - 2603:10e2:400:1::1a
+      interfaces:
+        Eth24-ASIC4:
+          lacp: 1
+        Eth25-ASIC4:
+          lacp: 1
+        Eth26-ASIC4:
+          lacp: 1
+        Eth27-ASIC4:
+          lacp: 1
+        Eth28-ASIC4:
+          lacp: 1
+        Eth29-ASIC4:
+          lacp: 1
+        Eth30-ASIC4:
+          lacp: 1
+        Eth31-ASIC4:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.12/31
+          ipv6: 2603:10e2:400:1::19/126
+    ASIC5:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.15
+          - 2603:10e2:400:1::1e
+      interfaces:
+        Eth24-ASIC5:
+          lacp: 2
+        Eth25-ASIC5:
+          lacp: 2
+        Eth26-ASIC5:
+          lacp: 2
+        Eth27-ASIC5:
+          lacp: 2
+        Eth28-ASIC5:
+          lacp: 2
+        Eth29-ASIC5:
+          lacp: 2
+        Eth30-ASIC5:
+          lacp: 2
+        Eth31-ASIC5:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.14/31
+          ipv6: 2603:10e2:400:1::1d/126
+ASIC4:
+  topology:
+    ASICs:
+      ASIC0:
+        vlans:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+      ASIC1:
+        vlans:
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
+      ASIC2:
+        vlans:
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+      ASIC3:
+        vlans:
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: BackEnd
+      Loopback4096:
+        - 8.0.0.4/32
+        - 2603:10e2:400::4/128
+  configuration:
+    ASIC0:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.0
+          - 2603:10e2:400:1::1
+      interfaces:
+        Eth16-ASIC0:
+          lacp: 1
+        Eth17-ASIC0:
+          lacp: 1
+        Eth18-ASIC0:
+          lacp: 1
+        Eth19-ASIC0:
+          lacp: 1
+        Eth20-ASIC0:
+          lacp: 1
+        Eth21-ASIC0:
+          lacp: 1
+        Eth22-ASIC0:
+          lacp: 1
+        Eth23-ASIC0:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.1/31
+          ipv6: 2603:10e2:400:1::2/126
+    ASIC1:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.4
+          - 2603:10e2:400:1::9
+      interfaces:
+        Eth16-ASIC1:
+          lacp: 2
+        Eth17-ASIC1:
+          lacp: 2
+        Eth18-ASIC1:
+          lacp: 2
+        Eth19-ASIC1:
+          lacp: 2
+        Eth20-ASIC1:
+          lacp: 2
+        Eth21-ASIC1:
+          lacp: 2
+        Eth22-ASIC1:
+          lacp: 2
+        Eth23-ASIC1:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.5/31
+          ipv6: 2603:10e2:400:1::a/126
+    ASIC2:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.8
+          - 2603:10e2:400:1::11
+      interfaces:
+        Eth16-ASIC2:
+          lacp: 3
+        Eth17-ASIC2:
+          lacp: 3
+        Eth18-ASIC2:
+          lacp: 3
+        Eth19-ASIC2:
+          lacp: 3
+        Eth20-ASIC2:
+          lacp: 3
+        Eth21-ASIC2:
+          lacp: 3
+        Eth22-ASIC2:
+          lacp: 3
+        Eth23-ASIC2:
+          lacp: 3
+        Port-Channel3:
+          ipv4: 10.1.0.9/31
+          ipv6: 2603:10e2:400:1::12/126
+    ASIC3:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.12
+          - 2603:10e2:400:1::19
+      interfaces:
+        Eth16-ASIC3:
+          lacp: 4
+        Eth17-ASIC3:
+          lacp: 4
+        Eth18-ASIC3:
+          lacp: 4
+        Eth19-ASIC3:
+          lacp: 4
+        Eth20-ASIC3:
+          lacp: 4
+        Eth21-ASIC3:
+          lacp: 4
+        Eth22-ASIC3:
+          lacp: 4
+        Eth23-ASIC3:
+          lacp: 4
+        Port-Channel4:
+          ipv4: 10.1.0.13/31
+          ipv6: 2603:10e2:400:1::1a/126
+ASIC5:
+  topology:
+    ASICs:
+      ASIC0:
+        vlans:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+      ASIC1:
+        vlans:
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
+      ASIC2:
+        vlans:
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+      ASIC3:
+        vlans:
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+  configuration_properties:
+    common:
+      dut_asn: 65100
+      asic_type: BackEnd
+      Loopback4096:
+        - 8.0.0.5/32
+        - 2603:10e2:400::5/128
+  
+  configuration:
+    ASIC0:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.2
+          - 2603:10e2:400:1::5
+      interfaces:
+        Eth24-ASIC0:
+          lacp: 1
+        Eth25-ASIC0:
+          lacp: 1
+        Eth26-ASIC0:
+          lacp: 1
+        Eth27-ASIC0:
+          lacp: 1
+        Eth28-ASIC0:
+          lacp: 1
+        Eth29-ASIC0:
+          lacp: 1
+        Eth30-ASIC0:
+          lacp: 1
+        Eth31-ASIC0:
+          lacp: 1
+        Port-Channel1:
+          ipv4: 10.1.0.3/31
+          ipv6: 2603:10e2:400:1::6/126
+    ASIC1:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.6
+          - 2603:10e2:400:1::d
+      interfaces:
+        Eth24-ASIC1:
+          lacp: 2
+        Eth25-ASIC1:
+          lacp: 2
+        Eth26-ASIC1:
+          lacp: 2
+        Eth27-ASIC1:
+          lacp: 2
+        Eth28-ASIC1:
+          lacp: 2
+        Eth29-ASIC1:
+          lacp: 2
+        Eth30-ASIC1:
+          lacp: 2
+        Eth31-ASIC1:
+          lacp: 2
+        Port-Channel2:
+          ipv4: 10.1.0.7/31
+          ipv6: 2603:10e2:400:1::e/126
+    ASIC2:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.10
+          - 2603:10e2:400:1::15
+      interfaces:
+        Eth24-ASIC2:
+          lacp: 3
+        Eth25-ASIC2:
+          lacp: 3
+        Eth26-ASIC2:
+          lacp: 3
+        Eth27-ASIC2:
+          lacp: 3
+        Eth28-ASIC2:
+          lacp: 3
+        Eth29-ASIC2:
+          lacp: 3
+        Eth30-ASIC2:
+          lacp: 3
+        Eth31-ASIC2:
+          lacp: 3
+        Port-Channel3:
+          ipv4: 10.1.0.11/31
+          ipv6: 2603:10e2:400:1::16/126
+    ASIC3:
+      bgp:
+        asn: 65100
+        peers:
+          65100:
+          - 10.1.0.14
+          - 2603:10e2:400:1::1d
+      interfaces:
+        Eth24-ASIC3:
+          lacp: 4
+        Eth25-ASIC3:
+          lacp: 4
+        Eth26-ASIC3:
+          lacp: 4
+        Eth27-ASIC3:
+          lacp: 4
+        Eth28-ASIC3:
+          lacp: 4
+        Eth29-ASIC3:
+          lacp: 4
+        Eth30-ASIC3:
+          lacp: 4
+        Eth31-ASIC3:
+          lacp: 4
+        Port-Channel4:
+          ipv4: 10.1.0.15/31
+          ipv6: 2603:10e2:400:1::1e/126


### PR DESCRIPTION
- Add new topo files to define internal asic topology
for Virtual Switch hwsku msft_multi_asic_vs and
msft_four_asic_vs.
- Add changes in topo_facts to parse the new ASIC topo files.
- Add changes in port_alias to generate list of asic names for
front-end interfaces.
- Add additional dictionary in port_alias to generate
interfaces list for all ASICs.

Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To support minigraph generation for multi-asic platforms.

#### How did you do it?
Multi-asic minigraph will include internal asic topology and asic metadata.
- To provide the internal asic information, a new topo file is added. The new topo file will hwsku specific, and will contain asic topology similar to the other topo files. A single topo file will be used to provide topology of all asics for that hwsku.
In the pull request, topo files for 2 Virtual switch hwsku's is added: - topo_msft_multi_asic_vs.yml and topo_msft_four_asic_vs.yml.
- Made changes to topo_facts.py to parse the newly added topo files similar to the parsing logic of existing topo files.
- Made changes to port_alias.py to generate a list of front-end ASIC interface names and list of interfaces of each ASIC which will be used in minigraph templates.
- Made changes to config config_sonic_basedon_testbed to pass hwsku to topo_facts.py. Based on the hwsku, topo_facts will look for hwsku specific topo file.

#### How did you verify/test it?
- No change in single-asic minigraph generation.
- For multi-asic platform, minigraph can be generated along with minigraph template changes added in PR https://github.com/Azure/sonic-mgmt/pull/3025

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
