### PR TITLE
Include Broadcom th3 asic in get_asic_name function

### DIFF
--- a/tests/common/devices.py
+++ b/tests/common/devices.py
@@ -1162,6 +1162,8 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             asic = "td2"
         elif "Broadcom Limited Device b870" in output:
             asic = "td3"
+        elif "Broadcom Limited Device b980" in output:
+            asic = "th3"
 
         return asic
 


### PR DESCRIPTION

### Description of PR
Include Broadcom th3 asic in get_asic_name function

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
th3 asic case is missing in the list 
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
