### PR TITLE
Add "verbose" option for suppressing unnecessary log

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -89,7 +89,7 @@ def parse_exabgp_dump(host):
     Parse the dump file of exabgp, and build a set for checking routes
     """
     routes = set()
-    output_lines = host.shell("cat {}".format(DUMP_FILE))['stdout_lines']
+    output_lines = host.shell("cat {}".format(DUMP_FILE), verbose=False)['stdout_lines']
     for line in output_lines:
         routes.add(line)
     return routes
@@ -100,7 +100,7 @@ def parse_rib(host, ip_ver):
     """
     routes = {}
     cmd = "vtysh -c \"show bgp ipv%d json\"" % ip_ver
-    route_data = json.loads(host.shell(cmd)['stdout'])
+    route_data = json.loads(host.shell(cmd, verbose=False)['stdout'])
     for ip, nexthops in route_data['routes'].iteritems():
         aspath = set()
         for nexthop in nexthops:

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -55,9 +55,15 @@ class AnsibleHostBase(object):
         previous_frame = inspect.currentframe().f_back
         filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
 
-        logging.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}"\
-            .format(filename, function_name, line_number, self.hostname,
-                    self.module_name, json.dumps(module_args), json.dumps(complex_args)))
+        verbose = complex_args.pop('verbose', True)
+
+        if verbose:
+            logging.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}"\
+                .format(filename, function_name, line_number, self.hostname,
+                        self.module_name, json.dumps(module_args), json.dumps(complex_args)))
+        else:
+            logging.debug("{}::{}#{}: [{}] AnsibleModule::{} executing..."\
+                .format(filename, function_name, line_number, self.hostname, self.module_name))
 
         module_ignore_errors = complex_args.pop('module_ignore_errors', False)
         module_async = complex_args.pop('module_async', False)
@@ -70,8 +76,13 @@ class AnsibleHostBase(object):
             return pool, result
 
         res = self.module(*module_args, **complex_args)[self.hostname]
