### PR TITLE
Announce route support for T2 chassis topology

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -405,6 +405,9 @@ def main():
     elif topo_type == "t1":
         fib_t1_lag(topo, ptf_ip)
         module.exit_json(changed=True)
+    elif topo_type == "t2":
+        fib_t2_lag(topo, ptf_ip)
+        module.exit_json(changed=True)
     else:
         module.fail_json(msg='Unsupported topology "{}"'.format(topo_name))
 

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -50,7 +50,7 @@ IPV6_BASE_PORT = 6000
 
 
 def get_topo_type(topo_name):
-    pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor)')
+    pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2)')
     match = pattern.match(topo_name)
     if not match:
         raise Exception("Unsupported testbed type - {}".format(topo_name))
@@ -87,16 +87,18 @@ def announce_routes(ptf_ip, port, routes):
 def generate_routes(family, podset_number, tor_number, tor_subnet_number,
                     spine_asn, leaf_asn_start, tor_asn_start,
                     nexthop, nexthop_v6,
-                    tor_subnet_size, max_tor_subnet_number,
-                    router_type = "leaf", tor_index=None):
+                    tor_subnet_size, max_tor_subnet_number, topo,
+                    router_type = "leaf", tor_index=None, set_num=None):
     routes = []
 
     default_route_as_path = "6666 6667"
 
-    if router_type == "leaf":
+    if router_type == "leaf" and topo != "t2":
         default_route_as_path = "{} {}".format(spine_asn, default_route_as_path)
-
-    if router_type != 'tor':
+    if router_type == "core" and topo == "t2":
+        default_route_as_path = "{}".format(default_route_as_path)
+    # Default route for T2 is adventised by the core routers.
+    if (topo != "t2" and router_type != 'tor') or (topo == "t2" and router_type == "core"):
         if family in ["v4", "both"]:
             routes.append(("0.0.0.0/0", nexthop, default_route_as_path))
         if family in ["v6", "both"]:
@@ -108,14 +110,41 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
     for podset in range(0, podset_number):
         for tor in range(0, tor_number):
             for subnet in range(0, tor_subnet_number):
+                if router_type == "core":
+                    # Advertise podset 3+ to T2 DUT
+                    if podset < 3:
+                        continue
+
+                    # First 3 pods are advertised from T1 - so remove 3 from the total pods being advertised by T3
+                    first_third_podset_number = int(math.ceil((podset_number - 3) / 3.0))
+                    second_third_podset_number = int(math.ceil(((podset_number - 3) * 2) / 3.0))
+
+                    if set_num is not None:
+                        # For T2, we have 3 sets - 1 set advertises first 1/3 podsets, second set advertises second 1/3 podsets, and all VM's advertises the last 1/3 podsets
+                        if podset <= first_third_podset_number and set_num != 0:
+                            continue
+                        elif podset > first_third_podset_number and podset < second_third_podset_number and set_num != 1:
+                            continue
                 if router_type == "spine":
                     # Skip podset 0 for T2
                     if podset == 0:
                         continue
                 elif router_type == "leaf":
-                    # Skip tor 0 podset 0 for T1
-                    if podset == 0 and tor == 0:
-                        continue
+                    if topo == 't2':
+                        # Send routes for podset 0-2 (first 3 pods) to the T2 DUT
+                        if podset > 2:
+                            continue
+
+                        if set_num is not None:
+                            # For T2, we have 3 sets - 1 set advertises podset 1, second set advertises podset 2, and all VM's advertises podset3
+                            if podset == 0 and set_num != 0:
+                                continue
+                            elif podset == 1 and set_num != 1:
+                                continue
+                    else:
+                        # Skip tor 0 podset 0 for T1
+                        if podset == 0 and tor == 0:
+                            continue
                 elif router_type == "tor":
                     # Skip non podset 0 for T0
                     if podset != 0:
@@ -140,13 +169,18 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
                 tor_asn  = tor_asn_start + tor
 
                 aspath = None
