### PR TITLE
[bgp] Fix test_bgp_update_timer

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -64,18 +64,6 @@ class BGPNeighbor(object):
     def start_session(self):
         """Start the BGP session."""
         logging.debug("start bgp session %s", self.name)
-        self.ptfhost.exabgp(
-            name=self.name,
-            state="started",
-            local_ip=self.ip,
-            router_id=self.ip,
-            peer_ip=self.peer_ip,
-            local_asn=self.asn,
-            peer_asn=self.peer_asn,
-            port=self.port
-        )
-        if not wait_tcp_connection(self.ptfhost, self.ptfip, self.port):
-            raise RuntimeError("Failed to start BGP neighbor %s" % self.name)
 
         _write_variable_from_j2_to_configdb(
             self.duthost,
@@ -98,6 +86,19 @@ class BGPNeighbor(object):
             local_addr=self.peer_ip,
             peer_name=self.name
         )
+
+        self.ptfhost.exabgp(
+            name=self.name,
+            state="started",
+            local_ip=self.ip,
+            router_id=self.ip,
+            peer_ip=self.peer_ip,
+            local_asn=self.asn,
+            peer_asn=self.peer_asn,
+            port=self.port
+        )
+        if not wait_tcp_connection(self.ptfhost, self.ptfip, self.port):
+            raise RuntimeError("Failed to start BGP neighbor %s" % self.name)
 
         if self.is_quagga:
             allow_ebgp_multihop_cmd = (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
`FRR` checks if a new neighbor is a already-defined neighbor within the
dynamic range. And `BGPNeighbor.start_session` always starts `exa_bgp`
then pushs the neighbor definitions to config_db. For t0 testbeds, the
neighbor is within subnet `192.168.0.0/21` that occurs to be same as the
one used by `BGPVac`. So after `BGPNeighbor.start_session` starts
`exa_bgp`, `FRR` will detects the new connections as `BGPVac`, so
subsequent neighbor will make `FRR` complain.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes #3188 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
As issue #3188 

#### How did you do it?
Starts `exa_bgp` session after pushing neighbor definitions.

#### How did you verify/test it?
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer PASSED                                                                                                                                     [100%]

===================================================================================== 1 passed in 166.85 seconds =====================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
