### PR TITLE
[Platform API][SFP] Enhance test_sfp to deal with SFP xcvrs which can't reset

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -161,6 +161,12 @@ class TestSfpApi(PlatformApiTestBase):
             return False
         return True
 
+    def is_xcvr_resettable(self, xcvr_info_dict):
+        xcvr_type = xcvr_info_dict.get("type_abbrv_name")
+        if xcvr_type == "SFP":
+            return False
+        return True
+
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -370,8 +376,15 @@ class TestSfpApi(PlatformApiTestBase):
     def test_reset(self, duthost, localhost, platform_api_conn):
         # TODO: Verify that the transceiver was actually reset
         for i in self.candidate_sfp:
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+               continue
+
             ret = sfp.reset(platform_api_conn, i)
-            self.expect(ret is True, "Failed to reset transceiver {}".format(i))
+            if self.is_xcvr_resettable(info_dict):
+               self.expect(ret is True, "Failed to reset transceiver {}".format(i))
+            else:
+               self.expect(ret is False, "Resetting transceiver {} succeeded but should have failed".format(i))
         self.assert_expectations()
 
     def test_tx_disable(self, duthost, localhost, platform_api_conn):


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Modify test_reset test case in test_sfp to check for a return value of False if the xcvr module is not resettable

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
SFP xcvrs do not have a reset mechanism: there is no pin and no EEPROM register to perform a reset (according to SFF8472). The existing reset test case checks for a return value of True (i.e. a successful reset), but this would not be possible for SFP xcvrs.

#### How did you do it?
Added helper function, is_xcvr_resettable, which checks if a xcvr can be reset based on its type. Currently, anything that is not SFP is assumed to be resettable. This function is then called in test_reset test case to determine whether True or False should be the expected return value of calling reset on the xcvr.

#### How did you verify/test it?
Manually ran test case on a 7260CX3 (which has SFP xcvrs).
