### PR TITLE
Add tests cont_link_flap, system_health, platform_info, reboot to run on T2 topology for VoQ chassis

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -68,7 +68,7 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
             return False
 
         # Cross check the interface SFP presence status
-        if intf not in xcvr_skip_list:
+        if intf not in xcvr_skip_list[dut.hostname]:
             check_presence_output = dut.command(check_intf_presence_command.format(intf))
             presence_list = check_presence_output["stdout_lines"][2].split()
             assert intf in presence_list, "Wrong interface name in the output: %s" % str(presence_list)

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -45,8 +45,8 @@ def all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
     asichost = dut.asic_instance(asic_index)
     docker_cmd = asichost.get_docker_cmd(cmd, "database")
     db_output = dut.command(docker_cmd)["stdout_lines"]
-    not_detected_interfaces = [intf for intf in interfaces if intf not in xcvr_skip_list[dut.hostname] if
-                               "TRANSCEIVER_INFO|%s" % intf not in db_output]
+    not_detected_interfaces = [intf for intf in interfaces if (intf not in xcvr_skip_list[dut.hostname] and
+                               "TRANSCEIVER_INFO|{}".format(intf) not in db_output)]
     if len(not_detected_interfaces) > 0:
         logging.info("Interfaces not detected: %s" % str(not_detected_interfaces))
         return False

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -45,7 +45,8 @@ def all_transceivers_detected(dut, asic_index, interfaces, xcvr_skip_list):
     asichost = dut.asic_instance(asic_index)
     docker_cmd = asichost.get_docker_cmd(cmd, "database")
     db_output = dut.command(docker_cmd)["stdout_lines"]
-    not_detected_interfaces = [intf for intf in interfaces if "TRANSCEIVER_INFO|%s" % intf not in db_output]
+    not_detected_interfaces = [intf for intf in interfaces if intf not in xcvr_skip_list[dut.hostname] if
+                               "TRANSCEIVER_INFO|%s" % intf not in db_output]
     if len(not_detected_interfaces) > 0:
         logging.info("Interfaces not detected: %s" % str(not_detected_interfaces))
         return False
@@ -65,7 +66,7 @@ def check_transceiver_basic(dut, asic_index, interfaces, xcvr_skip_list):
     xcvr_info = dut.command(docker_cmd)
     parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
     for intf in interfaces:
-        if intf not in xcvr_skip_list:
+        if intf not in xcvr_skip_list[dut.hostname]:
             assert intf in parsed_xcvr_info, "TRANSCEIVER INFO of %s is not found in DB" % intf
 
 
@@ -79,7 +80,7 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     logging.info("Check detailed transceiver information of each connected port")
     expected_fields = ["type", "hardware_rev", "serial", "manufacturer", "model"]
     for intf in interfaces:
-        if intf not in xcvr_skip_list:
+        if intf not in xcvr_skip_list[dut.hostname]:
             cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_INFO|%s"' % intf
             docker_cmd = asichost.get_docker_cmd(cmd, "database")
             port_xcvr_info = dut.command(docker_cmd)
@@ -101,7 +102,7 @@ def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_li
     xcvr_dom_sensor = dut.command(docker_cmd)
     parsed_xcvr_dom_sensor = parse_transceiver_dom_sensor(xcvr_dom_sensor["stdout_lines"])
     for intf in interfaces:
-        if intf not in xcvr_skip_list:
+        if intf not in xcvr_skip_list[dut.hostname]:
             assert intf in parsed_xcvr_dom_sensor, "TRANSCEIVER_DOM_SENSOR of %s is not found in DB" % intf
 
 
@@ -116,7 +117,7 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_
     expected_fields = ["temperature", "voltage", "rx1power", "rx2power", "rx3power", "rx4power", "tx1bias",
                        "tx2bias", "tx3bias", "tx4bias", "tx1power", "tx2power", "tx3power", "tx4power"]
     for intf in interfaces:
-        if intf not in xcvr_skip_list:
+        if intf not in xcvr_skip_list[dut.hostname]:
             cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|%s"' % intf
             docker_cmd = asichost.get_docker_cmd(cmd, "database")
             port_xcvr_dom_sensor = dut.command(docker_cmd)

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -18,6 +18,11 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     inv_mgr = duthost.host.options["inventory_manager"]
     pdu_host_list = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
