### PR TITLE
[reporting] Add support for uploading pdu status info from devutils

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -46,6 +46,14 @@ class ReportDBConnector(ABC):
         """
         pass
 
+    @abstractmethod
+    def upload_pdu_status_data(self, pdu_status_output: List) -> None:
+        """Upload PDU status data to the back-end data store.
+
+        Args:
+            pdu_status_output: A list of PDU status results from devutils.
+        """
+
 
 class KustoConnector(ReportDBConnector):
     """KustoReportDB is a wrapper for storing test reports in Kusto/Azure Data Explorer."""
@@ -54,19 +62,22 @@ class KustoConnector(ReportDBConnector):
     SUMMARY_TABLE = "TestReportSummary"
     RAW_CASE_TABLE = "RawTestCases"
     RAW_REACHABILITY_TABLE = "RawReachabilityData"
+    RAW_PDU_STATUS_TABLE = "RawPduStatusData"
 
     TABLE_FORMAT_LOOKUP = {
         METADATA_TABLE: DataFormat.JSON,
         SUMMARY_TABLE: DataFormat.JSON,
         RAW_CASE_TABLE: DataFormat.MULTIJSON,
-        RAW_REACHABILITY_TABLE: DataFormat.MULTIJSON
+        RAW_REACHABILITY_TABLE: DataFormat.MULTIJSON,
+        RAW_PDU_STATUS_TABLE: DataFormat.MULTIJSON
     }
 
     TABLE_MAPPING_LOOKUP = {
         METADATA_TABLE: "FlatMetadataMappingV1",
         SUMMARY_TABLE: "FlatSummaryMappingV1",
         RAW_CASE_TABLE: "RawCaseMappingV1",
-        RAW_REACHABILITY_TABLE: "RawReachabilityMappingV1"
+        RAW_REACHABILITY_TABLE: "RawReachabilityMappingV1",
+        RAW_PDU_STATUS_TABLE: "RawPduStatusMapping"
     }
 
     def __init__(self, db_name: str):
@@ -113,6 +124,21 @@ class KustoConnector(ReportDBConnector):
         reachability_data = {"data": ping_output}
 
         self._ingest_data(self.RAW_REACHABILITY_TABLE, reachability_data)
+
+    def upload_pdu_status_data(self, pdu_status_output: List) -> None:
+        time = str(datetime.utcnow())
+        data = []
+        for result in pdu_status_output:
+            if not result["PDU status"]:
+                status = {"Timestamp": time, "Host": result["Host"], "data_present": False}
+                data.append(status)
+                continue
+
+            for status in result["PDU status"]:
+                status.update({"Timestamp": time, "Host": result["Host"], "data_present": True})
+                data.append(status)
+
+        self._ingest_data(self.RAW_PDU_STATUS_TABLE, data)
 
     def _upload_metadata(self, report_json, external_tracking_id, report_guid):
         metadata = {

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -49,6 +49,11 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
             reachability_data = json.load(f)
 
         kusto_db.upload_reachability_data(reachability_data)
+    elif args.category == "pdu_status":
+        with open(args.path_name) as f:
+            pdu_data = json.load(f)
+
+        kusto_db.upload_pdu_status_data(pdu_data)
     else:
         print('Unknown category "{}"'.format(args.category))
         sys.exit(1)


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add support for uploading pdu status info from devutils
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We would like to be able to monitor PDU status info and query it.

#### How did you do it?
I added a new method to post-process the PDU data from devutils so that it can be sent to kusto in a flattened/row-compatible format.

#### How did you verify/test it?
Verified that the JSON list that was produced has all the correct fields to upload to Kusto.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
