### PR TITLE
Simplify the code for getting DUT management IP

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -14,7 +14,7 @@ def test_cacl_function(duthosts, rand_one_dut_hostname, localhost, creds):
     """Test control plane ACL functionality on a SONiC device
     """
     duthost = duthosts[rand_one_dut_hostname]
-    dut_mgmt_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
+    dut_mgmt_ip = duthost.mgmt_ip
 
     # Ensure we can gather basic SNMP facts from the device
     res = localhost.snmp_facts(host=dut_mgmt_ip, version='v2c', community=creds['snmp_rocommunity'])

--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -122,7 +122,7 @@ def wait_for_device_reachable(localhost):
     """
 
     def wait_for_device_reachable(duthost, timeout=300):
-        dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
+        dut_ip = duthost.mgmt_ip
         logger.info("Waiting for ssh to startup on {}"
                     .format((duthost.hostname)))
         res = localhost.wait_for(host=dut_ip,

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -33,10 +33,9 @@ class PFCStorm(object):
                 Other keys: 'pfc_storm_defer_time', 'pfc_storm_stop_defer_time', 'pfc_asym'
         """
         self.dut = duthost
-        dut_facts = duthost.setup()['ansible_facts']
         hostvars = self.dut.host.options['variable_manager']._hostvars[self.dut.hostname]
         self.inventory = hostvars['inventory_file'].split('/')[-1]
-        self.ip_addr = dut_facts['ansible_eth0']['ipv4']['address']
+        self.ip_addr = duthost.mgmt_ip
         self.fanout_info = fanout_graph_facts
         self.fanout_hosts = fanouthosts
         self.pfc_gen_file = kwargs.pop('pfc_gen_file', "pfc_gen.py")

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -100,7 +100,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
 
     # pool for executing tasks asynchronously
     pool = ThreadPool()
-    dut_ip = duthost.setup()['ansible_facts']['ansible_eth0']['ipv4']['address']
+    dut_ip = duthost.mgmt_ip
 
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -162,7 +162,7 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type):
               "myip": test_params.myip,
               "peerip": test_params.peerip}
 
-    dut_ip = dut.setup()["ansible_facts"]["ansible_eth0"]["ipv4"]["address"]
+    dut_ip = dut.mgmt_ip
     device_sockets = ["0-{}@tcp://127.0.0.1:10900".format(test_params.nn_target_port),
                       "1-{}@tcp://{}:10900".format(test_params.nn_target_port, dut_ip)]
 
@@ -244,7 +244,7 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo):
         config_reload(dut)
 
     logging.info("Configure syncd RPC for testing")
-    copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface, 
+    copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
                                test_params.nn_target_namespace, creds)
 
 def _teardown_testbed(dut, creds, ptf, test_params, tbinfo):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -43,7 +43,6 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     dhcp_relay_data_list = []
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    host_facts = duthost.setup()['ansible_facts']
 
     switch_loopback_ip = mg_facts['minigraph_lo_interfaces'][0]['addr']
 

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -96,9 +96,7 @@ def setup_pfc_test(
     port_list = mg_facts['minigraph_ports'].keys()
     ports = (' ').join(port_list)
     neighbors = conn_graph_facts['device_conn'][duthost.hostname]
-    dut_facts = duthost.setup()['ansible_facts']
-    dut_eth0_ip = dut_facts['ansible_eth0']['ipv4']['address']
-    dut_eth0_mac = dut_facts['ansible_eth0']['macaddress']
+    dut_eth0_ip = duthost.mgmt_ip
     vlan_nw = None
 
     if mg_facts['minigraph_vlans']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Some of the scirpts use ansible module `setup()` to get DUT's management
IP address. The `setup()` module is a little bit too heavy and generts too much
debug level log. 

#### How did you do it?
The infrastructure code already supplied attribute `mgmt_ip` to objects decended from AnsibleBaseHost class. This change is to simplify the code to use the existing `mgmt_ip` attribute.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
