### PR TITLE
[dualtor]: Add tor reboot tests

### DIFF
--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -5,7 +5,8 @@ Shutdown the LinkProber on a ToR
 Blackhole all traffic on a ToR
 Reboot a ToR
 """
-from tests.common.reboot import *
+from tests.common.reboot import reboot, SONIC_SSH_PORT, SONIC_SSH_REGEX, \
+                                REBOOT_TYPE_COLD
 import ipaddress
 import pytest
 import logging
@@ -17,13 +18,14 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def shutdown_tor_bgp():
     """
-    Shutdown all BGP sessions 
+    Shutdown all BGP sessions
     """
     torhost = []
+
     def shutdown_tor_bgp(duthost, shutdown_all=True):
         torhost.append(duthost)
         bgp_neighbors = duthost.get_bgp_neighbors()
-        up_bgp_neighbors = [ k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established" ]
+        up_bgp_neighbors = [k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established"]
         if shutdown_all and up_bgp_neighbors:
             logger.info("Shutdown BGP sessions on {}".format(duthost.hostname))
             duthost.shell("config bgp shutdown all")
@@ -42,6 +44,7 @@ def shutdown_tor_heartbeat():
     Shutdown the LinkProber
     """
     torhost = []
+
     def shutdown_tor_heartbeat(duthost):
         # TODO - verify support after LinkProber submodule is ready
         torhost.append(duthost)
