### PR TITLE
[tacacs] Skip ipintutil check on older OS versions

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -21,7 +21,11 @@ def ssh_remote_allow_run(localhost, remote_ip, username, password, cmd):
     res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
     # Verify that the command is allowed
     logger.info("check command \"{}\" rc={}".format(cmd, res['rc']))
-    return res['rc'] == 0 or (res['rc'] != 0 and "Make sure your account has RW permission to current device" not in res['stderr'])
+    expected = res['rc'] == 0 or (res['rc'] != 0 and "Make sure your account has RW permission to current device" not in res['stderr'])
+    if not expected:
+        logger.error("error output=\"{}\"".format(res["stderr"]))
+    return expected
+
 
 def ssh_remote_ban_run(localhost, remote_ip, username, password, cmd):
     res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
@@ -74,18 +78,24 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             '"sudo vtysh -c \'show ip bgp su\'"',
             '"sudo vtysh -n 0 -c \'show ip bgp su\'"',
             'sudo decode-syseeprom',
-            'sudo generate_dump',
+            'sudo generate_dump -s "5 secs ago"',
             'sudo lldpshow',
             'sudo pcieutil check',
             # 'sudo psuutil *',
             # 'sudo sfputil show *',
-            'sudo ip netns identify 1',
+            'sudo ip netns identify 1'
+    ]
+
+    # Some newer commands may not be available in 201911 or 202012
+    if not any(version in duthost.os_version for version in ("201911", "202012")):
+        commands_direct += [
             'sudo ipintutil',
             'sudo ipintutil -a ipv6',
             'sudo ipintutil -n asic0 -d all',
             'sudo ipintutil -n asic0 -d all -a ipv6'
-    ]
-        # Run as readonly use the commands allowed indirectly based on sudoers file
+        ]
+
+    # Run as readonly use the commands allowed indirectly based on sudoers file
     commands_indirect = [
             'show version',
             'show interface status',

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -83,7 +83,7 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'sudo pcieutil check',
             # 'sudo psuutil *',
             # 'sudo sfputil show *',
-            'sudo ip netns identify 1'
+            'sudo ip netns identify 1',
     ]
 
     # Some newer commands may not be available in 201911 or 202012
@@ -92,7 +92,7 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'sudo ipintutil',
             'sudo ipintutil -a ipv6',
             'sudo ipintutil -n asic0 -d all',
-            'sudo ipintutil -n asic0 -d all -a ipv6'
+            'sudo ipintutil -n asic0 -d all -a ipv6',
         ]
 
     # Run as readonly use the commands allowed indirectly based on sudoers file
@@ -103,7 +103,7 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'show ip bgp summary',
             'show ip interface',
             'show ipv6 interface',
-            'show lldp table'
+            'show lldp table',
     ]
 
     for command in commands_direct + commands_indirect:


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fixes https://github.com/Azure/sonic-mgmt/issues/3116 and unblocks buildimage PRs.

#### How did you do it?
Interestingly, if a file exists in the `sudoers` file but does not exist on the system, we still see the following error:

```
Make sure your account has RW permission to current device.
Otherwise sudo requests will be rejected.
```

So we need to be sure that the commands we test here actually exist in the image. Because skipping over scripts that are not found on the system may actually mask issues as well, I have opted to include an explicit version check in the test code.

#### How did you verify/test it?
Re-ran the `ro_user_allowed_command` test case against the 201911 and 202012 images.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
