### PR TITLE
[Pytest] Support per-module log file

### DIFF
--- a/tests/common/plugins/logging_utils/__init__.py
+++ b/tests/common/plugins/logging_utils/__init__.py
@@ -1,0 +1,25 @@
+"""Plugin that contains logging utilities to facilitate a better log."""
+import os
+import pytest
+
+
+def pytest_addoption(parser):
+
+    parser.addoption(
+        "--log-directory",
+        action="store",
+        dest="log_dir",
+        help="Per-module logs save directory, each test module will be saved under separate subdirs within."
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    config = item.config
+    log_dir = config.getoption("log_dir")
+    if log_dir:
+        logging_pluggin = config.pluginmanager.get_plugin("logging-plugin")
+        relpath = str(item.fspath)[len(str(config.rootdir)):].lstrip("/")
+        logfile = os.path.join(log_dir, os.path.splitext(relpath)[0] + ".log")
+        logging_pluggin.set_log_path(logfile)
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.test_completeness',
                   'tests.common.plugins.log_section_start',
                   'tests.common.plugins.custom_fixtures',
+                  'tests.common.plugins.logging_utils',
                   'tests.common.dualtor',
                   'tests.vxlan')
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add an option `--log-directory` to specify a directory to save log files, in which case the log file will be saved separately for each test `.py` module. 

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make `Pytest` the capability to store logs per module.

#### How did you do it?
Before each test item is setup, set the log file for each module.

#### How did you verify/test it?
Run `Pytest`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
