### PR TITLE
[acl] Re-enable IPv6 ACL tests for 201911

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -166,9 +166,6 @@ def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
     if tbinfo["topo"]["type"] == "t0" and request.param == "ipv6":
         pytest.skip("IPV6 ACL test not currently supported on t0 testbeds")
 
-    if "201911" in duthosts[rand_one_dut_hostname].os_version and request.param == "ipv6":
-        pytest.skip("acl-loader does not handle IPV6 default drop rule correctly in 201911")
-
     return request.param
 
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [acl] Re-enable IPv6 ACL tests for 201911
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The fix for default drop rule for IPv6 dataplane ACLs was merged to 201911 recently, so the IPv6 ACL tests are now valid again.

#### How did you do it?
Remove the if-check for 201911/IPv6 dataacl testing.

#### How did you verify/test it?
Ran the tests against a few devices with latest 201911 image

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
