### PR TITLE
[SPAN] Add local port mirroring test plan and test cases

### DIFF
--- a/tests/span/Port-mirroring-test-plan.md
+++ b/tests/span/Port-mirroring-test-plan.md
@@ -1,0 +1,119 @@
+# Port mirroring test plan
+
+## Rev 0.1
+
+- [Revision](#revision)
+- [Definition/Abbrevation](#definition/abbrevation)
+- [Overview](#overview)
+  - [Scope](#scope)
+  - [Testbed](#testbed)
+- [Setup configuration](#setup-configuration)
+- [Test cases](#test-cases)
+  - [test_port_mirroring_rx](#Test-case-test_port_mirroring_rx)
+  - [test_port_mirroring_tx](#Test-case-test_port_mirroring_tx)
+  - [test_port_mirroring_rx_tx](#Test-case-test_port_mirroring_rx_tx)
+  - [test_port_mirroring_from_multiple_ports](#Test-case-test_port_mirroring_from_multiple_ports)
+
+## Revision
+
+| Rev |     Date    |       Author            |     Change Description      |
+|:---:|:-----------:|:------------------------|:----------------------------|
+| 0.1 |  05/02/2021 | Intel : Viktor Cheketa  |       Initial version       |
+
+## Definition/Abbrevation
+
+| **Term**     | **Meaning**                            |
+|--------------|----------------------------------------|
+|    SPAN      | Switched Port ANalyzer                 |
+| Monitor port | Destination port of mirroring session  |
+| Mirrored port| Source port of mirroring session       |
+
+## Overview
+
+The purpose is to test the functionality of port mirroring (SPAN) feature on SONiC switch DUT.
+
+## Scope
+
+The test is targeting a runninc SONiC system with fully functioning configuration.
+Purpose of test is to verify that a SONiC switch system correctly performs port mirroring implementation
+based on configured sessions.
+
+## Testbed
+
+Supported topologies: t0
+
+## Setup configuration
+
+No setup pre-configuration is required, test will configure and clean-up all the configuration.
+
+### Setup of DUT switch
+
+Each test creates a mirroring session with specific parameters. In order to create a session, monitor port must not
+be a VLAN member.
+
+On setup, tests create a mirroring session via CLI commands on DUT:
+```
+sudo config vlan member del {VLAN} {monitor_port}
+sudo config mirror-session span add {session_name} {monitor_port} {mirrored_port} {direction}
+```
+
+On teardown, these changes are reverted:
+```
+sudo config mirror-session remove {session_name}
+sudo config vlan member add {VLAN} {monitor_port}
+```
+## Test cases
+
+## Test case test_port_mirroring_rx
+
+### Test objective
+
+Verify that INGRESS traffic is mirrored.
+
+### Test steps
+
+- Create mirroring session on DUT with direction 'rx'.
+- Create ICMP packet.
+- Send ICMP packet from PTF to DUT.
+- Verify that DUT mirrors packet to monitor port.
+
+## Test case test_port_mirroring_tx
+
+### Test objective
+
+Verify that EGRESS traffic is mirrored.
+
+### Test steps
+
+- Create mirroring session on DUT with direction 'tx'.
+- Create ICMP packet.
+- Send packet to PTF.
+- Verify that DUT mirrors packet to monitor port.
+
+## Test case test_port_mirroring_rx_tx
+
+### Test objective
+
+Verify that both INGRESS and EGRESS traffic is mirrored.
+
+### Test steps
+
+- Create mirroring session on DUT with direction 'both'.
+- Create ICMP packets.
+- Send packet from PTF to DUT.
+- Verify that DUT mirrors packet to monitor port.
+- Send ICMP packet to PTF.
+- Verify that DUT mirrors packet to monitor port.
+
+## Test case test_port_mirroring_from_multiple_ports
+
+### Test objective
+
+Verify that packets from multiple ports within same session are mirrored
+
+### Test steps
+
+- Create mirroring session with two mirrored ports.
+- Create ICMP packets.
+- Send packets from first and second mirrored ports.
+- Verify that DUT mirrors both packets to monitor port.

--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -1,0 +1,145 @@
+'''
+Conftest file for span tests
+'''
+
+import pytest
+
+@pytest.fixture(scope="module")
+def cfg_facts(duthosts, rand_one_dut_hostname):
+    '''
+    Used to get config facts for selected DUT
+
+    Args:
+        duthosts: All DUTs belonging to the testbed.
+        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    return duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+
+@pytest.fixture(scope="module")
+def ports_for_test(cfg_facts):
+    '''
+    Used to select 3 ports for test and generate info on them
+
+    Args:
+        duthosts: All DUTs belonging to the testbed.
+        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+        cfg_facts: pytest fixture
+
+    Return:
+        dict: port info for 3 selected ports
+    '''
+    # Select vlan for test
+    vlans = cfg_facts['VLAN']
+    vlan = [vlans[vlan]['vlanid'] for vlan in vlans.keys()][0]
+
+    # Select 3 ports for test
+    ports = cfg_facts['VLAN_MEMBER']['Vlan{}'.format(vlan)]
+    port_names = ports.keys()
+    selected_ports = [port_names[0], port_names[1], port_names[-1]]
+
+    # Generate port info for selected ports
+    port_info = []
+    for port in selected_ports:
+        port_info.append({'name': port,
+                          'tagging_mode': ports[port]['tagging_mode'],
+                          'index': cfg_facts['port_index_map'][port]}
+                        )
+
+    return {
+        'source1': port_info[0],
+        'source2': port_info[1],
+        'monitor': port_info[2],
+        'vlan': vlan
+    }
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_monitor_port(duthosts, rand_one_dut_hostname, ports_for_test):
+    '''
+    Used to prepare monitor port for test
+
+    Args:
+        duthosts: All DUTs belonging to the testbed.
+        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+        ports_for_test: pytest fixture containing info on selected ports
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+
+    port = ports_for_test['monitor']['name']
+    tagging_mode = ports_for_test['monitor']['tagging_mode']
+    vlan = ports_for_test['vlan']
+
+    # Remove monitor port from vlan members
+    duthost.command('config vlan member del {} {}'.format(vlan, port))
+
+    yield
+
+    # Add monitor port to vlan members
+    duthost.command('config vlan member add {} {} --{}'.format(vlan, port, tagging_mode))
+
+@pytest.fixture
+def session_info(request, ports_for_test):
+    '''
+    Used to generate mirroring session info based on selected ports
+
+    Args:
+        request: pytest request object.
+        ports_for_test: pytest fixture containing info on selected ports
+
+    Return:
+        dict: mirroring session configuration params and port indices
+    '''
+    src1 = ports_for_test['source1']
+    src2 = ports_for_test['source2']
+    dst = ports_for_test['monitor']
+    src = src1['name']
+
+    if 'rx' in request.node.name:
+        direction = 'rx'
+    elif 'tx' in request.node.name:
+        direction = 'tx'
+    elif 'both' in request.node.name:
+        direction = 'both'
+    elif 'multiple' in request.node.name:
+        direction = 'rx'
+        src = '{},{}'.format(src1['name'], src2['name'])
+
+    return {
+        'session_name':'session_1',
+        'session_destination_port': dst['name'],
+        'destination_index': dst['index'],
+        'session_source_ports': src,
+        'source1_index': src1['index'],
+        'source2_index': src2['index'],
+        'session_direction': direction,
+    }
+
+@pytest.fixture
+def setup_session(duthosts, rand_one_dut_hostname, session_info):
+    '''
+    Used to add/remove mirroring session on DUT
+
+    Args:
+        duthosts: All DUTs belonging to the testbed.
+        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+        session_info: pytest fixture containing mirroring session info
+
+    Return:
+        dict: ptf port indices for session source ports and monitor port
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    # Add mirroring session
+    duthost.command('config mirror_session span add {} {} {} {}'.format(
+        session_info["session_name"],
+        session_info["session_destination_port"],
+        session_info["session_source_ports"],
+        session_info["session_direction"]
+        )
+                   )
+    yield {
+        'source1_index': session_info['source1_index'],
+        'source2_index': session_info['source2_index'],
+        'destination_index': session_info['destination_index']
+    }
+    # Remove mirroring session
+    duthost.command('config mirror_session remove {}'.format(session_info["session_name"]))

--- a/tests/span/span_helpers.py
+++ b/tests/span/span_helpers.py
@@ -1,0 +1,22 @@
+'''
+Helper functions for span tests
+'''
+
+import ptf.testutils as testutils
+
+def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
+    '''
+    Send packet from ptf and verify it on monitor port
+
+    Args:
+        ptfadapter: ptfadapter fixture
+        src_port: ptf port index, from which packet will be sent
+        monitor: ptf port index, where packet will be verified on
+    '''
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port)
+
+    pkt = testutils.simple_icmp_packet(eth_src=src_mac, eth_dst='ff:ff:ff:ff:ff:ff')
+
+    ptfadapter.dataplane.flush()
+    testutils.send(ptfadapter, src_port, pkt)
+    testutils.verify_packet(ptfadapter, pkt, monitor)

--- a/tests/span/test_port_mirroring.py
+++ b/tests/span/test_port_mirroring.py
@@ -1,0 +1,90 @@
+'''
+Test local port mirroring on SONiC
+'''
+
+import pytest
+
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
+from span_helpers import send_and_verify_mirrored_packet
+
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
+def test_mirroring_rx(ptfadapter, setup_session):
+    '''
+    Test case #1
+    Verify ingress direction session
+
+    Steps:
+        1. Create ICMP packet
+        2. Send packet from PTF to DUT
+        3. Verify that packet is mirrored to monitor port
+
+    Pass Criteria: PTF gets ICMP packet on monitor port.
+    '''
+    send_and_verify_mirrored_packet(ptfadapter,
+                                    setup_session['source1_index'],
+                                    setup_session['destination_index'])
+
+def test_mirroring_tx(ptfadapter, setup_session):
+    '''
+    Test case #2
+    Verify egress direction session
+
+    Steps:
+        1. Create ICMP packet
+        2. Send packet from DUT to PTF
+        3. Verify that packet is mirrored to monitor port
+
+    Pass Criteria: PTF gets ICMP packet on monitor port.
+    '''
+    send_and_verify_mirrored_packet(ptfadapter,
+                                    setup_session['source2_index'],
+                                    setup_session['destination_index'])
+
+def test_mirroring_both(ptfadapter, setup_session):
+    '''
+    Test case #3
+    Verify bidirectional session
+
+    Steps:
+        1. Create ICMP packet
+        2. Send packet from PTF to DUT
+        3. Verify that packet is mirrored to monitor port
+        4. Create ICMP packet
+        5. Send packet from DUT to PTF
+        6. Verify that packet is mirrored to monitor port
+
+    Pass Criteria: PTF gets both ICMP packets on monitor port.
+    '''
+    send_and_verify_mirrored_packet(ptfadapter,
+                                    setup_session['source1_index'],
+                                    setup_session['destination_index'])
+
+    send_and_verify_mirrored_packet(ptfadapter,
+                                    setup_session['source2_index'],
+                                    setup_session['destination_index'])
+
+def test_mirroring_multiple_source(ptfadapter, setup_session):
+    '''
+    Test case #4
+    Verify ingress direction session with multiple source ports
+
+    Steps:
+        1. Create ICMP packet
+        2. Send packet from PTF to first source port on DUT
+        3. Verify that packet is mirrored to monitor port
+        4. Create ICMP packet
+        5. Send packet from PTF to second source port on DUT
+        6. Verify that packet is mirrored to monitor port
+
+    Pass Criteria: PTF gets both ICMP packets on monitor port.
+    '''
+    send_and_verify_mirrored_packet(ptfadapter,
+                                    setup_session['source1_index'],
+                                    setup_session['destination_index'])
+
+    send_and_verify_mirrored_packet(ptfadapter,
+                                    setup_session['source2_index'],
+                                    setup_session['destination_index'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Initial version of test plan for port mirroring feature.

- Created test plan based on [Port mirroring HLD](https://github.com/Azure/SONiC/blob/master/doc/SONiC_Port_Mirroring_HLD.md)
- Implemented 4 basic tests according to test plan

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Port mirroring is defined in [Port mirroring HLD](https://github.com/Azure/SONiC/blob/master/doc/SONiC_Port_Mirroring_HLD.md). 
At this point only ERSPAN part of port mirroring is covered by everflow tests.
There are no tests that verify local SPAN behavior.
#### How did you do it?
Added basic test plan to cover local SPAN feature testing.
This test plan is designed to cover only local port mirroring, and will not involve any cases regarding ERSPAN.
It will be extended in the future with new cases according to port mirroring HLD (i.e. LAG, ACL).

Implemented 4 basic tests:

- Verify ingress mirroring session
- Verify egress mirroring session
- Verify bidirectional mirroring session
- Verify ingress mirroring session with multiple sources

#### How did you verify/test it?
Run implemented tests on T0 topo.

#### Any platform specific information?
Tests are designed for SONiC.202012 and SONiC.master

```
SONiC Software Version: SONiC.master.134-dirty-20210225.114416
Distribution: Debian 10.8
Kernel: 4.19.0-12-2-amd64
Build commit: 2a339faf
Build date: Thu Feb 25 11:54:08 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```

#### Supported testbed topology if it's a new test case?
t0
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
