### PR TITLE
[SFlowTest] Dynamic Agent-id and ifindex issue resolved

### DIFF
--- a/ansible/roles/test/files/ptftests/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/sflow_test.py
@@ -254,7 +254,7 @@ class SflowTest(BaseTest):
                time.sleep(self.polling_int)
         else:
            self.sendTraffic()
-           time.sleep(5)
+           time.sleep(10) # For Test Stability
         self.stop_collector = True
         thr1.join()
         thr2.join()

--- a/ansible/roles/test/files/ptftests/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/sflow_test.py
@@ -195,15 +195,15 @@ class SflowTest(BaseTest):
         logging.info("packets collected from interfaces ifindex : %s" %data['flow_port_count'])
         logging.info("Expected number of packets from each port : %s to %s" % (100 * 0.6, 100 * 1.4))
         for port in self.interfaces:
-            ifindex = self.interfaces[port]['ifindex']
-            logging.info("....%s : Flow packets collected from port %s = %s"%(collector,port,data['flow_port_count'][ifindex]))
+            index = self.interfaces[port]['port_index'] ##NOTE: hsflowd is sending index instead of ifindex.
+            logging.info("....%s : Flow packets collected from port %s = %s"%(collector,port,data['flow_port_count'][index]))
             if port in self.enabled_intf :
                 # Checking samples with tolerance of 40 % as the sampling is random and  not deterministic.Over many samples it should converge to a mean of 1:N
                 # Number of packets sent = 100 * sampling rate of interface
-                self.assertTrue(100 * 0.6 <= data['flow_port_count'][ifindex] <= 100 * 1.4 ,
-                        "Expected Number of samples are not collected  collected from Interface %s  in collector %s , Received %s" %(port,collector,data['flow_port_count'][ifindex]))
+                self.assertTrue(100 * 0.6 <= data['flow_port_count'][index] <= 100 * 1.4 ,
+                        "Expected Number of samples are not collected  collected from Interface %s  in collector %s , Received %s" %(port,collector,data['flow_port_count'][index]))
             else:
-                self.assertTrue(data['flow_port_count'][ifindex] == 0 ,
+                self.assertTrue(data['flow_port_count'][index] == 0 ,
                                "Packets are collected from Non Sflow interface %s in collector %s"%(port,collector))
 
     #---------------------------------------------------------------------------

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -123,6 +123,7 @@ def config_sflow_agent(duthosts, rand_one_dut_hostname):
     # NOTE: When no agent-id is set, hsflowd chooses the agent-id based on simple heuristics
     # Hence, this fixture to keep the test stable
     duthost = duthosts[rand_one_dut_hostname]
+    duthost.shell("config sflow agent-id del") # Remove any existing agent-id
     duthost.shell("config sflow agent-id add Loopback0")
     yield   
     duthost.shell("config sflow agent-id del")
@@ -307,21 +308,22 @@ class TestSflowCollector():
 
 
 # ------------------------------------------------------------------------------
-
+@pytest.mark.usefixtures("sflowbase_config")
+@pytest.mark.usefixtures("config_sflow_agent")
 class TestSflowPolling():
     """
     Test Sflow polling with different polling interval and check whether the test interface sends one counter sample for every polling interval
     Disable polling and check the dut doesn't send counter samples .
     """
 
-    def testPolling(self, sflowbase_config, config_sflow_agent, duthost, partial_ptf_runner):
+    def testPolling(self, duthost, partial_ptf_runner):
         duthost.shell("config sflow polling-interval 20")
         verify_show_sflow(duthost,status='up',polling_int=20)
         partial_ptf_runner(
               polling_int=20,
               active_collectors="['collector0','collector1']" )
 
-    def testDisablePolling(self, sflowbase_config, config_sflow_agent, duthost, partial_ptf_runner):
+    def testDisablePolling(self, duthost, partial_ptf_runner):
         duthost.shell("config sflow polling-interval 0")
 
         verify_show_sflow(duthost,status='up',polling_int=0)
@@ -329,7 +331,7 @@ class TestSflowPolling():
               polling_int=0,
               active_collectors="['collector0','collector1']" )
 
