### PR TITLE
Update 'get_crm_facts' helper function

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1264,7 +1264,7 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             logging.warning("CRM counters are not ready yet, will retry after 10 seconds")
             time.sleep(10)
             timeout -= 10
-        assert(timeout > 0)
+        assert(timeout >= 0)
 
         return crm_facts
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import time
 
 from collections import defaultdict
 from datetime import datetime
@@ -1217,39 +1218,53 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
                 'low': int(threshold['low threshold']),
                 'type': threshold['threshold type']
             }
+        def _show_and_parse_crm_resources():
+            # Get output of all resources
+            not_ready_prompt = "CRM counters are not ready"
+            output = self.command('crm show resources all')['stdout_lines']
+            in_section = False
+            sections = defaultdict(list)
+            section_id = 0
+            for line in output:
+                if not_ready_prompt in line:
+                    return False
+                if len(line.strip()) != 0:
+                    if not in_section:
+                        in_section = True
+                        section_id += 1
+                    sections[section_id].append(line)
+                else:
+                    in_section=False
+                    continue
+            # Output of 'crm show resources all' has 3 sections.
+            #   section 1: resources usage
+            #   section 2: ACL group
+            #   section 3: ACL table
+            if 1 in sections.keys():
+                crm_facts['resources'] = {}
+                resources = self._parse_show(sections[1])
+                for resource in resources:
+                    crm_facts['resources'][resource['resource name']] = {
+                        'used': int(resource['used count']),
+                        'available': int(resource['available count'])
+                    }
 
-        # Get output of all resources
-        output = self.command('crm show resources all')['stdout_lines']
-        in_section = False
-        sections = defaultdict(list)
-        section_id = 0
-        for line in output:
-            if len(line.strip()) != 0:
-                if not in_section:
-                    in_section = True
-                    section_id += 1
-                sections[section_id].append(line)
-            else:
-                in_section=False
-                continue
-        # Output of 'crm show resources all' has 3 sections.
-        #   section 1: resources usage
-        #   section 2: ACL group
-        #   section 3: ACL table
-        if 1 in sections.keys():
-            crm_facts['resources'] = {}
-            resources = self._parse_show(sections[1])
-            for resource in resources:
-                crm_facts['resources'][resource['resource name']] = {
-                    'used': int(resource['used count']),
-                    'available': int(resource['available count'])
-                }
+            if 2 in sections.keys():
+                crm_facts['acl_group'] = self._parse_show(sections[2])
 
-        if 2 in sections.keys():
-            crm_facts['acl_group'] = self._parse_show(sections[2])
-
-        if 3 in sections.keys():
-            crm_facts['acl_table'] = self._parse_show(sections[3])
+            if 3 in sections.keys():
+                crm_facts['acl_table'] = self._parse_show(sections[3])
+            return True
+        # Retry until crm resources are ready
+        timeout = crm_facts['polling_interval'] + 10
+        while timeout >= 0:
+            ret = _show_and_parse_crm_resources()
+            if ret:
+                break
+            logging.warning("CRM counters are not ready yet, will retry after 10 seconds")
+            time.sleep(10)
+            timeout -= 10
+        assert(timeout > 0)
 
         return crm_facts
 


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The command ```crm show resource all``` is not available for some time after config reload.
```
admin@str2-7050cx3-acs-01:~$ crm show resources all

CRM counters are not ready. They would be populated after the polling interval.

Stage    Bind Point    Resource Name    Used Count    Available Count
-------  ------------  ---------------  ------------  -----------------


Table ID    Resource Name    Used Count    Available Count
----------  ---------------  ------------  -----------------

```
This PR adds a retry logic for handling this scenario.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```get_crm_facts``` for some corner cases.

#### How did you do it?
Add a retry logic.

#### How did you verify/test it?
Verified on 7050cx3-1.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
