### PR TITLE
Set warm reboot expected downtime expectation to 0s

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -85,6 +85,11 @@ class AdvancedReboot:
         if self.rebootLimit is None:
             if self.kvmTest:
                 self.rebootLimit = 200 # Default reboot limit for kvm
+            elif 'warm-reboot' in self.rebootType:
+                if isMellanoxDevice(self.duthost):
+                    self.rebootLimit = 1
+                else:
+                    self.rebootLimit = 0
             else:
                 self.rebootLimit = 30 # Default reboot limit for physical devices
 

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -14,6 +14,7 @@ from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
 from tests.common import reboot
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
 from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
+from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
@@ -88,12 +89,16 @@ def prepare_ptf(ptfhost, duthost, tbinfo):
     ptfhost.shell("supervisorctl update")
 
 
-@pytest.fixture(scope="module")
-def ptf_params(duthosts, rand_one_dut_hostname, creds, tbinfo):
-    duthost = duthosts[rand_one_dut_hostname]
+def ptf_params(duthost, creds, tbinfo, upgrade_type):
 
+    reboot_command = get_reboot_command(duthost, upgrade_type)
     if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-        reboot_limit_in_seconds = 150
+        reboot_limit_in_seconds = 200
+    elif 'warm-reboot' in reboot_command:
+        if isMellanoxDevice(duthost):
+            reboot_limit_in_seconds = 1
+        else:
+            reboot_limit_in_seconds = 0
     else:
         reboot_limit_in_seconds = 30
 
@@ -117,7 +122,7 @@ def ptf_params(duthosts, rand_one_dut_hostname, creds, tbinfo):
         "alt_password": sonicadmin_alt_password,
         "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
         "reboot_limit_in_seconds": reboot_limit_in_seconds,
-        "reboot_type": "warm-reboot",
+        "reboot_type": reboot_command,
         "portchannel_ports_file": TMP_VLAN_PORTCHANNEL_FILE,
         "vlan_ports_file": TMP_VLAN_FILE,
         "ports_file": TMP_PORTS_FILE,
@@ -209,7 +214,7 @@ def check_services(duthost):
         
 
 @pytest.mark.device_type('vs')
-def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgrade_path_lists, ptf_params, setup, tbinfo):
+def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgrade_path_lists, setup, creds, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
     from_list = from_list_images.split(',')
@@ -229,9 +234,8 @@ def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgra
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
             target_version = install_sonic(duthost, to_image, tbinfo)
-            test_params = ptf_params
+            test_params = ptf_params(duthost, creds, tbinfo, upgrade_type)
             test_params['target_version'] = target_version
-            test_params['reboot_type'] = get_reboot_command(duthost, upgrade_type)
             prepare_testbed_ssh_keys(duthost, ptfhost, test_params['dut_username'])
             log_file = "/tmp/advanced-reboot.ReloadTest.{}.log".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
             if test_params['reboot_type'] == reboot_ctrl_dict.get(REBOOT_TYPE_COLD).get("command"):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Set warm reboot expected downtime expectation to 0s. Allow 1s for Mellanox platforms.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To accurately measure warmboot downtime scenarios for advance reboot and upgrade tests.

#### How did you do it?
#### How did you verify/test it?
Verified on physical device:
`test_upgrade_path` from 201811 to 201811 image:
```
2021-03-31 23:44:30 : --------------------------------------------------
2021-03-31 23:44:30 : Summary:
2021-03-31 23:44:30 : --------------------------------------------------
2021-03-31 23:44:30 : Longest downtime period was 0:00:00
2021-03-31 23:44:30 : Reboot time was 0:00:00
2021-03-31 23:44:30 : Expected downtime is less then 0:00:00
2021-03-31 23:44:30 : --------------------------------------------------
```

test_advanced_reboot::test_warm_reboot:
```
2021-04-01 00:04:57 : --------------------------------------------------
2021-04-01 00:04:57 : Summary:
2021-04-01 00:04:57 : --------------------------------------------------
2021-04-01 00:04:57 : Longest downtime period was 0:00:00
2021-04-01 00:04:57 : Reboot time was 0:00:00
2021-04-01 00:04:57 : Expected downtime is less then 0:00:00
2021-04-01 00:04:57 : --------------------------------------------------
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