-        logging.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}"\
-            .format(filename, function_name, line_number, self.hostname, self.module_name, json.dumps(res)))
+
+        if verbose:
+            logging.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}"\
+                .format(filename, function_name, line_number, self.hostname, self.module_name, json.dumps(res)))
+        else:
+            logging.debug("{}::{}#{}: [{}] AnsibleModule::{} done"\
+                .format(filename, function_name, line_number, self.hostname, self.module_name))
 
         if (res.is_failed or 'exception' in res) and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -333,7 +333,7 @@ class SonicHost(AnsibleHostBase):
         """
         monit_services_status = {}
 
-        services_status_result = self.shell("sudo monit status", module_ignore_errors=True)
+        services_status_result = self.shell("sudo monit status", module_ignore_errors=True, verbose=False)
 
         exit_code = services_status_result["rc"]
         if exit_code != 0:
@@ -1079,7 +1079,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
     def run_redis_cli_cmd(self, redis_cmd):
         cmd = "/usr/bin/redis-cli {}".format(redis_cmd)
-        return self.command(cmd)
+        return self.command(cmd, verbose=False)
 
     def get_asic_name(self):
         asic = "unknown"
@@ -1099,7 +1099,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         return asic
 
     def get_running_config_facts(self):
-        return self.config_facts(host=self.hostname, source='running')['ansible_facts']
+        return self.config_facts(host=self.hostname, source='running', verbose=False)['ansible_facts']
 
     def get_vlan_intfs(self):
         '''

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -146,7 +146,7 @@ class SonicAsic(object):
         if self.namespace != DEFAULT_NAMESPACE:
             redis_cli = "/usr/bin/redis-cli"
             cmd = "sudo ip netns exec {} {} {}".format(self.namespace, redis_cli,redis_cmd)
-            return self.sonichost.command(cmd)
+            return self.sonichost.command(cmd, verbose=False)
         # for single asic platforms there are not Namespaces, so the redis-cli command is same the DUT host
         return self.sonichost.run_redis_cli_cmd(redis_cmd)
 

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -22,7 +22,7 @@ def is_check_item(member):
     '''
     Function to filter for valid check items
 
-    Used in conjuction with inspect.getmembers to make sure that only valid check functions/fixtures executed 
+    Used in conjuction with inspect.getmembers to make sure that only valid check functions/fixtures executed
 
     Valid check items must meet the following criteria:
     - Is a function
@@ -82,7 +82,7 @@ def print_logs(duthosts):
         logger.info("Run commands to print logs, logs to be collected on {}:\n{}"\
             .format(dut.hostname, json.dumps(constants.PRINT_LOGS, indent=4)))
         for cmd in constants.PRINT_LOGS.values():
-            res = dut.shell(cmd, module_ignore_errors=True)
+            res = dut.shell(cmd, module_ignore_errors=True, verbose=False)
             logger.info("cmd='%s', output:\n%s" % (cmd, json.dumps(res["stdout_lines"], indent=4)))
 
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -125,7 +125,7 @@ def check_interfaces(duthosts):
             for asic in dut.asics:
                 ip_interfaces = []
                 cfg_facts = asic.config_facts(host=dut.hostname,
-                                            source="persistent")['ansible_facts']
+                                            source="persistent", verbose=False)['ansible_facts']
                 phy_interfaces = [k for k, v in cfg_facts["PORT"].items() if "admin_status" in v and v["admin_status"] == "up"]
                 if "PORTCHANNEL_INTERFACE" in cfg_facts:
                     ip_interfaces = cfg_facts["PORTCHANNEL_INTERFACE"].keys()
@@ -340,7 +340,7 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
                                                         ip_snd=lower_tor_mgmt_ip,
                                                         ip_tgt=lower_tor_ping_tgt_ip,
                                                         hw_snd=lower_tor_intf_mac)
-        
+
         ptf_arp_pkt = testutils.simple_arp_packet(ip_tgt=ptf_arp_tgt_ip,
                                                 ip_snd=ptf_arp_tgt_ip,
                                                 arp_op=2)

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -126,12 +126,12 @@ def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
         route_data.append(route_command)
 
     # Copy json file to DUT
-    duthost.copy(content=json.dumps(route_data, indent=4), dest=dir)
+    duthost.copy(content=json.dumps(route_data, indent=4), dest=dir, verbose=False)
 
 def count_routes(host):
     num = host.shell(
         'sonic-db-cli ASIC_DB eval "return #redis.call(\'keys\', \'{}*\')" 0'.format(ROUTE_TABLE_NAME),
-        module_ignore_errors=True)['stdout']
+        module_ignore_errors=True, verbose=True)['stdout']
     return int(num)
 
 def exec_routes(duthost, prefixes, str_intf_nexthop, op):
@@ -174,7 +174,8 @@ def exec_routes(duthost, prefixes, str_intf_nexthop, op):
     end_time = datetime.now()
 
     # Check route entries are correct
-    asic_route_keys = duthost.shell('sonic-db-cli ASIC_DB eval "return redis.call(\'keys\', \'{}*\')" 0'.format(ROUTE_TABLE_NAME))['stdout_lines']
+    asic_route_keys = duthost.shell('sonic-db-cli ASIC_DB eval "return redis.call(\'keys\', \'{}*\')" 0'\
+        .format(ROUTE_TABLE_NAME), verbose=False)['stdout_lines']
     asic_prefixes = []
     for key in asic_route_keys:
         json_obj = key[len(ROUTE_TABLE_NAME) + 1 : ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When execute an ansible module, the detailed arguments and module result are logged
at DEBUG level by default. Sometimes, the module result could be too huge to be logged
even at DEBUG level.

#### How did you do it?
This change added keyword option "verbose" to the method in AnsibleHostBase class
for executing ansible modules. Default value of "verbose" is "True". If "verbose" is set to
"False", only simplified messages will be logged at DEBUG level. This change also updated
some test scripts and the sanity check scripts to use this option.

#### How did you verify/test it?
* Test run the affected scripts with sanity check enabled.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
