### PR TITLE
[mux_sim_ctrl]: Fix url fixture when specifying interface

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -34,7 +34,7 @@ def mux_server_url(request, tbinfo):
     return "http://{}:{}/mux/{}".format(ip, port, vmset_name)
 
 @pytest.fixture(scope='module')
-def url(mux_server_url, duthost):
+def url(mux_server_url, duthost, tbinfo):
     """
     A helper function is returned to make fixture accept arguments
     """
@@ -51,7 +51,7 @@ def url(mux_server_url, duthost):
         """
         if not interface_name:
             return mux_server_url
-        mg_facts = duthost.get_extended_minigraph_facts()
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         mbr_index = mg_facts['minigraph_ptf_indices'][interface_name]
         if not action:
             return mux_server_url + "/{}".format(mbr_index)


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Generating a mux server URL for a specific interface name fails because of the missing tbinfo argument when getting minigraph facts

#### How did you do it?


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
