### PR TITLE
Add support for fast and cold upgrade in test_upgrade_path

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -56,10 +56,10 @@ def download_new_sonic_image(module, new_image_url, save_as):
                  cmd="rm -f {}".format(save_as),
                  msg="clean up previously downloaded image",
                  ignore_error=True)
-
-    exec_command(module,
-                 cmd="curl -o {} {}".format(save_as, new_image_url),
-                 msg="downloading new image")
+    if new_image_url:
+        exec_command(module,
+                    cmd="curl -o {} {}".format(save_as, new_image_url),
+                    msg="downloading new image")
 
     if path.exists(save_as):
         _, out, _ = exec_command(module, cmd="sonic_installer binary_version {}".format(save_as))

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -6,6 +6,12 @@ def pytest_addoption(parser):
     options_group = parser.getgroup("Upgrade_path test suite options")
 
     options_group.addoption(
+        "--upgrade_type",
+        default="warm",
+        help="Specify the type (warm/fast/cold) of upgrade that is needed from source to target image",
+    )
+
+    options_group.addoption(
         "--base_image_list",
         default="",
         help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
@@ -33,7 +39,8 @@ def pytest_runtest_setup(item):
 
 @pytest.fixture(scope="module")
 def upgrade_path_lists(request):
+    upgrade_type = request.config.getoption('upgrade_type')
     from_list = request.config.getoption('base_image_list')
     to_list = request.config.getoption('target_image_list')
     restore_to_image = request.config.getoption('restore_to_image')
-    return from_list, to_list, restore_to_image
+    return upgrade_type, from_list, to_list, restore_to_image

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -12,7 +12,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
 from tests.common import reboot
-from tests.common.reboot import get_reboot_cause
+from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
 from tests.common.reboot import REBOOT_TYPE_WARM
 
 
@@ -44,7 +44,7 @@ def setup(localhost, ptfhost, duthosts, rand_one_dut_hostname, upgrade_path_list
 
 
 def cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo):
-    _, _, restore_to_image = upgrade_path_lists
+    _, _, _, restore_to_image = upgrade_path_lists
     if restore_to_image:
         logger.info("Preparing to cleanup and restore to {}".format(restore_to_image))
         # restore orignial image
@@ -135,16 +135,15 @@ def ptf_params(duthosts, rand_one_dut_hostname, nbrhosts, creds, tbinfo):
     return ptf_params
 
 
-def get_reboot_type(duthost):
-    next_os_version = duthost.shell('sonic_installer list | grep Next | cut -f2 -d " "')['stdout']
-    current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
- 
-    # warm-reboot has to be forced for an upgrade from 201811 to 201811+ to bypass ASIC config changed error
-    if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201811' not in next_os_version:
-        reboot_type = "warm-reboot -f"
-    else:
-        reboot_type = "warm-reboot"
-    return reboot_type
+def get_reboot_command(duthost, upgrade_type):
+    reboot_command = reboot_ctrl_dict.get(upgrade_type).get("command")
+    if upgrade_type == REBOOT_TYPE_WARM:
+        next_os_version = duthost.shell('sonic_installer list | grep Next | cut -f2 -d " "')['stdout']
+        current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+        # warm-reboot has to be forced for an upgrade from 201811 to 201811+ to bypass ASIC config changed error
+        if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201811' not in next_os_version:
+            reboot_command = "warm-reboot -f"
+    return reboot_command
 
 
 def check_sonic_version(duthost, target_version):
@@ -182,6 +181,7 @@ def install_sonic(duthost, image_url, tbinfo):
             duthost.shell("mkdir -p /tmp/tmpfs", module_ignore_errors=True)
             duthost.shell("umount /tmp/tmpfs", module_ignore_errors=True)
             duthost.shell("mount -t tmpfs -o size=1300M tmpfs /tmp/tmpfs", module_ignore_errors=True)
+        logger.info("Image exists locally. Copying the image {} into the device path {}".format(image_url, save_as))
         duthost.copy(src=image_url, dest=save_as)
         res = duthost.reduce_and_add_sonic_images(save_as=save_as)
 
@@ -213,7 +213,7 @@ def check_services(duthost):
 @pytest.mark.device_type('vs')
 def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgrade_path_lists, ptf_params, setup, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    from_list_images, to_list_images, _ = upgrade_path_lists
+    upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
     from_list = from_list_images.split(',')
     to_list = to_list_images.split(',')
     assert (from_list and to_list)
@@ -233,7 +233,7 @@ def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgra
             target_version = install_sonic(duthost, to_image, tbinfo)
             test_params = ptf_params
             test_params['target_version'] = target_version
-            test_params['reboot_type'] = get_reboot_type(duthost)
+            test_params['reboot_type'] = get_reboot_command(duthost, upgrade_type)
             prepare_testbed_ssh_keys(duthost, ptfhost, test_params['dut_username'])
             log_file = "/tmp/advanced-reboot.ReloadTest.{}.log".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
 
@@ -246,7 +246,7 @@ def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgra
                        qlen=10000,
                        log_file=log_file)
             reboot_cause = get_reboot_cause(duthost)
