### PR TITLE
Added recover_method param for sanity_check

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -161,6 +161,9 @@ def sanity_check(localhost, duthosts, request, fanouthosts, tbinfo):
     if request.config.option.allow_recover:
         allow_recover = True
 
+    if request.config.option.recover_method:
+        recover_method = request.config.getoption("--recover_method")
+
     if request.config.option.post_check:
         post_check = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,8 @@ def pytest_addoption(parser):
                      help="Perform post test sanity check if sanity check is enabled")
     parser.addoption("--post_check_items", action="store", default=False,
                      help="Change (add|remove) post test check items based on pre test check items")
+    parser.addoption("--recover_method", action="store", default="adaptive",
+                     help="Set method to use for recover if sanity failed")
 
     ########################
     #   pre-test options   #


### PR DESCRIPTION
User can specify recovery type after sanity check failed.

Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
By default if an engineer specified `--allow_recover` option when run TC ` recovery_type = "adaptive"`
This PR allows engineer use predefined recover type. 
#### How did you do it?
Added option to conftest and if statement into sanity_check __init__ file.
#### How did you verify/test it?
Run bgp_facts TC with/without new option.
`pytest bgp/test_bgp_facts --allow_recover` - TC use default "adaptive" method for recovery TB
`pytest bgp/test_bgp_facts --allow_recover --recovery_type=reboot` - TC use "reboot" method for recovery TB
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
