### PR TITLE
[multi-asic][minigraph]: Modify minigraph templates  for multi-asic platform

### DIFF
--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -14,6 +14,18 @@
         <HoldTime>10</HoldTime>
         <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
+{% if vm_asic_ifnames is defined %}
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>{{ vm_asic_ifnames[vm][0].split('-')[1] }}</StartRouter>
+        <StartPeer>{{ vm_topo_config['vm'][vm]['bgp_ipv4'][dut_index|int] }}</StartPeer>
+        <EndRouter>{{ vm }}</EndRouter>
+        <EndPeer>{{ vm_topo_config['vm'][vm]['peer_ipv4'][dut_index|int] }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+{% endif %}
 {% endif %}
 {% if vm_topo_config['vm'][vm]['peer_ipv6'][dut_index|int] %}
       <BGPSession>
@@ -25,7 +37,45 @@
         <HoldTime>10</HoldTime>
         <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
+{% if vm_asic_ifnames is defined %}
+      <BGPSession>
+        <StartRouter>{{ vm_asic_ifnames[vm][0].split('-')[1] }}</StartRouter>
+        <StartPeer>{{ vm_topo_config['vm'][vm]['bgp_ipv6'][dut_index|int] }}</StartPeer>
+        <EndRouter>{{ vm }}</EndRouter>
+        <EndPeer>{{ vm_topo_config['vm'][vm]['peer_ipv6'][dut_index|int] }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
 {% endif %}
+{% endif %}
+{% endfor %}
+{% for asic in asic_topo_config %}
+{% for neigh_asic in  asic_topo_config[asic]['asic'] %}
+{% if asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] %}
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>{{ asic }}</StartRouter>
+        <StartPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv4'][0] }}</StartPeer>
+        <EndRouter>{{ neigh_asic }}</EndRouter>
+        <EndPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+{% endif %}
+{% if asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv6'][0] %}
+      <BGPSession>
+        <StartRouter>{{ asic }}</StartRouter>
+        <StartPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv6'][0] }}</StartPeer>
+        <EndRouter>{{ neigh_asic }}</EndRouter>
+        <EndPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv6'][0] }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+{% endif %}
+{% endfor %} 
 {% endfor %}
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
@@ -77,6 +127,35 @@
 {% endif %}
 {% endfor %}
 {% endif %}
+{% for asic in asic_topo_config %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+        <a:Hostname>{{ asic }}</a:Hostname>
+        <a:Peers>
+{% for index in range( vms_number) %}
+{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
+          <BGPPeer>
+            <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% for neigh_asic in asic_topo_config %}
+{% if neigh_asic in asic_topo_config[asic]['asic'] and asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] %}
+          <BGPPeer>
+            <Address>{{ asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% endfor %}
     </Routers>
   </CpgDec>
 

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -51,25 +51,25 @@
 {% endif %}
 {% endfor %}
 {% for asic in asic_topo_config %}
-{% for neigh_asic in  asic_topo_config[asic]['asic'] %}
-{% if asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] %}
+{% for neigh_asic in  asic_topo_config[asic]['neigh_asic'] %}
+{% if asic_topo_config[asic]['neigh_asic'][neigh_asic]['peer_ipv4'][0] %}
       <BGPSession>
         <MacSec>false</MacSec>
         <StartRouter>{{ asic }}</StartRouter>
-        <StartPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv4'][0] }}</StartPeer>
+        <StartPeer>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv4'][0] }}</StartPeer>
         <EndRouter>{{ neigh_asic }}</EndRouter>
-        <EndPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] }}</EndPeer>
+        <EndPeer>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['peer_ipv4'][0] }}</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>0</HoldTime>
         <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
 {% endif %}
