### PR TITLE
[warm-reboot] Fix test to catch reboot errors and verify warmboot finalizer states

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -800,10 +800,10 @@ class ReloadTest(BaseTest):
 
     def get_now_time(self):
         stdout, stderr, _ = self.dut_connection.execCommand('date +"%Y-%m-%d %H:%M:%S"')
-        if stdout == []:
+        if not stdout:
             self.fails['dut'].add('Error collecting current date from DUT: empty value returned')
             raise Exception('Error collecting current date from DUT: empty value returned')
-        if stderr != []:
+        if stderr:
             self.fails['dut'].add("Error collecting current date from DUT: %s" % (str(stderr)))
             raise Exception('Error collecting current date from DUT: empty value returned')
         return datetime.datetime.strptime(stdout[0].strip(), "%Y-%m-%d %H:%M:%S")

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -237,7 +237,6 @@ class ReloadTest(BaseTest):
             self.kvm_test = True
         else:
             self.kvm_test = False
-
         return
 
     def read_json(self, name):
@@ -813,10 +812,12 @@ class ReloadTest(BaseTest):
         self.log('waiting for warmboot-finalizer service to become activating')
         finalizer_state = self.get_warmboot_finalizer_state()
         warm_up_timeout_secs = int(self.test_params['warm_up_timeout_secs'])
+        finalizer_timeout = 60 + self.test_params['reboot_limit_in_seconds']
+
         while finalizer_state != 'activating':
             dut_datetime_after_ssh = self.get_now_time()
             time_passed = float(dut_datetime_after_ssh.strftime("%s")) - float(dut_datetime.strftime("%s"))
-            if time_passed > 90:
+            if time_passed > finalizer_timeout:
                 self.fails['dut'].add('warmboot-finalizer never reached state "activating"')
                 raise TimeoutError
             time.sleep(1)

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -787,6 +787,54 @@ class ReloadTest(BaseTest):
         watcher = self.pool.apply_async(self.reachability_watcher)
         time.sleep(5)
 
+    def get_warmboot_finalizer_state(self):
+        stdout, stderr, _ = self.dut_connection.execCommand('sudo systemctl is-active warmboot-finalizer.service')
+
+        if stdout == []:
+            self.log('Finalizer state not returned from DUT')
+            #self.fails['dut'].add('Error collecting Finalizer state from DUT')
+            return ''
+        if stderr != []:
+            self.fails['dut'].add("stderr from DUT while collecting Finalizer state: %s" % (str(stderr)))
+
+        finalizer_state = stdout[0].strip()
+        return finalizer_state
+
+    def get_now_time(self):
+        stdout, stderr, _ = self.dut_connection.execCommand('date +"%Y-%m-%d %H:%M:%S"')
+        if stdout == []:
+            self.fails['dut'].add('Error collecting current date from DUT: empty value returned')
+        if stderr != []:
+            self.fails['dut'].add("Error collecting current date from DUT: %s" % (str(stderr)))
+        return datetime.datetime.strptime(stdout[0].strip(), "%Y-%m-%d %H:%M:%S")
+
+    def check_warmboot_finalizer(self):
+        dut_datetime = self.get_now_time()
+        self.log('waiting for warmboot-finalizer service to become activating')
+        finalizer_state = self.get_warmboot_finalizer_state()
+        warm_up_timeout_secs = int(self.test_params['warm_up_timeout_secs'])
+        while finalizer_state != 'activating':
+            dut_datetime_after_ssh = self.get_now_time()
+            time_passed = float(dut_datetime_after_ssh.strftime("%s")) - float(dut_datetime.strftime("%s"))
+            if time_passed > 90:
+                self.fails['dut'].add('warmboot-finalizer never reached state "activating"')
+                raise TimeoutError
+            time.sleep(1)
+            finalizer_state = self.get_warmboot_finalizer_state()
+        self.log('waiting for warmboot-finalizer service to finish')
+        finalizer_state = self.get_warmboot_finalizer_state()
+        self.log('warmboot finalizer service state {}'.format(finalizer_state))
+        count = 0
+        while finalizer_state == 'activating':
+            finalizer_state = self.get_warmboot_finalizer_state()
+            self.log('warmboot finalizer service state {}'.format(finalizer_state))
+            time.sleep(10)
+            if count * 10 > warm_up_timeout_secs:
+                self.fails['dut'].add('warmboot-finalizer.service did not finish')
+                raise TimeoutError
+            count += 1
+        self.log('warmboot-finalizer service finished')
+
     def wait_until_reboot(self):
         self.log("Wait until Control plane is down")
         self.timeout(self.wait_until_cpu_port_down, self.task_timeout, "DUT hasn't shutdown in {} seconds".format(self.task_timeout))
