### PR TITLE
[pfcwd] Update dynamic_th value in existing table instead of creating a new one

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -95,7 +95,7 @@ class PfcCmd(object):
         asic = dut.get_port_asic_instance(port)
         asic.run_redis_cmd(
             argv = [
-                "redis-cli", "-n", "4", "HSET", "profile", "dynamic_th", value
+                "redis-cli", "-n", "4", "HSET", profile, "dynamic_th", value
             ]
         )
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes the bug introduced in #3130 
During the test run, instead of updating the existing dynamic_threshold under a profile, we were creating a new table. This resulted in config db parsing failure while trying to do a "config save -y" and we end up with an empty config_db. 

127.0.0.1:6379[4]> keys *profile*
1) "BUFFER_PROFILE|ingress_lossy_profile"
2) "profile"
3) "BUFFER_PROFILE|egress_lossy_profile"
4) "BUFFER_PROFILE|egress_lossless_profile"
5) "BUFFER_PROFILE|pg_lossless_40000_300m_profile"

127.0.0.1:6379[4]> hgetall "profile"
1) "dynamic_th"
2) "-3"

admin@str-7260cx3-acs-7:/etc/sonic$ sudo config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 415, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 339, in main
    deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 458, in get_config
    cur = self.__get_config(client, pipe, data, cur)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 435, in __get_config
    (table_name, row) = key.split(self.TABLE_NAME_SEPARATOR, 1)
ValueError: need more than 1 value to unpack
admin@str-7260cx3-acs-7:/etc/sonic$ ls -l config-db         
-rw-r--r-- 1 root root     0 Apr  7 21:55 config_db.json

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran the test prior to the fix and observed the behavior mentioned above. 
With the fix, dynamic_th is getting updated correctly and don't observe the behavior mentioned above