### PR TITLE
Adapting fib test for T2 topology

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -292,8 +292,9 @@ class FibTest(BaseTest):
             exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
             actual_src_mac = Ether(rcvd_pkt).src
             if exp_src_mac != actual_src_mac:
-                logging.warn("Rcvd pkt on {} which is one of the expected ports, but the src mac doesn't match, expected {}, got {}".format(dst_port_list[rcvd_port],exp_src_mac, actual_src_mac))
-                return (0, None)
+                raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                                "but the src mac doesn't match, expected {}, got {}".
+                                format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
@@ -366,8 +367,9 @@ class FibTest(BaseTest):
             exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
             actual_src_mac = Ether(rcvd_pkt).src
             if actual_src_mac != exp_src_mac:
-                logging.warning("Rcvd packet on {} which is one of the expected ports, but src mac doesn't match. Expected {}, got {}".format(dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
-                return (0, None)
+                raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                                "but the src mac doesn't match, expected {}, got {}".
+                                format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -97,11 +97,12 @@ class FibTest(BaseTest):
          - ipv4/ipv6: enable ipv4/ipv6 tests
 
         Other test parameters:
-         - ttl:             ttl of test pkts. Auto decrease 1 for expected pkts.
-         - ip_options       enable ip option header in ipv4 pkts. Default: False(disable)
-         - src_vid          vlan tag id of src pkts. Default: None(untag)
-         - dst_vid          vlan tag id of dst pkts. Default: None(untag)
-         - ignore_ttl:      mask the ttl field in the expected packet
+         - ttl:                   ttl of test pkts. Auto decrease 1 for expected pkts.
+         - ip_options             enable ip option header in ipv4 pkts. Default: False(disable)
+         - src_vid                vlan tag id of src pkts. Default: None(untag)
+         - dst_vid                vlan tag id of dst pkts. Default: None(untag)
+         - ignore_ttl:            mask the ttl field in the expected packet
+         - single_fib_for_duts:   have a single fib file for all DUTs in multi-dut case. Default: False
         '''
         self.dataplane = ptf.dataplane_instance
 
@@ -134,6 +135,7 @@ class FibTest(BaseTest):
             self.src_ports = [int(port) for port in self.ptf_test_port_map.keys()]
         
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
+        self.single_fib = self.test_params.get('single_fib_for_duts', False)
 
     def check_ip_ranges(self, ipv4=True):
         for dut_index, fib in enumerate(self.fibs):
@@ -157,7 +159,10 @@ class FibTest(BaseTest):
     def get_src_and_exp_ports(self, dst_ip):
         while True:
             src_port = int(random.choice(self.src_ports))
-            active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
+            if self.single_fib:
+                active_dut_index = 0
+            else:
+                active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
             next_hop = self.fibs[active_dut_index][dst_ip]
             exp_port_list = next_hop.get_next_hop_list()
             if src_port in exp_port_list:

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -237,7 +237,6 @@ class FibTest(BaseTest):
         src_mac = self.dataplane.get_mac(0, src_port)
 
         router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
-        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
 
         pkt = simple_tcp_packet(
                             pktlen=self.pktlen,
@@ -253,7 +252,6 @@ class FibTest(BaseTest):
                             vlan_vid=self.src_vid or 0)
         exp_pkt = simple_tcp_packet(
                             self.pktlen,
-                            eth_src=exp_router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
                             tcp_sport=sport,
@@ -264,6 +262,7 @@ class FibTest(BaseTest):
                             vlan_vid=self.dst_vid or 0)
         masked_exp_pkt = Mask(exp_pkt)
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
@@ -281,7 +280,7 @@ class FibTest(BaseTest):
                     dport,
                     src_port))
         logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'\
-            .format(exp_router_mac,
+            .format('any',
                     'any',
                     ip_src,
                     ip_dst,
@@ -289,7 +288,13 @@ class FibTest(BaseTest):
                     dport))
 
         if self.pkt_action == self.ACTION_FWD:
-            return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+            rcvd_port, rcvd_pkt = verify_packet_any_port(self,masked_exp_pkt,dst_port_list)
+            exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
+            actual_src_mac = Ether(rcvd_pkt).src
+            if exp_src_mac != actual_src_mac:
+                logging.warn("Rcvd pkt on {} which is one of the expected ports, but the src mac doesn't match, expected {}, got {}".format(dst_port_list[rcvd_port],exp_src_mac, actual_src_mac))
+                return (0, None)
+            return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
     #---------------------------------------------------------------------
@@ -309,7 +314,6 @@ class FibTest(BaseTest):
         src_mac = self.dataplane.get_mac(0, src_port)
 
         router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
-        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
 
         pkt = simple_tcpv6_packet(
                                 pktlen=self.pktlen,
@@ -324,7 +328,6 @@ class FibTest(BaseTest):
                                 vlan_vid=self.src_vid or 0)
         exp_pkt = simple_tcpv6_packet(
                                 pktlen=self.pktlen,
-                                eth_src=exp_router_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,
                                 tcp_sport=sport,
@@ -334,6 +337,7 @@ class FibTest(BaseTest):
                                 vlan_vid=self.dst_vid or 0)
         masked_exp_pkt = Mask(exp_pkt)
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"dst")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether,"src")
 
         # mask the chksum also if masking the ttl
         if self.ignore_ttl:
@@ -350,7 +354,7 @@ class FibTest(BaseTest):
                     sport,
                     dport))
         logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
-            .format(exp_router_mac,
+            .format('any',
                     'any',
                     ip_src,
                     ip_dst,
@@ -358,7 +362,13 @@ class FibTest(BaseTest):
                     dport))
 
         if self.pkt_action == self.ACTION_FWD:
-            return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+            rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+            exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
+            actual_src_mac = Ether(rcvd_pkt).src
+            if actual_src_mac != exp_src_mac:
+                logging.warning("Rcvd packet on {} which is one of the expected ports, but src mac doesn't match. Expected {}, got {}".format(dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+                return (0, None)
+            return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
 

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -80,11 +80,15 @@ class HashTest(BaseTest):
         self.balancing_test_times = self.test_params.get('balancing_test_times', self.BALANCING_TEST_TIMES)
 
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
+        self.single_fib = self.test_params.get('single_fib_for_duts', False)
 
     def get_src_and_exp_ports(self, dst_ip):
         while True:
             src_port = int(random.choice(self.src_ports))
-            active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
+            if self.single_fib:
+                active_dut_index = 0
+            else:
+                active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
             next_hop = self.fibs[active_dut_index][dst_ip]
             exp_port_list = next_hop.get_next_hop_list()
             if src_port in exp_port_list:

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -245,9 +245,9 @@ class HashTest(BaseTest):
         exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
         actual_src_mac = Ether(rcvd_pkt).src
         if exp_src_mac != actual_src_mac:
-            logging.warn(
-                "Rcvd pkt on {} which is one of the expected ports, but the src mac doesn't match, expected {}, got {}".format(
-                    dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
             return (0, None)
         return (rcvd_port, rcvd_pkt)
 
@@ -325,9 +325,9 @@ class HashTest(BaseTest):
         exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
         actual_src_mac = Ether(rcvd_pkt).src
         if exp_src_mac != actual_src_mac:
-            logging.warn(
-                "Rcvd pkt on {} which is one of the expected ports, but the src mac doesn't match, expected {}, got {}".format(
-                    dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
             return (0, None)
         return (rcvd_port, rcvd_pkt)
 

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -190,7 +190,6 @@ class HashTest(BaseTest):
             if hash_key == 'src-mac' else base_mac
 
         router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
-        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
 
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
@@ -207,7 +206,6 @@ class HashTest(BaseTest):
                             tcp_dport=dport,
                             ip_ttl=64)
         exp_pkt = simple_tcp_packet(
-                            eth_src=exp_router_mac,
                             ip_src=ip_src,
                             ip_dst=ip_dst,
                             tcp_sport=sport,
@@ -224,7 +222,7 @@ class HashTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
-
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
         send_packet(self, src_port, pkt)
         logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={} on port {})'\
@@ -236,14 +234,22 @@ class HashTest(BaseTest):
                     dport,
                     src_port))
         logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'\
-            .format(exp_router_mac,
+            .format('any',
                     'any',
                     ip_src,
                     ip_dst,
                     sport,
                     dport))
 
-        return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+        rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+        exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
+        actual_src_mac = Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            logging.warn(
+                "Rcvd pkt on {} which is one of the expected ports, but the src mac doesn't match, expected {}, got {}".format(
+                    dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+            return (0, None)
+        return (rcvd_port, rcvd_pkt)
 
     def check_ipv6_route(self, hash_key, src_port, dst_port_list):
         '''
@@ -263,7 +269,6 @@ class HashTest(BaseTest):
         src_mac = (base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else base_mac
         router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
-        exp_router_mac = self.router_macs[self.ptf_test_port_map[str(src_port)]['target_dut']]
 
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto(ipv6=True) if hash_key == "ip-proto" else None
@@ -280,7 +285,6 @@ class HashTest(BaseTest):
                                 tcp_dport=dport,
                                 ipv6_hlim=64)
         exp_pkt = simple_tcpv6_packet(
-                                eth_src=exp_router_mac,
                                 ipv6_dst=ip_dst,
                                 ipv6_src=ip_src,
                                 tcp_sport=sport,
@@ -298,6 +302,7 @@ class HashTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
             masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
         send_packet(self, src_port, pkt)
         logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={} on port {})'\
@@ -309,14 +314,22 @@ class HashTest(BaseTest):
                     dport,
                     src_port))
         logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
