### PR TITLE
[techsupport][pytest] Add pytest for show techsupport commands

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -1,0 +1,208 @@
+import re
+
+ignore_list = {
+    "cp_proc_files": {},
+}
+
+copy_proc_files = [
+    "/proc/buddyinfo",
+    "/proc/cmdline",
+    "/proc/consoles",
+    "/proc/cpuinfo",
+    "/proc/devices",
+    "/proc/diskstats",
+    "/proc/dma",
+    "/proc/interrupts",
+    "/proc/iomem",
+    "/proc/ioports",
+    "/proc/kallsyms",
+    "/proc/loadavg",
+    "/proc/locks",
+    "/proc/meminfo",
+    "/proc/misc",
+    "/proc/modules",
+    "/proc/self/mounts",
+    "/proc/self/net",
+    "/proc/pagetypeinfo",
+    "/proc/partitions",
+    "/proc/sched_debug",
+    "/proc/slabinfo",
+    "/proc/softirqs",
+    "/proc/stat",
+    "/proc/swaps",
+    "/proc/sysvipc",
+    "/proc/timer_list",
+    "/proc/uptime",
+    "/proc/version",
+    "/proc/vmallocinfo",
+    "/proc/vmstat",
+    "/proc/zoneinfo",
+]
+
+show_platform_cmds = [
+    "show platform syseeprom",
+    "show platform psustatus",
+    "show platform ssdhealth",
+    "show platform temperature",
+    "show platform fan",
+    "show platform summary",
+]
+
+ip_cmds = [
+    "ip link",
+    "ip addr",
+    "ip rule",
+    "ip route show table all",
+    "ip neigh",
+    "ip -s neigh show nud noarp",
+]
+
+bridge_cmds = [
+    "bridge fdb show",
+    "bridge vlan show",
+]
+
+frr_cmds = [
+    "vtysh{} -c 'show running-config'",
+    "vtysh{} -c 'show ip route vrf all'",
+    "vtysh{} -c 'show ipv6 route vrf all'",
+    "vtysh{} -c 'show zebra fpm stats'",
+    "vtysh{} -c 'show zebra dplane detailed'",
+    "vtysh{} -c 'show interface vrf all'",
+    "vtysh{} -c 'show zebra client summary'",
+]
+
+
+bgp_cmds = [
+    "vtysh{} -c 'show ip bgp summary'",
+    "vtysh{} -c 'show ip bgp neighbors'",
+    "vtysh{} -c 'show ip bgp'",
+    "vtysh{} -c 'show bgp ipv6 summary'",
+    "vtysh{} -c 'show bgp ipv6 neighbors'",
+    "vtysh{} -c 'show bgp ipv6'",
+    re.compile('vtysh{}\s+-c "show ip bgp neighbors .* advertised-routes"'),
+    re.compile('vtysh{}\s+-c "show ip bgp neighbors .* routes"'),
+    re.compile('vtysh{}\s+-c "show bgp ipv6 neighbors .* advertised-routes"'),
+    re.compile('vtysh{}\s+-c "show bgp ipv6 neighbors .* routes"'),
+]
+
+nat_cmds = [
+    "iptables -t nat -nv -L",
+    "conntrack -j -L",
+    "conntrack -j -L | wc",
+    "conntrack -L",
+    "conntrack -L | wc",
+    "show nat config",
+]
+
+bfd_cmds = [
+    "vtysh{} -c 'show bfd peers'",
+    "vtysh{} -c 'show bfd peers counters'",
+    "vtysh{} -c 'show bfd peers json'",
+    "vtysh{} -c 'show bfd peers counters json'",
+]
+
+redis_db_cmds = [
+    "{}sonic-db-dump -n 'APPL_DB' -y",
+    "{}sonic-db-dump -n 'ASIC_DB' -y",
+    "{}sonic-db-dump -n 'COUNTERS_DB' -y",
+    "{}sonic-db-dump -n 'CONFIG_DB' -y",
+    "{}sonic-db-dump -n 'FLEX_COUNTER_DB' -y",
+    "{}sonic-db-dump -n 'STATE_DB' -y",
+    "{}sonic-db-dump -n 'COUNTERS_DB' -y",
+]
+
+docker_cmds = [
+    "docker exec -it syncd{} saidump",
+    "docker stats --no-stream",
+    "docker ps -a",
+    "docker top pmon",
+    "docker exec -it lldp{} lldpcli show statistics",
+    "docker logs bgp{}",
+    "docker logs swss{}",
+]
+
+misc_show_cmds = [
+    "show services",
+    "show reboot-cause",
+    "show vlan brief",
+    "show version",
+    "show interface status -d all",
+    "show interface transceiver presence",
+    "show interface transceiver eeprom --dom",
+    "show ip interface",
+    "show interface counters",
+    "{}show queue counters",
+    "{}netstat -i",
+    "{}ifconfig -a",
+]
+
+misc_cmds = [
+    "systemd-analyze blame",
+    "systemd-analyze dump",
+    "systemd-analyze plot",
+    "sensors",
+    "lspci -vvv -xx",
+    "lsusb -v",
+    "sysctl -a",
+    "lldpctl",
+    "ps aux",
+    "top -b -n 1",
+    "free",
+    "vmstat 1 5",
+    "vmstat -m",
+    "vmstat -s",
+    "mount",
+    "df",
+    "dmesg",
+    "cat /host/machine.conf",
+    "cp -r /etc",
+]
+
+copy_config_cmds = [
+    "cp .{}/buffers.json.j2",
+    "cp .{}/buffers_defaults",
+    "cp .{}/pg_profile_lookup.ini",
+    "cp .{}/port_config.ini",
+    "cp .{}/qos.json.j2",
+    "cp .{}/sai.profile",
+]
+
+broadcom_cmd_bcmcmd = [
+    'bcmcmd{} -t5 version',
+    'bcmcmd{} -t5 soc',
+    'bcmcmd{} -t5 ps',
+    'bcmcmd{} "l3 nat_ingress show"',
+    'bcmcmd{} "l3 nat_egress show"',
+    'bcmcmd{} "ipmc table show"',
+    'bcmcmd{} "multicast show"',
+    'bcmcmd{} "conf show"',
+    'bcmcmd{} "fp show"',
+    'bcmcmd{} "pvlan show"',
+    'bcmcmd{} "l2 show"',
+    'bcmcmd{} "l3 intf show"',
+    'bcmcmd{} "l3 defip show"',
+    'bcmcmd{} "l3 l3table show"',
+    'bcmcmd{} "l3 egress show"',
+    'bcmcmd{} "l3 ecmp egress show"',
+    'bcmcmd{} "l3 multipath show"',
+    'bcmcmd{} "l3 ip6host show"',
+    'bcmcmd{} "l3 ip6route show"',
+    'bcmcmd{} "mc show"',
+    'bcmcmd{} "cstat *"',
+    'bcmcmd{} "mirror show"',
+    'bcmcmd{} "mirror dest show"',
+    'bcmcmd{} "port *"',
+    'bcmcmd{} "d chg my_station_tcam"',
+]
+
+broadcom_cmd_misc = [
+    "cat /proc/bcm/knet/debug",
+    "cat /proc/bcm/knet/dma",
+    "cat /proc/bcm/knet/link",
+    "cat /proc/bcm/knet/rate",
+    "cat /proc/bcm/knet/dstats",
+    "cat /proc/bcm/knet/stats",
+    "docker cp syncd{}:/var/log/bcm_diag_post",
+    "docker cp syncd{}:/var/log/diagrun.log",
+]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Added pytest for show techsupport to verify the commands run by the tech support command.

#### How did you do it?
Created a list of commands that must be run during show tech support. 
This standard list is compared with the commands run, which is obtained
by specifying the "-noop" option to generate_dump script.

#### How did you verify/test it?

Verified on:
* BCM t0 and t1 topology
* Mellanox t0 topology
* Multi ASIC t1 topology

```
================================================================================ test session starts ================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 3 items / 2 deselected / 1 selected                                                                                                                                       

show_techsupport/test_techsupport.py .                                                                                                                                        [100%]

================================================================================= warnings summary ==================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================ 1 passed, 2 deselected, 1 warnings in 28.42 seconds ================================================================
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$  pytest show_techsupport/test_techsupport.py --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library --disable_loganalyzer --skip_sanity  -k commands              
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 3 items / 2 deselected / 1 selected                                                                                                                                                                                                                                                                                                                            

show_techsupport/test_techsupport.py .                                                                                                                                                                                                                                                                                                                             [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================================================== 1 passed, 2 deselected, 1 warnings in 25.57 seconds ===========================================================================================================================================================
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t0 and t1

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