@@ -1062,6 +1110,11 @@ class ReloadTest(BaseTest):
             thr.setDaemon(True)
             thr.start()
 
+            if 'warm-reboot' in self.reboot_type:
+                thr = threading.Thread(target=self.check_warmboot_finalizer)
+                thr.setDaemon(True)
+                thr.start()
+
             self.wait_until_reboot()
             if self.kvm_test:
                 self.handle_advanced_reboot_health_check_kvm()
@@ -1125,11 +1178,14 @@ class ReloadTest(BaseTest):
         time.sleep(self.reboot_delay)
 
         self.log("Rebooting remote side")
-        stdout, stderr, return_code = self.dut_connection.execCommand("sudo " + self.reboot_type)
+        stdout, stderr, return_code = self.dut_connection.execCommand("sudo " + self.reboot_type, timeout=30)
         if stdout != []:
             self.log("stdout from %s: %s" % (self.reboot_type, str(stdout)))
         if stderr != []:
             self.log("stderr from %s: %s" % (self.reboot_type, str(stderr)))
+            self.fails['dut'].add("{} failed with error {}".format(self.reboot_type, stderr))
+            thread.interrupt_main()
+            raise Exception("{} failed with error {}".format(self.reboot_type, stderr))
         self.log("return code from %s: %s" % (self.reboot_type, str(return_code)))
 
         # Note: a timeout reboot in ssh session will return a 255 code

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -789,11 +789,10 @@ class ReloadTest(BaseTest):
     def get_warmboot_finalizer_state(self):
         stdout, stderr, _ = self.dut_connection.execCommand('sudo systemctl is-active warmboot-finalizer.service')
 
-        if stdout == []:
+        if not stdout:
             self.log('Finalizer state not returned from DUT')
-            #self.fails['dut'].add('Error collecting Finalizer state from DUT')
             return ''
-        if stderr != []:
+        if stderr:
             self.fails['dut'].add("stderr from DUT while collecting Finalizer state: %s" % (str(stderr)))
 
         finalizer_state = stdout[0].strip()
@@ -803,8 +802,10 @@ class ReloadTest(BaseTest):
         stdout, stderr, _ = self.dut_connection.execCommand('date +"%Y-%m-%d %H:%M:%S"')
         if stdout == []:
             self.fails['dut'].add('Error collecting current date from DUT: empty value returned')
+            raise Exception('Error collecting current date from DUT: empty value returned')
         if stderr != []:
             self.fails['dut'].add("Error collecting current date from DUT: %s" % (str(stderr)))
