### PR TITLE
Update BGP allow list testing to support t1-64-lag topology

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -201,7 +201,7 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
             used_subnets = set()
             if mg_facts["minigraph_interfaces"]:
                 for intf in mg_facts["minigraph_interfaces"]:
-                    if _is_ipv4_address[intf["address"]]:
+                    if _is_ipv4_address[intf["addr"]]:
                         ipv4_interfaces.append(intf["attachto"])
                         used_subnets.add(ipaddress.ip_network(intf["subnet"]))
 

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -201,7 +201,7 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
             used_subnets = set()
             if mg_facts["minigraph_interfaces"]:
                 for intf in mg_facts["minigraph_interfaces"]:
-                    if _is_ipv4_address[intf["addr"]]:
+                    if _is_ipv4_address(intf["addr"]):
                         ipv4_interfaces.append(intf["attachto"])
                         used_subnets.add(ipaddress.ip_network(intf["subnet"]))
 

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -197,27 +197,44 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
     def _setup_interfaces_t1(mg_facts, peer_count):
         try:
             connections = []
-            ipv4_interfaces = [_ for _ in mg_facts["minigraph_interfaces"] if _is_ipv4_address(_['addr'])]
-            used_subnets = [ipaddress.ip_network(_["subnet"]) for _ in ipv4_interfaces]
-            subnet_prefixlen = used_subnets[0].prefixlen
-            used_subnets = set(used_subnets)
-            for pt in mg_facts["minigraph_portchannel_interfaces"]:
-                if _is_ipv4_address(pt["addr"]):
-                    used_subnets.add(ipaddress.ip_network(pt["subnet"]))
+            ipv4_interfaces = []
+            used_subnets = set()
+            if mg_facts["minigraph_interfaces"]:
+                for intf in mg_facts["minigraph_interfaces"]:
+                    if _is_ipv4_address[intf["address"]]:
+                        ipv4_interfaces.append(intf["attachto"])
+                        used_subnets.add(ipaddress.ip_network(intf["subnet"]))
+
+            ipv4_lag_interfaces = []
+            if mg_facts["minigraph_portchannel_interfaces"]:
+                for pt in mg_facts["minigraph_portchannel_interfaces"]:
+                    if _is_ipv4_address(pt["addr"]):
+                        pt_members = mg_facts["minigraph_portchannels"][pt["attachto"]]["members"]
+                        # Only use LAG with 1 member for bgpmon session between PTF,
+                        # It's because exabgp on PTF is bind to single interface
+                        if len(pt_members) == 1:
+                            ipv4_lag_interfaces.append(pt["attachto"])
+                        used_subnets.add(ipaddress.ip_network(pt["subnet"]))
+
+            subnet_prefixlen = list(used_subnets)[0].prefixlen
             _subnets = ipaddress.ip_network(u"10.0.0.0/24").subnets(new_prefix=subnet_prefixlen)
             subnets = (_ for _ in _subnets if _ not in used_subnets)
 
-            for intf, subnet in zip(random.sample(ipv4_interfaces, peer_count), subnets):
+            for intf, subnet in zip(random.sample(ipv4_interfaces + ipv4_lag_interfaces, peer_count), subnets):
                 conn = {}
                 local_addr, neighbor_addr = [_ for _ in subnet][:2]
-                conn["local_intf"] = "%s" % intf["attachto"]
+                conn["local_intf"] = "%s" % intf
                 conn["local_addr"] = "%s/%s" % (local_addr, subnet_prefixlen)
                 conn["neighbor_addr"] = "%s/%s" % (neighbor_addr, subnet_prefixlen)
-                conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][intf["attachto"]]
+                if intf.startswith("PortChannel"):
+                    member_intf = mg_facts["minigraph_portchannels"][intf]["members"][0]
+                    conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][member_intf]
+                else:
+                    conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][intf]
                 connections.append(conn)
 
             for conn in connections:
-                # bind the ip to the interface and notify bgpcfgd 
+                # bind the ip to the interface and notify bgpcfgd
                 duthost.shell("config interface ip add %s %s" % (conn["local_intf"], conn["local_addr"]))
                 ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"], conn["neighbor_addr"]))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The BGP allow list testing needs to setup BGP monitor session with exabgp
process running in PTF. The current code needs a routed interface for such
BGP monitor session. For topology t1-64-lag, all the interfaces are portchannel.
The BGP allow list testing does not work for t1-64-lag topology.

#### How did you do it?
This change is to update the BGP testing to support t1-64-lag topology. The
setup code was updated to support using port channel with 1 member interface
to establish BGP monitor session with exabgp process in PTF.

#### How did you verify/test it?
Tested on KVM running t1-64-lag topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
