### PR TITLE
[garp_service]: Make module scoped

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -200,7 +200,7 @@ def run_icmp_responder(duthost, ptfhost, tbinfo):
     ptfhost.shell("supervisorctl stop icmp_responder")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses):
 
     garp_config = {}

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -4,6 +4,7 @@ import time
 
 from tests.common.dualtor.dual_tor_utils import get_crm_nexthop_counter, lower_tor_host # lgtm[py/unused-import]
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.fixtures.ptfhost_utils import run_garp_service
 
 
 CRM_POLL_INTERVAL = 1
@@ -48,3 +49,8 @@ def pytest_addoption(parser):
         type=int,
         help="The number of iterations for mux stress test"
     )
+
+@pytest.fixture(scope="module", autouse=True)
+def common_setup_teardown(request, tbinfo):
+    if 'dualtor' in tbinfo['topo']['name']:
+        request.getfixturevalue('run_garp_service')

--- a/tests/dualtor/test_normal_op.py
+++ b/tests/dualtor/test_normal_op.py
@@ -12,11 +12,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="session", autouse=True)
-def common_setup_teardown(run_arp_service):
-    pass
-
-
 def test_normal_op_upstream(upper_tor_host, lower_tor_host,
                             send_server_to_t1_with_action,
                             toggle_all_simulator_ports_to_upper_tor):


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Different test modules may configure garp_service differently.

#### How did you do it?

* Make fixture module scoped
* Move dualtor common setup fixture to dualtor/conftest.py and only run garp_service fixture for true dual ToR testbeds.

#### How did you verify/test it?
Run dual ToR test cases and verify they pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
