### PR TITLE
[chassis][multi-dut]changes to support fabric asic in gen-mg and chassis TestbedProcessing

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -133,6 +133,7 @@ def makeMain(data, outfile):
         }
     }
     with open(outfile, "w") as toWrite:
+        toWrite.write( "supported_vm_types: [ 'veos', 'ceos', 'vsonic' ]\n" ),
         yaml.dump(dictData, stream=toWrite, default_flow_style=False)
         toWrite.write("# proxy\n")
         yaml.dump(proxy, stream=toWrite, default_flow_style=False)
@@ -164,7 +165,7 @@ generates files/sonic_lab_devices.csv by pulling hostname, managementIP, hwsku, 
 error handling: checks if attribute values are None type or string "None"
 """
 def makeSonicLabDevices(data, outfile):
-    csv_columns = "Hostname,ManagementIp,HwSku,Type"
+    csv_columns = "Hostname,ManagementIp,HwSku,Type,CardType"
     topology = data
     csv_file = outfile
 
@@ -175,8 +176,8 @@ def makeSonicLabDevices(data, outfile):
                 hostname = device
                 managementIP = str(deviceDetails.get("ansible").get("ansible_host"))
                 hwsku = deviceDetails.get("hwsku")
-                devType = deviceDetails.get("device_type")
-
+                devType = deviceDetails.get("device_type") #DevSonic, server, FanoutRoot etc
+                cardType = deviceDetails.get("card_type") #supervisor, Linecard etc
                 # catch empty values
                 if not managementIP:
                     managementIP = ""
@@ -184,8 +185,10 @@ def makeSonicLabDevices(data, outfile):
                     hwsku = ""
                 if not devType:
                     devType = ""
+                if not cardType:
+                    cardType = ""
 
-                row = hostname + "," + managementIP + "," + hwsku + "," + devType
+                row = hostname + "," + managementIP + "," + hwsku + "," + devType + "," + cardType
                 f.write(row + "\n")
     except IOError:
         print("I/O error: makeSonicLabDevices")
@@ -240,6 +243,11 @@ def makeTestbed(data, outfile):
                     ptf = ""
                 if not comment:
                     comment = ""
+                # dut is a list for multi-dut testbed, convert it to string
+                if type(dut) is not str:
+                   dut = dut.__str__()
+                dut = dut.replace(",", ";")
+                dut = dut.replace(" ", "")
 
                 row = confName + "," + groupName + "," + topo + "," + ptf_image_name + "," + ptf + "," + ptf_ip + "," + ptf_ipv6 + ","+ server + "," + vm_base + "," + dut + "," + comment
                 f.write(row + "\n")
@@ -265,6 +273,8 @@ def makeSonicLabLinks(data, outfile):
             for key, item in topology.items():
                 startDevice = key
                 interfacesDetails = item.get("interfaces")
+                if not interfacesDetails:
+                    continue
 
                 for startPort, element in interfacesDetails.items():
                     startPort = startPort
@@ -363,6 +373,7 @@ makeLab(data, veos, devices, outfile)
 """
 def makeLab(data, devices, testbed, outfile):
     deviceGroup = data
+    start_switchid = 0
     with open(outfile, "w") as toWrite:
         for key, value in deviceGroup.items():
             #children section
@@ -377,45 +388,143 @@ def makeLab(data, devices, testbed, outfile):
                 toWrite.write("[" + key + "]\n")
                 for host in value.get("host"):
                     entry = host
+                    dev = devices.get(host.lower())
 
                     if "ptf" in key:
                         try: #get ansible host
-                            ansible_host = testbed.get(host).get("ansible").get("ansible_host")
+                            ansible_host = dev.get("ansible").get("ansible_host")
                             entry += "\tansible_host=" + ansible_host.split("/")[0]
                         except:
                             print("\t\t" + host + ": ansible_host not found")
 
                         if ansible_host:
                             try: # get ansible ssh username
