### PR TITLE
[minigraph_facts] support PortChannel inside Vlan, improve module fail message

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -4,6 +4,7 @@ import os
 import sys
 import socket
 import struct
+import traceback
 import json
 import copy
 import ipaddr as ipaddress

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -222,7 +222,6 @@ def parse_dpg(dpg, hname):
             mgmt_intf = {'addr': ipaddr, 'alias': intfname, 'prefixlen': prefix_len, 'mask': ipmask, 'gwaddr': gwaddr}
 
         pcintfs = child.find(str(QName(ns, "PortChannelInterfaces")))
-        pc_intfs = []
         pcs = {}
         for pcintf in pcintfs.findall(str(QName(ns, "PortChannel"))):
             pcintfname = pcintf.find(str(QName(ns, "Name"))).text
@@ -233,12 +232,11 @@ def parse_dpg(dpg, hname):
                 ports[port_alias_to_name_map[member]] = {'name': port_alias_to_name_map[member], 'alias': member}
             pcs[pcintfname] = {'name': pcintfname, 'members': pcmbr_list}
             fallback_node = pcintf.find(str(QName(ns, "Fallback")))
-            if  fallback_node is not None:
+            if fallback_node is not None:
                 pcs[pcintfname]['fallback'] = fallback_node.text
-            ports.pop(pcintfname)
+            ports.pop(pcintfname, None)
 
         vlanintfs = child.find(str(QName(ns, "VlanInterfaces")))
-        vlan_intfs = []
         dhcp_servers = []
         vlans = {}
         for vintf in vlanintfs.findall(str(QName(ns, "VlanInterface"))):
@@ -253,6 +251,9 @@ def parse_dpg(dpg, hname):
                 vlandhcpservers = ""
             dhcp_servers = vlandhcpservers.split(";")
             for i, member in enumerate(vmbr_list):
+                # Skip PortChannel inside Vlan
+                if member in pcs:
+                    continue
                 vmbr_list[i] = port_alias_to_name_map[member]
                 ports[port_alias_to_name_map[member]] = {'name': port_alias_to_name_map[member], 'alias': member}
             vlan_attributes = {'name': vintfname, 'members': vmbr_list, 'vlanid': vlanid}
@@ -590,8 +591,9 @@ def main():
         results_clean = json.loads(json.dumps(results, cls=minigraph_encoder))
         module.exit_json(ansible_facts=results_clean)
     except Exception as e:
+        tb = traceback.format_exc()
         # all attempts to find a minigraph failed.
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=e.message + "\n" + tb)
 
 
 def print_parse_xml(hostname):


### PR DESCRIPTION
### Description of PR
If there is PortChannel inside Vlan, original code with throw and the module will fail with a short message like
```
E           RunAnsibleModuleFail: run module minigraph_facts failed, Ansible Results =>
E           {
E               "changed": false,
E               "failed": true,
E               "invocation": {
E                   "module_args": {
E                       "filename": null,
E                       "host": "str-msn2700-20"
E                   }
E               },
E               "msg": "PortChannel101"
E           }
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Test `vlan/test_vlan.py` with
1. DUT SKU: Mellanox-SN2700-D48C8
2. topo: t0-56-po2vlan

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
