### PR TITLE
Dual ToR IO test enhancements

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -62,14 +62,20 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay):
             if duplication_length > longest_duplication:
                 longest_duplication = duplication_length
 
+        disruption_before_traffic = result['disruption_before_traffic']
+        disruption_after_traffic = result['disruption_after_traffic']
+
         server_summary = {
             'received_packets': total_received_packets,
             'received_packet_diff': received_packet_diff,
             'total_disruptions': total_disruptions,
             'longest_disruption': longest_disruption,
             'total_duplications': total_duplications,
-            'longest_duplication': longest_duplication
+            'longest_duplication': longest_duplication,
+            'disruption_before_traffic': disruption_before_traffic,
+            'disruption_after_traffic': disruption_after_traffic
         }
+
         logger.info('Server {} summary:\n{}'.format(server_ip, json.dumps(server_summary, indent=4, sort_keys=True)))
         server_summaries[server_ip] = server_summary
 
@@ -97,6 +103,16 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay):
             failures.append("Traffic on server {} was duplicated for {}s. "
                             "Maximum allowed duplication: {}s"
                             .format(server_ip, longest_duplication, delay))
+
+        if bool(disruption_before_traffic):
+            failures.append("Traffic on server {} was disrupted prior to test start, "
+                            "missing {} packets from the start of the packet flow"
+                            .format(server_ip, disruption_before_traffic))
+
+        if bool(disruption_after_traffic):
+            failures.append("Traffic on server {} was disrupted after test end, "
+                            "missing {} packets from the end of the packet flow"
+                            .format(server_ip, disruption_after_traffic))
 
     pytest_assert(len(failures) == 0, '\n' + '\n'.join(failures))
 

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -69,11 +69,10 @@ def generate_test_report(tor_IO):
             "duplicated_packets_count": tor_IO.get_duplicated_packets_count(),
             "disruptions": {
                 "total_disruptions": tor_IO.get_total_disruptions(),
-                "total_disrupted_packets": tor_IO.get_total_disrupted_packets(),
-                "total_disruption_time": tor_IO.get_total_disrupt_time(),
                 "longest_disruption": tor_IO.get_longest_disruption(),
                 "total_lost_packets": tor_IO.get_total_lost_packets()
-            }
+            },
+            "per_server_report": tor_IO.get_per_server_report()
     }
     logger.info("Data plane traffic test results: \n{}".format(json.dumps(data_plane_test_report, indent=4)))
     return data_plane_test_report
@@ -163,7 +162,9 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
                 default - `None`: No action will be performed and traffic will run
                 between server to T1 router.
             verify (boolean): If set to True, test will automatically verify packet
-                drops/duplication based on given qualification critera
+                drops/duplication based on given qualification criteria
+        Returns:
+            data_plane_test_report (dict): traffic test statistics (sent/rcvd/dropped)
         """
         duthosts_list.append(activehost)
 
@@ -219,6 +220,8 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
                 between server to T1 router.
             verify (boolean): If set to True, test will automatically verify packet
                 drops/duplication based on given qualification critera
+        Returns:
+            data_plane_test_report (dict): traffic test statistics (sent/rcvd/dropped)
         """
         duthosts_list.append(activehost)
 

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -82,7 +82,12 @@ class DualTorIO:
         self.time_to_listen = 180.0
         self.sniff_time_incr = 0
         # Inter-packet send-interval (minimum interval 3.5ms)
