### PR TITLE
[dualtor] TOR BGP failure testcases

### DIFF
--- a/tests/dualtor/test_tor_bgp_failure.py
+++ b/tests/dualtor/test_tor_bgp_failure.py
@@ -1,0 +1,110 @@
+import pytest
+
+from tests.common.dualtor.control_plane_utils import verify_tor_states
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor, toggle_all_simulator_ports_to_lower_tor         # lgtm[py/unused-import] 
+from tests.common.dualtor.tor_failure_utils import shutdown_tor_bgp                                                                             # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+'''
+Below cases are out of scope:
+Case: T1 -> Standby ToR -> Server (Standby ToR BGP Down)
+Out of scope: taking down the standby ToR's BGP sessions means the T1 will never send traffic to that ToR
+Case: T1 -> Active ToR -> Server (Active ToR BGP Down)
+Out of scope: taking down the active ToR's BGP sessions means the T1 will never send traffic to that ToR
+
+Remaining cases for bgp shutdown are defined in this module.
+'''
+
+def test_active_tor_shutdown_bgp_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp):
+    '''
+    Case: Server -> ToR -> T1 (Active ToR BGP Down)
+    Action: Shutdown all BGP sessions on the active ToR
+    Expectation:
+        Verify packet flow after the active ToR (A) loses BGP sessions
+        ToR A DBs indicate standby, ToR B DBs indicate active
+        T1 switch receives packet from the new active ToR (B) and not the new standby ToR (A)
+        Verify traffic interruption < 1 second
+    '''
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=lambda: shutdown_tor_bgp(upper_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
+
+
+def test_standby_tor_shutdown_bgp_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp):
+    '''
+    Case: Server -> ToR -> T1 (Standby ToR BGP Down)
+    Action: Shutdown all BGP sessions on the standby ToR
+    Expectation:
+        Verify packet flow after the standby ToR (B) loses BGP sessions
+        ToR A DBs indicate active, ToR B DBs indicate standby
+        T1 switch receives packet from the active ToR (A), and not the standby ToR (B)
+    '''
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True,
+        action=lambda: shutdown_tor_bgp(lower_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
+
+
+def test_standby_tor_shutdown_bgp_downstream_active(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp,
+    tunnel_traffic_monitor):
+    '''
+    Case: T1 -> Active ToR -> Server (Standby ToR BGP Down)
+    Action: Shutdown all BGP sessions on the standby ToR
+    Expectation:
+        Verify packet flow after the standby ToR (B) loses BGP sessions
+        T1 switch receives no IP-in-IP packet; server receives packet
+    '''
+    with tunnel_traffic_monitor(lower_tor_host, existing=False):
+        send_t1_to_server_with_action(
+            upper_tor_host, verify=True,
+            action=lambda: shutdown_tor_bgp(lower_tor_host)
+        )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
+
+
+def test_active_tor_shutdown_bgp_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp,
+    tunnel_traffic_monitor):
+    '''
+    Case: T1 -> Standby ToR -> Server (Active ToR BGP Down)
+    Action: Shutdown all BGP sessions on the active ToR
+    Expectation:
+        Verify packet flow after the active ToR (A) loses BGP sessions
+        T1 switch receives no IP-in-IP packet; server receives packet;
+        verify traffic interruption is < 1 second
+    '''
+    with tunnel_traffic_monitor(lower_tor_host, existing=False):
+        send_t1_to_server_with_action(
+            lower_tor_host, verify=True, delay=1,
+            action=lambda: shutdown_tor_bgp(upper_tor_host)
+        )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Dual TOR BGP failure testcases

Fixes: https://github.com/Azure/sonic-mgmt/issues/2767
Fixes: https://github.com/Azure/sonic-mgmt/issues/2768

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
New testcases to verify dualtor operation during bgp shutdown on active/standby

#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
1. `dualtor/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_upstream `
FAILED (switchover did not happen when bgp sessions were cleared on activetor)

```
21:34:28 INFO data_plane_utils.py:generate_test_report:51: Traffic summary:
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.2, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.3, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.4, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.5, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.6, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.7, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.8, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.9, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.10, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.11, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.12, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.13, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.14, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.15, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.16, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.17, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.18, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.19, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.20, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.21, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.22, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.23, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.24, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.25, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:34:28 INFO control_plane_utils.py:expect_db_values:71: Verifying APP_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-09: expected state = active, expected health = None
FAILED  
```

2. `dualtor/test_tor_bgp_failure.py::test_standby_tor_shutdown_bgp_upstream `
```
21:44:39 INFO data_plane_utils.py:generate_test_report:51: Traffic summary:
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.2, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.3, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.4, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.5, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.6, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.7, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.8, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.9, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.10, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.11, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.12, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.13, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.14, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.15, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.16, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.17, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.18, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.19, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.20, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.21, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.22, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.23, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.24, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.25, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:44:39 INFO control_plane_utils.py:expect_db_values:71: Verifying APP_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-08: expected state = active, expected health = None
21:44:44 INFO control_plane_utils.py:expect_db_values:71: Verifying STATE_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-08: expected state = active, expected health = healthy
21:44:48 INFO control_plane_utils.py:expect_db_values:71: Verifying APP_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-09: expected state = standby, expected health = None
21:44:52 INFO control_plane_utils.py:expect_db_values:71: Verifying STATE_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-09: expected state = standby, expected health = healthy
PASSED
```

3. `dualtor/test_tor_bgp_failure.py::test_standby_tor_shutdown_bgp_downstream_active `
```
21:53:47 INFO data_plane_utils.py:generate_test_report:51: Traffic summary:
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.2, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.3, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.4, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.5, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.6, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.7, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.8, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.9, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.10, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.11, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.12, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.13, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.14, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.15, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.16, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.17, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.18, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.19, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.20, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.21, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.22, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.23, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.24, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO data_plane_utils.py:generate_test_report:69: Server 192.168.0.25, stats: {'received': 1500, 'sent': 1500, 'duplicated': 0}, disruptions count: 0
21:53:47 INFO control_plane_utils.py:expect_db_values:71: Verifying APP_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-08: expected state = active, expected health = None
21:53:51 INFO control_plane_utils.py:expect_db_values:71: Verifying STATE_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-08: expected state = active, expected health = healthy
21:53:55 INFO control_plane_utils.py:expect_db_values:71: Verifying APP_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-09: expected state = standby, expected health = None
21:53:59 INFO control_plane_utils.py:expect_db_values:71: Verifying STATE_DB values on <MultiAsicSonicHost> str2-7050cx3-acs-09: expected state = standby, expected health = healthy
PASSED    
```

4. `dualtor/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_downstream_standby `
FAILED - several packets lost, disruptions. Validation in progress.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