-                                ansible_ssh_user = testbed.get(host.lower()).get("ansible").get("ansible_ssh_user")
+                                ansible_ssh_user = dev.get("ansible").get("ansible_ssh_user")
                                 entry += "\tansible_ssh_user=" + ansible_ssh_user
                             except:
                                 print("\t\t" + host + ": ansible_ssh_user not found")
 
                             try: # get ansible ssh pass
-                                ansible_ssh_pass = testbed.get(host.lower()).get("ansible").get("ansible_ssh_pass")
+                                ansible_ssh_pass = dev.get("ansible").get("ansible_ssh_pass")
                                 entry += "\tansible_ssh_pass=" + ansible_ssh_pass
                             except:
                                 print("\t\t" + host + ": ansible_ssh_pass not found")
                     else: #not ptf container
                         try: #get ansible host
-                            ansible_host = devices.get(host.lower()).get("ansible").get("ansible_host")
+                            ansible_host = dev.get("ansible").get("ansible_host")
                             entry += "\tansible_host=" + ansible_host.split("/")[0]
                         except:
                             print("\t\t" + host + ": ansible_host not found")
 
                         if ansible_host:
                             try: # get ansible ssh username
-                                ansible_ssh_user = devices.get(host.lower()).get("ansible").get("ansible_ssh_user")
+                                ansible_ssh_user = dev.get("ansible").get("ansible_ssh_user")
                                 entry += "\tansible_ssh_user=" + ansible_ssh_user
                             except:
                                 print("\t\t" + host + ": ansible_ssh_user not found")
 
                             try: # get ansible ssh pass
-                                ansible_ssh_pass = devices.get(host.lower()).get("ansible").get("ansible_ssh_pass")
+                                ansible_ssh_pass = dev.get("ansible").get("ansible_ssh_pass")
                                 entry += "\tansible_ssh_pass=" + ansible_ssh_pass
                             except:
                                 print("\t\t" + host + ": ansible_ssh_pass not found")
