### PR TITLE
[framework]Implement mux-cable flap counter in mux_simulator_server

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -64,7 +64,7 @@ def clear_flap_counter(vm_set, port_index):
     flap_counter[mbr_name] = 0
 
 
-def fill_flap_counter():
+def init_flap_counter():
     """
     Fill 0 to global flap counter
     """
@@ -729,7 +729,7 @@ if __name__ == '__main__':
     $ sudo python <prog> <port>
     '''
     config_logging()
-    fill_flap_counter()
+    init_flap_counter()
     if '-v' in sys.argv:
         app.logger.setLevel(logging.DEBUG)
         for handler in app.logger.handlers:

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -28,6 +28,50 @@ UPPER_TOR = 'upper_tor'
 LOWER_TOR = 'lower_tor'
 NIC = 'nic'
 
+# Global variable for storing mux cable flapping
+flap_counter = {}
+
+def get_flap_counter(vm_set, port_index):
+    """
+    @summary: Get the flap counter for a certain mbr
+    @param vm_set: A str, vm_set name
+    @param port_index: An integer, the port_index
+    @return: An dict {'mbr-vms17-8-0': 10}
+    """
+    mbr_name = "mbr-{}-{}".format(vm_set, port_index)
+    return {mbr_name: flap_counter.get(mbr_name, 0)}
+
+
+def increase_flap_counter(vm_set, port_index):
+    """
+    @summary: Increase the flap counter for a certain mbr by 1
+    @param vm_set: A str, vm_set name
+    @param port_index: An integer, the port_index
+    @return: None
+    """
+    mbr_name = "mbr-{}-{}".format(vm_set, port_index)
+    flap_counter[mbr_name] = flap_counter.get(mbr_name, 0) + 1
+
+
+def clear_flap_counter(vm_set, port_index):
+    """
+    @summary: Clear the flap counter for a certain mbr
+    @param vm_set: A str, vm_set name
+    @param port_index: An integer, the port_index
+    @return: None
+    """
+    mbr_name = "mbr-{}-{}".format(vm_set, port_index)
+    flap_counter[mbr_name] = 0
+
+
+def fill_flap_counter():
+    """
+    Fill 0 to global flap counter
+    """
+    for intf in os.listdir('/sys/class/net'):
+        if intf.startswith('mbr-'):
+            flap_counter[intf] = 0
+
 
 def run_cmd(cmdline):
     """Use subprocess to run a command line with shell=True
@@ -287,6 +331,9 @@ def set_active_side(vm_set, port_index, new_active_side):
         return mux_status
 
     # Need to toggle active side anyway
+    # Increase flap counter
+    increase_flap_counter(vm_set, port_index)
+
     flows = get_flows(vm_set, port_index)
     active_port = get_active_port(flows)
     if new_active_side == 'toggle':
@@ -606,6 +653,63 @@ def mux_cable_flow_update(vm_set, port_index, action):
         app.logger.error('{} {} {}'.format(request.method, request.url, err_msg))
         return jsonify({'err_msg': err_msg}), 500
 
+@app.route('/mux/<vm_set>/<port_index>/flap_counter', methods=['GET'])
+def flap_counter_port(vm_set, port_index):
+    """
+    Handler for retrieving flap counter for a given port
+    """
+    valid, msg = _validate_param(vm_set, port_index)
+    if not valid:
+        app.logger.error('{} {} {}'.format(request.method, request.url, msg))
+        return jsonify({'err_msg': msg}), 400
+    
+    return get_flap_counter(vm_set, port_index)
+
+
+@app.route('/mux/<vm_set>/flap_counter', methods=['GET'])
+def flap_counter_all(vm_set):
+    """
+    Handler for retrieving flap counter for all ports
+    """
+    ret = {}
+
+    pattern = "mbr-{}".format(vm_set)
+    for mbr, counter in flap_counter.items():
+        if mbr.startswith(pattern):
+            ret[mbr] = counter
+    
+    return ret
+
+
+@app.route('/mux/<vm_set>/clear_flap_counter', methods=['POST'])
+def clear_flap_counter_handler(vm_set):
+    """
+    Handler for clearing flap counter for all ports or a given port
+    Data posted should be {'port_to_clear': '0|1...'} or {'port_to_clear': 'all'}
+    """
+    ret = {}
+    data = request.get_json()
+    if 'port_to_clear' not in data:
+        msg = 'Bad posted data, expected: {"port_to_clear": "all|integer"}'
+        return jsonify({'err_msg': msg}), 400
+    port_indexes = data['port_to_clear']
+    if port_indexes == "all":
+        pattern = "mbr-{}".format(vm_set)
+        for mbr, counter in flap_counter.items():
+            if mbr.startswith(pattern):
+                flap_counter[mbr] = 0
+                ret[mbr] = 0
+    else:
+        indexes = port_indexes.split('|')
+        for index in indexes:
+            valid, msg = _validate_param(vm_set, index)
+            if not valid:
+                continue
+            clear_flap_counter(vm_set, index)
+            mbr_name = "mbr-{}-{}".format(vm_set, index)
+            ret[mbr_name] = 0
+
+    return ret
 
 def config_logging():
     rfh = RotatingFileHandler(
@@ -625,7 +729,7 @@ if __name__ == '__main__':
     $ sudo python <prog> <port>
     '''
     config_logging()