-            .format(exp_router_mac,
+            .format('any',
                     'any',
                     ip_src,
                     ip_dst,
                     sport,
                     dport))
 
-        return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+        rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+        exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
+        actual_src_mac = Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            logging.warn(
+                "Rcvd pkt on {} which is one of the expected ports, but the src mac doesn't match, expected {}, got {}".format(
+                    dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+            return (0, None)
+        return (rcvd_port, rcvd_pkt)
 
     def check_within_expected_range(self, actual, expected):
         '''

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -248,7 +248,6 @@ class HashTest(BaseTest):
             raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                             "but the src mac doesn't match, expected {}, got {}".
                             format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
-            return (0, None)
         return (rcvd_port, rcvd_pkt)
 
     def check_ipv6_route(self, hash_key, src_port, dst_port_list):
@@ -328,7 +327,6 @@ class HashTest(BaseTest):
             raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                             "but the src mac doesn't match, expected {}, got {}".
                             format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
-            return (0, None)
         return (rcvd_port, rcvd_pkt)
 
     def check_within_expected_range(self, actual, expected):

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -78,6 +78,12 @@ def get_t2_fib_info(duthosts, ptfhost, all_duts_config_facts, all_duts_mg_facts)
 
     for prefix, prefix_info in all_prefix_dict.items():
         for dut_index, dut_prefix_route in prefix_info.items():
+            #Ignore directly connected networks
+            if prefix.startswith('10.0.0') or prefix.startswith('100.1.0'):
+                continue
+            # Ignore directly connected IPv6 networks
+            if prefix.startswith('2064:100') or prefix.startswith("fc00::"):
+                continue
             dutname = duthosts.frontend_nodes[dut_index].hostname
             dut_cfg_facts = all_duts_config_facts[dutname]
             dut_mg_facts = all_duts_mg_facts[dutname]

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -18,7 +18,7 @@ from tests.common.dualtor.mux_simulator_control import mux_server_url
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any', 't0-52')
+    pytest.mark.topology('any')
 ]
 
 # Usually src-mac, dst-mac, vlan-id are optional hash keys. Not all the platform supports these optional hash keys. Not enable these three by default.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Need to make the FIB tests work against a T2 chassis. 

#### How did you do it?
Even though a T2 chassis has multiple DUTs (linecards), we have a single PTF instance that has all the injected ptf ports that connect to all the DUTs frontpanel ports. For the fib test, the src port and the expected rcv ports are from this list of all the
injected ptf ports.

In a T2 chassis, we have multiple linecards, and routes learnt from a linecard are distributed over the fabric to the other linecards. But, the fib on the other linecards points to the inband recyle port Ethernet-IB0. Therefore, when generating the fib_info_file
for the linecards, if the route is learned over the inband recyle port, we have to figure out which other linecard this route was learnt on, and use its frontpanel ports as the outgoing ports for this route.

Since a route learnt across the fabric will have an outgoing port on another linecard, and this route could be learnt from multiple linecards (as is the case with routes announced from T1 VMs in a T2 topology), the logic to validate the src_mac of the received packet in fib_test/hash_test has been modified to not check for the src_mac in the expected packet for the verify_packet_any_port call. The src mac is compared to the target_mac defined in ptf_test_port_map.json for the dut that has the rcvd_port. If it doesn't match then we fail.

#### How did you verify/test it?
Tested against a T2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
