### PR TITLE
[fanout] Improve SONiC fanout support

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -1,29 +1,55 @@
 - debug: msg="{{ device_info[inventory_hostname] }}"
 
 - name: prepare fanout switch admin login info
-  set_fact: ansible_user={{ fanout_sonic_user }} ansible_password={{ fanout_sonic_password }}
+  set_fact: ansible_ssh_user={{ fanout_sonic_user }} ansible_ssh_password={{ fanout_sonic_password }}
+
+- name: get fanout switch hwsku
+  set_fact: fanout_hwsku="{{ device_info[inventory_hostname]["HwSku"] }}"
+
+- name: check if fanout hwsku is supported
+  fail: msg="SONiC fanout switch with HwSku {{ device_info[inventory_hostname]['HwSku'] }} not supported"
+  when:
+    - fanout_hwsku != "Arista-7060CX-32S-C32"
+    - fanout_hwsku != "DellEMC-Z9332f-M-O16C64"
+    - fanout_hwsku != "DellEMC-Z9332f-O32"
 
 - name: find interface name mapping
-  port_alias: hwsku="{{ device_info[inventory_hostname]["HwSku"] }}"
-
-- name: build fanout vlan config
-  fail: msg="SONiC fanout switch with HwSku {{ device_info[inventory_hostname]['HwSku'] }} not supported"
-  when: device_info[inventory_hostname]["HwSku"] != "Arista-7060CX-32S-C32"
+  port_alias: hwsku="{{ fanout_hwsku }}"
 
 - name: build fanout startup config for Arista 7060 SONiC leaf fanout
   template: src=sonic_deploy_arista_7060.j2
             dest=/etc/sonic/vlan.json
-  when: device_info[inventory_hostname]["HwSku"] == "Arista-7060CX-32S-C32"
+  when: fanout_hwsku == "Arista-7060CX-32S-C32"
   become: yes
 
-- name: disable all copp rules
+- name: build fanout startup config for Dell 9332 SONiC leaf fanout
+  template: src=sonic_deploy.j2
+            dest=/etc/sonic/vlan.json
+  when: fanout_hwsku == "DellEMC-Z9332f-M-O16C64" or fanout_hwsku == "DellEMC-Z9332f-O32"
+
+- name: disable all copp rules for 201911 and earlier
   shell:
     cmd: docker exec swss bash -c 'echo [] > /etc/swss/config.d/00-copp.config.json'
   become: yes
 
-- name: generate config_db.json
-  shell: sonic-cfggen -H -j /etc/sonic/vlan.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+- name: disable all copp rules for 202012 and later
+  shell:
+    cmd: echo {} > /etc/sonic/copp_cfg.json
   become: yes
+
+- name: generate config_db.json
+  shell: sonic-cfggen -H -j /etc/sonic/vlan.json --print-data > /etc/sonic/config_db.json
+  become: yes
+
+- name: reload running config
+  shell: config reload -y
+  become: yes
+
+- name: detach all fp entries for brcm-based fanouts
+  shell:
+    cmd: bcmcmd "fp detach" && bcmcmd "fp init"
+  become: yes
+  when: fanout_hwsku == "DellEMC-Z9332f-M-O16C64" or fanout_hwsku == "DellEMC-Z9332f-O32" or fanout_hwsku == "Arista-7060CX-32S-C32"
 
 - name: stop and disable lldp service
   service: name=lldp state=stopped enabled=no

--- a/ansible/roles/fanout/tasks/main.yml
+++ b/ansible/roles/fanout/tasks/main.yml
@@ -34,5 +34,5 @@
   - import_tasks: rootfanout_connect.yml
     vars:
       deploy_leaf: true
-  when: sw_type == 'FanoutLeaf'
+  when: sw_type == 'FanoutLeaf' or sw_type == 'FanoutLeafSonic'
   tags: always

--- a/ansible/roles/fanout/templates/sonic_deploy.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy.j2
@@ -1,56 +1,329 @@
 {
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hwsku": "{{ device_info[inventory_hostname]["HwSku"] }}",
+            "hostname": "{{ inventory_hostname }}"
+        }
+    },
 
