### PR TITLE
[ptfadapter] Check the reachablity of ptf_nn_agent

### DIFF
--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -1,10 +1,22 @@
+import nnpy
 import ptf
-from ptf.base_tests import BaseTest
-from ptf.dataplane import DataPlane
 import ptf.platforms.nn as nn
 import ptf.ptfutils as ptfutils
 import ptf.packet as scapy
 import ptf.mask as mask
+
+from ptf.base_tests import BaseTest
+from ptf.dataplane import DataPlane
+from tests.common.utilities import wait_until
+
+
+class PtfAdapterNNConnectionError(Exception):
+
+    def __init__(self, remote_sock_addr):
+        super(PtfAdapterNNConnectionError, self).__init__(
+            "Failed to connect to ptf_nn_agent('%s')" % remote_sock_addr
+        )
+        self.remote_sock_addr = remote_sock_addr
 
 
 class PtfTestAdapter(BaseTest):
@@ -13,6 +25,9 @@ class PtfTestAdapter(BaseTest):
     DEFAULT_PTF_QUEUE_LEN = 100000
     DEFAULT_PTF_TIMEOUT = 2
     DEFAULT_PTF_NEG_TIMEOUT = 0.1
+
+    # the number of currently established connections
+    NN_STAT_CURRENT_CONNECTIONS = 201
 
     def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set):
         """ initialize PtfTestAdapter
@@ -37,6 +52,15 @@ class PtfTestAdapter(BaseTest):
 
         self.kill()
 
+    def _check_ptf_nn_agent_availability(self, socket_addr):
+        """Verify the nanomsg socket address exposed by ptf_nn_agent is available."""
+        sock = nnpy.Socket(nnpy.AF_SP, nnpy.PAIR)
+        sock.connect(socket_addr)
+        try:
+            return wait_until(1, 0.2, lambda:sock.get_statistic(self.NN_STAT_CURRENT_CONNECTIONS) == 1)
+        finally:
+            sock.close()
+
     def _init_ptf_dataplane(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptf_config=None):
         """
         initialize ptf framework and establish connection to ptf_nn_agent
@@ -55,16 +79,21 @@ class PtfTestAdapter(BaseTest):
         ptfutils.default_timeout = self.DEFAULT_PTF_TIMEOUT
         ptfutils.default_negative_timeout = self.DEFAULT_PTF_NEG_TIMEOUT
 
+        ptf_nn_sock_addr = 'tcp://{}:{}'.format(ptf_ip, ptf_nn_port)
+
         ptf.config.update({
             'platform': 'nn',
             'device_sockets': [
-                (device_num, ptf_port_set, 'tcp://{}:{}'.format(ptf_ip, ptf_nn_port))
+                (device_num, ptf_port_set, ptf_nn_sock_addr)
             ],
             'qlen': self.DEFAULT_PTF_QUEUE_LEN,
             'relax': True,
         })
         if ptf_config is not None:
             ptf.config.update(ptf_config)
+
+        if not self._check_ptf_nn_agent_availability(ptf_nn_sock_addr):
+            raise PtfAdapterNNConnectionError(ptf_nn_sock_addr)
 
         # update ptf.config based on NN platform and create dataplane instance
         nn.platform_config_update(ptf.config)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
If two pytest clients try to use the same testbed and connect to the
ptf_nn_agent on the ptf, due to that ptf_nn_agent uses PAIR pattern, the
the second client actually fails to connect to ptf_nn_agent, but ptfadapter
won't notify the user of this failure.

Add an extra check `_check_ptf_nn_agent_availability` that tries to
connect to the nanomsg socket exposed by ptf_nn_agent, it will verify
if there is one established connection. If not, it will raise an error.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If two pytest clients try to use the same testbed and connect to the
ptf_nn_agent on the ptf, due to that ptf_nn_agent uses PAIR pattern, the
the second client actually fails to connect to ptf_nn_agent, but ptfadapter
won't notify the user of this failure.

#### How did you do it?
Add an extra check `_check_ptf_nn_agent_availability` that tries to
connect to the nanomsg socket exposed by ptf_nn_agent, it will verify
if there is one established connection. If not, it will raise an error.

#### How did you verify/test it?
1. start a client to occupy `ptf_nn_agent` socket
```
>>> s = nnpy.Socket(nnpy.AF_SP, nnpy.PAIR)
>>> s.connect("tcp://127.0.0.1:10900")
1
>>> s.recv()
'\x04\x00\x00\x008\x00\x00\x00|\x00\x00\x00\x01\x80\xc2\x00\x00\x02\x94\x8e\xd3\x04\xeb(\x88\t\x01\x01\x01\x14\xff\xff\x94\x8e\xd3\x04\xeb(\x00\x00\x00\xff\x00\x19=\x00\x00\x00\x02\x14\x80\x00RT\x000\xfd\xf1\x00\x01\x80\x00\x00\x01=\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
```
2. run Pytest
```
common/plugins/ptfadapter/__init__.py:108:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
common/plugins/ptfadapter/ptfadapter.py:44: in __init__
    self._init_ptf_dataplane(ptf_ip, ptf_nn_port, device_num, ptf_port_set)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
dualtor/test_ipinip.py::test_decap_active_tor ERROR                                                                                                         [ 50%]
self = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>, ptf_ip = '10.64.246.147', ptf_nn_port = 10900, device_num = 0, ptf_port_set = [0, 1, 2, 3, 4, 5, ...]
ptf_config = None

    def _init_ptf_dataplane(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptf_config=None):
        """
        initialize ptf framework and establish connection to ptf_nn_agent
        running on PTF host
        :param ptf_ip: PTF host IP
        :param ptf_nn_port: PTF nanomessage agent port
        :param device_num: device number
        :param ptf_port_set: PTF ports
        :return:
        """
        self.ptf_ip = ptf_ip
        self.ptf_nn_port = ptf_nn_port
        self.device_num = device_num
        self.ptf_port_set = ptf_port_set

        ptfutils.default_timeout = self.DEFAULT_PTF_TIMEOUT
        ptfutils.default_negative_timeout = self.DEFAULT_PTF_NEG_TIMEOUT

        ptf_nn_sock_addr = 'tcp://{}:{}'.format(ptf_ip, ptf_nn_port)

        ptf.config.update({
            'platform': 'nn',
            'device_sockets': [
                (device_num, ptf_port_set, ptf_nn_sock_addr)
            ],
            'qlen': self.DEFAULT_PTF_QUEUE_LEN,
            'relax': True,
        })
        if ptf_config is not None:
            ptf.config.update(ptf_config)

>       if not wait_until(1, 0.2, self._check_ptf_nn_agent_availability, ptf_nn_sock_addr):
E       PtfAdapterNNConnectionError: Failed to connect to ptf_nn_agent('tcp://10.64.246.147:10900')
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