@@ -62,19 +65,22 @@ def tor_blackhole_traffic():
     Install a blackhole route
     """
     torhost = []
+
     def tor_blackhole_traffic(duthost, kernel=False, asic=False):
         torhost.append(duthost)
         if asic:
             duthost.shell("ip route del 0.0.0.0/0")
         elif kernel:
-            pass # TODO
+            pass  # TODO
 
     yield tor_blackhole_traffic
 
     for duthost in torhost:
         lo_ipv4 = None
         lo_ipv6 = None
-        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        config_facts = duthost.config_facts(
+                            host=duthost.hostname, source="running"
+                       )['ansible_facts']
         los = config_facts.get("LOOPBACK_INTERFACE", {})
         logger.info("Loopback IPs: {}".format(los))
         for k, v in los.items():
@@ -86,33 +92,49 @@ def tor_blackhole_traffic():
                     elif ip.version == 6:
                         lo_ipv6 = ip
 
-        duthost.shell("ip -4 route add 0.0.0.0/0 nexthop via {}".format(lo_ipv4.ip))
+        duthost.shell("ip -4 route add 0.0.0.0/0 nexthop via {}"
+                      .format(lo_ipv4.ip))
 
 
 @pytest.fixture
-def reboot_tor(localhost):
+def reboot_tor(localhost, wait_for_device_reachable):
     """
     Reboot TOR
     """
     torhost = []
+
     def reboot_tor(duthost, reboot_type=REBOOT_TYPE_COLD):
         torhost.append(duthost)
-        logger.info("Issuing reboot of type {} on {}".format(reboot_type, duthost.hostname))
+        logger.info("Issuing reboot of type {} on {}"
+                    .format(reboot_type, duthost.hostname))
         reboot(duthost, localhost, reboot_type=reboot_type, wait_for_ssh=False)
 
     yield reboot_tor
     # TODO Add IO check capability
 
     for duthost in torhost:
+        wait_for_device_reachable(duthost)
+
+@pytest.fixture
+def wait_for_device_reachable(localhost):
+    """
+    Returns a function that waits for a device to become reachable over SSH
+    """
+
+    def wait_for_device_reachable(duthost, timeout=300):
         dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
-        logger.info("Waiting for ssh to startup on {}".format((duthost.hostname)))
+        logger.info("Waiting for ssh to startup on {}"
+                    .format((duthost.hostname)))
         res = localhost.wait_for(host=dut_ip,
-                                port=SONIC_SSH_PORT,
-                                state='started',
-                                search_regex=SONIC_SSH_REGEX,
-                                delay=10,
-                                timeout=300,
-                                module_ignore_errors=True)
+                                 port=SONIC_SSH_PORT,
+                                 state='started',
+                                 search_regex=SONIC_SSH_REGEX,
+                                 delay=10,
+                                 timeout=timeout,
+                                 module_ignore_errors=True)
         if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
-            raise Exception("DUT {} did not startup after reboot".format((duthost.hostname)))
+            raise Exception("DUT {} did not startup after reboot"
+                            .format((duthost.hostname)))
         logger.info("SSH started on {}".format((duthost.hostname)))
+
+    return wait_for_device_reachable

--- a/tests/dualtor/test_tor_failure.py
+++ b/tests/dualtor/test_tor_failure.py
@@ -1,0 +1,93 @@
+
+import pytest 
+
+from tests.common.dualtor.control_plane_utils import verify_tor_states
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor, toggle_all_simulator_ports_to_lower_tor         # lgtm[py/unused-import] 
+from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable                                 # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+
+def test_active_tor_reboot_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    wait_for_device_reachable
+):
+    """
+    Send upstream traffic and reboot the active ToR. Confirm switchover
+    occurred and disruption lasts < 1 second
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=lambda: reboot_tor(upper_tor_host)
+    )
+    wait_for_device_reachable(upper_tor_host)
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
+
+
+def test_active_tor_reboot_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    wait_for_device_reachable
+):
+    """
+    Send downstream traffic to the standby ToR and reboot the active ToR.
+    Confirm switchover occurred and disruption lasts < 1 second
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=1,
+        action=lambda: reboot_tor(upper_tor_host)
+    )
+    wait_for_device_reachable(upper_tor_host)
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
+
+
+def test_standby_tor_reboot_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    wait_for_device_reachable
+):
+    """
+    Send upstream traffic and reboot the standby ToR. Confirm no switchover
+    occurred and no disruption
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True,
+        action=lambda: reboot_tor(lower_tor_host)
+    )
+    wait_for_device_reachable(lower_tor_host)
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
+
+
+def test_standby_tor_reboot_downstream_active(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    wait_for_device_reachable
+):
+    """
+    Send downstream traffic to the active ToR and reboot the standby ToR.
+    Confirm no switchover occurred and no disruption
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True,
+        action=lambda: reboot_tor(lower_tor_host)
+    )
+    wait_for_device_reachable(lower_tor_host)
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Closes #2773 
Closes #2774 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Test cases:
* Upstream traffic:
    * Reboot active ToR
    * Reboot standby ToR
* Downstream to active:
    * Reboot standby ToR
* Downstream to standby:
    * Reboot active ToR

#### How did you verify/test it?
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================== test session starts ====================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 4 items

dualtor/test_tor_failure.py::test_active_tor_reboot_upstream
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------
01:36:11 ERROR dual_tor_io.py:start_io_test:176: The longest disruption lasted 0.045 seconds.3 packet(s) lost.
01:36:11 ERROR dual_tor_io.py:start_io_test:179: Total disruptions count is 50. All disruptions lasted 0.517 seconds. Total 59 packet(s) lost
FAILED                                                                                                                                                                               [ 25%]
dualtor/test_tor_failure.py::test_active_tor_reboot_downstream_standby
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------
01:44:38 ERROR dual_tor_io.py:start_io_test:176: The longest disruption lasted 89.771 seconds.23955 packet(s) lost.
01:44:38 ERROR dual_tor_io.py:start_io_test:179: Total disruptions count is 925. All disruptions lasted 95.717 seconds. Total 25520 packet(s) lost
FAILED                                                                                                                                                                               [ 50%]
dualtor/test_tor_failure.py::test_standby_tor_reboot_upstream PASSED                                                                                                                 [ 75%]
dualtor/test_tor_failure.py::test_standby_tor_reboot_downstream_active
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------
02:05:31 ERROR dual_tor_io.py:start_io_test:176: The longest disruption lasted 0.090 seconds.14 packet(s) lost.
02:05:31 ERROR dual_tor_io.py:start_io_test:179: Total disruptions count is 133. All disruptions lasted 2.759 seconds. Total 551 packet(s) lost
FAILED                                                                                                                                                                               [100%]
```
The failures are currently expected, since the disruption measurement is not per-server but rather for the entire ToR.

The last test case (standby ToR reboot while sending downstream traffic to the active ToR) fails because of a known bug in the reboot script: https://github.com/Azure/sonic-utilities/pull/1500. When the fix is applied the test passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
dual ToR
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
