### PR TITLE
Fixed tacacs/test_ro_user test for 201911

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -80,7 +80,6 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'sudo decode-syseeprom',
             'sudo generate_dump -s "5 secs ago"',
             'sudo lldpshow',
-            'sudo pcieutil check',
             # 'sudo psuutil *',
             # 'sudo sfputil show *',
             'sudo ip netns identify 1',
@@ -94,6 +93,10 @@ def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, cre
             'sudo ipintutil -n asic0 -d all',
             'sudo ipintutil -n asic0 -d all -a ipv6',
         ]
+
+    # pcieutil may not be available in 201911
+    if '201911' not in duthost.os_version:
+        commands_direct += ['sudo pcieutil check']
 
     # Run as readonly use the commands allowed indirectly based on sudoers file
     commands_indirect = [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Update the tacacs/test_ro_user test in order to work on SONiC 201911

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test fails for 201911 when it attempts to execute a command not available in that version - `pcieutil `
#### How did you do it?
Checked availability of CLI commands test uses on 201911, excluded `pcieutil`
#### How did you verify/test it?
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library tacacs/test_ro_user.py
#### Any platform specific information?
SONiC Software Version: SONiC.201911.231-dirty-20210225.063935
Distribution: Debian 9.13
Kernel: 4.9.0-14-2-amd64
Build commit: 5822b42f
Build date: Thu Feb 25 06:46:05 UTC 2021
Platform: x86_64-arista_7170_32cd
HwSKU: Arista
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