+                        try: #get hwsku
+                            hwsku = dev.get("hwsku")
+                            if hwsku is not None:
+                               entry += "\thwsku=" + hwsku
+                        except AttributeError:
+                            print("\t\t" + host + ": hwsku not found")
+
+                        try: #get card_type
+                            card_type = dev.get("card_type")
+                            if card_type is not None:
+                               entry += "\tcard_type=" + card_type
+                        except AttributeError:
+                           print("\t\t" + host + ": card_type not found")
+
+                        try: #get num_fabric_asics
+                            num_fabric_asics = dev.get("num_fabric_asics")
+                            if num_fabric_asics is not None:
+                               entry += "\tnum_fabric_asics=" + str( num_fabric_asics )
+                        except AttributeError:
+                            print("\t\t" + host + " num_fabric_asics not found")
+
+                        try: #get num_asics
+                            num_asics = dev.get("num_asics")
+                            if num_asics is not None:
+                               entry += "\tnum_asics=" + str( num_asics )
+                        except AttributeError:
+                            print("\t\t" + host + " num_asics not found")
+
+                        if card_type != 'supervisor':
+                           entry += "\tstart_switchid=" + str( start_switchid )
+                           if num_asic is not None:
+                              start_switchid += int( num_asic )
+                           else:
+                              start_switchid += 1
+
+                        try: #get frontend_asics
+                            frontend_asics = dev.get("frontend_asics")
+                            if frontend_asics is not None:
+                               entry += "\tfrontend_asics=" + frontend_asics.__str__()
+                        except AttributeError:
+                            print("\t\t" + host + ": frontend_asics not found")
+
+                        try: #get asics_host_ip
+                            asics_host_ip = dev.get("asics_host_ip")
+                            if asics_host_ip is not None:
+                               entry += " \tasics_host_ip=" + str( asics_host_ip )
+                        except AttributeError:
+                            print("\t\t" + host + " asics_host_ip not found")
+
+                        try: #get asics_host_ipv6
+                            asics_host_ipv6 = dev.get("asics_host_ipv6")
+                            if asics_host_ipv6 is not None:
+                               entry += "\tasics_host_ipv6=" + str( asics_host_ipv6 )
+                        except AttributeError:
+                            print("\t\t" + host + " asics_host_ipv6 not found")
+
+                        try: #get voq_inband_ip
+                            voq_inband_ip = dev.get("voq_inband_ip")
+                            if voq_inband_ip is not None:
+                               entry += "\tvoq_inband_ip=" + str( voq_inband_ip )
+                        except AttributeError:
+                            print("\t\t" + host + " voq_inband_ip not found")
+
+                        try: #get voq_inband_ipv6
+                            voq_inband_ipv6 = dev.get("voq_inband_ipv6")
+                            if voq_inband_ipv6 is not None:
+                               entry += "\tvoq_inband_ipv6=" + str( voq_inband_ipv6 )
+                        except AttributeError:
+                            print("\t\t" + host + " voq_inband_ipv6 not found")
+
+                        try: #get voq_inband_intf
+                            voq_inband_intf = dev.get("voq_inband_intf")
+                            if voq_inband_intf is not None:
+                               entry += "\tvoq_inband_intf=" + str( voq_inband_intf )
+                        except AttributeError:
+                            print("\t\t" + host + " voq_inband_intf not found")
+
+                        try: #get voq_inband_type
+                            voq_inband_type = dev.get("voq_inband_type")
+                            if voq_inband_type is not None:
+                               entry += "\tvoq_inband_type=" + str( voq_inband_type )
+                        except AttributeError:
+                            print("\t\t" + host + " voq_inband_type not found")
+
+                        try: #get switch_type
+                            switch_type = dev.get("switch_type")
+                            if switch_type is not None:
+                               entry += "\tswitch_type=" + str( switch_type )
+                        except AttributeError:
+                            print("\t\t" + host + " switch_type not found")
+
+                        try: #get max_cores
+                            max_cores = dev.get("max_cores")
+                            if max_cores is not None:
+                               entry += "\tmax_cores=" + str( max_cores )
+                        except AttributeError:
+                            print("\t\t" + host + " max_cores not found")
 
                     toWrite.write(entry + "\n")
                 toWrite.write("\n")
@@ -455,8 +564,13 @@ def makeVeos(data, veos, devices, outfile):
                     entry = host
 
                     try:
-                        ansible_host = devices.get(host.lower()).get("ansible").get("ansible_host")
+                        dev = devices.get(host.lower())
+                        ansible_host = dev.get("ansible").get("ansible_host")
                         entry += "\tansible_host=" + ansible_host.split("/")[0]
+                        if dev.get("device_type") == "DevSonic":
+                            entry += "\ttype=" + dev.get("type")
+                            entry += "\thwsku=" + dev.get("hwsku")
+                            entry += "\tcard_type=" + dev.get("card_type")
                     except:
                         try:
                             ansible_host = veos.get(key).get(host).get("ansible_host")

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -80,13 +80,41 @@
     ignore_errors: true
 
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}"
+    port_alias:
+      hwsku: "{{ hwsku }}"
+      card_type: "{{ card_type | default('fixed') }}"
+      hostname: "{{ inventory_hostname | default('') }}"
+      start_switchid: "{{ start_switchid | default(0) }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
-    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
+    port_alias:
+      hwsku: "{{ hwsku }}"
+      num_asic: "{{ num_asics }}"
+      card_type: "{{ card_type | default('fixed') }}"
+      hostname: "{{ inventory_hostname | default('') }}"
+      start_switchid: "{{ start_switchid | default(0) }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
+
+  - name: find and generate fabric ASIC infomation
+    fabric_info:
+      num_fabric_asic: "{{ num_fabric_asics | default(0) }}"
+      asics_host_basepfx: "{{ asics_host_ip | default(None) }}"
+      asics_host_basepfx6: "{{ asics_host_ipv6 | default(None) }}"
+
+  - name: set all VoQ system ports information
+    set_fact:
+      all_sysports: "{{ all_sysports | default( [] ) + hostvars[item]['sysports'] }}"
+    when: hostvars[item]['sysports'] is defined
+    loop: "{{ ansible_play_batch }}"
+
+  - name: set all VoQ information for iBGP
+    set_fact:
+      all_inbands: "{{ all_inbands | default( [] ) + [ hostvars[item]['voq_inband_ip'] ] }}"
+      all_hostnames: "{{ all_hostnames | default( [] ) + [ item ] }}"
+    when: hostvars[item]['voq_inband_ip'] is defined
+    loop: "{{ ansible_play_batch }}"
 
   - name: find all enabled host_interfaces
     set_fact:

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -163,8 +163,12 @@ class Parse_Lab_Graph():
                     deviceinfo[hostname] = {}
                     hwsku = dev.attrib['HwSku']
                     devtype = dev.attrib['Type']