-        self.send_interval = send_interval if send_interval and send_interval > 0.0035 else 0.0035
+        if send_interval < 0.0035:
+            logger.warn("Minimum packet send-interval is .0035s. \
+                Ignoring user-provided interval {}".format(send_interval))
+            self.send_interval = 0.0035
+        else:
+            self.send_interval = send_interval
         # How many packets to be sent by sender thread
         self.packets_to_send = min(int(self.time_to_listen /
             (self.send_interval + 0.0015)), 45000)

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -239,10 +239,6 @@ class DualTorIO:
         @summary: Generate (not send) the packets to be sent from server to T1
         """
         eth_src = self.ptfadapter.dataplane.get_mac(0, 0)
-        if self.tor_vlan_port:
-            from_server_src_port = self.tor_vlan_port
-        else:
-            from_server_src_port = random.choice(self.vlan_ports.values())
         tcp_dport = TCP_DST_PORT
 
         for server_src_addr in self.server_ip_list:
@@ -250,19 +246,16 @@ class DualTorIO:
             self.servers_with_disruptions.update({server_src_addr: list()})
 
         if self.tor_vlan_port:
-            from_server_src_port = self.tor_vlan_port
-            server_port_ip_list = cycle([self.tor_vlan_port, random.choice(self.vlan_host_map[from_server_src_port])])
+            server_port_ip_list = cycle([self.tor_vlan_port, random.choice(self.vlan_host_map[self.tor_vlan_port])])
         else:
             server_ip_list = cycle(self.server_ip_list)
-            from_server_src_port = None
             server_port_ip_list = list()
             for tor_vlan_port in self.vlan_host_map.keys():
                 from_server_src_addr = next(server_ip_list)
                 # find out the selected server is connected to which tor port
                 if from_server_src_addr in self.vlan_host_map[tor_vlan_port]:
-                    from_server_src_port = tor_vlan_port
                     # add tuple of (tor_vlan_port, server_to_that_vlan) to server_ip_list
-                    server_port_ip_list.append((from_server_src_port, from_server_src_addr))
+                    server_port_ip_list.append((tor_vlan_port, from_server_src_addr))
             server_port_ip_list = cycle(server_port_ip_list)
 
         logger.info("-"*20 + "Server to T1 packet" + "-"*20)

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -243,9 +243,6 @@ class DualTorIO:
             from_server_src_port = self.tor_vlan_port
         else:
             from_server_src_port = random.choice(self.vlan_ports.values())
-        # self.from_server_src_addr = random.choice(
-        #     self.vlan_host_map[from_server_src_port])
-        # self.from_server_dst_addr = self.random_host_ip()
         tcp_dport = TCP_DST_PORT
 
         for server_src_addr in self.server_ip_list:
@@ -269,10 +266,7 @@ class DualTorIO:
             server_port_ip_list = cycle(server_port_ip_list)
 
         logger.info("-"*20 + "Server to T1 packet" + "-"*20)
-        # logger.info("Source port: {}".format(from_server_src_port))
         logger.info("Ethernet address: dst: {} src: {}".format(self.vlan_mac, eth_src))
-        # logger.info("IP address: dst: {} src: {}".format(self.from_server_dst_addr,
-        #     self.from_server_src_addr))
         logger.info("TCP port: dst: {} src: 1234".format(tcp_dport))
         logger.info("Active ToR MAC: {}, Standby ToR MAC: {}".format(self.active_mac,
             self.standby_mac))

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 class DualTorIO:
     def __init__(self, activehost, standbyhost, ptfhost, ptfadapter, tbinfo,
-                io_ready, tor_vlan_port=None, send_interval=None):
+                io_ready, tor_vlan_port=None, send_interval=0.0035):
         self.tor_port = None
         self.tor_vlan_port = tor_vlan_port
         self.duthost = activehost
@@ -53,7 +53,12 @@ class DualTorIO:
         self.time_to_listen = 180.0
         self.sniff_time_incr = 60
         # Inter-packet send-interval (minimum interval 3.5ms)
-        self.send_interval = send_interval if send_interval and send_interval > 0.0035 else 0.0035
+        if send_interval < 0.0035:
+            logger.warn("Minimum packet send-interval is .0035s. \
+                Ignoring user-provided interval {}".format(send_interval))
+            self.send_interval = 0.0035
+        else:
+            self.send_interval = send_interval
         # How many packets to be sent by sender thread
         self.packets_to_send = min(int(self.time_to_listen /
             (self.send_interval + 0.0015)), 45000)

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -204,6 +204,7 @@ def force_active_tor():
     """
     forced_intfs = []
     def force_active_tor_fn(dut, intf):
+        logger.info('Setting {} as active for intfs {}'.format(dut, intf))
         if type(intf) == str:
             cmds = ["config muxcable mode active {}; true".format(intf)]
             forced_intfs.append((dut, intf))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Dualtor I/O tests organized into per-link packet streams, and measure per-server traffic disruptions.
Fixes # (issue) https://github.com/Azure/sonic-mgmt/issues/3106

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Change the data plane I/O tests to send traffic from/to each server (28 servers as of now).
These changes are made in order to accurately measure packet loss and disruptions for individual links.
Changes:
1. Send downstream traffic to each server in round-robin fashion.
2. Send upstream traffic from each server in round-robin fashion.
3. Detect packet loss and collect disruptions data per-server (for every link).
4. Create a report per server.

#### What is the motivation for this PR?
Enhancements of dualtor data plane utils.

#### How did you do it?

#### How did you verify/test it?
Tested on physical testbeds. Scenarios tested: Upstream/Downstream traffic with disruptive/non-disruptive actions.
Examples of non-disruptive test:
```
{
    "longest_disruption": 0,
    "longest_duplication": 0,
    "received_packet_diff": 0,
    "received_packets": 1500,
    "total_disruptions": 0,
    "total_duplications": 0
}
```

Traffic with disruptive action (CLI switchover):
```
{
    "longest_disruption": 0,
    "longest_duplication": 0.7100210189819336,
    "received_packet_diff": 9,
    "received_packets": 1509,
    "total_disruptions": 0,
    "total_duplications": 1
}
```
or
```
{
    "longest_disruption": 6.295104026794434,
    "longest_duplication": 0,
    "received_packet_diff": -69,
    "received_packets": 1431,
    "total_disruptions": 1,
    "total_duplications": 0
}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
