### PR TITLE
[pytest.ini]: Restore color to log levels

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -13,6 +13,6 @@ markers:
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)
     supported_completeness_level: test supported levels of completeness (coverage) level (Debug, Basic, Confident, Thorough)
 
-log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-5.5s| %(message)s
-log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-5.5s| %(message)s
+log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
+log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_date_format: %d/%m/%Y %H:%M:%S


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The recent change to Pytest's log format (#3299) removed the color from log levels when printed to `stdout` (e.g. INFO printed in green, ERROR in red, etc.). 

This proposal is to slightly change the new log format to allow log levels to be colored automatically by pytest.

#### How did you do it?
Remove the precision formatting from the log level output, and instead pad the log level to the length of the longest level name (`WARNING` at 7 characters) to keep alignment.

#### How did you verify/test it?
Run pytests with the new log format and confirm logs printed to `stdout` included color

New output:
```
23:02:58 test_quick.test_quick                    L0023 INFO   | info log
23:02:58 test_quick.test_quick                    L0024 WARNING| warning log
23:02:58 test_quick.test_quick                    L0025 ERROR  | error log
```

Old output:
```
23:08:24 test_quick.test_quick                    L0023 INFO | info log
23:08:24 test_quick.test_quick                    L0024 WARNI| warning log
23:08:24 test_quick.test_quick                    L0025 ERROR| error log
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
