### PR TITLE
Send the t1 to server traffic to all servers

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -56,6 +56,7 @@ def generate_test_report(tor_IO):
             "disruptions": {
                 "total_disruptions": tor_IO.get_total_disruptions(),
                 "total_disrupted_packets": tor_IO.get_total_disrupted_packets(),
+                "total_disruption_time": tor_IO.get_total_disrupt_time(),
                 "longest_disruption": tor_IO.get_longest_disruption(),
                 "total_lost_packets": tor_IO.get_total_lost_packets()
             }

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -68,7 +68,7 @@ def generate_test_report(tor_IO):
                 "total_lost_packets": tor_IO.get_total_lost_packets()
             }
     }
-    logger.info(pprint.pformat(data_plane_test_report))
+    logger.info("Data plane traffic test results: \n{}".format(pprint.pformat(data_plane_test_report)))
     return data_plane_test_report
 
 

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -32,19 +32,19 @@ def validate_no_traffic_loss(tor_IO, allowed_disruption, delay):
     duplicated_packets = tor_IO.get_duplicated_packets_count()
 
     if received_counter:
-        pytest_assert(total_disruptions <= allowed_disruption, "Traffic was"\
+        pytest_assert(total_disruptions <= allowed_disruption, "Traffic was "\
             "disrupted {} times. Allowed number of disruption: {}"\
             .format(total_disruptions, allowed_disruption))
-        pytest_assert(longest_disruption <= delay, "Traffic was disrupted for {}s."\
+        pytest_assert(longest_disruption <= delay, "Traffic was disrupted for {}s. "\
             "Maximum allowed disruption: {}s".format(longest_disruption, delay))
     else:
-        pytest_assert(received_counter > 0, "Test failed to capture any meaningful"\
+        pytest_assert(received_counter > 0, "Test failed to capture any meaningful "\
             "received packet")
 
     if total_lost_packets:
         logging.warn("Packets were lost during the test. Total lost count: {}"\
             .format(total_lost_packets))
-    pytest_assert(duplicated_packets == 0, "Duplicated packets received."\
+    pytest_assert(duplicated_packets == 0, "Duplicated packets received. "\
         "Count: {}.".format(duplicated_packets))
 
 

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -7,9 +7,7 @@ import struct
 import ipaddress
 import logging
 import json
-from netaddr import IPNetwork
 from collections import defaultdict
-from ipaddress import ip_interface
 
 import scapy.all as scapyall
 import ptf.testutils as testutils

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -164,10 +164,10 @@ class DualTorIO:
             self.no_routing_stop, self.no_routing_start =\
                 datetime.datetime.fromtimestamp(self.no_routing_stop),\
                 datetime.datetime.fromtimestamp(self.no_routing_start)
-            logger.error("The longest disruption lasted %.3f seconds.\
-                %d packet(s) lost." % (self.max_disrupt_time, self.max_lost_id))
-            logger.error("Total disruptions count is %d. All disruptions lasted\
-                %.3f seconds. Total %d packet(s) lost" % \
+            logger.error("The longest disruption lasted %.3f seconds."\
+                "%d packet(s) lost." % (self.max_disrupt_time, self.max_lost_id))
+            logger.error("Total disruptions count is %d. All disruptions lasted "\
+                "%.3f seconds. Total %d packet(s) lost" % \
                 (self.disrupts_count, self.total_disrupt_time, self.total_disrupt_packets))
 
 

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -234,7 +234,7 @@ class DualTorIO:
         else:
             self.from_server_src_port = random.choice(self.vlan_ports.values())
         self.from_server_src_addr  = random.choice(
-            self.vlan_host_map[self.from_server_src_port].keys())
+            self.vlan_host_map[self.from_server_src_port])
         self.from_server_dst_addr  = self.upstream_dst_ip if self.upstream_dst_ip\
             else self.random_host_ip()
         tcp_dport = TCP_DST_PORT


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Send T1 to server traffic to all the available servers
Fixes: https://github.com/Azure/sonic-mgmt/issues/3011

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Instead of sending the downstream traffic to single server, populate all the available server addresses, and send packets to randomly selected server IPs.

#### What is the motivation for this PR?
Improve data plane testing in dualtor

#### How did you do it?


#### How did you verify/test it?
Verified in physical testbed, the traffic is now destined to all the server IP addresses (selected randomly).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