-                if router_type == "spine":
+                if router_type == "core":
+                    aspath = "{} {}".format(leaf_asn, tor_asn)
+                elif router_type == "spine":
                     aspath = "{} {}".format(leaf_asn, tor_asn)
                 elif router_type == "leaf":
-                    if podset == 0:
+                    if topo == "t2":
                         aspath = "{}".format(tor_asn)
                     else:
-                        aspath = "{} {} {}".format(spine_asn, leaf_asn, tor_asn)
+                        if podset == 0:
+                            aspath = "{}".format(tor_asn)
+                        else:
+                            aspath = "{} {} {}".format(spine_asn, leaf_asn, tor_asn)
 
                 if family in ["v4", "both"]:
                     routes.append((prefix, nexthop, aspath))
@@ -178,10 +212,10 @@ def fib_t0(topo, ptf_ip):
 
         routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
                                     spine_asn, leaf_asn_start, tor_asn_start,
-                                    nhipv4, nhipv4, tor_subnet_size, max_tor_subnet_number)
+                                    nhipv4, nhipv4, tor_subnet_size, max_tor_subnet_number, "t0")
         routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                     spine_asn, leaf_asn_start, tor_asn_start,
-                                    nhipv6, nhipv6, tor_subnet_size, max_tor_subnet_number)
+                                    nhipv6, nhipv6, tor_subnet_size, max_tor_subnet_number, "t0")
 
         announce_routes(ptf_ip, port, routes_v4)
         announce_routes(ptf_ip, port6, routes_v6)
@@ -218,11 +252,11 @@ def fib_t1_lag(topo, ptf_ip):
         if router_type:
             routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
                                         None, leaf_asn_start, tor_asn_start,
-                                        nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number,
+                                        nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t1",
                                         router_type=router_type, tor_index=tor_index)
             routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                         None, leaf_asn_start, tor_asn_start,
-                                        nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number,
+                                        nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t1",
                                         router_type=router_type, tor_index=tor_index)
             announce_routes(ptf_ip, port, routes_v4)
             announce_routes(ptf_ip, port6, routes_v6)
@@ -232,6 +266,119 @@ def fib_t1_lag(topo, ptf_ip):
             for prefix in v["vips"]["ipv4"]["prefixes"]:
                 routes_vips.append((prefix, nhipv4, v["vips"]["ipv4"]["asn"]))
             announce_routes(ptf_ip, port, routes_vips)
