### PR TITLE
[dualtor-bgp]: Improve BGP failure tests

### DIFF
--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -27,15 +27,16 @@ def shutdown_tor_bgp():
         bgp_neighbors = duthost.get_bgp_neighbors()
         up_bgp_neighbors = [k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established"]
         if shutdown_all and up_bgp_neighbors:
-            logger.info("Shutdown BGP sessions on {}".format(duthost.hostname))
-            duthost.shell("config bgp shutdown all")
+            logger.info("Kill bgpd process on {}".format(duthost.hostname))
+            duthost.shell("pkill -9 bgpd")
 
     yield shutdown_tor_bgp
 
     time.sleep(1)
     for duthost in torhost:
-        logger.info("Starting BGP sessions on {}".format(duthost.hostname))
-        duthost.shell("config bgp startup all")
+        logger.info("Restarting BGP container on {}".format(duthost.hostname))
+        duthost.shell("systemctl reset-failed bgp")
+        duthost.shell("systemctl restart bgp")
 
 
 @pytest.fixture

--- a/tests/common/dualtor/tor_failure_utils.py
+++ b/tests/common/dualtor/tor_failure_utils.py
@@ -16,13 +16,13 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def shutdown_tor_bgp():
+def kill_bgpd():
     """
-    Shutdown all BGP sessions
+    Kill bgpd process on a device
     """
     torhost = []
 
-    def shutdown_tor_bgp(duthost, shutdown_all=True):
+    def kill_bgpd(duthost, shutdown_all=True):
         torhost.append(duthost)
         bgp_neighbors = duthost.get_bgp_neighbors()
         up_bgp_neighbors = [k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established"]
@@ -30,7 +30,7 @@ def shutdown_tor_bgp():
             logger.info("Kill bgpd process on {}".format(duthost.hostname))
             duthost.shell("pkill -9 bgpd")
 
-    yield shutdown_tor_bgp
+    yield kill_bgpd
 
     time.sleep(1)
     for duthost in torhost:

--- a/tests/dualtor/test_tor_bgp_failure.py
+++ b/tests/dualtor/test_tor_bgp_failure.py
@@ -39,8 +39,8 @@ def test_active_tor_shutdown_bgp_upstream(
         action=lambda: shutdown_tor_bgp(upper_tor_host)
     )
     verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
     )
 
 
@@ -99,12 +99,12 @@ def test_active_tor_shutdown_bgp_downstream_standby(
         T1 switch receives no IP-in-IP packet; server receives packet;
         verify traffic interruption is < 1 second
     '''
-    with tunnel_traffic_monitor(lower_tor_host, existing=False):
+    with tunnel_traffic_monitor(lower_tor_host, existing=True):
         send_t1_to_server_with_action(
             lower_tor_host, verify=True, delay=1,
             action=lambda: shutdown_tor_bgp(upper_tor_host)
         )
     verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
     )

--- a/tests/dualtor/test_tor_bgp_failure.py
+++ b/tests/dualtor/test_tor_bgp_failure.py
@@ -30,8 +30,8 @@ def test_active_tor_shutdown_bgp_upstream(
     Action: Shutdown all BGP sessions on the active ToR
     Expectation:
         Verify packet flow after the active ToR (A) loses BGP sessions
-        ToR A DBs indicate standby, ToR B DBs indicate active
-        T1 switch receives packet from the new active ToR (B) and not the new standby ToR (A)
+        ToR A DBs indicate active, ToR B DBs indicate standby
+        T1 switch receives packet from the initial active ToR (A) and not the standby ToR (B)
         Verify traffic interruption < 1 second
     '''
     send_server_to_t1_with_action(
@@ -96,7 +96,8 @@ def test_active_tor_shutdown_bgp_downstream_standby(
     Action: Shutdown all BGP sessions on the active ToR
     Expectation:
         Verify packet flow after the active ToR (A) loses BGP sessions
-        T1 switch receives no IP-in-IP packet; server receives packet;
+        T1 switch continues to receive IP-in-IP traffic, from lower to upper ToR
+        No switchover occurs
         verify traffic interruption is < 1 second
     '''
     with tunnel_traffic_monitor(lower_tor_host, existing=True):

--- a/tests/dualtor/test_tor_bgp_failure.py
+++ b/tests/dualtor/test_tor_bgp_failure.py
@@ -4,7 +4,7 @@ from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                                                                  # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor, toggle_all_simulator_ports_to_lower_tor         # lgtm[py/unused-import] 
-from tests.common.dualtor.tor_failure_utils import shutdown_tor_bgp                                                                             # lgtm[py/unused-import]
+from tests.common.dualtor.tor_failure_utils import kill_bgpd                                                                                    # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 
@@ -22,9 +22,9 @@ Out of scope: taking down the active ToR's BGP sessions means the T1 will never 
 Remaining cases for bgp shutdown are defined in this module.
 '''
 
-def test_active_tor_shutdown_bgp_upstream(
+def test_active_tor_kill_bgpd_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
-    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp):
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd):
     '''
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
     Action: Shutdown all BGP sessions on the active ToR
@@ -36,7 +36,7 @@ def test_active_tor_shutdown_bgp_upstream(
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=1,
-        action=lambda: shutdown_tor_bgp(upper_tor_host)
+        action=lambda: kill_bgpd(upper_tor_host)
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -44,9 +44,9 @@ def test_active_tor_shutdown_bgp_upstream(
     )
 
 
-def test_standby_tor_shutdown_bgp_upstream(
+def test_standby_tor_kill_bgpd_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
-    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp):
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd):
     '''
     Case: Server -> ToR -> T1 (Standby ToR BGP Down)
     Action: Shutdown all BGP sessions on the standby ToR
@@ -57,7 +57,7 @@ def test_standby_tor_shutdown_bgp_upstream(
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True,
-        action=lambda: shutdown_tor_bgp(lower_tor_host)
+        action=lambda: kill_bgpd(lower_tor_host)
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -65,9 +65,9 @@ def test_standby_tor_shutdown_bgp_upstream(
     )
 
 
-def test_standby_tor_shutdown_bgp_downstream_active(
+def test_standby_tor_kill_bgpd_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp,
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd,
     tunnel_traffic_monitor):
     '''
     Case: T1 -> Active ToR -> Server (Standby ToR BGP Down)
@@ -79,7 +79,7 @@ def test_standby_tor_shutdown_bgp_downstream_active(
     with tunnel_traffic_monitor(lower_tor_host, existing=False):
         send_t1_to_server_with_action(
             upper_tor_host, verify=True,
-            action=lambda: shutdown_tor_bgp(lower_tor_host)
+            action=lambda: kill_bgpd(lower_tor_host)
         )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -87,9 +87,9 @@ def test_standby_tor_shutdown_bgp_downstream_active(
     )
 
 
-def test_active_tor_shutdown_bgp_downstream_standby(
+def test_active_tor_kill_bgpd_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor, shutdown_tor_bgp,
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd,
     tunnel_traffic_monitor):
     '''
     Case: T1 -> Standby ToR -> Server (Active ToR BGP Down)
@@ -103,7 +103,7 @@ def test_active_tor_shutdown_bgp_downstream_standby(
     with tunnel_traffic_monitor(lower_tor_host, existing=True):
         send_t1_to_server_with_action(
             lower_tor_host, verify=True, delay=1,
-            action=lambda: shutdown_tor_bgp(upper_tor_host)
+            action=lambda: kill_bgpd(upper_tor_host)
         )
     verify_tor_states(
         expected_active_host=upper_tor_host,


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The previous BGP failure test involved running `config bgp shutdown` on the active ToR, which was not a supported use case. The new test more accurately captures a possible production scenario, where the `bgpd` process crashes.

#### How did you do it?
- Change the BGP failure utility to send `SIGKILL` to the bgpd process
    - All bgpd crashes seen in production are with `SIGKILL`
- Change the BGP failure tests to expect no switchovers during traffic tests
	- We may still experience some disruptions in traffic, if the BGP container is auto-restarted then the BGP sessions will temporarily disconnect


#### How did you verify/test it?
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================== test session starts ====================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, profiling-1.7.0, ansible-2.2.2
collected 4 items

dualtor/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_upstream PASSED                                                                                                        [ 25%]
dualtor/test_tor_bgp_failure.py::test_standby_tor_shutdown_bgp_upstream PASSED                                                                                                       [ 50%]
dualtor/test_tor_bgp_failure.py::test_standby_tor_shutdown_bgp_downstream_active PASSED                                                                                              [ 75%]
dualtor/test_tor_bgp_failure.py::test_active_tor_shutdown_bgp_downstream_standby PASSED                                                                                              [100%]

---------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/tr.xml -----------------------------------------------------------------
=============================================================================== 4 passed in 2078.55 seconds ================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
DualToR topologies only

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
