### PR TITLE
[port_utils] Update port_utils for new 9332 port layout

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -26,10 +26,10 @@ def get_port_alias_to_name_map(hwsku):
             port_alias_to_name_map["hundredGigE1/%d" % (i / 4 + 1)] = "Ethernet%d" % i
     elif hwsku == "DellEMC-Z9332f-M-O16C64":
         # 100G ports
-        s100G_ports = [x for x in range(0, 32, 2)] + [x for x in range(64, 96, 2)] + [x for x in range(160, 192, 2)] + [x for x in range(224, 256, 2)]
+        s100G_ports = [x for x in range(0, 96, 2)] + [x for x in range(128, 160, 2)]
 
         # 400G ports
-        s400G_ports = [x for x in range(32, 64, 8)] + [x for x in range(96, 160, 8)] + [x for x in range(192, 224, 8)]
+        s400G_ports = [x for x in range(96, 128, 8)] + [x for x in range(160, 256, 8)]
 
         # 10G ports
         s10G_ports = [x for x in range(256, 258)]


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The port layout for the DellEMC-Z9332f-M-O16C64 SKU recently changed, so port_utils needs to be updated as well.

#### How did you do it?
Re-arranged the ports to match the 100G/400G links.

#### How did you verify/test it?
Deployed a new minigraph and ran some pytests with the changes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
