### PR TITLE
[NAT] Added an argument to enable NAT feature on DUT

### DIFF
--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -1,5 +1,6 @@
 import re
 import copy
+import time
 
 import pytest
 
@@ -24,6 +25,32 @@ def protocol_type(request):
     :return: protocol type
     """
     return request.param
+
+
+def pytest_addoption(parser):
+    """
+    Adds options to pytest that are used by the NAT tests.
+    """
+    parser.addoption(
+        "--enable_nat_feature",
+        action="store_true",
+        default=False,
+        help="Enable NAT feature on DUT",
+    )
+
+
+@pytest.fixture(scope='module')
+def config_nat_feature_enabled(request, duthost):
+    """
+    Enable NAT feature if optional argument was provided
+    :param request: pytest request object
+    :param duthost: DUT host object
+    """
+    if request.config.getoption("--enable_nat_feature"):
+        feature_status, _ = duthost.get_feature_status()
+        if feature_status['nat'] == 'disabled':
+            duthost.shell("sudo config feature state nat enabled")
+            time.sleep(2)
 
 
 @pytest.fixture(autouse=True)
@@ -145,14 +172,14 @@ def nat_global_config(duthost):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def apply_global_nat_config(duthost):
+def apply_global_nat_config(duthost, config_nat_feature_enabled):
     """
     applies DUT's global NAT configuration;
     after test run cleanup DUT's NAT configration
     :param duthost: DUT host object
     """
     status, _ = duthost.get_feature_status()
-    if 'nat' not in status:
+    if 'nat' not in status or status['nat'] == 'disabled':
         pytest.skip('nat feature is not enabled with image version {}'.format(duthost.os_version))
 
     nat_global_config(duthost)


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: NAT test suite checks if NAT feature is enabled on DUT, and if not then skips all tests. 
By default, NAT is disabled on DUT - [init_cfg](https://github.com/Azure/sonic-buildimage/blob/afee1a851c5e96c54bfb933bd82fe369df932a88/files/build_templates/init_cfg.json.j2#L34), [config](https://github.com/Azure/sonic-buildimage/blob/9e90fac18b3b741bc5dedc4a9d37ec423c0304dd/rules/config#L112)
So in order to run this tests automatically without manually turning NAT feature, I added argument which can be passed to test to turn NAT feature on DUT. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Be able to run NAT test cases automatically by passing an argument to TC, without manually changing NAT feature status on DUT before TC run. 
#### How did you do it?
Added a fixture that enables NAT feature on DUT by passing an argument.
#### How did you verify/test it?
Run NAT test cases with `--enable_nat_feature` argument, test cases wasn't skipped.
#### Any platform specific information?
```
SONiC.master.134-dirty-20210225.033210                                                                                                           
Distribution: Debian 10.8                                                                                                                                                
Kernel: 4.19.0-12-2-amd64                                                                                                                                                
Build commit: 2a339faf                                                                                                                                                   
Build date: Thu Feb 25 10:55:43 UTC 2021                                                                                                                                 
Built by: johnar@worker-sbc3a50                                                                                                                                          
Platform: x86_64-accton_wedge100bf_32x-r0                                                                                                                                
HwSKU: montara
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
