### PR TITLE
Parallelizing sanity check and log analyzer on DUTs in a multi-dut testbed

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -127,7 +127,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
         # start bgpd if not started
         node_results = []
         node['host'].start_bgpd()
-        logger.info('disable graceful restart on neighbor {}'.format(k))
+        logger.info('disable graceful restart on neighbor {}'.format(node))
         node_results.append(node['host'].eos_config(
                 lines=['no graceful-restart'], \
                 parents=['router bgp {}'.format(node['conf']['bgp']['asn']), 'address-family ipv4'], \

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -246,7 +246,7 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
         tor1_asn = setup['tor1_asn']
 
         vm_route = nbrhosts[node]['host'].get_route(route.prefix)
-        vm_route = {'failed': False}
+        vm_route['failed'] = False
         vm_route['tor_route'] = vm_route
         if accepted:
             if route.prefix not in vm_route['vrfs']['default']['bgpRouteEntries'].keys():

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -3,12 +3,42 @@ import pytest
 
 from loganalyzer import LogAnalyzer
 from tests.common.errors import RunAnsibleModuleFail
-import re
+from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 
 
 def pytest_addoption(parser):
     parser.addoption("--disable_loganalyzer", action="store_true", default=False,
                      help="disable loganalyzer analysis for 'loganalyzer' fixture")
+
+
+@reset_ansible_local_tmp
+def analyzer_logrotate(node=None, results=None):
+    logging.info("logrotate called on {}".format(node.hostname))
+    try:
+        node.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+    except RunAnsibleModuleFail as e:
+        logging.warning("logrotate is failed. Command returned:\n"
+                        "Stdout: {}\n"
+                        "Stderr: {}\n"
+                        "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
+
+
+@reset_ansible_local_tmp
+def analyzer_add_marker(analyzers, node=None, results=None):
+    logging.info("add marker called on {}".format(node.hostname))
+    loganalyzer = analyzers[node.hostname]
+    logging.info("Add start marker into DUT syslog for host {}".format(node.hostname))
+    marker = loganalyzer.init()
+    logging.info("Load config and analyze log for host {}".format(node.hostname))
+    # Read existed common regular expressions located with legacy loganalyzer module
+    loganalyzer.load_common_config()
+    results[node.hostname] = marker
+
+
+@reset_ansible_local_tmp
+def analyze_logs(analyzers, markers, node=None, results=None):
+    dut_analyzer = analyzers[node.hostname]
+    dut_analyzer.analyze(markers[node.hostname])
 
 
 @pytest.fixture(autouse=True)
@@ -18,34 +48,18 @@ def loganalyzer(duthosts, request):
         yield
         return
 
-    analyzers = {}
-    markers = {}
     # Analyze all the duts
+    analyzers = {}
+    parallel_run(analyzer_logrotate, [], {}, duthosts, timeout=120)
     for duthost in duthosts:
-        # Force rotate logs
-        try:
-            duthost.shell(
-                "/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1"
-                )
-        except RunAnsibleModuleFail as e:
-            logging.warning("logrotate is failed. Command returned:\n"
-                            "Stdout: {}\n"
-                            "Stderr: {}\n"
-                            "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
-
-        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
-        logging.info("Add start marker into DUT syslog")
-        marker = loganalyzer.init()
-        logging.info("Load config and analyze log")
-        # Read existed common regular expressions located with legacy loganalyzer module
-        loganalyzer.load_common_config()
-        analyzers[duthost.hostname] = loganalyzer
-        markers[duthost.hostname] = marker
+        analyzers[duthost.hostname] = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
+    markers = parallel_run(analyzer_add_marker, [analyzers], {}, duthosts, timeout=120)
 
     yield analyzers
 
     # Skip LogAnalyzer if case is skipped
     if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped:
         return
-    for dut_hostname, dut_analyzer in analyzers.items():
-        dut_analyzer.analyze(markers[dut_hostname])
+    logging.info("Starting to analyse on all DUTs")
+    parallel_run(analyze_logs, [analyzers, markers], {}, duthosts, timeout=120)
+

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -88,7 +88,7 @@ def print_logs(duthosts):
             res.pop('stdout')
             res.pop('stderr')
             outputs.append(res)
-        logger.info(json.dumps(outputs, indent=4))
+        logger.info("dut={}, cmd_outputs={}".format(dut.hostname,json.dumps(outputs, indent=4)))
 
 
 def filter_check_items(tbinfo, check_items):

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -33,11 +33,11 @@ __all__ = [
 @pytest.fixture(scope="module")
 def check_services(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, (args), kwargs, duthosts, timeout=SYSTEM_STABILIZE_MAX_TIME)
+        result = parallel_run(_check_services_on_dut, (args), kwargs, duthosts, timeout=SYSTEM_STABILIZE_MAX_TIME)
         return result.values()
 
     @reset_ansible_local_tmp
-    def _check_on_dut(*args, **kwargs):
+    def _check_services_on_dut(*args, **kwargs):
         dut=kwargs['node']
         results = kwargs['results']
         logger.info("Checking services status on %s..." % dut.hostname)
@@ -118,11 +118,11 @@ def _find_down_ports(dut, phy_interfaces, ip_interfaces):
 @pytest.fixture(scope="module")
 def check_interfaces(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
+        result = parallel_run(_check_interfaces_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
         return result.values()
 
     @reset_ansible_local_tmp
-    def _check_on_dut(*args, **kwargs):
+    def _check_interfaces_on_dut(*args, **kwargs):
         dut = kwargs['node']
         results = kwargs['results']
         logger.info("Checking interfaces status on %s..." % dut.hostname)
@@ -179,11 +179,11 @@ def check_interfaces(duthosts):
 @pytest.fixture(scope="module")
 def check_bgp(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
+        result = parallel_run(_check_bgp_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
         return result.values()
 
     @reset_ansible_local_tmp
-    def _check_on_dut(*args, **kwargs):
+    def _check_bgp_on_dut(*args, **kwargs):
         dut = kwargs['node']
         results = kwargs['results']
 
@@ -263,11 +263,11 @@ def _is_db_omem_over_threshold(command_output):
 @pytest.fixture(scope="module")
 def check_dbmemory(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        result = parallel_run(_check_dbmemory_on_dut, args, kwargs, duthosts, timeout=600)
         return result.values()
 
     @reset_ansible_local_tmp
-    def _check_on_dut(*args, **kwargs):
+    def _check_dbmemory_on_dut(*args, **kwargs):
         dut = kwargs['node']
         results = kwargs['results']
 
@@ -468,11 +468,11 @@ def check_monit(duthosts):
     @return: A dictionary contains the testing result (failed or not failed) and the status of each service.
     """
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        result = parallel_run(_check_monit_on_dut, args, kwargs, duthosts, timeout=600)
         return result.values()
 
     @reset_ansible_local_tmp
-    def _check_on_dut(*args, **kwargs):
+    def _check_monit_on_dut(*args, **kwargs):
         dut = kwargs['node']
         results = kwargs['results']
 
@@ -531,11 +531,11 @@ def check_monit(duthosts):
 @pytest.fixture(scope="module")
 def check_processes(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=600)
         return result.values()
 
     @reset_ansible_local_tmp
-    def _check_on_dut(*args, **kwargs):
+    def _check_processes_on_dut(*args, **kwargs):
         dut = kwargs['node']
         results = kwargs['results']
         logger.info("Checking process status on %s..." % dut.hostname)

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -11,6 +11,7 @@ from tests.common.dualtor.mux_simulator_control import *
 from tests.common.dualtor.dual_tor_utils import *
 from tests.common.cache import FactsCache
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
+from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 
 logger = logging.getLogger(__name__)
 SYSTEM_STABILIZE_MAX_TIME = 300
@@ -32,39 +33,43 @@ __all__ = [
 @pytest.fixture(scope="module")
 def check_services(duthosts):
     def _check(*args, **kwargs):
-        check_results = []
-        for dut in duthosts:
-            logger.info("Checking services status on %s..." % dut.hostname)
+        result = parallel_run(_check_on_dut, (args), kwargs, duthosts, timeout=SYSTEM_STABILIZE_MAX_TIME)
+        return result.values()
 
-            networking_uptime = dut.get_networking_uptime().seconds
-            timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
-            interval = 20
-            logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" % \
-                        (networking_uptime, timeout, interval))
+    @reset_ansible_local_tmp
+    def _check_on_dut(*args, **kwargs):
+        dut=kwargs['node']
+        results = kwargs['results']
+        logger.info("Checking services status on %s..." % dut.hostname)
 
-            check_result = {"failed": True, "check_item": "services", "host": dut.hostname}
-            if timeout == 0:    # Check services status, do not retry.
+        networking_uptime = dut.get_networking_uptime().seconds
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
+        interval = 20
+        logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" % \
+                    (networking_uptime, timeout, interval))
+
+        check_result = {"failed": True, "check_item": "services", "host": dut.hostname}
+        if timeout == 0:    # Check services status, do not retry.
+            services_status = dut.critical_services_status()
+            check_result["failed"] = False if all(services_status.values()) else True
+            check_result["services_status"] = services_status
+        else:
+            start = time.time()
+            elapsed = 0
+            while elapsed < timeout:
                 services_status = dut.critical_services_status()
                 check_result["failed"] = False if all(services_status.values()) else True
                 check_result["services_status"] = services_status
-            else:               # Retry checking service status
-                start = time.time()
-                elapsed = 0
-                while elapsed < timeout:
-                    services_status = dut.critical_services_status()
-                    check_result["failed"] = False if all(services_status.values()) else True
-                    check_result["services_status"] = services_status
 
-                    if check_result["failed"]:
-                        wait(interval, msg="Not all services are started, wait %d seconds to retry. Remaining time: %d %s" % \
-                            (interval, int(timeout - elapsed), str(check_result["services_status"])))
-                        elapsed = time.time() - start
-                    else:
-                        break
+                if check_result["failed"]:
+                    wait(interval, msg="Not all services are started, wait %d seconds to retry. Remaining time: %d %s" % \
+                                       (interval, int(timeout - elapsed), str(check_result["services_status"])))
+                    elapsed = time.time() - start
+                else:
+                    break
 
-            logger.info("Done checking services status on %s" % dut.hostname)
-            check_results.append(check_result)
-        return check_results
+        logger.info("Done checking services status on %s" % dut.hostname)
+        results[dut.hostname] = check_result
     return _check
 
 
@@ -113,115 +118,127 @@ def _find_down_ports(dut, phy_interfaces, ip_interfaces):
 @pytest.fixture(scope="module")
 def check_interfaces(duthosts):
     def _check(*args, **kwargs):
-        check_results = []
-        for dut in duthosts.frontend_nodes:
-            logger.info("Checking interfaces status on %s..." % dut.hostname)
+        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        return result.values()
 
-            networking_uptime = dut.get_networking_uptime().seconds
-            timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
-            interval = 20
-            logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" % \
-                        (networking_uptime, timeout, interval))
+    @reset_ansible_local_tmp
+    def _check_on_dut(*args, **kwargs):
+        dut = kwargs['node']
+        results = kwargs['results']
+        logger.info("Checking interfaces status on %s..." % dut.hostname)
 
-            down_ports = []
-            check_result = {"failed": True, "check_item": "interfaces", "host": dut.hostname}
-            for asic in dut.asics:
-                ip_interfaces = []
-                cfg_facts = asic.config_facts(host=dut.hostname,
-                                            source="persistent", verbose=False)['ansible_facts']
-                phy_interfaces = [k for k, v in cfg_facts["PORT"].items() if "admin_status" in v and v["admin_status"] == "up"]
-                if "PORTCHANNEL_INTERFACE" in cfg_facts:
-                    ip_interfaces = cfg_facts["PORTCHANNEL_INTERFACE"].keys()
-                if "VLAN_INTERFACE" in cfg_facts:
-                    ip_interfaces += cfg_facts["VLAN_INTERFACE"].keys()
+        networking_uptime = dut.get_networking_uptime().seconds
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
+        interval = 20
+        logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" % \
+                    (networking_uptime, timeout, interval))
 
-                logger.info(json.dumps(phy_interfaces, indent=4))
-                logger.info(json.dumps(ip_interfaces, indent=4))
+        down_ports = []
+        check_result = {"failed": True, "check_item": "interfaces", "host": dut.hostname}
+        for asic in dut.asics:
+            ip_interfaces = []
+            cfg_facts = asic.config_facts(host=dut.hostname,
+                                          source="persistent", verbose=False)['ansible_facts']
+            phy_interfaces = [k for k, v in cfg_facts["PORT"].items() if
+                              "admin_status" in v and v["admin_status"] == "up"]
+            if "PORTCHANNEL_INTERFACE" in cfg_facts:
+                ip_interfaces = cfg_facts["PORTCHANNEL_INTERFACE"].keys()
+            if "VLAN_INTERFACE" in cfg_facts:
+                ip_interfaces += cfg_facts["VLAN_INTERFACE"].keys()
 
-                if timeout == 0:    # Check interfaces status, do not retry.
-                    down_ports += _find_down_ports(asic, phy_interfaces, ip_interfaces)
+            logger.info(json.dumps(phy_interfaces, indent=4))
+            logger.info(json.dumps(ip_interfaces, indent=4))
+
+            if timeout == 0:  # Check interfaces status, do not retry.
+                down_ports += _find_down_ports(asic, phy_interfaces, ip_interfaces)
+                check_result["failed"] = True if len(down_ports) > 0 else False
+                check_result["down_ports"] = down_ports
+            else:  # Retry checking interface status
+                start = time.time()
+                elapsed = 0
+                while elapsed < timeout:
+                    down_ports = _find_down_ports(asic, phy_interfaces, ip_interfaces)
                     check_result["failed"] = True if len(down_ports) > 0 else False
                     check_result["down_ports"] = down_ports
-                else:               # Retry checking interface status
-                    start = time.time()
-                    elapsed = 0
-                    while elapsed < timeout:
-                        down_ports = _find_down_ports(asic, phy_interfaces, ip_interfaces)
-                        check_result["failed"] = True if len(down_ports) > 0 else False
-                        check_result["down_ports"] = down_ports
 
-                        if check_result["failed"]:
-                            wait(interval, msg="Found down ports, wait %d seconds to retry. Remaining time: %d, down_ports=%s" % \
-                                (interval, int(timeout - elapsed), str(check_result["down_ports"])))
-                            elapsed = time.time() - start
-                        else:
-                            break
+                    if check_result["failed"]:
+                        wait(interval,
+                             msg="Found down ports, wait %d seconds to retry. Remaining time: %d, down_ports=%s" % \
+                                 (interval, int(timeout - elapsed), str(check_result["down_ports"])))
+                        elapsed = time.time() - start
+                    else:
+                        break
 
-            logger.info("Done checking interfaces status on %s" % dut.hostname)
-            check_result["failed"] = True if len(down_ports) > 0 else False
-            check_result["down_ports"] = down_ports
-            check_results.append(check_result)
-        return check_results
+        logger.info("Done checking interfaces status on %s" % dut.hostname)
+        check_result["failed"] = True if len(down_ports) > 0 else False
+        check_result["down_ports"] = down_ports
+        results[dut.hostname] = check_result
     return _check
 
 
 @pytest.fixture(scope="module")
 def check_bgp(duthosts):
     def _check(*args, **kwargs):
-        check_results = []
-        for dut in duthosts.frontend_nodes:
-            def _check_bgp_status_helper():
-                asic_check_results = []
-                bgp_facts = dut.bgp_facts(asic_index='all')
-                for asic_index, a_asic_facts in enumerate(bgp_facts):
-                    a_asic_result = False
-                    a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']
-                    if a_asic_neighbors:
-                        down_neighbors = [k for k, v in a_asic_neighbors.items()
-                                        if v['state'] != 'established']
-                        if down_neighbors:
-                            if dut.facts['num_asic'] == 1:
-                                check_result['bgp'] = {'down_neighbors' : down_neighbors }
-                            else:
-                                check_result['bgp' + str(asic_index)] = {'down_neighbors' : down_neighbors }
-                            a_asic_result = True
+        result = parallel_run(_check_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
+        return result.values()
+
+    @reset_ansible_local_tmp
+    def _check_on_dut(*args, **kwargs):
+        dut = kwargs['node']
+        results = kwargs['results']
+
+        def _check_bgp_status_helper():
+            asic_check_results = []
+            bgp_facts = dut.bgp_facts(asic_index='all')
+            for asic_index, a_asic_facts in enumerate(bgp_facts):
+                a_asic_result = False
+                a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']
+                if a_asic_neighbors:
+                    down_neighbors = [k for k, v in a_asic_neighbors.items()
+                                      if v['state'] != 'established']
+                    if down_neighbors:
+                        if dut.facts['num_asic'] == 1:
+                            check_result['bgp'] = {'down_neighbors': down_neighbors}
                         else:
-                            a_asic_result = False
-                            if dut.facts['num_asic'] == 1:
-                                if 'bgp' in check_result:
-                                    check_result['bgp'].pop('down_neighbors', None)
-                            else:
-                                if 'bgp' + str(asic_index) in check_result:
-                                    check_result['bgp' + str(asic_index)].pop('down_neighbors', None)
-                    else:
+                            check_result['bgp' + str(asic_index)] = {'down_neighbors': down_neighbors}
                         a_asic_result = True
+                    else:
+                        a_asic_result = False
+                        if dut.facts['num_asic'] == 1:
+                            if 'bgp' in check_result:
+                                check_result['bgp'].pop('down_neighbors', None)
+                        else:
+                            if 'bgp' + str(asic_index) in check_result:
+                                check_result['bgp' + str(asic_index)].pop('down_neighbors', None)
+                else:
+                    a_asic_result = True
 
-                    asic_check_results.append(a_asic_result)
+                asic_check_results.append(a_asic_result)
 
-                if any(asic_check_results):
-                    check_result['failed'] = True
-                return not check_result['failed']
+            if any(asic_check_results):
+                check_result['failed'] = True
+            return not check_result['failed']
 
-            logger.info("Checking bgp status on host %s ..." % dut.hostname)
-            check_result = {"failed": False, "check_item": "bgp", "host": dut.hostname}
+        logger.info("Checking bgp status on host %s ..." % dut.hostname)
+        check_result = {"failed": False, "check_item": "bgp", "host": dut.hostname}
 
-            networking_uptime = dut.get_networking_uptime().seconds
-            timeout = max(SYSTEM_STABILIZE_MAX_TIME - networking_uptime, 1)
-            interval = 20
-            wait_until(timeout, interval, _check_bgp_status_helper)
-            if (check_result['failed']):
-                for a_result in check_result.keys():
-                    if a_result != 'failed':
-                        # Dealing with asic result
-                        if 'down_neighbors' in check_result[a_result]:
-                            logger.info('BGP neighbors down: %s on bgp instance %s on dut %s' % (check_result[a_result]['down_neighbors'], a_result, dut.hostname))
-            else:
-                logger.info('No BGP neighbors are down on %s' % dut.hostname)
+        networking_uptime = dut.get_networking_uptime().seconds
+        timeout = max(SYSTEM_STABILIZE_MAX_TIME - networking_uptime, 1)
+        interval = 20
+        wait_until(timeout, interval, _check_bgp_status_helper)
+        if (check_result['failed']):
+            for a_result in check_result.keys():
+                if a_result != 'failed':
+                    # Dealing with asic result
+                    if 'down_neighbors' in check_result[a_result]:
+                        logger.info('BGP neighbors down: %s on bgp instance %s on dut %s' % (
+                            check_result[a_result]['down_neighbors'], a_result, dut.hostname))
+        else:
+            logger.info('No BGP neighbors are down on %s' % dut.hostname)
 
-            logger.info("Done checking bgp status on %s" % dut.hostname)
-            check_results.append(check_result)
+        logger.info("Done checking bgp status on %s" % dut.hostname)
+        results[dut.hostname] = check_result
 
-        return check_results
     return _check
 
 
@@ -246,23 +263,28 @@ def _is_db_omem_over_threshold(command_output):
 @pytest.fixture(scope="module")
 def check_dbmemory(duthosts):
     def _check(*args, **kwargs):
-        check_results = []
-        for dut in duthosts:
-            logger.info("Checking database memory on %s..." % dut.hostname)
-            redis_cmd = "client list"
-            check_result = {"failed": False, "check_item": "dbmemory", "host": dut.hostname}
-            # check the db memory on the redis instance running on each instance
-            for asic in dut.asics:
-                res = asic.run_redis_cli_cmd(redis_cmd)['stdout_lines']
-                result, total_omem = _is_db_omem_over_threshold(res)
-                if result:
-                    check_result["failed"] = True
-                    check_result["total_omem"] = total_omem
-                    logging.info("{} db memory over the threshold ".format(str(asic.namespace or '')))
-                    break
-            logger.info("Done checking database memory on %s" % dut.hostname)
-            check_results.append(check_result)
-        return check_results
+        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        return result.values()
+
+    @reset_ansible_local_tmp
+    def _check_on_dut(*args, **kwargs):
+        dut = kwargs['node']
+        results = kwargs['results']
+
+        logger.info("Checking database memory on %s..." % dut.hostname)
+        redis_cmd = "client list"
+        check_result = {"failed": False, "check_item": "dbmemory", "host": dut.hostname}
+        # check the db memory on the redis instance running on each instance
+        for asic in dut.asics:
+            res = asic.run_redis_cli_cmd(redis_cmd)['stdout_lines']
+            result, total_omem = _is_db_omem_over_threshold(res)
+            if result:
+                check_result["failed"] = True
+                check_result["total_omem"] = total_omem
+                logging.info("{} db memory over the threshold ".format(str(asic.namespace or '')))
+                break
+        logger.info("Done checking database memory on %s" % dut.hostname)
+        results[dut.hostname] = check_result
     return _check
 
 
@@ -446,76 +468,98 @@ def check_monit(duthosts):
     @return: A dictionary contains the testing result (failed or not failed) and the status of each service.
     """
     def _check(*args, **kwargs):
-        check_results = []
-        for dut in duthosts:
-            logger.info("Checking status of each Monit service...")
-            networking_uptime = dut.get_networking_uptime().seconds
-            timeout = max((MONIT_STABILIZE_MAX_TIME - networking_uptime), 0)
-            interval = 20
-            logger.info("networking_uptime = {} seconds, timeout = {} seconds, interval = {} seconds" \
-                        .format(networking_uptime, timeout, interval))
+        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        return result.values()
 
-            check_result = {"failed": False, "check_item": "monit", "host": dut.hostname}
+    @reset_ansible_local_tmp
+    def _check_on_dut(*args, **kwargs):
+        dut = kwargs['node']
+        results = kwargs['results']
 
-            if timeout == 0:
+        logger.info("Checking status of each Monit service...")
+        networking_uptime = dut.get_networking_uptime().seconds
+        timeout = max((MONIT_STABILIZE_MAX_TIME - networking_uptime), 0)
+        interval = 20
+        logger.info("networking_uptime = {} seconds, timeout = {} seconds, interval = {} seconds" \
+                    .format(networking_uptime, timeout, interval))
+
+        check_result = {"failed": False, "check_item": "monit", "host": dut.hostname}
+
+        if timeout == 0:
+            monit_services_status = dut.get_monit_services_status()
+            if not monit_services_status:
+                logger.info("Monit was not running.")
+                check_result["failed"] = True
+                check_result["failed_reason"] = "Monit was not running"
+                logger.info("Checking status of each Monit service was done!")
+                return check_result
+
+            check_result = _check_monit_services_status(check_result, monit_services_status)
+        else:
+            start = time.time()
+            elapsed = 0
+            is_monit_running = False
+            while elapsed < timeout:
+                check_result["failed"] = False
                 monit_services_status = dut.get_monit_services_status()
                 if not monit_services_status:
-                    logger.info("Monit was not running.")
-                    check_result["failed"] = True
-                    check_result["failed_reason"] = "Monit was not running"
-                    logger.info("Checking status of each Monit service was done!")
-                    return check_result
+                    wait(interval, msg="Monit was not started and wait {} seconds to retry. Remaining time: {}." \
+                         .format(interval, timeout - elapsed))
+                    elapsed = time.time() - start
+                    continue
 
+                is_monit_running = True
                 check_result = _check_monit_services_status(check_result, monit_services_status)
-            else:
-                start = time.time()
-                elapsed = 0
-                is_monit_running = False
-                while elapsed < timeout:
-                    check_result["failed"] = False
-                    monit_services_status = dut.get_monit_services_status()
-                    if not monit_services_status:
-                        wait(interval, msg="Monit was not started and wait {} seconds to retry. Remaining time: {}." \
-                            .format(interval, timeout - elapsed))
-                        elapsed = time.time() - start
-                        continue
+                if check_result["failed"]:
+                    wait(interval,
+                         msg="Services were not monitored and wait {} seconds to retry. Remaining time: {}. Services status: {}" \
+                         .format(interval, timeout - elapsed, str(check_result["services_status"])))
+                    elapsed = time.time() - start
+                else:
+                    break
 
-                    is_monit_running = True
-                    check_result = _check_monit_services_status(check_result, monit_services_status)
-                    if check_result["failed"]:
-                        wait(interval, msg="Services were not monitored and wait {} seconds to retry. Remaining time: {}. Services status: {}" \
-                            .format(interval, timeout - elapsed, str(check_result["services_status"])))
-                        elapsed = time.time() - start
-                    else:
-                        break
+            if not is_monit_running:
+                logger.info("Monit was not running.")
+                check_result["failed"] = True
+                check_result["failed_reason"] = "Monit was not running"
 
-                if not is_monit_running:
-                    logger.info("Monit was not running.")
-                    check_result["failed"] = True
-                    check_result["failed_reason"] = "Monit was not running"
-
-            logger.info("Checking status of each Monit service was done on %s" % dut.hostname)
-            check_results.append(check_result)
-
-        return check_results
+        logger.info("Checking status of each Monit service was done on %s" % dut.hostname)
+        results[dut.hostname] = check_result
     return _check
 
 
 @pytest.fixture(scope="module")
 def check_processes(duthosts):
     def _check(*args, **kwargs):
-        check_results = []
-        for dut in duthosts:
-            logger.info("Checking process status on %s..." % dut.hostname)
+        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        return result.values()
 
-            networking_uptime = dut.get_networking_uptime().seconds
-            timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
-            interval = 20
-            logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" % \
-                        (networking_uptime, timeout, interval))
+    @reset_ansible_local_tmp
+    def _check_on_dut(*args, **kwargs):
+        dut = kwargs['node']
+        results = kwargs['results']
+        logger.info("Checking process status on %s..." % dut.hostname)
 
-            check_result = {"failed": False, "check_item": "processes", "host": dut.hostname}
-            if timeout == 0:    # Check processes status, do not retry.
+        networking_uptime = dut.get_networking_uptime().seconds
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
+        interval = 20
+        logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" % \
+                    (networking_uptime, timeout, interval))
+
+        check_result = {"failed": False, "check_item": "processes", "host": dut.hostname}
+        if timeout == 0:  # Check processes status, do not retry.
+            processes_status = dut.all_critical_process_status()
+            check_result["processes_status"] = processes_status
+            check_result["services_status"] = {}
+            for k, v in processes_status.items():
+                if v['status'] == False or len(v['exited_critical_process']) > 0:
+                    check_result['failed'] = True
+                check_result["services_status"].update({k: v['status']})
+        else:  # Retry checking processes status
+            start = time.time()
+            elapsed = 0
+            while elapsed < timeout:
+                check_result["failed"] = False
                 processes_status = dut.all_critical_process_status()
                 check_result["processes_status"] = processes_status
                 check_result["services_status"] = {}
@@ -523,30 +567,17 @@ def check_processes(duthosts):
                     if v['status'] == False or len(v['exited_critical_process']) > 0:
                         check_result['failed'] = True
                     check_result["services_status"].update({k: v['status']})
-            else:               # Retry checking processes status
-                start = time.time()
-                elapsed = 0
-                while elapsed < timeout:
-                    check_result["failed"] = False
-                    processes_status = dut.all_critical_process_status()
-                    check_result["processes_status"] = processes_status
-                    check_result["services_status"] = {}
-                    for k, v in processes_status.items():
-                        if v['status'] == False or len(v['exited_critical_process']) > 0:
-                            check_result['failed'] = True
-                        check_result["services_status"].update({k: v['status']})
 
-                    if check_result["failed"]:
-                        wait(interval, msg="Not all processes are started, wait %d seconds to retry. Remaining time: %d %s" % \
-                            (interval, int(timeout - elapsed), str(check_result["processes_status"])))
-                        elapsed = time.time() - start
-                    else:
-                        break
+                if check_result["failed"]:
+                    wait(interval,
+                         msg="Not all processes are started, wait %d seconds to retry. Remaining time: %d %s" % \
+                             (interval, int(timeout - elapsed), str(check_result["processes_status"])))
+                    elapsed = time.time() - start
+                else:
+                    break
 
-            logger.info("Done checking processes status on %s" % dut.hostname)
-            check_results.append(check_result)
-
-        return check_results
+        logger.info("Done checking processes status on %s" % dut.hostname)
+        results[dut.hostname] = check_result
     return _check
 
 @pytest.fixture(scope="module")

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -118,7 +118,7 @@ def _find_down_ports(dut, phy_interfaces, ip_interfaces):
 @pytest.fixture(scope="module")
 def check_interfaces(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_on_dut, args, kwargs, duthosts, timeout=600)
+        result = parallel_run(_check_on_dut, args, kwargs, duthosts.frontend_nodes, timeout=600)
         return result.values()
 
     @reset_ansible_local_tmp
@@ -193,7 +193,7 @@ def check_bgp(duthosts):
             for asic_index, a_asic_facts in enumerate(bgp_facts):
                 a_asic_result = False
                 a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']
-                if a_asic_neighbors:
+                if a_asic_neighbors is not None:
                     down_neighbors = [k for k, v in a_asic_neighbors.items()
                                       if v['state'] != 'established']
                     if down_neighbors:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

In a 3 DUT testbed, the sanity check is done once in most of the modules and took about 3 minutes to execute.  The log analyzer on the 3 DUTs at the end of every test case took about 10 seconds.

The above adds a lot to the execution time when executing 100's of tests. Need to parallelize the sanity check and log analyzer to reduce the execution time.

#### How did you do it?

- Using the build-in support for parallelization in tests.common.helpers.parallel.parallel_run in sonic-mgmt, we see sanity check on the 3 DUTs to about 90 seconds, and the log analyzer time also cut to about 7 seconds. These are big reductions in execution time when running lots of tests in a multi-dut setup

- There is an issue parallel_run, where if there is an exception or failure (Exception raised) as part of the target function call,
then it is not captured as a failure, and the process is marked as finished.

    As an example, lets consider check_interfaces sanity check. This check calls _find_down_ip_ports which would get the ip interfaces using show_ip_interface ansible library
     ```
      ip_intf_facts = dut.show_ip_interface()['ansible_facts']['ip_interfaces']
    ```
   On a multi-asic DUT that was running with older sonic code that did not support show ip interface -n <asic#>,the above show_ip_interface call would fail. However, if this was part of a parallelized taks, then the failure will be ignored and sanity check would pass.

   Added code in parallel.py to check the exitcode of the processes, and if any is non-zero then we would fail.

   This exposed two issues with bgp tests that were using parallel_run that have been fixed as well:
    - conftest.py - in restore_nbr_gr, the log message at line 130 was using 'k' instead of 'node' and thus failing
    - test_bgp_bbr.py - in check_other_vms at line 249, we were assiging vm_route as '{'failed': False}'. Thus, we were failing at line 252, where we are checking for key 'vrfs' and that doesn't exist in vm_route. Instead we should have added 'failed' key to vm_route dictionary


#### How did you verify/test it?
Ran tests in a multi-dut testbed and single testbed to make sure sanity checks are log analysis still happens.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
