### PR TITLE
Fix vrf MGMT default gw for t1 type topologies

### DIFF
--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -42,7 +42,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -41,7 +41,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -42,7 +42,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -41,7 +41,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -41,7 +41,11 @@ ip routing
 ip routing vrf MGMT
 ipv6 unicast-routing
 !
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
 ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
 !
 interface Management {{ mgmt_if_index }}
  description TO LAB MGMT SWITCH


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently the topology infrastructure supports a different management gateway for VMs.
The VM startup config templates for t0 topologies have the logic of using {{ vm_mgmt_gw }}
for vrf MGMT. If {{ vm_mgmt_gw }} is not defined, fallback to use {{ mgmt_gw }}. Variables
"vm_mgmt_gw" and "mgmt_gw" can be defined in test server's host var file under
ansible/host_vars'. The VM startup config templates for t1 topologies do not have the same
logic. They always use {{ mgmt_gw }} as default gateway of vrf MGMT. This change is to align
t1 with t0. Same logic is added to the VM startup config templates for t1 topologies.

#### How did you do it?
Updated the VM startup config templates for t1 topologies. Use the same logic to firstly use
{{ vm_mgmt_gw }} as default gateway for vrf MGMT. When it is not defined, fallback to use
{{ mgmt_gw }}.

#### How did you verify/test it?
Test run add-topo for t1-lag topology. Verify the default gateway of vrf MGMT after topology is deployed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
