### PR TITLE
[reporting] Fix root for pdu status data upload

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -121,24 +121,25 @@ class KustoConnector(ReportDBConnector):
         ping_time = str(datetime.utcnow())
         for result in ping_output:
             result.update({"Timestamp": ping_time})
-        reachability_data = {"data": ping_output}
 
+        reachability_data = {"data": ping_output}
         self._ingest_data(self.RAW_REACHABILITY_TABLE, reachability_data)
 
     def upload_pdu_status_data(self, pdu_status_output: List) -> None:
         time = str(datetime.utcnow())
-        data = []
+        pdu_output = []
         for result in pdu_status_output:
             if not result["PDU status"]:
                 status = {"Timestamp": time, "Host": result["Host"], "data_present": False}
-                data.append(status)
+                pdu_output.append(status)
                 continue
 
             for status in result["PDU status"]:
                 status.update({"Timestamp": time, "Host": result["Host"], "data_present": True})
-                data.append(status)
+                pdu_output.append(status)
 
-        self._ingest_data(self.RAW_PDU_STATUS_TABLE, data)
+        pdu_status_data = {"data": pdu_output}
+        self._ingest_data(self.RAW_PDU_STATUS_TABLE, pdu_status_data)
 
     def _upload_metadata(self, report_json, external_tracking_id, report_guid):
         metadata = {


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix root for pdu status data upload
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Kusto expects the PDU status data to be in a list under the "data" attribute.

#### How did you do it?
Added "data" to the output and also changed the formatting to make this step/requirement more clearly visible.

#### How did you verify/test it?
Perform an upload and verify that the contents show up in Kusto.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
