### PR TITLE
[Mellanox] Fixed allowed CPU temperature

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -490,10 +490,12 @@ sensors_checks:
     compares:
       power: []
       temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - lm75-i2c-7-4a/Ambient Port Temp/temp1_input
         - lm75-i2c-7-4a/Ambient Port Temp/temp1_max
@@ -652,14 +654,16 @@ sensors_checks:
     compares:
       power: []
       temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-48/Ambient Port Temp/temp1_input
         - tmp102-i2c-7-48/Ambient Port Temp/temp1_max
@@ -835,10 +839,12 @@ sensors_checks:
     compares:
       power: []
       temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - lm75-i2c-7-4a/Ambient Port Temp/temp1_input
         - lm75-i2c-7-4a/Ambient Port Temp/temp1_max
@@ -939,14 +945,16 @@ sensors_checks:
     compares:
       power: []
       temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - lm75-i2c-7-4b/Ambient Fan Side Temp (air intake)/temp1_input
         - lm75-i2c-7-4b/Ambient Fan Side Temp (air intake)/temp1_max
@@ -1032,14 +1040,16 @@ sensors_checks:
     compares:
       power: []
       temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - lm75-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
         - lm75-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
@@ -1238,15 +1248,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -1442,11 +1452,11 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -1699,15 +1709,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -2007,15 +2017,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -3372,11 +3382,11 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -3669,15 +3679,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
@@ -3958,15 +3968,15 @@ sensors_checks:
       power: []
       temp:
       - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
-        - coretemp-isa-0000/Core 0/temp2_max
+        - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
-        - coretemp-isa-0000/Core 1/temp3_max
+        - coretemp-isa-0000/Core 1/temp3_crit
       - - coretemp-isa-0000/Core 2/temp4_input
-        - coretemp-isa-0000/Core 2/temp4_max
+        - coretemp-isa-0000/Core 2/temp4_crit
       - - coretemp-isa-0000/Core 3/temp5_input
-        - coretemp-isa-0000/Core 3/temp5_max
+        - coretemp-isa-0000/Core 3/temp5_crit
 
       - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
         - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max


### PR DESCRIPTION
### Description of PR

Summary: CPU temperature validation based on Critical High Threshold and not High Threshold.

Example of CPU temp:
```
                 Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------------------  -------------  ---------  --------        --------------   -------------  ---------  -----------------
       CPU Core 0 Temp           62.0       82.0       N/A           104.0            N/A                 False       20210324 14:04:50
       CPU Core 1 Temp           62.0       82.0       N/A           104.0            N/A                 False       20210324 14:04:50

```
Previously in test we used as threshold temperature from column **High TH**, now we use temperature from column **Crit High TH**
Fixes # 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
During nightly regression it was identified that the CPU temperature is 82C, which caused test to fail as false alarm. This value is assumed to be a valid temperature.

#### How did you do it?
Align the validation with **Crit High TH** and not **High TH**.

#### How did you verify/test it?
Run tests/platform_tests/test_sensors.py test 

#### Any platform specific information?
Mellanox only

#### Supported testbed topology if it's a new test case?

### Documentation 
