### PR TITLE
Fix deploy-mg - handle inventory var separately for announce_routes

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -12,7 +12,7 @@ function usage
   echo "    $0 [options] refresh-dut <topo-name> <vault-password-file>"
   echo "    $0 [options] (connect-vms | disconnect-vms) <topo-name> <vault-password-file>"
   echo "    $0 [options] config-vm <topo-name> <vm-name> <vault-password-file>"
-  echo "    $0 [options] announce-routes <topo-name> <vault-password-file>"
+  echo "    $0 [options] announce-routes <topo-name> <inventory> <vault-password-file>"
   echo "    $0 [options] (gen-mg | deploy-mg | test-mg) <topo-name> <inventory> <vault-password-file>"
   echo "    $0 [options] (create-master | destroy-master) <k8s-server-name> <vault-password-file>"
   echo
@@ -52,7 +52,7 @@ function usage
   echo "To connect a topology: $0 connect-topo 'topo-name' ~/.password"
   echo "To refresh DUT in a topology: $0 refresh-dut 'topo-name' ~/.password"
   echo "To configure a VM on a server: $0 config-vm 'topo-name' 'vm-name' ~/.password"
-  echo "To announce routes to DUT: $0 announce-routes 'topo-name' ~/.password"
+  echo "To announce routes to DUT: $0 announce-routes 'topo-name' 'inventory' ~/.password"
   echo "To generate minigraph for DUT in a topology: $0 gen-mg 'topo-name' 'inventory' ~/.password"
   echo "To deploy minigraph to DUT in a topology: $0 deploy-mg 'topo-name' 'inventory' ~/.password"
   echo "    gen-mg, deploy-mg, test-mg supports enabling/disabling data ACL with parameter"
@@ -348,6 +348,7 @@ function announce_routes
   topology=$1
   inventory=$2
   passfile=$3
+  shift
   shift
   shift
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -100,7 +100,6 @@ function read_csv
   vm_base=${line_arr[8]}
   dut=${line_arr[9]//;/,}
   duts=${dut//[\[\] ]/}
-  inventory=${line_arr[10]}
 }
 
 function read_yaml
@@ -141,7 +140,6 @@ function read_yaml
   vm_base=${line_arr[8]}
   dut=${line_arr[9]}
   duts=$(python -c "from __future__ import print_function; print(','.join(eval(\"$dut\")))")
-  inventory=${line_arr[10]}
 }
 
 function read_file
@@ -348,7 +346,8 @@ function disconnect_vms
 function announce_routes
 {
   topology=$1
-  passfile=$2
+  inventory=$2
+  passfile=$3
   shift
   shift
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix deploy-mg task.
Fixes # (issue)

`inventory` variable for the deploy-mg is updated when `read_file $topology` is called. This is due to new definition for `inventory` is put inside `read_file` function.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The `deploy-mg` task is failing in the internal testbeds due to inconsistent columns in testbed.csv for public and internal. 


```
2021-03-24 09:03:54.629  Deploying minigraph 'vms7-t0-7260-2'
2021-03-24 09:03:54.630  reading
2021-03-24 09:03:54.632  Found topology vms7-t0-7260-2
2021-03-24 09:03:55.041  /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
2021-03-24 09:03:55.041    from cryptography.exceptions import InvalidSignature
2021-03-24 09:03:55.633  [WARNING]: Unable to parse
2021-03-24 09:03:55.633  /var/sonicbld/workspace/TestRun/nightly_pytest/03_reconfig/ansible/**** as
2021-03-24 09:03:55.633  an inventory source
2021-03-24 09:03:55.634  [WARNING]: No inventory was parsed, only implicit localhost is available
2021-03-24 09:03:55.634  [WARNING]: provided hosts list is empty, only localhost is available. Note that
2021-03-24 09:03:55.634  the implicit localhost does not match 'all'
2021-03-24 09:03:55.635  [WARNING]: Could not match supplied host pattern, ignoring: str-********
2021-03-24 09:03:56.562  [WARNING]: Could not match supplied host pattern, ignoring: sonic
2021-03-24 09:03:56.563  
2021-03-24 09:03:56.563  PLAY [sonic] *******************************************************************
2021-03-24 09:03:56.564  skipping: no hosts matched
2021-03-24 09:03:56.564  
2021-03-24 09:03:56.564  PLAY RECAP *********************************************************************
2021-03-24 09:03:56.564  
2021-03-24 09:03:56.564  Wednesday 24 March 2021  16:03:55 +0000 (0:00:00.091)       0:00:00.091 ******* 
2021-03-24 09:03:56.564  =============================================================================== 
2021-03-24 09:03:56.607  Done
2021-03-24 09:03:56.880  [03_reconfig] $ /bin/bash -x /tmp/jenkins16903197805494794356.sh
2021-03-24 09:03:56.883  + sleep 180
2021-03-24 09:07:07.851  Started calculate disk usage of build
2021-03-24 09:07:07.893  Finished Calculation of disk usage of build in 0 seconds
2021-03-24 09:07:07.975  Started calculate disk usage of workspace
2021-03-24 09:07:09.113  Finished Calculation of disk usage of workspace in  1 second
2021-03-24 09:07:09.342  Finished: SUCCESS
```
#### How did you do it?

#### How did you verify/test it?
After fix, `deploy-mg` successfully passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
