### PR TITLE
Add hwsku Nokia-7215 support in port_utils.py

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -101,7 +101,7 @@ def get_port_alias_to_name_map(hwsku):
     elif hwsku == "Celestica-E1031-T48S4":
         for i in range(1, 53):
             port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % ((i - 1))
-    elif hwsku == "et6448m":
+    elif hwsku == "et6448m" or hwsku == "Nokia-7215":
         for i in range(0, 52):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
     elif hwsku == "newport":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add  hwsku Nokia-7215 to port_utils,py 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add support for Nokia-7215 hwsku in port_utils.py used to get port alias map
#### How did you do it?
Use existing mapping for et6448m as Nokia-7215 uses same mapping:

#### How did you verify/test it?
verified config facts and minigraph facts are correct for hwsku Nokia-7215

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
N/A
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