+            raise Exception('Error collecting current date from DUT: empty value returned')
         return datetime.datetime.strptime(stdout[0].strip(), "%Y-%m-%d %H:%M:%S")
 
     def check_warmboot_finalizer(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The advance warm-reboot test is seen to pass even with failures or when reboot never happened. This change:
1. Increase the paramiko command execution timeout from default (10) to 30. This helps in retaining any errors that might happen during warm/fast reboot.
2. Check warmboot finalizer states. Sometimes, after warmreboot, the finalizer never reaches `activating` state, and this is missed by test.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

The existing issue (false negative) - **The DUT never rebooted: reboot error missed, and test passed**

```
2021-03-18 19:40:05 : Schedule to reboot the remote switch in 10 sec
2021-03-18 19:40:05 : Wait until Control plane is down
2021-03-18 19:40:16 : Rebooting remote side
2021-03-18 19:40:26 : return code from warm-reboot: 255
2021-03-18 19:40:29 : Control plane state transition from up to down
2021-03-18 19:40:29 : Dut reboots: reboot start 2021-03-18 19:40:29.624804
2021-03-18 19:40:29 : Sniffer started at 2021-03-18 19:40:29.628128
2021-03-18 19:40:37 : Control plane state transition from down to up
2021-03-18 19:45:43 : Pcap file dumped to /tmp/capture.pcap
2021-03-18 19:45:43 : Packet flow examine started 0:05:13.803719 after the reboot
2021-03-18 19:48:24 : Gaps in forwarding not found.
```


**Catching finalizer errors**
```
2021-03-19 08:29:58 : Control plane state transition from up to down
2021-03-19 08:29:59 : waiting for warmboot-finalizer service to become activating
2021-03-19 08:30:00 : ==================================================
2021-03-19 08:30:00 : Report:
2021-03-19 08:30:00 : ==================================================
2021-03-19 08:30:00 : LACP/BGP were down for (extracted from cli):
2021-03-19 08:30:00 : --------------------------------------------------
2021-03-19 08:30:00 : --------------------------------------------------
2021-03-19 08:30:00 : Extracted from VM logs:
2021-03-19 08:30:00 : --------------------------------------------------
2021-03-19 08:30:00 : Summary:
2021-03-19 08:30:00 : --------------------------------------------------
2021-03-19 08:30:00 : --------------------------------------------------
2021-03-19 08:30:00 : Fails:
2021-03-19 08:30:00 : --------------------------------------------------
2021-03-19 08:30:00 : FAILED:dut:warmboot-finalizer never reached state "activating"
2021-03-19 08:30:00 : FAILED:dut:
2021-03-19 08:30:00 : ==================================================
```


**Catching warm-reboot errors (eg. RESTARTCHECK failure)**
```
2021-03-19 08:46:35 : Send   100 Received   100 servers->t1
2021-03-19 08:46:37 : Send   500 Received   500 t1->servers
2021-03-19 08:46:38 : Send    10 Received    10 ping DUT
2021-03-19 08:46:38 : Schedule to reboot the remote switch in 10 sec
2021-03-19 08:46:38 : Wait until Control plane is down
2021-03-19 08:46:40 : Send     1 Received     1 arp ping
2021-03-19 08:46:42 : Send   100 Received   100 servers->t1
2021-03-19 08:46:47 : Send   500 Received   500 t1->servers
2021-03-19 08:46:48 : Send    10 Received    10 ping DUT
2021-03-19 08:46:48 : Rebooting remote side
2021-03-19 08:46:49 : Send     1 Received     1 arp ping
2021-03-19 08:46:52 : Send   100 Received   100 servers->t1
2021-03-19 08:46:57 : Send   500 Received   500 t1->servers
2021-03-19 08:46:58 : Send    10 Received    10 ping DUT
2021-03-19 08:46:59 : Send     1 Received     1 arp ping
2021-03-19 08:47:01 : Send   100 Received   100 servers->t1
2021-03-19 08:47:06 : stderr from warm-reboot: [u'RESTARTCHECK failed\n']
2021-03-19 08:47:06 : ==================================================
2021-03-19 08:47:06 : Report:
2021-03-19 08:47:06 : ==================================================
2021-03-19 08:47:06 : LACP/BGP were down for (extracted from cli):
2021-03-19 08:47:06 : --------------------------------------------------
2021-03-19 08:47:06 : --------------------------------------------------
2021-03-19 08:47:06 : Extracted from VM logs:
2021-03-19 08:47:06 : --------------------------------------------------
2021-03-19 08:47:06 : Summary:
2021-03-19 08:47:06 : --------------------------------------------------
2021-03-19 08:47:06 : --------------------------------------------------
2021-03-19 08:47:06 : Fails:
2021-03-19 08:47:06 : --------------------------------------------------
2021-03-19 08:47:06 : FAILED:dut:warm-reboot failed with error [u'RESTARTCHECK failed\n']
2021-03-19 08:47:06 : FAILED:dut:DUT hasn't shutdown in 300 seconds
2021-03-19 08:47:06 : ==================================================


======================================================================
FAIL: advanced-reboot.ReloadTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ptftests/advanced-reboot.py", line 1126, in runTest
    self.handle_post_reboot_test_reports()
  File "ptftests/advanced-reboot.py", line 1095, in handle_post_reboot_test_reports
    self.assertTrue(is_good, errors)
AssertionError: 

Something went wrong. Please check output below:

FAILED:dut:warm-reboot failed with error [u'RESTARTCHECK failed\n']
FAILED:dut:DUT hasn't shutdown in 300 seconds


----------------------------------------------------------------------
Ran 1 test in 104.834s

FAILED (failures=1)
```


**Catching all finalizer states**
```
2021-03-19 18:02:00 : Data plane state transition from partial to up (500)
2021-03-19 18:02:30 : Schedule to reboot the remote switch in 10 sec
2021-03-19 18:02:30 : Wait until Control plane is down
2021-03-19 18:02:30 : waiting for warmboot-finalizer service to become activating
2021-03-19 18:02:40 : Rebooting remote side
2021-03-19 18:03:16 : return code from warm-reboot: 255
2021-03-19 18:03:18 : Control plane state transition from up to down
2021-03-19 18:03:18 : Dut reboots: reboot start 2021-03-19 18:03:18.403867
2021-03-19 18:03:18 : Sniffer started at 2021-03-19 18:03:18.407278
2021-03-19 18:04:05 : waiting for warmboot-finalizer service to finish
2021-03-19 18:04:05 : warmboot finalizer service state activating
2021-03-19 18:04:05 : warmboot finalizer service state activating
2021-03-19 18:04:16 : warmboot finalizer service state activating
2021-03-19 18:04:25 : Control plane state transition from down to up
2021-03-19 18:04:27 : warmboot finalizer service state activating
2021-03-19 18:04:37 : warmboot finalizer service state activating
2021-03-19 18:04:39 : VLAN ARP state transition from up to down
2021-03-19 18:04:47 : warmboot finalizer service state activating
2021-03-19 18:04:59 : warmboot finalizer service state activating
2021-03-19 18:05:02 : VLAN ARP state transition from down to up
2021-03-19 18:05:09 : warmboot finalizer service state activating
2021-03-19 18:05:21 : warmboot finalizer service state activating
2021-03-19 18:05:31 : warmboot finalizer service state activating
2021-03-19 18:05:41 : warmboot finalizer service state activating
2021-03-19 18:05:52 : warmboot finalizer service state activating
2021-03-19 18:06:02 : warmboot finalizer service state activating
2021-03-19 18:06:12 : warmboot finalizer service state activating
2021-03-19 18:06:14 : VLAN ARP state transition from up to down
2021-03-19 18:06:17 : VLAN ARP state transition from down to up
2021-03-19 18:06:19 : VLAN ARP state transition from up to down
2021-03-19 18:06:23 : warmboot finalizer service state activating
2021-03-19 18:06:33 : warmboot finalizer service state activating
2021-03-19 18:06:44 : warmboot finalizer service state activating
2021-03-19 18:06:45 : VLAN ARP state transition from down to up
2021-03-19 18:06:54 : warmboot finalizer service state activating
2021-03-19 18:07:04 : warmboot finalizer service state activating
2021-03-19 18:07:15 : warmboot finalizer service state activating
2021-03-19 18:07:18 : Sniffer has been running for 0:04:00.282754
2021-03-19 18:07:18 : Stopping reachability state watch thread.
2021-03-19 18:07:25 : warmboot finalizer service state activating
2021-03-19 18:07:36 : warmboot finalizer service state activating
2021-03-19 18:07:46 : warmboot finalizer service state activating
2021-03-19 18:07:57 : warmboot finalizer service state activating
2021-03-19 18:08:07 : warmboot finalizer service state activating
2021-03-19 18:08:18 : warmboot finalizer service state activating
2021-03-19 18:08:28 : warmboot finalizer service state activating
2021-03-19 18:08:38 : warmboot finalizer service state activating
2021-03-19 18:08:49 : warmboot finalizer service state activating
2021-03-19 18:08:54 : Pcap file dumped to /tmp/capture.pcap
2021-03-19 18:08:54 : Packet flow examine started 0:05:36.284414 after the reboot
2021-03-19 18:09:00 : warmboot finalizer service state activating
2021-03-19 18:09:11 : warmboot finalizer service state activating
2021-03-19 18:09:22 : warmboot finalizer service state inactive
2021-03-19 18:09:32 : warmboot-finalizer service finished
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
