### PR TITLE
[Mellanox][QoS] Fix an error in checking whether shared headroom pool is enabled

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -36,7 +36,10 @@ class QosParamMellanox(object):
         self.ingressLossyProfile = ingressLossyProfile
         self.egressLosslessProfile = egressLosslessProfile
         self.egressLossyProfile = egressLossyProfile
-        self.sharedHeadroomPoolSize = sharedHeadroomPoolSize
+        if sharedHeadroomPoolSize and int(sharedHeadroomPoolSize) != 0:
+            self.sharedHeadroomPoolSize = sharedHeadroomPoolSize
+        else:
+            self.sharedHeadroomPoolSize = None
         self.dutConfig = dutConfig
 
         return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix an error in the logic to check whether the shared headroom pool is enabled when generating QoS parameters for Mellanox platform

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix error in checking whether shared headroom pool is enabled

#### How did you do it?
Treat shared headroom pool as enabled only if shared headroom pool size isn't 0

#### How did you verify/test it?
Run regression test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