-{% if asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv6'][0] %}
+{% if asic_topo_config[asic]['neigh_asic'][neigh_asic]['peer_ipv6'][0] %}
       <BGPSession>
         <StartRouter>{{ asic }}</StartRouter>
-        <StartPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv6'][0] }}</StartPeer>
+        <StartPeer>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv6'][0] }}</StartPeer>
         <EndRouter>{{ neigh_asic }}</EndRouter>
-        <EndPeer>{{ asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv6'][0] }}</EndPeer>
+        <EndPeer>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['peer_ipv6'][0] }}</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>0</HoldTime>
         <KeepAliveTime>0</KeepAliveTime>
@@ -143,9 +143,9 @@
 {% endif %}
 {% endfor %}
 {% for neigh_asic in asic_topo_config %}
-{% if neigh_asic in asic_topo_config[asic]['asic'] and asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] %}
+{% if neigh_asic in asic_topo_config[asic]['neigh_asic'] and asic_topo_config[asic]['neigh_asic'][neigh_asic]['peer_ipv4'][0] %}
           <BGPPeer>
-            <Address>{{ asic_topo_config[asic]['asic'][neigh_asic]['peer_ipv4'][0] }}</Address>
+            <Address>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['peer_ipv4'][0] }}</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -93,7 +93,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ asic_if_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ front_panel_asic_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv4'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv4mask'][dut_index|int] }}</Prefix>
         </IPInterface>
@@ -102,7 +102,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ asic_if_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ front_panel_asic_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv6'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv6mask'][dut_index|int] }}</Prefix>
         </IPInterface>
@@ -177,7 +177,7 @@
 {% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
-{% set a_intf = asic_if_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
+{% set a_intf = front_panel_asic_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endif %}

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -93,7 +93,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ front_panel_asic_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv4'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv4mask'][dut_index|int] }}</Prefix>
         </IPInterface>
@@ -102,7 +102,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ front_panel_asic_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv6'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv6mask'][dut_index|int] }}</Prefix>
         </IPInterface>
@@ -177,7 +177,7 @@
 {% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
-{% set a_intf = front_panel_asic_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
+{% set a_intf = front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endif %}

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -1,3 +1,6 @@
+{% macro port_channel_id(asic_idx, neigh_asic_idx) -%}
+{{ ((4000 + asic_idx + (10*neigh_asic_idx))|string) }}
+{%- endmacro -%}
 {% for asic in asic_topo_config %}
 {% set asic_index = asic.split('ASIC')[1]|int %}
     <DeviceDataPlaneInfo>
@@ -75,7 +78,7 @@
 {%- set port_channel_intf=pc_intfs|join(';') -%}
 {% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
         <PortChannel>
-          <Name>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</Name>
+          <Name>PortChannel{{ port_channel_id(asic_index, neigh_asic_index).zfill(4) }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
@@ -114,7 +117,7 @@
           <Name i:nil="true"/>
 {%- if 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower %}
 {%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
-          <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
+          <AttachTo>PortChannel{{ port_channel_id(asic_index, neigh_asic_index).zfill(4) }}</AttachTo>
 {% else %}
           <AttachTo>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0][0] }}</AttachTo>
 {% endif %}
@@ -124,7 +127,7 @@
           <Name i:nil="true"/>
 {%- if 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower %}
 {%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
-          <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
+          <AttachTo>PortChannel{{ port_channel_id(asic_index, neigh_asic_index).zfill(4) }}</AttachTo>
 {% else %}
           <AttachTo>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0][0] }}</AttachTo>
 {% endif %}
@@ -168,7 +171,7 @@
 {% for neigh_asic in asic_topo_config %}
 {% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
 {%- if neigh_asic in asic_topo_config[asic]['neigh_asic'] and 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower -%}
-{% set a_intf = 'PortChannel' + ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) %}
+{% set a_intf = 'PortChannel' + port_channel_id(asic_index, neigh_asic_index).zfill(4) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endfor %}

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -68,9 +68,9 @@
 {% endfor %}
 {% for neigh_asic in asic_topo_config %}
 {%- set pc_intfs = [] -%}
