### PR TITLE
[crm] Skip crm test for acl if DATAACL table doesn't exist.

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -111,14 +111,14 @@ def apply_acl_config(duthost, asichost, test_name, collector, entry_num=1):
         raise Exception("Incorrect number of ACL entries specified - {}".format(entry_num))
 
     logger.info("Applying {}".format(dut_conf_file_path))
-    duthost.command("acl-loader update full {}".format(dut_conf_file_path))
+    output = duthost.command("acl-loader update full {}".format(dut_conf_file_path))['stdout']
+    if 'DATAACL table does not exist' in output:
+        pytest.skip("DATAACL does not exist")
 
     # Make sure CRM counters updated
     time.sleep(CRM_UPDATE_TIME)
 
     collector["acl_tbl_key"] = get_acl_tbl_key(asichost)
-
-
 
 
 def generate_mac(num):
@@ -210,8 +210,8 @@ def get_acl_tbl_key(asichost):
         if "2048" in out:
             key = item
             break
-        else:
-            pytest.fail("Ether type was not found in SAI ACL Entry table")
+    else:
+        pytest.fail("Ether type was not found in SAI ACL Entry table")
 
     # Get ACL table key
     cmd = "{db_cli} ASIC_DB HGET {key} \"SAI_ACL_ENTRY_ATTR_TABLE_ID\""


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
An exception will be raised if ```DATAACL``` doesn't exist. 
```
    def get_acl_tbl_key(asichost):
        """ Get ACL entry keys """
        cmd = "{} ASIC_DB KEYS \"*SAI_OBJECT_TYPE_ACL_ENTRY*\"".format(asichost.sonic_db_cli)
        acl_tbl_keys = asichost.shell(cmd)["stdout"].split()
    
        # Get ethertype for ACL entry and match ACL which was configured to ethertype value
        cmd = "{db_cli} ASIC_DB HGET {item} \"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE\""
        for item in acl_tbl_keys:
            out = asichost.shell(cmd.format(db_cli = asichost.sonic_db_cli, item=item))["stdout"]
            logging.info(out)
            if "2048" in out:
                key = item
                break
            else:
                pytest.fail("Ether type was not found in SAI ACL Entry table")
    
        # Get ACL table key
        cmd = "{db_cli} ASIC_DB HGET {key} \"SAI_ACL_ENTRY_ATTR_TABLE_ID\""
>       oid = asichost.shell(cmd.format(db_cli = asichost.sonic_db_cli, key=key))["stdout"]
E       UnboundLocalError: local variable 'key' referenced before assignment
```
This PR add a check for output of ```acl-loader update```, and skip current test case if ```DATAACL``` table doesn't exist.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to skip crm test for acl if DATAACL table doesn't exist.

#### How did you do it?
Check the output of ```acl-loader update```.

#### How did you verify/test it?
Verified on dx-010, without ```DATAACL``` table.
```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-dx010-acs-4 --module-path ../ansible --testbed vms7-t0-dx010-4 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level info --collect_techsupport=False --topology=t0,any,util crm/test_crm.py::test_acl_entry
========================================================================================= test session starts =========================================================================================
----------------------------------------------------------------------------------------- live log collection -----------------------------------------------------------------------------------------
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
08:15:55 conftest.generate_param_asic_index       L0724 INFO | generating frontend_asics asic indicies for  DUT [['str-dx010-acs-4']] in 
08:15:55 conftest.generate_param_asic_index       L0739 INFO | dut name str-dx010-acs-4  asics params = [None]
collected 1 item                                                                                                                                                                                      

crm/test_crm.py::test_acl_entry[str-dx010-acs-4-None] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
08:15:55 __init__.set_default                     L0049 INFO | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
08:15:55 __init__.check_test_completeness         L0139 INFO | Test has no defined levels. Continue without test completeness checks
08:16:03 conftest.generate_params_dut_hostname    L0757 INFO | DUTs in testbed 'vms7-t0-dx010-4' are: ['str-dx010-acs-4']
08:16:03 conftest.rand_one_dut_hostname           L0224 INFO | Randomly select dut str-dx010-acs-4 for testing
08:16:03 conftest.creds_on_dut                    L0415 INFO | dut str-dx010-acs-4 belongs to groups [u'sonic', u'sonic_dx010_100', u'str', 'fanout']
08:16:03 conftest.creds_on_dut                    L0427 INFO | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
08:16:03 conftest.creds_on_dut                    L0427 INFO | skip empty var file ../ansible/group_vars/all/README.yml
08:16:07 __init__.sanity_check                    L0121 INFO | Prepare sanity check
08:16:07 __init__.sanity_check                    L0131 INFO | Found marker: m.name=topology, m.args=('any',), m.kwargs={}
08:16:07 __init__.sanity_check                    L0157 INFO | Skip sanity check according to command line argument or configuration of test script.
08:16:20 conftest.set_polling_interval            L0097 INFO | Waiting 2 sec for CRM counters to become updated
08:16:22 __init__.loganalyzer                     L0017 INFO | Log analyzer is disabled
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
08:16:22 test_crm.apply_acl_config                L0095 INFO | Generating config for ACL rule, ACL table - DATAACL
08:16:23 test_crm.apply_acl_config                L0113 INFO | Applying /tmp-0/acl.json
SKIPPED                                                                                                                                                                                         [100%]

-------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/tr.xml --------------------------------------------------------------------------
=============================================================================== 1 skipped, 1 warnings in 29.38 seconds ================================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
