### PR TITLE
[start_topo] Announce route for non-fullmesh topos

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -125,6 +125,7 @@
 
   - name: Announce routes
     include_tasks: announce_routes.yml
+    when: topo != 'fullmesh'
 
   - name: Start mux simulator
     include_tasks: control_mux_simulator.yml


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
No need to announce route for `fullmesh` topo testbed.
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add check to only announce route for non-fullmesh topo testbeds.

#### How did you do it?
Add an extra check.

#### How did you verify/test it?
* before
```
TASK [vm_set : Start exabgp processes for IPv4 on PTF] ***********************************************************************************************************************************************
Monday 22 March 2021  06:55:05 +0000 (0:00:00.061)       0:02:16.394 **********
fatal: [STR2-ACS-SERV-16]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'None' has no attribute 'key'\n\nThe error appears to be in '/data/repo/spytest/test/sonic-mgmt/ansible/roles/vm_set/tasks/announce_routes.yml': line 26, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Start exabgp processes for IPv4 on PTF\n  ^ here\n"}
```
* now add-topo succeeds without error.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