-    def testDifferntPollingInt(self, sflowbase_config, config_sflow_agent, duthost, partial_ptf_runner):
+    def testDifferntPollingInt(self, duthost, partial_ptf_runner):
         duthost.shell("config sflow polling-interval 60")
 
         verify_show_sflow(duthost,status='up',polling_int=60)
@@ -398,7 +400,7 @@ class TestSflowInterface():
               active_collectors="['collector0','collector1']" )
 
 # ------------------------------------------------------------------------------
-
+@pytest.mark.usefixtures("sflowbase_config")
 class TestAgentId():
     """
     Add loopback0 ip as the agent id and check the samples are received with intended agent-id.
@@ -406,7 +408,7 @@ class TestAgentId():
     Add eth0 ip as the agent ip and check the samples are received with intended agent-id.
     """
 
-    def testNonDefaultAgent(self, sflowbase_config, duthost, partial_ptf_runner):
+    def testNonDefaultAgent(self, duthost, partial_ptf_runner):
         agent_ip = var['lo_ip']
         duthost.shell(" config sflow agent-id del")
         duthost.shell(" config sflow agent-id  add Loopback0")
@@ -417,7 +419,7 @@ class TestAgentId():
               active_collectors="['collector0','collector1']" )
 
 
-    def testDelAgent(self, sflowbase_config, duthost, partial_ptf_runner):
+    def testDelAgent(self, duthost, partial_ptf_runner):
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost,status='up',agent_id='default')
         time.sleep(5)
@@ -427,7 +429,7 @@ class TestAgentId():
               agent_id=var['lo_ip'],
               active_collectors="['collector0','collector1']" )
 
-    def testAddAgent(self, sflowbase_config, duthost, partial_ptf_runner):
+    def testAddAgent(self, duthost, partial_ptf_runner):
         agent_ip = var['mgmt_ip']
         duthost.shell(" config sflow agent-id  add  eth0")
         verify_show_sflow(duthost,status='up',agent_id='eth0')
@@ -463,7 +465,7 @@ class TestReboot():
               active_collectors="['collector0','collector1']" )
 
 
-    def testRebootSflowDisable(self, sflowbase_config, config_sflow_agent, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testRebootSflowDisable(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):
         config_sflow(duthost,sflow_status='disable')
         verify_show_sflow(duthost,status='down')
         partial_ptf_runner(


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR addresses the following issues:

1) Currently, hsflowd trasmits index in the SFlow UDP datagram, but the test expects ifindex. Considering, index as a valid option, the test has to be fixed. Modified test to collect index info and then made the ptftests/sflow_test.py to verify on index in the datagram received. More Info on [#3234 ](https://github.com/Azure/sonic-mgmt/issues/3234)

2) If the Agent-id is left to default, the hsflowd assigns docker0 (When nothing is assigned, it's upto to the hsflowd to choose any ip) as the agent-id, but the test was hard coded to verify for mgmt-ip as the agent-id. As a fix, used a fixture in the test to set Loopback0 address as agent-id before running these tests.  More Info on [#3233 ](https://github.com/Azure/sonic-mgmt/issues/3233)
 
3) Point 23 in [HLD:Test_Plan](https://github.com/Azure/SONiC/blob/master/doc/sflow/sflow_hld.md#11-unit-test-cases) suggests a test case for warm-reboot. Essentially, the test programs a valid configuration for sflow and then performs a warm-reboot and then to check if the sflow is working as expected. This test case is not intend to test sFlow working during warmboot and that warmboot traffic is not affected but rather making sure than when sFlow is configured and activated warmboot can be executed and completed with no issue. [#3236 ](https://github.com/Azure/sonic-mgmt/issues/3236)

4) Minor refactoring of TestSflowPolling & TestAgentId Classes by running the fixture once per class instead of running it for every method.


### Type of change


<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Community Test is failing

#### How did you do it?
Modified the test

#### How did you verify/test it?
Ran the Community Test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
