### PR TITLE
[ptf]: Support port channel configuration in PTF container

### DIFF
--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -27,6 +27,7 @@ EXAMPLES = '''
 
 import os
 import re
+import traceback
 
 import jinja2
 from ansible.module_utils.basic import *
@@ -182,9 +183,8 @@ def main():
             disable_portchannel(module, teamd_config)
             remove_supervisor_conf(module, teamd_config)
             remove_teamd_conf(module, teamd_config)
-    except:
-        err = str(sys.exc_info())
-        module.fail_json(msg="Error: %s" % err)
+    except Exception as e:
+        module.fail_json(msg=traceback.format_exc())
 
     module.exit_json(**result)
 

--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+
+DOCUMENTATION = '''
+module:  ptf_portchannel
+version_added:  "1.0"
+
+short_description: manage portchannel interface in PTF container
+description: start/stop portchannel interface in PTF container with certain configurations
+
+Options:
+    - option-name: cmd
+      description: An action string as [start|stop]
+      required: True
+    - option-name: portchannel_config
+      description: A dict to indicate the portchannel configuration. E.G. {"PortChannel101": { "intfs": [0, 4] } }
+      required: True
+'''
+
+
+EXAMPLES = '''
+- name: Start PTF portchannel
+  ptf_portchannel:
+    cmd: "start"
+    portchannel_config: "{{ portchannel_config }}"
+'''
+
+
+import os
+import re
+
+import jinja2
+from ansible.module_utils.basic import *
+
+
+portchannel_conf_path = "/etc/portchannel"
+
+
+portchannel_conf_tmpl = '''\
+{
+    "device": "{{ name }}",
+    "runner": {
+        "active": true,
+        "name": "lacp",
+        "min_ports": 1
+    },
+    "ports": {
+{%- for intf in intfs %}
+        "{{ intf }}": {}{{ "," if not loop.last else "" }}
+{%- endfor %}
+    }
+}
+'''
+
+
+portchannel_supervisord_path = "/etc/supervisor/conf.d"
+
+
+portchannel_supervisord_conf_tmpl = '''\
+[program:portchannel-{{ name }}]
+command=/usr/bin/teamd -r -t {{ name }} -f '''+ portchannel_conf_path + '''/{{ name }}.conf
+stdout_logfile=/tmp/portchannel-{{ name }}.out.log
+stderr_logfile=/tmp/portchannel-{{ name }}.err.log
+redirect_stderr=false
+autostart=true
+autorestart=true
+startsecs=1
+numprocs=1
+'''
+
+
+def exec_command(module, cmd, ignore_error=False, msg="executing command"):
+    rc, out, err = module.run_command(cmd)
+    if not ignore_error and rc != 0:
+        module.fail_json(msg="Failed %s: rc=%d, out=%s, err=%s" %
+                         (msg, rc, out, err))
+    return out
+
+
+def get_portchannel_status(module, name):
+    output = exec_command(module, cmd="supervisorctl status portchannel-%s" % name)
+    m = re.search('^([\w|-]*)\s+(\w*).*$', output.decode("utf-8"))
+    return m.group(2)
+
+
+def refresh_supervisord(module):
+    exec_command(module, cmd="supervisorctl reread", ignore_error=True)
+    exec_command(module, cmd="supervisorctl update", ignore_error=True)
+
+
+def parse_teamd_config(module, portchannel_config):
+    conf = []
+    for name, intfs in portchannel_config.items():
+        intfs_names = []
+        if not intfs["intfs"]:
+            continue
+        for intf in intfs["intfs"]:
+            intfs_names.append("eth" + str(intf))
+        conf.append({"name": name, "intfs": intfs_names})
+    return conf
+
+
+def create_teamd_conf(module, teamd_config):
+    t = jinja2.Template(portchannel_conf_tmpl)
+    for conf in teamd_config:
+        with open(os.path.join(portchannel_conf_path, "{}.conf".format(conf["name"])), 'w') as fd:
+            fd.write(t.render(conf))
+
+
+def remove_teamd_conf(module, teamd_config):
+    for conf in teamd_config:
+        try:
+            os.remove(os.path.join(portchannel_conf_path, "{}.conf".format(conf["name"])))
+        except Exception:
+            pass
+
+
+def create_supervisor_conf(module, teamd_config):
+    t = jinja2.Template(portchannel_supervisord_conf_tmpl)
+    for conf in teamd_config:
+        with open(os.path.join(portchannel_supervisord_path, "portchannel-{}.conf".format(conf["name"])), 'w') as fd:
+            fd.write(t.render(conf))
+    refresh_supervisord(module)
+
+
+def remove_supervisor_conf(module, teamd_config):
+    for conf in teamd_config:
+        try:
+            os.remove(os.path.join(portchannel_supervisord_path, "portchannel-{}.conf".format(conf["name"])))
+        except Exception:
+            pass
+    refresh_supervisord(module)
+
+
+def enable_portchannel(module, teamd_config):
+    for conf in teamd_config:
+        for intf in conf["intfs"]:
+            exec_command(module, "ip link set dev {} down".format(intf))
+        exec_command(module, "supervisorctl start portchannel-{}".format(conf["name"]))
+        for count in range(0, 60):
+            time.sleep(1)
+            status = get_portchannel_status(module, conf["name"])
+            if u'RUNNING' == status:
+                break
+        assert u'RUNNING' == status
+        exec_command(module, "ip link set dev {} up".format(conf["name"]))
+
+
+
+def disable_portchannel(module, teamd_config):
+    for conf in teamd_config:
+        exec_command(module, cmd="supervisorctl stop portchannel-{}".format(conf["name"]), ignore_error=True)
+
+
+def setup_portchannel_conf():
+    try:
+        os.mkdir(portchannel_conf_path, 0755)
+    except OSError:
+        pass
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            cmd=dict(required=True, choices=['start', 'stop'], type='str'),
+            portchannel_config=dict(required=True, type='dict'),
+        ),
+        supports_check_mode=False)
+
+    cmd = module.params['cmd']
+    portchannel_config = module.params['portchannel_config']
+    teamd_config = parse_teamd_config(module, portchannel_config)
+
+    setup_portchannel_conf()
+
+    result = {}
+    try:
+        if cmd == 'start':
+            create_teamd_conf(module, teamd_config)
+            create_supervisor_conf(module, teamd_config)
+            enable_portchannel(module, teamd_config)
+        elif cmd == 'stop':
+            disable_portchannel(module, teamd_config)
+            remove_supervisor_conf(module, teamd_config)
+            remove_teamd_conf(module, teamd_config)
+    except:
+        err = str(sys.exc_info())
+        module.fail_json(msg="Error: %s" % err)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -2,7 +2,6 @@
 
 DOCUMENTATION = '''
 module:  ptf_portchannel
