### PR TITLE
[multi asic] multi asic changes for traffic_shift test

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -144,10 +144,8 @@ def remove_bgp_neighbors(duthost, asic_index):
 
     # Convert the json formatted result of sonic-cfggen into bgp_neighbors dict
     bgp_neighbors = json.loads(duthost.command("sudo sonic-cfggen {} -d --var-json {}".format('-n ' + namespace if namespace else '', "BGP_NEIGHBOR"))["stdout"])
-    cmds = []
-    for neighbor in bgp_neighbors.keys():
-        cmds.append('sudo sonic-db-cli {} CONFIG_DB del "BGP_NEIGHBOR|{}"'.format('-n ' + namespace if namespace else '', neighbor))
-    duthost.shell_cmds(cmds=cmds)
+    cmd = 'sudo sonic-db-cli -n {} CONFIG_DB keys "BGP_NEI*" | xargs sonic-db-cli -n {} CONFIG_DB del'.format(namespace, namespace)
+    duthost.shell(cmd)
 
     # Restart BGP instance on that asic
     restart_bgp(duthost, asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -113,7 +113,7 @@ def parse_rib(host, ip_ver):
             aspath = set()
             for nexthop in nexthops:
                 # if internal route with aspath as '' skip adding
-                if nexthop['aspath'] =='':
+                if nexthop.has_key('path') and nexthop['path'] =='':
                     continue
                 aspath.add(nexthop['path'])
             # if aspath is valid, add it into routes
@@ -141,15 +141,16 @@ def remove_bgp_neighbors(duthost, asic_index):
     Remove the bgp neigbors for a particular BGP instance
     """
     namespace = duthost.get_namespace_from_asic_id(asic_index)
+    namespace_prefix = '-n ' + namespace if namespace else ''
 
     # Convert the json formatted result of sonic-cfggen into bgp_neighbors dict
-    bgp_neighbors = json.loads(duthost.command("sudo sonic-cfggen {} -d --var-json {}".format('-n ' + namespace if namespace else '', "BGP_NEIGHBOR"))["stdout"])
-    cmd = 'sudo sonic-db-cli -n {} CONFIG_DB keys "BGP_NEI*" | xargs sonic-db-cli -n {} CONFIG_DB del'.format(namespace, namespace)
+    bgp_neighbors = json.loads(duthost.command("sudo sonic-cfggen {} -d --var-json {}".format(namespace_prefix, "BGP_NEIGHBOR"))["stdout"])
+    cmd = 'sudo sonic-db-cli {} CONFIG_DB keys "BGP_NEI*" | xargs sonic-db-cli {} CONFIG_DB del'.format(namespace_prefix, namespace_prefix)
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
     restart_bgp(duthost, asic_index)
-    
+
     return bgp_neighbors
 
 def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
@@ -157,11 +158,12 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     Restore the bgp neigbors for a particular BGP instance
     """
     namespace = duthost.get_namespace_from_asic_id(asic_index)
+    namespace_prefix = '-n ' + namespace if namespace else ''
 
     # Convert the bgp_neighbors dict into json format after adding the table name.
     bgp_neigh_dict = {"BGP_NEIGHBOR":bgp_neighbors}
     bgp_neigh_json = json.dumps(bgp_neigh_dict)
-    duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format('-n ' + namespace if namespace else '', bgp_neigh_json))
+    duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
     restart_bgp(duthost, asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -2,7 +2,7 @@ import os
 import re
 import time
 import json
-from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
+from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -104,22 +104,21 @@ def parse_rib(host, ip_ver):
     """
     routes = {}
 
-    # In case of Multi-aisc device get the routes in ASIC0.
-    namespace = "asic0" if host.is_multi_asic else DEFAULT_NAMESPACE
-    bgp_cmd = "vtysh -c \"show bgp ipv%d json\"" % ip_ver
-    cmd = host.get_vtysh_cmd_for_namespace(bgp_cmd, namespace)
+    for namespace in host.get_frontend_asic_namespace_list():
+        bgp_cmd = "vtysh -c \"show bgp ipv%d json\"" % ip_ver
+        cmd = host.get_vtysh_cmd_for_namespace(bgp_cmd, namespace)
 
-    route_data = json.loads(host.shell(cmd, verbose=False)['stdout'])
-    for ip, nexthops in route_data['routes'].iteritems():
-        aspath = set()
-        for nexthop in nexthops:
-            # if internal route with aspath as '' skip adding
-            if nexthop['aspath'] =='':
-                continue
-            aspath.add(nexthop['path'])
-        # if aspath is valid, add it into routes
-        if aspath:
-            routes[ip] = aspath
+        route_data = json.loads(host.shell(cmd, verbose=False)['stdout'])
+        for ip, nexthops in route_data['routes'].iteritems():
+            aspath = set()
+            for nexthop in nexthops:
+                # if internal route with aspath as '' skip adding
+                if nexthop['aspath'] =='':
+                    continue
+                aspath.add(nexthop['path'])
+            # if aspath is valid, add it into routes
+            if aspath:
+                routes[ip] = aspath
 
     return routes
 

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -2,6 +2,9 @@ import os
 import re
 import time
 import json
+from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))
@@ -19,7 +22,6 @@ BGP_MONITOR_NAME = "bgp_monitor"
 BGP_MONITOR_PORT = 7000
 BGP_ANNOUNCE_TIME = 30 #should be enough to receive and parse bgp updates
 
-
 def apply_bgp_config(duthost, template_name):
     """
     Apply bgp configuration on the bgp docker of DUT
@@ -32,15 +34,17 @@ def apply_bgp_config(duthost, template_name):
     restart_bgp(duthost)
 
 
-def restart_bgp(duthost):
+def restart_bgp(duthost, asic_index=DEFAULT_ASIC_ID):
     """
     Restart bgp services on the DUT
 
     Args:
         duthost: DUT host object
     """
-    duthost.shell('systemctl restart bgp')
-    time.sleep(60)
+    duthost.asic_instance(asic_index).reset_service("bgp")
+    duthost.asic_instance(asic_index).restart_service("bgp")
+    docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
+    pytest_assert(wait_until(100, 10, duthost.is_service_fully_started, docker_name), "BGP not started.")
 
 
 def define_config(duthost, template_src_path, template_dst_path):
@@ -99,18 +103,30 @@ def parse_rib(host, ip_ver):
     Parse output of 'show bgp ipv4/6' and parse into a dict for checking routes
     """
     routes = {}
-    for asic_index in host.get_frontend_asic_ids():
-        namespace = '-n {}'.format(asic_index) if host.is_multi_asic else ''
-        cmd = "vtysh %s -c \"show bgp ipv%d json\"" % (namespace, ip_ver)
-        route_data = json.loads(host.shell(cmd, verbose=False)['stdout'])
-        for ip, nexthops in route_data['routes'].iteritems():
-            aspath = set()
-            for nexthop in nexthops:
-                aspath.add(nexthop['path'])
+
+    # In case of Multi-aisc device get the routes in ASIC0.
+    namespace = "asic0" if host.is_multi_asic else DEFAULT_NAMESPACE
+    bgp_cmd = "vtysh -c \"show bgp ipv%d json\"" % ip_ver
+    cmd = host.get_vtysh_cmd_for_namespace(bgp_cmd, namespace)
+
+    route_data = json.loads(host.shell(cmd, verbose=False)['stdout'])
+    for ip, nexthops in route_data['routes'].iteritems():
+        aspath = set()
+        for nexthop in nexthops:
+            # if internal route with aspath as '' skip adding
+            if nexthop['aspath'] =='':
+                continue
+            aspath.add(nexthop['path'])
+        # if aspath is valid, add it into routes
+        if aspath:
             routes[ip] = aspath
+
     return routes
 
 def verify_all_routes_announce_to_bgpmon(duthost, ptfhost):
+    """
+    Verify that the routes are announced by checking neighbors route dump.
+    """
     time.sleep(BGP_ANNOUNCE_TIME)
     bgpmon_routes = parse_exabgp_dump(ptfhost)
     rib_v4 = parse_rib(duthost, 4)
@@ -120,3 +136,35 @@ def verify_all_routes_announce_to_bgpmon(duthost, ptfhost):
         if route not in bgpmon_routes:
             return False
     return True
+
+def remove_bgp_neighbors(duthost, asic_index):
+    """
+    Remove the bgp neigbors for a particular BGP instance
+    """
+    namespace = duthost.get_namespace_from_asic_id(asic_index)
+
+    # Convert the json formatted result of sonic-cfggen into bgp_neighbors dict
+    bgp_neighbors = json.loads(duthost.command("sudo sonic-cfggen {} -d --var-json {}".format('-n ' + namespace if namespace else '', "BGP_NEIGHBOR"))["stdout"])
+    cmds = []
+    for neighbor in bgp_neighbors.keys():
+        cmds.append('sudo sonic-db-cli {} CONFIG_DB del "BGP_NEIGHBOR|{}"'.format('-n ' + namespace if namespace else '', neighbor))
+    duthost.shell_cmds(cmds=cmds)
+
+    # Restart BGP instance on that asic
+    restart_bgp(duthost, asic_index)
+    
+    return bgp_neighbors
+
+def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
+    """
+    Restore the bgp neigbors for a particular BGP instance
+    """
+    namespace = duthost.get_namespace_from_asic_id(asic_index)
+
+    # Convert the bgp_neighbors dict into json format after adding the table name.
+    bgp_neigh_dict = {"BGP_NEIGHBOR":bgp_neighbors}
+    bgp_neigh_json = json.dumps(bgp_neigh_dict)
+    duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format('-n ' + namespace if namespace else '', bgp_neigh_json))
+
+    # Restart BGP instance on that asic
+    restart_bgp(duthost, asic_index)

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -225,8 +225,8 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
                 if netaddr.IPAddress(intf["addr"]).version == 4:
                     loopback_ip = intf["addr"]
                     break
-                if not loopback_ip:
-                    pytest.fail("ipv4 lo interface not found")
+            if not loopback_ip:
+                pytest.fail("ipv4 lo interface not found")
 
             for intf, subnet in zip(random.sample(ipv4_interfaces + ipv4_lag_interfaces, peer_count), subnets):
                 conn = {}

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -8,6 +8,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from bgp_helpers import apply_bgp_config
 from bgp_helpers import get_no_export_output
+from bgp_helpers import BGP_ANNOUNCE_TIME
 
 pytestmark = [
     pytest.mark.topology('t1')
@@ -39,12 +40,18 @@ def test_bgp_bounce(duthost, nbrhosts, deploy_plain_bgp_config, deploy_no_export
     # Apply bgp plain config
     apply_bgp_config(duthost, bgp_plain_config)
 
+    # Give additional delay for routes to be propogated
+    time.sleep(BGP_ANNOUNCE_TIME)
+
     # Take action on one of the ToR VM
     no_export_route_num = get_no_export_output(vm_host)
     pytest_assert(not no_export_route_num, "Routes has no_export attribute")
 
     # Apply bgp no export config
     apply_bgp_config(duthost, bgp_no_export_config)
+
+    # Give additional delay for routes to be propogated
+    time.sleep(BGP_ANNOUNCE_TIME)
 
     # Take action on one of the ToR VM
     no_export_route_num = get_no_export_output(vm_host)

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -7,8 +7,7 @@ from tests.common.helpers.assertions import pytest_assert
 import re
 
 pytestmark = [
-    pytest.mark.topology('t1'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.topology('t1')
 ]
 
 logger = logging.getLogger(__name__)
@@ -210,14 +209,12 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown):
         pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index), "ASIC is not having no neighbors")
 
         # Recover to Normal state
-        # Verify ASIC0 has no neighbors message.
         duthost.shell("TSB")['stdout_lines']
 
         # Verify DUT is in Normal state, and ASIC0 has no neighbors message.
         pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index), "ASIC is not having no neighbors")
 
         # Check the traffic state
-        # Verify ASIC0 has no neighbors message.
         duthost.shell("TSC")['stdout_lines']
 
         # Verify DUT is in Normal state, and ASIC0 has no neighbors message.

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -233,12 +233,26 @@ class MultiAsicSonicHost(object):
                 return asic
         return None
 
+    def start_service(self, service):
+        if service in self._DEFAULT_SERVICES:
+            return self.sonichost.start_service(service, service)
+
+        for asic in self.asics:
+            asic.start_service(service)
+
     def stop_service(self, service):
         if service in self._DEFAULT_SERVICES:
             return self.sonichost.stop_service(service, service)
 
         for asic in self.asics:
             asic.stop_service(service)
+
+    def restart_service(self, service):
+        if service in self._DEFAULT_SERVICES:
+            return self.sonichost.restart_service(service, service)
+
+        for asic in self.asics:
+            asic.restart_service(service)
 
     def delete_container(self, service):
         if service in self._DEFAULT_SERVICES:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1270,11 +1270,31 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         return crm_facts
 
+    def start_service(self, service_name, docker_name):
+        logging.debug("Starting {}".format(service_name))
+        if not self.is_service_fully_started(docker_name):
+            self.command("sudo systemctl start {}".format(service_name))
+            logging.debug("started {}".format(service_name))
+
     def stop_service(self, service_name, docker_name):
         logging.debug("Stopping {}".format(service_name))
         if self.is_service_fully_started(docker_name):
-            self.command("systemctl stop {}".format(service_name))
+            self.command("sudo systemctl stop {}".format(service_name))
         logging.debug("Stopped {}".format(service_name))
+
+    def restart_service(self, service_name, docker_name):
+        logging.debug("Restarting {}".format(service_name))
+        if self.is_service_fully_started(docker_name):
+            self.command("sudo systemctl restart {}".format(service_name))
+            logging.debug("Restarted {}".format(service_name))
+        else:
+            self.command("sudo systemctl start {}".format(service_name))
+            logging.debug("started {}".format(service_name))
+
+    def reset_service(self, service_name, docker_name):
+        logging.debug("Stopping {}".format(service_name))
+        self.command("sudo systemctl reset-failed {}".format(service_name))
+        logging.debug("Resetting {}".format(service_name))
 
     def delete_container(self, service):
         self.command(

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -172,6 +172,14 @@ class SonicAsic(object):
         complex_args['namespace'] = self.namespace
         return self.sonichost.interface_facts(*module_args, **complex_args)
 
+    def get_service_name(self, service):
+        if (not self.sonichost.is_multi_asic or
+            service not in self._DEFAULT_ASIC_SERVICES
+        ):
+            return service
+
+        return self._MULTI_ASIC_SERVICE_NAME.format(service, self.asic_index)
+
     def get_docker_name(self, service):
         if (not self.sonichost.is_multi_asic or
             service not in self._DEFAULT_ASIC_SERVICES
@@ -180,18 +188,25 @@ class SonicAsic(object):
 
         return self._MULTI_ASIC_DOCKER_NAME.format(service, self.asic_index)
 
+    def start_service(self, service):
+        service_name = self.get_service_name(service)
+        docker_name = self.get_docker_name(service)
+        return self.sonichost.start_service(service_name, docker_name)
+
     def stop_service(self, service):
-        if not self.sonichost.is_multi_asic:
-            service_name = service
-            docker_name = service
-        else:
-            service_name = self._MULTI_ASIC_SERVICE_NAME.format(
-                service, self.asic_index
-            )
-            docker_name = self._MULTI_ASIC_DOCKER_NAME.format(
-                service, self.asic_index
-            )
+        service_name = self.get_service_name(service)
+        docker_name = self.get_docker_name(service)
         return self.sonichost.stop_service(service_name, docker_name)
+
+    def restart_service(self, service):
+        service_name = self.get_service_name(service)
+        docker_name = self.get_docker_name(service)
+        return self.sonichost.restart_service(service_name, docker_name)
+
+    def reset_service(self, service):
+        service_name = self.get_service_name(service)
+        docker_name = self.get_docker_name(service)
+        return self.sonichost.reset_service(service_name, docker_name)
 
     def delete_container(self, service):
         if self.sonichost.is_multi_asic:


### PR DESCRIPTION
### Description of PR
This PR addresses the following changes 

1. For multi-asic the console output changes to the following format, below is the case where there are **4 front-end ASIC's**

```
admin@str--acs-1:~$ TSA
BGP0 : System Mode: Normal -> Maintenance
BGP1 : System Mode: Normal -> Maintenance
BGP2 : System Mode: Normal -> Maintenance
BGP3 : System Mode: Normal -> Maintenance
admin@str--acs-1:~$ TSC
BGP0 : System Mode: Maintenance
BGP1 : System Mode: Maintenance
BGP2 : System Mode: Maintenance
BGP3 : System Mode: Maintenance
admin@str--acs-1:~$ TSB
BGP0 : System Mode: Maintenance -> Normal
BGP1 : System Mode: Maintenance -> Normal
BGP2 : System Mode: Maintenance -> Normal
BGP3 : System Mode: Maintenance -> Normal
admin@str--acs-1:~$ TSC
BGP0 : System Mode: Normal
BGP1 : System Mode: Normal
BGP2 : System Mode: Normal
BGP3 : System Mode: Normal
```
2. Also added additional testcase **test_TSA_B_C_with_no_neighbors** to handle the new console message in case there are **no external BGP neighbors** for that BGP instance. This is more predominantly seen in multi-asic where one ASIC may have no interfaces up and hence no external BGP neighbors Ref: https://github.com/Azure/sonic-buildimage/pull/7171


```
admin@STG01-0101-0102-01T1:~$ TSA
BGP0 : System Mode: Normal -> Maintenance
BGP1 : System Mode: Normal -> Maintenance
BGP2 : System Mode: No external neighbors
BGP3 : System Mode: Normal -> Maintenance 
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
The tests was run against single-asic/ multi-asic platform with result PASS

```
Single ASIC DUT

jujoseph@63d6771d2f5f:/var/mgmt/Networking-acs-sonic-mgmt/tests$ ./run_tests.sh -d str-dx010-acs-1 -n vms3-t1-dx010-1 -i ../ansible/veos,../ansible/str -f ../ansible/testbed.csv -c  bgp/test_traffic_shift.py -u -e "--skip_sanity"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================================================== test session starts ===================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/mgmt/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 3 items                                                                                                                                                                                                                                         

bgp/test_traffic_shift.py::test_TSA PASSED                                                                                                                                                                                                          [ 33%]
bgp/test_traffic_shift.py::test_TSB PASSED                                                                                                                                                                                                          [ 66%]
bgp/test_traffic_shift.py::test_TSA_B_C_with_no_neighbors PASSED                                                                                                                                                                                    [100%]

---------------------------------------------------------------------------------------- generated xml file: /var/mgmt/Networking-acs-sonic-mgmt/tests/logs/tr.xml ----------------------------------------------------------------------------------------
=============================================================================================================== 3 passed in 907.57 seconds ================================================================================================================

multi-asic DUT 

jujoseph@63d6771d2f5f:/var/mgmt/Networking-acs-sonic-mgmt/tests$ ./run_tests.sh -d str2--acs-1 -n vms17-t1--acs-1 -i ../ansible/veos,../ansible/str2 -f ../ansible/testbed.csv -c  bgp/test_traffic_shift.py -u -e "--skip_sanity"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================================================== test session starts ===================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/mgmt/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 3 items                                                                                                                                                                                                                                         

bgp/test_traffic_shift.py::test_TSA PASSED                                                                                                                                                                                                          [ 33%]
bgp/test_traffic_shift.py::test_TSB PASSED                                                                                                                                                                                                          [ 66%]
bgp/test_traffic_shift.py::test_TSA_B_C_with_no_neighbors PASSED                                                                                                                                                                                    [100%]

---------------------------------------------------------------------------------------- generated xml file: /var/mgmt/Networking-acs-sonic-mgmt/tests/logs/tr.xml ----------------------------------------------------------------------------------------
=============================================================================================================== 3 passed in 814.77 seconds ================================================================================================================
```



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
