### PR TITLE
[pfc] Skip pfc pause lossless test

### DIFF
--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -198,6 +198,11 @@ def run_test(pfc_test_setup, fanouthosts, duthost, ptfhost, conn_graph_facts,
 
     return results
 
+# For this test, we use the fanout connected to the DUT to send PFC pause frames.
+# The fanout needs to send PFC frames fast enough so that the queue remains completely paused for the entire duration of the test.
+# The inter packet interval between PFC frames to completely block a queue vary based on link speed and we have seen flakiness in our test runs.
+# Since this test is already covered under the 'ixia' folder where we use a traffic generator to generate pause frames, skipping this here.
+@pytest.mark.skip(reason="Fanout needs to send PFC frames fast enough to completely pause the queue")
 def test_pfc_pause_lossless(pfc_test_setup, fanouthosts, duthost, ptfhost,
                             conn_graph_facts, fanout_graph_facts,
                             lossless_prio_dscp_map, enum_dut_lossless_prio):


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The pfc pause lossless testcase needs fanout to send PFC frames fast enough to completely block the queue. Depending on the link speeds, the inter packet interval to pause the queue varies.  We are seeing flakiness in our test runs due to packets getting leaked out of the queue because the frames are not sent fast enough. The reliable way to test this scenario is to use a traffic generator and we have the same tests covered under the ixia folder. Hence skipping this one.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)