### PR TITLE
Fix incorrect logging of 'is_failed' field of ansible module execution result

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -83,7 +83,7 @@ class AnsibleHostBase(object):
         else:
             logging.debug("{}::{}#{}: [{}] AnsibleModule::{} done, is_failed={}, rc={}"\
                 .format(filename, function_name, line_number, self.hostname, self.module_name, \
-                        res.get('is_failed', None), res.get('rc', None)))
+                        res.is_failed, res.get('rc', None)))
 
         if (res.is_failed or 'exception' in res) and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In case an ansible module is executed with 'verbose=False', the log message
will not include full result. Instead, the log message will only have some
brief information of the result, including the failure status. The current implementation
uses code like `res.get('is_failed', None)` to get failure status of ansible module
execution result. However, "is_failed" is not a dict key of the result object. It is an
attribute that is always available. Trying to get "is_failed" key will return None for
most of the results. 

#### How did you do it?
The fix is to simply get the "is_failed" attribute which is always available in the result object. 
Then the log message will have correct failure indication.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
