### PR TITLE
[devutils] skip ping action if ansible_host is missing

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -159,8 +159,9 @@ def action_ping(parameters):
     header = ['Host', 'Hostname', 'Ping result']
     data = []
     for name, vars in hosts.items():
-        cmd = 'timeout 1 ping -q -c 1 -w 1 {}'.format(vars['ansible_host'])
-        g_task_runner.submit_task(name + '|' + vars['ansible_host'], run_cmd, cmd=cmd)
+        if 'ansible_host' in vars:
+            cmd = 'timeout 1 ping -q -c 1 -w 1 {}'.format(vars['ansible_host'])
+            g_task_runner.submit_task(name + '|' + vars['ansible_host'], run_cmd, cmd=cmd)
     if parameters['json']:
         for name, result in g_task_runner.task_results():
             data.append(


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
devutils will generate exception when ping'ing hosts that doesn't have ansible_host attribute.

#### How did you do it?
skip ping action for these hosts that don't have ansible_host attribute.

#### How did you verify/test it?
ping all hosts in an inventory contains hosts have no ansible_host attribute.