### PR TITLE
[port_utils] Add port alias mapping for z9332f

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -24,6 +24,32 @@ def get_port_alias_to_name_map(hwsku):
     elif hwsku == "Force10-Z9100":
         for i in range(0, 128, 4):
             port_alias_to_name_map["hundredGigE1/%d" % (i / 4 + 1)] = "Ethernet%d" % i
+    elif hwsku == "DellEMC-Z9332f-M-O16C64":
+        # 100G ports
+        s100G_ports = [x for x in range(0, 32, 2)] + [x for x in range(64, 96, 2)] + [x for x in range(160, 192, 2)] + [x for x in range(224, 256, 2)]
+
+        # 400G ports
+        s400G_ports = [x for x in range(32, 64, 8)] + [x for x in range(96, 160, 8)] + [x for x in range(192, 224, 8)]
+
+        # 10G ports
+        s10G_ports = [x for x in range(256, 258)]
+
+        for i in s100G_ports:
+            alias = "hundredGigE1/{}/{}".format(((i + 8) // 8), ((i // 2) % 4) + 1)
+            port_alias_to_name_map[alias] = "Ethernet{}".format(i)
+        for i in s400G_ports:
+            alias = "fourhundredGigE1/{}".format((i // 8) + 1)
+            port_alias_to_name_map[alias] = "Ethernet{}".format(i)
+        for i in s10G_ports:
+            alias = "tenGigE1/{}".format(33 if i == 256 else 34)
+            port_alias_to_name_map[alias] = "Ethernet{}".format(i)
+    elif hwsku == "DellEMC-Z9332f-O32":
+        for i in range(0, 256, 8):
+            alias = "fourhundredGigE1/{}".format((i // 8) + 1)
+            port_alias_to_name_map[alias] = "Ethernet{}".format(i)
+        for i in range(256, 258):
+            alias = "tenGigE1/{}".format(33 if i == 256 else 34)
+            port_alias_to_name_map[alias] = "Ethernet{}".format(i)
     elif hwsku == "Arista-7050-QX32":
         for i in range(1, 25):
             port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
@@ -112,4 +138,3 @@ def get_port_alias_to_name_map(hwsku):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
 
     return port_alias_to_name_map
-


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To allow users to create testbeds with the 9332.

#### How did you do it?
Updated the port alias mapping to match the port_config.ini specified in sonic-buildimage.

#### How did you verify/test it?
Ran locally, confirmed output matched sonic-buildimage.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