+                    card_type = "Linecard"
+                    if 'CardType' in dev.attrib:
+                        card_type = dev.attrib['CardType']
                     deviceinfo[hostname]['HwSku'] = hwsku
                     deviceinfo[hostname]['Type'] = devtype
+                    deviceinfo[hostname]['CardType'] = card_type
                     self.links[hostname] = {}
         devicel2info = {}
         devicel3s = self.root.find(self.dpgtag).findall('DevicesL3Info')

--- a/ansible/library/fabric_info.py
+++ b/ansible/library/fabric_info.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import ipaddress
+
+DOCUMENTATION = '''
+module: fabric_info.py
+short_description:   Find SONiC Fabric ASIC inforamtion if applicable for the DUT
+Description:
+        When the testbed has Fabric ASICs, this module helps to collect that information
+        which helps in generating the minigraph
+    Input:
+        num_fabric_asic asics_host_basepfx asics_host_basepfx6
+
+    Return Ansible_facts:
+    fabric_info:  SONiC Fabric ASIC information
+
+'''
+
+EXAMPLES = '''
+    - name: get Fabric ASIC info
+      fabric_info: num_fabric_asic=1 asics_host_basepfx="10.1.0.1/32" asics_host_basepfx="FC00:1::1/128"
+'''
+
+RETURN = '''
+      ansible_facts{
+        fabric_info: [{'asicname': 'ASIC0', 'ip_prefix': '10.1.0.1/32', 'ip6_prefix': 'FC00:1::1/128'},
+                      {'asicname': 'ASIC1', 'ip_prefix': '10.1.0.2/32', 'ip6_prefix': 'FC00:1::2/128'}]
+      }
+'''
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            num_fabric_asic=dict(type='str', required=True),
+            asics_host_basepfx=dict(type='str', required=False),
+            asics_host_basepfx6=dict(type='str', required=False)
+        ),
+        supports_check_mode=True
+    )
+    m_args = module.params
+    try:
+        fabric_info = []
+        # num_fabric_asic may not be present for fixed systems which have no Fabric ASIC.
+        # Then return empty fabric_info
+        if 'num_fabric_asic' not in m_args or int(m_args['num_fabric_asic']) < 1:
+           module.exit_json(ansible_facts={'fabric_info': fabric_info})
+           return
+        num_fabric_asic = int( m_args[ 'num_fabric_asic' ] )
+        v4pfx = str( m_args[ 'asics_host_basepfx' ] ).split("/")
+        v6pfx = str( m_args[ 'asics_host_basepfx6' ] ).split("/")
+        v4base = int( ipaddress.IPv4Address(v4pfx[0]) )
+        v6base = int( ipaddress.IPv6Address(v6pfx[0]) )
+        for asic_id in range(num_fabric_asic):
+            key = "ASIC%d" % asic_id
+            next_v4addr = str( ipaddress.IPv4Address(v4base + asic_id) )
+            next_v6addr = str( ipaddress.IPv6Address(v6base + asic_id) )
+            data = { 'asicname': key,
+                     'ip_prefix': next_v4addr + "/" + v4pfx[-1],
+                     'ip6_prefix': next_v6addr + "/" + v6pfx[-1] }
+            fabric_info.append( data )
+        module.exit_json(ansible_facts={'fabric_info': fabric_info})
+    except (IOError, OSError), e:
+        fail_msg = "IO error" + str(e)
+        module.fail_json(msg=fail_msg)
+    except Exception, e:
+        fail_msg = "failed to find the correct fabric asic info " + str(e)
+        module.fail_json(msg=fail_msg)
+
+from ansible.module_utils.basic import *
+if __name__ == "__main__":
+    main()

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -130,6 +130,10 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
         s100G_ports = [x for x in range(13, 21)]
 
         port_alias_to_name_map = _port_alias_to_name_map_50G(all_ports, s100G_ports)
