### PR TITLE
Warmboot KVM tests - replace docker-exec 1s timeout with 5s

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -40,6 +40,14 @@ class AdvancedReboot:
         )
 
         if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+            cmd_format = "sed -i 's/{}/{}/' {}"
+            warmboot_script_path = duthost.shell('which warm-reboot')['stdout']
+            original_line = 'timeout 1s docker exec $container echo "success"'
+            replaced_line = 'timeout 5s docker exec $container echo "success"'
+            replace_cmd = cmd_format.format(original_line, replaced_line, warmboot_script_path)
+            logger.info("Increase docker exec timeout from 1s to 5s in {}".format(warmboot_script_path))
+            duthost.shell(replace_cmd)
+
             self.kvmTest = True
             device_marks = [arg for mark in request.node.iter_markers(name='device_type') for arg in mark.args]
             if 'vs' not in device_marks:

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -40,6 +40,15 @@ class AdvancedReboot:
         )
 
         if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+            # Fast and Warm-reboot procedure now test if "docker exec" works.
+            # The timeout for check_docker_exec test is 1s. This timeout is good
+            # enough for test in physical devices. However, the KVM devices are
+            # inherently slow, and the 1s timeout for check_docker_exec test has
+            # intermittently failed in Azure Pipeline PR tests.
+            # Therefore, the 1s timeout is increased to 5s for KVM testing.
+            # 5s timeout is believed to be generous enough for the KVM device,
+            # however more test results are needed to prove this.
+
             cmd_format = "sed -i 's/{}/{}/' {}"
             warmboot_script_path = duthost.shell('which warm-reboot')['stdout']
             original_line = 'timeout 1s docker exec $container echo "success"'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Warm reboot tests are failing in PR checks. Increase docker-exec timeout from 1s to 5s for KVM testing.

Fixes: https://github.com/Azure/sonic-mgmt/issues/3264

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Find the path to warm-reboot script.
Replace 1s docker exec timeout with 5s.

#### What is the motivation for this PR?
Fix PR test failures.

Failure is due to 1s timeout set here for the warmboot pre-reboot-check
https://github.com/Azure/sonic-utilities/blob/master/scripts/fast-reboot#L322

#### How did you do it?

#### How did you verify/test it?
Tested on local KVM. Wait for PR results for this PR.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
