### PR TITLE
[dualtor]: Make `force_active_tor` a fixture

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -193,7 +193,7 @@ def force_active_tor():
     @param intf: One or a list of names of interface or 'all' for all interfaces
     """
     forced_intfs = []
-    def _force_active_tor(dut, intf):
+    def force_active_tor_fn(dut, intf):
         if type(intf) == str:
             cmds = ["config muxcable mode active {}; true".format(intf)]
             forced_intfs.append((dut, intf))
@@ -204,11 +204,10 @@ def force_active_tor():
                 cmds.append("config muxcable mode active {}; true".format(i))
         dut.shell_cmds(cmds=cmds, continue_on_fail=True)
 
-    yield _force_active_tor
+    yield force_active_tor_fn
 
-    if bool(forced_intfs):
-        for x in forced_intfs:
-            x[0].shell("config muxcable mode auto {}; true".format(x[1]))
+    for x in forced_intfs:
+        x[0].shell("config muxcable mode auto {}; true".format(x[1]))
 
 
 


### PR DESCRIPTION
* Enables automatic teardown/cleanup

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This util runs `config mux mode active` on a DUT, which may leave it in an unexpected state when starting the next test.

#### How did you do it?
Use the 'fixture yields function' pattern to enable automatic cleanup (running `config mux mode auto` for the affected ports during teardown)

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