-            logger.info("Check reboot cause. Expected cause {}".format(REBOOT_TYPE_WARM))
-            pytest_assert(reboot_cause == REBOOT_TYPE_WARM, "Reboot cause {} did not match the trigger - {}".format(reboot_cause, REBOOT_TYPE_WARM))
+            logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
+            pytest_assert(reboot_cause == upgrade_type, "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))
             check_services(duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Support `fast` and `cold` upgrades in `test_upgrade_path`. The default upgrade type remains as `warm`.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Allow upgrade_type (fast/warm/cold) to be passed as an argument to `test_upgrade_path` testcase.

#### What is the motivation for this PR?

#### How did you do it?
Upgrade using the `upgrade_type` argument. This will support fast and cold upgrades too.

#### How did you verify/test it?
To be tested in a physical testbed.
Tested fastboot in a physical testbed:

```
./run_tests.sh -n vms7-t0-s6100 -d str-s6100-acs-2 -f ../ansible/testbed.csv -i ../ansible/str -u -c upgrade_path/test_upgrade_path.py -e "--base_image_list=http://1.1.1.1/installer/sonic-broadcom.bin --target_image_list=http://1.1.1.1/installer/public/sonic-broadcom.bin --upgrade_type=fast" -l info    

upgrade_path/test_upgrade_path.py::test_upgrade_path
--------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------
18:16:14 INFO test_upgrade_path.py:test_upgrade_path:226: Test upgrade path from http://100.127.20.23/installer/sonic/broadcom/internal-201811/sonic-broadcom.bin to http://100.127.20.23/installer/sonic/broadcom/public/sonic-broadcom.bin
18:16:14 INFO test_upgrade_path.py:test_upgrade_path:228: Installing http://100.127.20.23/installer/sonic/broadcom/internal-201811/sonic-broadcom.bin
18:16:14 INFO devices.py:get_ip_route_info:799: route raw info for 0.0.0.0/0: [u'default proto bgp src 10.1.0.32 metric 20 ', u'\tnexthop via 10.0.0.1 dev PortChannel0001 weight 1 ', u'\tnexthop via 10.0.0.5 dev PortChannel0002 weight 1 ', u'\tnexthop via 10.0.0.9 dev PortChannel0003 weight 1 ', u'\tnexthop via 10.0.0.13 dev PortChannel0004 weight 1 ']
18:16:14 INFO devices.py:get_ip_route_info:834: route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
18:16:14 INFO test_upgrade_path.py:install_sonic:171: Add default mgmt-gateway-route to the device via 10.64.246.1
18:17:05 INFO test_upgrade_path.py:install_sonic:195: Remove default mgmt-gateway-route earlier added
18:17:06 INFO test_upgrade_path.py:test_upgrade_path:231: Cold reboot the DUT to make the base image as current
18:17:10 INFO reboot.py:reboot:124: waiting for ssh to drop
18:17:10 INFO reboot.py:execute_reboot_command:108: rebooting with command "reboot"
18:17:34 INFO reboot.py:reboot:145: waiting for ssh to startup
18:19:35 INFO reboot.py:reboot:156: ssh has started up
18:19:35 INFO reboot.py:reboot:158: waiting for switch to initialize
18:21:35 INFO reboot.py:reboot:186: cold reboot finished
18:21:36 INFO reboot.py:reboot:189: DUT up since 2021-02-26 18:18:56
18:21:37 INFO test_upgrade_path.py:test_upgrade_path:236: Upgrading to http://100.127.20.23/installer/sonic/broadcom/public/sonic-broadcom.bin
18:21:38 INFO devices.py:get_ip_route_info:799: route raw info for 0.0.0.0/0: [u'default proto zebra src 10.1.0.32 ', u'\tnexthop via 10.0.0.5  dev PortChannel0002 weight 1', u'\tnexthop via 10.0.0.1  dev PortChannel0001 weight 1', u'\tnexthop via 10.0.0.9  dev PortChannel0003 weight 1', u'\tnexthop via 10.0.0.13  dev PortChannel0004 weight 1']
18:21:38 INFO devices.py:get_ip_route_info:834: route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
18:21:38 INFO test_upgrade_path.py:install_sonic:171: Add default mgmt-gateway-route to the device via 10.64.246.1
18:22:38 INFO test_upgrade_path.py:install_sonic:195: Remove default mgmt-gateway-route earlier added
18:22:39 INFO ssh_utils.py:prepare_testbed_ssh_keys:17: Remove old keys from ptfhost
18:22:42 INFO ssh_utils.py:prepare_testbed_ssh_keys:26: Generate public key for ptf host
18:28:25 INFO reboot.py:get_reboot_cause:198: Getting reboot cause from dut str-s6100-acs-2
18:28:31 INFO test_upgrade_path.py:test_upgrade_path:256: Check reboot cause. Expected cause fast
18:28:31 INFO test_upgrade_path.py:check_services:204: Wait until DUT uptime reaches 300s
18:31:43 INFO test_upgrade_path.py:check_services:207: Wait until all critical services are fully started
18:31:43 INFO test_upgrade_path.py:check_services:208: Check critical service status
PASSED 
```


Cold upgrade:
```
18:02:03 INFO test_upgrade_path.py:test_upgrade_path:226: Test upgrade path from http://100.127.20.23/installer/sonic/broadcom/internal-201811/sonic-broadcom.bin to http://100.127.20.23/installer/sonic/broadcom/public/sonic-broadcom.bin
18:02:03 INFO test_upgrade_path.py:test_upgrade_path:228: Installing http://1.1.1.1/internal-201811/sonic-broadcom.bin
18:02:03 INFO devices.py:get_ip_route_info:799: route raw info for 0.0.0.0/0: [u'default proto bgp src 10.1.0.32 metric 20 ', u'\tnexthop via 10.0.0.1 dev PortChannel0001 weight 1 ', u'\tnexthop via 10.0.0.5 dev PortChannel0002 weight 1 ', u'\tnexthop via 10.0.0.9 dev PortChannel0003 weight 1 ', u'\tnexthop via 10.0.0.13 dev PortChannel0004 weight 1 ']
18:02:03 INFO devices.py:get_ip_route_info:834: route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
18:02:03 INFO test_upgrade_path.py:install_sonic:171: Add default mgmt-gateway-route to the device via 10.64.246.1
18:02:52 INFO test_upgrade_path.py:install_sonic:195: Remove default mgmt-gateway-route earlier added
18:02:53 INFO test_upgrade_path.py:test_upgrade_path:231: Cold reboot the DUT to make the base image as current
18:02:57 INFO reboot.py:reboot:124: waiting for ssh to drop
18:02:57 INFO reboot.py:execute_reboot_command:108: rebooting with command "reboot"
18:03:20 INFO reboot.py:reboot:145: waiting for ssh to startup
18:05:19 INFO reboot.py:reboot:156: ssh has started up
18:05:19 INFO reboot.py:reboot:158: waiting for switch to initialize
18:07:20 INFO reboot.py:reboot:186: cold reboot finished
18:07:21 INFO reboot.py:reboot:189: DUT up since 2021-02-26 18:04:40
18:07:22 INFO test_upgrade_path.py:test_upgrade_path:236: Upgrading to http://1.1.1.1/public/sonic-broadcom.bin
18:07:22 INFO devices.py:get_ip_route_info:799: route raw info for 0.0.0.0/0: [u'default proto zebra src 10.1.0.32 ', u'\tnexthop via 10.0.0.13  dev PortChannel0004 weight 1', u'\tnexthop via 10.0.0.1  dev PortChannel0001 weight 1', u'\tnexthop via 10.0.0.5  dev PortChannel0002 weight 1', u'\tnexthop via 10.0.0.9  dev PortChannel0003 weight 1']
18:07:22 INFO devices.py:get_ip_route_info:834: route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.13'), u'PortChannel0004'), (IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003')]}
18:07:22 INFO test_upgrade_path.py:install_sonic:171: Add default mgmt-gateway-route to the device via 1.1.1.1
18:08:22 INFO test_upgrade_path.py:install_sonic:195: Remove default mgmt-gateway-route earlier added
18:08:22 INFO ssh_utils.py:prepare_testbed_ssh_keys:17: Remove old keys from ptfhost
18:08:25 INFO ssh_utils.py:prepare_testbed_ssh_keys:26: Generate public key for ptf host
18:08:32 INFO reboot.py:reboot:124: waiting for ssh to drop
18:08:32 INFO reboot.py:execute_reboot_command:108: rebooting with command "reboot"
18:08:47 INFO reboot.py:reboot:145: waiting for ssh to startup
18:10:18 INFO reboot.py:reboot:156: ssh has started up
18:10:18 INFO reboot.py:reboot:158: waiting for switch to initialize
18:12:19 INFO reboot.py:reboot:186: cold reboot finished
18:12:23 INFO reboot.py:reboot:189: DUT up since 2021-02-26 18:09:30
18:12:23 INFO reboot.py:get_reboot_cause:198: Getting reboot cause from dut str-s6100-acs-2
18:12:24 INFO test_upgrade_path.py:test_upgrade_path:256: Check reboot cause. Expected cause cold
18:12:24 INFO test_upgrade_path.py:check_services:204: Wait until DUT uptime reaches 300s
18:14:30 INFO test_upgrade_path.py:check_services:207: Wait until all critical services are fully started
18:14:30 INFO test_upgrade_path.py:check_services:208: Check critical service status
PASSED
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
