### PR TITLE
Poll for 10min for reboot cause to appear

### DIFF
--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -6,7 +6,7 @@ from paramiko.ssh_exception import BadHostKeyException, AuthenticationException,
 from pip._vendor.retrying import retry
 logger = logging.getLogger(__name__)
 
-DEFAULT_CMD_EXECUTION_TIMEOUT_SEC = 10
+DEFAULT_CMD_EXECUTION_TIMEOUT_SEC = 300
 
 class DeviceConnection:
     '''

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -246,6 +246,16 @@ def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgra
                         platform="remote",
                         qlen=10000,
                         log_file=log_file)
+
+            ctr = 120
+            # Poll every 5s for 10min
+            while ctr:
+                reboot_cause = get_reboot_cause(duthost)
+                if reboot_cause == upgrade_type:
+                    break
+                else:
+                    time.sleep(5)
+                ctr -= 1
             reboot_cause = get_reboot_cause(duthost)
             logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
             pytest_assert(reboot_cause == upgrade_type, "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
On some platforms and in some types of boots like fastboot, the device needs some time for the reboot cause file to be created and populated. We need to wait for some time before asserting the reboot type.

The command execution timeout needs to be increased as some platforms need more than 10s.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [-] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
On some platforms the reboot-cause file needs some time to be created.
#### How did you do it?
Poll for the reboot-cause for 10min and then assert.
#### How did you verify/test it?
The test now passes as the reboot-cause shows up.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
