### PR TITLE
[dualtor] Improve mocking fixtures

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -5,12 +5,24 @@ import pytest
 
 from ipaddress import ip_interface, IPv4Interface, IPv6Interface, \
                       ip_address, IPv4Address
-
+from tests.common import config_reload
 from tests.common.dualtor.dual_tor_utils import tor_mux_intfs
 
-__all__ = ['apply_active_state_to_orchagent', 'apply_dual_tor_neigh_entries', 'apply_dual_tor_peer_switch_route', 'apply_mock_dual_tor_kernel_configs',
-           'apply_mock_dual_tor_tables', 'apply_mux_cable_table_to_dut', 'apply_peer_switch_table_to_dut', 'apply_standby_state_to_orchagent', 'apply_tunnel_table_to_dut',
-           'mock_peer_switch_loopback_ip', 'mock_server_base_ip_addr', 'mock_server_ip_mac_map']
+__all__ = [
+    'apply_active_state_to_orchagent',
+    'apply_dual_tor_neigh_entries',
+    'apply_dual_tor_peer_switch_route',
+    'apply_mock_dual_tor_kernel_configs',
+    'apply_mock_dual_tor_tables',
+    'apply_mux_cable_table_to_dut',
+    'apply_peer_switch_table_to_dut',
+    'apply_standby_state_to_orchagent',
+    'apply_tunnel_table_to_dut',
+    'cleanup_mocked_configs',
+    'mock_peer_switch_loopback_ip',
+    'mock_server_base_ip_addr',
+    'mock_server_ip_mac_map'
+]
 
 logger = logging.getLogger(__name__)
 
@@ -347,3 +359,14 @@ def apply_mock_dual_tor_kernel_configs(request, tbinfo):
         request.getfixturevalue("apply_dual_tor_peer_switch_route")
         request.getfixturevalue("apply_dual_tor_neigh_entries")
         logger.info("Done applying kernel configs for dual ToR mock")
+
+
+@pytest.fixture(scope="module")
+def cleanup_mocked_configs(duthost, tbinfo):
+    """Config reload to reset the mocked configs applied to DUT."""
+
+    yield
+
+    if tbinfo["topo"]["type"] == "t0" and 'dualtor' not in tbinfo["topo"]["name"]:
+        logger.info("Load minigraph to reset the DUT %s", duthost.hostname)
+        config_reload(duthost, config_source="minigraph")

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -105,12 +105,12 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             self.ptfadapter = ptfadapter
 
             standby_tor_cfg_facts = self.standby_tor.config_facts(
-                host=self.standby_tor.hostname, source="persistent"
+                host=self.standby_tor.hostname, source="running"
             )["ansible_facts"]
             self.standby_tor_lo_addr = self._find_ipv4_lo_addr(standby_tor_cfg_facts)
             if self.active_tor:
                 active_tor_cfg_facts = self.active_tor.config_facts(
-                    host=self.active_tor.hostname, source="persistent"
+                    host=self.active_tor.hostname, source="running"
                 )["ansible_facts"]
                 self.active_tor_lo_addr = self._find_ipv4_lo_addr(active_tor_cfg_facts)
             else:

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -200,7 +200,7 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
     ptfhost.shell("supervisorctl stop icmp_responder")
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='session')
 def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses):
 
     garp_config = {}

--- a/tests/dualtor/test_normal_op.py
+++ b/tests/dualtor/test_normal_op.py
@@ -12,6 +12,11 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(scope="session", autouse=True)
+def common_setup_teardown(run_arp_service):
+    pass
+
+
 def test_normal_op_upstream(upper_tor_host, lower_tor_host,
                             send_server_to_t1_with_action,
                             toggle_all_simulator_ports_to_upper_tor):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. add fixture `cleanup_mocked_configs` to do a load minigraph in
dualtor mocking testcase teardown.

2. Remove `run_garp_service` autouse since for dualtor mocking
testcases, single T0 DUT doesn't have the mux cable table set in config
DB. Users now should explicitly call `run_garp_service` after calling
those mocking fixtures to setup mux cable table.

3. For tunnel traffic monitor, modify it to use the running configs that
have those configs from mocking fixtures.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
1. As teardowns in the mocking fixtures could not reset the ToR.
2. Mocking test cases need `run_garp_service` to setup mac table.
3. Tunnel server utility uses persistent configs that don't have configs set by the mocking fixtures.

#### How did you do it?
1. add fixture `cleanup_mocked_configs` to do a load minigraph in
dualtor mocking testcase teardown.

2. Remove `run_garp_service` autouse since for dualtor mocking
testcases, single T0 DUT doesn't have the mux cable table set in config
DB. Users now should explicitly call `run_garp_service` after calling
those mocking fixtures to setup mux cable table.

3. For tunnel traffic monitor, modify it to use the running configs that
have those configs from mocking fixtures.

#### How did you verify/test it?
```
dualtor/test_ipinip.py::test_decap_active_tor PASSED                                                                                              [ 50%]
dualtor/test_ipinip.py::test_decap_standby_tor FAILED                                                                                            [100%]
...
E               RuntimeError: Detected tunnel traffic from host str2-7050cx3-acs-02.

common/dualtor/tunnel_traffic_utils.py:150: RuntimeError
```
* the failure of standby_tor is due to the known issue that standby tor redirects the encapsulated packets back to T1s.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
