### PR TITLE
[dualtor] Add neighbor entry orchagent testcase

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -24,7 +24,8 @@ __all__ = [
     'mock_server_base_ip_addr',
     'mock_server_ip_mac_map',
     'set_dual_tor_state_to_orchagent',
-    'del_dual_tor_state_from_orchagent'
+    'del_dual_tor_state_from_orchagent',
+    'is_t0_mocked_dualtor'
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -738,6 +738,7 @@ def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo):
     servers = mux_cable_server_ip(standby_tor)
     random_server_iface = random.choice(servers.keys())
 
+    res['selected_port'] = random_server_iface
     res['target_server_ip'] = servers[random_server_iface]['server_ipv4'].split('/')[0]
     res['target_server_port'] = standby_tor_mg_facts['minigraph_ptf_indices'][random_server_iface]
 

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -86,7 +86,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             logging.debug("Outer packet DSCP: {0:06b}, inner packet DSCP: {1:06b}".format(outer_dscp, inner_dscp))
             logging.debug("Outer packet ECN: {0:02b}, inner packet ECN: {0:02b}".format(outer_ecn, inner_ecn))
             check_res = []
-            if outer_dscp != inner_ecn:
+            if outer_dscp != inner_dscp:
                 check_res.append("outer packet DSCP not same as inner packet DSCP")
             if outer_ecn != inner_ecn:
                 check_res.append("outer packet ECN not same as inner packet ECN")

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -1,4 +1,3 @@
-import ptf
 import pytest
 import random
 import time


### PR DESCRIPTION
Verify that, for standby ToR, the traffic to the server will be dropped if the neighbor entry of server is removed.


Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2805

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Verify that, for standby ToR, the traffic to the server will be dropped if the neighbor entry of server is removed.

#### How did you do it?
Verify that the traffic to server is neither passed to server directly by standby ToR or encapsulated to the active ToR.

#### How did you verify/test it?
```
dualtor/test_t1_to_standby.py::test_standby_tor_remove_neighbor_downstream_standby PASSED                                                                                                      [100%]

===================================================================================== 1 passed in 28.33 seconds ======================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