-{%- if neigh_asic in asic_topo_config[asic]['asic'] and 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower -%}
-{%- for intf in asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0] %}
-{{- pc_intfs.append(asic_names[asic][intf]) }} 
+{%- if neigh_asic in asic_topo_config[asic]['neigh_asic'] and 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower -%}
+{%- for intf in asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0] %}
+{{- pc_intfs.append(asic_if_names[asic][intf]) }} 
 {%- endfor -%}
 {%- set port_channel_intf=pc_intfs|join(';') -%}
 {% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
@@ -109,26 +109,26 @@
 {% endif %}
 {% endif %}
 {% endfor %}
-{% for neigh_asic in asic_topo_config[asic]['asic'] %}
+{% for neigh_asic in asic_topo_config[asic]['neigh_asic'] %}
         <IPInterface>
           <Name i:nil="true"/>
-{%- if 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower %}
+{%- if 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower %}
 {%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
           <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
+          <AttachTo>{{ asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
 {% endif %}
-          <Prefix>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv4'][0] }}/{{ asic_topo_config[asic]['asic'][neigh_asic]['ipv4mask'][0] }}</Prefix>
+          <Prefix>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv4'][0] }}/{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['ipv4mask'][0] }}</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
-{%- if 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower %}
+{%- if 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower %}
 {%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
           <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
+          <AttachTo>{{ asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
 {% endif %}
-          <Prefix>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv6'][0] }}/{{ asic_topo_config[asic]['asic'][neigh_asic]['ipv6mask'][0] }}</Prefix>
+          <Prefix>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv6'][0] }}/{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['ipv6mask'][0] }}</Prefix>
         </IPInterface>
 {% endfor %}
       </IPInterfaces>
@@ -167,7 +167,7 @@
 {% endfor %}
 {% for neigh_asic in asic_topo_config %}
 {% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
-{%- if neigh_asic in asic_topo_config[asic]['asic'] and 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower -%}
+{%- if neigh_asic in asic_topo_config[asic]['neigh_asic'] and 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower -%}
 {% set a_intf = 'PortChannel' + ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
@@ -184,9 +184,9 @@
 {% endif %}
 {% endfor -%}
 {%- for neigh_asic in asic_topo_config -%}
-{%- if neigh_asic in asic_topo_config[asic]['asic'] and 'port-channel' not in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower -%}
-{% if asic_topo_config[asic]['asic'][neigh_asic]['intfs'][0]|length %}
-{% set a_intf = asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][0]] %}
+{%- if neigh_asic in asic_topo_config[asic]['neigh_asic'] and 'port-channel' not in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower -%}
+{% if asic_topo_config[asic]['neigh_asic'][neigh_asic]['intfs'][0]|length %}
+{% set a_intf = asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][0]] %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endif %}

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -1,8 +1,8 @@
-  <DpgDec>
+{% for asic in asic_topo_config %}
+{% set asic_index = asic.split('ASIC')[1]|int %}
     <DeviceDataPlaneInfo>
       <IPSecTunnels/>
       <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if type is not defined or type != 'supervisor' %}
         <a:LoopbackIPInterface>
           <Name>HostIP</Name>
           <AttachTo>Loopback0</AttachTo>
@@ -19,28 +19,16 @@
           </a:Prefix>
           <a:PrefixStr>{{ lp_ipv6 }}</a:PrefixStr>
         </a:LoopbackIPInterface>
-      {%- if 'addl_loopbacks' in dual_tor_facts -%}
-      {%- for loopback_num in dual_tor_facts['addl_loopbacks'][inventory_hostname] -%}
-        {%- set loopback_facts = dual_tor_facts['addl_loopbacks'][inventory_hostname][loopback_num] -%}
+{% for lo4096 in asic_topo_config[asic]['Loopback4096'] %}
         <a:LoopbackIPInterface>
-          <Name>HostIP{{ loopback_facts['host_ip_base_index'] }}</Name>
-          <AttachTo>Loopback{{ loopback_num }}</AttachTo>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>{{ loopback_facts['ipv4'] }}</b:IPPrefix>
+            <b:IPPrefix>{{ lo4096 }}</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>{{ loopback_facts['ipv4'] }}</a:PrefixStr>
+          <a:PrefixStr>{{ lo4096 }}</a:PrefixStr>
         </a:LoopbackIPInterface>
-        <a:LoopbackIPInterface>
-          <Name>HostIP{{ loopback_facts['host_ip_base_index'] + 1 }}</Name>
-          <AttachTo>Loopback{{ loopback_num }}</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>{{ loopback_facts['ipv6'] }}</b:IPPrefix>
-          </a:Prefix>
-          <a:PrefixStr>{{ loopback_facts['ipv6'] }}</a:PrefixStr>
-        </a:LoopbackIPInterface>
-      {%- endfor -%}
-      {%- endif -%}
-{% endif %}
+{% endfor %}
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
         <a:ManagementIPInterface>
@@ -64,57 +52,48 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>{{ inventory_hostname }}</Hostname>
+      <Hostname>{{ asic }}</Hostname>
       <PortChannelInterfaces>
 {% for index in range(vms_number) %}
+{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-{% set port_channel_intf=';'.join(intf_names[vms[index]])  %}
+{% set port_channel_intf=';'.join(vm_asic_ifnames[vms[index]])  %}
         <PortChannel>
           <Name>PortChannel{{ ((index+1)|string).zfill(4) }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
 {% endif %}
+{% endif %}
+{% endfor %}
+{% for neigh_asic in asic_topo_config %}
+{%- set pc_intfs = [] -%}
+{%- if neigh_asic in asic_topo_config[asic]['asic'] and 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower -%}
+{%- for intf in asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0] %}
+{{- pc_intfs.append(asic_names[asic][intf]) }} 
+{%- endfor -%}
+{%- set port_channel_intf=pc_intfs|join(';') -%}
+{% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
+        <PortChannel>
+          <Name>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</Name>
+          <AttachTo>{{ port_channel_intf }}</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+{% endif %}
 {% endfor %}
       </PortChannelInterfaces>
-{% if tunnel_configs | length > 0 %}
-      <TunnelInterfaces>
-{% for tunnel, tunnel_param in tunnel_configs.items() %}
-        <TunnelInterface Name="{{ tunnel }}" Type="{{ tunnel_param['type'] }}" AttachTo="{{ tunnel_param['attach_to'] }}" DifferentiatedServicesCodePointMode="{{ tunnel_param['dscp'] }}" EcnEncapsulationMode="{{ tunnel_param['ecn_encap'] }}" EcnDecapsulationMode="{{ tunnel_param['ecn_decap'] }}" TtlMode="{{ tunnel_param['ttl_mode'] }}" />
-{% endfor %}
-      </TunnelInterfaces>
-{% endif %}
-      <VlanInterfaces>
-{% if 'tor' in vm_topo_config['dut_type'] | lower %}
-{% for vlan, vlan_param in vlan_configs.items() %}
-        <VlanInterface>
-          <Name>{{ vlan }}</Name>
-{% set vlan_intf_str=';'.join(vlan_param['intfs']) %}
-          <AttachTo>{{ vlan_intf_str }}</AttachTo>
-          <NoDhcpRelay>False</NoDhcpRelay>
-          <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
-          <Type i:nil="true"/>
-{% set dhcp_servers_str=';'.join(dhcp_servers) %}
-          <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
-          <VlanID>{{ vlan_param['id'] }}</VlanID>
-          <Tag>{{ vlan_param['tag'] }}</Tag>
-          <Subnets>{{ vlan_param['prefix'] | ipaddr('network') }}/{{ vlan_param['prefix'] | ipaddr('prefix') }}</Subnets>
-{% if 'mac' in vlan_param %}
-          <MacAddress>{{ vlan_param['mac'] }}</MacAddress>
-{% endif %}
-        </VlanInterface>
-{% endfor %}
-{% endif %}
-      </VlanInterfaces>
+      <SubInterfaces/>
+      <VlanInterfaces/>
       <IPInterfaces>
 {% for index in range(vms_number) %}
+{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ asic_if_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv4'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv4mask'][dut_index|int] }}</Prefix>
         </IPInterface>
@@ -123,34 +102,38 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ asic_if_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv6'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv6mask'][dut_index|int] }}</Prefix>
         </IPInterface>
 {% endif %}
-{% endfor %}
-{% if 'tor' in vm_topo_config['dut_type'] | lower %}
-{% for vlan, vlan_param in vlan_configs.items() %}
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>{{ vlan }}</AttachTo>
-          <Prefix>{{ vlan_param['prefix'] }}</Prefix>
-        </IPInterface>
-{% endfor %}
-{% for vlan, vlan_param in vlan_configs.items() %}
-{%   if 'prefix_v6' in vlan_param %}
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>{{ vlan }}</AttachTo>
-          <Prefix>{{ vlan_param['prefix_v6'] }}</Prefix>
-        </IPInterface>
-{%   endif %}
-{% endfor %}
 {% endif %}
+{% endfor %}
+{% for neigh_asic in asic_topo_config[asic]['asic'] %}
+        <IPInterface>
+          <Name i:nil="true"/>
+{%- if 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower %}
+{%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
+          <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
+{% else %}
+          <AttachTo>{{ asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
+{% endif %}
+          <Prefix>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv4'][0] }}/{{ asic_topo_config[asic]['asic'][neigh_asic]['ipv4mask'][0] }}</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+{%- if 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower %}
+{%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
+          <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
+{% else %}
+          <AttachTo>{{ asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
+{% endif %}
+          <Prefix>{{ asic_topo_config[asic]['asic'][neigh_asic]['bgp_ipv6'][0] }}/{{ asic_topo_config[asic]['asic'][neigh_asic]['ipv6mask'][0] }}</Prefix>
+        </IPInterface>
+{% endfor %}
       </IPInterfaces>
       <DataAcls/>
       <AclInterfaces>
-{% if type is not defined or type != 'supervisor' %}
         <AclInterface>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
@@ -171,35 +154,52 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
-{% if enable_data_plane_acl|default('true')|bool %}
         <AclInterface>
           <AttachTo>
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
-{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% set a_intf = 'PortChannel' + ((index+1) |string).zfill(4) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
+{% endif %}
 {% endfor %}
-{% for index in range(vms_number) %}
-{% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf']|lower %}
+{% for neigh_asic in asic_topo_config %}
+{% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
+{%- if neigh_asic in asic_topo_config[asic]['asic'] and 'port-channel' in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower -%}
+{% set a_intf = 'PortChannel' + ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) %}
+{{- acl_intfs.append(a_intf) -}}
+{% endif %}
+{% endfor %}
+
+{%- for index in range(vms_number) -%}
+{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
+{% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
-{% set a_intf = port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
+{% set a_intf = asic_if_names[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endif %}
+{% endif %}
 {% endfor -%}
+{%- for neigh_asic in asic_topo_config -%}
+{%- if neigh_asic in asic_topo_config[asic]['asic'] and 'port-channel' not in asic_topo_config[asic]['asic'][neigh_asic]['ip_intf'][0]|lower -%}
+{% if asic_topo_config[asic]['asic'][neigh_asic]['intfs'][0]|length %}
+{% set a_intf = asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][0]] %}
+{{- acl_intfs.append(a_intf) -}}
+{% endif %}
+{% endif %}
+{% endfor %}
+
 {{- acl_intfs|join(';') -}}
           </AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-{% endif %}
-{% endif %}
       </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
-{% include 'minigraph_dpg_asic.j2' %}
-  </DpgDec>
+{% endfor %}
 

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -69,8 +69,8 @@
 {% for neigh_asic in asic_topo_config %}
 {%- set pc_intfs = [] -%}
 {%- if neigh_asic in asic_topo_config[asic]['neigh_asic'] and 'port-channel' in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower -%}
-{%- for intf in asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0] %}
-{{- pc_intfs.append(asic_if_names[asic][intf]) }} 
+{%- for intf in asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0] %}
+{{- pc_intfs.append(intf) }} 
 {%- endfor -%}
 {%- set port_channel_intf=pc_intfs|join(';') -%}
 {% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
@@ -116,7 +116,7 @@
 {%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
           <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
+          <AttachTo>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0][0] }}</AttachTo>
 {% endif %}
           <Prefix>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv4'][0] }}/{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['ipv4mask'][0] }}</Prefix>
         </IPInterface>
@@ -126,7 +126,7 @@
 {%- set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
           <AttachTo>PortChannel{{ ((4000 + asic_index + (10*neigh_asic_index))|string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][0]] }}</AttachTo>
+          <AttachTo>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0][0] }}</AttachTo>
 {% endif %}
           <Prefix>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv6'][0] }}/{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['ipv6mask'][0] }}</Prefix>
         </IPInterface>
@@ -186,7 +186,7 @@
 {%- for neigh_asic in asic_topo_config -%}
 {%- if neigh_asic in asic_topo_config[asic]['neigh_asic'] and 'port-channel' not in asic_topo_config[asic]['neigh_asic'][neigh_asic]['ip_intf'][0]|lower -%}
 {% if asic_topo_config[asic]['neigh_asic'][neigh_asic]['intfs'][0]|length %}
-{% set a_intf = asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][0]] %}
+{% set a_intf = asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0][0] %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endif %}

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -93,6 +93,18 @@
 {% endif %}
         </a:Properties>
       </a:DeviceMetadata>
+{% for asic in asic_topo_config %}
+      <a:DeviceMetadata>
+        <a:Name>{{ asic }}</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>SubRole</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ asic_topo_config[asic]['asic_type'] }}</a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+{% endfor %}
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -36,6 +36,36 @@
 {% endfor %}
 {% endif %}
 {% endif %}
