### PR TITLE
[Platform] Changed MAX acceptable fan speed tolerance from 10 to 15 percent

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -7,7 +7,7 @@ import logging
 from tests.common.mellanox_data import get_platform_data
 from tests.common.utilities import wait_until
 
-MAX_FAN_SPEED_THRESHOLD = 0.1
+MAX_FAN_SPEED_THRESHOLD = 0.15
 
 
 def check_sysfs(dut):


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increased tolerance value of MAX acceptable Fan speed in platfom tests.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [+] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
From time to time test "test_reload_configuration" can fail with such message:
`AssertionError: Invalid fan speed: actual speed=27508, set speed=255, min=1500, max=25000, exception=Fan speed 27508 not in range: [1500, 27500] `

As Fan speed is mechanical dependent and different environmental factors can have impact on the fan speed, there can be higher deviation then 10%. So it was decided that 15% tolerance is acceptable for Max Fan speed.

So MAX_FAN_SPEED_THRESHOLD was changed from 10 to 15 % tolerance.

``

#### How did you do it?

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
