### PR TITLE
[Dynamic Buffer Calc] Enhance dynamic buffer calculation test

### DIFF
--- a/tests/qos/args/buffer_args.py
+++ b/tests/qos/args/buffer_args.py
@@ -1,0 +1,21 @@
+# Dynamic buffer calculation args file
+
+def add_dynamic_buffer_calculation_args(parser):
+    """
+        Adding arguments required for dynamic buffer calculation test cases
+
+       Args:
+            parser: pytest parser object
+
+        Returns:
+            None
+    """
+    dynamic_buffer_calculation_group = parser.getgroup("Dynamic buffer calculation test suite options")
+
+    dynamic_buffer_calculation_group.addoption(
+        "--enable_shared_headroom_pool",
+        action="store",
+        type=bool,
+        default=False,
+        help="Whether the shared headroom pool should be enabled before dynamic buffer calculation test",
+    )

--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -1,6 +1,7 @@
 from .args.qos_sai_args import add_qos_sai_args
+from .args.buffer_args import add_dynamic_buffer_calculation_args
 
-# WR-ARP pytest arguments
+# QoS pytest arguments
 def pytest_addoption(parser):
     '''
         Adds option to QoS pytest
@@ -12,3 +13,4 @@ def pytest_addoption(parser):
             None
     '''
     add_qos_sai_args(parser)
+    add_dynamic_buffer_calculation_args(parser)

--- a/tests/qos/files/dynamic_buffer_param.json
+++ b/tests/qos/files/dynamic_buffer_param.json
@@ -25,6 +25,10 @@
 		"dynamic_th": "2"
 	    }
 	},
+	"lossy_pg": {
+	    "400000": "37888",
+	    "default": "19456"
+	},
 	"shared-headroom-pool": {
 	    "size": "1024000"
 	}

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -161,11 +161,14 @@ class QosSaiBase:
                 size (str) size of shared headroom pool
                 None if shared headroom pool isn't enabled
         """
+        if self.isBufferInApplDb(duthost):
+            db = "0"
+            keystr = "BUFFER_POOL_TABLE:ingress_lossless_pool"
+        else:
+            db = "4"
+            keystr = "BUFFER_POOL|ingress_lossless_pool"
         result = dut_asic.run_redis_cmd(
-            argv = [
-                "redis-cli", "-n", "4", "HGETALL",
-                "BUFFER_POOL|ingress_lossless_pool"
-            ]
+            argv = ["redis-cli", "-n", db, "HGETALL", keystr]
         )
         it = iter(result)
         ingressLosslessPool = dict(zip(it, it))

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -162,6 +162,7 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
         duthost: The DUT host object
     """
     global DEFAULT_SHARED_HEADROOM_POOL_ENABLED
+    global DEFAULT_OVER_SUBSCRIBE_RATIO
 
     duthost = duthosts[rand_one_dut_hostname]
     detect_buffer_model(duthost)
@@ -179,6 +180,8 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
 
         if enable_shared_headroom_pool and not DEFAULT_SHARED_HEADROOM_POOL_ENABLED:
             configure_shared_headroom_pool(duthost, True)
+            DEFAULT_SHARED_HEADROOM_POOL_ENABLED = True
+            DEFAULT_OVER_SUBSCRIBE_RATIO = 2
             logging.info("Shared headroom pool enabled according to test option")
             need_to_disable_shared_headroom_pool_after_test = True
     else:

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -1488,7 +1488,6 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, p
     original_speed = duthost.shell('redis-cli -n 4 hget "PORT|{}" speed'.format(port_to_test))['stdout']
     original_over_subscribe_ratio = duthost.shell('redis-cli -n 4 hget "DEFAULT_LOSSLESS_BUFFER_PARAMETER|AZURE" over_subscribe_ratio')['stdout']
     original_configured_shp_size = duthost.shell('redis-cli -n 4 hget "BUFFER_POOL|ingress_lossless_pool" xoff')['stdout']
-    original_profile = 'pg_lossless_{}_{}_profile'.format(original_speed, original_cable_len)
     original_pool_size = duthost.shell('redis-cli hget BUFFER_POOL_TABLE:ingress_lossless_pool size')['stdout']
     original_shp_size = duthost.shell('redis-cli hget BUFFER_POOL_TABLE:ingress_lossless_pool xoff')['stdout']
 

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -1320,7 +1320,6 @@ def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port
     original_cable_len = duthost.shell('redis-cli -n 4 hget "CABLE_LENGTH|AZURE" {}'.format(port_to_test))['stdout']
     original_profile = duthost.shell('redis-cli hget "BUFFER_PG_TABLE:{}:3-4" profile'.format(port_to_test))['stdout'][1:-1]
     original_pg_size = duthost.shell('redis-cli hget "{}" size'.format(original_profile))['stdout']
-    original_pg_xoff = int(duthost.shell('redis-cli hget "{}" xoff'.format(original_profile))['stdout']) if DEFAULT_OVER_SUBSCRIBE_RATIO else None
     original_pool_size = duthost.shell('redis-cli hget BUFFER_POOL_TABLE:ingress_lossless_pool size')['stdout']
 
     new_cable_len = '15m'

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -32,7 +32,7 @@ TESTPARAM_LOSSY_PG = None
 BUFFER_MODEL_DYNAMIC = True
 
 def detect_buffer_model(duthost):
