### PR TITLE
[topo_facts]: Modify the 'type' argument used 

### DIFF
--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -68,29 +68,29 @@ class ParseTestbedTopoinfo():
         self.vm_topo_config = {}
         self.asic_topo_config = {}
 
-    def parse_topo_defintion(self, topo_definition, po_map, dut_num, type='VMs'):
+    def parse_topo_defintion(self, topo_definition, po_map, dut_num, neigh_type='VMs'):
         dut_asn = topo_definition['configuration_properties']['common']['dut_asn']
         vmconfig = dict()
-        for vm in topo_definition['topology'][type]:
+        for vm in topo_definition['topology'][neigh_type]:
             vmconfig[vm] = dict()
             vmconfig[vm]['intfs'] = [[] for i in range(dut_num)]
             if 'properties' in vmconfig[vm]:
                 vmconfig[vm]['properties']=topo_definition['configuration'][vm]['properties']
-            if type == 'VMs':
+            if neigh_type == 'VMs':
                 vmconfig[vm]['interface_indexes'] = [[] for i in range(dut_num)]
-                for vlan in topo_definition['topology'][type][vm]['vlans']:
+                for vlan in topo_definition['topology'][neigh_type][vm]['vlans']:
                     (dut_index, vlan_index, _) = parse_vm_vlan_port(vlan)
                     vmconfig[vm]['interface_indexes'][dut_index].append(vlan_index)
-            if type == 'NEIGH_ASIC':
+            if neigh_type == 'NEIGH_ASIC':
                 vmconfig[vm]['asic_intfs'] = [[] for i in range(dut_num)]
                 dut_index = 0
-                for asic_intf in topo_definition['topology'][type][vm]['asic_intfs']:
+                for asic_intf in topo_definition['topology'][neigh_type][vm]['asic_intfs']:
                     vmconfig[vm]['asic_intfs'][dut_index].append(asic_intf)
         
             # physical interface
             for intf in topo_definition['configuration'][vm]['interfaces']:
-                if (type == 'VMs' and 'Ethernet' in intf) or \
-                   (type == 'NEIGH_ASIC' and re.match("Eth(\d+)-", intf)):
+                if (neigh_type == 'VMs' and 'Ethernet' in intf) or \
+                   (neigh_type == 'NEIGH_ASIC' and re.match("Eth(\d+)-", intf)):
                     dut_index = 0
                     if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
                         dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
@@ -109,8 +109,8 @@ class ParseTestbedTopoinfo():
         
             for intf in topo_definition['configuration'][vm]['interfaces']:
                 dut_index = 0
-                if (type == 'VMs' and 'Ethernet' in intf) or \
-                   (type == 'NEIGH_ASIC' and re.match("Eth(\d+)-", intf)):
+                if (neigh_type == 'VMs' and 'Ethernet' in intf) or \
+                   (neigh_type == 'NEIGH_ASIC' and re.match("Eth(\d+)-", intf)):
                     if 'dut_index' in topo_definition['configuration'][vm]['interfaces'][intf]:
                         dut_index = topo_definition['configuration'][vm]['interfaces'][intf]['dut_index']
                 elif 'Port-Channel' in intf:


### PR DESCRIPTION
 [topo_facts]: Modify the 'type' argument used to 'neigh_type' to
 avoid overriding python 'type' function.
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
https://github.com/Azure/sonic-mgmt/pull/3024 introduced a new function with an argument called 'type'.
This will override existing python 'type' function. To avoid this, modify the argument name to 'neigh_type'
which can be 'VMs' or 'NEIGH_ASIC' based on the topo file being parsed. 

#### How did you do it?
Modify the argument name to 'neigh_type'.

#### How did you verify/test it?
Bring up single-asic and multi-asic VS testbed with this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
