### PR TITLE
[dual_tor_io] Improve packet generation

### DIFF
--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -232,13 +232,13 @@ class DualTorIO:
                     eth_src = self.ptfadapter.dataplane.get_mac(
                         0, ptf_t1_src_intf
                     )
-                    packet[scapyall.Ether].src = eth_src
+                packet[scapyall.Ether].src = eth_src
                 packet[scapyall.IP].src = self.random_host_ip()
                 packet[scapyall.IP].dst = server_ip
                 payload = str(i) + payload_suffix
                 packet.load = payload
-                packet[scapyall.IP].chksum = None
                 packet[scapyall.TCP].chksum = None
+                packet[scapyall.IP].chksum = None
                 self.packets_list.append((ptf_t1_src_intf, str(packet)))
 
         self.sent_pkt_dst_mac = self.dut_mac
@@ -310,8 +310,8 @@ class DualTorIO:
                 packet[scapyall.IP].src = server_ip
                 packet[scapyall.IP].dst = self.random_host_ip()
                 packet.load = payload
-                packet[scapyall.IP].chksum = None
                 packet[scapyall.TCP].chksum = None
+                packet[scapyall.IP].chksum = None
                 self.packets_list.append((ptf_src_intf, str(packet)))
         self.sent_pkt_dst_mac = self.vlan_mac
         self.received_pkt_src_mac = [self.active_mac, self.standby_mac]

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -213,8 +213,17 @@ class DualTorIO:
         # This way, when sending packets we continuously send for all servers
         # instead of sending all packets for server #1, then all packets for
         # server #2, etc.
+        tcp_tx_packet_orig = testutils.simple_tcp_packet(
+            eth_dst=eth_dst,
+            eth_src=eth_src,
+            ip_ttl=ip_ttl,
+            tcp_dport=TCP_DST_PORT
+        )
+        tcp_tx_packet_orig = scapyall.Ether(str(tcp_tx_packet_orig))
+        payload_suffix = "X" * 60
         for i in range(self.packets_per_server):
             for server_ip in server_ip_list:
+                packet = tcp_tx_packet_orig.copy()
                 if random_source:
                     tor_pc_src_intf = random.choice(
                         self.tor_pc_intfs
@@ -223,17 +232,13 @@ class DualTorIO:
                     eth_src = self.ptfadapter.dataplane.get_mac(
                         0, ptf_t1_src_intf
                     )
-                tcp_tx_packet = testutils.simple_tcp_packet(
-                    eth_dst=eth_dst,
-                    eth_src=eth_src,
-                    ip_dst=server_ip,
-                    ip_src=self.random_host_ip(),
-                    ip_ttl=ip_ttl,
-                    tcp_dport=TCP_DST_PORT
-                )
-                payload = str(i) + 'X' * 60
-                packet = scapyall.Ether(str(tcp_tx_packet))
+                    packet[scapyall.Ether].src = eth_src
+                packet[scapyall.IP].src = self.random_host_ip()
+                packet[scapyall.IP].dst = server_ip
+                payload = str(i) + payload_suffix
                 packet.load = payload
+                packet[scapyall.IP].chksum = None
+                packet[scapyall.TCP].chksum = None
                 self.packets_list.append((ptf_t1_src_intf, str(packet)))
 
         self.sent_pkt_dst_mac = self.dut_mac
@@ -288,21 +293,25 @@ class DualTorIO:
         # This way, when sending packets we continuously send for all servers
         # instead of sending all packets for server #1, then all packets for
         # server #2, etc.
+        tcp_tx_packet_orig = testutils.simple_tcp_packet(
+            eth_dst=self.vlan_mac,
+            tcp_dport=TCP_DST_PORT
+        )
+        tcp_tx_packet_orig = scapyall.Ether(str(tcp_tx_packet_orig))
+        payload_suffix = "X" * 60
         for i in range(self.packets_per_server):
             for vlan_intf in vlan_src_intfs:
                 ptf_src_intf = self.tor_to_ptf_intf_map[vlan_intf]
                 server_ip = self.ptf_intf_to_server_ip_map[ptf_src_intf]
                 eth_src = ptf_intf_to_mac_map[ptf_src_intf]
-                payload =  str(i) + 'X' * 60
-                tcp_tx_packet = testutils.simple_tcp_packet(
-                    eth_dst=self.vlan_mac,
-                    eth_src=eth_src,
-                    ip_src=server_ip,
-                    ip_dst=self.random_host_ip(),
-                    tcp_dport=TCP_DST_PORT
-                )
-                packet = scapyall.Ether(str(tcp_tx_packet))
+                payload = str(i) + payload_suffix
+                packet = tcp_tx_packet_orig.copy()
+                packet[scapyall.Ether].src = eth_src
+                packet[scapyall.IP].src = server_ip
+                packet[scapyall.IP].dst = self.random_host_ip()
                 packet.load = payload
+                packet[scapyall.IP].chksum = None
+                packet[scapyall.TCP].chksum = None
                 self.packets_list.append((ptf_src_intf, str(packet)))
         self.sent_pkt_dst_mac = self.vlan_mac
         self.received_pkt_src_mac = [self.active_mac, self.standby_mac]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Improve the packet generation speed by
1. putting common calculations out of the loop.
2. call `simple_tcp_packet` once and use the packet as template to
generate other packets.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To speed up packet generation.

#### How did you do it?
1. putting common calculations out of the loop.
2. call `simple_tcp_packet` once and use the packet as template to
generate other packets.

#### How did you verify/test it?
Timing the packet generation function call
* before: 106s
```
12/04/2021 09:55:09 dual_tor_io.start_io_test                L0157 DEBUG| 106
```
* after: 36s
```
12/04/2021 10:06:40 dual_tor_io.start_io_test                L0157 DEBUG| 36
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
