### PR TITLE
[tacacs] Check if commands exist on the device before attempting to run them

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -17,6 +17,21 @@ def ssh_remote_run(localhost, remote_ip, username, password, cmd):
     return res
 
 
+def does_command_exist(localhost, remote_ip, username, password, command):
+    usr_find_cmd = "find /usr -name {}".format(command)
+    usr_result = ssh_remote_run(localhost, remote_ip, username, password, usr_find_cmd)
+
+    bin_find_cmd = "find /bin -name {}".format(command)
+    bin_result = ssh_remote_run(localhost, remote_ip, username, password, bin_find_cmd)
+
+    if usr_result["rc"] != 0:
+        logger.warning('unexpected rc={} from "{}"'.format(usr_result["rc"], usr_find_cmd))
+
+    if bin_result["rc"] != 0:
+        logger.warning('unexpected rc={} from "{}"'.format(bin_result["rc"], bin_find_cmd))
+
+    return len(usr_result["stdout_lines"]) > 0 or len(bin_result["stdout_lines"]) > 0
+
 def ssh_remote_allow_run(localhost, remote_ip, username, password, cmd):
     res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
     # Verify that the command is allowed
@@ -56,59 +71,56 @@ def test_ro_user_ipv6(localhost, duthosts, rand_one_dut_hostname, creds, test_ta
 
 def test_ro_user_allowed_command(localhost, duthosts, rand_one_dut_hostname, creds, test_tacacs):
     duthost = duthosts[rand_one_dut_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    dutip = duthost.host.options["inventory_manager"].get_host(duthost.hostname).vars["ansible_host"]
 
-    # Run as readonly use the commands allowed by sudoers file
-    # TODO: some commands need further preparation, will enable when runable directly
-    # TODO: `tail -F` will not exit, not posssible to test here
-    # Note: the quagga command could only run on image with quagga
-    commands_direct = [
-            'sudo cat /var/log/syslog',
-            'sudo cat /var/log/syslog.1',
-            'sudo cat /var/log/syslog.2.gz',
-            'sudo brctl show',
-            'sudo docker exec snmp cat /etc/snmp/snmpd.conf',
-            # 'sudo docker exec bgp cat /etc/quagga/bgpd.conf',
+    # Run as RO and use the commands allowed by the sudoers file
+    commands = {
+        "cat": ["sudo cat /var/log/syslog", "sudo cat /var/log/syslog.1", "sudo cat /var/log/syslog.2.gz"],
+        "brctl": ["sudo brctl show"],
+        "docker": [
+            "sudo docker exec snmp cat /etc/snmp/snmpd.conf",
             'sudo docker images --format "table {% raw %}{{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}{% endraw %}"',
-            'sudo docker ps',
-            'sudo docker ps -a',
-            'sudo lldpctl',
-            # 'sudo sensors',
-            # 'sudo tail -F /var/log/syslog',
-            '"sudo vtysh -c \'show ip bgp su\'"',
-            '"sudo vtysh -n 0 -c \'show ip bgp su\'"',
-            'sudo decode-syseeprom',
-            'sudo generate_dump -s "5 secs ago"',
-            'sudo lldpshow',
-            'sudo pcieutil check',
-            # 'sudo psuutil *',
-            # 'sudo sfputil show *',
-            'sudo ip netns identify 1',
-    ]
+            "sudo docker ps",
+            "sudo docker ps -a",
+        ],
+        "lldpctl": ["sudo lldpctl"],
+        "vtysh": ['sudo vtysh -c "show ip bgp su"', 'sudo vtysh -n 0 -c "show ip bgp su"'],
+        "decode-syseeprom": ["sudo decode-syseeprom"],
+        "generate_dump": ['sudo generate_dump -s "5 secs ago"'],
+        "lldpshow": ["sudo lldpshow"],
+        "pcieutil": ["sudo pcieutil check"],
+        "ip": ["sudo ip netns identify 1"],
+        "ipintutil": [
+            "sudo ipintutil",
+            "sudo ipintutil -a ipv6",
+            "sudo ipintutil -n asic0 -d all",
+            "sudo ipintutil -n asic0 -d all -a ipv6",
+        ],
+        "show": [
+            "show version",
+            "show interface status",
+            "show interface portchannel",
+            "show ip bgp summary",
+            "show ip interface",
+            "show ipv6 interface",
+            "show lldp table",
+        ],
+    }
 
-    # Some newer commands may not be available in 201911 or 202012
-    if not any(version in duthost.os_version for version in ("201911", "202012")):
-        commands_direct += [
-            'sudo ipintutil',
-            'sudo ipintutil -a ipv6',
-            'sudo ipintutil -n asic0 -d all',
-            'sudo ipintutil -n asic0 -d all -a ipv6',
-        ]
+    # NOTE: `sudo tail -F /var/log/syslog` will not exit, not posssible to test here
+    # NOTE: `sudo docker exec bgp cat /etc/quagga/bgpd.conf` can only run on image with quagga
+    # TODO: some commands need further preparation, will enable when runable directly:
+    # sudo sensors
+    # sudo psuutil *
+    # sudo sfputil show
 
-    # Run as readonly use the commands allowed indirectly based on sudoers file
-    commands_indirect = [
-            'show version',
-            'show interface status',
-            'show interface portchannel',
-            'show ip bgp summary',
-            'show ip interface',
-            'show ipv6 interface',
-            'show lldp table',
-    ]
-
-    for command in commands_direct + commands_indirect:
-        allowed = ssh_remote_allow_run(localhost, dutip, creds['tacacs_ro_user'], creds['tacacs_ro_user_passwd'], command)
-        pytest_assert(allowed, "command '{}' not authorized".format(command))
+    for command in commands:
+        if does_command_exist(localhost, dutip, creds['tacacs_ro_user'], creds['tacacs_ro_user_passwd'], command):
+            for subcommand in commands[command]:
+                allowed = ssh_remote_allow_run(localhost, dutip, creds['tacacs_ro_user'], creds['tacacs_ro_user_passwd'], subcommand)
+                pytest_assert(allowed, "command '{}' not authorized".format(subcommand))
+        else:
+            logger.info('"{}" not found on DUT, skipping...'.format(command))
 
     dash_allowed = ssh_remote_allow_run(localhost, dutip, creds['tacacs_ro_user'], creds['tacacs_ro_user_passwd'], 'sudo sonic-installer list')
     if not dash_allowed:


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We tried adding a version check to avoid running commands that don't exist in older versions, however this check is not helpful on PR builds b/c the version string doesn't clearly indicate 201911 v. 202012 v. some other version. So, we need a smarter check.

#### How did you do it?
We can use the `find` command in `Linux` to see if the desired command even exists before attempting to run it. Everything should be under `usr` or `bin`, so if find comes up empty we know that attempting to run it will cause problems.

#### How did you verify/test it?
Re-ran the tests locally against DUTs running 201911 and 202012.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