+    elif hwsku == "Arista-7800R3-48CQ-LC" or\
+         hwsku == "Arista-7800R3K-48CQ-LC":
+         for i in range(1, 48):
+             port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
     elif hwsku == "INGRASYS-S9100-C32":
         for i in range(1, 33):
             port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -500,6 +500,8 @@ class VMTopology(object):
                 vm_iface = OVS_FP_TAP_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], idx)
                 (dut_index, vlan_index, ptf_index) = VMTopology.parse_vm_vlan_port(vlan)
                 injected_iface = adaptive_name(INJECTED_INTERFACES_TEMPLATE, self.vm_set_name, ptf_index)
+                if len( self.duts_fp_ports[self.duts_name[dut_index]] ) == 0:
+                    continue
                 self.bind_ovs_ports(br_name, self.duts_fp_ports[self.duts_name[dut_index]][str(vlan_index)], injected_iface, vm_iface, disconnect_vm)
 
         if self.topo and 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -1,6 +1,7 @@
   <CpgDec>
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
+{% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
 {% set vm=vms[index] %}
 {% if vm_topo_config['vm'][vm]['peer_ipv4'][dut_index|int] %}
@@ -77,9 +78,26 @@
 {% endif %}
 {% endfor %} 
 {% endfor %}
+{% endif %}
+{% if switch_type is defined and switch_type == 'voq' %}
+{% for all_idx in range(all_inbands|length) %}
+{% if voq_inband_ip != all_inbands[all_idx] %}
+      <BGPSession>
+        <StartRouter>{{ inventory_hostname  }}</StartRouter>
+        <StartPeer>{{ voq_inband_ip.split('/')[0] }}</StartPeer>
+        <EndRouter>{{ all_hostnames[all_idx] }}</EndRouter>
+        <EndPeer>{{ all_inbands[all_idx].split('/')[0] }}</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+        <VoQChassisInternal>true</VoQChassisInternal>
+      </BGPSession>
+{% endif %}
+{% endfor %}
+{% endif %}
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if type is not defined or type != 'supervisor' %}
+{% if card_type is not defined or card_type != 'supervisor' %}
       <a:BGPRouterDeclaration>
         <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
         <a:Hostname>{{ inventory_hostname }}</a:Hostname>
@@ -94,6 +112,18 @@
           </BGPPeer>
 {% endif %}
 {% endfor %}
