### PR TITLE
[BFN] Add regex to match device which combined L2 and L3 drop counters

### DIFF
--- a/tests/drop_packets/combined_drop_counters.yml
+++ b/tests/drop_packets/combined_drop_counters.yml
@@ -23,6 +23,8 @@ l2_l3:
     - "x86_64-dell.*"
     - "x86_64-arista.*"
     - "x86_64-cel_seastone.*"
+    - "x86_64-accton_as9516.*"
+    - "x86_64-accton_wedge100bf.*"
 
 acl_l2:
     - "x86_64-mlnx"


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Barefoot platforms have combined L2 and L3 drop counters. This PR adds new devices to [combined_drop_counters.yml](https://github.com/bratashX/sonic-mgmt/blob/master/tests/drop_packets/combined_drop_counters.yml).
### Type of change 

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Defined new regular expressions to match Barefoot devices with combined L2 and L3 drop counters.

#### How did you verify/test it?
Run `drop_packets` tests on Barefoot devices:
- x86_64-accton_as9516_32d-r0
- x86_64-accton_as9516bf_32d-r0
- x86_64-accton_wedge100bf_32x-r0
- x86_64-accton_wedge100bf_65x-r0

Platform name can be obtained by calling CLI command: `show platform summary
`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
