### PR TITLE
DHCP Relay Testing for Dual ToR

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -146,6 +146,10 @@ class DHCPTest(DataplaneBaseTest):
         self.option82 += remote_id_string
 
         # In 'dual' testing mode, vlan ip is stored as suboption 5 of option 82.
+        # It consists of the following:
+        #  Byte 0: Suboption number, always set to 5
+        #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
+        #  Bytes 2+: vlan ip addr
         if self.dual_tor:
             link_selection = ''.join([chr(int(byte)) for byte in self.relay_iface_ip.split('.')])
             self.option82 += struct.pack('BB', 5, 4)

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -118,6 +118,12 @@ class DHCPTest(DataplaneBaseTest):
         self.client_port_index = int(self.test_params['client_port_index'])
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
 
+        self.switch_loopback_ip = self.test_params['switch_loopback_ip']
+
+        # 'dual' for dual tor testing
+        # 'default' for regular single tor testing
+        self.dual_tor = (self.test_params['testing_mode'] == 'dual')
+
         # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.
         # circuit_id is stored as suboption 1 of option 82.
         # It consists of the following:
@@ -138,6 +144,12 @@ class DHCPTest(DataplaneBaseTest):
         remote_id_string = self.relay_iface_mac
         self.option82 += struct.pack('BB', 2, len(remote_id_string))
         self.option82 += remote_id_string
+
+        # In 'dual' testing mode, vlan ip is stored as suboption 5 of option 82.
+        if self.dual_tor:
+            link_selection = ''.join([chr(int(byte)) for byte in self.relay_iface_ip.split('.')])
+            self.option82 += struct.pack('BB', 5, 4)
+            self.option82 += link_selection
 
         # We'll assign our client the IP address 1 greater than our relay interface (i.e., gateway) IP
         self.client_ip = incrementIpAddress(self.relay_iface_ip, 1) 
@@ -195,7 +207,7 @@ class DHCPTest(DataplaneBaseTest):
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.DEFAULT_ROUTE_IP,
                     siaddr=self.DEFAULT_ROUTE_IP,
