### PR TITLE
Add tor_mux_intfs fixture and use it in dual tor mock utility

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -13,19 +13,31 @@ from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR
 
-__all__ = ['tor_mux_intf', 'ptf_server_intf', 't1_upper_tor_intfs', 't1_lower_tor_intfs', 'upper_tor_host', 'lower_tor_host']
+__all__ = ['tor_mux_intf', 'tor_mux_intfs', 'ptf_server_intf', 't1_upper_tor_intfs', 't1_lower_tor_intfs', 'upper_tor_host', 'lower_tor_host']
 
 logger = logging.getLogger(__name__)
 
 
+def get_tor_mux_intfs(duthost):
+    return sorted(duthost.get_vlan_intfs(), key=lambda intf: int(intf.replace('Ethernet', '')))
+
+
 @pytest.fixture(scope='session')
-def tor_mux_intf(duthosts):
+def tor_mux_intfs(duthosts):
     '''
-    Returns the server-facing interface on the ToR to be used for testing
+    Returns the server-facing interfaces on the ToR to be used for testing
     '''
     # The same ports on both ToRs should be connected to the same PTF port
-    dut = duthosts[0]
-    return sorted(dut.get_vlan_intfs(), key=lambda intf: int(intf.replace('Ethernet', '')))[0]
+    return get_tor_mux_intfs(duthosts[0])
+
+
+@pytest.fixture(scope='session')
+def tor_mux_intf(tor_mux_intfs):
+    '''
+    Returns the first server-facing interface on the ToR to be used for testing
+    '''
+    # The same ports on both ToRs should be connected to the same PTF port
+    return tor_mux_intfs[0]
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The dual tor mock utilities needs to get the list of interfaces connected to mux
cable multiple times. Each time the config_facts module is executed to get the
running config. Then the list of interfaces is parsed from config facts. This is
inefficient and unnecessarily generated too much log while getting config facts.

#### How did you do it?
This change introduced a common fixture tor_mux_intfs. The dual tor mock
utility script is updated to use this new fixture.

Another change is to use shell_cmds to run multiple commands in batch to save
test execution time.

#### How did you verify/test it?
Tested using a script like below:
```
import logging

from tests.common.dualtor.dual_tor_mock import *
from tests.common.dualtor.dual_tor_utils import *

logger = logging.getLogger(__name__)

def test_case1(rand_selected_dut, apply_active_state_to_orchagent):
    logger.info('case1')

def test_case2(rand_selected_dut, apply_standby_state_to_orchagent):
    logger.info('case2')

def test_case3(rand_selected_dut, apply_dual_tor_neigh_entries):
    logger.info('case3')

def test_case4(rand_selected_dut, apply_mux_cable_table_to_dut):
    logger.info('case4')
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