+{% if switch_type is defined and switch_type == 'voq' %}
+{% for all_idx in range(all_inbands|length) %}
+{% if voq_inband_ip != all_inbands[all_idx] %}
+          <BGPPeer>
+            <Address>{{ all_inbands[all_idx].split('/')[0] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if 'tor' in vm_topo_config['dut_type'] | lower %}
           <BGPPeer i:type="a:BGPPeerPassive">
             <ElementType>BGPPeer</ElementType>
@@ -117,6 +147,17 @@
         </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
+{% if switch_type is defined and switch_type == 'voq' %}
+{% for all_idx in range(all_inbands|length) %}
+{% if voq_inband_ip != all_inbands[all_idx] %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+        <a:Hostname>{{ all_hostnames[all_idx]  }}</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% endif %}
+{% endfor %}
+{% endif %}
 {% for index in range( vms_number) %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length > 0 %}
       <a:BGPRouterDeclaration>

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -27,6 +27,24 @@
 {% endfor %}
 {% endif %}
       </EthernetInterfaces>
+{% if switch_type is defined and switch_type == 'voq' %}
+      <SystemPorts>
+{% set num_of_sysports = all_sysports | length %}
+{% for index in range(num_of_sysports) %}
+        <SystemPort>
+          <Name>{{ all_sysports[index]['name'] }}</Name>
+          <Hostname>{{ all_sysports[index]['hostname'] }}</Hostname>
+          <AsicName>{{ all_sysports[index]['asic_name'] }}</AsicName>
+          <Speed>{{ all_sysports[index]['speed'] }}</Speed>
+          <SystemPortId>{{ index }}</SystemPortId>
+          <SwitchId>{{ all_sysports[index]['switchid'] }}</SwitchId>
+          <CoreId>{{ all_sysports[index]['coreid'] }}</CoreId>
+          <CorePortId>{{ all_sysports[index]['core_portid'] }}</CorePortId>
+          <NumVoq>{{ all_sysports[index]['num_voq'] }}</NumVoq>
+        </SystemPort>
+{% endfor %}
+      </SystemPorts>
+{% endif %}
       <FlowControl>true</FlowControl>
       <Height>0</Height>
       <HwSku>{{ hwsku }}</HwSku>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -61,6 +61,24 @@
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+{% if voq_inband_ip is defined or voq_inband_ipv6 is defined %}
+      <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+{% if voq_inband_ip is defined %}
+        <a:VoqInbandInterface>
+          <Name>{{ voq_inband_intf }}</Name>
+          <Type>{{ voq_inband_type }}</Type>
+          <a:PrefixStr>{{ voq_inband_ip }}</a:PrefixStr>
+        </a:VoqInbandInterface>
+{% endif %}
+{% if voq_inband_ipv6 is defined %}
+        <a:VoqInbandInterface>
+          <Name>{{ voq_inband_intf }}</Name>
+          <Type>{{ voq_inband_type }}</Type>
+          <a:PrefixStr>{{ voq_inband_ipv6 }}</a:PrefixStr>
+        </a:VoqInbandInterface>
+{% endif %}
+      </VoqInbandInterfaces>
+{% endif %}      
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
@@ -117,6 +135,7 @@
 {% endif %}
       </VlanInterfaces>
       <IPInterfaces>
+{% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
 {% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
         <IPInterface>
@@ -156,6 +175,7 @@
         </IPInterface>
 {%   endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
       </IPInterfaces>
       <DataAcls/>

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -57,6 +57,7 @@
       <RsvpInterfaces/>
       <Hostname>{{ asic }}</Hostname>
       <PortChannelInterfaces>
+{% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
 {% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
@@ -84,10 +85,12 @@
         </PortChannel>
 {% endif %}
 {% endfor %}
+{% endif %}
       </PortChannelInterfaces>
       <SubInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
+{% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
 {% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
@@ -134,6 +137,7 @@
           <Prefix>{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['bgp_ipv6'][0] }}/{{ asic_topo_config[asic]['neigh_asic'][neigh_asic]['ipv6mask'][0] }}</Prefix>
         </IPInterface>
 {% endfor %}
+{% endif %}
       </IPInterfaces>
       <DataAcls/>
       <AclInterfaces>
@@ -160,6 +164,7 @@
         <AclInterface>
           <AttachTo>
 {%- set acl_intfs = [] -%}
+{% if card_type is not defined or card_type != 'supervisor' %}
 {%- for index in range(vms_number) %}
 {% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
@@ -194,6 +199,7 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}
 
 {{- acl_intfs|join(';') -}}
           </AttachTo>
@@ -204,5 +210,41 @@
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
+{% for asic in fabric_info %}
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>{{ asic['ip_prefix'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ asic['ip_prefix'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>{{ asic['ip6_prefix'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ asic['ip6_prefix'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      </ManagementIPInterfaces>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>{{ asic['asicname'] }}</Hostname>
+      <PortChannelInterfaces/>
+      <VlanInterfaces/>
+      <IPInterfaces/>
+      <DataAcls/>
+      <AclInterfaces/>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+{% endfor %}
 {% endfor %}
 

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -91,8 +91,28 @@
             <a:Value>{{ erspan_dest_str }}</a:Value>
          </a:DeviceProperty>
 {% endif %}
+{% if switch_type is defined and switch_type == 'voq' %}
+          <a:DeviceProperty>
+            <a:Name>SwitchType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switch_type }}</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ start_switchid }}</a:Value>
+          </a:DeviceProperty>         
+{% endif %}
+{% if max_cores is defined %}
+          <a:DeviceProperty>
+            <a:Name>MaxCores</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ max_cores }}</a:Value>
+          </a:DeviceProperty>
+{% endif %}
         </a:Properties>
       </a:DeviceMetadata>
+{% set idx = 0 %}
 {% for asic in asic_topo_config %}
       <a:DeviceMetadata>
         <a:Name>{{ asic }}</a:Name>
@@ -103,8 +123,47 @@
             <a:Value>{{ asic_topo_config[asic]['asic_type'] }}</a:Value>
           </a:DeviceProperty>
         </a:Properties>
+{% if switch_type is defined and switch_type == 'voq' %}
+          <a:DeviceProperty>
+            <a:Name>SwitchType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switch_type }}</a:Value>
+         </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ start_switchid + idx }}</a:Value>
+{% set idx = idx + 1 %}
+          </a:DeviceProperty>         
+{% endif %}
+{% if max_cores is defined %}
+          <a:DeviceProperty>
+            <a:Name>MaxCores</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ max_cores }}</a:Value>
+         </a:DeviceProperty>
+{% endif %}
       </a:DeviceMetadata>
 {% endfor %}
+
+{% for asic in fabric_info %}
+      <a:DeviceMetadata>
+        <a:Name>{{ asic['asicname'] }}</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>SwitchType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>fabric</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SubRole</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Fabric</a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+{% endfor %}
+
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -1,5 +1,6 @@
   <PngDec>
     <DeviceInterfaceLinks>
+{% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
 {% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
 {% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
@@ -84,6 +85,7 @@
         <Validate>true</Validate>
       </DeviceLinkBase>
 {% endfor %}
+{% endif %}
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="{{ vm_topo_config['dut_type'] }}">
@@ -208,6 +210,11 @@
         <SerialNumber i:nil="true"/>
         <Hostname>{{ asic }}</Hostname>
         <HwSku>Broadcom-Trident2</HwSku>
+      </Device>
+{% endfor %}
+{% for asic in fabric_info %}
+      <Device i:type="Asic">
+        <Hostname>{{ asic['asicname'] }}</Hostname>
       </Device>
 {% endfor %}
     </Devices>


### PR DESCRIPTION
1. Support chassis, multi-duts scenarios in TestbedProcessing.
When testbed.yaml file contains cardtype=Linecard or cardtype=supervisor,
TestbedProcessing will add that to lab, veos inventory files.
When dut is multi-dut, TestbedProcessing will convert the dut type list to string.
2. Support fabric_info generation in fabric_info.py when the num_asic > 0 and cardtype is supervisor.
3. Use the fabric_info in minigraph templates to generated the fabric asic info
4. Use variable name cardtype instead of type in ansible, dut_utils.py and minigraph templates to be more explicit
5. allow t2 as a topo in testbed.py

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
