### PR TITLE
fixed tests which parse "show platform psustatus" output by regex

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -177,9 +177,9 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     psu_status_output_lines = duthost.command(cmd)["stdout_lines"]
 
     if "201811" in duthost.os_version or "201911" in duthost.os_version:
-        psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
+        psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+(OK|NOT OK|NOT PRESENT)")
     else:
-        psu_line_pattern = re.compile(r"PSU\s+\d+\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
 
     # Check that all PSUs are showing valid status and also at least one PSU is OK
     num_psu_ok = 0
@@ -187,7 +187,7 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     for line in psu_status_output_lines[2:]:
         psu_match = psu_line_pattern.match(line)
         pytest_assert(psu_match, "Unexpected PSU status output: '{}' on '{}'".format(line, duthost.hostname))
-        psu_status = psu_match.group(1)
+        psu_status = psu_match.group(2)
         if psu_status == "OK":
             num_psu_ok += 1
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed tests which parse output of command "show platform psustatus" by regular expression 
Fixes # (issue)1) https://github.com/Azure/sonic-mgmt/issues/3224;   2) old regex didn't works

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

1. 

Old regexp did not work with output like:
```
PSU    Model    Serial                          Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------  ----------------------------  -------------  -------------  -----------  --------  -----
PSU 1  0XNMHJ   CN-0XNMHJ-DED00-036-00M3-A00          12.19           8.37       102.10  OK        green
PSU 2  0XNMHJ   CN-0XNMHJ-DED00-036-00H0-A00          12.18          10.07       122.70  OK        green
```

Or this:
```
PSU    Model    Serial    Voltage (V)    Current (A)    Power (W)    Status    LED
-----  -------  --------  -------------  -------------  -----------  --------  -----
PSU 1                                                                NOT OK    red
PSU 2                     12.068         34.0           410.5        OK        red
```

2. 
Fix for the issue - [https://github.com/Azure/sonic-mgmt/issues/3224](url)

3.
Usage of regex instead of parsing by split



#### How did you do it?
1. regex changed
2. added filling of dictionary in "else" condition(for https://github.com/Azure/sonic-mgmt/issues/3224)
3. changed using of parsing by split to using regex groups 


#### How did you verify/test it?


1. Executed tests:
- test_turn_on_off_psu_and_check_psustatus
- test_thermal_control_psu_absence

2. Manually tested regexp with different outputs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
