### PR TITLE
[dualtor] add 'test_link_drop'

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -117,7 +117,8 @@ def _post(server_url, data):
         return False
     return True
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope='function')
 def set_drop(url, recover_all_directions):
     """
     A helper function is returned to make fixture accept arguments
@@ -142,7 +143,8 @@ def set_drop(url, recover_all_directions):
     for intf in drop_intfs:
         recover_all_directions(intf)
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope='function')
 def set_output(url):
     """
     A helper function is returned to make fixture accept arguments

--- a/tests/dualtor/test_link_drop.py
+++ b/tests/dualtor/test_link_drop.py
@@ -1,0 +1,191 @@
+import logging
+import pytest
+import time
+
+from tests.common.dualtor.control_plane_utils import verify_tor_states
+from tests.common.dualtor.dual_tor_utils import upper_tor_host
+from tests.common.dualtor.dual_tor_utils import lower_tor_host
+from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action
+from tests.common.dualtor.mux_simulator_control import set_drop
+from tests.common.dualtor.mux_simulator_control import set_output
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory
+
+
+def _set_drop_factory(set_drop_func, direction, tor_mux_intfs):
+    """Factory to get set drop function for either upper_tor or lower_tor."""
+    def _set_drop_all_interfaces():
+        logging.debug("Start set drop for %s at %s", direction, time.time())
+        for intf in tor_mux_intfs:
+            set_drop_func(intf, [direction])
+    return _set_drop_all_interfaces
+
+
+@pytest.fixture(scope="function")
+def drop_flow_upper_tor(set_drop, set_output, tor_mux_intfs):
+    """Drop the flow to the upper ToR."""
+    direction = "upper_tor"
+    yield _set_drop_factory(set_drop, direction, tor_mux_intfs)
+
+    for intf in tor_mux_intfs:
+        set_output(intf, [direction])
+
+
+@pytest.fixture(scope="function")
+def drop_flow_lower_tor(set_drop, set_output, tor_mux_intfs):
+    """Drop the flow to the lower ToR."""
+    direction = "lower_tor"
+    yield _set_drop_factory(set_drop, direction, tor_mux_intfs)
+
+    for intf in tor_mux_intfs:
+        set_output(intf, [direction])
+
+
+def test_active_link_drop_upstream(
+    upper_tor_host,
+    lower_tor_host,
+    send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    drop_flow_upper_tor
+):
+    """
+    Send traffic from servers to T1 and remove the flow between the servers and the active ToR.
+    Verify the switchover and disruption last < 1 second.
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host,
+        verify=True,
+        delay=1,
+        action=drop_flow_upper_tor
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health="unhealthy"
+    )
+
+
+def test_active_link_drop_downstream_active(
+    upper_tor_host,
+    lower_tor_host,
+    send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    drop_flow_upper_tor
+):
+    """
+    Send traffic from the T1s to the servers via the active Tor and remove the flow between the
+    servers and the active ToR.
+    Verify the switchover and disruption last < 1 second.
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host,
+        verify=True,
+        delay=1,
+        action=drop_flow_upper_tor
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health="unhealthy"
+    )
+
+
+def test_active_link_drop_downstream_standby(
+    upper_tor_host,
+    lower_tor_host,
+    send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    drop_flow_upper_tor
+):
+    """
+    Send traffic from the T1s to the servers via the standby Tor and remove the flow between the
+    servers and the active ToR.
+    Verify the switchover and disruption last < 1 second.
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host,
+        verify=True,
+        delay=1,
+        action=drop_flow_upper_tor
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health="unhealthy"
+    )
+
+
+def test_standby_link_drop_upstream(
+    upper_tor_host,
+    lower_tor_host,
+    send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    drop_flow_lower_tor
+):
+    """
+    Send traffic from servers to T1 and remove the flow between the servers and the standby ToR.
+    Verify that no switchover and disruption occur.
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host,
+        verify=True,
+        delay=1,
+        action=drop_flow_lower_tor
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health="unhealthy"
+    )
+
+
+def test_standby_link_drop_downstream_active(
+    upper_tor_host,
+    lower_tor_host,
+    send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    drop_flow_lower_tor
+):
+    """
+    Send traffic from the T1s to the servers via the active Tor and remove the flow between the
+    servers and the standby ToR.
+    Verify that no switchover and disruption occur.
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host,
+        verify=True,
+        delay=1,
+        action=drop_flow_lower_tor
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health="unhealthy"
+    )
+
+def test_standby_link_drop_downstream_standby(
+    upper_tor_host,
+    lower_tor_host,
+    send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    drop_flow_lower_tor
+):
+    """
+    Send traffic from the T1s to the servers via the standby Tor and remove the flow between the
+    servers and the standby ToR.
+    Verify that no switchover and disruption occur.
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host,
+        verify=True,
+        delay=1,
+        action=drop_flow_lower_tor
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health="unhealthy"
+    )

--- a/tests/dualtor/test_link_drop.py
+++ b/tests/dualtor/test_link_drop.py
@@ -1,5 +1,7 @@
 import logging
+import json
 import pytest
+import tabulate
 import time
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
@@ -9,6 +11,7 @@ from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action
 from tests.common.dualtor.mux_simulator_control import set_drop
 from tests.common.dualtor.mux_simulator_control import set_output