+
+
+"""
+For T2, we have 3 sets of routes that we are going to advertise
+    - 1st set of 1/3 routes are advertised by the first 1/3 of the VMs
+    - 2nd set of 1/3 routes are advertised by the remaining 2/3rd of the VMs
+    - 3rd set of 1/3 routes are advertised by all the VMs
+Also, T1 VM's are potentially distributed over 2 linecards (asics). The same set of routes should be sent by
+the same set in both the linecards. So, if linecard1 and linecard2 have T1 VMs connected, then
+    -  1st set of routes should be advertised by the first 1/3 of the VMs on linecard1 and also by the first
+       1/3 of the VMs on linecard2.
+    -  2nd set of routes should be advertised by the remaining 2/3 of the VMs on linecard1 and also by the remaining
+        2/3 of the VMs on linecard2.
+    -  3rd set of routes should be advertised by the all VMs on linecard1 and also by all VMs on linecard2
+It is assumed that tne number of T1 VMs that on both the linecards is the same.
+If we don't have 2 linecards for T1 VMs, then routes above would be advertised only by the first linecard that has T1 VMs
+
+The total number of routes are controlled by the podset_number, tor_number, and tor_subnet_number from the topology file.
+With the proposed T2 topology with 400 podsets, and 32 routes per podset we would have 12K routes.
+In this topology, we have 24 VMs on each linecard (24 T3 VMs and 48 T1 VMs over 2 linecards).
+We would have the following distribution:
+- T1 Routes:
+   - 192.168.xx.xx (32 routes) from the first 8 T1 VM's from linecard2 and linecard3 (VM25-VM32, and VM49-VM56)
+   - 192.169.xx.xx (32 routes) from the remaining 16 T1 VM's on linecard2 and linecard3 (VM33-VM48, and VM64-VM72)
+   - 192.170.xx.xx (32 routes) from all T1 VMs on linecard2 and linecard3 (VM25-VM48, and VM49-VM72)
+- T2 Routes:
+   - 192.171.xx.xx to 193.45.xx.xx (4K routes) from from first 8 T3 VM's on linecard1 (VM1-VM8)
+   - 193.46.xx.xx to 193.176.xx.xx (4K routes) from the remaining 16 T3 VM's on linecard1 (VM9-VM24)
+   - 193.177.xx.xx - 194.55.xx.xx (4K routes) from all 24 T3 VM's on linecard1 (VM1-VM24)
+   - default route from all 24 T3 VM's on linecard1 (VM1-VM24)
+"""
+def fib_t2_lag(topo, ptf_ip):
+
+    vms = topo['topology']['VMs']
+    # T1 VMs per linecard(asic) - key is the dut index, and value is a list of T1 VMs
+    t1_vms = {}
+    # T3 VMs per linecard(asic) - key is the dut index, and value is a list of T3 VMs
+    t3_vms = {}
+
+    for key, value in vms.items():
+        m = re.match("(\d+)\.(\d+)@(\d+)", value['vlans'][0])
+        dut_index = int(m.group(1))
+        if 'T1' in key:
+            if dut_index not in t1_vms:
+                t1_vms[dut_index] = list()
+            t1_vms[dut_index].append(key)
+
+        if 'T3' in key:
+            if dut_index not in t3_vms:
+                t3_vms[dut_index] = list()
+            t3_vms[dut_index].append(key)
+    generate_t2_routes(t1_vms, topo, ptf_ip)
+    generate_t2_routes(t3_vms, topo, ptf_ip)
+
+def generate_t2_routes(dut_vm_dict, topo, ptf_ip):
+    common_config = topo['configuration_properties'].get('common', {})
+    vms = topo['topology']['VMs']
+    vms_config = topo['configuration']
+
+    podset_number = common_config.get("podset_number", PODSET_NUMBER)
+    tor_number = common_config.get("tor_number", TOR_NUMBER)
+    tor_subnet_number = common_config.get("tor_subnet_number", TOR_SUBNET_NUMBER)
+    max_tor_subnet_number = common_config.get("max_tor_subnet_number", MAX_TOR_SUBNET_NUMBER)
+    tor_subnet_size = common_config.get("tor_subnet_size", TOR_SUBNET_SIZE)
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+    leaf_asn_start = common_config.get("leaf_asn_start", LEAF_ASN_START)
+    tor_asn_start = common_config.get("tor_asn_start", TOR_ASN_START)
+
+    # generate routes for t1 vms
+    for a_dut_index in dut_vm_dict:
+        # sort the list of VMs
+        all_vms = sorted(dut_vm_dict[a_dut_index])
+        n_vms = len(all_vms)
+        first_third_vm_index = int(math.ceil(n_vms / 3))
+
+        for a_vm_index, a_vm in enumerate(all_vms):
+            if all_vms == 1:
+                # Only 1 VM, have it advertise all sets of routes
+                set_num = None
+            elif a_vm_index < first_third_vm_index:
+                set_num = 0
+            else:
+                set_num = 1
+            vm_offset = vms[a_vm]['vm_offset']
+            port = IPV4_BASE_PORT + vm_offset
+            port6 = IPV6_BASE_PORT + vm_offset
+
+            router_type = None
+            if 'leaf' in vms_config[a_vm]['properties']:
+                router_type = 'leaf'
+            elif 'core' in vms_config[a_vm]['properties']:
+                router_type = 'core'
+
+            tor_index = None
+
+            if router_type:
+                routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
+                                            common_config['dut_asn'], leaf_asn_start, tor_asn_start,
+                                            nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t2",
+                                            router_type=router_type, tor_index=tor_index, set_num=set_num)
+                routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
+                                            common_config['dut_asn'], leaf_asn_start, tor_asn_start,
+                                            nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t2",
+                                            router_type=router_type, tor_index=tor_index, set_num=set_num)
+                announce_routes(ptf_ip, port, routes_v4)
+                announce_routes(ptf_ip, port6, routes_v6)
+
+                if 'vips' in vms_config[a_vm]:
+                    routes_vips = []
+                    for prefix in vms_config[a_vm]["vips"]["ipv4"]["prefixes"]:
+                        routes_vips.append((prefix, nhipv4, vms_config[a_vm]["vips"]["ipv4"]["asn"]))
+                    announce_routes(ptf_ip, port, routes_vips)
 
 
 def main():

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -41,7 +41,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -1,0 +1,132 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ no switchport
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 2
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} maximum-routes 0
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -1,0 +1,136 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ no switchport
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} maximum-routes 0
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/vars/topo_t2.yml
+++ b/ansible/vars/topo_t2.yml
@@ -331,18 +331,24 @@ topology:
 
 configuration_properties:
   common:
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
     dut_asn: 65100
     dut_type: Spine
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
-  spine:
-    swrole: spine
-
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
 configuration:
   ARISTA01T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
       asn: 65200
       peers:
