### PR TITLE
Advance reboot test - timing measurement and status collection

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -169,8 +169,10 @@ class ReloadTest(BaseTest):
 
         if self.sad_oper:
            self.log_file_name = '/tmp/%s-%s.log' % (self.test_params['reboot_type'], self.sad_oper)
+           self.report_file_name = '/tmp/%s-%s.json' % (self.test_params['reboot_type'], self.sad_oper)
         else:
            self.log_file_name = '/tmp/%s.log' % self.test_params['reboot_type']
+           self.report_file_name = '/tmp/%s-report.json' % self.test_params['reboot_type']
         self.log_fp = open(self.log_file_name, 'w')
 
         self.packets_list = []
@@ -1096,6 +1098,14 @@ class ReloadTest(BaseTest):
                     errors += "FAILED:%s:%s\n" % (name, fail)
 
         self.log("="*50)
+
+        self.report = {
+            "downtime": (self.no_routing_stop - self.no_routing_start).total_seconds(),
+            "reboot_time": "0:00:00" if self.no_routing_stop and self.routing_always \
+                else (self.no_routing_stop - self.reboot_start).total_seconds()
+        }
+        with open(self.report_file_name, 'w') as reportfile:
+            json.dump(self.report, reportfile)
 
         self.assertTrue(is_good, errors)
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -342,6 +342,7 @@ class AdvancedReboot:
         '''
         if rebootOper is None:
             rebootLog = '/tmp/{0}.log'.format(self.rebootType)
+            rebootReport = '/tmp/{0}-report.json'.format(self.rebootType)
             capturePcap = '/tmp/capture.pcap'
             filterPcap = '/tmp/capture_filtered.pcap'
             syslogFile = '/tmp/syslog'
@@ -349,6 +350,7 @@ class AdvancedReboot:
             swssRec = '/tmp/swss.rec'
         else:
             rebootLog = '/tmp/{0}-{1}.log'.format(self.rebootType, rebootOper)
+            rebootReport = '/tmp/{0}-{1}-report.json'.format(self.rebootType, rebootOper)
             capturePcap = '/tmp/capture_{0}.pcap'.format(rebootOper)
             filterPcap = '/tmp/capture_filtered_{0}.pcap'.format(rebootOper)
             syslogFile = '/tmp/syslog_{0}'.format(rebootOper)
@@ -368,6 +370,7 @@ class AdvancedReboot:
         logFiles = {
             self.ptfhost: [
                 {'src': rebootLog, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
+                {'src': rebootReport, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
                 {'src': capturePcap, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
                 {'src': filterPcap, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
             ],

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -1,6 +1,10 @@
-import pytest
+import glob
 import json
+import pytest
 import os
+import re
+from datetime import datetime
+
 import logging
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from .args.advanced_reboot_args import add_advanced_reboot_args
@@ -8,6 +12,8 @@ from .args.cont_warm_reboot_args import add_cont_warm_reboot_args
 from .args.normal_reboot_args import add_normal_reboot_args
 from .args.api_sfp_args import add_api_sfp_args
 
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 
 @pytest.fixture(autouse=True, scope="module")
 def skip_on_simx(duthosts, rand_one_dut_hostname):
@@ -55,6 +61,90 @@ def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):
         # Enable outer interfaces
         for port in ports:
             duthost.no_shutdown(ifname=port)
+
+@pytest.fixture(autouse=True)
+def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname):
+    """
+    Advance reboot log analysis.
+    This fixture starts log analysis at the beginning of the test. At the end,
+    the collected expect messages are verified and timing of start/stop is calculated.
+
+    Args:
+        duthosts : List of DUT hosts
+        rand_one_dut_hostname: hostname of a randomly selected DUT
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="test_advanced_reboot")
+    marker = loganalyzer.init()
+    loganalyzer.load_common_config()
+
+    ignore_file = os.path.join(TEMPLATES_DIR, "ignore_boot_messages")
+    expect_file = os.path.join(TEMPLATES_DIR, "expect_boot_messages")
+    ignore_reg_exp = loganalyzer.parse_regexp_file(src=ignore_file)
+    expect_reg_exp = loganalyzer.parse_regexp_file(src=expect_file)
+
+    loganalyzer.ignore_regex.extend(ignore_reg_exp)
+    loganalyzer.expect_regex = []
+    loganalyzer.expect_regex.extend(expect_reg_exp)
+    loganalyzer.match_regex = []
+
+    yield
+
+    result = loganalyzer.analyze(marker, fail=False)
+    messages = result["expect_messages"].values()
+    if not messages:
+        logging.error("Expected messages not found in syslog")
+        return
+    messages = messages[0]
+
+    service_restart_times = dict()
+    service_patterns = {
+        "Stopping": re.compile(r'.*Stopping.*service.*'),
+        "Stopped": re.compile(r'.*Stopped.*service.*'),
+        "Starting": re.compile(r'.*Starting.*service.*'),
+        "Started": re.compile(r'.*Started.*service.*')
+    }
+
+    def service_time_check(message, status):
+        time = message.split(duthost.hostname)[0].strip()
+        service_name = message.split(status + " ")[1].split()[0]
+        service_dict = service_restart_times.get(service_name, {"timestamp": {}})
+        timestamps = service_dict.get("timestamp")
+        if status in timestamps:
+            service_dict[status+" count"] = service_dict.get(status+" count", 1) + 1
+        timestamps[status] = time
+        service_restart_times.update({service_name: service_dict})
+    for message in messages:
+        for status, pattern in service_patterns.items():
+            if re.search(pattern, message):
+                service_time_check(message, status)
+
+    loganalyzer.save_extracted_log(dest="/tmp/log/syslog")
+    logging.info(json.dumps(service_restart_times, indent=4))
+
+    FMT = "%b %d %H:%M:%S.%f"
+    for _, timings in service_restart_times.items():
+        timestamps = timings["timestamp"]
+        timings["stop_time"] = (datetime.strptime(timestamps["Stopped"], FMT) -\
+            datetime.strptime(timestamps["Stopping"], FMT)).total_seconds() \
+                if "Stopped" in timestamps and "Stopping" in timestamps else None
+
+        timings["start_time"] = (datetime.strptime(timestamps["Started"], FMT) -\
+            datetime.strptime(timestamps["Starting"], FMT)).total_seconds() \
+                if "Started" in timestamps and "Starting" in timestamps else None
+
+        timings["reboot_time"] = (datetime.strptime(timestamps["Started"], FMT) -\
+            datetime.strptime(timestamps["Stopped"], FMT)).total_seconds() \
+                if "Started" in timestamps and "Stopped" in timestamps else None
+
+    files = glob.glob('/tmp/*-report.json')
+    if files:
+        filepath = files[0]
+        with open(filepath) as json_file:
+            report = json.load(json_file)
+            service_restart_times.update(report)
+    result = service_restart_times
+    logging.info(json.dumps(result, indent=4))
 
 
 def pytest_addoption(parser):

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -114,6 +114,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname):
             service_dict[status+" count"] = service_dict.get(status+" count", 1) + 1
         timestamps[status] = time
         service_restart_times.update({service_name: service_dict})
+
     for message in messages:
         for status, pattern in service_patterns.items():
             if re.search(pattern, message):

--- a/tests/platform_tests/templates/expect_boot_messages
+++ b/tests/platform_tests/templates/expect_boot_messages
@@ -1,0 +1,4 @@
+r, ".* NOTICE admin: (Stopping|Stopped|Starting|Started).* (?!syncd|swss|gbsyncd).* service.*"
+r, ".* NOTICE admin: Stopped.* swss.* service.*"
+r, ".* NOTICE root: (Stopping|Stopped|Starting|Started).* (swss|syncd|gbsyncd).* service.*"
+r, ".* NOTICE root: WARMBOOT_FINALIZER.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add different time and status metrics for advance reboot testcases.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Use Log Analyzer to collect service start and stop string from syslog.
Analyze the collected matches, and measure the time taken by services to start and stop.
Add reboot and downtime to this report.

#### What is the motivation for this PR?
To provide better visibility of the state of services during reboot, and to measure time taken by each service during warm/fastreboot.

#### How did you do it?

#### How did you verify/test it?

Tested the change for different tests on physical and KVM devices:

**Physical WARM reboot**
```
{
    "bgp": {
        "timestamp": {
            "Stopping": "Mar 31 07:56:30.129108",
            "Starting": "Mar 31 07:57:32.044121",
            "Stopped": "Mar 31 07:56:34.730009",
            "Started": "Mar 31 07:57:35.190256"
        },
        "start_time": 3.146135,
        "stop_time": 4.600901,
        "reboot_time": 60.460247
    },
    "radv": {
        "timestamp": {
            "Stopping": "Mar 31 07:56:28.859164",
            "Starting": "Mar 31 07:57:42.016972",
            "Stopped": "Mar 31 07:56:30.090121",
            "Started": "Mar 31 07:57:46.156788"
        },
        "start_time": 4.139816,
        "Stopping count": 2,
        "stop_time": 1.230957,
        "reboot_time": 76.066667
    },
    "teamd": {
        "timestamp": {
            "Stopping": "Mar 31 07:56:50.526067",
            "Starting": "Mar 31 07:57:38.737031",
            "Stopped": "Mar 31 07:56:56.336791",
            "Started": "Mar 31 07:57:41.713812"
        },
        "start_time": 2.976781,
        "stop_time": 5.810724,
        "reboot_time": 45.377021
    },
    "syncd": {
        "timestamp": {
            "Stopping": "Mar 31 07:56:56.375025",
            "Starting": "Mar 31 07:57:38.759721",
            "Stopped": "Mar 31 07:57:08.161672",
            "Started": "Mar 31 07:57:41.918674"
        },
        "start_time": 3.158953,
        "stop_time": 11.786647,
        "reboot_time": 33.757002
    },
    "swss": {
        "timestamp": {
            "Stopping": "Mar 31 07:56:47.228218",
            "Starting": "Mar 31 07:57:36.052694",
            "Stopped": "Mar 31 07:56:48.151228",
            "Started": "Mar 31 07:57:38.700252"
        },
        "start_time": 2.647558,
        "stop_time": 0.92301,
        "reboot_time": 50.549024
    },
    "reboot_time": 55.283063,
    "downtime": 0.883376
}
```
**Physical FAST reboot**
```
{
    "bgp": {
        "timestamp": {
            "Stopping": "Mar 31 06:09:45.752372", 
            "Starting": "Mar 31 06:10:42.977740", 
            "Stopped": "Mar 31 06:09:50.975573", 
            "Started": "Mar 31 06:10:45.789459"
        }, 
        "start_time": 2.811719, 
        "stop_time": 5.223201, 
        "reboot_time": 54.813886
    }, 
    "radv": {
        "timestamp": {
            "Stopping": "Mar 31 06:09:45.013699", 
            "Starting": "Mar 31 06:10:55.561660", 
            "Stopped": "Mar 31 06:09:45.728387", 
            "Started": "Mar 31 06:10:59.084463"
        }, 
        "start_time": 3.522803, 
        "Stopping count": 2, 
        "stop_time": 0.714688, 
        "reboot_time": 73.356076
    }, 
    "teamd": {
        "timestamp": {
            "Stopping": "Mar 31 06:09:54.266425", 
            "Starting": "Mar 31 06:10:52.349778", 
            "Stopped": "Mar 31 06:09:56.918952", 
            "Started": "Mar 31 06:10:55.073266"
        }, 
        "start_time": 2.723488, 
        "stop_time": 2.652527, 
        "reboot_time": 58.154314
    }, 
    "syncd": {
        "timestamp": {
            "Stopping": "Mar 31 06:10:06.232162", 
            "Starting": "Mar 31 06:10:52.347673", 
            "Stopped": "Mar 31 06:10:19.270387", 
            "Started": "Mar 31 06:10:55.496329"
        }, 
        "start_time": 3.148656, 
        "stop_time": 13.038225, 
        "reboot_time": 36.225942
    }, 
    "swss": {
        "timestamp": {
            "Stopping": "Mar 31 06:10:05.132984", 
            "Starting": "Mar 31 06:10:46.933005", 
            "Stopped": "Mar 31 06:10:06.207191", 
            "Started": "Mar 31 06:10:52.290693"
        }, 
        "start_time": 5.357688, 
        "stop_time": 1.074207, 
        "reboot_time": 46.083502
    }
}
```
**KVM WARM reboot**
```
{
    "bgp": {
        "timestamp": {
            "Stopping": "Mar 31 07:30:49.803249", 
            "Starting": "Mar 31 07:32:02.515363", 
            "Stopped": "Mar 31 07:30:53.775328", 
            "Started": "Mar 31 07:32:04.142191"
        }, 
        "start_time": 1.626828, 
        "stop_time": 3.972079, 
        "reboot_time": 70.366863
    }, 
    "radv": {
        "timestamp": {
            "Stopping": "Mar 31 07:30:48.832813", 
            "Starting": "Mar 31 07:32:07.479673", 
            "Stopped": "Mar 31 07:30:49.755096", 
            "Started": "Mar 31 07:32:09.086825"
        }, 
        "start_time": 1.607152, 
        "Stopping count": 2, 
        "stop_time": 0.922283, 
        "reboot_time": 79.331729
    }, 
    "teamd": {
        "timestamp": {
            "Stopping": "Mar 31 07:31:08.313207", 
            "Starting": "Mar 31 07:32:05.958211", 
            "Stopped": "Mar 31 07:31:14.216653", 
            "Started": "Mar 31 07:32:07.254263"
        }, 
        "start_time": 1.296052, 
        "stop_time": 5.903446, 
        "reboot_time": 53.03761
    }, 
    "gbsyncd": {
        "timestamp": {
            "Stopping": "Mar 31 07:31:27.618410", 
            "Starting": "Mar 31 07:32:05.957936", 
            "Stopped": "Mar 31 07:31:28.122841", 
            "Started": "Mar 31 07:32:07.441467"
        }, 
        "start_time": 1.483531, 
        "stop_time": 0.504431, 
        "reboot_time": 39.318626
    }, 
    "syncd": {
        "timestamp": {
            "Stopping": "Mar 31 07:31:14.260814", 
            "Starting": "Mar 31 07:32:05.958404", 
            "Stopped": "Mar 31 07:31:25.168590", 
            "Started": "Mar 31 07:32:07.435851"
        }, 
        "start_time": 1.477447, 
        "stop_time": 10.907776, 
        "reboot_time": 42.267261
    }, 
    "swss": {
        "timestamp": {
            "Stopping": "Mar 31 07:31:05.520110", 
            "Starting": "Mar 31 07:32:04.129881", 
            "Stopped": "Mar 31 07:31:06.662096", 
            "Started": "Mar 31 07:32:05.921980"
        }, 
        "start_time": 1.792099, 
        "stop_time": 1.141986, 
        "reboot_time": 59.259884
    },
    "reboot_time": 133.376129, 
    "downtime": 135.043188
}
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
