### PR TITLE
[platform_test/api]: fix psu key in test_psu_fans

### DIFF
--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -69,7 +69,7 @@ class TestPsuFans(PlatformApiTestBase):
         expected_value = None
 
         if self.chassis_facts:
-            expected_psus = self.chassis_facts.get("psu")
+            expected_psus = self.chassis_facts.get("psus")
             if expected_psus:
                 expected_fans = expected_psus[psu_idx].get("fans")
                 if expected_fans:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix typo in test_psu_fans test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
- The test script cannot detect psus config

#### How did you do it?
- Fix psu key in test_psu_fans

#### How did you verify/test it?
- Run platform pytest with the Testbed 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