@@ -368,9 +374,9 @@ configuration:
   ARISTA03T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65201
       peers:
         65100:
           - 10.0.0.4
@@ -394,9 +400,9 @@ configuration:
   ARISTA05T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65202
       peers:
         65100:
           - 10.0.0.8
@@ -420,9 +426,9 @@ configuration:
   ARISTA07T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65203
       peers:
         65100:
           - 10.0.0.12
@@ -446,9 +452,9 @@ configuration:
   ARISTA09T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65204
       peers:
         65100:
           - 10.0.0.16
@@ -472,9 +478,9 @@ configuration:
   ARISTA11T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65205
       peers:
         65100:
           - 10.0.0.20
@@ -498,9 +504,9 @@ configuration:
   ARISTA13T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65206
       peers:
         65100:
           - 10.0.0.24
@@ -524,9 +530,9 @@ configuration:
   ARISTA15T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65207
       peers:
         65100:
           - 10.0.0.28
@@ -550,9 +556,9 @@ configuration:
   ARISTA17T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65208
       peers:
         65100:
           - 10.0.0.32
@@ -571,9 +577,9 @@ configuration:
   ARISTA18T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65209
       peers:
         65100:
           - 10.0.0.34
@@ -592,9 +598,9 @@ configuration:
   ARISTA19T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65210
       peers:
         65100:
           - 10.0.0.36
@@ -613,9 +619,9 @@ configuration:
   ARISTA20T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65211
       peers:
         65100:
           - 10.0.0.38
@@ -634,9 +640,9 @@ configuration:
   ARISTA21T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65212
       peers:
         65100:
           - 10.0.0.40
@@ -655,9 +661,9 @@ configuration:
   ARISTA22T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65213
       peers:
         65100:
           - 10.0.0.42
@@ -676,9 +682,9 @@ configuration:
   ARISTA23T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65214
       peers:
         65100:
           - 10.0.0.44
@@ -697,9 +703,9 @@ configuration:
   ARISTA24T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65215
       peers:
         65100:
           - 10.0.0.46
@@ -718,9 +724,9 @@ configuration:
   ARISTA25T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65216
       peers:
         65100:
           - 10.0.0.48
@@ -739,9 +745,9 @@ configuration:
   ARISTA26T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65217
       peers:
         65100:
           - 10.0.0.50
@@ -760,9 +766,9 @@ configuration:
   ARISTA27T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65218
       peers:
         65100:
           - 10.0.0.52
@@ -781,9 +787,9 @@ configuration:
   ARISTA28T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65219
       peers:
         65100:
           - 10.0.0.54
@@ -802,9 +808,9 @@ configuration:
   ARISTA29T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65220
       peers:
         65100:
           - 10.0.0.56
@@ -823,9 +829,9 @@ configuration:
   ARISTA30T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65221
       peers:
         65100:
           - 10.0.0.58
