### PR TITLE
[Mellanox] Remove check for /var/run/hw-management/config/suspend

### DIFF
--- a/tests/platform_tests/mellanox/check_hw_mgmt_service.py
+++ b/tests/platform_tests/mellanox/check_hw_mgmt_service.py
@@ -13,10 +13,6 @@ def check_hw_management_service(dut):
     assert hw_mgmt_service_state["ActiveState"] == "active", "The hw-management service is not active"
     assert hw_mgmt_service_state["SubState"] == "exited", "The hw-management service is not exited"
 
-    logging.info("Check thermal control status")
-    tc_suspend = dut.command("cat /var/run/hw-management/config/suspend")
-    assert tc_suspend["stdout"] == "1", "Thermal control is not suspended"
-
     logging.info("Check dmesg")
     dmesg = dut.command("sudo dmesg")
     error_keywords = ["crash", "Out of memory", "Call Trace", "Exception", "panic"]

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -814,9 +814,6 @@ class RandomThermalStatusMocker(CheckMockerResultMixin, ThermalStatusMocker):
     RandomThermalStatusMocker class to help generate random thermal status and check it with actual data.
     """
 
-    # Thermal algorithm status sys fs path.
-    THERMAL_ALGO_STATUS_FILE_PATH = '/run/hw-management/config/suspend'
-
     # Default threshold diff between high threshold and critical threshold
     DEFAULT_THRESHOLD_DIFF = 5
 
@@ -894,12 +891,12 @@ class RandomThermalStatusMocker(CheckMockerResultMixin, ThermalStatusMocker):
 
     def check_thermal_algorithm_status(self, expected_status):
         """
+        Deprecated.
         Check if actual thermal algorithm status match given expected value.
         :param expected_status: True if enable else False.
         :return: True if match else False
         """
-        expected_value = '0' if expected_status else '1'
-        return expected_value == self.mock_helper.read_value(RandomThermalStatusMocker.THERMAL_ALGO_STATUS_FILE_PATH)
+        return True
 
 
 @mocker('SingleFanMocker')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove check for /var/run/hw-management/config/suspend

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Remove check for /var/run/hw-management/config/suspend since it is not used in SONiC any more

#### How did you do it?

Remove check for /var/run/hw-management/config/suspend

#### How did you verify/test it?

Manually run the test

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
