### PR TITLE
Fixed allowed CPU temperature for Mellanox

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -491,9 +491,9 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - lm75-i2c-7-4a/Ambient Port Temp/temp1_input
         - lm75-i2c-7-4a/Ambient Port Temp/temp1_max
@@ -653,13 +653,13 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-48/Ambient Port Temp/temp1_input
         - tmp102-i2c-7-48/Ambient Port Temp/temp1_max
@@ -836,9 +836,9 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - lm75-i2c-7-4a/Ambient Port Temp/temp1_input
         - lm75-i2c-7-4a/Ambient Port Temp/temp1_max
@@ -940,13 +940,13 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - lm75-i2c-7-4b/Ambient Fan Side Temp (air intake)/temp1_input
         - lm75-i2c-7-4b/Ambient Fan Side Temp (air intake)/temp1_max
@@ -1033,13 +1033,13 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - lm75-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
         - lm75-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
@@ -1238,15 +1238,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+        - coretemp-isa-0000/Physical id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -1442,11 +1442,11 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+        - coretemp-isa-0000/Physical id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -1699,15 +1699,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+        - coretemp-isa-0000/Physical id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -2007,15 +2007,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+        - coretemp-isa-0000/Physical id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -3338,11 +3338,11 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+        - coretemp-isa-0000/Physical id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -3634,15 +3634,15 @@ x86_64-mlnx_msn4410-r0:
       power: []
       temp:
       - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+        - coretemp-isa-0000/Physical id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max


### PR DESCRIPTION
### Description of PR

Summary: Increase allowed CPU temperature.
Example of CPU temp.
                 Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------------------  -------------  ---------  --------        --------------   -------------  ---------  -----------------
       CPU Core 0 Temp           62.0       82.0       N/A           104.0            N/A                 False       20210324 14:04:50
       CPU Core 1 Temp           62.0       82.0       N/A           104.0            N/A                 False       20210324 14:04:50

Previously in test we used as threshold temperatute from column High TH, now we use temperature from column Crit High TH
Fixes # 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
time time time when CPU temp was 82C - we got failures, not it should not fail until 104C.

#### How did you do it?
Now as threshold we use data from column Crit High TH, previously it was column High TH.

#### How did you verify/test it?
Run tests/platform_tests/test_sensors.py test 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

