### PR TITLE
[Vrf] Fix errors with missing mandatory parameters fib_info_files and…

### DIFF
--- a/ansible/roles/test/files/ptftests/vrf_test.py
+++ b/ansible/roles/test/files/ptftests/vrf_test.py
@@ -24,7 +24,7 @@ import fib
 
 class FwdTest(FibTest):
     _required_params = [
-        'router_mac',
+        'router_macs',
     ]
     class FwdDict(object):
         def __init__(self):
@@ -34,10 +34,11 @@ class FwdTest(FibTest):
         def parse_fwd_info(self, file_path):
             # filter out empty lines and lines starting with '#'
             pattern = re.compile("^#.*$|^[ \t]*$")
+            file_path = file_path[0]
 
             with open(file_path, 'r') as f:
                 for line in f.readlines():
-                    if pattern.match(line): 
+                    if pattern.match(line):
                         continue
                     prefix, dst_ports = line.split(' ', 1)
                     self.add_entry(prefix, dst_ports)
@@ -68,13 +69,13 @@ class FwdTest(FibTest):
         """
         super(FwdTest, self).setUp()
         self.test_balancing = self.test_params.get('test_balancing', False)  # default not to test balancing
-        self.fwd_info = self.test_params.get('fwd_info', None)
+        self.fib_info_files = self.test_params.get('fib_info_files', None)
         self.dst_ports = self.test_params.get('dst_ports', None)  # dst_ports syntax example: [[0, 1], [2, 3, 4]]
         self.dst_ips = self.test_params.get('dst_ips', None)
 
         self.fwd_dict = FwdTest.FwdDict()
-        if self.fwd_info is not None:
-            self.fwd_dict.parse_fwd_info(self.fwd_info)
+        if self.fib_info_files is not None:
+            self.fwd_dict.parse_fwd_info(self.fib_info_files)
         else:
             for ip in self.dst_ips:
                 self.fwd_dict.add_entry(ip, str(self.dst_ports))
@@ -105,7 +106,7 @@ class FwdTest(FibTest):
 
 class CapTest(FwdTest):
     _required_params=[
-        'router_mac',
+        'router_macs',
         'random_vrf_list',
         'src_base_vid',
         'dst_base_vid'

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -6,6 +6,7 @@ import yaml
 import json
 import random
 import logging
+import tempfile
 
 from collections import OrderedDict
 from natsort import natsorted
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 # global variables
 g_vars = {}
+PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 
 # helper functions
 def get_vlan_members(vlan_name, cfg_facts):
@@ -333,6 +335,31 @@ def gen_vrf_neigh_file(vrf, ptfhost, render_file):
 
     ptfhost.template(src="vrf/vrf_neigh.j2", dest=render_file)
 
+def gen_specific_neigh_file(dst_ips, dst_ports, render_file, ptfhost):
+    dst_ports = [str(port[0]) for port in dst_ports]
+    tmp_file = tempfile.NamedTemporaryFile()
+    for ip in dst_ips:
+        tmp_file.write('{} [{}]\n'.format(ip, ' '.join(dst_ports)))
+    tmp_file.flush()
+    ptfhost.copy(src=tmp_file.name, dest=render_file)
+
+# For dualtor
+def get_dut_enabled_ptf_ports(tbinfo, hostname):
+    dut_index = str(tbinfo['duts_map'][hostname])
+    ptf_ports = set(tbinfo['topo']['ptf_map'][dut_index].values())
+    disabled_ports = set()
+    if dut_index in tbinfo['topo']['ptf_map_disabled']:
+        disabled_ports = set(tbinfo['topo']['ptf_map_disabled'][dut_index].values())
+    return ptf_ports - disabled_ports
+
+# For dualtor
+def get_dut_vlan_ptf_ports(mg_facts):
+    ports = set()
+    for vlan in mg_facts['minigraph_vlans']:
+        for member in mg_facts['minigraph_vlans'][vlan]['members']:
+            ports.add(mg_facts['minigraph_port_indices'][member])
+    return ports
+
 # fixtures
 
 @pytest.fixture(scope="module")
@@ -421,7 +448,9 @@ def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost):
 def partial_ptf_runner(request, ptfhost, tbinfo, dut_facts):
     def _partial_ptf_runner(testname, **kwargs):
         params = {'testbed_type': tbinfo['topo']['name'],
-                  'router_mac': dut_facts['router_mac']}
+                  'router_macs': [dut_facts['router_mac']],
+                  'ptf_test_port_map': PTF_TEST_PORT_MAP
+                  }
         params.update(kwargs)
         ptf_runner(host=ptfhost,
                    testdir="ptftests",
@@ -431,6 +460,44 @@ def partial_ptf_runner(request, ptfhost, tbinfo, dut_facts):
                    log_file="/tmp/{}.{}.log".format(request.cls.__name__, request.function.__name__))
     return _partial_ptf_runner
 
+@pytest.fixture(scope="module")
+def mg_facts(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    return mg_facts
+
+# For dualtor
+@pytest.fixture(scope='module')
+def vlan_mac(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    config_facts = duthost.config_facts(host=duthost.hostname, source='running')['ansible_facts']
+    dut_vlan_mac = None
+    for vlan in config_facts.get('VLAN', {}).values():
+        if 'mac' in vlan:
+            logger.debug('Found VLAN mac')
+            dut_vlan_mac = vlan['mac']
+            break
+    if not dut_vlan_mac:
+        logger.debug('No VLAN mac, use default router_mac')
+        dut_vlan_mac = duthost.facts['router_mac']
+    return dut_vlan_mac
+
+@pytest.fixture(scope="module", autouse=True)
+def ptf_test_port_map(tbinfo, duthosts, mg_facts, ptfhost, rand_one_dut_hostname, vlan_mac):
+    duthost = duthosts[rand_one_dut_hostname]
+    ptf_test_port_map = {}
+    enabled_ptf_ports = get_dut_enabled_ptf_ports(tbinfo, duthost.hostname)
+    vlan_ptf_ports = get_dut_vlan_ptf_ports(mg_facts)
+    for port in enabled_ptf_ports:
+        if port in vlan_ptf_ports:
+            target_mac = vlan_mac
+        else:
+            target_mac = duthost.facts['router_mac']
+        ptf_test_port_map[str(port)] = {
+            'target_dut': 0,
+            'target_mac': target_mac
+        }
+    ptfhost.copy(content=json.dumps(ptf_test_port_map), dest=PTF_TEST_PORT_MAP)
 
 # tests
 class TestVrfCreateAndBind():
@@ -497,7 +564,7 @@ class TestVrfNeigh():
 
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
-            fwd_info="/tmp/vrf1_neigh.txt",
+            fib_info_files=["/tmp/vrf1_neigh.txt"],
             src_ports=g_vars['vrf_member_port_indices']['Vrf1']
         )
 
@@ -506,7 +573,7 @@ class TestVrfNeigh():
 
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
-            fwd_info="/tmp/vrf2_neigh.txt",
+            fib_info_files=["/tmp/vrf2_neigh.txt"],
             src_ports=g_vars['vrf_member_port_indices']['Vrf2']
         )
 
@@ -544,14 +611,14 @@ class TestVrfFib():
     def test_vrf1_fib(self, partial_ptf_runner):
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/vrf1_fib.txt",
+            fib_info_files=["/tmp/vrf1_fib.txt"],
             src_ports=g_vars['vrf_member_port_indices']['Vrf1']
         )
 
     def test_vrf2_fib(self, partial_ptf_runner):
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/vrf2_fib.txt",
+            fib_info_files=["/tmp/vrf2_fib.txt"],
             src_ports=g_vars['vrf_member_port_indices']['Vrf2']
         )
 
@@ -576,7 +643,7 @@ class TestVrfIsolation():
         # send packets from Vrf1
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
-            fwd_info="/tmp/vrf2_neigh.txt",
+            fib_info_files=["/tmp/vrf2_neigh.txt"],
             pkt_action='drop',
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
@@ -585,7 +652,7 @@ class TestVrfIsolation():
         # send packets from Vrf2
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
-            fwd_info="/tmp/vrf1_neigh.txt",
+            fib_info_files=["/tmp/vrf1_neigh.txt"],
             pkt_action='drop',
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
         )
@@ -594,7 +661,7 @@ class TestVrfIsolation():
         # send packets from Vrf1
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/vrf2_fib.txt",
+            fib_info_files=["/tmp/vrf2_fib.txt"],
             pkt_action='drop',
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
@@ -603,7 +670,7 @@ class TestVrfIsolation():
         # send packets from Vrf2
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/vrf1_fib.txt",
+            fib_info_files=["/tmp/vrf1_fib.txt"],
             pkt_action='drop',
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
         )
@@ -671,48 +738,56 @@ class TestVrfAclRedirect():
         duthost.shell("redis-cli -n 4 del 'ACL_TABLE|VRF_ACL_REDIRECT_V4'")
         duthost.shell("redis-cli -n 4 del 'ACL_TABLE|VRF_ACL_REDIRECT_V6'")
 
-    def test_origin_ports_recv_no_pkts_v4(self, partial_ptf_runner):
+    def test_origin_ports_recv_no_pkts_v4(self, partial_ptf_runner, ptfhost):
         # verify origin dst ports should not receive packets any more
+        gen_specific_neigh_file(self.c_vars['pc1_v4_neigh_ips'], self.c_vars['dst_ports'],
+                                '/tmp/pc01_neigh_ipv4.txt', ptfhost)
+
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             pkt_action='drop',
             src_ports=self.c_vars['src_ports'],
-            dst_ports=self.c_vars['dst_ports'],
-            dst_ips=self.c_vars['pc1_v4_neigh_ips']
+            fib_info_files=['/tmp/pc01_neigh_ipv4.txt']
         )
 
-    def test_origin_ports_recv_no_pkts_v6(self, partial_ptf_runner):
+    def test_origin_ports_recv_no_pkts_v6(self, partial_ptf_runner, ptfhost):
         # verify origin dst ports should not receive packets any more
+        gen_specific_neigh_file(self.c_vars['pc1_v6_neigh_ips'], self.c_vars['dst_ports'],
+                                '/tmp/pc01_neigh_ipv6.txt', ptfhost)
+
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             pkt_action='drop',
             src_ports=self.c_vars['src_ports'],
-            dst_ports=self.c_vars['dst_ports'],
-            dst_ips=self.c_vars['pc1_v6_neigh_ips']
+            fib_info_files=['/tmp/pc01_neigh_ipv6.txt']
         )
 
-    def test_redirect_to_new_ports_v4(self, partial_ptf_runner):
+    def test_redirect_to_new_ports_v4(self, partial_ptf_runner, ptfhost):
         # verify redicect ports should receive packets
+        gen_specific_neigh_file(self.c_vars['pc1_v4_neigh_ips'], self.c_vars['redirect_dst_ports'],
+                                '/tmp/redirect_pc01_neigh_ipv4.txt', ptfhost)
+
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             src_ports=self.c_vars['src_ports'],
-            dst_ports=self.c_vars['redirect_dst_ports'],
             test_balancing=True,
             balancing_test_times=1000,
             balancing_test_ratio=1.0,  # test redirect balancing
-            dst_ips=self.c_vars['pc1_v4_neigh_ips']
+            fib_info_files=['/tmp/redirect_pc01_neigh_ipv4.txt']
         )
 
-    def test_redirect_to_new_ports_v6(self, partial_ptf_runner):
+    def test_redirect_to_new_ports_v6(self, partial_ptf_runner, ptfhost):
         # verify redicect ports should receive packets
+        gen_specific_neigh_file(self.c_vars['pc1_v6_neigh_ips'], self.c_vars['redirect_dst_ports'],
+                                '/tmp/redirect_pc01_neigh_ipv6.txt', ptfhost)
+
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             src_ports=self.c_vars['src_ports'],
-            dst_ports=self.c_vars['redirect_dst_ports'],
             test_balancing=True,
             balancing_test_times=1000,
             balancing_test_ratio=1.0,  # test redirect balancing
-            dst_ips=self.c_vars['pc1_v6_neigh_ips']
+            fib_info_files=['/tmp/redirect_pc01_neigh_ipv6.txt']
         )
 
 
@@ -916,7 +991,7 @@ class TestVrfWarmReboot():
             'ptf_runner': partial_ptf_runner,
             'exc_queue': exc_que,  # use for store exception infos
             'testname': 'vrf_test.FibTest',
-            'fib_info': "/tmp/vrf1_fib.txt",
+            'fib_info_files': ["/tmp/vrf1_fib.txt"],
             'src_ports': g_vars['vrf_member_port_indices']['Vrf1']
         }
 
@@ -960,7 +1035,7 @@ class TestVrfWarmReboot():
             'ptf_runner': partial_ptf_runner,
             'exc_queue': exc_que,  # use for store exception infos
             'testname': 'vrf_test.FibTest',
-            'fib_info': "/tmp/vrf1_fib.txt",
+            'fib_info_files': ["/tmp/vrf1_fib.txt"],
             'src_ports': g_vars['vrf_member_port_indices']['Vrf1']
         }
         traffic_in_bg = threading.Thread(target=ex_ptf_runner, kwargs=params)
@@ -1194,16 +1269,16 @@ class TestVrfCapacity():
 
         duthost.shell('/tmp/vrf_capacity_ping.sh')
 
-    def test_ip_fwd(self, partial_ptf_runner, random_vrf_list):
+    def test_ip_fwd(self, partial_ptf_runner, random_vrf_list, ptfhost):
         ptf_port1 = g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000'][1]
         ptf_port2 = g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000'][1]
         dst_ips = [str(IPNetwork(self.route_prefix)[1])]
+        gen_specific_neigh_file(dst_ips, [[ptf_port2]], '/tmp/vrf_capability_fwd.txt', ptfhost)
 
         partial_ptf_runner(
             testname="vrf_test.CapTest",
             src_ports=[ptf_port1],
-            dst_ports=[[ptf_port2]],
-            dst_ips=dst_ips,
+            fib_info_files=['/tmp/vrf_capability_fwd.txt'],
             random_vrf_list=random_vrf_list,
             src_base_vid=self.src_base_vid,
             dst_base_vid=self.dst_base_vid
@@ -1269,18 +1344,19 @@ class TestVrfUnbindIntf():
         # show_ndp = duthost.shell("show ndp")['stdout']
         # assert 'PortChannel0001' not in show_ndp, "The neighbors on PortChannel0001 should be flushed after unbind from vrf."
 
-    def test_pc1_neigh_flushed_by_traffic(self, partial_ptf_runner):
+    def test_pc1_neigh_flushed_by_traffic(self, partial_ptf_runner, ptfhost):
         pc1_neigh_ips = []
         for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].iteritems():
             for ip in ips:
                 pc1_neigh_ips.append(str(ip.ip+1))
 
+        gen_specific_neigh_file(pc1_neigh_ips, [g_vars['vrf_intf_member_port_indices']['Vrf1']['PortChannel0001']],
+                                '/tmp/unbindvrf_neigh_1.txt', ptfhost)
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             pkt_action='drop',
-            dst_ips=pc1_neigh_ips,
+            fib_info_files=['/tmp/unbindvrf_neigh_1.txt'],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000'],
-            dst_ports=[g_vars['vrf_intf_member_port_indices']['Vrf1']['PortChannel0001']],
             ipv4=True,
             ipv6=False
         )
@@ -1294,22 +1370,23 @@ class TestVrfUnbindIntf():
         partial_ptf_runner(
             testname="vrf_test.FibTest",
             pkt_action='drop',
-            fib_info="/tmp/unbindvrf_fib_1.txt",
+            fib_info_files=["/tmp/unbindvrf_fib_1.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
-    def test_pc2_neigh(self, partial_ptf_runner):
+    def test_pc2_neigh(self, partial_ptf_runner, ptfhost):
         pc2_neigh_ips = []
         for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0002'].iteritems():
             for ip in ips:
                 pc2_neigh_ips.append(str(ip.ip+1))
 
+        gen_specific_neigh_file(pc2_neigh_ips, [g_vars['vrf_intf_member_port_indices']['Vrf1']['PortChannel0002']],
+                                '/tmp/unbindvrf_neigh_2.txt', ptfhost)
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             pkt_action='fwd',
-            dst_ips=pc2_neigh_ips,
+            fib_info_files=['/tmp/unbindvrf_neigh_2.txt'],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000'],
-            dst_ports=[g_vars['vrf_intf_member_port_indices']['Vrf1']['PortChannel0002']]
         )
 
     def test_pc2_fib(self, ptfhost, tbinfo, partial_ptf_runner):
@@ -1319,24 +1396,18 @@ class TestVrfUnbindIntf():
 
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/unbindvrf_fib_2.txt",
+            fib_info_files=["/tmp/unbindvrf_fib_2.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
 
     @pytest.mark.usefixtures('setup_vrf_rebind_intf')
     def test_pc1_neigh_after_rebind(self, partial_ptf_runner):
-        pc1_neigh_ips = []
-        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].iteritems():
-            for ip in ips:
-                pc1_neigh_ips.append(str(ip.ip+1))
-
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             pkt_action='fwd',
-            dst_ips=pc1_neigh_ips,
+            fib_info_files=['/tmp/unbindvrf_neigh_1.txt'],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000'],
-            dst_ports=[g_vars['vrf_intf_member_port_indices']['Vrf1']['PortChannel0001']],
             ipv4=True,
             ipv6=False
         )
@@ -1349,7 +1420,7 @@ class TestVrfUnbindIntf():
 
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/rebindvrf_vrf1_fib.txt",
+            fib_info_files=["/tmp/rebindvrf_vrf1_fib.txt"],
             src_ports=g_vars['vrf_member_port_indices']['Vrf1']
         )
 
@@ -1431,7 +1502,7 @@ class TestVrfDeletion():
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
             pkt_action='drop',
-            fwd_info="/tmp/vrf1_neigh.txt",
+            fib_info_files=["/tmp/vrf1_neigh.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
@@ -1439,21 +1510,21 @@ class TestVrfDeletion():
         partial_ptf_runner(
             testname="vrf_test.FibTest",
             pkt_action='drop',
-            fib_info="/tmp/vrf1_fib.txt",
+            fib_info_files=["/tmp/vrf1_fib.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
     def test_vrf2_neigh(self, partial_ptf_runner):
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
-            fwd_info="/tmp/vrf2_neigh.txt",
+            fib_info_files=["/tmp/vrf2_neigh.txt"],
             src_ports= g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
         )
 
     def test_vrf2_fib(self, partial_ptf_runner):
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/vrf2_fib.txt",
+            fib_info_files=["/tmp/vrf2_fib.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
         )
 
@@ -1461,7 +1532,7 @@ class TestVrfDeletion():
     def test_vrf1_neigh_after_restore(self, partial_ptf_runner):
         partial_ptf_runner(
             testname="vrf_test.FwdTest",
-            fwd_info="/tmp/vrf1_neigh.txt",
+            fib_info_files=["/tmp/vrf1_neigh.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
@@ -1469,6 +1540,6 @@ class TestVrfDeletion():
     def test_vrf1_fib_after_resotre(self, partial_ptf_runner):
         partial_ptf_runner(
             testname="vrf_test.FibTest",
-            fib_info="/tmp/vrf1_fib.txt",
+            fib_info_files=["/tmp/vrf1_fib.txt"],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -5,9 +5,9 @@ from test_vrf import setup_vrf              # lgtm[py/unused-import]
 from test_vrf import dut_facts             # lgtm[py/unused-import]
 from test_vrf import gen_vrf_neigh_file
 from test_vrf import partial_ptf_runner     # lgtm[py/unused-import]
-from test_vrf import ptf_test_port_map
-from test_vrf import mg_facts
-from test_vrf import vlan_mac
+from test_vrf import ptf_test_port_map      # lgtm[py/unused-import]
+from test_vrf import mg_facts      # lgtm[py/unused-import]
+from test_vrf import vlan_mac      # lgtm[py/unused-import]
 from test_vrf import PTF_TEST_PORT_MAP
 
 from tests.ptf_runner import ptf_runner

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -5,6 +5,10 @@ from test_vrf import setup_vrf              # lgtm[py/unused-import]
 from test_vrf import dut_facts             # lgtm[py/unused-import]
 from test_vrf import gen_vrf_neigh_file
 from test_vrf import partial_ptf_runner     # lgtm[py/unused-import]
+from test_vrf import ptf_test_port_map
+from test_vrf import mg_facts
+from test_vrf import vlan_mac
+from test_vrf import PTF_TEST_PORT_MAP
 
 from tests.ptf_runner import ptf_runner
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory
@@ -52,7 +56,7 @@ class TestVrfAttrSrcMac():
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             pkt_action='drop',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
@@ -63,16 +67,17 @@ class TestVrfAttrSrcMac():
                 "vrf_test.FwdTest",
                 platform_dir='ptftests',
                 params={'testbed_type': tbinfo['topo']['name'],
-                        'router_mac': self.new_vrf1_router_mac,
-                        'fwd_info': "/tmp/vrf1_neigh.txt",
-                        'src_ports': g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']},
+                        'router_macs': [self.new_vrf1_router_mac],
+                        'fib_info_files': ["/tmp/vrf1_neigh.txt"],
+                        'src_ports': g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000'],
+                        'ptf_test_port_map': PTF_TEST_PORT_MAP},
                 log_file="/tmp/vrf_attr_src_mac_test.FwdTest2.log")
 
     def test_vrf2_neigh_with_default_router_mac(self, partial_ptf_runner):
         # verify router_mac of Vrf2 keep to be default router_mac
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf2_neigh.txt',
+            fib_info_files=['/tmp/vrf2_neigh.txt'],
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
         )
 
@@ -102,7 +107,7 @@ class TestVrfAttrTTL():
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             pkt_action='drop',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             ttl=1,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
@@ -111,7 +116,7 @@ class TestVrfAttrTTL():
         # verify packets in Vrf1 with ttl=2 should be forward
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             ttl=2,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
@@ -120,7 +125,7 @@ class TestVrfAttrTTL():
         # verify packets in Vrf2 with ttl=1 should be forward
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf2_neigh.txt',
+            fib_info_files=['/tmp/vrf2_neigh.txt'],
             ttl=1,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
         )
@@ -151,7 +156,7 @@ class TestVrfAttrIpAction():
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             pkt_action='drop',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             ip_option=True,
             ipv4=True,
             ipv6=False,
@@ -162,7 +167,7 @@ class TestVrfAttrIpAction():
         # verify packets in Vrf1 without ip_option should be forward
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             ip_option=False,
             ipv4=True,
             ipv6=False,
@@ -173,7 +178,7 @@ class TestVrfAttrIpAction():
         # verify packets in Vrf2 with ip_option should be forward
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf2_neigh.txt',
+            fib_info_files=['/tmp/vrf2_neigh.txt'],
             ip_option=True,
             ipv4=True,
             ipv6=False,
@@ -205,7 +210,7 @@ class TestVrfAttrIpState():
         # verify ipv4 L3 traffic is dropped in vrf1
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             pkt_action='drop',
             ipv4=True,
             ipv6=False,
@@ -216,7 +221,7 @@ class TestVrfAttrIpState():
         # verify ipv6 L3 traffic is forwarded in vrf1
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf1_neigh.txt',
+            fib_info_files=['/tmp/vrf1_neigh.txt'],
             ipv4=False,
             ipv6=True,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
@@ -226,7 +231,7 @@ class TestVrfAttrIpState():
         # verify ipv4 L3 traffic is forwarded in vrf2
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
-            fwd_info='/tmp/vrf2_neigh.txt',
+            fib_info_files=['/tmp/vrf2_neigh.txt'],
             ipv4=True,
             ipv6=False,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']
@@ -237,7 +242,7 @@ class TestVrfAttrIpState():
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             pkt_action='drop',
-            fwd_info='/tmp/vrf2_neigh.txt',
+            fib_info_files=['/tmp/vrf2_neigh.txt'],
             ipv4=False,
             ipv6=True,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']

--- a/tests/vrf/vrf_acl_redirect.j2
+++ b/tests/vrf/vrf_acl_redirect.j2
@@ -16,7 +16,7 @@
         "VRF_ACL_REDIRECT_V4|rule1": {
             "priority": "55",
             "SRC_IP": "10.0.0.1",
-            "packet_action": "redirect:{% for intf, ip in redirect_dst_ipv6s %}{{ ip ~ "@" ~ intf }}{{ "," if not loop.last else "" }}{% endfor %}"
+            "packet_action": "redirect:{% for intf, ip in redirect_dst_ips %}{{ ip ~ "@" ~ intf }}{{ "," if not loop.last else "" }}{% endfor %}"
         },
         "VRF_ACL_REDIRECT_V6|rule1": {
             "priority": "55",


### PR DESCRIPTION
… ptf_test_port_map

Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR should fix `test_vrf.py` and `test_vrf_attr.py` which fail with missing mandatory parameters such as `fib_info_files` and `ptf_test_port_map`. 
Fixes # (https://github.com/Azure/sonic-mgmt/issues/3039)

**Actual results:** 
```
E           RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {
E               "changed": true, 
E               "cmd": "ptf --test-dir ptftests vrf_test.FwdTest --platform-dir ptftests --platform remote -t 'testbed_type='\"'\"'t0'\"'\"';router_mac=u'\"'\"'fc:bd:67:62:45:30'\"'\"';fwd_info='\"'\"'/tmp/vrf1_neigh.txt'\"'\"';src_ports=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 28, 29]' --relax --debug info --log-file /tmp/TestVrfNeigh.test_vrf1_neigh_ip_fwd.log", 
E               "delta": "0:00:00.653615", 
E               "end": "2021-03-07 05:28:25.053839", 
E               "failed": true, 
E               "invocation": {
E                   "module_args": {
E                       "_raw_params": "ptf --test-dir ptftests vrf_test.FwdTest --platform-dir ptftests --platform remote -t 'testbed_type='\"'\"'t0'\"'\"';router_mac=u'\"'\"'fc:bd:67:62:45:30'\"'\"';fwd_info='\"'\"'/tmp/vrf1_neigh.txt'\"'\"';src_ports=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 28, 29]' --relax --debug info --log-file /tmp/TestVrfNeigh.test_vrf1_neigh_ip_fwd.log", 
E                       "_uses_shell": true, 
E                       "argv": null, 
E                       "chdir": "/root", 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2021-03-07 05:28:24.400224", 
E               "stderr": "WARNING: No route found for IPv6 destination :: (no default route?)\n/usr/local/lib/python2.7/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.\n  from cryptography.hazmat.backends import default_backend\nvrf_test.FwdTest ... ERROR\n\n======================================================================\nERROR: vrf_test.FwdTest\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"ptftests/vrf_test.py\", line 69, in setUp\n    super(FwdTest, self).setUp()\n  File \"ptftests/fib_test.py\", line 108, in setUp\n    for fib_info_file in self.test_params.get('fib_info_files'):\nTypeError: 'NoneType' object is not iterable\n\n----------------------------------------------------------------------\nRan 1 test in 0.001s\n\nFAILED (errors=1)", 
E               "stderr_lines": [
E                   "WARNING: No route found for IPv6 destination :: (no default route?)", 
E                   "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.", 
E                   "  from cryptography.hazmat.backends import default_backend", 
E                   "vrf_test.FwdTest ... ERROR", 
E                   "", 
E                   "======================================================================", 
E                   "ERROR: vrf_test.FwdTest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"ptftests/vrf_test.py\", line 69, in setUp", 
E                   "    super(FwdTest, self).setUp()", 
E                   "  File \"ptftests/fib_test.py\", line 108, in setUp", 
E                   "    for fib_info_file in self.test_params.get('fib_info_files'):", 
E                   "TypeError: 'NoneType' object is not iterable", 
E                   "", 
E                   "----------------------------------------------------------------------", 
E                   "Ran 1 test in 0.001s", 
E                   "", 
E                   "FAILED (errors=1)"
E               ], 
E               "stdout": "", 
E               "stdout_lines": []
E           }
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make Vrf test cases working
#### How did you do it?

#### How did you verify/test it?
Run `test_vrf.py` and `test_vrf_attr.py` on t0 topology.
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.155-dirty-20210323.032731
Distribution: Debian 10.8
Kernel: 4.19.0-12-2-amd64
Build commit: c7cc4b46
Build date: Tue Mar 23 12:44:48 UTC 2021
Built by: johnar@worker-s35a2e0
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
