### PR TITLE
[dualtor] Add script testing heartbeat failure scenario

### DIFF
--- a/tests/dualtor/test_heartbeat_failure.py
+++ b/tests/dualtor/test_heartbeat_failure.py
@@ -1,0 +1,122 @@
+import random
+
+import pytest
+
+from tests.common.dualtor.control_plane_utils import verify_tor_states
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
+from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                                                                       # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+
+def test_active_tor_heartbeat_failure_upstream(
+    toggle_all_simulator_ports_to_upper_tor,
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    shutdown_tor_heartbeat):
+    """
+    Send upstream traffic and stop the LinkProber module on the active ToR.
+    Confirm switchover and disruption lasts < 1 second.
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
+
+
+def test_active_tor_heartbeat_failure_downstream_active(
+    toggle_all_simulator_ports_to_upper_tor,
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    shutdown_tor_heartbeat):
+    """
+    Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the active ToR.
+    Confirm switchover and disruption lasts < 1 second.
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True, delay=1,
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
+
+
+def test_active_tor_heartbeat_failure_downstream_standby(
+    toggle_all_simulator_ports_to_upper_tor,
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    shutdown_tor_heartbeat):
+    """
+    Send downstream traffic from T1 to the standby ToR and stop the LinkProber module on the active ToR.
+    Confirm switchover and disruption lasts < 1 second.
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=1,
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
+
+
+def test_standby_tor_heartbeat_failure_upstream(
+    toggle_all_simulator_ports_to_upper_tor,
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    shutdown_tor_heartbeat):
+    """
+    Send upstream traffic and stop the LinkProber module on the standby ToR.
+    Confirm no switchover and no disruption.
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True,
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
+
+
+def test_standby_tor_heartbeat_failure_downstream_active(
+    toggle_all_simulator_ports_to_upper_tor,
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    shutdown_tor_heartbeat):
+    """
+    Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the standby ToR.
+    Confirm no switchover and no disruption.
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True, tor_vlan_port='Ethernet4',
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
+
+
+def test_standby_tor_heartbeat_failure_downstream_standby(
+    toggle_all_simulator_ports_to_upper_tor,
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    shutdown_tor_heartbeat):
+    """
+    Send downstream traffic from T1 to the standby ToR and stop the LinkProber module on the standby ToR.
+    Confirm no switchover and no disruption.
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True,
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )

--- a/tests/dualtor/test_heartbeat_failure.py
+++ b/tests/dualtor/test_heartbeat_failure.py
@@ -95,7 +95,7 @@ def test_standby_tor_heartbeat_failure_downstream_active(
     Confirm no switchover and no disruption.
     """
     send_t1_to_server_with_action(
-        upper_tor_host, verify=True, tor_vlan_port='Ethernet4',
+        upper_tor_host, verify=True,
         action=lambda: shutdown_tor_heartbeat(lower_tor_host)
     )
     verify_tor_states(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #2769, #2770

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Need to cover dualtor traffic handling behavior in case of heartbeat failure.

#### How did you do it?
Add a new test script to test dualtor traffic handling behavior in case of heartbeat failure.

#### How did you verify/test it?
Tested on dualtor testbed. The image still has issue with handling switching over in case of heartbeat failed on active node. The test script should be OK.
```
test_active_tor_heartbeat_failure_upstream		FAILED, disruption exceeds 1s.
test_active_tor_heartbeat_failure_downstream_active	FAILED, drop in the middle to the end
test_active_tor_heartbeat_failure_downstream_standby  	FAILED, disruption exceeds 1s.

test_standby_tor_heartbeat_failure_upstream 		PASSED
test_standby_tor_heartbeat_failure_downstream_active	PASSED
test_standby_tor_heartbeat_failure_downstream_standby	PASSED
```

#### Any platform specific information?
Dualtor only

#### Supported testbed topology if it's a new test case?
dualtor, dualtor-56, dualtor-120

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/dual_tor/dual_tor_test_hld.md 