### PR TITLE
[dualtor]: Recover interfaces after set_drop action

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -113,10 +113,11 @@ def _post(server_url, data):
     return True
 
 @pytest.fixture(scope='module')
-def set_drop(url):
+def set_drop(url, recover_all_directions):
     """
     A helper function is returned to make fixture accept arguments
     """
+    drop_intfs = set()
     def _set_drop(interface_name, directions):
         """
         A fixture to set drop for a certain direction on a port
@@ -126,11 +127,15 @@ def set_drop(url):
         Returns:
             None.
         """
+        drop_intfs.add(interface_name)
         server_url = url(interface_name, DROP)
         data = {"out_ports": directions}
         pytest_assert(_post(server_url, data), "Failed to set drop on {}".format(directions))
 
-    return _set_drop
+    yield _set_drop
+
+    for intf in drop_intfs:
+        recover_all_directions(intf)
 
 @pytest.fixture(scope='module')
 def set_output(url):


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Restore mux simulator to a healthy state after 'set_drop' action

#### How did you do it?
Add teardown action after `yield` for the `set_drop` fixture

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
