### PR TITLE
[platform] Update 'show platform psustatus' tests to handle new expanded output

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -203,7 +203,7 @@ def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname):
         pytest.skip("JSON output not available in this version")
 
     logging.info("Check pmon daemon status")
-    assert check_pmon_daemon_status(duthost), "Not all pmon daemons running."
+    pytest_assert(check_pmon_daemon_status(duthost), "Not all pmon daemons running.")
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus", "--json"])
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -214,7 +214,7 @@ def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname):
     # TODO: Compare against expected platform-specific output
     for psu_info in psu_info_list:
         expected_keys = ["index", "name", "presence", "status", "led_status", "model", "serial", "voltage", "current", "power"]
-        pytest_assert(all(key in psu_info for key in expected_keys), "Unexpected PSU status JSON output: '{}'".format(psu_status_output))
+        pytest_assert(all(key in psu_info for key in expected_keys), "Expected key(s) missing from JSON output: '{}'".format(psu_status_output))
         pytest_assert(psu_info["status"] in ["OK", "NOT OK", "NOT PRESENT"], "Unexpected PSU status value: '{}'".format(psu_info["status"]))
         pytest_assert(psu_info["led_status"] in ["green", "amber", "red", "off"], "Unexpected PSU led_status value: '{}'".format(psu_info["led_status"]))
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -181,7 +181,7 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     else:
         psu_line_pattern = re.compile(r"PSU\s+\d+\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
 
-    # Check that all psus are showing valid status and also at-least one PSU is OK.
+    # Check that all PSUs are showing valid status and also at least one PSU is OK
     num_psu_ok = 0
 
     for line in psu_status_output_lines[2:]:
@@ -190,7 +190,8 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
         psu_status = psu_match.group(1)
         if psu_status == "OK":
             num_psu_ok += 1
-    pytest_assert(num_psu_ok > 0, " No PSU's are displayed with OK status on '{}'".format(duthost.hostname))
+
+    pytest_assert(num_psu_ok > 0, "No PSUs are displayed with OK status on '{}'".format(duthost.hostname))
 
 
 def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname):

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -213,17 +213,10 @@ def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname):
 
     # TODO: Compare against expected platform-specific output
     for psu_info in psu_info_list:
-        pytest_assert(("index" in psu_info and
-                       "name" in psu_info and
-                       "presence" in psu_info and
-                       "status" in psu_info and psu_info["status"] in ["OK", "NOT OK", "NOT PRESENT"] and
-                       "led_status" in psu_info and psu_info["led_status"] in ["green", "amber", "red", "off"] and
-                       "model" in psu_info and
-                       "serial" in psu_info and
-                       "voltage" in psu_info and
-                       "current" in psu_info and
-                       "power" in psu_info),
-                      "Unexpected PSU status JSON output: '{}'".format(psu_status_output))
+        expected_keys = ["index", "name", "presence", "status", "led_status", "model", "serial", "voltage", "current", "power"]
+        pytest_assert(all(key in psu_info for key in expected_keys), "Unexpected PSU status JSON output: '{}'".format(psu_status_output))
+        pytest_assert(psu_info["status"] in ["OK", "NOT OK", "NOT PRESENT"], "Unexpected PSU status value: '{}'".format(psu_info["status"]))
+        pytest_assert(psu_info["led_status"] in ["green", "amber", "red", "off"], "Unexpected PSU led_status value: '{}'".format(psu_info["led_status"]))
 
 
 def verify_show_platform_fan_output(duthost, raw_output_lines):

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -4,6 +4,7 @@ Check platform information
 This script covers the test case 'Check platform information' in the SONiC platform test plan:
 https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
+import json
 import logging
 import re
 import time
@@ -20,6 +21,7 @@ pytestmark = [
 ]
 
 CMD_PLATFORM_PSUSTATUS = "show platform psustatus"
+CMD_PLATFORM_PSUSTATUS_JSON = "{} --json".format(CMD_PLATFORM_PSUSTATUS)
 CMD_PLATFORM_FANSTATUS = "show platform fan"
 CMD_PLATFORM_TEMPER = "show platform temperature"
 
@@ -145,7 +147,11 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
     if dut.facts["asic_type"] in ["mellanox"]:
         from .mellanox.check_sysfs import check_psu_sysfs
 
-        psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
+        if "201811" in dut.os_version or "201911" in dut.os_version:
+            psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
+        else:
+            psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+
         psu_match = psu_line_pattern.match(psu_status_line)
         psu_id = psu_match.group(1)
         psu_status = psu_match.group(2)
@@ -163,16 +169,25 @@ def turn_all_outlets_on(pdu_ctrl):
 
 
 def check_all_psu_on(dut, psu_test_results):
-    cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
     power_off_psu_list = []
-    for line in cli_psu_status["stdout_lines"][2:]:
-        fields = line.split()
-        psu_test_results[fields[1]] = False
-        if " ".join(fields[2:]) == "NOT OK":
-            power_off_psu_list.append(fields[1])
+
+    if "201811" in dut.os_version or "201911" in dut.os_version:
+        cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
+        for line in cli_psu_status["stdout_lines"][2:]:
+            fields = line.split()
+            psu_test_results[fields[1]] = False
+            if " ".join(fields[2:]) == "NOT OK":
+                power_off_psu_list.append(fields[1])
+    else:
+        # Use JSON output
+        cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS_JSON)
+        psu_info_list = json.loads(cli_psu_status["stdout"])
+        for psu_info in psu_info_list:
+            if psu_info["status"] == "NOT OK":
+                power_off_psu_list.append(psu_info["index"])
 
     if power_off_psu_list:
-        logging.warn('Power off PSU list: {}'.format(power_off_psu_list))
+        logging.warn('Powered off PSUs: {}'.format(power_off_psu_list))
 
     return len(power_off_psu_list) == 0
 


### PR DESCRIPTION
### Description of PR

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Update testing of `show platform psustatus` to handle the new, expanded output provided by https://github.com/Azure/sonic-utilities/pull/1416. Maintain backward-compatibility with the previous syntax in 201811 and 201911 versions.

#### How did you do it?

Support both output formats based on observed OS version

#### How did you verify/test it?

Tested against one platform with old and new output formats

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
