### PR TITLE
[dualtor-arp]: Make compatible with older images

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -5,7 +5,7 @@ import time
 
 from ipaddress import ip_network, IPv6Network, IPv4Network
 from tests.arp.arp_utils import clear_dut_arp_cache, increment_ipv6_addr, increment_ipv4_addr
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 
 pytestmark = [
     pytest.mark.topology('t0', 'dualtor')
@@ -32,38 +32,43 @@ def setup_ptf_arp(config_facts, ptfhost, intfs_for_test):
 
     # The VLAN interface on the DUT has an x.x.x.1 address assigned (or x::1 in the case of IPv6)
     # But the network_address property returns an x.x.x.0 address (or x::0 for IPv6) so we increment by two to avoid conflict
-    ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=2)
-    ptf_intf_ipv6_addr = increment_ipv6_addr(intf_ipv6_addr.network_address, incr=2)
     ptf_intf_name = "eth{}".format(intf1_index)
 
-    logger.info("Configuring {} and {} on PTF interface {}".format(ptf_intf_ipv4_addr, ptf_intf_ipv6_addr, ptf_intf_name))
-    ptfhost.shell(ip_addr_config_cmd.format('add', ptf_intf_ipv4_addr, intf_ipv4_addr.prefixlen, ptf_intf_name))
-    ptfhost.shell(ip_addr_config_cmd.format('add', ptf_intf_ipv6_addr, intf_ipv6_addr.prefixlen, ptf_intf_name))
+    if intf_ipv4_addr is not None:
+        ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=2)
+        ptfhost.shell(ip_addr_config_cmd.format('replace', ptf_intf_ipv4_addr, intf_ipv4_addr.prefixlen, ptf_intf_name))
+    else:
+        ptf_intf_ipv4_addr = None
+
+    if intf_ipv6_addr is not None:
+        ptf_intf_ipv6_addr = increment_ipv6_addr(intf_ipv6_addr.network_address, incr=2)
+        ptfhost.shell(ip_addr_config_cmd.format('replace', ptf_intf_ipv6_addr, intf_ipv6_addr.prefixlen, ptf_intf_name))
+    else:
+        ptf_intf_ipv6_addr = None
+
+    logger.info("Configured {} and {} on PTF interface {}".format(ptf_intf_ipv4_addr, ptf_intf_ipv6_addr, ptf_intf_name))
 
     yield ptf_intf_ipv4_addr, ptf_intf_ipv6_addr, ptf_intf_name 
 
     logger.info("Removing {} and {} from PTF interface {}".format(ptf_intf_ipv4_addr, ptf_intf_ipv6_addr, ptf_intf_name))
-    ptfhost.shell(ip_addr_config_cmd.format('del', ptf_intf_ipv4_addr, intf_ipv4_addr.prefixlen, ptf_intf_name))
-    ptfhost.shell(ip_addr_config_cmd.format('del', ptf_intf_ipv6_addr, intf_ipv6_addr.prefixlen, ptf_intf_name))
+
+    if intf_ipv4_addr is not None:
+        ptfhost.shell(ip_addr_config_cmd.format('del', ptf_intf_ipv4_addr, intf_ipv4_addr.prefixlen, ptf_intf_name))
+
+    if intf_ipv6_addr is not None:
+        ptfhost.shell(ip_addr_config_cmd.format('del', ptf_intf_ipv6_addr, intf_ipv6_addr.prefixlen, ptf_intf_name))
 
 
-def test_arp_garp_enabled(common_setup_teardown, setup_ptf_arp, intfs_for_test, config_facts, ptfadapter):
-    '''
-    Send a gratuitous ARP (GARP) packet from the PTF to the DUT
-
-    The DUT should learn the (previously unseen) ARP info from the packet
-    '''
-    duthost, _,  _ = common_setup_teardown
-    ptf_intf_ipv4_addr, _, ptf_intf_name = setup_ptf_arp
-
-    arp_request_ip = increment_ipv4_addr(ptf_intf_ipv4_addr)
-    arp_src_mac = '00:00:07:08:09:0a'
-    _, _, intf1_index, _, = intfs_for_test
+@pytest.fixture
+def garp_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, config_facts):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     clear_dut_arp_cache(duthost)
 
     vlan_intfs = config_facts['VLAN_INTERFACE'].keys()
     garp_enable_cmd = 'redis-cli -n 4 HSET "VLAN_INTERFACE|{}" grat_arp enabled'
+    cat_arp_accept_cmd = 'cat /proc/sys/net/ipv4/conf/{}/arp_accept'
+    arp_accept_vals = []
     for vlan in vlan_intfs:
         res = duthost.shell(garp_enable_cmd.format(vlan))
 
