### PR TITLE
Fixed regexp for parse output show_platform_psustatus

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -179,7 +179,7 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     if "201811" in duthost.os_version or "201911" in duthost.os_version:
         psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
     else:
-        psu_line_pattern = re.compile(r"PSU\s+\d+\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+        psu_line_pattern = re.compile(r"PSU\s+\d+\s+\S+\s+\S+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
 
     # Check that all PSUs are showing valid status and also at least one PSU is OK
     num_psu_ok = 0

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -150,7 +150,7 @@ def check_vendor_specific_psustatus(dut, psu_status_line):
         if "201811" in dut.os_version or "201911" in dut.os_version:
             psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
         else:
-            psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+            psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\S+\s+\S+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
 
         psu_match = psu_line_pattern.match(psu_status_line)
         psu_id = psu_match.group(1)


### PR DESCRIPTION

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed regular expression for test which parse output for command "show platform psustatus" 
Fixes # (issue) old regexp did not work

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Old regexp did not work with output like:
```
PSU    Model    Serial                          Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------  ----------------------------  -------------  -------------  -----------  --------  -----
PSU 1  0XNMHJ   CN-0XNMHJ-DED00-036-00M3-A00          12.19           8.37       102.10  OK        green
PSU 2  0XNMHJ   CN-0XNMHJ-DED00-036-00H0-A00          12.18          10.07       122.70  OK        green
```

#### How did you do it?
Changed regexp

#### How did you verify/test it?
Manually tested regexp with different outputs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

