### PR TITLE
[pytest] Add get_test_server_visible_vars

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -319,6 +319,59 @@ def get_test_server_vars(inv_files, server, variable=None):
         return None
 
 
+def get_test_server_visible_vars(inv_files, server, variable=None):
+    """Use ansible's VariableManager and InventoryManager to get value of variables visible to the specified server
+    group.
+
+    In testbed.csv file, we can get the server name of each test setup under the 'server' column. For example
+    'server_1', 'server_2', etc. This server name is indeed a group name in used ansible inventory files. This group
+    contains children groups for test server and VMs. This function is try to just return the variables visible to
+    the server group.
+
+    Args:
+        inv_files (list or string): List of inventory file pathes, or string of a single inventory file path. In tests,
+            it can be get from request.config.getoption("ansible_inventory").
+        server (string): Server of test setup in testbed.csv file.
+        variable (string or None): Variable name. Defaults to None.
+
+    Returns:
+        string or dict or None: If variable name is specified, return the variable value. If variable is not found,
+            return None. If variable name is not specified, return all variables in a dictionary. If the group is not
+            found or there is no host in the group, return None.
+    """
+    cached_vars = cache.read(server, 'test_server_visible_vars')
+    if cached_vars and cached_vars['inv_files'] == inv_files:
+        test_server_visible_vars = cached_vars['vars']
+    else:
+        test_server_visible_vars = None
+
+        vm = get_variable_manager(inv_files)
+        im = vm._inventory
+        group = im.groups.get(server, None)
+        if not group:
+            logger.error("Unable to find group {} in {}".format(server, str(inv_files)))
+            return None
+        for host in group.get_hosts():
+            if not re.match(r'VM\d+', host.name):   # This must be the test server host
+                test_server = host.name
+        test_server_host = im.get_host(test_server)
+        if not test_server_host:
+            logger.error("Unable to find host %s in %s", test_server_host, inv_files)
+            return None
+
+        test_server_visible_vars = vm.get_vars(host=test_server_host)
+        cache.write(server, 'test_server_visible_vars', {'inv_files': inv_files, 'vars': test_server_visible_vars})
+
+    if test_server_visible_vars:
+        if variable:
+            return test_server_visible_vars.get(variable, None)
+        else:
+            return test_server_visible_vars
+    else:
+        logger.error("Unable to find test server host under group {}".format(server))
+        return None
+
+
 def is_ipv4_address(ip_address):
     """Check if ip address is ipv4."""
     try:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To let test users could access the test server visible host variables.

#### How did you do it?
Use variable manager `get_vars` to retrieve all the host variables.

#### How did you verify/test it?
```
(Pdb) utils.get_test_server_visible_vars(inv_files, "server_17").keys()
[u'ansible_become_password', u'eos_login', u'skip_ceos_image_downloading', u'ceos_image', 'ansible_check_mode', u'vm_mgmt_gw', u'sonic_default_passwords', u'telemetry_certs', 'ansible_diff_mode', 'ansible_forks', u'eos_root_user', 'playbook_dir', u'eos_default_password', u'vm_console_base', 'ansible_playbook_python', u'mux_simulator_port', u'external_port', 'ansible_facts', u'eos_root_password', 'ansible_verbosity', 'inventory_hostname', u'k8s_master_login', u'secret_group_vars', 'omit', u'host_var_file', u'topologies', u'str2', u'ceos_image_filename', u'memory', u'mgmt_bridge', u'proxy_env', u'eos_default_login', u'ceos_image_orig', u'max_fp_num', u'ptf_bp_ipv6', 'inventory_file', u'switch_login', u'secret_host_vars', u'mgmt_prefixlen', u'skip_image_downloading', u'secret_vars', 'group_names', u'corefile_uploader', u'lab', u'mgmt_gw', u'ansible_user', 'groups', u'hwsku_map', u'restapi_certs', u'ansible_host', u'sonic_image_filename', u'sonic_login', 'ansible_inventory_sources', u'vm_images_url', u'cd_image_filename', u'eos_password', u'root_path', u'example_ixia', 'inventory_dir', u'ptf_bp_ip', u'sonic_password', u'hdd_image_filename', 'ansible_version', u'str', 'inventory_hostname_short', u'supported_vm_types', u'k8s_master_password', u'ansible_password']
(Pdb) utils.get_test_server_visible_vars(inv_files, "server_17")["external_port"]
u'enp59s0f1'
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