+{% for asic in asic_topo_config %}
+{% for neigh_asic in  asic_topo_config[asic]['asic'] %}
+{% for intf in asic_topo_config[asic]['asic'][neigh_asic]['intfs'][0] | sort %}
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>{{ neigh_asic }}</EndDevice>
+        <EndPort>{{ intf }}</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>{{ asic }}</StartDevice>
+        <StartPort>{{ asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][loop.index-1]] }}</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% for asic_intf in asic_ifnames %}
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>{{ asic_intf.split('-')[1] }}</EndDevice>
+        <EndPort>{{ asic_intf }}</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>{{ inventory_hostname }}</StartDevice>
+        <StartPort>{{ port_alias[loop.index - 1] }}</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+{% endfor %}
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="{{ vm_topo_config['dut_type'] }}">
@@ -135,6 +165,33 @@
 {% endif %}
 {% endfor %}
 {% endif %}
+{% for asic in asic_topo_config %}
+      <Device i:type="Asic">
+        <ElementType>Asic</ElementType>
+        <Address xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>0.0.0.0/0</a:IPPrefix>
+        </Address>
+        <AddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>::/0</a:IPPrefix>
+        </AddressV6>
+        <AssociatedClustersStr/>
+        <AssociatedSliceStr/>
+        <AssociatedTagsStr/>
+        <ClusterName/>
+        <DeploymentId i:nil="true"/>
+        <DeviceLocation i:nil="true"/>
+        <HomeDatacenter i:nil="true"/>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>0.0.0.0/0</a:IPPrefix>
+        </ManagementAddress>
+        <ManagementAddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>::/0</a:IPPrefix>
+        </ManagementAddressV6>
+        <SerialNumber i:nil="true"/>
+        <Hostname>{{ asic }}</Hostname>
+        <HwSku>Broadcom-Trident2</HwSku>
+      </Device>
+{% endfor %}
     </Devices>
   </PngDec>
 

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -37,8 +37,8 @@
 {% endif %}
 {% endif %}
 {% for asic in asic_topo_config %}
