### PR TITLE
Fixed test test_bgp_update_timer for t0 topo

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -230,8 +230,17 @@ def constants(is_quagga, setup_interfaces):
         )
     return _constants
 
+# disable Dynamic neighbors for the test to let in configure neighbors byself
+@pytest.fixture
+def turn_off_on_dynamic_neighbor_feature(duthost, tbinfo):
+    if tbinfo["topo"]["type"] == "t0":
+        duthost.shell("vtysh -c 'configure' -c 'router bgp' -c 'neighbor BGPVac shutdown'")
+        yield
+        duthost.shell("vtysh -c 'configure' -c 'router bgp' -c 'no neighbor BGPVac shutdown'")
+    else:
+        yield
 
-def test_bgp_update_timer(common_setup_teardown, constants, duthost):
+def test_bgp_update_timer(common_setup_teardown, constants, duthost, turn_off_on_dynamic_neighbor_feature):
 
     def bgp_update_packets(pcap_file):
         """Get bgp update packets from pcap file."""


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Fixed test_bgp_update_timer for t0 topo

Test fails with:
```
assert n0.ip in bgp_facts["bgp_neighbors"]
AttributeError: 'module' object has no attribute 'locals'
```

The test creates 2 pseudoswitches with IPs took from subnet of Vlan1000, so their IPs are 192.168.0.2 and 192.168.0.3. When the test puts config on DUT to setup those switches as neighbors, it may fail since DUT has peer-group BGPVac with IP 192.168.0.0/21, so at the moment the test configures neighbors on DUT they'are already being configured as dynamic neighbors. Corresponding syslog entries appear after some time test puts config to DUT's DB:

```
... Operation not allowed on a dynamic neighbor#012', stderr: 'line 86: Failure to communicate[13] to bgpd, line:   neighbor 192.168.0.2 remote-as 61000 ...
```

 In the end DUT is left with neighbors not configured since the test fails to configure them because of auto-config attemps, but auto-config attempts fail in turn because the test does not rely on it and sets ASNs for pseudoswitches different than BGPVac expects.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Update the test in order to work properly
#### How did you do it?
Disabled Dynamic neighboors feature before test and enabled afterwards

#### How did you verify/test it?
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library bgp/test_bgp_update_timer.py
#### Any platform specific information?
SONiC Software Version: SONiC.201911.231-dirty-20210225.063935
Distribution: Debian 9.13
Kernel: 4.9.0-14-2-amd64
Build commit: 5822b42f
Build date: Thu Feb 25 06:46:05 UTC 2021
Platform: x86_64-arista_7170_32cd
HwSKU: Arista
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
