### PR TITLE
[pfcwd] Address the start-limit hit failure for swss restart testcases

### DIFF
--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -267,6 +267,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(ixia_api,
     lossless_prio = int(lossless_prio)
 
     logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
+    duthost.command("systemctl reset-failed {}".format(restart_service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),
@@ -323,6 +324,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(ixia_api,
     duthost = duthosts[rand_one_dut_hostname]
 
     logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
+    duthost.command("systemctl reset-failed {}".format(restart_service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Some of the pfcwd tgen testcases restart swss mutiple times within a short interval. This leads to start-limit-hit failure and fails to restart swss. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


#### How did you do it?
Adding the 'reset-failed' command prior to attempting a restart.
