### PR TITLE
[Mellanox] Fixes issue: support gearbox threshold in thermal test cases mocker

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -36,7 +36,9 @@ THERMAL_NAMING_RULE = {
     },
     "gearbox": {
         "name": "Gearbox {} Temp",
-        "temperature": "gearbox{}_temp_input"
+        "temperature": "gearbox{}_temp_input",
+        "high_threshold": "mlxsw-gearbox{}/temp_trip_hot",
+        "high_critical_threshold": "mlxsw-gearbox{}/temp_trip_crit"
     },
     "asic_ambient": {
         "name": "ASIC",
@@ -61,6 +63,11 @@ THERMAL_NAMING_RULE = {
 ASIC_THERMAL_RULE_201911 = {
     "name": "Ambient ASIC Temp",
     "temperature": "asic"
+}
+
+GEARBOX_THERMAL_RULE_201911 = {
+    "name": "Gearbox {} Temp",
+    "temperature": "gearbox{}_temp_input"
 }
 
 FAN_NAMING_RULE = {
@@ -547,9 +554,11 @@ class TemperatureData:
         :param index: Thermal index.
         """
         self.helper = mock_helper
-        if 'ASIC' in naming_rule['name']:
-            if self.helper.is_201911():
+        if self.helper.is_201911():
+            if 'ASIC' in naming_rule['name']:
                 naming_rule = ASIC_THERMAL_RULE_201911
+            elif 'Gearbox' in naming_rule['name']:
+                naming_rule = GEARBOX_THERMAL_RULE_201911
 
         self.name = naming_rule['name']
         self.temperature_file = naming_rule['temperature']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue: support gearbox threshold in thermal test cases mocker

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

On master/202012 branch, mellanox platform support getting gearbox temperature threshold. But the test case still expect "N/A" when mock gearbox temperature data. This PR is to fix it.

#### How did you do it?

On master or newer branch, mock gearbox temperature threshold data.

#### How did you verify/test it?

Manually run test case "test_show_platform_temperature_mocked"

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