+from tests.common.dualtor.mux_simulator_control import simulator_flap_counter
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
@@ -28,20 +31,49 @@ def _set_drop_factory(set_drop_func, direction, tor_mux_intfs):
 def drop_flow_upper_tor(set_drop, set_output, tor_mux_intfs):
     """Drop the flow to the upper ToR."""
     direction = "upper_tor"
-    yield _set_drop_factory(set_drop, direction, tor_mux_intfs)
-
-    for intf in tor_mux_intfs:
-        set_output(intf, [direction])
+    return _set_drop_factory(set_drop, direction, tor_mux_intfs)
 
 
 @pytest.fixture(scope="function")
 def drop_flow_lower_tor(set_drop, set_output, tor_mux_intfs):
     """Drop the flow to the lower ToR."""
     direction = "lower_tor"
-    yield _set_drop_factory(set_drop, direction, tor_mux_intfs)
+    return _set_drop_factory(set_drop, direction, tor_mux_intfs)
 
-    for intf in tor_mux_intfs:
-        set_output(intf, [direction])
+
+@pytest.fixture(scope="function")
+def check_simulator_flap_counter(
+    simulator_flap_counter,
+    toggle_all_simulator_ports_to_upper_tor,
+    tor_mux_intfs
+):
+    """Check the flap count for each server-facing interfaces."""
+    def set_expected_counter_diff(diff):
+        """Set expected counter difference."""
+        expected_diff.append(diff)
+
+    expected_diff = []
+    tor_mux_intfs = [str(_) for _ in tor_mux_intfs]
+    counters_before = {intf: simulator_flap_counter(intf) for intf in tor_mux_intfs}
+    yield set_expected_counter_diff
+    counters_after = {intf: simulator_flap_counter(intf) for intf in tor_mux_intfs}
+    logging.info(
+        "\n%s\n",
+        tabulate.tabulate(
+            [[intf, counters_before[intf], counters_after[intf]] for intf in tor_mux_intfs],
+            headers=["port", "flap counter before", "flap counter after"]
+        )
+    )
+    counter_diffs = {intf: counters_after[intf] - counters_before[intf] for intf in tor_mux_intfs}
+    if expected_diff:
+        not_expected_counter_diffs = [
+            intf for intf, counter_diff in counter_diffs.items() if counter_diff != expected_diff[-1]
+        ]
+
+        error_str = json.dumps(not_expected_counter_diffs, indent=4)
+        if not_expected_counter_diffs:
+            logging.error(error_str)
+            raise ValueError(error_str)
 
 
 def test_active_link_drop_upstream(
@@ -122,7 +154,7 @@ def test_standby_link_drop_upstream(
     upper_tor_host,
     lower_tor_host,
     send_server_to_t1_with_action,
-    toggle_all_simulator_ports_to_upper_tor,
+    check_simulator_flap_counter,
     drop_flow_lower_tor
 ):
     """
@@ -132,7 +164,7 @@ def test_standby_link_drop_upstream(
     send_server_to_t1_with_action(
         upper_tor_host,
         verify=True,
-        delay=1,
+        delay=0,
         action=drop_flow_lower_tor
     )
     verify_tor_states(
@@ -140,13 +172,14 @@ def test_standby_link_drop_upstream(
         expected_standby_host=lower_tor_host,
         expected_standby_health="unhealthy"
     )
+    check_simulator_flap_counter(0)
 
 
 def test_standby_link_drop_downstream_active(
     upper_tor_host,
     lower_tor_host,
     send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor,
+    check_simulator_flap_counter,
     drop_flow_lower_tor
 ):
     """
@@ -157,7 +190,7 @@ def test_standby_link_drop_downstream_active(
     send_t1_to_server_with_action(
         upper_tor_host,
         verify=True,
-        delay=1,
+        delay=0,
         action=drop_flow_lower_tor
     )
     verify_tor_states(
@@ -165,12 +198,14 @@ def test_standby_link_drop_downstream_active(
         expected_standby_host=lower_tor_host,
         expected_standby_health="unhealthy"
     )
+    check_simulator_flap_counter(0)
+
 
 def test_standby_link_drop_downstream_standby(
     upper_tor_host,
     lower_tor_host,
     send_t1_to_server_with_action,
-    toggle_all_simulator_ports_to_upper_tor,
+    check_simulator_flap_counter,
     drop_flow_lower_tor
 ):
     """
@@ -181,7 +216,7 @@ def test_standby_link_drop_downstream_standby(
     send_t1_to_server_with_action(
         lower_tor_host,
         verify=True,
-        delay=1,
+        delay=0,
         action=drop_flow_lower_tor
     )
     verify_tor_states(
@@ -189,3 +224,4 @@ def test_standby_link_drop_downstream_standby(
         expected_standby_host=lower_tor_host,
         expected_standby_health="unhealthy"
     )
+    check_simulator_flap_counter(0)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add the following tests to cover link drop scenarios:
1. test_active_link_drop_upstream
2. test_active_link_drop_downstream_active
3. test_active_link_drop_downstream_standby
4. test_standby_link_drop_upstream
5. test_standby_link_drop_downstream_active
6. test_standby_link_drop_downstream_standby

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes #2766 #2765

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Cover the following test scenarios:
1. Test all packet flow scenarios when link between active ToR and OVS bridge is dropping all packets
2. Test all packet flow scenarios when link between standby ToR and OVS bridge is dropping all packets

#### How did you do it?
Add tests to cover the different traffic travel paths for the above two link drop scenarios.

#### How did you verify/test it?
Run `test_link_drop`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
