### PR TITLE
[devices]: Add `shutdown_multiple` method to SONiC and EOS hosts

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -62,16 +62,24 @@ class EosHost(AnsibleHostBase):
     def shutdown(self, interface_name):
         out = self.eos_config(
             lines=['shutdown'],
-            parents='interface %s' % interface_name)
+            parents=['interface {}'.format(interface_name)])
         logging.info('Shut interface [%s]' % interface_name)
         return out
+
+    def shutdown_multiple(self, interfaces):
+        intf_str = ','.join(interfaces)
+        return self.shutdown(intf_str)
 
     def no_shutdown(self, interface_name):
         out = self.eos_config(
             lines=['no shutdown'],
-            parents='interface %s' % interface_name)
+            parents=['interface {}'.format(interface_name)])
         logging.info('No shut interface [%s]' % interface_name)
         return out
+
+    def no_shutdown_multiple(self, interfaces):
+        intf_str = ','.join(interfaces)
+        return self.no_shutdown(intf_str)
 
     def check_intf_link_state(self, interface_name):
         show_int_result = self.eos_command(

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -48,9 +48,41 @@ class FanoutHost(object):
         return self.type
 
     def shutdown(self, interface_name):
+        """
+        Shuts down the given interface.
+
+        If a list of interfaces is provided, checks if the host object has
+        a method that can shut down multiple interfaces at once. If no
+        such method is found, an AttributeError is raised
+        """
+        if isinstance(interface_name, list):
+            shutdown_multiple = getattr(self.host, "shutdown_multiple", None)
+            if callable(shutdown_multiple):
+                return shutdown_multiple(interface_name)
+            else:
+                raise AttributeError("Host of type {} does not contain a"
+                                     "'shutdown_multiple' method"
+                                     .format(type(self.host)))
+
         return self.host.shutdown(interface_name)
 
     def no_shutdown(self, interface_name):
+        """
+        Starts up the given interface.
+
+        If a list of interfaces is provided, checks if the host object has
+        a method that can startup multiple interfaces at once. If no
+        such method is found, an AttributeError is raised
+        """
+        if isinstance(interface_name, list):
+            no_shutdown_multiple = getattr(self.host, "no_shutdown_multiple", None)
+            if callable(no_shutdown_multiple):
+                return no_shutdown_multiple(interface_name)
+            else:
+                raise AttributeError("Host of type {} does not contain a"
+                                     "'no_shutdown_multiple' method"
+                                     .format(type(self.host)))
+
         return self.host.no_shutdown(interface_name)
 
     def __str__(self):

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -650,6 +650,16 @@ class SonicHost(AnsibleHostBase):
         """
         return self.command("sudo config interface shutdown {}".format(ifname))
 
+    def shutdown_multiple(self, ifnames):
+        """
+            Shutdown multiple interfaces
+
+            Args:
+                ifnames (list): the interface names to shutdown
+        """
+        intf_str = ','.join(ifnames)
+        return self.shutdown(intf_str)
+
     def no_shutdown(self, ifname):
         """
             Bring up interface specified by ifname
@@ -658,6 +668,16 @@ class SonicHost(AnsibleHostBase):
                 ifname: the interface to bring up
         """
         return self.command("sudo config interface startup {}".format(ifname))
+
+    def no_shutdown_multiple(self, ifnames):
+        """
+            Bring up multiple interfaces
+
+            Args:
+                ifnames (list): the interface names to bring up
+        """
+        intf_str = ','.join(ifnames)
+        return self.no_shutdown(intf_str)
 
     def get_ip_route_info(self, dstip, ns=""):
         """

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -282,12 +282,9 @@ def _shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None
             Defaults to None.
 
     Returns:
-        list of tuple: Return a list of tuple. Each tuple has two items. The first item is the host object for fanout.
-            The second item is the fanout interface that has been shutdown. The returned list makes it easy to recover
-            the interfaces.
+        dict (fanouthost: list): Each key is a fanout host, and the corresponding value is the interfaces that were shut down 
+                                 on that host device.
     """
-    down_intfs = []
-
     if not dut_intfs:
         # If no interface is specified, shutdown all VLAN ports
         vlan_intfs = []

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime
 from tests.ptf_runner import ptf_runner
 
+from collections import defaultdict
 from natsort import natsorted
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
@@ -277,7 +278,7 @@ def _shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None
         tbinfo (dict): Testbed info from the tbinfo fixture.
         dut_intfs (list, optional): List of DUT interface names, for example: ['Ethernet0', 'Ethernet4']. All the
             fanout interfaces that are connected to the specified DUT interfaces will be shutdown. If dut_intfs is not
-            specified, the function will shutdown all the fanout interfaces that are connected to the tor_host DUT.
+            specified, the function will shutdown all the fanout interfaces that are connected to the tor_host DUT and in a VLAN.
             Defaults to None.
 
     Returns:
@@ -288,9 +289,13 @@ def _shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None
     down_intfs = []
 
     if not dut_intfs:
-        # If no interface is specified, shutdown all ports
-        mg_facts = tor_host.get_extended_minigraph_facts(tbinfo)
-        dut_intfs = mg_facts['minigraph_ports'].keys()
+        # If no interface is specified, shutdown all VLAN ports
+        vlan_intfs = []
+        vlan_member_table = tor_host.get_running_config_facts()['VLAN_MEMBER']
+        for vlan_members in vlan_member_table.values():
+            vlan_intfs.extend(list(vlan_members.keys()))
+
+        dut_intfs = vlan_intfs
 
     dut_intfs = natsorted(dut_intfs)
 
@@ -304,22 +309,27 @@ def _shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None
 
     logger.debug('full_dut_fanout_port_map: {}'.format(full_dut_fanout_port_map))
 
+    fanout_shut_intfs = defaultdict(list)
+
     for dut_intf in dut_intfs:
         encoded_dut_intf = encode_dut_port_name(tor_host.hostname, dut_intf)
         if encoded_dut_intf in full_dut_fanout_port_map:
             fanout_host = full_dut_fanout_port_map[encoded_dut_intf]['fanout_host']
             fanout_intf = full_dut_fanout_port_map[encoded_dut_intf]['fanout_intf']
-            fanout_host.shutdown(fanout_intf)
-            down_intfs.append((fanout_host, fanout_intf))
+            fanout_shut_intfs[fanout_host].append(fanout_intf)
         else:
             logger.error('No dut intf "{}" in full_dut_fanout_port_map'.format(encoded_dut_intf))
 
-    return down_intfs
+    for fanout_host, intf_list in fanout_shut_intfs.items():
+        fanout_host.shutdown(intf_list)
+
+    return fanout_shut_intfs
 
 
 @pytest.fixture
 def shutdown_fanout_upper_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo):
-    """Fixture for shutting down fanout interfaces connected to specified upper_tor interfaces.
+    """
+    Fixture for shutting down fanout interfaces connected to specified upper_tor interfaces.
 
     Args:
         upper_tor_host (object): Host object for upper_tor.
@@ -329,22 +339,25 @@ def shutdown_fanout_upper_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinf
     Yields:
         function: A function for shutting down fanout interfaces connected to specified upper_tor interfaces
     """
-    down_intfs = []
+    shut_fanouts = []
 
     def shutdown(dut_intfs=None):
         logger.info('Shutdown fanout ports connected to upper_tor')
-        down_intfs.extend(_shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs))
+        shut_fanouts.append(_shutdown_fanout_tor_intfs(upper_tor_host, upper_tor_fanouthosts, tbinfo, dut_intfs))
 
     yield shutdown
 
     logger.info('Recover fanout ports connected to upper_tor')
