### PR TITLE
Improve the method of getting interface MAC address

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -913,11 +913,12 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
         Returns:
             str: The MAC address of the specified interface, or None if it is not found.
         """
-        for iface, iface_info in self.setup()['ansible_facts'].items():
-            if iface_name in iface:
-                return iface_info["macaddress"]
-
-        return None
+        try:
+            mac = self.command('cat /sys/class/net/{}/address'.format(iface_name))['stdout']
+            return mac
+        except Exception as e:
+            logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(iface_name, repr(e)))
+            return None
 
     def get_container_autorestart_states(self):
         """

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -252,7 +252,7 @@ def get_mac_dut(duthost, interface):
 
     Returns: MAC address
     """
-    return duthost.setup()['ansible_facts']['ansible_{}'.format(interface)]['macaddress']
+    return duthost.get_dut_iface_mac(interface)
 
 
 def get_port_number(interface):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The current infrastructure uses the ansible `setup` module to get MAC address of interfaces.
The problem is that the `setup` module is a little bit too heavy and generates too much log.

#### How did you do it?
This change improved the method of getting interface MAC address from system files like
'/sys/class/net/{interface_name}/address'.

#### How did you verify/test it?
Test run a script like below:
```
import logging

logger = logging.getLogger(__name__)

def test_case1(duthost):
    logger.info(duthost.get_dut_iface_mac('Ethernet0'))
    logger.info(duthost.get_dut_iface_mac('eth0'))
    logger.info(duthost.get_dut_iface_mac('Vlan1000'))
    logger.info(duthost.get_dut_iface_mac('PortChannel0001'))
    logger.info(duthost.get_dut_iface_mac('Ethernet1'))
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
