### PR TITLE
[dualtor]: Add link down test cases

### DIFF
--- a/tests/dualtor/test_link_failure.py
+++ b/tests/dualtor/test_link_failure.py
@@ -1,0 +1,133 @@
+import pytest 
+
+from tests.common.dualtor.control_plane_utils import verify_tor_states
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, shutdown_fanout_upper_tor_intfs, \
+                                                shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, lower_tor_fanouthosts                   # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor, toggle_all_simulator_ports_to_lower_tor         # lgtm[py/unused-import]
+from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable                                 # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+
+def test_active_link_down_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    shutdown_fanout_upper_tor_intfs
+):
+    """
+    Send traffic from server to T1 and shutdown the active ToR link.
+    Verify switchover and disruption lasts < 1 second
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=shutdown_fanout_upper_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_active_link_down_downstream_active(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    shutdown_fanout_upper_tor_intfs
+):
+    """
+    Send traffic from T1 to active ToR and shutdown the active ToR link.
+    Verify switchover and disruption lasts < 1 second
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=shutdown_fanout_upper_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_active_link_down_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    shutdown_fanout_upper_tor_intfs
+):
+    """
+    Send traffic from T1 to standby ToR and shutdown the active ToR link.
+    Verify switchover and disruption lasts < 1 second
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=1,
+        action=shutdown_fanout_upper_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_standby_link_down_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    shutdown_fanout_lower_tor_intfs
+):
+    """
+    Send traffic from server to T1 and shutdown the standby ToR link.
+    Verify no switchover and no disruption
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=shutdown_fanout_lower_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_standby_link_down_downstream_active(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    shutdown_fanout_lower_tor_intfs
+):
+    """
+    Send traffic from T1 to active ToR and shutdown the standby ToR link.
+    Confirm no switchover and no disruption
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=shutdown_fanout_lower_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_standby_link_down_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    shutdown_fanout_lower_tor_intfs
+):
+    """
+    Send traffic from T1 to standby ToR and shutdwon the standby ToR link.
+    Confirm no switchover and no disruption
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=1,
+        action=shutdown_fanout_lower_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health='unhealthy'
+    )

--- a/tests/dualtor/test_link_failure.py
+++ b/tests/dualtor/test_link_failure.py
@@ -5,7 +5,6 @@ from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action,
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, shutdown_fanout_upper_tor_intfs, \
                                                 shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, lower_tor_fanouthosts                   # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor, toggle_all_simulator_ports_to_lower_tor         # lgtm[py/unused-import]
-from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable                                 # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 
 pytestmark = [
@@ -15,7 +14,7 @@ pytestmark = [
 
 def test_active_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
-    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    toggle_all_simulator_ports_to_upper_tor,
     shutdown_fanout_upper_tor_intfs
 ):
     """
@@ -35,7 +34,7 @@ def test_active_link_down_upstream(
 
 def test_active_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    toggle_all_simulator_ports_to_upper_tor,
     shutdown_fanout_upper_tor_intfs
 ):
     """
@@ -55,7 +54,7 @@ def test_active_link_down_downstream_active(
 
 def test_active_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    toggle_all_simulator_ports_to_upper_tor,
     shutdown_fanout_upper_tor_intfs
 ):
     """
@@ -75,7 +74,7 @@ def test_active_link_down_downstream_standby(
 
 def test_standby_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
-    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    toggle_all_simulator_ports_to_upper_tor,
     shutdown_fanout_lower_tor_intfs
 ):
     """
@@ -95,7 +94,7 @@ def test_standby_link_down_upstream(
 
 def test_standby_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    toggle_all_simulator_ports_to_upper_tor,
     shutdown_fanout_lower_tor_intfs
 ):
     """
@@ -115,7 +114,7 @@ def test_standby_link_down_downstream_active(
 
 def test_standby_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor, reboot_tor,
+    toggle_all_simulator_ports_to_upper_tor,
     shutdown_fanout_lower_tor_intfs
 ):
     """


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Closes #2763 
Closes #2764 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test link down scenarios for dual ToR

#### How did you do it?

For each traffic scenario (upstream, downstream to active, downstream to standby):
- Take down the active ToR fanout link to server
- Take down the standby ToR fanout link to server

#### How did you verify/test it?
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================== test session starts ====================================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, profiling-1.7.0, ansible-2.2.2
collected 6 items

dualtor/test_link_failure.py::test_active_link_down_upstream
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------03:33:59 WARNING dual_tor_io.py:__init__:87: Minimum packet send-interval is .0035s.                 Ignoring user-provided interval None
PASSED                                                                                                                                                                               [ 16%]
dualtor/test_link_failure.py::test_active_link_down_downstream_active
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------03:43:08 WARNING dual_tor_io.py:__init__:87: Minimum packet send-interval is .0035s.                 Ignoring user-provided interval None
FAILED                                                                                                                                                                               [ 33%]
dualtor/test_link_failure.py::test_active_link_down_downstream_standby
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------03:51:59 WARNING dual_tor_io.py:__init__:87: Minimum packet send-interval is .0035s.                 Ignoring user-provided interval None
FAILED                                                                                                                                                                               [ 50%]
dualtor/test_link_failure.py::test_standby_link_down_upstream
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------03:59:57 WARNING dual_tor_io.py:__init__:87: Minimum packet send-interval is .0035s.                 Ignoring user-provided interval None
PASSED                                                                                                                                                                               [ 66%]
dualtor/test_link_failure.py::test_standby_link_down_downstream_active
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------04:09:04 WARNING dual_tor_io.py:__init__:87: Minimum packet send-interval is .0035s.                 Ignoring user-provided interval None
FAILED                                                                                                                                                                               [ 83%]
dualtor/test_link_failure.py::test_standby_link_down_downstream_standby
-------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------04:17:22 WARNING dual_tor_io.py:__init__:87: Minimum packet send-interval is .0035s.                 Ignoring user-provided interval None
FAILED                                                                                                                                                                               [100%]
```

The tests themselves are able to run to completion. The failures are caused by traffic disruption lasting too long (the cause of which is still under investigation).


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Dual ToR topology only

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
