### PR TITLE
[dualtor] Refact test_ipinip

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -598,3 +598,13 @@ def flush_neighbor(duthost, neighbor, restore=True):
         if restore:
             logging.info("restore neighbor entry for %s", neighbor)
             duthost.shell("ip -4 neighbor replace {address} lladdr {hwaddress} dev {iface}".format(**neighbor_info))
+
+
+@pytest.fixture(scope="function")
+def rand_selected_interface(rand_selected_dut):
+    """Select a random interface to test."""
+    tor = rand_selected_dut
+    server_ips = mux_cable_server_ip(tor)
+    iface = str(random.choice(server_ips.keys()))
+    logging.info("select DUT interface %s to test.", iface)
+    return iface, server_ips[iface]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,6 +200,7 @@ def duthost(duthosts, request):
 
     return duthost
 
+
 @pytest.fixture(scope="module")
 def rand_one_dut_hostname(request):
     """
@@ -209,12 +210,14 @@ def rand_one_dut_hostname(request):
         dut_hostnames = random.sample(dut_hostnames, 1)
     return dut_hostnames[0]
 
+
 @pytest.fixture(scope="module")
 def rand_selected_dut(duthosts, rand_one_dut_hostname):
     """
     Return the randomly selected duthost
     """
     return duthosts[rand_one_dut_hostname]
+
 
 @pytest.fixture(scope="module")
 def rand_unselected_dut(request, duthosts, rand_one_dut_hostname):

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -34,13 +34,3 @@ def verify_crm_nexthop_counter_not_increased(lower_tor_host):
     yield
     diff = get_crm_nexthop_counter(lower_tor_host) - original_counter
     py_assert(diff == 0, "crm nexthop counter is increased by {}.".format(diff))
-
-
-@pytest.fixture(scope="function")
-def rand_selected_interface(rand_selected_dut):
-    """Select a random interface to test."""
-    tor = rand_selected_dut
-    server_ips = mux_cable_server_ip(tor)
-    iface = str(random.choice(server_ips.keys()))
-    logging.info("select DUT interface %s to test.", iface)
-    return iface, server_ips[iface]

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -1,10 +1,8 @@
 import pytest
 import logging
-import random
 import time
 
 from tests.common.dualtor.dual_tor_utils import get_crm_nexthop_counter, lower_tor_host # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.helpers.assertions import pytest_assert as py_assert
 
 

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -1,11 +1,16 @@
 import pytest
 import logging
+import random
 import time
+
 from tests.common.dualtor.dual_tor_utils import get_crm_nexthop_counter, lower_tor_host # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.helpers.assertions import pytest_assert as py_assert
+
 
 CRM_POLL_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
+
 
 @pytest.fixture
 def set_crm_polling_interval(lower_tor_host):
@@ -19,6 +24,7 @@ def set_crm_polling_interval(lower_tor_host):
     yield
     lower_tor_host.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
 
+
 @pytest.fixture
 def verify_crm_nexthop_counter_not_increased(lower_tor_host):
     """
@@ -29,3 +35,12 @@ def verify_crm_nexthop_counter_not_increased(lower_tor_host):
     diff = get_crm_nexthop_counter(lower_tor_host) - original_counter
     py_assert(diff == 0, "crm nexthop counter is increased by {}.".format(diff))
 
+
+@pytest.fixture(scope="function")
+def rand_selected_interface(rand_selected_dut):
+    """Select a random interface to test."""
+    tor = rand_selected_dut
+    server_ips = mux_cable_server_ip(tor)
+    iface = str(random.choice(server_ips.keys()))
+    logging.info("select DUT interface %s to test.", iface)
+    return iface, server_ips[iface]

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -14,6 +14,7 @@ from ptf import testutils
 from scapy.all import Ether, IP
 from tests.common.dualtor.dual_tor_mock import *
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
+from tests.common.dualtor.dual_tor_utils import rand_selected_interface
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.utilities import is_ipv4_address
 


### PR DESCRIPTION
Use fixtures defined in common places instead of local ones.
1. Use `rand_selected_dut` and remove local `tor`
2. Rename `test_interface` to `rand_selected_interface` and put in
dualtor subdirectory `conftest` file to make it shareable by other test
scripts.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Reduce code duplication.

#### How did you do it?
1. use common fixture instead of defining a new one.
    * use `rand_selected_dut` and remove local fixture `tor`
2. put `test_interface` into `conftest.py` file to make it accessible to other scripts.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
