### PR TITLE
Modified library/port_alias.py to have flexibility to include internal interface

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -89,7 +89,7 @@ class SonicPortAliasMap():
             return portconfig
         return None
 
-    def get_portmap(self, asic_id=None):
+    def get_portmap(self, asic_id=None, include_internal=False):
         aliases = []
         portmap = {}
         aliasmap = {}
@@ -125,7 +125,7 @@ class SonicPortAliasMap():
                             asic_name_index = index
             else:
                 #added support to parse recycle port
-                if re.match('^Ethernet', line) or re.match('^Inband', line):
+                if re.match('^Ethernet', line):
                     mapping = line.split()
                     name = mapping[0]
                     if (role_index != -1) and (len(mapping) > role_index):
@@ -136,7 +136,14 @@ class SonicPortAliasMap():
                         alias = mapping[alias_index]
                     else:
                         alias = name
-                    if role == 'Ext':
+                    if not include_internal:
+                        if role == 'Ext':
+                            aliases.append(alias)
+                            portmap[name] = alias
+                            aliasmap[alias] = name
+                            if (speed_index != -1) and (len(mapping) > speed_index):
+                                portspeed[alias] = mapping[speed_index]
+                    else:
                         aliases.append(alias)
                         portmap[name] = alias
                         aliasmap[alias] = name
@@ -155,7 +162,8 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             hwsku=dict(required=True, type='str'),
-            num_asic=dict(type='int', required=False)
+            num_asic=dict(type='int', required=False),
+            include_internal=dict(required=False, default=False)
         ),
         supports_check_mode=True
     )
@@ -182,10 +190,15 @@ def main():
                 num_asic = multi_asic.get_num_asics()
             except Exception, e:
                 num_asic = 1
+        # if m_args['include_internal'] is not None:
+        #     include_internal = m_args['include_internal']
+
+
         for asic_id in range(num_asic):
             if num_asic == 1:
                 asic_id = None
-            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, asicifnames_asic) = allmap.get_portmap(asic_id)
+            (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, asicifnames_asic)\
+                = allmap.get_portmap(asic_id, m_args['include_internal'])
             if aliases_asic is not None:
                 aliases.extend(aliases_asic)
             if portmap_asic is not None:

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -136,20 +136,13 @@ class SonicPortAliasMap():
                         alias = mapping[alias_index]
                     else:
                         alias = name
-                    if not include_internal:
-                        if role == 'Ext':
-                            aliases.append(alias)
-                            portmap[name] = alias
-                            aliasmap[alias] = name
-                            if (speed_index != -1) and (len(mapping) > speed_index):
-                                portspeed[alias] = mapping[speed_index]
-                    else:
+                    if role == 'Ext' or (role == "Int" and include_internal):
                         aliases.append(alias)
                         portmap[name] = alias
                         aliasmap[alias] = name
                         if (speed_index != -1) and (len(mapping) > speed_index):
                             portspeed[alias] = mapping[speed_index]
-                        if (asic_name_index != -1) and (len(mapping) > asic_name_index):
+                        if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
                             front_panel_asic_ifnames.append(asicifname)
                     if (asic_name_index != -1) and (len(mapping) > asic_name_index):
@@ -163,7 +156,7 @@ def main():
         argument_spec=dict(
             hwsku=dict(required=True, type='str'),
             num_asic=dict(type='int', required=False),
-            include_internal=dict(required=False, default=False)
+            include_internal=dict(required=False, type='bool', default=False)
         ),
         supports_check_mode=True
     )

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -183,8 +183,6 @@ def main():
                 num_asic = multi_asic.get_num_asics()
             except Exception, e:
                 num_asic = 1
-        # if m_args['include_internal'] is not None:
-        #     include_internal = m_args['include_internal']
 
 
         for asic_id in range(num_asic):

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -27,7 +27,7 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
 
     hwsku = duthost.facts['hwsku']
     minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    port_alias_facts = duthost.port_alias(hwsku=hwsku)['ansible_facts']
+    port_alias_facts = duthost.port_alias(hwsku=hwsku, include_internal=True)['ansible_facts']
     up_ports = minigraph_facts['minigraph_ports'].keys()
     default_interfaces = port_alias_facts['port_name_map'].keys()
     minigraph_portchannels = minigraph_facts['minigraph_portchannels']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Modified library/port_alias.py to have flexibility to include=True or False the internal interfaces in VOQ system.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To have flexibility to include or exclude internal interfaces inside a testcase.

#### How did you do it?
Added 'include_internal' flag in port_alias.py
#### How did you verify/test it?
Tested on a VOQ chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
