### PR TITLE
[SAI QOS] Update SAI QoS tests  PGHeadroomWatermarkTest and QSharedWatermark to handle LAG

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1714,13 +1714,24 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         tos |= ecn
         ttl = 64
         default_packet_length = 64
-        pkt = simple_tcp_packet(pktlen=default_packet_length,
-                                eth_dst=router_mac if router_mac != '' else dst_port_mac,
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        pkt = simple_ip_packet(pktlen=default_packet_length,
+                                eth_dst=pkt_dst_mac,
                                 eth_src=src_port_mac,
                                 ip_src=src_port_ip,
                                 ip_dst=dst_port_ip,
                                 ip_tos=tos,
                                 ip_ttl=ttl)
+
+        print >> sys.stderr, "dst_port_id: %d, src_port_id: %d" % (dst_port_id, src_port_id)
+        # in case dst_port_id is part of LAG, find out the actual dst port
+        # for given IP parameters
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip
+        )
+        print >> sys.stderr, "actual dst_port_id: %d" % (dst_port_id)
+
+
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed
@@ -1810,13 +1821,23 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         tos = dscp << 2
         tos |= ecn
         ttl = 64
-        pkt = simple_tcp_packet(pktlen=packet_length,
-                                eth_dst=router_mac if router_mac != '' else dst_port_mac,
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        pkt = simple_ip_packet(pktlen=packet_length,
+                                eth_dst=pkt_dst_mac,
                                 eth_src=src_port_mac,
                                 ip_src=src_port_ip,
                                 ip_dst=dst_port_ip,
                                 ip_tos=tos,
                                 ip_ttl=ttl)
+
+        print >> sys.stderr, "dst_port_id: %d, src_port_id: %d" % (dst_port_id, src_port_id)
+        # in case dst_port_id is part of LAG, find out the actual dst port
+        # for given IP parameters
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip
+        )
+        print >> sys.stderr, "actual dst_port_id: %d" % (dst_port_id)
+
         # Add slight tolerance in threshold characterization to consider
         # the case that cpu puts packets in the egress queue after we pause the egress
         # or the leak out is simply less than expected as we have occasionally observed


### PR DESCRIPTION
…e LAG ports

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 Update SAI QoS tests  PGHeadroomWatermarkTest and QSharedWatermark to handle LAG ports.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Handle LAG destination ports in SAI tests PGHeadroomWatermarkTest and QSharedWatermark

#### How did you do it?
Determine the actual destination port by monitoring the PTF ports that receives the packet sent for this purpose.

#### How did you verify/test it?
```
========================================================================================================================================================= 4 passed, 34 deselected, 1 warnings in 716.24 seconds ==========================================================================================================================================================
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest qos/test_qos_sai.py --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library --disable_loganalyzer --skip_sanity -s -k QSharedWatermark  
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
WARNING: No route found for IPv6 destination :: (no default route?)
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collected 38 items / 34 deselected / 4 selected                                                                                                                                                                                                                                                                                                                          

qos/test_qos_sai.py Loading callback plugin unnamed of type old, v1.0 from /usr/local/lib/python2.7/dist-packages/pytest_ansible-2.2.2-py2.7.egg/pytest_ansible/module_dispatcher/v28.py
Loading callback plugin profile_tasks of type aggregate, v2.0 from /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/profile_tasks.pyc
META: ran handlers
Wednesday 17 March 2021  02:28:12 +0000 (0:00:00.125)       0:00:00.125 ******* 


============================================================================================================================================================================ warnings summary ============================================================================================================================================================================/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================================================= 4 passed, 34 deselected, 1 warnings in 716.24 seconds ==========================================================================================================================================================

```

Single ASIC
```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest --count=3 qos/test_qos_sai.py  --testbed=vms3-t1-dx010-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-dx010-acs-1 --module-path=../ansible/library --disable_loganalyzer --skip_sanity -k  QSharedWatermark                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.                                                                                                          
  from cryptography.exceptions import InvalidSignature                                                                                                                                                                                                                                                                                                                    
=========================================================================================================================================================================== test session starts ==========================================================================================================================================================================
==                                                                                                                                                                                                                                                                                                                                                                        
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1                                                                                                                                                                                                                                                                                                  
ansible: 2.8.12                                                                                                                                                                                                                                                                                                                                                           
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini                                                                                                                                                                                                                                                                                                                       
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2                                                                                                                                                                                                                                                                            collected 57 items / 51 deselected / 6 selected                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                          qos/test_qos_sai.py ......                                                                                                                                                                                                                                                                                                                                         [100%]                                                                                                                                                                                                                                                                                                                                                                           ============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538                                                                                                                                                                                                                                                                                                     
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor                                                                                                                                                                                                 
    self.import_plugin(import_spec)                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                          
-- Docs: https://docs.pytest.org/en/latest/warnings.html                                                                                                                                                                                                                                                                                                                  
========================================================================================================================================================= 6 passed, 51 deselected, 1 warnings in 1115.78 seconds =========================================================================================================================================================
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest --count=3 qos/test_qos_sai.py  --testbed=vms3-t1-dx010-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=str-dx010-acs-1 --module-path=../ansible/library --disable_loganalyzer --skip_sanity -k  PgSharedWatermark                                                                
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.                                                                                                          
  from cryptography.exceptions import InvalidSignature                                                                                                                                                                                                                                                                                                                    
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1                                                                                                                                                                                                                                                                                                  
ansible: 2.8.12                                                                                                                                                                                                                                                                                                                                                           
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini                                                                                                                                                                                                                                                                                                                       
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2                                                                                                                                                                                                                                                                            
collected 57 items / 51 deselected / 6 selected                                                                                                                                                                                                                                                                                                                          

qos/test_qos_sai.py ......                                                                                                                                                                                                                                                                                                                                           [100%
]

============================================================================================================================================================================= warnings summary ===========================================================================================================================================================================
==
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)
    
-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================================================== 6 passed, 51 deselected, 1 warnings in 1098.24 seconds ========================================================================================================================================================
==

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