-
+    fill_flap_counter()
     if '-v' in sys.argv:
         app.logger.setLevel(logging.DEBUG)
         for handler in app.logger.handlers:

--- a/tests/common/dualtor/constants.py
+++ b/tests/common/dualtor/constants.py
@@ -8,3 +8,5 @@ NIC = "nic"
 
 DROP = "drop"
 OUTPUT = "output"
+FLAP_COUNTER = "flap_counter"
+CLEAR_FLAP_COUNTER = "clear_flap_counter"

--- a/tests/common/dualtor/constants.py
+++ b/tests/common/dualtor/constants.py
@@ -10,3 +10,4 @@ DROP = "drop"
 OUTPUT = "output"
 FLAP_COUNTER = "flap_counter"
 CLEAR_FLAP_COUNTER = "clear_flap_counter"
+

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -1,11 +1,12 @@
 import logging
+from typing import Counter
 import pytest
 import json
 import urllib2
 
 from tests.common import utilities
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT
+from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT, FLAP_COUNTER, CLEAR_FLAP_COUNTER
 
 __all__ = ['check_simulator_read_side', 'mux_server_url', 'url', 'recover_all_directions', 'set_drop', 'set_output', 'toggle_all_simulator_ports_to_another_side', \
            'toggle_all_simulator_ports_to_lower_tor', 'toggle_all_simulator_ports_to_random_side', 'toggle_all_simulator_ports_to_upper_tor', \
@@ -45,11 +46,16 @@ def url(mux_server_url, duthost, tbinfo):
         Args:
             interface_name: a str, the name of interface
                             If interface_name is none, the returned url contains no '/port/action' (For polling/toggling all ports)
+                            or /mux/vms/flap_counter for retrieving flap counter for all ports 
+                            or /mux/vms/clear_flap_counter for clearing flap counter for given ports 
             action: a str, output|drop|None. If action is None, the returned url contains no '/action'
         Returns:
             The url for posting flow update request, like http://10.0.0.64:8080/mux/vms17-8[/1/drop|output]
         """
         if not interface_name:
+            if action:
+                # Only for flap_counter or clear_flap_counter
+                return mux_server_url + "/{}".format(action)
             return mux_server_url
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         mbr_index = mg_facts['minigraph_ptf_indices'][interface_name]
@@ -322,3 +328,51 @@ def simulator_server_down(set_drop, set_output):
 
     yield _drop_helper
     set_output(tmp_list[0], [UPPER_TOR, LOWER_TOR])
+
+@pytest.fixture
+def simulator_flap_counter(url):
+    """
+    A function level fixture to retrieve mux simulator flap counter for a given interface
+    """
+    def _simulator_flap_counter(interface_name):
+        server_url = url(interface_name, FLAP_COUNTER)
+        counter = _get(server_url)
+        assert(counter and len(counter) == 1)
+        return counter.values()[0]
+
+    return _simulator_flap_counter
+
+
+@pytest.fixture
+def simulator_flap_counters(url):
+    """
+    A function level fixture to retrieve mux simulator flap counter for all ports of a testbed
+    """
+    server_url = url(action=FLAP_COUNTER)
+    return _get(server_url)
+
+
+@pytest.fixture
+def simulator_clear_flap_counter(url, duthost, tbinfo):
+    """
+    A function level fixture to clear mux simulator flap counter for given port(s)
+    """
+    def _simulator_clear_flap_counter(interface_name):
+        server_url = url(action=CLEAR_FLAP_COUNTER)
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        mbr_index = mg_facts['minigraph_ptf_indices'][interface_name]
+        data = {"port_to_clear": str(mbr_index)}
+        pytest_assert(_post(server_url, data), "Failed to clear flap counter for all ports")
+
+    return _simulator_clear_flap_counter
+
+
+@pytest.fixture
+def simulator_clear_flap_counters(url):
+    """
+    A function level fixture to clear mux simulator flap counter for all ports of a testbed
+    """
+    server_url = url(action=CLEAR_FLAP_COUNTER)
+    data = {"port_to_clear": "all"}
+    pytest_assert(_post(server_url, data), "Failed to clear flap counter for all ports")
+    

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Counter
 import pytest
 import json
 import urllib2
@@ -46,8 +45,8 @@ def url(mux_server_url, duthost, tbinfo):
         Args:
             interface_name: a str, the name of interface
                             If interface_name is none, the returned url contains no '/port/action' (For polling/toggling all ports)
-                            or /mux/vms/flap_counter for retrieving flap counter for all ports 
-                            or /mux/vms/clear_flap_counter for clearing flap counter for given ports 
+                            or /mux/vms/flap_counter for retrieving flap counter for all ports
+                            or /mux/vms/clear_flap_counter for clearing flap counter for given ports
             action: a str, output|drop|None. If action is None, the returned url contains no '/action'
         Returns:
             The url for posting flow update request, like http://10.0.0.64:8080/mux/vms17-8[/1/drop|output]
@@ -375,4 +374,4 @@ def simulator_clear_flap_counters(url):
     server_url = url(action=CLEAR_FLAP_COUNTER)
     data = {"port_to_clear": "all"}
     pytest_assert(_post(server_url, data), "Failed to clear flap counter for all ports")
-    
+

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -337,7 +337,7 @@ def simulator_flap_counter(url):
         server_url = url(interface_name, FLAP_COUNTER)
         counter = _get(server_url)
         assert(counter and len(counter) == 1)
-        return counter.values()[0]
+        return list(counter.values())[0]
 
     return _simulator_flap_counter
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR implements mux_cable flap counter in ```mux_simulator_server```.
The flap counter can be retrieved and cleared by HTTP request.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to implement mux-cable flap counter in mux_simulator.

#### How did you do it?
Please see code.

#### How did you verify/test it?
Verified by a demo test script.
```
def test_flap_counter(simulator_flap_counter, simulator_flap_counters, toggle_simulator_port_to_upper_tor, toggle_simulator_port_to_lower_tor, simulator_clear_flap_counter, simulator_clear_flap_counters):
    counter1 = simulator_flap_counter('Ethernet0')
    assert(counter1 == 0)
    toggle_simulator_port_to_upper_tor('Ethernet0')
    counter2 = simulator_flap_counter('Ethernet0')
    assert(counter2 == counter1 + 1)
    simulator_clear_flap_counter('Ethernet0')
    counter3 = simulator_flap_counter('Ethernet0')
    assert(counter3 == 0)
```
#### Any platform specific information?
dualtor specific.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
