### PR TITLE
[multi asic] Update the "show ip interface" cmd for multi asic

### DIFF
--- a/ansible/library/show_ip_interface.py
+++ b/ansible/library/show_ip_interface.py
@@ -40,7 +40,7 @@ class ShowIpInterfaceModule(object):
         self.ns = ""
         ns = self.m_args["namespace"]
         if ns is not None:
-            self.ns = " -n {} ".format(ns)
+            self.ns = " -n {} -d all  ".format(ns)
         
     def run(self):
         """

--- a/ansible/library/show_ip_interface.py
+++ b/ansible/library/show_ip_interface.py
@@ -40,7 +40,7 @@ class ShowIpInterfaceModule(object):
         self.ns = ""
         ns = self.m_args["namespace"]
         if ns is not None:
-            self.ns = "sudo ip netns exec {} ".format(ns)
+            self.ns = " -n {} ".format(ns)
         
     def run(self):
         """

--- a/ansible/library/show_ip_interface.py
+++ b/ansible/library/show_ip_interface.py
@@ -63,7 +63,7 @@ class ShowIpInterfaceModule(object):
         self.ip_int = {}
         try:
             rc, self.out, err = self.module.run_command(
-                    "{}show ip interfaces".format(self.ns),
+                    "show ip interfaces{}".format(self.ns),
                     executable='/bin/bash',
                     use_unsafe_shell=True
                 )


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR https://github.com/Azure/sonic-utilities/pull/1396 add support of `show ip interface` for multi asic.
This PR is update the `show_ip_interface.py ` ansible module to use the new cli syntax for multi asic

#### How did you do it?
Update `show_ip_interface.py` to use option `-n <namespace>` to get the ip interfaces from each namespace

-->
