### PR TITLE
[rdma] Test PFC watchdog under many to one traffic pattern

### DIFF
--- a/tests/ixia/pfcwd/test_pfcwd_a2a.py
+++ b/tests/ixia/pfcwd/test_pfcwd_a2a.py
@@ -13,17 +13,17 @@ from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 @pytest.mark.topology("tgen")
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-def test_pfcwd_a2a(ixia_api,
-                   ixia_testbed,
-                   conn_graph_facts,
-                   fanout_graph_facts,
-                   duthosts,
-                   rand_one_dut_hostname,
-                   rand_one_dut_portname_oper_up,
-                   rand_one_dut_lossless_prio,
-                   lossy_prio_list,
-                   prio_dscp_map,
-                   trigger_pfcwd):
+def test_pfcwd_all_to_all(ixia_api,
+                          ixia_testbed,
+                          conn_graph_facts,
+                          fanout_graph_facts,
+                          duthosts,
+                          rand_one_dut_hostname,
+                          rand_one_dut_portname_oper_up,
+                          rand_one_dut_lossless_prio,
+                          lossy_prio_list,
+                          prio_dscp_map,
+                          trigger_pfcwd):
 
     """
     Run PFC watchdog test under all to all traffic pattern

--- a/tests/ixia/pfcwd/test_pfcwd_m2o.py
+++ b/tests/ixia/pfcwd/test_pfcwd_m2o.py
@@ -13,17 +13,17 @@ from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 @pytest.mark.topology("tgen")
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-def test_pfcwd_m2o(ixia_api,
-                   ixia_testbed,
-                   conn_graph_facts,
-                   fanout_graph_facts,
-                   duthosts,
-                   rand_one_dut_hostname,
-                   rand_one_dut_portname_oper_up,
-                   rand_one_dut_lossless_prio,
-                   lossy_prio_list,
-                   prio_dscp_map,
-                   trigger_pfcwd):
+def test_pfcwd_many_to_one(ixia_api,
+                           ixia_testbed,
+                           conn_graph_facts,
+                           fanout_graph_facts,
+                           duthosts,
+                           rand_one_dut_hostname,
+                           rand_one_dut_portname_oper_up,
+                           rand_one_dut_lossless_prio,
+                           lossy_prio_list,
+                           prio_dscp_map,
+                           trigger_pfcwd):
 
     """
     Run PFC watchdog test under many to one traffic pattern

--- a/tests/ixia/pfcwd/test_pfcwd_m2o.py
+++ b/tests/ixia/pfcwd/test_pfcwd_m2o.py
@@ -1,0 +1,66 @@
+import pytest
+
+from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+    fanout_graph_facts
+from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
+    ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed
+from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
+    lossless_prio_list, lossy_prio_list
+
+from files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
+
+@pytest.mark.topology("tgen")
+
+@pytest.mark.parametrize("trigger_pfcwd", [True, False])
+def test_pfcwd_m2o(ixia_api,
+                   ixia_testbed,
+                   conn_graph_facts,
+                   fanout_graph_facts,
+                   duthosts,
+                   rand_one_dut_hostname,
+                   rand_one_dut_portname_oper_up,
+                   rand_one_dut_lossless_prio,
+                   lossy_prio_list,
+                   prio_dscp_map,
+                   trigger_pfcwd):
+
+    """
+    Run PFC watchdog test under many to one traffic pattern
+
+    Args:
+        ixia_api (pytest fixture): IXIA session
+        ixia_testbed (pytest fixture): L2/L3 config of a T0 testbed
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        rand_one_dut_hostname (str): hostname of DUT
+        rand_one_dut_portname_oper_up (str): port to test, e.g., 's6100-1|Ethernet0'
+        rand_one_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
+        lossy_prio_list (pytest fixture): list of lossy priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority)
+        trigger_pfcwd (bool): if PFC watchdog is expected to be triggered
+
+    Returns:
+        N/A
+    """
+    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+    dut_hostname2, lossless_prio = rand_one_dut_lossless_prio.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname == dut_hostname2,
+                   "Priority and port are not mapped to the expected DUT")
+
+    duthost = duthosts[rand_one_dut_hostname]
+    lossless_prio = int(lossless_prio)
+
+    run_pfcwd_multi_node_test(api=ixia_api,
+                              testbed_config=ixia_testbed,
+                              conn_data=conn_graph_facts,
+                              fanout_data=fanout_graph_facts,
+                              duthost=duthost,
+                              dut_port=dut_port,
+                              pause_prio_list=[lossless_prio],
+                              test_prio_list=[lossless_prio],
+                              bg_prio_list=lossy_prio_list,
+                              prio_dscp_map=prio_dscp_map,
+                              trigger_pfcwd=trigger_pfcwd,
+                              pattern="many to one")


### PR DESCRIPTION
Signed-off-by: Wei Bai webai@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Test PFC watchdog under many to one traffic pattern
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We need more PFC watchdog test cases

#### How did you do it?
1. Add a new traffic pattern "many to one" in tests/ixia/pfcwd/files/pfcwd_multi_node_helper.py
2. Add a new function __gen_m2o_traffic in tests/ixia/pfcwd/files/pfcwd_multi_node_helper.py to generate traffic, including a PFC pause storm sent from port_id, and many data traffic items sent to port_id.
3. Add a new test function test_pfcwd_m2o in tests/ixia/pfcwd/test_pfcwd_m2o.py

#### How did you verify/test it?
I did test using SONiC switches and IXIA chassis. The Tgen API version is 0.0.75. The IXIA Linux API server version is 9.10.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
T0 topology using IXIA chassis as the fanout

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
