### PR TITLE
Log bgp routing status in SSH VM thread

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -137,13 +137,13 @@ class Arista(object):
             v4_routing, bgp_route_v4_output = self.check_bgp_route(self.v4_routes)
             if v4_routing != v4_routing_ok:
                 v4_routing_ok = v4_routing
-                self.log('bgp_route_v4: %s' % (v4_routing_ok))
+                self.log('BGP routing for ipv4 OK: %s' % (v4_routing_ok))
             info['bgp_route_v4'] = v4_routing_ok
 
             v6_routing, bgp_route_v6_output = self.check_bgp_route(self.v6_routes, ipv6=True)
             if v6_routing != v6_routing_ok:
                 v6_routing_ok = v6_routing
-                self.log('bgp_route_v6: %s' % (v6_routing_ok))
+                self.log('BGP routing for ipv6 OK: %s' % (v6_routing_ok))
             info["bgp_route_v6"] = v6_routing_ok
 
             portchannel_output = self.do_cmd("show interfaces po1 | json")

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -134,10 +134,16 @@ class Arista(object):
             bgp_neig_output = self.do_cmd('show ip bgp neighbors')
             info['bgp_neig'] = self.parse_bgp_neighbor(bgp_neig_output)
 
-            v4_routing_ok, bgp_route_v4_output = self.check_bgp_route(self.v4_routes)
+            v4_routing, bgp_route_v4_output = self.check_bgp_route(self.v4_routes)
+            if v4_routing != v4_routing_ok:
+                v4_routing_ok = v4_routing
+                self.log('bgp_route_v4: %s' % (v4_routing_ok))
             info['bgp_route_v4'] = v4_routing_ok
 
-            v6_routing_ok, bgp_route_v6_output = self.check_bgp_route(self.v6_routes, ipv6=True)
+            v6_routing, bgp_route_v6_output = self.check_bgp_route(self.v6_routes, ipv6=True)
+            if v6_routing != v6_routing_ok:
+                v6_routing_ok = v6_routing
+                self.log('bgp_route_v6: %s' % (v6_routing_ok))
             info["bgp_route_v6"] = v6_routing_ok
 
             portchannel_output = self.do_cmd("show interfaces po1 | json")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add log for bgp routing status in SSH VM thread
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add log for bgp routing status in SSH VM thread for better debugging

#### How did you do it?
Add log when bgp routing status changes in SSH VM thread

#### How did you verify/test it?
Verified in kvm warm reboot test
```
2021-03-29 17:52:44 : SSH thread for VM 10.250.0.54 started
2021-03-29 17:52:44 : SSH thread for VM 10.250.0.53 started
2021-03-29 17:52:44 : SSH thread for VM 10.250.0.52 started
2021-03-29 17:52:44 : SSH thread for VM 10.250.0.51 started
...
2021-03-29 17:53:57 : SSH thread VM=10.250.0.52: BGP routing for ipv4 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.52: BGP routing for ipv6 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.53: BGP routing for ipv4 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.53: BGP routing for ipv6 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.54: BGP routing for ipv4 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.54: BGP routing for ipv6 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.51: BGP routing for ipv4 OK: True
2021-03-29 17:53:58 : SSH thread VM=10.250.0.51: BGP routing for ipv6 OK: True
...
2021-03-29 17:56:02 : SSH thread VM=10.250.0.52: BGP routing for ipv4 OK: False
2021-03-29 17:56:02 : SSH thread VM=10.250.0.52: BGP routing for ipv4 OK: True
...
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
