### PR TITLE
Put dualtor related constants in common place

### DIFF
--- a/tests/common/dualtor/constants.py
+++ b/tests/common/dualtor/constants.py
@@ -1,0 +1,10 @@
+
+UPPER_TOR = "upper_tor"
+LOWER_TOR = "lower_tor"
+TOGGLE = "toggle"
+RANDOM = "random"
+
+NIC = "nic"
+
+DROP = "drop"
+OUTPUT = "output"

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -11,13 +11,11 @@ from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.dut_ports import encode_dut_port_name
+from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 
 __all__ = ['tor_mux_intf', 'ptf_server_intf', 't1_upper_tor_intfs', 't1_lower_tor_intfs', 'upper_tor_host', 'lower_tor_host']
 
 logger = logging.getLogger(__name__)
-
-UPPER_TOR = 'upper_tor'
-LOWER_TOR = 'lower_tor'
 
 
 @pytest.fixture(scope='session')

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -2,8 +2,10 @@ import logging
 import pytest
 import json
 import urllib2
-from tests.common.helpers.assertions import pytest_assert
+
 from tests.common import utilities
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT
 
 __all__ = ['check_simulator_read_side', 'mux_server_url', 'url', 'recover_all_directions', 'set_drop', 'set_output', 'toggle_all_simulator_ports_to_another_side', \
            'toggle_all_simulator_ports_to_lower_tor', 'toggle_all_simulator_ports_to_random_side', 'toggle_all_simulator_ports_to_upper_tor', \
@@ -11,17 +13,8 @@ __all__ = ['check_simulator_read_side', 'mux_server_url', 'url', 'recover_all_di
 
 logger = logging.getLogger(__name__)
 
-UPPER_TOR = "upper_tor"
-LOWER_TOR = "lower_tor"
-TOGGLE = "toggle"
-RANDOM = "random"
-
 TOGGLE_SIDES = [UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM]
 
-NIC = "nic"
-
-DROP = "drop"
-OUTPUT = "output"
 
 @pytest.fixture(scope='session')
 def mux_server_url(request, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Multiple dualtor utility scripts defined same constants. It would be better to define the same set of constants in a common place.

#### How did you do it?
Moved the constants defined in individual dualtor utilit scripts to a common script `tests/common/dualtor/constants.py`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
