### PR TITLE
[vxlan decap] make sure that count_matched_packets_helper will return

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -46,7 +46,8 @@ def count_matched_packets_helper(test, exp_packet, exp_packet_number, port, devi
         raise Exception("%s() requires positive timeout value." % sys._getframe().f_code.co_name)
 
     total_rcv_pkt_cnt = 0
-    while True:
+    end_time = time.time() + timeout
+    while time.time() < end_time:
         result = dp_poll(test, device_number=device_number, port_number=port, timeout=timeout)
         if isinstance(result, test.dataplane.PollSuccess):
             if ptf.dataplane.match_exp_pkt(exp_packet, result.packet):

--- a/ansible/roles/test/files/ptftests/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/vxlan-decap.py
@@ -48,12 +48,11 @@ def count_matched_packets_helper(test, exp_packet, exp_packet_number, port, devi
     total_rcv_pkt_cnt = 0
     end_time = time.time() + timeout
     while time.time() < end_time:
-        result = dp_poll(test, device_number=device_number, port_number=port, timeout=timeout)
+        result = dp_poll(test, device_number=device_number, port_number=port, timeout=timeout, exp_pkt=exp_packet)
         if isinstance(result, test.dataplane.PollSuccess):
-            if ptf.dataplane.match_exp_pkt(exp_packet, result.packet):
-                total_rcv_pkt_cnt += 1
-                if total_rcv_pkt_cnt == exp_packet_number:
-                    break
+            total_rcv_pkt_cnt += 1
+            if total_rcv_pkt_cnt == exp_packet_number:
+                break
         else:
             break
 


### PR DESCRIPTION
### Description of PR

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
vxlan decap test was observed stuck waiting for matching packet.

#### How did you do it?
count_matched_packets_helper has a chance to stuck forever if there is always paket received but never have a match.

this change makes sure that the timeout value is honored

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify it?
Run vxlan test on a DUT got pass. and run on the DUT previously stuck, the test fail properly.

vxlan/test_vxlan_decap.py::test_vxlan_decap[NoVxLAN] PASSED                                                                                                                        [ 33%]
vxlan/test_vxlan_decap.py::test_vxlan_decap[Enabled] PASSED                                                                                                                        [ 66%]
vxlan/test_vxlan_decap.py::test_vxlan_decap[Removed] PASSED                                                                                                                        [100%]

