### PR TITLE
Fix enabld/disable rsyslog rate limitation.

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -51,7 +51,7 @@ def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     cmd_enable_rate_limit = r"docker exec -i {} sed -i 's/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' /etc/rsyslog.conf"
     cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"
     for feature_name, state in features_dict.items():
-        if state == "disabled":
+        if 'enabled' not in state:
             continue
         cmds = []
         cmds.append(cmd_enable_rate_limit.format(feature_name))

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -85,7 +85,7 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     cmd_disable_rate_limit = r"docker exec -i {} sed -i 's/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' /etc/rsyslog.conf"
     cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"
     for feature_name, state in features_dict.items():
-        if state == "disabled":
+        if 'enabled' not in state:
             continue
         cmds = []
         cmds.append(cmd_disable_rate_limit.format(feature_name))


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure of ```test_disable_rsyslog_rate_limit``` and ```test_recover_rsyslog_rate_limit``` in ```pretest``` and ```posttest```.
The state of feature may be ```always_enabled``` or ```always_disabled```. Therefore, we have to update the logic to check if a feature is enabled.
```
admin@str-msn4600c-acs-02:~$ show feature status
Feature     State            AutoRestart     SystemState    UpdateTime           ContainerId    Version           SetOwner    CurrentOwner    RemoteState
----------  ---------------  --------------  -------------  -------------------  -------------  ----------------  ----------  --------------  -------------
acms        enabled          enabled         up             2021-04-06 00:23:35  acms                             local       local           none
bgp         enabled          enabled         up             2021-04-06 00:23:35  bgp                              local       local           none
database    always_enabled   always_enabled                                                                       local
dhcp_relay  enabled          enabled         up             2021-04-06 00:24:26  dhcp_relay     20201231.beta.16  kube        local
lldp        enabled          enabled         up             2021-04-06 00:24:26  lldp           20201231.beta.16  kube        local
mux         always_disabled  enabled                                                                              local
pmon        enabled          enabled         up             2021-04-06 00:24:21  pmon           20201231.beta.16  kube        local
radv        enabled          enabled         up             2021-04-06 00:24:23  radv           20201231.beta.16  kube        local
restapi     enabled          enabled         up             2021-04-06 00:23:35  restapi                          local       local           none
snmp        enabled          enabled         up             2021-04-06 00:26:51  snmp           20201231.beta.16  kube        local
swss        enabled          enabled         up             2021-04-06 00:23:37  swss                             local       local           none
syncd       enabled          enabled         up             2021-04-06 00:24:20  syncd                            local       local           none
teamd       enabled          enabled         up             2021-04-06 00:23:38  teamd                            local       local           none
telemetry   enabled          enabled         up             2021-04-06 00:26:55  telemetry      20201231.beta.16  kube        local
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure of ```test_disable_rsyslog_rate_limit``` and ```test_recover_rsyslog_rate_limit``` in ```pretest``` and ```posttest```.

#### How did you do it?
Update the logic to check if a feature is enabled.

#### How did you verify/test it?
Verified on MSN4600c, T0 testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