@@ -71,6 +76,38 @@ def test_arp_garp_enabled(common_setup_teardown, setup_ptf_arp, intfs_for_test, 
             pytest.fail("Unable to enable GARP for {}".format(vlan))
         else:
             logger.info("Enabled GARP for {}".format(vlan))
+
+            # Get the `arp_accept` values for each VLAN interface and yield them
+            # to the caller, who can decide how to proceed
+            arp_accept_res = duthost.shell(cat_arp_accept_cmd.format(vlan))
+            arp_accept_vals.append(arp_accept_res['stdout'])
+
+    yield arp_accept_vals
+
+    garp_disable_cmd = 'redis-cli -n 4 HDEL "VLAN_INTERFACE|{}" grat_arp'
+    for vlan in vlan_intfs:
+        res = duthost.shell(garp_disable_cmd.format(vlan))
+
+        if res['rc'] != 0:
+            pytest.fail("Unable to disable GARP for {}".format(vlan))
+        else:
+            logger.info("GARP disabled for {}".format(vlan))
+
+
+def test_arp_garp_enabled(duthosts, enum_rand_one_per_hwsku_frontend_hostname, garp_setup, setup_ptf_arp, intfs_for_test, config_facts, ptfadapter):
+    '''
+    Send a gratuitous ARP (GARP) packet from the PTF to the DUT
+
+    The DUT should learn the (previously unseen) ARP info from the packet
+    '''
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    ptf_intf_ipv4_addr, _, _ = setup_ptf_arp
+    arp_accept_vals = garp_setup
+    pytest_require(all(int(val) == 1 for val in arp_accept_vals), 'Gratuitous ARP not enabled for this device')
+
+    arp_request_ip = increment_ipv4_addr(ptf_intf_ipv4_addr)
+    arp_src_mac = '00:00:07:08:09:0a'
+    _, _, intf1_index, _, = intfs_for_test
 
     pkt = testutils.simple_arp_packet(pktlen=60,
                                 eth_dst='ff:ff:ff:ff:ff:ff',
@@ -86,22 +123,30 @@ def test_arp_garp_enabled(common_setup_teardown, setup_ptf_arp, intfs_for_test, 
     logger.info("Sending GARP for target {} from PTF interface {}".format(arp_request_ip, intf1_index))
     testutils.send_packet(ptfadapter, intf1_index, pkt)
 
+    vlan_intfs = config_facts['VLAN_INTERFACE'].keys()
+
     switch_arptable = duthost.switch_arptable()['ansible_facts']
     pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'] == arp_src_mac)
     pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
 
 
 @pytest.mark.parametrize('ip_version', ['v4', 'v6'])
-def test_proxy_arp(common_setup_teardown, setup_ptf_arp, intfs_for_test, ptfhost, config_facts, ip_version, tbinfo):
+def test_proxy_arp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_ptf_arp, intfs_for_test, ptfhost, config_facts, ip_version, tbinfo):
     '''
     Send an ARP request or neighbor solicitation (NS) to the DUT for an IP address within the subnet of the DUT's VLAN.
 
     DUT should reply with an ARP reply or neighbor advertisement (NA) containing the DUT's own MAC
     '''
-    duthost, _, router_mac = common_setup_teardown
-
-
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     ptf_intf_ipv4_addr, ptf_intf_ipv6_addr, ptf_intf_name = setup_ptf_arp
+
+    pytest_require(duthost.has_config_subcommand('config vlan proxy_arp'), "Proxy ARP command does not exist on device")
+
+    if ip_version == 'v4':
+        pytest_require(ptf_intf_ipv4_addr is not None, 'No IPv4 VLAN address configured on device')
+    elif ip_version == 'v6':
+        pytest_require(ptf_intf_ipv6_addr is not None, 'No IPv6 VLAN address configured on device')
+
     proxy_arp_config_cmd = 'config vlan proxy_arp {} {}'
 
     # We are leveraging the fact that ping will automatically send a neighbor solicitation/ARP request for us
@@ -138,6 +183,7 @@ def test_proxy_arp(common_setup_teardown, setup_ptf_arp, intfs_for_test, ptfhost
         for vlan_details in vlans.values():
             dut_macs.append(vlan_details['mac'])
     else:
+        router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
         dut_macs = [router_mac]
 
     pytest_assert(ping_addr in neighbor_table.keys())

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -3,6 +3,7 @@ import ipaddress
 import json
 import logging
 
+from tests.common.errors import RunAnsibleModuleFail
 from tests.common.devices.sonic import SonicHost
 from tests.common.devices.sonic_asic import SonicAsic
 from tests.common.helpers.assertions import pytest_assert
@@ -325,3 +326,23 @@ class MultiAsicSonicHost(object):
         """
         asic = self.get_port_asic_instance(port)
         return asic.get_queue_oid(port, queue_num)
+
+    def has_config_subcommand(self, command):
+        """
+        Check if a config/show subcommand exists on the device
+        
+        It is up to the caller of the function to ensure that `command` 
+        does not have any unintended side effects when run
+
+        Args:
+            command (str): the command to be checked, which should begin with 'config' or 'show'
+        Returns:
+            (bool) True if the command exists, false otherwise
+        """
+        try:
+            self.shell(command) 
+            # If the command executes successfully, we can assume it exists
+            return True
+        except RunAnsibleModuleFail as e:
+            # If 'No such command' is found in stderr, the command doesn't exist
+            return 'No such command' not in e.results['stderr']


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Dual ToR specific ARP tests were not compatible with 201911 and older images, causing additional failures when running nightly tests.

#### How did you do it?
Check if the features under test are supported on the device before running test:

- For GARP, check if `/proc/sys/net/ipv4/conf/intf/arp_accept` is actually changed after setting the config DB field.
- For proxy ARP, check if the `config vlan proxy_arp` exists on the device

If these checks don't pass for their respective tests, skip the test.

Also remove dependency on `common_setup_teardown` to avoid unnecessary `config reload` during test teardown

#### How did you verify/test it?
- Ran tests on testbed with 202012 image, verified all passed
- Ran tests on testbed with 201911 image, verified all skipped
- Ran tests on dual ToR testbed with 202012 image, verified all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
