### PR TITLE
[dualtor]: Fix `expect_db_values` arguments order

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -43,7 +43,7 @@ def _dump_db(duthost, db, key_pattern):
     return json.loads(lines[0])
 
 
-def expect_db_values(duthost, db, intf_names='all', state, health=None):
+def expect_db_values(duthost, db, state, health=None, intf_names='all'):
     """
     Query db on `tor_host` and check if the mux-related fields match the expected values.
 
@@ -52,9 +52,9 @@ def expect_db_values(duthost, db, intf_names='all', state, health=None):
     Args:
         duthost: DUT host object (needs to be passed by calling function from duthosts fixture)
         db: Database number to check. Should be either 0 for APP_DB or 6 for STATE_DB
-        intf_names: A list of the PORTNAME to check in each table, or 'all' (by default) to check all MUX_CABLE interfaces
         state: The expected value for each of the `state` fields in both tables
         health: The expected value for the `state` field in the MUX_LINKMGR_TABLE table (only needed for STATE_DB)
+        intf_names: A list of the PORTNAME to check in each table, or 'all' (by default) to check all MUX_CABLE interfaces
 
     Raises:
         AssertionError if th mux cable fields don't match the given states.


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
