### PR TITLE
[iface_namingmode] Change route for test_show_ip_route_v6

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -881,7 +881,7 @@ class TestShowIP():
         as per the configured naming mode
         """
         dutHostGuest, mode, ifmode = setup_config_mode
-        route = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show ipv6 route 20c0:a800::/64'.format(ifmode))['stdout']
+        route = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show ipv6 route ::/0'.format(ifmode))['stdout']
         logger.info('route:\n{}'.format(route))
 
         if mode == 'alias':


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_show_ip_route_v6 fails due to route used in test have a nexthop to ToRouter, when it is expected to find 16 nexthops to SpineRouters. With route changed to `::/0` test passed successfully. 
Fixes # (issue)

```
show ipv6 route 20c0:a800::/64                                                                                                                     
Routing entry for 20c0:a800::/64                                                                                                                                        
  Known via "bgp", distance 20, metric 0, best                                                                                                                          
  Last update 00:21:31 ago                                                                                                                                              
  * fc00::42, via Ethernet64, weight 1
  
show ipv6 route ::/0
Routing entry for ::/0
  Known via "bgp", distance 20, metric 0, best
  Last update 00:21:30 ago
  * fc00::2, via Ethernet0, weight 1
  * fc00::6, via Ethernet4, weight 1
  * fc00::a, via Ethernet8, weight 1
  * fc00::e, via Ethernet12, weight 1
  * fc00::12, via Ethernet16, weight 1
  * fc00::16, via Ethernet20, weight 1
  * fc00::1a, via Ethernet24, weight 1
  * fc00::1e, via Ethernet28, weight 1
  * fc00::22, via Ethernet32, weight 1
  * fc00::26, via Ethernet36, weight 1
  * fc00::2a, via Ethernet40, weight 1
  * fc00::2e, via Ethernet44, weight 1
  * fc00::32, via Ethernet48, weight 1
  * fc00::36, via Ethernet52, weight 1
  * fc00::3a, via Ethernet56, weight 1
  * fc00::3e, via Ethernet60, weight 1
```
As an example here is route used for test_show_ip_route_v4: 
```
show ip route 192.168.1.1                                                                                                                          
Routing entry for 0.0.0.0/0                                                                                                                                             
  Known via "bgp", distance 20, metric 0, best                                                                                                                          
  Last update 00:20:56 ago                                                                                                                                              
  * 10.0.0.1, via Ethernet0, weight 1                                                                                                                                   
  * 10.0.0.3, via Ethernet4, weight 1                                                                                                                                   
  * 10.0.0.5, via Ethernet8, weight 1                                                                                                                                   
  * 10.0.0.7, via Ethernet12, weight 1                                                                                                                                  
  * 10.0.0.9, via Ethernet16, weight 1                                                                                                                                  
  * 10.0.0.11, via Ethernet20, weight 1                                                                                                                                 
  * 10.0.0.13, via Ethernet24, weight 1                                                                                                                                 
  * 10.0.0.15, via Ethernet28, weight 1                                                                                                                                 
  * 10.0.0.17, via Ethernet32, weight 1                                                                                                                                 
  * 10.0.0.19, via Ethernet36, weight 1                                                                                                                                 
  * 10.0.0.21, via Ethernet40, weight 1                                                                                                                                 
  * 10.0.0.23, via Ethernet44, weight 1                                                                                                                                 
  * 10.0.0.25, via Ethernet48, weight 1                                                                                                                                 
  * 10.0.0.27, via Ethernet52, weight 1                                                                                                                                 
  * 10.0.0.29, via Ethernet56, weight 1                                                                                                                                 
  * 10.0.0.31, via Ethernet60, weight 1  
```

**Actual results:** 
```
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[alias]   FAILED
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[default]   FAILED

           for intf in spine_ports['interface']:
>               assert re.search(r'via {}'.format(alias), route) is not None
E               AttributeError: 'module' object has no attribute 'locals'

spine_ports['interface']
[u'Ethernet8', u'Ethernet0', u'Ethernet4', u'Ethernet52', u'Ethernet56', u'Ethernet32', u'Ethernet16', u'Ethernet36', 
u'Ethernet12', u'Ethernet48', u'Ethernet44', u'Ethernet40', u'Ethernet28', u'Ethernet60', u'Ethernet20', u'Ethernet24']
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make TC pass 
#### How did you do it?
Change ipv6 route used for test
#### How did you verify/test it?
Run TC on t1 topo
```
PASSED iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[alias]
PASSED iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[default]
```
#### Any platform specific information?
```
SONiC.master.152-dirty-20210317.033059
Distribution: Debian 10.8
Kernel: 4.19.0-12-2-amd64
Build commit: 43d4d456
Build date: Wed Mar 17 14:05:52 UTC 2021
Built by: johnar@worker-s1fe620
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
