### PR TITLE
[test_vlan] Test case for QinQ packet switched based on outer vlan tag

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -245,6 +245,18 @@ def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff
                                 ip_ttl=ttl)
     return pkt
 
+def build_qinq_packet(outer_vlan_id, vlan_id,
+                      src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
+                      src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
+    pkt = testutils.simple_qinq_tcp_packet(eth_dst=dst_mac,
+                             eth_src=src_mac,
+                             dl_vlan_outer=outer_vlan_id,
+                             vlan_vid=vlan_id,
+                             ip_src=src_ip,
+                             ip_dst=dst_ip,
+                             ip_ttl=ttl)
+    return pkt
+
 def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], device_number=0, timeout=1):
     for port in ports:
         result = testutils.dp_poll(test, device_number=device_number, port_number=port,
@@ -465,5 +477,46 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
         logger.info ("Two Way Untagged Packet Transmission Works")
         logger.info ("Untagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
+    else:
+        pytest.fail("Expected packet was not received")
+
+
+def test_vlan_tc6_tagged_qinq_switch_on_outer_tag(ptfadapter, vlan_ports_list, duthost):
+    """
+    Test case #6
+    Send qinq packets w/ src and dst specified over tagged ports in vlan
+    Verify that the qinq packet is switched based on outer vlan tag + src/dst mac
+    """
+
+    # Add more supported platforms to the list as they are tested
+    qinq_switching_supported_platforms = ['mellanox']
+    if duthost.facts["asic_type"] not in qinq_switching_supported_platforms:
+        pytest.skip("Unsupported platform")
+
+    vlan_ids = vlan_ports_list[0]['permit_vlanid'].keys()
+    tagged_test_vlan = vlan_ids[0]
+
+    ports_for_test = []
+    for vlan_port in vlan_ports_list:
+        if vlan_port['pvid'] != tagged_test_vlan:
+            ports_for_test.append(vlan_port['port_index'][0])
+
+    #take two tagged ports for test
+    src_port = ports_for_test[0]
+    dst_port = ports_for_test[-1]
+
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port)
+    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port)
+
+    transmit_qinq_pkt = build_qinq_packet(outer_vlan_id=tagged_test_vlan, vlan_id=250, src_mac=src_mac, dst_mac=dst_mac)
+    logger.info ("QinQ packet to be sent from port {} to port {}".format(src_port, dst_port))
+    testutils.send(ptfadapter, src_port, transmit_qinq_pkt)
+
+    result_dst_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=dst_port,
+                                      timeout=1, exp_pkt=transmit_qinq_pkt)
+
+    if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
+        logger.info ("QinQ Packet Transmission Works")
+        logger.info ("QinQ packet successfully sent from port {} to port {}".format(src_port, dst_port))
     else:
         pytest.fail("Expected packet was not received")

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -512,11 +512,5 @@ def test_vlan_tc6_tagged_qinq_switch_on_outer_tag(ptfadapter, vlan_ports_list, d
     logger.info ("QinQ packet to be sent from port {} to port {}".format(src_port, dst_port))
     testutils.send(ptfadapter, src_port, transmit_qinq_pkt)
 
-    result_dst_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=dst_port,
-                                      timeout=1, exp_pkt=transmit_qinq_pkt)
-
-    if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
-        logger.info ("QinQ Packet Transmission Works")
-        logger.info ("QinQ packet successfully sent from port {} to port {}".format(src_port, dst_port))
-    else:
-        pytest.fail("Expected packet was not received")
+    testutils.verify_packet(ptfadapter, transmit_qinq_pkt, dst_port)
+    logger.info ("QinQ packet switching worked successfully...")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Vlan test enhancement to test L2 packet switching for QinQ packets. We test if the packet is switched based on the outer QinQ vlan tag, given tagged vlan configuration for associated port on the switch. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To test packet switching for QinQ packets
#### How did you do it?
Enhance test_vlan to include PTF based packet test where we send QinQ packet
#### How did you verify/test it?
Tested on DUT where sonic-mgmt test_vlan was run
#### Any platform specific information?
Currently tested on the Mellanox platform: limited the test case for Mellanox only and marked pytest skip for others. Once it is tested on other platforms, the pytest skip list may be modified/platform check removed altogether.
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
