### PR TITLE
[tacacs]: log tac_plus to /var/log/tac_plus.log

### DIFF
--- a/tests/common/plugins/tacacs.py
+++ b/tests/common/plugins/tacacs.py
@@ -40,6 +40,7 @@ def setup_tacacs_server(ptfhost, creds):
     ptfhost.template(src="tacacs/tac_plus.conf.j2", dest="/etc/tacacs+/tac_plus.conf")
 
     # start tacacs server
+    ptfhost.lineinfile(path="/etc/default/tacacs+", line="DAEMON_OPTS=\"-d 10 -l /var/log/tac_plus.log -C /etc/tacacs+/tac_plus.conf\"", regexp='^DAEMON_OPTS=.*')
     ptfhost.service(name="tacacs_plus", state="started")
 
 


### PR DESCRIPTION
this is used for debugging tac_plus start issue

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
log tac_plus to /var/log/tac_plus.log

#### How did you do it?
detailed log in /var/log/tac_plus.log to debug start failures

#### How did you verify/test it?

    run ./run_tests.sh -i veos_vtb -d vlab-01 -n vms-kvm-t0 -f vtestbed.csv -k debug -l warning -m individual -q 1 -a False -e --disable_loganalyzer -u -c tacacs/test_ro_user.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
