### PR TITLE
[multi_asic_host]: Add __repr__ method

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -44,7 +44,7 @@ class MultiAsicSonicHost(object):
         self.critical_services_tracking_list()
 
     def __repr__(self):
-            return '<MultiAsicSonicHost> {}'.format(self.hostname)
+        return '<MultiAsicSonicHost> {}'.format(self.hostname)
 
     def critical_services_tracking_list(self):
         """Get the list of services running on the DUT

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -43,6 +43,9 @@ class MultiAsicSonicHost(object):
 
         self.critical_services_tracking_list()
 
+    def __repr__(self):
+            return self.hostname
+
     def critical_services_tracking_list(self):
         """Get the list of services running on the DUT
            The services on the sonic devices are:

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -44,7 +44,7 @@ class MultiAsicSonicHost(object):
         self.critical_services_tracking_list()
 
     def __repr__(self):
-            return self.hostname
+            return '<MultiAsicSonicHost> {}'.format(self.hostname)
 
     def critical_services_tracking_list(self):
         """Get the list of services running on the DUT


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When viewing stack traces for failed tests, any `duthost` objects are displayed using the default Python representation which simply gives the object's location in memory. On single DUT testbeds this is not an issue, but on dual ToR systems it is difficult to tell which DUT is relevant to the failure.

#### How did you do it?
Add the `__repr__` method to the `MultiAsicSonicHost` class, which makes the class readable by using the device hostname as the representation.

This also gives the added benefit of returning the hostname when the duthost object is cast to a string (for example when formatting a string)

#### How did you verify/test it?
Run a test that failed. Confirm in the stack trace that the device hostname is shown instead of the host object's memory location.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
