### PR TITLE
[SAI QoS Test] modify DSCP SAI QoS test to handle destination port that's part of port channel

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -216,6 +216,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         print >> sys.stderr, "port list {}".format(port_list)
         # Get a snapshot of counter values
 
+        time.sleep(10)
         # port_results is not of our interest here
         port_results, queue_results_base = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
 
@@ -268,9 +269,9 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # dscp 48 -> queue 6
             # So for the 64 pkts sent the mapping should be -> 58 queue 1, and 1 for queue0, queue2, queue3, queue4, queue5, and queue6
             # Check results
+            # LAG ports can have LACP packets on queue 0, hence using >= comparison
             assert(queue_results[QUEUE_0] >= 1 + queue_results_base[QUEUE_0])
-            # +1 to account for the pkt sent by get_rx_port()
-            assert(queue_results[QUEUE_1] == 58 + queue_results_base[QUEUE_1]) + 1
+            assert(queue_results[QUEUE_1] == 58 + queue_results_base[QUEUE_1])
             assert(queue_results[QUEUE_2] == 1 + queue_results_base[QUEUE_2])
             assert(queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
             assert(queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -7,6 +7,7 @@ import logging
 import ptf.packet as scapy
 import socket
 import ptf.dataplane as dataplane
+import ptf.testutils as testutils
 import sai_base_test
 import operator
 import sys
@@ -59,6 +60,41 @@ STOP_PORT_MAX_RATE = 1
 RELEASE_PORT_MAX_RATE = 0
 ECN_INDEX_IN_HEADER = 53 # Fits the ptf hex_dump_buffer() parse function
 DSCP_INDEX_IN_HEADER = 52 # Fits the ptf hex_dump_buffer() parse function
+
+def get_rx_port(dp, device_number, src_port_id, dst_mac, dst_ip, src_ip):
+    ip_id = 0xBABE
+    tos = (0 << 2) | 1
+    src_port_mac = dp.dataplane.get_mac(device_number, src_port_id)
+    pkt = testutils.simple_ip_packet(pktlen=64,
+                            eth_dst=dst_mac,
+                            eth_src=src_port_mac,
+                            ip_src=src_ip,
+                            ip_dst=dst_ip,
+                            ip_tos=tos,
+                            ip_id=ip_id)
+
+    send_packet(dp, src_port_id, pkt, 1)
+
+    exp_pkt = testutils.simple_ip_packet(pktlen=48,
+                            eth_dst=dst_mac,
+                            eth_src=src_port_mac,
+                            ip_src=src_ip,
+                            ip_dst=dst_ip,
+                            ip_tos=tos,
+                            ip_id=ip_id)
+
+    masked_exp_pkt = Mask(exp_pkt, ignore_extra_bytes=True)
+    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+    masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+    masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+    masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
+
+    result = dp.dataplane.poll(device_number=0, exp_pkt=masked_exp_pkt, timeout=3)
+    if isinstance(result, dp.dataplane.PollFailure):
+        dp.fail("Expected packet was not received. Received on port:{} {}".format(result.port, result.format()))
+
+    return result.port
 
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
@@ -154,6 +190,7 @@ class ReleaseAllPorts(sai_base_test.ThriftInterfaceDataPlane):
 
 # DSCP to queue mapping
 class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
+
     def runTest(self):
         switch_init(self.client)
 
@@ -164,22 +201,26 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         src_port_id = int(self.test_params['src_port_id'])
         src_port_ip = self.test_params['src_port_ip']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
-        print >> sys.stderr, "dst_port_id: %d, src_port_id: %d" % (dst_port_id, src_port_id)
-        print >> sys.stderr, "dst_port_mac: %s, src_port_mac: %s, src_port_ip: %s, dst_port_ip: %s" % (dst_port_mac, src_port_mac, src_port_ip, dst_port_ip)
         exp_ip_id = 101
         exp_ttl = 63
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        pkt_rx_port = get_rx_port(self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip)
 
+        print >> sys.stderr, "dst_port_id: %d, src_port_id: %d" % (pkt_rx_port, src_port_id)
+        print >> sys.stderr, "dst_port_mac: %s, src_port_mac: %s, src_port_ip: %s, dst_port_ip: %s" % (dst_port_mac, src_port_mac, src_port_ip, dst_port_ip)
+        print >> sys.stderr, "port list {}".format(port_list)
         # Get a snapshot of counter values
+
         # port_results is not of our interest here
-        port_results, queue_results_base = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+        port_results, queue_results_base = sai_thrift_read_port_counters(self.client, port_list[pkt_rx_port])
 
         # DSCP Mapping test
         try:
             for dscp in range(0, 64):
                 tos = (dscp << 2)
                 tos |= 1
-                pkt = simple_tcp_packet(pktlen=64,
-                                        eth_dst=router_mac if router_mac != '' else dst_port_mac,
+                pkt = testutils.simple_ip_packet(pktlen=64,
+                                        eth_dst=pkt_dst_mac,
                                         eth_src=src_port_mac,
                                         ip_src=src_port_ip,
                                         ip_dst=dst_port_ip,
@@ -192,9 +233,9 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
                 cnt = 0
                 dscp_received = False
                 while not dscp_received:
-                    result = self.dataplane.poll(device_number=0, port_number=dst_port_id, timeout=3)
+                    result = self.dataplane.poll(device_number=0, port_number=pkt_rx_port, timeout=3)
                     if isinstance(result, self.dataplane.PollFailure):
-                        self.fail("Expected packet was not received on port %d. Total received: %d.\n%s" % (dst_port_id, cnt, result.format()))
+                        self.fail("Expected packet was not received on port %d. Total received: %d.\n%s" % (pkt_rx_port, cnt, result.format()))
                     recv_pkt = scapy.Ether(result.packet)
                     cnt += 1
 
@@ -210,7 +251,7 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
 
             # Read Counters
             time.sleep(10)
-            port_results, queue_results = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])
+            port_results, queue_results = sai_thrift_read_port_counters(self.client, port_list[pkt_rx_port])
 
             print >> sys.stderr, map(operator.sub, queue_results, queue_results_base)
             # According to SONiC configuration all dscp are classified to queue 1 except:
@@ -222,13 +263,13 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # dscp 48 -> queue 6
             # So for the 64 pkts sent the mapping should be -> 58 queue 1, and 1 for queue0, queue2, queue3, queue4, queue5, and queue6
             # Check results
-            assert(queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
-            assert(queue_results[QUEUE_1] == 58 + queue_results_base[QUEUE_1])
-            assert(queue_results[QUEUE_2] == 1 + queue_results_base[QUEUE_2])
-            assert(queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
-            assert(queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
-            assert(queue_results[QUEUE_5] == 1 + queue_results_base[QUEUE_5])
-            assert(queue_results[QUEUE_6] == 1 + queue_results_base[QUEUE_6])
+            assert(queue_results[QUEUE_0] >= 1 + queue_results_base[QUEUE_0])
+            assert(queue_results[QUEUE_1] >= 1 + queue_results_base[QUEUE_1])
+            assert(queue_results[QUEUE_2] >= 1 + queue_results_base[QUEUE_2])
+            assert(queue_results[QUEUE_3] >= 1 + queue_results_base[QUEUE_3])
+            assert(queue_results[QUEUE_4] >= 1 + queue_results_base[QUEUE_4])
+            assert(queue_results[QUEUE_5] >= 1 + queue_results_base[QUEUE_5])
+            assert(queue_results[QUEUE_6] >= 1 + queue_results_base[QUEUE_6])
 
         finally:
             print >> sys.stderr, "END OF TEST"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Modify DSCP SAI QoS test to handle destination port that's part of port channel. The QoS test script returns
the first member of the port channel group, for both source and destination ports to test with. For source
port there is not issue, but for destination port (on which to expect rx packets) that part of a port channel,
packets can be received in any of the port channel members.

#### How did you do it?

Before running the actual test, use the pkt used for testing to send one packet on source port and find out
the port which it is received. Use that port for the testing.

NOTE: This PR has changes only for DSCP queue mapping test. Similar changes will be made for rest of the QoS SAI Tests.

#### How did you verify/test it?

verified on both Multi ASIC and Single ASIC platform.

```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest --count=10 qos/test_qos_sai.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library --disable_loga
nalyzer --skip_sanity -k QueueMapping --log-level DEBUG
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================================= test session starts =============================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collected 760 items / 720 deselected / 40 selected

qos/test_qos_sai.py ........................................                                                                                                                                                                                                            [100%]

================================================================================================================ 40 passed, 720 deselected in 3612.23 seconds =================================================================================================================
```

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest --count=10 qos/test_qos_sai.py  --testbed=vms12-t1-lag-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8 --module-path=../ansible/library --disable_loganalyzer --skip_sanity  -k QueueMapping --log-level DEBUG
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 190 items / 180 deselected / 10 selected

qos/test_qos_sai.py ..........                                                                                                                                                                                                        [100%]

=============================================================================================== 10 passed, 180 deselected in 1916.97 seconds ================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
