### PR TITLE
Convert tests test_cpu_memory_usage, test_port_toggle to support T2 c…

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -149,9 +149,25 @@ class SonicHost(AnsibleHostBase):
         facts.update(self._get_platform_info())
         facts["num_asic"] = self._get_asic_count(facts["platform"])
         facts["router_mac"] = self._get_router_mac()
+        facts["modular_chassis"] = self._get_modular_chassis()
 
         logging.debug("Gathered SonicHost facts: %s" % json.dumps(facts))
         return facts
+
+    def _get_modular_chassis(self):
+        py_res = self.shell("python -c \"import sonic_platform\"", module_ignore_errors=True)
+        if py_res["failed"]:
+            out = self.shell(
+                "python3 -c \"import sonic_platform.platform as P; print(P.Platform().get_chassis().is_modular_chassis()); exit()\"",
+                module_ignore_errors=True)
+        else:
+            out = self.shell(
+                "python -c \"import sonic_platform.platform as P; print(P.Platform().get_chassis().is_modular_chassis()); exit()\"",
+                module_ignore_errors=True)
+        res = "False" if out["failed"] else out["stdout"]
+        return res
+
+
 
     def _get_asic_count(self, platform):
         """

--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -33,10 +33,10 @@ def parse_chassis_module(output, expected_headers):
     return result
 
 
-def test_show_chassis_module_status(duthosts, enum_dut_hostname):
+def test_show_chassis_module_status(duthosts, enum_rand_one_per_hwsku_hostname):
     cmd = " ".join([CMD_SHOW_CHASSIS_MODULE, "status"])
     logger.info("verifying output of cli command {}".format(cmd))
-    duthost = duthosts[enum_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     exp_headers = ["Name", "Description", "Physical-Slot", "Oper-Status", "Admin-Status"]
     skip_mod_list = get_skip_mod_list(duthost)
 
@@ -55,7 +55,7 @@ def test_show_chassis_module_status(duthosts, enum_dut_hostname):
                               mod_idx, res[mod_idx]['Oper-Status']))
 
 
-def test_show_chassis_module_midplane_status(duthosts, enum_dut_hostname, skip_module_list):
+def test_show_chassis_module_midplane_status(duthosts, enum_rand_one_per_hwsku_hostname):
     """
        @summary: Verify output of `show chassis-module midplane-status`
     """
@@ -63,7 +63,7 @@ def test_show_chassis_module_midplane_status(duthosts, enum_dut_hostname, skip_m
     logger.info("verifying output of cli command {}".format(cmd))
     expected_headers = ["Name", "IP-Address", "Reachability"]
 
-    duthost = duthosts[enum_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     output = duthost.command(cmd)
     res_mid_status = parse_chassis_module(output['stdout_lines'], expected_headers)
     mod_key= ['line-cards']

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -11,8 +11,8 @@ pytestmark = [
 
 
 @pytest.fixture(scope='module')
-def setup_thresholds(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cpu_threshold = 50
     memory_threshold = 60
     if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0'):
@@ -20,9 +20,9 @@ def setup_thresholds(duthosts, rand_one_dut_hostname):
     return memory_threshold, cpu_threshold
 
 
-def test_cpu_memory_usage(duthosts, rand_one_dut_hostname, setup_thresholds):
+def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thresholds):
     """Check DUT memory usage and process cpu usage are within threshold."""
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     MonitResult = namedtuple('MonitResult', ['processes', 'memory'])
     monit_results = duthost.monit_process(iterations=12)['monit_results']
 

--- a/tests/platform_tests/test_port_toggle.py
+++ b/tests/platform_tests/test_port_toggle.py
@@ -17,7 +17,7 @@ class TestPortToggle(object):
     TestPortToggle class for testing port toggle
     """
 
