### PR TITLE
[pfc_asym] Set proper router MAC in pfc_asym saitest and fix storm stop template

### DIFF
--- a/tests/common/templates/pfc_storm_stop_eos.j2
+++ b/tests/common/templates/pfc_storm_stop_eos.j2
@@ -1,5 +1,9 @@
 bash
 cd /mnt/flash
+{% if (pfc_asym  is defined) and (pfc_asym == True) %}
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo pkill -f "sudo python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
+{% else %}
 {% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f "sudo python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
+{% endif %}
 exit
 exit

--- a/tests/saitests/pfc_asym.py
+++ b/tests/saitests/pfc_asym.py
@@ -70,6 +70,10 @@ class PfcAsymBaseTest(ThriftInterfaceDataPlane):
         self.setUpArpResponder(self.server_ports)
         self.shell(["supervisorctl", "start", "arp_responder"])
 
+        attr_value = sai_thrift_attribute_value_t(mac=self.router_mac)
+        attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
+        self.client.sai_thrift_set_switch_attribute(attr)
+
     def tearDown(self):
         ThriftInterfaceDataPlane.tearDown(self)
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

### Description of PR

Summary:

Configure proper DUT router MAC pfc_asym.py saitest and fix storm stop template for Arista fanout.  

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
* During SAI thrift switch initialization the default router MAC is configured (https://github.com/Azure/sonic-mgmt/blob/master/tests/saitests/switch.py#L79) instead of the one passed to the test. Due to this the traffic sent from PTF isn't forwarded by the DUT. 
* The PFC storm stop template for Arista fanout wasn't updated to support pfc_asym which caused the pfc_gen.py script not stopped after each test case execution.

#### How did you do it?

#### How did you verify/test it?
Ran pfc_asym and pfc_wd tests on BFN platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