-version_added:  "1.0"
 
 short_description: manage portchannel interface in PTF container
 description: start/stop portchannel interface in PTF container with certain configurations
@@ -173,7 +172,6 @@ def main():
 
     setup_portchannel_conf()
 
-    result = {}
     try:
         if cmd == 'start':
             create_teamd_conf(module, teamd_config)
@@ -186,7 +184,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=traceback.format_exc())
 
-    module.exit_json(**result)
+    module.exit_json()
 
 
 if __name__ == '__main__':

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -123,6 +123,9 @@
     include_tasks: start_ptf_tgen.yml
     when: topo == 'fullmesh'
 
+  - name: Start PTF portchannel service
+    include_tasks: ptf_portchannel.yml
+
   - name: Announce routes
     include_tasks: announce_routes.yml
 

--- a/ansible/roles/vm_set/tasks/ptf_portchannel.yml
+++ b/ansible/roles/vm_set/tasks/ptf_portchannel.yml
@@ -1,0 +1,30 @@
+---
+- name: Include variables for PTF containers
+  include_vars:
+    dir: "{{ playbook_dir }}/group_vars/ptf_host/"
+
+- name: Set ptf host
+  set_fact:
+    ptf_host: "ptf_{{ vm_set_name }}"
+    ptf_host_ip: "{{ ptf_ip.split('/')[0] }}"
+
+- name: Add ptf host
+  add_host:
+    hostname: "{{ ptf_host }}"
+    ansible_user: "{{ ptf_host_user }}"
+    ansible_ssh_host: "{{ ptf_host_ip }}"
+    ansible_ssh_pass: "{{ ptf_host_pass }}"
+    ansible_python_interpreter: "/usr/bin/python"
+    groups:
+      - ptf_host
+
+- name: find downlink portchannel configuration
+  set_fact:
+    portchannel_config: "{{ topology['DUT']['portchannel_config'] | default({})}}"
+
+- name: Start PTF portchannel
+  ptf_portchannel:
+    cmd: "start"
+    portchannel_config: "{{ portchannel_config }}"
+  delegate_to: "{{ ptf_host }}"
+


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
#### How did you do it?
Add `ptf_portchannel.yml` and `ptf_portchannel.py` to support portchannel_configuration in ptf.
#### How did you verify/test it?
Create the topology, `topo_t0-56-po2vlan.yml`, and execute `show int portchannel` in DUT, we should see that the PortChannel101 is `UP`.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