@@ -844,9 +850,9 @@ configuration:
   ARISTA31T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65222
       peers:
         65100:
           - 10.0.0.60
@@ -865,9 +871,9 @@ configuration:
   ARISTA32T3:
     properties:
       - common
-      - spine
+      - core
     bgp:
-      asn: 65200
+      asn: 65223
       peers:
         65100:
           - 10.0.0.62
@@ -886,7 +892,7 @@ configuration:
   ARISTA01T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
       asn: 65000
       peers:
@@ -912,9 +918,9 @@ configuration:
   ARISTA03T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65001
+      asn: 65000
       peers:
         65100:
           - 10.0.0.68
@@ -938,9 +944,9 @@ configuration:
   ARISTA05T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65002
+      asn: 65000
       peers:
         65100:
           - 10.0.0.72
@@ -964,9 +970,9 @@ configuration:
   ARISTA07T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65003
+      asn: 65000
       peers:
         65100:
           - 10.0.0.76
@@ -990,9 +996,9 @@ configuration:
   ARISTA09T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65004
+      asn: 65000
       peers:
         65100:
           - 10.0.0.80
@@ -1016,9 +1022,9 @@ configuration:
   ARISTA11T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65005
+      asn: 65000
       peers:
         65100:
           - 10.0.0.84
@@ -1042,9 +1048,9 @@ configuration:
   ARISTA13T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65006
+      asn: 65000
       peers:
         65100:
           - 10.0.0.88
@@ -1068,9 +1074,9 @@ configuration:
   ARISTA15T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65007
+      asn: 65000
       peers:
         65100:
           - 10.0.0.92
@@ -1094,9 +1100,9 @@ configuration:
   ARISTA17T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65008
+      asn: 65000
       peers:
         65100:
           - 10.0.0.96
@@ -1112,12 +1118,17 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.49/24
       ipv6: fc0a::62/64
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
   ARISTA18T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65009
+      asn: 65000
       peers:
         65100:
           - 10.0.0.98
@@ -1133,12 +1144,17 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.50/24
       ipv6: fc0a::64/64
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
   ARISTA19T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65010
+      asn: 65000
       peers:
         65100:
           - 10.0.0.100
@@ -1157,9 +1173,9 @@ configuration:
   ARISTA20T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65011
+      asn: 65000
       peers:
         65100:
           - 10.0.0.102
@@ -1178,9 +1194,9 @@ configuration:
   ARISTA21T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65012
+      asn: 65000
       peers:
         65100:
           - 10.0.0.104
@@ -1199,9 +1215,9 @@ configuration:
   ARISTA22T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65013
+      asn: 65000
       peers:
         65100:
           - 10.0.0.106
@@ -1220,9 +1236,9 @@ configuration:
   ARISTA23T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65014
+      asn: 65000
       peers:
         65100:
           - 10.0.0.108
@@ -1241,9 +1257,9 @@ configuration:
   ARISTA24T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65015
+      asn: 65000
       peers:
         65100:
           - 10.0.0.110
@@ -1262,9 +1278,9 @@ configuration:
   ARISTA25T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65016
+      asn: 65000
       peers:
         65100:
           - 10.0.0.112
@@ -1283,9 +1299,9 @@ configuration:
   ARISTA26T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65017
+      asn: 65000
       peers:
         65100:
           - 10.0.0.114
@@ -1304,9 +1320,9 @@ configuration:
   ARISTA27T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65018
+      asn: 65000
       peers:
         65100:
           - 10.0.0.116
@@ -1325,9 +1341,9 @@ configuration:
   ARISTA28T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65019
+      asn: 65000
       peers:
         65100:
           - 10.0.0.118
@@ -1346,9 +1362,9 @@ configuration:
   ARISTA29T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65020
+      asn: 65000
       peers:
         65100:
           - 10.0.0.120
@@ -1367,9 +1383,9 @@ configuration:
   ARISTA30T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65021
+      asn: 65000
       peers:
         65100:
           - 10.0.0.122
@@ -1388,9 +1404,9 @@ configuration:
   ARISTA31T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65022
