### PR TITLE
[sanity] Fix uncaught exception in mux sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -6,7 +6,6 @@ import pytest
 import time
 
 from ipaddress import ip_network, IPv4Network
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait, wait_until
 from tests.common.dualtor.mux_simulator_control import *
 from tests.common.dualtor.dual_tor_utils import *
@@ -356,9 +355,7 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
         # Run tests with upper ToR active
         toggle_simulator_port_to_upper_tor(tor_mux_intf)
 
-        try:
-            pytest_assert(check_simulator_read_side(tor_mux_intf) == 1)
-        except AssertionError:
+        if check_simulator_read_side(tor_mux_intf) != 1:
             results['failed'] = True
             results['failed_reason'] = 'Unable to switch active link to upper ToR'
             return results
@@ -387,25 +384,19 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
 
         upper_tor_arp_table = upper_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
         lower_tor_arp_table = lower_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
-        try:
-            pytest_assert(ptf_arp_tgt_ip in upper_tor_arp_table)
-        except AssertionError:
+        if ptf_arp_tgt_ip not in upper_tor_arp_table:
             results['failed'] = True
             results['failed_reason'] = 'Packet from PTF not received on active upper ToR'
             return results
 
-        try:
-            pytest_assert(ptf_arp_tgt_ip in lower_tor_arp_table)
-        except AssertionError:
+        if ptf_arp_tgt_ip not in lower_tor_arp_table:
             results['failed'] = True
             results['failed_reason'] = 'Packet from PTF not received on standby lower ToR'
             return results
 
         # Repeat all tests with lower ToR active
         toggle_simulator_port_to_lower_tor(tor_mux_intf)
-        try:
-            pytest_assert(check_simulator_read_side(tor_mux_intf) == 2)
-        except AssertionError:
+        if check_simulator_read_side(tor_mux_intf) != 2:
             results['failed'] = True
             results['failed_reason'] = 'Unable to switch active link to lower ToR'
             return results
@@ -432,16 +423,12 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
 
         upper_tor_arp_table = upper_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
         lower_tor_arp_table = lower_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
-        try:
-            pytest_assert(ptf_arp_tgt_ip in upper_tor_arp_table)
-        except AssertionError:
+        if ptf_arp_tgt_ip not in upper_tor_arp_table:
             results['failed'] = True
             results['failed_reason'] = 'Packet from PTF not received on standby upper ToR'
             return results
 
-        try:
-            pytest_assert(ptf_arp_tgt_ip in lower_tor_arp_table)
-        except AssertionError:
+        if ptf_arp_tgt_ip not in lower_tor_arp_table:
             results['failed'] = True
             results['failed_reason'] = 'Packet from PTF not received on active lower ToR'
             return results
@@ -675,4 +662,4 @@ def check_secureboot(duthosts, request):
             check_results.append(check_result)
 
         return check_results
-    return _check 
+    return _check


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In mux sanity check, 'pytest_assert' is used to verify some conditions. The pytest_assert
checks are protected using try...except AssertionError. However, 'pytest_assert' does
raise exception AssertionError. It simply calls pytest.fail(msg) to fail the test earlier.
Ideally, all the sanity check function should be fully executed and only return results
to indication if it is successful. Then the sanity check plugin can have a chance to recover
the testbed after inspected all the checked results.

#### How did you do it?
This change simply replaced "pytest_assert" in the check_mux_simulator
function with plain "if" check.

#### How did you verify/test it?
Run tests on dualtor testbed with sanity check enabled.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
