### PR TITLE
[Sub-ports] Added test case which validates that packets are routed between sub-ports

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -79,7 +79,7 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
         # but name of LAG port should have prefix 'PortChannel' and suffix
         # '<0-9999>' on SONiC. So max length of LAG port suffix have be 3 characters
         # For example: 'PortChannel1.99'
-        if request.param == 'port_in_lag':
+        if 'port_in_lag' in request.param:
             max_numbers_of_sub_ports = max_numbers_of_sub_ports if max_numbers_of_sub_ports <= 99 else 99
             vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
             vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -1,6 +1,7 @@
 import os
 import ipaddress
 import time
+import random
 import jinja2
 
 import pytest
@@ -16,6 +17,11 @@ from sub_ports_helpers import remove_member_from_vlan
 from sub_ports_helpers import get_port
 from sub_ports_helpers import remove_sub_port
 from sub_ports_helpers import remove_lag_port
+from sub_ports_helpers import add_port_to_namespace
+from sub_ports_helpers import add_static_route
+from sub_ports_helpers import remove_namespace
+from sub_ports_helpers import remove_static_route
+from sub_ports_helpers import get_ptf_port_list
 
 
 def pytest_addoption(parser):
@@ -59,8 +65,8 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
     """
     sub_ports_config = {}
     max_numbers_of_sub_ports = request.config.getoption("--max_numbers_of_sub_ports")
-    vlan_ranges_dut = range(10, 30, 10)
-    vlan_ranges_ptf = range(10, 30, 10)
+    vlan_ranges_dut = range(10, 50, 10)
+    vlan_ranges_ptf = range(10, 50, 10)
 
     if 'invalid' in request.node.name:
         vlan_ranges_ptf = range(11, 31, 10)
@@ -117,7 +123,7 @@ def apply_config_on_the_dut(define_sub_ports_configuration, duthost, reload_dut_
         Dictonary of parameters for configuration DUT and PTF host
     """
     sub_ports_vars = {
-        'sub_ports': define_sub_ports_configuration['sub_ports'],
+        'sub_ports': define_sub_ports_configuration['sub_ports']
     }
 
     parent_port_list = [sub_port.split('.')[0] for sub_port in define_sub_ports_configuration['sub_ports'].keys()]
