### PR TITLE
[multi-asic]: Fixes required for multi-asic vs testbed

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -71,7 +71,7 @@
     delegate_to: localhost
 
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
+    port_alias: hwsku="{{ hwsku }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data

--- a/ansible/vars/topo_msft_multi_asic_vs.yml
+++ b/ansible/vars/topo_msft_multi_asic_vs.yml
@@ -360,7 +360,7 @@ ASIC4:
           - Eth12-ASIC4
           - Eth13-ASIC4
           - Eth14-ASIC4
-          - Eth15
+          - Eth15-ASIC4
       ASIC2:
         asic_intfs:
           - Eth16-ASIC4

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -120,6 +120,9 @@ all:
           num_asics: 6
           ansible_password: password
           ansible_user: admin
+          iface_speed: 40000
+          start_topo_service: True
+          frontend_asics: [0,1,2,3]
         vlab-08:
           ansible_host: 10.250.0.112
           ansible_hostv6: fec0::ffff:afa:c
@@ -129,6 +132,9 @@ all:
           num_asics: 4
           ansible_password: password
           ansible_user: admin
+          iface_speed: 40000
+          start_topo_service: True
+          frontend_asics: [0,1]
         vlab-simx-01:
           ansible_host: 10.250.0.103
           ansible_hostv6: fec0::ffff:afa:3


### PR DESCRIPTION
- Fix interface name in msft_multi_asic_vs topo file.
- Pass num_asics parameter to port_alias.py only when
run on localhost. When port_alias.py is run on the DUT,
use library function to get number of asics.
-  Add parameters required for mulit-asic DUT in the veos_vtb
inventory file.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
- When deploy-mg is executed for multi-asic vs testbed, AnsibleUndefinedVariable: 'iface_speed' is undefined error is seen.
- Incorrect interface name was added in msft_multi_asic_vs topo file.
- num_asic parameter is not "required" in port_alias.py, multi_asic.get_num_asics() function is to be used when port_alias.py is run on the DUT. 
- 
#### How did you do it?
- Fix interface name in msft_multi_asic_vs topo file.
- Pass num_asics parameter to port_alias.py only when run on localhost. When port_alias.py is run on the DUT,
use library function to get number of asics. port_alias.py is run on DUT when deploy_mg is run.
-  Add parameters required for mulit-asic DUT in the veos_vtb.

#### How did you verify/test it?
Execute the below commands to bring up one of the multi-asic testbeds, ensure no error is seen and all interfaces and bgp sessions are up.
./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-four-asic-t1-lag password.txt
./testbed-cli.sh -t vtestbed.csv deploy-mg vms-kvm-four-asic-t1-lag veos_vtb password.txt 
Single asic vs testbed - no change.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