-{% for neigh_asic in  asic_topo_config[asic]['asic'] %}
-{% for intf in asic_topo_config[asic]['asic'][neigh_asic]['intfs'][0] | sort %}
+{% for neigh_asic in  asic_topo_config[asic]['neigh_asic'] %}
+{% for intf in asic_topo_config[asic]['neigh_asic'][neigh_asic]['intfs'][0] | sort %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <Bandwidth>40000</Bandwidth>
@@ -47,13 +47,13 @@
         <EndPort>{{ intf }}</EndPort>
         <FlowControl>true</FlowControl>
         <StartDevice>{{ asic }}</StartDevice>
-        <StartPort>{{ asic_names[asic][asic_topo_config[asic]['asic'][neigh_asic]['interface_indexes'][0][loop.index-1]] }}</StartPort>
+        <StartPort>{{ asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][loop.index-1]] }}</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
 {% endfor %}
 {% endfor %}
 {% endfor %}
-{% for asic_intf in asic_ifnames %}
+{% for asic_intf in front_panel_asic_ifnames %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <Bandwidth>40000</Bandwidth>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -47,7 +47,7 @@
         <EndPort>{{ intf }}</EndPort>
         <FlowControl>true</FlowControl>
         <StartDevice>{{ asic }}</StartDevice>
-        <StartPort>{{ asic_if_names[asic][asic_topo_config[asic]['neigh_asic'][neigh_asic]['interface_indexes'][0][loop.index-1]] }}</StartPort>
+        <StartPort>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['asic_intfs'][0][loop.index-1] }}</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
 {% endfor %}


