### PR TITLE
Warm reboot test logging changes, and wait for finalizer to finish

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1105,7 +1105,8 @@ class ReloadTest(BaseTest):
             "reboot_time": "0:00:00" if self.no_routing_stop and self.routing_always \
                 else (self.no_routing_stop - self.reboot_start).total_seconds()
         }
-        if 'warm-reboot' in self.reboot_type:
+        # Add total downtime (calculated in physical warmboot test using packet disruptions)
+        if 'warm-reboot' in self.reboot_type and not self.kvm_test:
             self.report["total_downtime"] = self.total_disrupt_time
 
         with open(self.report_file_name, 'w') as reportfile:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Changes:
Improve logging for date fetch errors seen in KVM warmboot.
Wait for warmboot finalizer to finish within timeout
Add total downtime to the report for warmboot test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added mentioned changes to the advanced-reboot test.

#### How did you verify/test it?
KVM tests pending.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