+      asn: 65000
       peers:
         65100:
           - 10.0.0.124
@@ -1409,9 +1425,9 @@ configuration:
   ARISTA32T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65023
+      asn: 65000
       peers:
         65100:
           - 10.0.0.126
@@ -1430,9 +1446,9 @@ configuration:
   ARISTA33T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65024
+      asn: 65000
       peers:
         65100:
           - 10.0.0.128
@@ -1456,9 +1472,9 @@ configuration:
   ARISTA35T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65025
+      asn: 65000
       peers:
         65100:
           - 10.0.0.132
@@ -1482,9 +1498,9 @@ configuration:
   ARISTA37T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65026
+      asn: 65000
       peers:
         65100:
           - 10.0.0.136
@@ -1508,9 +1524,9 @@ configuration:
   ARISTA39T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65027
+      asn: 65000
       peers:
         65100:
           - 10.0.0.140
@@ -1534,9 +1550,9 @@ configuration:
   ARISTA41T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65028
+      asn: 65000
       peers:
         65100:
           - 10.0.0.144
@@ -1560,9 +1576,9 @@ configuration:
   ARISTA43T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65029
+      asn: 65000
       peers:
         65100:
           - 10.0.0.148
@@ -1586,9 +1602,9 @@ configuration:
   ARISTA45T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65030
+      asn: 65000
       peers:
         65100:
           - 10.0.0.152
@@ -1612,9 +1628,9 @@ configuration:
   ARISTA47T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65031
+      asn: 65000
       peers:
         65100:
           - 10.0.0.156
@@ -1638,9 +1654,9 @@ configuration:
   ARISTA49T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65032
+      asn: 65000
       peers:
         65100:
           - 10.0.0.160
@@ -1659,9 +1675,9 @@ configuration:
   ARISTA50T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65033
+      asn: 65000
       peers:
         65100:
           - 10.0.0.162
@@ -1680,9 +1696,9 @@ configuration:
   ARISTA51T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65034
+      asn: 65000
       peers:
         65100:
           - 10.0.0.164
@@ -1701,9 +1717,9 @@ configuration:
   ARISTA52T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65035
+      asn: 65000
       peers:
         65100:
           - 10.0.0.166
@@ -1722,9 +1738,9 @@ configuration:
   ARISTA53T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65036
+      asn: 65000
       peers:
         65100:
           - 10.0.0.168
@@ -1743,9 +1759,9 @@ configuration:
   ARISTA54T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65037
+      asn: 65000
       peers:
         65100:
           - 10.0.0.170
@@ -1764,9 +1780,9 @@ configuration:
   ARISTA55T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65038
+      asn: 65000
       peers:
         65100:
           - 10.0.0.172
@@ -1785,9 +1801,9 @@ configuration:
   ARISTA56T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65039
+      asn: 65000
       peers:
         65100:
           - 10.0.0.174
@@ -1803,12 +1819,17 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.88/24
       ipv6: fc0a::b0/64
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
   ARISTA57T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65040
+      asn: 65000
       peers:
         65100:
           - 10.0.0.176
@@ -1824,12 +1845,17 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.89/24
       ipv6: fc0a::b2/64
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
   ARISTA58T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65041
+      asn: 65000
       peers:
         65100:
           - 10.0.0.178
@@ -1848,9 +1874,9 @@ configuration:
   ARISTA59T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65042
+      asn: 65000
       peers:
         65100:
           - 10.0.0.180
@@ -1869,9 +1895,9 @@ configuration:
   ARISTA60T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65043
+      asn: 65000
       peers:
         65100:
           - 10.0.0.182
@@ -1890,9 +1916,9 @@ configuration:
   ARISTA61T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65044
+      asn: 65000
       peers:
         65100:
           - 10.0.0.184
@@ -1911,9 +1937,9 @@ configuration:
   ARISTA62T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65045
+      asn: 65000
       peers:
         65100:
           - 10.0.0.186
@@ -1932,9 +1958,9 @@ configuration:
   ARISTA63T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65046
