### PR TITLE
[Qos] Update SAI QoS tests to include LAG ports in the tests

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -135,6 +135,16 @@ class TestQosSai(QosSaiBase):
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         qosConfig = dutQosConfig["param"]
+
+        dst_port_count = set([
+            dutConfig["testPorts"]["dst_port_id"],
+            dutConfig["testPorts"]["dst_port_2_id"],
+            dutConfig["testPorts"]["dst_port_3_id"],
+        ])
+
+        if len(dst_port_count) != 3:
+            pytest.skip("PFC Xon Limit test: Need at least 3 destination ports")
+
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1723,7 +1723,6 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 # as all lossy packets are now mapped to single pg 0
                 # so we remove the strict equity check, and use upper bound
                 # check instead
-                assert(1 * cell_size <= pg_shared_wm_res[pg])
                 assert(pg_shared_wm_res[pg] <= margin * cell_size)
 
             # send packet batch of fixed packet numbers to fill pg shared


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Updated SAI QoS tests to handle LAG ports. To determine the LAG rx port, one packet, with same parameters as test packet, is sent from source port to destination port. Port on which packet is received is used for testing.

Test case updated:
* PFCXon
* WRR
* LossyQueue
* PGSharedWatermark

Skip test if enough test ports are not provided for the test case. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Include LAG ports for testing

#### How did you do it?
To determine the LAG rx port, one packet, with same parameters as test packet, is sent from source port to destination port. Port on which packet is received is used for testing.

#### How did you verify/test it?

Single ASIC
```
============================================================== 2 passed, 17 deselected, 1 warnings in 483.26 seconds ===============================================================
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest qos/test_qos_sai.py --testbed vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos,../ansible/str2,../ansible/strsvc --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8  --module-path=../ansible/library --disable_loganalyzer --skip_sanity  -k "PfcXon or Dwrr or LossyQueue or PgSharedWatermark"
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================================================================================================== test session starts ============================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 19 items / 12 deselected / 7 selected                                                                                                                                                                                                                                                                                                                            

qos/test_qos_sai.py .......                                                                                                                                                                                                                                                                                                                                          [100%]

============================================================================================================================================================================= warnings summary =============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================================================== 7 passed, 12 deselected, 1 warnings in 703.40 seconds ===========================================================================================================================================================
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ 
```

Multi ASIC

```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$ pytest  qos/test_qos_sai.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library --disable_loganalyzer --skip_sanity  -k "PfcXon or Dwrr or LossyQueue or PgSharedWatermark"                         
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collected 19 items / 12 deselected / 7 selected                                                                                                                                                                                                                                                                                                                          

qos/test_qos_sai.py s....s.                                                                                                                                                   [100%]

================================================================================= warnings summary ==================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================= 5 passed, 2 skipped, 12 deselected, 1 warnings in 369.12 seconds ==========================================================
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$ 
[
```

NOTE: Skip is expected on the testbed this test was run as there are not enough test ports for XonLimit test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
