### PR TITLE
Increase timeout by 300 seconds for waiting VM starting up and shutting down

### DIFF
--- a/ansible/roles/eos/handlers/main.yml
+++ b/ansible/roles/eos/handlers/main.yml
@@ -14,7 +14,7 @@
     port: 22
     state: stopped
     delay: 10
-    timeout: 300
+    timeout: 600
   delegate_to: "{{ VM_host[0] }}"
   listen: "Update VM state"
 
@@ -24,6 +24,6 @@
     port: 22
     state: started
     delay: 10
-    timeout: 1200
+    timeout: 1500
   delegate_to: "{{ VM_host[0] }}"
   listen: "Update VM state"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some errors were noticed when running 'add-topo' for some testbed, which is caused by timeout of waiting for VM shutdown/starup.
```
fatal: [VM1779 -> x]: FAILED! => {"changed": false, "elapsed": 1200, "msg": "Timeout when waiting for x:22"}
```
```
fatal: [VM1717 -> x]: FAILED! => {"changed": false, "elapsed": 300, "msg": "Timeout when waiting for x:22 to stop."}
fatal: [VM1712 -> x]: FAILED! => {"changed": false, "elapsed": 300, "msg": "Timeout when waiting for x:22 to stop."}
```
To mitigate the issue, I increased the timeout by 300 seconds.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to increase timeout for waiting VM starting up and shutting down.

#### How did you do it?

#### How did you verify/test it?
Verified by running ```add-topo``` for two testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
