### PR TITLE
[dualtor][test_ipinip] Fix bugs

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -49,7 +49,7 @@ sudo_exe = sudo
 #sudo_flags = -H
 
 # SSH timeout
-timeout = 10
+timeout = 30
 
 # default user to use for playbooks if user is not specified
 # (/usr/bin/ansible will use current user as default)

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -194,7 +194,7 @@ def mock_server_ip_mac_map(rand_selected_dut, tbinfo, ptfadapter, mock_server_ba
 
 
 @pytest.fixture(scope='module')
-def apply_dual_tor_neigh_entries(rand_selected_dut, tbinfo, mock_server_ip_mac_map):
+def apply_dual_tor_neigh_entries(cleanup_mocked_configs, rand_selected_dut, tbinfo, mock_server_ip_mac_map):
     '''
     Apply neighbor table entries for servers
     '''
@@ -222,7 +222,7 @@ def apply_dual_tor_neigh_entries(rand_selected_dut, tbinfo, mock_server_ip_mac_m
 
 
 @pytest.fixture(scope='module')
-def apply_dual_tor_peer_switch_route(rand_selected_dut, mock_peer_switch_loopback_ip):
+def apply_dual_tor_peer_switch_route(cleanup_mocked_configs, rand_selected_dut, mock_peer_switch_loopback_ip):
     '''
     Apply the tunnel route to reach the peer switch via the T1 switches
     '''
@@ -254,7 +254,7 @@ def apply_dual_tor_peer_switch_route(rand_selected_dut, mock_peer_switch_loopbac
 
 
 @pytest.fixture(scope='module')
-def apply_peer_switch_table_to_dut(rand_selected_dut, mock_peer_switch_loopback_ip):
+def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_peer_switch_loopback_ip):
     '''
     Adds the PEER_SWITCH table to config DB and the peer_switch field to the device metadata
     Also adds the 'subtype' field in the device metadata table and sets it to 'DualToR'
@@ -278,7 +278,7 @@ def apply_peer_switch_table_to_dut(rand_selected_dut, mock_peer_switch_loopback_
 
 
 @pytest.fixture(scope='module')
-def apply_tunnel_table_to_dut(rand_selected_dut, mock_peer_switch_loopback_ip):
+def apply_tunnel_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_peer_switch_loopback_ip):
     '''
     Adds the TUNNEL table to config DB
     '''
@@ -307,7 +307,7 @@ def apply_tunnel_table_to_dut(rand_selected_dut, mock_peer_switch_loopback_ip):
 
 
 @pytest.fixture(scope='module')
-def apply_mux_cable_table_to_dut(rand_selected_dut, mock_server_base_ip_addr, tor_mux_intfs):
+def apply_mux_cable_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_server_base_ip_addr, tor_mux_intfs):
     '''
     Adds the MUX_CABLE table to config DB
     '''

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -211,14 +211,7 @@ def apply_dual_tor_neigh_entries(cleanup_mocked_configs, rand_selected_dut, tbin
         cmds.append('ip -4 neigh replace {} lladdr {} dev {}'.format(ip, mac, vlan))
     dut.shell_cmds(cmds=cmds)
 
-    yield
-
-    logger.info("Removing dual ToR neighbor entries")
-
-    cmds = []
-    for ip in mock_server_ip_mac_map.keys():
-        cmds.append('ip -4 neigh del {} dev {}'.format(ip, vlan))
-    dut.shell_cmds(cmds=cmds)
+    return
 
 
 @pytest.fixture(scope='module')
@@ -246,11 +239,7 @@ def apply_dual_tor_peer_switch_route(cleanup_mocked_configs, rand_selected_dut, 
     # If there are no pre-existing routes, equivalent to `ip route add`
     dut.shell('ip route replace {} {}'.format(mock_peer_switch_loopback_ip, nexthop_str))
 
-    yield
-
-    logger.info("Removing dual ToR peer switch loopback route")
-
-    dut.shell('ip route del {}'.format(mock_peer_switch_loopback_ip))
+    return
 
 
 @pytest.fixture(scope='module')
@@ -269,12 +258,7 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
     dut.shell('redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'dualToR'))
     dut.shell('redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'peer_switch', peer_switch_hostname))
 
-    yield
-    logger.info("Removing peer switch table")
-
-    dut.shell('redis-cli -n 4 DEL "{}"'.format(peer_switch_key))
-    dut.shell('redis-cli -n 4 HDEL"{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'dualToR'))
-    dut.shell('redis-cli -n 4 HDEL "{}" "{}" "{}"'.format(device_meta_key, 'peer_switch', peer_switch_hostname))
+    return
 
 
 @pytest.fixture(scope='module')
@@ -300,10 +284,7 @@ def apply_tunnel_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_pe
     for param, value in tunnel_params.items():
         dut.shell('redis-cli -n 4 HSET "{}" "{}" "{}"'.format(tunnel_key, param, value))
 
-    yield
-    logger.info("Removing tunnel table")
-
-    dut.shell('redis-cli -n 4 DEL "{}"'.format(tunnel_key))
+    return
 
 
 @pytest.fixture(scope='module')
@@ -329,13 +310,7 @@ def apply_mux_cable_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock
         cmds.append('redis-cli -n 4 HSET "{}" "state" "auto"'.format(key))
     dut.shell_cmds(cmds=cmds)
 
-    yield
-    logger.info("Removing mux cable table")
-
-    cmds = []
-    for key in keys_inserted:
-        cmds.append('redis-cli -n 4 DEL "{}"'.format(key))
-    dut.shell_cmds(cmds=cmds)
+    return
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
1. Ensure `cleanup_mocked_configs` runs after those `apply_*` fixtures
in teardown. So that `apply_*` mocking fixtures could find those mocked
configs applied by themselves in teardown(not cleaned by `cleanup_mocked_configs`).
2. For `test_decap_standby_tor`, add function to verify the traffic to
server before `tunnel_traffic_monitor` does its job, in which
`ptfadapter` will pop out packets from packet queues so that subsequent
verification using `ptfadapter` will have no access to those packets.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. Ensure `cleanup_mocked_configs` runs after those `apply_*` fixtures
in teardown. So that `apply_*` mocking fixtures could find those mocked
configs in teardown(not cleaned by `cleanup_mocked_configs`).
2. For `test_decap_standby_tor`, add function to verify the traffic to
server before `tunnel_traffic_monitor` does its job, in which
`ptfadapter` will pop out packets from packet queues so that subsequent
verification using `ptfadapter` will have no access to those packets.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
1. Fix the server traffic verification.
2. Fix the teardown execution order for mocking fixtures.

#### How did you do it?
1. Add function `verify_downstream_packet_to_server` to verify the traffic before the `tunnel_traffic_monitor` does its job.
2. Make those mocking fixtures `apply_*` depend on `cleanup_mocked_configs` so they will be executed first before `cleanup_mocked_configs`.

#### How did you verify/test it?
Run `test_ipinip`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