### PR DESCRIPTION
Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Minigraph template changes to support minigraph generation for multi-asic platform.

#### How did you do it?
Pre-requisite: https://github.com/Azure/sonic-mgmt/pull/3024/
Add changes to minigraph templates to use the new data structure asic_topo_config and include asic topology.

#### How did you verify/test it?
With the changes in PR#3024:
Bring up four-asic VS testbed using the changes in: https://github.com/Azure/sonic-mgmt/pull/2858/
testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-four-asic-t1-lag password.txt
Deploy minigraph using:
./testbed-cli.sh -t vtestbed.csv -m veos_vtb deploy-mg vms-kvm-four-asic-t1-lag lab password.txt
With this, minigraph should be generated and deployed on the multi-asic VS DUT.
Check all interfaces status and BGP status.
```
admin@vlab-08:~$ show ip bgp summary -d all

IPv4 Unicast Summary:
asic0: BGP router identifier 8.0.0.0, local AS number 65100 vrf-id 0
BGP table version 12784
asic1: BGP router identifier 8.0.0.1, local AS number 65100 vrf-id 0
BGP table version 12779
asic2: BGP router identifier 8.0.0.2, local AS number 65100 vrf-id 0
BGP table version 6398
asic3: BGP router identifier 8.0.0.3, local AS number 65100 vrf-id 0
BGP table version 6398
RIB entries 51176, using 9416384 bytes of memory
Peers 14, using 292880 KiB of memory
Peer groups 12, using 768 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       3945       7122         0      0       0  00:38:31             6370  ARISTA01T2
10.0.0.5       4  65200       3946       6988         0      0       0  00:38:29             6370  ARISTA03T2
10.0.0.33      4  64001        775       6788         0      0       0  00:38:28                3  ARISTA01T0
10.0.0.35      4  64002        773       6788         0      0       0  00:38:27                3  ARISTA02T0
10.0.0.37      4  64003        782       6784         0      0       0  00:38:22                4  ARISTA03T0
10.0.0.39      4  64004        773       6781         0      0       0  00:38:24                3  ARISTA04T0
10.1.0.0       4  65100       3949       3945         0      0       0  00:37:14             6398  ASIC2
10.1.0.1       4  65100       3945       3950         0      0       0  00:37:18             6377  ASIC0
10.1.0.2       4  65100       3944       3940         0      0       0  00:37:18             6398  ASIC3
10.1.0.3       4  65100       3942       3947         0      0       0  00:37:25             6377  ASIC0
10.1.0.4       4  65100       3946        763         0      0       0  00:37:24             6398  ASIC2
10.1.0.5       4  65100        763       3947         0      0       0  00:37:26               21  ASIC1
10.1.0.6       4  65100       3946        763         0      0       0  00:37:25             6398  ASIC3
10.1.0.7       4  65100        765       3948         0      0       0  00:37:30               21  ASIC1

Total number of neighbors 14
admin@vlab-08:~$ show interfaces status -d all
      Interface        Lanes    Speed    MTU    FEC        Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  -----------  -------  -----  -----  -----------  ---------------  ------  -------  ------  ----------
      Ethernet0      1,2,3,4      40G   9100    N/A  Ethernet1/1  PortChannel0002      up       up     N/A         off
      Ethernet4      5,6,7,8      40G   9100    N/A  Ethernet1/2  PortChannel0002      up       up     N/A         off
      Ethernet8   9,10,11,12      40G   9100    N/A  Ethernet1/3  PortChannel0005      up       up     N/A         off
     Ethernet12  13,14,15,16      40G   9100    N/A  Ethernet1/4  PortChannel0005      up       up     N/A         off
     Ethernet16      1,2,3,4      40G   9100    N/A  Ethernet1/5  PortChannel0001      up       up     N/A         off
     Ethernet20      5,6,7,8      40G   9100    N/A  Ethernet1/6  PortChannel0003      up       up     N/A         off
     Ethernet24   9,10,11,12      40G   9100    N/A  Ethernet1/7  PortChannel0004      up       up     N/A         off
     Ethernet28  13,14,15,16      40G   9100    N/A  Ethernet1/8  PortChannel0006      up       up     N/A         off
   Ethernet-BP0  17,18,19,20      40G   9100    N/A   Eth4-ASIC0  PortChannel4020      up       up     N/A         off
   Ethernet-BP4  21,22,23,24      40G   9100    N/A   Eth5-ASIC0  PortChannel4020      up       up     N/A         off
   Ethernet-BP8  25,26,27,28      40G   9100    N/A   Eth6-ASIC0  PortChannel4030      up       up     N/A         off
  Ethernet-BP12  29,30,31,32      40G   9100    N/A   Eth7-ASIC0  PortChannel4030      up       up     N/A         off
  Ethernet-BP16  17,18,19,20      40G   9100    N/A   Eth4-ASIC1  PortChannel4021      up       up     N/A         off
  Ethernet-BP20  21,22,23,24      40G   9100    N/A   Eth5-ASIC1  PortChannel4021      up       up     N/A         off
  Ethernet-BP24  25,26,27,28      40G   9100    N/A   Eth6-ASIC1  PortChannel4031      up       up     N/A         off
  Ethernet-BP28  29,30,31,32      40G   9100    N/A   Eth7-ASIC1  PortChannel4031      up       up     N/A         off
  Ethernet-BP32      1,2,3,4      40G   9100    N/A   Eth0-ASIC2  PortChannel4002      up       up     N/A         off
  Ethernet-BP36      5,6,7,8      40G   9100    N/A   Eth1-ASIC2  PortChannel4002      up       up     N/A         off
  Ethernet-BP40   9,10,11,12      40G   9100    N/A   Eth2-ASIC2  PortChannel4012      up       up     N/A         off
  Ethernet-BP44  13,14,15,16      40G   9100    N/A   Eth3-ASIC2  PortChannel4012      up       up     N/A         off
  Ethernet-BP48  17,18,19,20      N/A   9100    N/A   Eth4-ASIC2           routed    down     down     N/A         off
  Ethernet-BP52  21,22,23,24      N/A   9100    N/A   Eth5-ASIC2           routed    down     down     N/A         off
  Ethernet-BP56  25,26,27,28      N/A   9100    N/A   Eth6-ASIC2           routed    down     down     N/A         off
  Ethernet-BP60  29,30,31,32      N/A   9100    N/A   Eth7-ASIC2           routed    down     down     N/A         off
  Ethernet-BP64      1,2,3,4      40G   9100    N/A   Eth0-ASIC3  PortChannel4003      up       up     N/A         off
  Ethernet-BP68      5,6,7,8      40G   9100    N/A   Eth1-ASIC3  PortChannel4003      up       up     N/A         off
  Ethernet-BP72   9,10,11,12      40G   9100    N/A   Eth2-ASIC3  PortChannel4013      up       up     N/A         off
  Ethernet-BP76  13,14,15,16      40G   9100    N/A   Eth3-ASIC3  PortChannel4013      up       up     N/A         off
  Ethernet-BP80  17,18,19,20      N/A   9100    N/A   Eth4-ASIC3           routed    down     down     N/A         off
  Ethernet-BP84  21,22,23,24      N/A   9100    N/A   Eth5-ASIC3           routed    down     down     N/A         off
  Ethernet-BP92  25,26,27,28      N/A   9100    N/A   Eth6-ASIC3           routed    down     down     N/A         off
  Ethernet-BP96  29,30,31,32      N/A   9100    N/A   Eth7-ASIC3           routed    down     down     N/A         off
PortChannel0001          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0002          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0003          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0004          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0005          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0006          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4002          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4003          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4012          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4013          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4020          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4021          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4030          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4031          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
