### PR TITLE
[dualtor] Add server traffic utility

### DIFF
--- a/tests/common/devices/vmhost.py
+++ b/tests/common/devices/vmhost.py
@@ -1,0 +1,21 @@
+from tests.common.devices.base import AnsibleHostBase
+
+
+class VMHost(AnsibleHostBase):
+    """
+    @summary: Class for VM server
+
+    For running ansible module on VM server
+    """
+
+    def __init__(self, ansible_adhoc, hostname):
+        AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
+
+    @property
+    def external_port(self):
+        if not hasattr(self, "_external_port"):
+            vm = self.host.options["variable_manager"]
+            im = self.host.options["inventory_manager"]
+            hostvars = vm.get_vars(host=im.get_host(self.hostname), include_delegate_to=False)
+            setattr(self, "_external_port", hostvars["external_port"])
+        return getattr(self, "_external_port")

--- a/tests/common/dualtor/server_traffic_utils.py
+++ b/tests/common/dualtor/server_traffic_utils.py
@@ -1,0 +1,90 @@
+"""Utils to verify traffic between ToR and server."""
+import contextlib
+import logging
+import tempfile
+import sys
+import time
+
+from io import BytesIO
+from ptf.dataplane import match_exp_pkt
+from scapy.all import sniff
+from scapy.packet import ls
+
+
+@contextlib.contextmanager
+def dump_intf_packets(ansible_host, iface, pcap_save_path, dumped_packets, pcap_filter=None):
+    """Dump packets of the interface and save to a file."""
+    start_pcap = "tcpdump --immediate-mode -i %s -w %s" % (iface, pcap_save_path)
+    if pcap_filter:
+        start_pcap += (" " + pcap_filter)
+    start_pcap = "nohup %s  > /dev/null 2>&1 & echo $!" % start_pcap
+    pid = ansible_host.shell(start_pcap)["stdout"]
+    # sleep to let tcpdump starts to capture
+    time.sleep(1)
+    try:
+        yield
+    finally:
+        ansible_host.shell("kill -s 2 %s" % pid)
+        with tempfile.NamedTemporaryFile() as temp_pcap:
+            ansible_host.fetch(src=pcap_save_path, dest=temp_pcap.name, flat=True)
+            packets = sniff(offline=temp_pcap.name)
+            dumped_packets.extend(packets)
+
+
+class ServerTrafficMonitor(object):
+    """Monit traffic between ToR and server."""
+
+    VLAN_INTERFACE_TEMPLATE = "{external_port}.{vlan_id}"
+
+    def __init__(self, duthost, vmhost, dut_iface, conn_graph_facts, exp_pkt, existing=True):
+        self.duthost = duthost
+        self.dut_iface = dut_iface
+        self.exp_pkt = exp_pkt
+        self.vmhost = vmhost
+        self.conn_graph_facts = conn_graph_facts
+        self.captured_packets = []
+        self.matched_packets = []
+        self.vmhost_iface = self._find_vmhost_vlan_interface()
+        self.dump_utility = dump_intf_packets(
+            vmhost,
+            self.vmhost_iface,
+            tempfile.NamedTemporaryFile().name,
+            self.captured_packets
+        )
+        self.existing = existing
+
+    @staticmethod
+    def _list_layer_str(packet):
+        """Return list layer output string."""
+        _stdout, sys.stdout = sys.stdout, BytesIO()
+        try:
+            ls(packet)
+            return sys.stdout.getvalue()
+        finally:
+            sys.stdout = _stdout
+
+    def _find_vmhost_vlan_interface(self):
+        """Find the vmhost vlan interface that will be sniffed on."""
+        device_port_vlans = self.conn_graph_facts["device_port_vlans"][self.duthost.hostname]
+        vlan_id = device_port_vlans[self.dut_iface]["vlanlist"][0]
+        return self.VLAN_INTERFACE_TEMPLATE.format(external_port=self.vmhost.external_port, vlan_id=vlan_id)
+
+    def __enter__(self):
+        self.captured_packets[:] = []
+        self.matched_packets[:] = []
+        self.dump_utility.__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.dump_utility.__exit__(exc_type, exc_value, traceback)
+        logging.info("the expected packet:\n%s", str(self.exp_pkt))
+        self.matched_packets = [p for p in self.captured_packets if match_exp_pkt(self.exp_pkt, p)]
+        logging.info("received %d matched packets", len(self.matched_packets))
+        if self.matched_packets:
+            logging.info(
+                "display the most recent matched captured packet:\n%s",
+                self._list_layer_str(self.matched_packets[-1])
+            )
+        if self.existing and not self.matched_packets:
+            raise ValueError("Failed to find expected packet.")
+        if not self.existing and self.matched_packets:
+            raise ValueError("Found expected packet.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from tests.common.devices.fanout import FanoutHost
 from tests.common.devices.k8s import K8sMasterHost
 from tests.common.devices.k8s import K8sMasterCluster
 from tests.common.devices.duthosts import DutHosts
+from tests.common.devices.vmhost import VMHost
 
 from tests.common.helpers.constants import ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID
 from tests.common.helpers.dut_ports import encode_dut_port_name
@@ -26,6 +27,7 @@ from tests.common.testbed import TestbedInfo
 from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_vars
 from tests.common.utilities import get_host_visible_vars
+from tests.common.utilities import get_test_server_host
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node
 from tests.common.cache import FactsCache
 
@@ -373,6 +375,15 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
     except:
         pass
     return fanout_hosts
+
+
+@pytest.fixture(scope="session")
+def vmhost(ansible_adhoc, request, tbinfo):
+    server = tbinfo["server"]
+    inv_files = request.config.option.ansible_inventory
+    vmhost = get_test_server_host(inv_files, server)
+    return VMHost(ansible_adhoc, vmhost.name)
+
 
 @pytest.fixture(scope='session')
 def eos():


### PR DESCRIPTION
Add server traffic utility to check the traffic between the selected ToR
and the server.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2805

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add util to verify the traffic between ToR and servers.

#### How did you do it?
Add a context manager class to dump the traffic between ToR and server(from the vlan interface on vm host server) and
check if there are expected packets out of captured packets.

#### How did you verify/test it?
* demo testcase
```python
import logging
import pytest
import random
import time

from scapy.all import IP, Ether
from ptf import testutils, mask
from tests.common.dualtor.dual_tor_mock import *
from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports, rand_selected_interface, flush_neighbor
from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor


pytestmark = [
    pytest.mark.topology("t0")
]


@pytest.fixture(scope="function")
def build_packet_to_server(rand_selected_interface, ptfadapter, rand_selected_dut, tunnel_traffic_monitor):
    """Build packet destinated to server selected by test_interface."""
    tor = rand_selected_dut
    _, server_details = rand_selected_interface
    server_ipv4 = server_details["server_ipv4"].split("/")[0]
    pkt_dscp = random.choice(range(0, 33))
    pkt_ttl = random.choice(range(3, 65))
    pkt = testutils.simple_ip_packet(
        eth_dst=tor.facts["router_mac"],
        eth_src=ptfadapter.dataplane.get_mac(0, 0),
        ip_src="1.1.1.1",
        ip_dst=server_ipv4,
        ip_dscp=pkt_dscp,
        ip_ttl=pkt_ttl
    )
    logging.info("the packet destinated to server %s:\n%s", server_ipv4, tunnel_traffic_monitor._dump_show_str(pkt))
    return pkt


@pytest.fixture(scope="function")
def stop_garp_service(ptfhost):
    ptfhost.shell("supervisorctl stop garp_service")
    yield
    ptfhost.shell("supervisorctl start garp_service")


def test_standby_tor_remove_neighbor_downstream_standby(
    apply_mock_dual_tor_tables,
    apply_mock_dual_tor_kernel_configs,
    apply_standby_state_to_orchagent,
    conn_graph_facts, tbinfo,
    build_packet_to_server, rand_selected_interface, ptfadapter,
    rand_selected_dut, tunnel_traffic_monitor, vmhost,
    stop_garp_service, rand_unselected_dut
):

    def build_exp_pkt(packet):
        exp_pkt = mask.Mask(packet)
        exp_pkt.set_do_not_care_scapy(Ether, "dst")
        exp_pkt.set_do_not_care_scapy(Ether, "src")
        exp_pkt.set_do_not_care_scapy(IP, "tos")
        exp_pkt.set_do_not_care_scapy(IP, "ttl")
        exp_pkt.set_do_not_care_scapy(IP, "chksum")
        return exp_pkt

    tor = rand_selected_dut
    tor = rand_unselected_dut
    pkt = build_packet_to_server
    iface, server_details = rand_selected_interface
    server_ipv4 = server_details["server_ipv4"].split("/")[0]

    exp_pkt = build_exp_pkt(pkt)

    ptfadapter.before_send = lambda *args, **kwargs: time.sleep(0.5)

    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
    logging.info("send traffic to server %s from ptf t1 interface %s", server_ipv4, ptf_t1_intf)
    with flush_neighbor(tor, server_ipv4):
        with tunnel_traffic_monitor(tor, existing=False):
            with ServerTrafficMonitor(tor, vmhost, iface, conn_graph_facts, exp_pkt, existing=False):
                testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)


def test_active_tor_downstream_active(
    apply_mock_dual_tor_tables,
    apply_mock_dual_tor_kernel_configs,
    apply_active_state_to_orchagent,
    conn_graph_facts, tbinfo,
    build_packet_to_server, rand_selected_interface, ptfadapter,
    rand_selected_dut, vmhost,
):

    def build_exp_pkt(packet):
        exp_pkt = mask.Mask(packet)
        exp_pkt.set_do_not_care_scapy(Ether, "dst")
        exp_pkt.set_do_not_care_scapy(Ether, "src")
        exp_pkt.set_do_not_care_scapy(IP, "tos")
        exp_pkt.set_do_not_care_scapy(IP, "ttl")
        exp_pkt.set_do_not_care_scapy(IP, "chksum")
        return exp_pkt

    tor = rand_selected_dut
    pkt = build_packet_to_server
    iface, server_details = rand_selected_interface
    server_ipv4 = server_details["server_ipv4"].split("/")[0]

    exp_pkt = build_exp_pkt(pkt)

    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
    logging.info("send traffic to server %s from ptf t1 interface %s", server_ipv4, ptf_t1_intf)
    with ServerTrafficMonitor(tor, vmhost, iface, conn_graph_facts, exp_pkt, existing=True):
        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)
        time.sleep(1)

```
* result
```
dualtor/test_vmhost.py::test_standby_tor_remove_neighbor_downstream_standby PASSED                                                                                                             [ 50%]
dualtor/test_vmhost.py::test_active_tor_downstream_active PASSED                                                                                                                               [100%]

===================================================================================== 2 passed in 45.65 seconds ======================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
