### PR TITLE
[multi-asic]: Add set of test cases to be run on multi-asic testbed

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -175,6 +175,24 @@ test_t1_lag() {
     popd
 }
 
+test_multi_asic_t1_lag() {
+    tgname=multi_asic_t1_lag
+    tests="\
+    bgp/test_bgp_fact.py \
+    snmp/test_snmp_pfc_counters.py \
+    snmp/test_snmp_queue.py \
+    snmp/test_snmp_loopback.py \
+    snmp/test_snmp_default_route.py \
+    tacacs/test_rw_user.py \
+    tacacs/test_ro_user.py \
+    tacacs/test_jit_user.py"
+
+    pushd $SONIC_MGMT_DIR/tests
+    # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -u
+    popd
+}
+
 if [ -f /data/pkey.txt ]; then
     pushd $HOME
     mkdir -p .ssh
@@ -210,6 +228,8 @@ if [ x$test_suite == x"t0" ]; then
     test_t0
 elif [ x$test_suite == x"t1-lag" ]; then
     test_t1_lag
+elif [ x$test_suite == x"multi-asic-t1-lag" ]; then
+    test_multi_asic_t1_lag 
 else
     echo "unknown $test_suite"
     exit 1


### PR DESCRIPTION
[multi-asic]: Add set of test cases to be run on multi-asic testbed
testbed with t1-lag topology.

Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Current KVM testing is done on single asic KVM testbed.
Add set of mutli asic compatible testcases to be run on multi-asic KVM testbed for t1-lag topology.
Currently there is support for 2 hwsku for multi asic virtual switch : msft_multi_asic_vs [6 asics] and msft_four_asic_vs[4 asics]

#### How did you do it?
Added a new Testbed type and new function with initial set of tests that can be run on multi-asic KVM testbed.

#### How did you verify/test it?
Run kvmtest.sh on msft_four_asic_vs testbed.
kvmtest.sh -en -T multi-asic-t1-lag  vms-kvm-four-asic-t1-lag vlab-08
..
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================================================================== test session starts ===============================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: metadata-1.10.0, forked-1.3.0, html-1.22.1, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
collected 4 items                                                                                                                                                                

bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-0] PASSED                                                                                                                     [ 25%]
bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-1] PASSED                                                                                                                     [ 50%]
bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-2] PASSED                                                                                                                     [ 75%]
bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-3] PASSED  
...
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
