### PR TITLE
[framework] Fix exceptions in ptf_adapter

### DIFF
--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -1,3 +1,4 @@
+import logging
 import nnpy
 import ptf
 import ptf.platforms.nn as nn
@@ -6,7 +7,7 @@ import ptf.packet as scapy
 import ptf.mask as mask
 
 from ptf.base_tests import BaseTest
-from ptf.dataplane import DataPlane
+from ptf.dataplane import DataPlane, DataPlanePortNN
 from tests.common.utilities import wait_until
 
 
@@ -49,8 +50,8 @@ class PtfTestAdapter(BaseTest):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """ exit from 'with' block """
-
-        self.kill()
+        if exc_type != PtfAdapterNNConnectionError:
+            self.kill()
 
     def _check_ptf_nn_agent_availability(self, socket_addr):
         """Verify the nanomsg socket address exposed by ptf_nn_agent is available."""
@@ -108,8 +109,12 @@ class PtfTestAdapter(BaseTest):
         self.dataplane = ptf.dataplane_instance
 
     def kill(self):
-        """ kill data plane thread """
+        """ Close dataplane socket and kill data plane thread """
         self.dataplane.kill()
+        
+        for injector in DataPlanePortNN.packet_injecters.values():
+            injector.socket.close()
+        DataPlanePortNN.packet_injecters.clear()
 
     def reinit(self, ptf_config=None):
         """ reinitialize ptf data plane thread.

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -1,4 +1,3 @@
-import logging
 import nnpy
 import ptf
 import ptf.platforms.nn as nn
@@ -111,7 +110,7 @@ class PtfTestAdapter(BaseTest):
     def kill(self):
         """ Close dataplane socket and kill data plane thread """
         self.dataplane.kill()
-        
+
         for injector in DataPlanePortNN.packet_injecters.values():
             injector.socket.close()
         DataPlanePortNN.packet_injecters.clear()


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR fix two exceptions in ptf_adapter

1. Fix ```AttributeError: ports``` when ```del self.ports```
This error is observed in nightly test. The error is because ```_check_ptf_nn_agent_availability``` raised an exception, so ```ptf.dataplane``` is uninitialized. 
```
self = <DataPlane(Thread-72, stopped 139772790830848)>

    def kill(self):
        """
        Stop the dataplane thread.
        """
        self.killed = True
        self.waker.notify()
        self.join()
        # Explicitly release ports to ensure we don't run out of sockets
        # even if someone keeps holding a reference to the dataplane.
>       del self.ports
E       AttributeError: ports
```

2. Fix logic in ```reinit```.
The TCP connection in ```dataplane``` is not cleared during ```reinit```. So ```_check_ptf_nn_agent_availability``` will raise exception at the second connection.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to address issues in ptf_adapter.

#### How did you do it?
Please see code.

#### How did you verify/test it?
Verified on Arista-7260cx3-9.
1. Test pass when the connection to ```ptf_nn_agent``` is available.
2. Error is reported when the connection to ```ptf_nn_agent``` is occupied.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