+    if not pdu_host_list:
+        logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create pdu_controller" %
+                     duthost.hostname)
+        yield None
+        return
     pdu_hosts = {}
     for ph in pdu_host_list.split(','):
         var_list = inv_mgr.get_host(ph).get_vars()

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -18,11 +18,6 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     inv_mgr = duthost.host.options["inventory_manager"]
     pdu_host_list = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
-    if not pdu_host_list:
-        logging.info("No 'pdu_host' is defined in inventory file for {}. Unable to create pdu_controller".format(
-            duthost.hostname))
-        yield None
-        return
     pdu_hosts = {}
     for ph in pdu_host_list.split(','):
         var_list = inv_mgr.get_host(ph).get_vars()

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -19,8 +19,8 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
     inv_mgr = duthost.host.options["inventory_manager"]
     pdu_host_list = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
     if not pdu_host_list:
-        logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create pdu_controller" %
-                     duthost.hostname)
+        logging.info("No 'pdu_host' is defined in inventory file for {}. Unable to create pdu_controller".format(
+            duthost.hostname))
         yield None
         return
     pdu_hosts = {}

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -23,28 +23,29 @@ def skip_on_simx(duthosts, rand_one_dut_hostname):
         pytest.skip('skipped on this platform: {}'.format(platform))
 
 @pytest.fixture(scope="module")
