### PR TITLE
[pretest]: Inject mux client simulator to host

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -204,6 +204,7 @@ def test_inject_y_cable_simulator_client(duthosts, enum_dut_hostname, tbinfo):
     rendered = template.render(template_args)
 
     dut.copy(content=rendered, dest='/tmp/y_cable_simulator_client.py')
+    dut.shell('cp /tmp/y_cable_simulator_client.py /usr/lib/python3/dist-packages/')
     dut.shell('docker cp /tmp/y_cable_simulator_client.py pmon:/usr/lib/python3/dist-packages/')
     dut.shell('systemctl restart pmon')
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Some scripts/processes running on the Linux host require access to the Y cable API and the mocked version when using a mux simulator.

#### How did you do it?
When injecting the y cable simulator client to the pmon container, also inject it to the host.

#### How did you verify/test it?
Run `test_pretest.py::test_inject_y_cable_simulator_client`, then confirm that the simulator methods are usable on the host.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
