### PR TITLE
fixed interface naming tests on ARP commands output

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -755,7 +755,7 @@ class TestNeighbors():
 
         for item in arptable['v4']:
             # To ignore Midplane interface, added check on what is being set in setup fixture
-            if (arptable['v4'][item]['interface'] != 'eth0') and (arptable['v4'][item]['interface'] not in minigraph_portchannels) and (item in setup['port_name_map']):
+            if (arptable['v4'][item]['interface'] in setup['port_name_map']) and (arptable['v4'][item]['interface'] not in minigraph_portchannels):
                 if mode == 'alias':
                     assert re.search(r'{}.*\s+{}'.format(item, setup['port_name_map'][arptable['v4'][item]['interface']]), arp_output) is not None
                 elif mode == 'default':
@@ -777,7 +777,7 @@ class TestNeighbors():
         for addr, detail in arptable['v6'].items():
             if (
                     detail['macaddress'] != 'None' and
-                    detail['interface'] != 'eth0' and
+                    detail['interface'] in setup['port_name_map'] and
                     detail['interface'] not in minigraph_portchannels
             ):
                 if mode == 'alias':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed interface naming tests on ARP commands output
Fixes # (issue)
- fixed test_show_arp: fixed incorrect condition caused asserts to be skipped
The snippet below intended to skip the interfaces aliases aren't set for but it uses a wrong key value making a condition always False this way no assert is executed. `item` is address but keys in `setup['port_name_map']` are interface names
```(item in setup['port_name_map']```
- fixed test_show_ndp: skipped naming check for interfaces aliases are not set for
Here same decision applied as initially used for test_show_arp to skip interfaces with no aliases configured
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix test issue causing asserts to be skipped. Make similar interface name verification tests use same way to pick interfaces to be verified.
#### How did you do it?
Added a conditional clause for checking the interface to be verified has a configured alias.
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any iface_namingmode/test_iface_namingmode.py -k test_show_ndp -k test_show_arp
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