-def xcvr_skip_list(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    platform = duthost.facts['platform']
-    hwsku = duthost.facts['hwsku']
-    f_path = os.path.join('/usr/share/sonic/device', platform, hwsku, 'hwsku.json')
-    intf_skip_list = []
-    try:
-        out = duthost.command("cat {}".format(f_path))
-        hwsku_info = json.loads(out["stdout"])
-        for int_n in hwsku_info['interfaces']:
-            if hwsku_info['interfaces'][int_n]['port_type'] == "RJ45":
-                intf_skip_list.append(int_n)
+def xcvr_skip_list(duthosts):
+    intf_skip_list = {}
+    for dut in duthosts:
+        platform = dut.facts['platform']
+        hwsku = dut.facts['hwsku']
+        f_path = os.path.join('/usr/share/sonic/device', platform, hwsku, 'hwsku.json')
+        intf_skip_list[dut.hostname] = []
+        try:
+            out = dut.command("cat {}".format(f_path))
+            hwsku_info = json.loads(out["stdout"])
+            for int_n in hwsku_info['interfaces']:
+                if hwsku_info['interfaces'][int_n]['port_type'] == "RJ45":
+                    intf_skip_list[dut.hostname].append(int_n)
 
-    except Exception:
-        # hwsku.json does not exist will return empty skip list
-        logging.debug(
-            "hwsku.json absent or port_type for interfaces not included for hwsku {}".format(hwsku))
+        except Exception:
+            # hwsku.json does not exist will return empty skip list
+            logging.debug(
+                "hwsku.json absent or port_type for interfaces not included for hwsku {}".format(hwsku))
 
     return intf_skip_list
 
 @pytest.fixture()
-def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):
+def bring_up_dut_interfaces(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """
     Bring up outer interfaces on the DUT.
 
@@ -52,7 +53,7 @@ def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):
         request: pytest request object
         duthost: Fixture for interacting with the DUT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     yield
     if request.node.rep_call.failed:
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -26,7 +26,7 @@ class TestContLinkFlap(object):
     TestContLinkFlap class for continuous link flap
     """
 
-    def test_cont_link_flap(self, request, duthosts, rand_one_dut_hostname, fanouthosts, bring_up_dut_interfaces, tbinfo):
+    def test_cont_link_flap(self, request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, bring_up_dut_interfaces, tbinfo):
         """
         Validates that continuous link flap works as expected
 
@@ -41,7 +41,7 @@ class TestContLinkFlap(object):
         Pass Criteria: All routes must be re-learned with < 5% increase in Redis and 
             ORCH agent CPU consumption below threshold after 3 mins after stopping flaps.
         """
-        duthost = duthosts[rand_one_dut_hostname]
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         orch_cpu_threshold = request.config.getoption("--orch_cpu_threshold")
 
         # Record memory status at start

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -85,13 +85,13 @@ def stop_pmon_sensord_task(ans_host):
 
 
 @pytest.fixture(scope="module")
-def psu_test_setup_teardown(duthosts, rand_one_dut_hostname):
+def psu_test_setup_teardown(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     @summary: Sensord task will print out error msg when detect PSU offline,
               which can cause log analyzer fail the test. So stop sensord task
               before test and restart it after all test finished.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logging.info("Starting psu test setup")
     stop_pmon_sensord_task(duthost)
 
@@ -112,8 +112,8 @@ def psu_test_setup_teardown(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="function")
-def ignore_particular_error_log(request, duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def ignore_particular_error_log(request, duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='turn_on_off_psu_and_check_psustatus')
     loganalyzer.load_common_config()
 
@@ -278,11 +278,11 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
 
 @pytest.mark.disable_loganalyzer
-def test_show_platform_fanstatus_mocked(duthosts, rand_one_dut_hostname, mocker_factory, disable_thermal_policy):
+def test_show_platform_fanstatus_mocked(duthosts, enum_rand_one_per_hwsku_hostname, mocker_factory, disable_thermal_policy):
     """
     @summary: Check output of 'show platform fan'.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # Mock data and check
     mocker = mocker_factory(duthost, 'FanStatusMocker')
@@ -298,11 +298,11 @@ def test_show_platform_fanstatus_mocked(duthosts, rand_one_dut_hostname, mocker_
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP], indirect=True)
-def test_show_platform_temperature_mocked(duthosts, rand_one_dut_hostname, mocker_factory, ignore_particular_error_log):
+def test_show_platform_temperature_mocked(duthosts, enum_rand_one_per_hwsku_hostname, mocker_factory, ignore_particular_error_log):
     """
     @summary: Check output of 'show platform temperature'
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     # Mock data and check
     mocker = mocker_factory(duthost, 'ThermalStatusMocker')
     pytest_require(mocker, "No ThermalStatusMocker for %s, skip rest of the testing in this case" % duthost.facts['asic_type'])
@@ -316,23 +316,23 @@ def test_show_platform_temperature_mocked(duthosts, rand_one_dut_hostname, mocke
 
 
 @pytest.mark.disable_loganalyzer
-def test_thermal_control_load_invalid_format_json(duthosts, rand_one_dut_hostname):
+def test_thermal_control_load_invalid_format_json(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     @summary: Load a thermal policy file with invalid format, check thermal
               control daemon is up and there is an error log printed
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logging.info('Loading invalid format policy file...')
     check_thermal_control_load_invalid_file(duthost, THERMAL_POLICY_INVALID_FORMAT_FILE)
 
 
 @pytest.mark.disable_loganalyzer
-def test_thermal_control_load_invalid_value_json(duthosts, rand_one_dut_hostname):
+def test_thermal_control_load_invalid_value_json(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     @summary: Load a thermal policy file with invalid value, check thermal
               control daemon is up and there is an error log printed
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logging.info('Loading invalid value policy file...')
     check_thermal_control_load_invalid_file(duthost, THERMAL_POLICY_INVALID_VALUE_FILE)
 
@@ -438,11 +438,11 @@ def turn_off_outlet_and_check_thermal_control(dut, pdu_ctrl, outlet, mocker):
 
 
 @pytest.mark.disable_loganalyzer
-def test_thermal_control_fan_status(duthosts, rand_one_dut_hostname, mocker_factory):
+def test_thermal_control_fan_status(duthosts, enum_rand_one_per_hwsku_hostname, mocker_factory):
     """
     @summary: Make FAN absence, over speed and under speed, check logs and LED color.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='thermal_control')
     loganalyzer.load_common_config()
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -84,10 +84,11 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type =
     if dut.is_supervisor_node():
         logging.info("skipping interfaces related check for supervisor")
     else:
-        logging.info("Wait %d seconds for all the transceivers to be detected" % MAX_WAIT_TIME_FOR_INTERFACES)
-        assert wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, check_all_interface_information, dut, interfaces,
-                          xcvr_skip_list), \
-            "Not all transceivers are detected or interfaces are up in %d seconds" % MAX_WAIT_TIME_FOR_INTERFACES
+        logging.info("Wait {} seconds for all the transceivers to be detected".format(MAX_WAIT_TIME_FOR_INTERFACES))
+        result = wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, check_all_interface_information, dut, interfaces,
+                            xcvr_skip_list)
+        assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
+            MAX_WAIT_TIME_FOR_INTERFACES)
 
 
         logging.info("Check transceiver status")

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -87,13 +87,13 @@ def mocker(type_name):
 
 
 @pytest.fixture
-def mocker_factory(localhost, duthosts, rand_one_dut_hostname):
+def mocker_factory(localhost, duthosts, enum_rand_one_per_hwsku_hostname):
     """
     Fixture for thermal control data mocker factory.
     :return: A function for creating thermal control related data mocker.
     """
     mockers = []
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     def _create_mocker(dut, mocker_name):
         """
@@ -340,7 +340,7 @@ class ThermalPolicyFileContext:
 
 
 @pytest.fixture
-def disable_thermal_policy(duthosts, rand_one_dut_hostname):
+def disable_thermal_policy(duthosts, enum_rand_one_per_hwsku_hostname):
     """Fixture to help disable thermal policy during the test. After test, it will
        automatically re-enable thermal policy. The idea here is to make thermalctld
        load a invalid policy file. To use this fixture, the test case will probably 
@@ -348,9 +348,9 @@ def disable_thermal_policy(duthosts, rand_one_dut_hostname):
 
     Args:
         duthosts DUT object representing a SONiC switch under test
-        rand_one_dut_hostname random DUT hostname
+        enum_rand_one_per_hwsku_hostname random DUT hostname
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     invalid_policy_file = os.path.join(FILES_DIR, 'invalid_format_policy.json')
     with ThermalPolicyFileContext(duthost, invalid_policy_file):
         yield

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -63,8 +63,8 @@ def check_image_version(duthost):
     yield
 
 
-def test_service_checker(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_service_checker(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_DEVICE_CHECK_CONFIG_FILE)):
         cmd = "monit summary -B"
@@ -99,8 +99,8 @@ def test_service_checker(duthosts, rand_one_dut_hostname):
 
 
 @pytest.mark.disable_loganalyzer
-def test_device_checker(duthosts, rand_one_dut_hostname, device_mocker_factory, disable_thermal_policy):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname, device_mocker_factory, disable_thermal_policy):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, DEVICE_CHECK_CONFIG_FILE)):
@@ -228,8 +228,8 @@ def test_device_checker(duthosts, rand_one_dut_hostname, device_mocker_factory, 
             assert not value or expect_value not in value, 'Mock PSU good voltage, but it is still invalid'
 
 
-def test_external_checker(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, EXTERNAL_CHECK_CONFIG_FILE)):
         duthost.copy(src=os.path.join(FILES_DIR, EXTERNAL_CHECKER_MOCK_FILE),
@@ -241,8 +241,8 @@ def test_external_checker(duthosts, rand_one_dut_hostname):
         assert value == 'Device is broken', 'External checker does not work, value={}'.format(value)
 
 
-def test_system_health_config(duthosts, rand_one_dut_hostname, device_mocker_factory):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname, device_mocker_factory):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)
     wait_system_health_boot_up(duthost)
     logger.info('Ignore fan check, verify there is no error information about fan')


### PR DESCRIPTION

-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Change following tests  tests/platform_tests/link_flap/test_cont_link_flap.py, tests/platform_tests/test_platform_info.py,
 tests/platform_tests/test_reboot.py, tests/system_health/test_system_health.py on T2 chassis replacing rand_one_dut_hostname with enum_rand_one_per_hwsku_frontend_hostname 
#### How did you do it?
 ```tests/platform_tests/conftest.py```
	change bringup_all_interfaces to use enum_rand_one_per_hwsku_frontend_hostname instead of      rand_one_dut_hostname
	modify xcvr_skip_list to generate dictionary instead of list to accomodate mulitple duts by storing port list with dut 
	hostnames as key
	
changed following platform utils to use new xcvr_skip_list returned dictionary 
    ```tests/common/platform/interface_utils.py```
        Changed xcvr_skip_list to xcvr_skip_list with dut hostname as key
    ```tests/common/platform/transceiver_utils.py```
       Changed xcvr_skip_list to xcvr_skip_list with dut hostname as key 

following tests modified to use enum per hwsku enumeration
   ```tests/common/plugins/pdu_controller/__init__.py```
      enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname
  
  ```tests/platform_tests/link_flap/test_cont_link_flap.py```
      enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname
    
  ```tests/platform_tests/test_platform_info.py```
     enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname
  
  ```tests/platform_tests/test_reboot.py```
    enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname
  
  ```tests/platform_tests/thermal_control_test_helper.py```
      enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname
  
  ```tests/system_health/test_system_health.py```
      enum_rand_one_per_hwsku_frontend_hostname instead of rand_one_dut_hostname

#### How did you verify/test it?
Validated the modified tests against a chassis and pizza box

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
