### PR TITLE
Use string upto the first '_' to check for a supported topology

### DIFF
--- a/ansible/roles/eos/tasks/ceos_config.yml
+++ b/ansible/roles/eos/tasks/ceos_config.yml
@@ -27,6 +27,6 @@
 
 - name: update startup-config
   become: yes
-  template: src="{{ topo }}-{{ props.swrole }}.j2"
+  template: src="{{ base_topo }}-{{ props.swrole }}.j2"
             dest="/{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}/startup-config"
   delegate_to: "{{ VM_host[0] }}"

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -62,9 +62,12 @@
     fail: msg="Define topo variable with -e topo=something"
     when: topo is not defined
 
-  - name: Check if it is a known topology
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
+  - name: Check that topo is a known topology
     fail: msg="Unknown topology {{ topo }}"
-    when: topo not in topologies
+    when: base_topo not in topologies
 
   - name: Check that variable ptf_imagename is defined
     fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"
@@ -99,9 +102,12 @@
           fail: msg="Define topo variable with -e topo=something"
           when: topo is not defined
 
+        - set_fact:
+            base_topo: "{{ topo.split('_') | first }}"
+
         - name: Check if it is a known topology
           fail: msg="Unknown topology {{ topo }}"
-          when: topo not in topologies
+          when: base_topo not in topologies
 
         - name: Check that variable VM_base is defined
           fail: msg="Define VM_base variable with -e VM_base=something"

--- a/ansible/testbed_announce_routes.yml
+++ b/ansible/testbed_announce_routes.yml
@@ -25,9 +25,12 @@
     fail: msg="Define topo variable with -e topo=something"
     when: topo is not defined
 
-  - name: Check if it is a known topology
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
+  - name: Check that topo is a known topology
     fail: msg="Unknown topology {{ topo }}"
-    when: topo not in topologies
+    when: base_topo not in topologies
 
   - name: Check that variable ptf_ip is defined
     fail: msg="Define ptf ip variable with -e ptf_ip=something"

--- a/ansible/testbed_connect_topo.yml
+++ b/ansible/testbed_connect_topo.yml
@@ -31,9 +31,12 @@
     fail: msg="Define topo variable with -e topo=something"
     when: topo is not defined
 
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
   - name: Check if it is a known topology
     fail: msg="Unknown topology {{ topo }}"
-    when: topo not in topologies
+    when: base_topo not in topologies
 
   - name: Check that variable ptf_imagename is defined
     fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"

--- a/ansible/testbed_connect_vms.yml
+++ b/ansible/testbed_connect_vms.yml
@@ -36,7 +36,14 @@
 
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"
-    when: topo is not defined or topo not in topologies
+    when: topo is not defined
+
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: base_topo not in topologies
 
   - name: Load topo variables
     include_vars: "vars/topo_{{ topo }}.yml"

--- a/ansible/testbed_disconnect_vms.yml
+++ b/ansible/testbed_disconnect_vms.yml
@@ -36,7 +36,14 @@
 
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"
-    when: topo is not defined or topo not in topologies
+    when: topo is not defined
+
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: base_topo not in topologies
 
   - name: Load topo variables
     include_vars: "vars/topo_{{ topo }}.yml"

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -41,7 +41,14 @@
 
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"
-    when: topo is not defined or topo not in topologies
+    when: topo is not defined
+
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: base_topo not in topologies
 
   - name: Check that variable ptf_imagename is defined
     fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -44,7 +44,14 @@
 
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"
-    when: topo is not defined or topo not in topologies
+    when: topo is not defined
+
+  - set_fact:
+      base_topo: "{{ topo.split('_') | first }}"
+
+  - name: Check that variable topo is defined
+    fail: msg="Define topo variable with -e topo=something"
+    when: base_topo not in topologies
 
   - name: Check that variable ptf_imagename is defined
     fail: msg="Define ptf_imagename variable with -e ptf_imagename=something"


### PR DESCRIPTION


_

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We have support for DUTs that do not have all its ports connected to a fanout switch (discontiguous ports)
This implies that if we have multiple testbeds (each using different set of ports), then we have to a
topology file per testbed - identifying the different ports that are being used.  For example,
  - topo_t1-lag_testbed-1.yml
  - topo_t1-lag_testbed-2.yml

The current check for whether it is a supported topology simply compare the name of the topology (like t1-lag_testbed-1)
to the topologies defined in veos/veos_vtb file to see if it supported. This would require to add
entries for each testbed into the topologies defined in veos/veos_vtb.

Instead we can use the naming convention that the topology files will use '_' as a delimiter between
the topology we want and the testbed name, then we can use that topology name without the testbed
to check if it is a supported topology. Thus, we only need to put the topology name without the
testbed in topologies of veos/veos_vtb

#### How did you do it?

When checking for supported topologies, split the topology name (like t1-lag_testbed-1) with '_'
as a delimiter and checking the first element of the split list as a supported topology

#### How did you verify/test it?
Ran add-topo/remove-topo testbed-cli.sh command against topology files with no '_' and with '_'

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