-    for fanout_host, fanout_intf in down_intfs:
-        fanout_host.no_shutdown(fanout_intf)
+
+    for instance in shut_fanouts:
+        for fanout_host, intf_list in instance.items():
+            fanout_host.no_shutdown(intf_list)
 
 
 @pytest.fixture
 def shutdown_fanout_lower_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo):
-    """Fixture for shutting down fanout interfaces connected to specified lower_tor interfaces.
+    """
+    Fixture for shutting down fanout interfaces connected to specified lower_tor interfaces.
 
     Args:
         lower_tor_host (object): Host object for lower_tor.
@@ -354,17 +367,19 @@ def shutdown_fanout_lower_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinf
     Yields:
         function: A function for shutting down fanout interfaces connected to specified lower_tor interfaces
     """
-    down_intfs = []
+    shut_fanouts = []
 
     def shutdown(dut_intfs=None):
         logger.info('Shutdown fanout ports connected to lower_tor')
-        down_intfs.extend(_shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs))
+        shut_fanouts.append(_shutdown_fanout_tor_intfs(lower_tor_host, lower_tor_fanouthosts, tbinfo, dut_intfs))
 
     yield shutdown
 
     logger.info('Recover fanout ports connected to lower_tor')
-    for fanout_host, fanout_intf in down_intfs:
-        fanout_host.no_shutdown(fanout_intf)
+
+    for instance in shut_fanouts:
+        for fanout_host, intf_list in instance.items():
+            fanout_host.no_shutdown(intf_list)
 
 
 @pytest.fixture


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3146

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Shutting down interfaces on the fanout one-by-one takes too long when running traffic testing, since the traffic will be finished before all the interfaces are shutdown.

#### How did you do it?
Create `shutdown_multiple` and `no_shutdown_multiple` in `eos.py` and `sonic.py` to allow passing multiple interface names to be shutdown. Since these methods only need to connect to the device once, the operation is much faster (only a few seconds).

In `fanout.py:shutdown()` check if `self.host` has a `shutdown_multiple` attribute when a list of interface names is passed.

#### How did you verify/test it?

```
import time
from tests.common.dualtor.dual_tor_utils import shutdown_fanout_upper_tor_intfs, shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, lower_tor_fanouthosts                   # lgtm[py/unused-import]

def test_upper(shutdown_fanout_upper_tor_intfs, shutdown_fanout_lower_tor_intfs):
    shutdown_fanout_lower_tor_intfs()
    shutdown_fanout_upper_tor_intfs()
	time.sleep(30)
```

Run the above test and confirm that the interfaces are shutdown properly, then restored after the test.

#### Any platform specific information?
This will only work on SONiC and EOS fanouts

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