-                    giaddr=self.relay_iface_ip,
+                    giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     chaddr=my_chaddr)
         bootp /= scapy.DHCP(options=[('message-type', 'discover'),
                     ('relay_agent_Information', self.option82),
@@ -214,10 +226,10 @@ class DHCPTest(DataplaneBaseTest):
                     eth_dst=self.relay_iface_mac,
                     eth_client=self.client_mac,
                     ip_server=self.server_ip,
-                    ip_dst=self.relay_iface_ip,
+                    ip_dst=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     ip_offered=self.client_ip,
                     port_dst=self.DHCP_SERVER_PORT,
-                    ip_gateway=self.relay_iface_ip,
+                    ip_gateway=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     netmask_client=self.client_subnet,
                     dhcp_lease=self.LEASE_TIME,
                     padding_bytes=0,
@@ -246,7 +258,7 @@ class DHCPTest(DataplaneBaseTest):
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.client_ip,
                     siaddr=self.server_ip,
-                    giaddr=self.relay_iface_ip,
+                    giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     chaddr=my_chaddr)
         bootp /= scapy.DHCP(options=[('message-type', 'offer'),
                     ('server_id', self.server_ip),
@@ -300,7 +312,7 @@ class DHCPTest(DataplaneBaseTest):
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.DEFAULT_ROUTE_IP,
                     siaddr=self.DEFAULT_ROUTE_IP,
-                    giaddr=self.relay_iface_ip,
+                    giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     chaddr=my_chaddr)
         bootp /= scapy.DHCP(options=[('message-type', 'request'),
                     ('requested_addr', self.client_ip),
@@ -321,10 +333,10 @@ class DHCPTest(DataplaneBaseTest):
                     eth_dst=self.relay_iface_mac,
                     eth_client=self.client_mac,
                     ip_server=self.server_ip,
-                    ip_dst=self.relay_iface_ip,
+                    ip_dst=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     ip_offered=self.client_ip,
                     port_dst=self.DHCP_SERVER_PORT,
-                    ip_gateway=self.relay_iface_ip,
+                    ip_gateway=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     netmask_client=self.client_subnet,
                     dhcp_lease=self.LEASE_TIME,
                     padding_bytes=0,
@@ -353,7 +365,7 @@ class DHCPTest(DataplaneBaseTest):
                     ciaddr=self.DEFAULT_ROUTE_IP,
                     yiaddr=self.client_ip,
                     siaddr=self.server_ip,
-                    giaddr=self.relay_iface_ip,
+                    giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     chaddr=my_chaddr)
         bootp /= scapy.DHCP(options=[('message-type', 'ack'),
                     ('server_id', self.server_ip),

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -121,7 +121,7 @@ class DHCPTest(DataplaneBaseTest):
         self.switch_loopback_ip = self.test_params['switch_loopback_ip']
 
         # 'dual' for dual tor testing
-        # 'default' for regular single tor testing
+        # 'single' for regular single tor testing
         self.dual_tor = (self.test_params['testing_mode'] == 'dual')
 
         # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -123,6 +123,15 @@ def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_da
 def restart_dhcp_service(duthost):
     duthost.shell('systemctl restart dhcp_relay')
     duthost.shell('systemctl reset-failed dhcp_relay')
+
+    for retry in range(5):
+        time.sleep(30)
+        dhcp_status = duthost.shell('docker container top dhcp_relay | grep dhcrelay | cat')["stdout"]
+        if dhcp_status != "":
+            break
+    else:
+        assert False, "Failed to restart dhcp docker"
+
     time.sleep(30)
 
 
@@ -135,7 +144,10 @@ def get_subtype_from_configdb(duthost):
     return subtype_exist, subtype_value
 
 
-def set_tor_testing_mode(duthost, testing_mode):
+@pytest.fixture(scope="module", params=[SINGLE_TOR_MODE, DUAL_TOR_MODE])
+def testing_config(request, duthosts, rand_one_dut_hostname):
+    testing_mode = request.param
+    duthost = duthosts[rand_one_dut_hostname]
     subtype_exist, subtype_value = get_subtype_from_configdb(duthost)
 
     if testing_mode == SINGLE_TOR_MODE:
@@ -148,21 +160,19 @@ def set_tor_testing_mode(duthost, testing_mode):
             duthost.shell('redis-cli -n 4 HSET "DEVICE_METADATA|localhost" "subtype" "DualToR"')
             restart_dhcp_service(duthost)
 
+    yield testing_mode, duthost
 
-def clear_tor_testing_mode(duthost, testing_mode):
     if testing_mode == DUAL_TOR_MODE:
         duthost.shell('redis-cli -n 4 HDEL "DEVICE_METADATA|localhost" "subtype"')
         restart_dhcp_service(duthost)
 
 
-@pytest.mark.parametrize("testing_mode", [SINGLE_TOR_MODE, DUAL_TOR_MODE])
-def test_dhcp_relay_default(duthosts, rand_one_dut_hostname, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_mode):
+def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology.
 
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    set_tor_testing_mode(duthost, testing_mode)
+    testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
@@ -185,18 +195,14 @@ def test_dhcp_relay_default(duthosts, rand_one_dut_hostname, ptfhost, dut_dhcp_r
                            "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
-    clear_tor_testing_mode(duthost, testing_mode)
 
-
-@pytest.mark.parametrize("testing_mode", [SINGLE_TOR_MODE, DUAL_TOR_MODE])
-def test_dhcp_relay_after_link_flap(duthosts, rand_one_dut_hostname, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_mode):
+def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology after uplinks flap
 
        For each DHCP relay agent running on the DuT, with relay agent running, flap the uplinks,
        then test whether the DHCP relay agent relays packets properly.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    set_tor_testing_mode(duthost, testing_mode)
+    testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down
@@ -233,19 +239,15 @@ def test_dhcp_relay_after_link_flap(duthosts, rand_one_dut_hostname, ptfhost, du
                            "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
-    clear_tor_testing_mode(duthost, testing_mode)
 
-
-@pytest.mark.parametrize("testing_mode", [SINGLE_TOR_MODE, DUAL_TOR_MODE])
-def test_dhcp_relay_start_with_uplinks_down(duthosts, rand_one_dut_hostname, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_mode):
+def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology when relay agent starts with uplinks down
 
        For each DHCP relay agent running on the DuT, bring the uplinks down, then restart the
        relay agent while the uplinks are still down. Then test whether the DHCP relay agent
        relays packets properly.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    set_tor_testing_mode(duthost, testing_mode)
+    testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down
@@ -289,17 +291,13 @@ def test_dhcp_relay_start_with_uplinks_down(duthosts, rand_one_dut_hostname, ptf
                            "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
-    clear_tor_testing_mode(duthost, testing_mode)
 
-
-@pytest.mark.parametrize("testing_mode", [SINGLE_TOR_MODE, DUAL_TOR_MODE])
-def test_dhcp_relay_unicast_mac(duthosts, rand_one_dut_hostname, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_mode):
+def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology with unicast mac
 
        Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    set_tor_testing_mode(duthost, testing_mode)
+    testing_mode, duthost = testing_config
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
@@ -322,18 +320,14 @@ def test_dhcp_relay_unicast_mac(duthosts, rand_one_dut_hostname, ptfhost, dut_dh
                            "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
-    clear_tor_testing_mode(duthost, testing_mode)
 
-
-@pytest.mark.parametrize("testing_mode", [SINGLE_TOR_MODE, DUAL_TOR_MODE])
-def test_dhcp_relay_random_sport(duthosts, rand_one_dut_hostname, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_mode):
+def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology with random source port (sport)
 
        If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68).
        Verify that DHCP relay works with random high sport.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-    set_tor_testing_mode(duthost, testing_mode)
+    testing_mode, duthost = testing_config
 
     RANDOM_CLIENT_PORT = random.choice(range(1000, 65535))
     for dhcp_relay in dut_dhcp_relay_data:
@@ -356,5 +350,3 @@ def test_dhcp_relay_random_sport(duthosts, rand_one_dut_hostname, ptfhost, dut_d
                            "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
                            "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
-
-    clear_tor_testing_mode(duthost, testing_mode)

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -350,3 +350,4 @@ def test_dhcp_relay_random_sport(duthosts, rand_one_dut_hostname, ptfhost, dut_d
 
     if testing_mode == 'dual':
         reset_dual_tor(duthost)
+

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -137,7 +137,7 @@ def restart_dhcp_service(duthost):
 
 def get_subtype_from_configdb(duthost):
     # HEXISTS returns 1 if the key exists, otherwise 0
-    subtype_exist = duthost.shell('redis-cli -n 4 HEXISTS "DEVICE_METADATA|localhost" "subtype"')["stdout"]
+    subtype_exist = int(duthost.shell('redis-cli -n 4 HEXISTS "DEVICE_METADATA|localhost" "subtype"')["stdout"])
     subtype_value = ""
     if subtype_exist:
         subtype_value = duthost.shell('redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "subtype"')["stdout"]

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -121,6 +121,7 @@ def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_da
 
 
 def restart_dhcp_service(duthost):
+    duthost.shell('systemctl reset-failed dhcp_relay')
     duthost.shell('systemctl restart dhcp_relay')
     duthost.shell('systemctl reset-failed dhcp_relay')
 


### PR DESCRIPTION
DHCP Relay testing for dual tor

This PR extends the dhcp relay pytest to support dual tor testing.

All tests will first run in single tor testing mode and then in dual tor testing mode. The switch between different testing modes is realized by adding/deleting <subtype=DualToR> in configdb followed by dhcp docker restart. Shell output is checked to ensure that dhcp docker is up before proceeding with tests. 

Testing results are verified on a vs testbed.

![image](https://user-images.githubusercontent.com/22752629/109726976-6ff3dc80-7b68-11eb-9ea7-411f3288a460.png)