@@ -132,9 +138,8 @@ def apply_config_on_the_dut(define_sub_ports_configuration, duthost, reload_dut_
     duthost.copy(content=config_template.render(sub_ports_vars), dest=sub_ports_config_path)
     duthost.command('sonic-cfggen -j {} --write-to-db'.format(sub_ports_config_path))
 
-    for sub_port in sub_ports_vars['sub_ports']:
-        py_assert(wait_until(3, 1, check_sub_port, duthost, sub_port),
-                  "Sub-port {} was not created".format(sub_port))
+    py_assert(wait_until(3, 1, check_sub_port, duthost, sub_ports_vars['sub_ports'].keys()),
+              "Some sub-ports were not created")
 
     yield sub_ports_vars
 
@@ -158,6 +163,70 @@ def apply_config_on_the_ptf(define_sub_ports_configuration, ptfhost, reload_ptf_
         ptfhost.shell("ip link set {} up".format(sub_port_info['neighbor_port']))
 
 
+@pytest.fixture(params=['same', 'different'])
+def apply_route_config(request, define_sub_ports_configuration, apply_config_on_the_dut, apply_config_on_the_ptf, ptfhost):
+    """
+    Apply route configuration on the PTF and remove after tests
+
+    Args:
+        define_sub_ports_configuration: Dictonary of parameters for configuration DUT
+        apply_config_on_the_dut: fixture for applying sub-ports configuration on the DUT
+        apply_config_on_the_ptf: fixture for applying sub-ports configuration on the PTF
+        ptfhost: PTF host object
+
+    Yields:
+        Dictonary of parameters for configuration DUT and PTF host
+    """
+    new_sub_ports = {}
+    sub_ports = define_sub_ports_configuration['sub_ports']
+    dut_ports = define_sub_ports_configuration['dut_ports']
+    sub_ports_keys = sub_ports.copy()
+
+    for port in dut_ports.values():
+        if 'same' in request.param:
+            sub_ports_on_port = random.sample([sub_port for sub_port in sub_ports_keys if port + '.' in sub_port], 2)
+        else:
+            sub_ports_on_port = [
+                random.choice([sub_port for sub_port in sub_ports_keys if port + '.' in sub_port]),
+                random.choice([sub_port for sub_port in sub_ports_keys if port + '.' not in sub_port])
+            ]
+            for sub_port in sub_ports_on_port:
+                sub_ports_keys.pop(sub_port)
+
+        src_port = sub_ports_on_port.pop(0)
+        new_sub_ports[src_port] = []
+        src_port_network = ipaddress.ip_network(unicode(sub_ports[src_port]['ip']), strict=False)
+
+        for next_hop_sub_port in sub_ports_on_port:
+            name_of_namespace = 'vnet_for_{}'.format(next_hop_sub_port)
+            dst_port_network = ipaddress.ip_network(unicode(sub_ports[next_hop_sub_port]['neighbor_ip']), strict=False)
+
+            add_port_to_namespace(ptfhost,
+                                  name_of_namespace,
+                                  sub_ports[next_hop_sub_port]['neighbor_port'],
+                                  sub_ports[next_hop_sub_port]['neighbor_ip'])
+
+            add_static_route(ptfhost, src_port_network, sub_ports[next_hop_sub_port]['ip'], name_of_namespace)
+            add_static_route(ptfhost, dst_port_network, sub_ports[src_port]['ip'])
+
+            new_sub_ports[src_port].append((next_hop_sub_port, name_of_namespace))
+
+    yield {
+        'new_sub_ports': new_sub_ports,
+        'sub_ports': sub_ports
+    }
+
+    for src_port, next_hop_sub_ports in new_sub_ports.items():
+        src_port_network = ipaddress.ip_network(unicode(sub_ports[src_port]['ip']), strict=False)
+
+        for next_hop_sub_port in next_hop_sub_ports:
+            sub_port, name_of_namespace = next_hop_sub_port
+            dst_port_network = ipaddress.ip_network(unicode(sub_ports[sub_port]['ip']), strict=False)
+            remove_static_route(ptfhost, src_port_network, sub_ports[sub_port]['ip'], name_of_namespace)
+            remove_static_route(ptfhost, dst_port_network, sub_ports[src_port]['ip'])
+            remove_namespace(ptfhost, name_of_namespace)
+
+
 @pytest.fixture
 def reload_dut_config(request, duthost, define_sub_ports_configuration):
     """
@@ -175,6 +244,8 @@ def reload_dut_config(request, duthost, define_sub_ports_configuration):
 
     for sub_port, sub_port_info in sub_ports.items():
         remove_sub_port(duthost, sub_port, sub_port_info['ip'])
+
+    py_assert(check_sub_port(duthost, sub_ports.keys(), True), "Some sub-port were not deleted")
 
     if 'port_in_lag' in request.node.name:
         for lag_port in dut_ports.values():
@@ -194,19 +265,23 @@ def reload_ptf_config(request, ptfhost, define_sub_ports_configuration):
         define_sub_ports_configuration: Dictonary of parameters for configuration DUT
     """
     yield
+
     sub_ports = define_sub_ports_configuration['sub_ports']
+    ptf_port_list = get_ptf_port_list(ptfhost)
 
     for sub_port_info in sub_ports.values():
-        ptfhost.shell("ip address del {} dev {}".format(sub_port_info['neighbor_ip'], sub_port_info['neighbor_port']))
-        ptfhost.shell("ip link del {}".format(sub_port_info['neighbor_port']))
+        if sub_port_info['neighbor_port'] in ptf_port_list:
+            ptfhost.shell("ip address del {} dev {}".format(sub_port_info['neighbor_ip'], sub_port_info['neighbor_port']))
+            ptfhost.shell("ip link del {}".format(sub_port_info['neighbor_port']))
 
     if 'port_in_lag' in request.node.name:
         ptf_ports = define_sub_ports_configuration['ptf_ports']
         for bond_port, port_name in ptf_ports.items():
-            ptfhost.shell("ip link set {} nomaster".format(bond_port))
-            ptfhost.shell("ip link set {} nomaster".format(port_name))
-            ptfhost.shell("ip link set {} up".format(port_name))
-            ptfhost.shell("ip link del {}".format(bond_port))
+            if bond_port in ptf_port_list:
+                ptfhost.shell("ip link set {} nomaster".format(bond_port))
+                ptfhost.shell("ip link set {} nomaster".format(port_name))
+                ptfhost.shell("ip link set {} up".format(port_name))
+                ptfhost.shell("ip link del {}".format(bond_port))
 
     ptfhost.shell("supervisorctl restart ptf_nn_agent")
     time.sleep(5)

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -236,10 +236,13 @@ def check_sub_port(duthost, sub_port, removed=False):
     """
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     sub_ports = set(config_facts.get('VLAN_SUB_INTERFACE', {}).keys())
-    if removed:
-        return sub_port not in sub_ports
+    if not isinstance(sub_port, list):
+        sub_port = [sub_port]
 
-    return sub_port in sub_ports
+    if removed:
+        return sub_ports.isdisjoint(set(sub_port))
+
+    return sub_ports.issuperset(set(sub_port))
 
 
 def get_mac_dut(duthost, interface):
@@ -339,6 +342,59 @@ def create_bond_port(ptfhost, ptf_ports):
     return bond_port_map
 
 
+def add_port_to_namespace(ptfhost, name_of_namespace, port_name, port_ip):
+    """
+    Add port to namespace of the PTF
+
+    Args:
+        ptfhost: PTF host object
+        name_of_namespace: Name of namespace
+        port_name: Port of the PTF
+        port_ip: IP address of the port
+    """
+    if not check_namespace(ptfhost, name_of_namespace):
+        ptfhost.shell('ip netns add {}'.format(name_of_namespace))
+        ptfhost.shell('ip -n {} link set lo up'.format(name_of_namespace))
+
+    ptfhost.shell('ip link set {} netns {}'.format(port_name, name_of_namespace))
+    ptfhost.shell('ip -n {} addr add {} dev {}'.format(name_of_namespace, port_ip, port_name))
+    ptfhost.shell('ip -n {} link set {} up'.format(name_of_namespace, port_name))
+
+
+def add_static_route(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
+    """
+    Add static route on the PTF
+
+    Args:
+        ptfhost: PTF host object
+        network_ip: Network IP address
+        next_hop_ip: Next hop IP address
+        name_of_namespace: Name of namespace
+    """
+    next_hop_ip = next_hop_ip.split('/')[0]
+    if name_of_namespace:
+        ptfhost.shell('ip netns exec {} ip route add {} nexthop via {}'
+                      .format(name_of_namespace, network_ip, next_hop_ip))
+    else:
+        ptfhost.shell('ip route add {} nexthop via {}'
+                      .format(network_ip, next_hop_ip))
+
+
+def check_namespace(ptfhost, name_of_namespace):
+    """
+    Check that namespace is available on the PTF
+
+    Args:
+        ptfhost: PTF host object
+        name_of_namespace: Name of namespace
+
+    Returns:
+        Bool value which confirm availability of namespace on the PTF
+    """
+    out = ptfhost.shell('ip netns list')["stdout"]
+    return name_of_namespace in out
+
+
 def get_port(duthost, ptfhost, interface_ranges, port_type):
     """
     Get port configurations from DUT and PTF
@@ -347,6 +403,7 @@ def get_port(duthost, ptfhost, interface_ranges, port_type):
         duthost: DUT host object
         ptfhost: PTF host object
         interface_ranges: numbers of ports
+        port_type: Type of port
 
     Returns:
         Tuple with port configurations of DUT and PTF
@@ -357,7 +414,7 @@ def get_port(duthost, ptfhost, interface_ranges, port_type):
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
     ptf_ports = {port_id: ptf_ports_available_in_topo[port_id] for port_id in interface_ranges}
 
-    if port_type == 'port_in_lag':
+    if 'port_in_lag' in port_type:
         lag_port_map = create_lag_port(duthost, config_port_indices)
         bond_port_map = create_bond_port(ptfhost, ptf_ports)
 
@@ -373,11 +430,10 @@ def remove_sub_port(duthost, sub_port, ip):
     Args:
         duthost: DUT host object
         sub_port: Sub-port name
-        interface: Interface of DUT
+        ip: IP address of port
     """
     duthost.shell('config interface ip remove {} {}'.format(sub_port, ip))
     duthost.shell('redis-cli -n 4 del "VLAN_SUB_INTERFACE|{}"'.format(sub_port))
-    pytest_assert(check_sub_port(duthost, sub_port, True), "Sub-port {} was not deleted".format(sub_port))
 
 
 def remove_lag_port(duthost, cfg_facts, lag_port):
@@ -407,3 +463,49 @@ def remove_ip_from_port(duthost, port):
     if ip_addresses:
         for ip in ip_addresses:
             duthost.shell('config interface ip remove {} {}'.format(port, ip))
+
+
+def remove_namespace(ptfhost, name_of_namespace):
+    """
+    Remove namespace from the PTF
+
+    Args:
+        ptfhost: PTF host object
+        name_of_namespace: Name of namespace
+    """
+    if check_namespace(ptfhost, name_of_namespace):
+        ptfhost.shell('ip -n {} link set lo down'.format(name_of_namespace))
+        ptfhost.shell('ip netns del {}'.format(name_of_namespace))
+
+
+def remove_static_route(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
+    """
+    Remove static route from the PTF
+
+    Args:
+        ptfhost: PTF host object
+        network_ip: Network IP address
+        next_hop_ip: Next hop IP address
+        name_of_namespace: Name of namespace
+    """
+    next_hop_ip = next_hop_ip.split('/')[0]
+    if name_of_namespace:
+        ptfhost.shell('ip netns exec {} ip route del {} nexthop via {}'
+                      .format(name_of_namespace, network_ip, next_hop_ip))
+    else:
+        ptfhost.shell('ip route del {} nexthop via {}'
+                      .format(network_ip, next_hop_ip))
+
+
+def get_ptf_port_list(ptfhost):
+    """
+    Get list of ports of the PTF
+
+    Args:
+        ptfhost: PTF host object
+
+    Returns:
+        List with ports available on the PTF
+    """
+    out = ptfhost.shell("ls /sys/class/net")['stdout']
+    return out.split('\n')


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Added new sub-ports tests: [test_routing_between_sub_ports](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/32128a30c0b2728689a1350b354e59b783de006b/tests/sub_port_interfaces/test_sub_port_interfaces.py#L233-L268)
- Added fixture for setup route between port and port in namespace on the PTF: [apply_route_config](https://github.com/Azure/sonic-mgmt/compare/master...OleksandrKozodoi:add_routing_sub_ports_test_cases?expand=1#diff-c1a46395dc2a8ee7f7114c4a63ebc73394fbc59df9ea692c17350bc55b3ac090R166-R227)
- Added new helpers methods
- Changed approach to removing ports from the PTF
- Updated Test Plan
#### Note:
Tests verifies two cases of routing between sub-ports:
1) Routing between sub-ports on the same port
2) Routing between sub-ports on the different ports

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Coverage of sub-ports feature by test cases to improve the quality of SONiC.
#### How did you do it?
Added new test cases to PyTest.
Implementation is based on the [Sub-ports design spec](https://github.com/Azure/SONiC/blob/master/doc/subport/sonic-sub-port-intf-hld.md)
#### How did you verify/test it?
`py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library sub_port_interfaces`
#### Any platform specific information?
SONiC Software Version: SONiC.master.152-dirty-20210317.033059
Distribution: Debian 10.8
Kernel: 4.19.0-12-2-amd64
Build commit: 43d4d456
Build date: Wed Mar 17 14:05:52 UTC 2021
Platform: x86_64-accton_as9516_32d-r0
HwSKU: newport
ASIC: barefoot
#### Supported testbed topology if it's a new test case?
T0, T1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
