### PR TITLE
[Vrf] Change test_vrf topology marker to t0

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -32,7 +32,7 @@ from tests.common.reboot import reboot
 """
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('t0')
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Goal of this PR is to set correct topology marker for `test_vrf`, for some reason topology is marked as `any`, although it is not correct if to compare with vrf [test_plan](https://github.com/Azure/SONiC/blob/master/doc/vrf/vrf-ansible-test-plan.md#testbed) which points that vrf test_cases should run on `t0` topo. When run on `t1`, all tests cases fail on setup due to `"KeyError: 'VLAN_MEMBER'"`. 

```
ERROR    test_vrf:test_vrf.py:381 Exception raised in setup: KeyError('VLAN_MEMBER',)                                                                                    
ERROR    test_vrf:test_vrf.py:381 [                                                                                                                                      
  "Traceback (most recent call last):\n",                                                                                                                                
  "  File \"/var/user/jenkins/sonic-mgmt/tests/vrf/test_vrf.py\", line 381, in setup_vrf\n    setup_vrf_cfg(duthost, localhost, cfg_t0)\n",                              
  "  File \"/var/user/jenkins/sonic-mgmt/tests/vrf/test_vrf.py\", line 243, in setup_vrf_cfg\n    ports = get_vlan_members('Vlan1000', cfg_facts)\n",                    
  "  File \"/var/user/jenkins/sonic-mgmt/tests/vrf/test_vrf.py\", line 47, in get_vlan_members\n    for m in cfg_facts['VLAN_MEMBER'].keys():\n",                        
  "KeyError: 'VLAN_MEMBER'\n"                                                                                                                                            
]   
```
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Set correct topo marker for `test_vrf`, to prevent users from running test on a not supported topology. 
#### How did you do it?
Change topo marker to `t0`
#### How did you verify/test it?
Run test_vrf on `t0` and `t1` topo
#### Any platform specific information?
```
SONiC.master.134-dirty-20210225.033210
Distribution: Debian 10.8
Kernel: 4.19.0-12-2-amd64
Build commit: 2a339faf
Build date: Thu Feb 25 10:55:43 UTC 2021
Built by: johnar@worker-sbc3a50
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