-    def test_port_toggle(self, duthosts, rand_one_dut_hostname, bring_up_dut_interfaces, tbinfo):
+    def test_port_toggle(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, bring_up_dut_interfaces, tbinfo):
         """
         Validates that port toggle works as expected
 
@@ -27,5 +27,5 @@ class TestPortToggle(object):
 
         Pass Criteria: All interfaces are up correctly.
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         port_toggle(duthost, tbinfo)

--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -1,0 +1,92 @@
+
+import json
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('t2')
+]
+
+
+def get_chassis_db_ip(duthost):
+    out = duthost.command("cat /etc/sonic/chassisdb.conf")['stdout_lines']
+    for line in out:
+        if "chassis_db_address" in line.split("="):
+            chassis_db_ip = line.split("=")[1]
+            break
+    return chassis_db_ip
+
+
+def get_expected_num_thermals(duts, dutname=None):
+    num_of_therms = 0
+    cmd = "show platform temperature"
+    if dutname:
+        dut = duts[dutname]
+        therm_out = dut.show_and_parse(cmd)
+        num_of_therms = len(therm_out)
+    else:
+        for dut in duts:
+            therm_out = dut.show_and_parse(cmd)
+            num_of_therms += len(therm_out)
+
+    return num_of_therms
+
+
+def check_therm_data(thermal_dict):
+    failed_check_msg = []
+    for therm_sensor in thermal_dict.keys():
+        max_threshold = float(thermal_dict[therm_sensor]['value']['high_threshold'])
+        low_threshold = float(thermal_dict[therm_sensor]['value']['low_threshold'])
+        min_temp = float(thermal_dict[therm_sensor]['value']['maximum_temperature'])
+        high_temp = float(thermal_dict[therm_sensor]['value']['minimum_temperature'])
+        warning_status = thermal_dict[therm_sensor]['value']['warning_status']
+        if high_temp > max_threshold:
+            if warning_status == 'False':
+                failed_check_msg.append(
+                    "high temperature {} exceeded max threshold {} warning status expected true but is {} for {}"
+                    .format(high_temp, max_threshold, warning_status, therm_sensor))
+        elif min_temp < low_threshold:
+            if warning_status == 'False':
+                failed_check_msg.append(
+                    "Minimum temperature {} lower than min threshold {} warning status expected true but is {} for {}"
+                    .format(high_temp, max_threshold, warning_status, therm_sensor))
+        else:
+            if warning_status == 'True':
+                failed_check_msg.append(
+                    "warning status expected False but is {} for {}"
+                    .format(warning_status, therm_sensor))
+
+    return failed_check_msg
+
+
+def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
+    """
+     This test case will verify thermal local state db data on each hwsku type in chassis
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    num_thermals = get_expected_num_thermals(duthosts, enum_rand_one_per_hwsku_hostname)
+    thermal_out = duthost.command("redis-dump -d 6 -y -k \"*TEMP*\"")
+    out_dict = json.loads(thermal_out['stdout'])
+    pytest_assert(len(out_dict.keys()) == num_thermals, "number of thermal sensors incorrect expected  {} but got {}".format(num_thermals, len(out_dict.keys())))
+    result = check_therm_data(out_dict)
+    pytest_assert(not result,
+                  "Warning status incorrect for following thermal sensors:\n{}".format("\n".join(result)))
+
+
+def test_thermal_global_state_db(duthosts, enum_supervisor_dut_hostname, tbinfo):
+    """
+     This test case will verify global state db data on supervisor
+     Verify data for all sensors from line cards and fabric cards present in global state db
+    """
+    duthost = duthosts[enum_supervisor_dut_hostname]
+    chassis_db_ip = get_chassis_db_ip(duthost)
+    expected_num_thermals = get_expected_num_thermals(duthosts)
+    thermal_out = duthost.command("redis-dump -H {} -p 6380 -d 13 -y -k \"*TEMP*\"".format(chassis_db_ip))
+    out_dict = json.loads(thermal_out['stdout'])
+    actual_num_thermal_sensors = len(out_dict.keys())
+    pytest_assert(actual_num_thermal_sensors == expected_num_thermals,
+                  "got {} thermal sensors expected {}".format(actual_num_thermal_sensors, expected_num_thermals))
+    result = check_therm_data(out_dict)
+    pytest_assert(not result,
+                  "Warning status incorrect in global db for following thermal sensors:\n{}".format(
+                      "\n".join(result)))

--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -64,6 +64,8 @@ def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
      This test case will verify thermal local state db data on each hwsku type in chassis
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.facts['modular_chassis'] == "False":
+        pytest.skip("Test skipped applicable to modular chassis only")
     num_thermals = get_expected_num_thermals(duthosts, enum_rand_one_per_hwsku_hostname)
     thermal_out = duthost.command("redis-dump -d 6 -y -k \"*TEMP*\"")
     out_dict = json.loads(thermal_out['stdout'])
@@ -79,6 +81,8 @@ def test_thermal_global_state_db(duthosts, enum_supervisor_dut_hostname, tbinfo)
      Verify data for all sensors from line cards and fabric cards present in global state db
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
+    if duthost.facts['modular_chassis'] == "False":
+        pytest.skip("Test skipped applicable to modular chassis only")
     chassis_db_ip = get_chassis_db_ip(duthost)
     expected_num_thermals = get_expected_num_thermals(duthosts)
     thermal_out = duthost.command("redis-dump -H {} -p 6380 -d 13 -y -k \"*TEMP*\"".format(chassis_db_ip))


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)

### Approach

#### What is the motivation for this PR?
Add new attribute modular_chassis which will be set true if DUT is modular chassis and False for other
Add support to run tests  on tests/platform_tests/test_cpu_memory_usage.py, tests/platform_tests/test_port_toggle.py on  T2 chassis, change test_show_chassis_module to run duts per hwsku.
Add new tests to verify thermal local and global state db on VoQ chassis introduced by PRs https://github.com/Azure/sonic-swss-common/pull/395 and https://github.com/Azure/sonic-platform-daemons/pull/101

#### How did you do it?
modifications to current tests and new test file as below:

tests/common/devices/sonic.py
Add new attribute modular_chassis which can be used to skip tests only for modular chassis if DUT is not chassis
possible values for attribute are True if DUT is part of modular chassis and False if not part of modular chassis

tests/platform_tests/cli/test_show_chassis_module.py
 - change test select one dut per hwsku instead of running on all DUTs
 
tests/platform_tests/test_cpu_memory_usage.py
 - change rand_one_dut_hostname to enum_rand_one_per_hwsku_hostname to test per hwsku.

tests/platform_tests/test_port_toggle.py
 - change rand_one_dut_hostname to enum_rand_one_per_hwsku_hostname to test per hwsku.

tests/platform_tests/test_thermal_state_db.py
 - Add new test for t2 chassis to verify thermal data in  local state db for all thermal sensors
 - Verify global state db in supervisor has data for all sensors from all modules in chassis


#### How did you verify/test it?
Validated the modified tests against a chassis .

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