+      asn: 65000
       peers:
         65100:
           - 10.0.0.188
@@ -1953,9 +1979,9 @@ configuration:
   ARISTA64T1:
     properties:
       - common
-      - spine
+      - leaf
     bgp:
-      asn: 65047
+      asn: 65000
       peers:
         65100:
           - 10.0.0.190

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -204,7 +204,7 @@ class TestbedInfo(object):
                       explicit_start=True, Dumper=IncIndentDumper)
 
     def get_testbed_type(self, topo_name):
-        pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor)')
+        pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2)')
         match = pattern.match(topo_name)
         if match == None:
             raise Exception("Unsupported testbed type - {}".format(topo_name))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add support for announce_route to work against a T2 topology
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Need to advertise routes to the T2 VoQ chassis from the T1 and T3 to simulate a typical deployment of T2 chassis in a data center.

The requirements for the proposed T2 topology in ansible/vars/topo_t2.yml:
- Advertise total 12K routes to the chassis
  - ~100 routes from down-strem T1
  - 12K routes from upstream T3
- The upstream routes should have a mix of 8, 16 and 24 ECMP paths to the T3 VMs
- The down-stream routes should have a mix of 16,32, and 48 ECMP paths across 2 linecards to the T1 VMs
 
#### How did you do it?
For T2, we have 3 sets of routes that we are going to advertise
- 1st set of 1/3 routes are advertised by the first 1/3 of the VMs
- 2nd set of 1/3 routes are advertised by the remaining 2/3rd of the VMs
- 3rd set of 1/3 routes are advertised by all the VMs

Also, T1 VM's are distributed over 2 linecards (asics). The same set of routes should be sent by
the same set in both the linecards. So, if linecard1 and linecard2 have T1 VMs connected, then
-  1st set of routes should be advertised by the first 1/3 of the VMs on linecard1 and also by the first 1/3 of the VMs on linecard2.
-  2nd set of routes should be advertised by the remaining 2/3 of the VMs on linecard1 and also by the remaining 2/3 of the VMs on linecard2.
-  3rd set of routes should be advertised by the all VMs on linecard1 and also by all VMs on linecard2
It is assumed that tne number of T1 VMs that on both the linecards is the same.
If we don't have 2 linecards for T1 VMs, then routes above would be advertised only by the first linecard that has T1 VMs

The total number of routes are controlled by the podset_number, tor_number, and tor_subnet_number from the topology file.
With the proposed T2 topology with 400 podsets, and 32 routes per podset we would have 12K routes.
In this topology, we have 24 VMs on each linecard (24 T3 VMs and 48 T1 VMs over 2 linecards).
We would have the following distribution:
- T1 Routes:
   - 192.168.xx.xx (32 routes) from the first 8 T1 VM's from linecard2 and linecard3 (VM25-VM32, and VM49-VM56)
   - 192.169.xx.xx (32 routes) from the remaining 16 T1 VM's on linecard2 and linecard3 (VM33-VM48, and VM64-VM72)
   - 192.170.xx.xx (32 routes) from all T1 VMs on linecard2 and linecard3 (VM25-VM48, and VM49-VM72)
- T2 Routes:
   - 192.171.xx.xx to 193.45.xx.xx (4K routes) from from first 8 T3 VM's on linecard1 (VM1-VM8)
   - 193.46.xx.xx to 193.176.xx.xx (4K routes) from the remaining 16 T3 VM's on linecard1 (VM9-VM24)
   - 193.177.xx.xx - 194.55.xx.xx (4K routes) from all 24 T3 VM's on linecard1 (VM1-VM24)
   - default route from all 24 T3 VM's on linecard1 (VM1-VM24)

Other changes:
- testbed.py:
   - Added 't2' as the topology type.

- topo_t2.yml:
  - Updated topo_t2.yml to reflect the changes for routes (podset_number etc.) and also changing the ASN's to align with a typical T2 deployment

- Also added some missing template files for ceos dockers when doing add-topo for a T2 topology.

#### How did you verify/test it?
Ran announce_routes against a T2 chassis 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
