### PR TITLE
[test_ipinip] Strip ip prefix

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -29,7 +29,7 @@ def build_encapsulated_packet(rand_selected_interface, ptfadapter, rand_selected
     """Build the encapsulated packet sent from T1 to ToR."""
     tor = rand_selected_dut
     _, server_ips = rand_selected_interface
-    server_ipv4 = server_ips["server_ipv4"]
+    server_ipv4 = server_ips["server_ipv4"].split("/")[0]
     config_facts = tor.get_running_config_facts()
     try:
         peer_ipv4_address = [_["address_ipv4"] for _ in config_facts["PEER_SWITCH"].values()][0]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Strip the ip prefix in the ip address passed to `simple_ip_packet`

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Strip the ip prefix in the ip address passed to `simple_ip_packet`


#### How did you do it?
Strip the prefix.

#### How did you verify/test it?
```
dualtor/test_ipinip.py::test_decap_active_tor PASSED                                                                                                                                           [ 50%]
dualtor/test_ipinip.py::test_decap_standby_tor FAILED                                                                                                                                          [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
