### PR TITLE
[pytest common] Make backend portchannel check more robust

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -231,6 +231,20 @@ class SonicAsic(object):
             return False
         return True
 
+    def is_backend_portchannel(self, port_channel):
+        mg_facts = self.sonichost.minigraph_facts(
+            host = self.sonichost.hostname
+        )['ansible_facts']
+        if port_channel in mg_facts["minigraph_portchannels"]:
+            port_name = next(
+                iter(
+                    mg_facts["minigraph_portchannels"][port_channel]["members"]
+                )
+            )
+            if "BP" not in port_name:
+                return False
+        return True
+
     def get_active_ip_interfaces(self):
         """
         Return a dict of active IP (Ethernet or PortChannel) interfaces, with
@@ -243,7 +257,7 @@ class SonicAsic(object):
         ip_ifaces = {}
         for k,v in ip_ifs["ip_interfaces"].items():
             if (k.startswith("Ethernet") or
-                (k.startswith("PortChannel") and k.find("400") == -1)
+                (k.startswith("PortChannel") and not self.is_backend_portchannel(k))
             ):
                 if (v["admin"] == "up" and v["oper_state"] == "up" and
                         self.ping_v4(v["peer_ipv4"])

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -241,7 +241,7 @@ class SonicAsic(object):
                     mg_facts["minigraph_portchannels"][port_channel]["members"]
                 )
             )
-            if "BP" not in port_name:
+            if "Ethernet-BP" not in port_name:
                 return False
         return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Make backend portchannel check more robust. Instead of relying on port channel interface name, rely on it's member interface name.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make backend portchannel check more robust.

#### How did you do it?
Instead of relying on port channel interface name, rely on it's member interface name.

#### How did you verify/test it?
Manual unit test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
