### PR TITLE
[sonic] wait for switch become reachable after load minigraph

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -377,6 +377,18 @@
         become: true
         shell: config load_minigraph -y
 
+      - name: Wait for switch to become reachable again
+        become: false
+        local_action: wait_for
+        args:
+          host: "{{ ansible_host }}"
+          port: 22
+          state: started
+          search_regex: "OpenSSH_[\\w\\.]+ Debian"
+          delay: 10
+          timeout: 600
+        changed_when: false
+
       - name: execute cli "config bgp startup all" to bring up all bgp sessions for test
         become: true
         shell: config bgp startup all


### PR DESCRIPTION
### Description of PR

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
After switch over to sonic target service, load minigraph will return sooner than before, and the switch will become unreachable
while management interface is being reconfigured after the command returns. This delayed unreachable period causes next command to fail.

#### How did you do it?
Add a wait period after config reload to cope with this new behavior.

#### How did you verify/test it?
execute deploy minigraph several times and got pass consistently (was failing consistently before).

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
