### PR TITLE
Fix yaml testbed file issues of new "inv_name" and "auto_recover" fields

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -100,12 +100,12 @@ function read_csv
   vm_base=${line_arr[8]}
   dut=${line_arr[9]//;/,}
   duts=${dut//[\[\] ]/}
-  inventory=${line_arr[10]}
+  inv_name=${line_arr[10]}
 }
 
 function read_yaml
 {
-  content=$(python -c "from __future__ import print_function; import yaml; print('+'.join(str(tb) for tb in yaml.safe_load(open('$tbfile')) if '$1' in str(tb)))")
+  content=$(python -c "from __future__ import print_function; import yaml; print('+'.join(str(tb) for tb in yaml.safe_load(open('$tbfile')) if '$1'==tb['conf-name']))")
 
   IFS=$'+' read -r -a tb_lines <<< $content
   linecount=${#tb_lines[@]}
@@ -124,9 +124,9 @@ function read_yaml
 
   tb_line=${tb_lines[0]}
   line_arr=($1)
-  for attr in group-name topo ptf_image_name ptf ptf_ip ptf_ipv6 server vm_base dut comment;
+  for attr in group-name topo ptf_image_name ptf ptf_ip ptf_ipv6 server vm_base dut inv_name auto_recover comment;
   do
-    value=$(python -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(tb['$attr'])")
+    value=$(python -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(tb.get('$attr', None))")
     [ "$value" == "None" ] && value=
     line_arr=("${line_arr[@]}" "$value")
   done
@@ -141,7 +141,7 @@ function read_yaml
   vm_base=${line_arr[8]}
   dut=${line_arr[9]}
   duts=$(python -c "from __future__ import print_function; print(','.join(eval(\"$dut\")))")
-  inventory=${line_arr[10]}
+  inv_name=${line_arr[10]}
 }
 
 function read_file
@@ -356,7 +356,7 @@ function announce_routes
 
   read_file $topology
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i "$inventory" testbed_announce_routes.yml --vault-password-file="$passfile" \
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i "$inv_name" testbed_announce_routes.yml --vault-password-file="$passfile" \
       -l "$server" -e vm_set_name="$vm_set_name" -e topo="$topo" -e ptf_ip="$ptf_ip" $@
 
   echo done

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -11,6 +11,8 @@
   vm_base: VM0100
   dut:
     - vlab-01
+  inv_name: veos_vtb
+  auto_recover: 'False'
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-t0-64
@@ -24,6 +26,8 @@
   vm_base: VM0100
   dut:
     - vlab-02
+  inv_name: veos_vtb
+  auto_recover: 'False'
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-t1-lag
@@ -37,6 +41,8 @@
   vm_base: VM0104
   dut:
     - vlab-03
+  inv_name: veos_vtb
+  auto_recover: 'False'
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-t0-2
@@ -50,6 +56,8 @@
   vm_base: VM0104
   dut:
     - vlab-04
+  inv_name: veos_vtb
+  auto_recover: 'False'
   comment: Tests virtual switch vm
 
 - conf-name: vms-kvm-dual-t0
@@ -64,4 +72,36 @@
   dut:
     - vlab-05
     - vlab-06
+  inv_name: veos_vtb
+  auto_recover: 'False'
   comment: Dual-TOR testbed
+
+- conf-name: vms-kvm-multi-asic-t1-lag
+  group-name: vms6-4
+  topo: t1-64-lag
+  ptf_image_name: docker-ptf
+  ptf: ptf-05
+  ptf_ip: 10.250.0.110/24
+  ptf_ipv6: fec0::ffff:afa:a/64
+  server: server_1
+  vm_base: VM0104
+  dut:
+    - vlab-07
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests multi-asic virtual switch vm
+
+- conf-name: vms-kvm-four-asic-t1-lag
+  group-name: vms6-4
+  topo: t1-8-lag
+  ptf_image_name: docker-ptf
+  ptf: ptf-05
+  ptf_ip: 10.250.0.110/24
+  ptf_ipv6: fec0::ffff:afa:a/64
+  server: server_1
+  vm_base: VM0104
+  dut:
+    - vlab-08
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests multi-asic virtual switch vm

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -159,9 +159,9 @@ class TestbedInfo(object):
             if tb_dict["ptf_ipv6"]:
                 ptf_ipv6 = self._ip_mask_to_cidr(tb_dict["ptf_ipv6"],
                                                  tb_dict["ptf_netmask_v6"])
-            testbed_mapping = zip(
-                self.testbed_fields,
-                [
+
+            if len(self.testbed_fields) == len(self.TESTBED_FIELDS_DEPRECATED):
+                tb_dict_fields = [
                     tb_name,
                     tb_dict["group-name"],
                     tb_dict["topo"],
@@ -174,7 +174,23 @@ class TestbedInfo(object):
                     tb_dict["duts"],
                     tb_dict["comment"]
                 ]
-            )
+            elif len(self.testbed_fields) == len(self.TESTBED_FIELDS_RECOMMENDED):
+                tb_dict_fields = [
+                    tb_name,
+                    tb_dict["group-name"],
+                    tb_dict["topo"],
+                    tb_dict["ptf_image_name"],
+                    tb_dict["ptf"],
+                    ptf_ip,
+                    ptf_ipv6,
+                    tb_dict["server"],
+                    tb_dict["vm_base"] or None,
+                    tb_dict["duts"],
+                    tb_dict["inv_name"],
+                    tb_dict["auto_recover"],
+                    tb_dict["comment"]
+                ]
+            testbed_mapping = zip(self.testbed_fields, tb_dict_fields)
             testbed = OrderedDict(testbed_mapping)
             testbed_data.append(testbed)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
After the new "inv_name" and "auto_recover" fields were added to testbed.csv file, the testbed.py
tool for generating yaml format testbed file needs to be updated. The testbed-cli.sh tool also has
some issues with dealing with yaml format testbed file. This PR is to fix these issues.

#### How did you do it?

Changes:
1. Update tests/common/testbed.py to support generating testbed.yaml file based on the new
    testbed.csv file.
2. Tool testbed-cli.sh has issue of reading yaml testbed file. If a testbed name is substring of
    another testbed name, the tool may found multiple entries for the testbed with shorter name
    while parsing yaml testbed file. This PR changed the string "in" match with "==" match.
3. Another issue is that the testbed-cli.sh tool does not support reading new "inv_name" and
    "auto_recover" fields from yaml testbed file.
4. PR #3127 added 'announce-routes' function to the testbed-cli.sh tool. This new function
    depends on the new "inv_name" field. That PR added a new variable "inventory" to the
    read_file functions to store value of the "inv_name" field. Unfortunately, some other functions
    ,including deploy_minigraph and generate_minigraph, use a same "inventory" variable
    for storing inventory file name passed in from command line. There are potential conflicts
    under some scenarios. This change updated the variable name in read_file to "inv_file" to
    avoid this potential conflict.
5. Updated the vtestbed.yaml file to make it consistent with vtestbed.csv.

#### How did you verify/test it?
* Run testbed.py to generate yaml testbed file from csv testbed file.
* Run announce-routes with yaml and csv testbed file.
* Run deploy-mg with yaml and csv testbed file.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