-"DEVICE_METADATA": {
-    "localhost": {
-        "hwsku": "{{ device_info[inventory_hostname]["HwSku"] }}",
-        "hostname": "{{ inventory_hostname }}"
+    "PORT": {
+    {% for alias in device_conn[inventory_hostname] %}
+        "{{ alias }}": {
+    {% if device_conn[inventory_hostname][alias]['speed'] == "100000" %}
+            "fec" : "rs",
+    {% endif %}
+            "speed" : "{{ device_conn[inventory_hostname][alias]['speed'] }}",
+            "admin_status": "up"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "VLAN": {
+    {% for vlanid in device_vlan_list[inventory_hostname] | unique %}
+        "Vlan{{ vlanid }}": {
+            "vlanid": "{{ vlanid }}"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    {% set ns = {'firstPrinted': False} %}
+    "VLAN_MEMBER": {
+    {% for alias in device_port_vlans[inventory_hostname] %}
+    {% if device_port_vlans[inventory_hostname][alias]['mode'] == 'Access' %}
+    {% if ns.firstPrinted %},{% endif %}
+        "Vlan{{ device_port_vlans[inventory_hostname][alias]['vlanids'] }}|{{ alias }}": {
+            "tagging_mode" : "untagged"
+        }
+    {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% elif device_port_vlans[inventory_hostname][alias]['mode'] == 'Trunk' %}
+    {% for vlanid in device_port_vlans[inventory_hostname][alias]['vlanlist'] %}
+    {% if ns.firstPrinted %},{% endif %}
+        "Vlan{{ vlanid }}|{{ alias }}": {
+            "tagging_mode" : "tagged"
+        }
+    {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% endfor %}
+    {% endif %}
+    {% endfor %}
+    },
+
+    "MGMT_INTERFACE": {
+        "eth0|{{ device_info[inventory_hostname]["ManagementIp"] }}": {
+            "gwaddr": "{{ device_info[inventory_hostname]["ManagementGw"] }}"
+        }
+    },
+
+    "FLEX_COUNTER_TABLE": {
+        "PFCWD": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "PORT": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "QUEUE": {
+            "FLEX_COUNTER_STATUS": "enable"
+        }
+    },
+
+    "QUEUE": {
+    {% for alias in device_conn[inventory_hostname] %}
+        "{{ alias }}|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "{{ alias }}|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "{{ alias }}|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "{{ alias }}|3": {
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
+            "scheduler": "[SCHEDULER|scheduler.1]"
+        },
+        "{{ alias }}|4": {
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
+            "scheduler": "[SCHEDULER|scheduler.1]"
+        },
+        "{{ alias }}|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "{{ alias }}|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "BUFFER_QUEUE": {
+    {% for alias in device_conn[inventory_hostname] %}
+        "{{ alias }}|0-2": {
+            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "{{ alias }}|3-4": {
+            "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "{{ alias }}|5-6": {
+            "profile": "[BUFFER_PROFILE|egress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "BUFFER_PG": {
+    {% for alias in device_conn[inventory_hostname] %}
+        "{{ alias }}|0": {
+            "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "{{ alias }}|3-4": {
+            "profile": "[BUFFER_PROFILE|pg_lossless_100000_300m_profile]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "CABLE_LENGTH": {
+        "AZURE": {
+    {% for alias in device_conn[inventory_hostname] %}
+        "{{ alias }}": "300m"{% if not loop.last %},{% endif %}
+    {% endfor %}
+        }
+    },
+
+    "VERSIONS": {
+        "DATABASE": {
+            "VERSION": "version_1_0_1"
+        }
+    },
+
+    "PFC_WD": {
+        "GLOBAL": {
+            "POLL_INTERVAL": "200"
+        }
+    },
+
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS": {
+            "red_max_threshold": "2097152",
+            "red_drop_probability": "5",
+            "wred_green_enable": "true",
+            "ecn": "ecn_all",
+            "green_min_threshold": "250000",
+            "red_min_threshold": "1048576",
+            "wred_yellow_enable": "true",
+            "yellow_min_threshold": "1048576",
+            "green_max_threshold": "2097152",
+            "green_drop_probability": "5",
+            "yellow_max_threshold": "2097152",
+            "yellow_drop_probability": "5",
+            "wred_red_enable": "true"
+        }
+    },
+
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "type": "egress",
+            "mode": "static",
+            "size": "15982720"
+        },
+        "egress_lossy_pool": {
+            "type": "egress",
+            "mode": "dynamic",
+            "size": "9243812"
+        },
+        "ingress_lossless_pool": {
+            "xoff": "4194112",
+            "type": "ingress",
+            "mode": "dynamic",
+            "size": "10875072"
+        }
+    },
+
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "static_th": "15982720",
+            "pool": "[BUFFER_POOL|egress_lossless_pool]",
+            "size": "1518"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "[BUFFER_POOL|egress_lossy_pool]",
+            "size": "1518"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+            "size": "0"
+        },
+        "pg_lossless_100000_300m_profile": {
+            "xon_offset": "2288",
+            "dynamic_th": "0",
+            "xon": "2288",
+            "xoff": "268736",
+            "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+            "size": "1248"
+        }
+    },
+
+    "FEATURE": {
+        "bgp": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "database": {
+            "state": "always_enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "always_enabled",
+            "high_mem_alert": "disabled"
+        },
+        "dhcp_relay": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "lldp": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "pmon": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "radv": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "snmp": {
+            "state": "enabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "swss": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "syncd": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "teamd": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "mgmt-framework": {
+            "state": "disabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "nat": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "sflow": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "telemetry": {
+            "state": "disabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        }
     }
-},
-
-"PORT": {
-{% for alias in device_conn[inventory_hostname] %}
-    "{{ alias }}": {
-{% if device_conn[inventory_hostname][alias]['speed'] == "100000" %}
-        "fec" : "rs",
-{% endif %}
-        "speed" : "{{ device_conn[inventory_hostname][alias]['speed'] }}"
-    }{% if not loop.last %},{% endif %}
-{% endfor %}
-},
-
-"VLAN": {
-{% for vlanid in device_vlan_list[inventory_hostname] | unique %}
-    "Vlan{{ vlanid }}": {
-        "vlanid": "{{ vlanid }}"
-    }{% if not loop.last %},{% endif %}
-{% endfor %}
-},
-
-{% set ns = {'firstPrinted': False} %}
-"VLAN_MEMBER": {
-{% for alias in device_port_vlans[inventory_hostname] %}
-{% if device_port_vlans[inventory_hostname][alias]['mode'] == 'Access' %}
-{% if ns.firstPrinted %},{% endif %}
-    "Vlan{{ device_port_vlans[inventory_hostname][alias]['vlanids'] }}|{{ alias }}": {
-        "tagging_mode" : "untagged"
-    }
-{% if ns.update({'firstPrinted': True}) %} {% endif %}
-{% elif device_port_vlans[inventory_hostname][alias]['mode'] == 'Trunk' %}
-  {% for vlanid in device_port_vlans[inventory_hostname][alias]['vlanlist'] %}
-{% if ns.firstPrinted %},{% endif %}
-    "Vlan{{ vlanid }}|{{ alias }}": {
-        "tagging_mode" : "tagged"
-    }
-{% if ns.update({'firstPrinted': True}) %} {% endif %}
-  {% endfor %}
-{% endif %}
-{% endfor %}
-},
-
-"MGMT_INTERFACE": {
-    "eth0|{{ device_info[inventory_hostname]["ManagementIp"] }}": {
-        "gwaddr": "{{ device_info[inventory_hostname]["ManagementGw"] }}"
-    }
-}
-
 }


### PR DESCRIPTION
- Include 9332 as a supported SONiC fanout
- Add steps for master/202012 images to come up properly
- Add FEATURE table to fanout template

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We need to add a few steps to be able to deploy master/202012 images to SONiC leaf fanouts. Additionally, some support needs to be added to deploy the 9332 as a SONiC fanout.

#### How did you do it?
- Added the FEATURE table to the config DB so that snmp, bgp, etc. won't be started on fanout devices
- Added the 9332 as a supported SKU
- Added a few steps that are required in newer images (like disabling COPP and detaching FP entries on brcm based platforms)

#### How did you verify/test it?
Deployed a fanout switch with the new script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