-    """Detect the current buffer model (dynamic or traditional) and store it for futher use. Called only once when the module is initialized
+    """Detect the current buffer model (dynamic or traditional) and store it for further use. Called only once when the module is initialized
 
     Args:
         duthost: The DUT host object
@@ -43,7 +43,7 @@ def detect_buffer_model(duthost):
 
 
 def detect_ingress_pool_number(duthost):
-    """Detect the number of ingress buffer pools and store it for futher use. Called only once when the module is initialized
+    """Detect the number of ingress buffer pools and store it for further use. Called only once when the module is initialized
 
     Args:
         duthost: The DUT host object
@@ -75,7 +75,7 @@ def detect_shared_headroom_pool_mode(duthost):
 
 
 def detect_default_mtu(duthost, port_to_test):
-    """Detect the mtu and store it for futher use. Called only once when the module is initialized
+    """Detect the mtu and store it for further use. Called only once when the module is initialized
 
     Args:
         duthost: The DUT host object
@@ -179,7 +179,7 @@ def check_log_analyzer(loganalyzer, marker):
 
 
 def check_pool_size(duthost, ingress_lossless_pool_oid, **kwargs):
-    """Check whether the pool size has been updated correctedly
+    """Check whether the pool size has been updated correctly
 
     The expected pool size will be calculated based on the input arguments on a per-vendor basis
     After that, it will check the expected value against the buffer pool size in BUFFER_POOL_TABLE
@@ -588,7 +588,7 @@ def test_change_speed_cable(duthosts, rand_one_dut_hostname, conn_graph_facts, p
 
     The flow of the test case:
         1. Update the port configuration according to input parameters
-        2. Determine whether the profile removing behavior can be verifyed:
+        2. Determine whether the profile removing behavior can be verified:
            If neither mtu nor cable length is default value, they will be applied on the port_to_test only,
            and the generated profile will be removed after the configuration change because the profile is referenced by this port only.
            For example:
@@ -1063,7 +1063,7 @@ def test_shared_headroom_pool_configure(duthosts, rand_one_dut_hostname, conn_gr
         if original_configured_shp_size and original_configured_shp_size != '0':
             duthost.shell('config buffer shared-headroom-pool size 0')
 
-        # Make sure the shp configuration has been deployed
+        # Make sure the shared headroom pool configuration has been deployed
         time.sleep(30)
 
         # Check whether the buffer profile for lossless PGs are correct
@@ -1154,7 +1154,7 @@ def test_lossless_pg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_
 
     Test case to verify the static profile with non default dynamic th
     The buffer profile will be generated automatically after the profile has been applied to the port
-    The arguments required for the test are fetched from a predefiend json file on a per vendor basis.
+    The arguments required for the test are fetched from a predefined json file on a per vendor basis.
     Not providing any of the arguments results in the test case skipped.
 
     The flow of the test case:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhance the dynamic buffer calculation test

Signed-off-by: Stephen Sun <stephens@nvidia.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Enhance the dynamic buffer calculation test:
- Ensure the buffer pool size is recovered after all the configurations have been reverted
  - The buffer pool size is verified based on the value fetched from the switch at the beginning of the test. Afterwards, it will calculate the new buffer pool size according to the configuration change.
  - The configurations changed during the test will be restored at the end of the test and the switch will recalculate the buffer pool size according to the restored value. However, it can take a few seconds for buffer pool size to be recovered in rare conditions.
  - If the next test starts immediately after the previous one finished, it is possible that the buffer pool size is not fully recovered, which results in the next test verifies the buffer pool size based on a wrong value, which fails the test.
- Adjust the buffer pool size calculation while toggling the shared headroom pool and there are 400G ports on the system.
- Add test case for removing PGs when a port is administratively down.
- Bug fixes:
  - in `check_buffer_profiles_for_shp`: the check passes only if all lossless profiles satisfy the condition
  - in QoS test, the shared headroom pool size should be fetched from APPL_DB or CONFIG_DB according to whether buffer information is in APPL_DB or CONFIG_DB

#### How did you do it?
- Ensure the buffer pool size is recovered after all the configurations have been reverted
  - Change the scope of the methods `_check_pool_size` and `_get_pool_size_from_asic_db` from `check_pool_size` to global so that they can be called by other methods.
  - Check the buffer pool size after all configuration changes have been restored at the end of each test.
- Adjust the buffer pool size calculation while toggling the shared headroom pool and there are 400G ports on the system.
  - Introduce a new method `_fetch_size_difference_for_400g_ports` to calculate the difference in buffer pool sizes between the modes with/without shared headroom pool enabled.
  - Take the difference into consideration when calculating the buffer pool size during toggling the shared headroom pool
- Add test case for removing PGs when a port is administratively down.
  - Introduce a new method `test_port_admin_down` for it.

#### How did you verify/test it?
Run the regression test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
