### PR TITLE
[VM]: Polish variable name from sonic to vsonic

### DIFF
--- a/ansible/group_vars/vm_host/main.yml
+++ b/ansible/group_vars/vm_host/main.yml
@@ -1,4 +1,4 @@
-supported_vm_types: [ "veos", "sonic", "ceos" ]
+supported_vm_types: [ "veos", "ceos", "vsonic" ]
 root_path: veos-vm
 vm_images_url: https://acsbe.blob.core.windows.net/vmimages
 cd_image_filename: Aboot-veos-serial-8.0.0.iso

--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -109,4 +109,4 @@
     become: yes
     when: autostart|bool == true
 
-  when: not skip_this_vm and (vm_type | lower) == "sonic"
+  when: not skip_this_vm and (vm_type | lower) == "vsonic"

--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -61,7 +61,7 @@
     - set_fact:
         src_image_name: "{{ sonic_image_filename }}"
 
-  when: (vm_type | lower) == "sonic"
+  when: (vm_type | lower) == "vsonic"
 
 - name: Create VMs network
   become: yes

--- a/ansible/roles/vm_set/tasks/start_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vm.yml
@@ -19,7 +19,7 @@
 - set_fact:
     disk_image_name: "{{ vm_type }}_{{ vm_name }}.img"
     vm_xml_template: "sonic_vm.xml.j2"
-  when: (vm_type | lower) == "sonic"
+  when: (vm_type | lower) == "vsonic"
 
 - set_fact:
     disk_image: "{{ disk_image_dir }}/{{ disk_image_name }}"

--- a/ansible/roles/vm_set/tasks/stop_vm.yml
+++ b/ansible/roles/vm_set/tasks/stop_vm.yml
@@ -4,7 +4,7 @@
 
 - set_fact:
     disk_image_name: "{{ vm_type }}_{{ vm_name }}.img"
-  when: (vm_type | lower) == "sonic"
+  when: (vm_type | lower) == "vsonic"
 
 - set_fact:
     disk_image: "{{ disk_image_dir }}/{{ disk_image_name }}"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -19,7 +19,7 @@ function usage
   echo "Options:"
   echo "    -t <tbfile>     : testbed CSV file name (default: 'testbed.csv')"
   echo "    -m <vmfile>     : virtual machine file name (default: 'veos')"
-  echo "    -k <vmtype>     : vm type (veos|ceos|sonic) (default: 'veos')"
+  echo "    -k <vmtype>     : vm type (veos|ceos|vsonic) (default: 'veos')"
   echo "    -n <vm_num>     : vm num (default: 0)"
   echo "    -s <msetnumber> : master set identifier on specified <k8s-server-name> (default: 1)"
   echo "    -d <dir>        : sonic vm directory (default: $HOME/sonic-vm)"

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -139,7 +139,7 @@ Now we need to spin up some VMs on the host to act as neighboring devices to our
 ```
 $ ./testbed-cli.sh -m veos_vtb -n 4 start-vms server_1 password.txt
 ```
-If you use SONiC image as the VMs, you need to add extract parameters `-k sonic` so that this command is `./testbed-cli.sh -m veos_vtb -n 4 -k sonic start-vms server_1 password.txt`. Of course, if you want to stop VMs, you also need to append these parameters after original command.
+If you use SONiC image as the VMs, you need to add extract parameters `-k vsonic` so that this command is `./testbed-cli.sh -m veos_vtb -n 4 -k vsonic start-vms server_1 password.txt`. Of course, if you want to stop VMs, you also need to append these parameters after original command.
 
 - **Reminder:** By default, this shell script requires a password file. If you are not using Ansible Vault, just create a file with a dummy password and pass the filename to the command line.
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Rename variable name from `sonic` to `vsonic`. Because in the future, we will involve sonic container as the neighbor devices. The variable name `vsonic` is better and clearer to differentiate sonic vm with sonic container.
