### PR TITLE
[dualtor][DualTorIO] Fix thread hang waiting for io_ready

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -3,6 +3,7 @@ import pytest
 import json
 from tests.common.dualtor.dual_tor_io import DualTorIO
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import InterruptableThread
 import threading
 import logging
 from natsort import natsorted
@@ -136,8 +137,11 @@ def run_test(duthosts, activehost, ptfhost, ptfadapter, action,
     elif traffic_direction == "t1_to_server":
         traffic_generator = tor_IO.generate_from_t1_to_server
 
-    send_and_sniff = threading.Thread(target=tor_IO.start_io_test,
-        kwargs={'traffic_generator': traffic_generator})
+    send_and_sniff = InterruptableThread(
+        target=tor_IO.start_io_test,
+        kwargs={'traffic_generator': traffic_generator}
+    )
+    send_and_sniff.set_error_handler(lambda *args, **kargs: io_ready.set())
 
     send_and_sniff.start()
     if action:

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -264,7 +264,7 @@ class DualTorIO:
         else:
             ptf_port = self.tor_to_ptf_intf_map[self.tor_vlan_intf]
             src_mac = ptf_intf_to_mac_map[ptf_port]
-            src_ip = self.tor_to_ptf_intf_map[ptf_port]
+            src_ip = self.ptf_intf_to_server_ip_map[ptf_port]
         logger.info(
             "Ethernet address: dst: {} src: {}".format(
                 self.vlan_mac, src_mac
@@ -333,6 +333,8 @@ class DualTorIO:
         self.sender_thr = InterruptableThread(target=sender)
         self.sniff_thr = InterruptableThread(target=sniffer)
         self.sniffer_started = threading.Event()
+        self.sniff_thr.set_error_handler(lambda *args, **kargs: self.sniffer_started.set())
+        self.sender_thr.set_error_handler(lambda *args, **kargs: self.io_ready_event.set())
         self.sniff_thr.start()
         self.sender_thr.start()
         self.sniff_thr.join()

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -13,6 +13,7 @@ from itertools import cycle
 from operator import itemgetter
 from itertools import groupby
 
+from tests.common.utilities import InterruptableThread
 from tests.ptf_runner import ptf_runner
 from natsort import natsorted
 from collections import defaultdict
@@ -180,9 +181,10 @@ class DualTorIO:
         if self.tor_vlan_intf:
             # If destination VLAN intf is specified,
             # use only the connected server
-            server_ip_list = [self.ptf_intf_to_server_ip_map[
-                self.tor_vlan_intf
-                ]]
+            ptf_port = self.tor_to_ptf_intf_map[self.tor_vlan_intf]
+            server_ip_list = [
+                self.ptf_intf_to_server_ip_map[ptf_port]
+            ]
         else:
             # Otherwise send packets to all servers
             server_ip_list = self.ptf_intf_to_server_ip_map.values()
@@ -256,22 +258,23 @@ class DualTorIO:
             ptf_intf_to_mac_map[ptf_intf] = self.ptfadapter.dataplane.get_mac(0, ptf_intf)
 
         logger.info("-"*20 + "Server to T1 packet" + "-"*20)
-        logger.info("Ethernet address: dst: {} src: {}"
-                    .format(self.vlan_mac,
-                            'random' if self.tor_vlan_intf is None
-                                     else ptf_intf_to_mac_map[
-                                         self.tor_to_ptf_intf_map[self.tor_vlan_intf]
-                                         ]
-                           )
-                    )
-        logger.info("IP address: dst: {} src: {}"
-                    .format('random',
-                            'random' if self.tor_vlan_intf is None
-                                     else self.ptf_intf_to_server_ip_map[
-                                                   self.tor_vlan_intf
-                                               ]
-                           )
-                   )
+        if self.tor_vlan_intf is None:
+            src_mac = 'random'
+            src_ip = 'random'
+        else:
+            ptf_port = self.tor_to_ptf_intf_map[self.tor_vlan_intf]
+            src_mac = ptf_intf_to_mac_map[ptf_port]
+            src_ip = self.tor_to_ptf_intf_map[ptf_port]
+        logger.info(
+            "Ethernet address: dst: {} src: {}".format(
+                self.vlan_mac, src_mac
+            )
+        )
+        logger.info(
+            "IP address: dst: {} src: {}".format(
+                'random', src_ip
+            )
+        )
         logger.info("TCP port: dst: {} src: 1234".format(TCP_DST_PORT))
         logger.info("Active ToR MAC: {}, Standby ToR MAC: {}".format(self.active_mac,
             self.standby_mac))
@@ -327,8 +330,8 @@ class DualTorIO:
         """
         @summary: This method starts and joins two background threads in parallel: sender and sniffer
         """
-        self.sender_thr = threading.Thread(target=sender)
-        self.sniff_thr = threading.Thread(target=sniffer)
+        self.sender_thr = InterruptableThread(target=sender)
+        self.sniff_thr = InterruptableThread(target=sniffer)
         self.sniffer_started = threading.Event()
         self.sniff_thr.start()
         self.sender_thr.start()
@@ -381,8 +384,13 @@ class DualTorIO:
             ptf_bp_mac = output['stdout']
             sniff_filter = '({}) and (not ether dst {})'.format(sniff_filter, ptf_bp_mac)
 
-        scapy_sniffer = threading.Thread(target=self.scapy_sniff, kwargs={'sniff_timeout': wait,
-            'sniff_filter': sniff_filter})
+        scapy_sniffer = InterruptableThread(
+            target=self.scapy_sniff,
+            kwargs={
+                'sniff_timeout': wait,
+                'sniff_filter': sniff_filter
+            }
+        )
         scapy_sniffer.start()
         time.sleep(2)               # Let the scapy sniff initialize completely.
         self.sniffer_started.set()  # Unblock waiter for the send_in_background.

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -91,6 +91,10 @@ def wait_tcp_connection(client, server_hostname, listening_port, timeout_s = 30)
 class InterruptableThread(threading.Thread):
     """Thread class that can be interrupted by Exception raised."""
 
+    def set_error_handler(self, error_handler):
+        """Add error handler callback that will be called when the thread exits with error."""
+        self.error_handler = error_handler
+
     def run(self):
         """
         @summary: Run the target function, call `start()` to start the thread
@@ -101,6 +105,8 @@ class InterruptableThread(threading.Thread):
             threading.Thread.run(self)
         except Exception:
             self._e = sys.exc_info()
+            if self.error_handler:
+                self.error_handler(*self._e)
 
     def join(self, timeout=None, suppress_exception=False):
         """

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -105,7 +105,7 @@ class InterruptableThread(threading.Thread):
             threading.Thread.run(self)
         except Exception:
             self._e = sys.exc_info()
-            if self.error_handler:
+            if getattr(self, "error_handler", None) is not None:
                 self.error_handler(*self._e)
 
     def join(self, timeout=None, suppress_exception=False):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For the main thread, it will wait for the packet sender to set event
`io_ready`. If any error occurs within the sender thread and it fails to
set the event, the main thread will hang waiting for the event.

1. Add a error handler to InterruptableThread so it could call this
handelr as callback in case of any errors.

2. Make the sender thread an instance of InterruptableThread and add a
error handler to set `io_ready` to let main thread continue to run.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For the main thread, it will wait for the packet sender to set event
`io_ready`. If any error occurs within the sender thread and it fails to
set the event, the main thread will hang waiting for the event.

#### How did you do it?
1. Add a error handler to `InterruptableThread` so it could call this
handelr as callback in case of any errors.

2. Make the sender thread an instance of `InterruptableThread` and add a
error handler to set `io_ready` to let main thread continue to run.

#### How did you verify/test it?
* demo test
```python
import logging
import functools
import pdb
import random
import time

from tests.common.dualtor.dual_tor_utils import upper_tor_host
from tests.common.dualtor.dual_tor_utils import lower_tor_host
from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action
from tests.common.dualtor.mux_simulator_control import set_drop
from tests.common.dualtor.mux_simulator_control import set_output
from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
from tests.common.fixtures.ptfhost_utils import run_icmp_responder
from tests.common.fixtures.ptfhost_utils import run_garp_service
from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory


def test_active_link_drop_downstream_active(
    upper_tor_host,
    lower_tor_host,
    send_t1_to_server_with_action,
    set_drop,
    set_output,
    toggle_all_simulator_ports_to_upper_tor,
    tor_mux_intfs
):
    def timer(func):
        def decorated(*args, **kargs):
            start_time = time.time()
            logging.debug("Start time: %s", start_time)
            ret = func(*args, **kargs)
            end_time = time.time()
            logging.debug("End time: %s", end_time)
            return ret
        return decorated

    pdb.set_trace()
    intf = random.choice(tor_mux_intfs)
    logging.debug(intf)
    io_obj = send_t1_to_server_with_action(
        upper_tor_host,
        tor_vlan_port=intf,
        action=functools.partial(timer(set_drop), intf, ["upper_tor"])
    )
    set_output(intf, ["upper_tor", ])
```
```
dualtor/test_link_drop.py::test_active_link_drop_downstream_active PASSED                                                                                                                      [100%]

===================================================================================== 1 passed in 609.30 seconds =====================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
