### PR TITLE
[test_vlan] teardown: Handle cleanup for DUT and PTF separately

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -196,14 +196,6 @@ def tearDown(vlan_ports_list, duthost, ptfhost, vlan_intfs_list, portchannel_int
 
     logger.info("Delete VLAN intf")
     try:
-        for item in vlan_ports_list:
-            for i in vlan_ports_list[0]['permit_vlanid']:
-                duthost.command('ip route flush {}'.format(
-                    item['permit_vlanid'][i]['remote_ip']))
-    except RunAnsibleModuleFail as e:
-        logger.error(e)
-
-    try:
         for vlan_port in vlan_ports_list:
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
                 if int(permit_vlanid) != vlan_port["pvid"]:

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -200,7 +200,10 @@ def tearDown(vlan_ports_list, duthost, ptfhost, vlan_intfs_list, portchannel_int
             for i in vlan_ports_list[0]['permit_vlanid']:
                 duthost.command('ip route flush {}'.format(
                     item['permit_vlanid'][i]['remote_ip']))
+    except RunAnsibleModuleFail as e:
+        logger.error(e)
 
+    try:
         for vlan_port in vlan_ports_list:
             for permit_vlanid in vlan_port["permit_vlanid"].keys():
                 if int(permit_vlanid) != vlan_port["pvid"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Many of the regression tests failed (every test using ptfadapter) due to test_setup_failure:
```
    @pytest.fixture(scope='module')
    def ptfadapter(ptfhost, tbinfo, request):
        """return ptf test adapter object.
        The fixture is module scope, because usually there is not need to
        restart PTF nn agent and reinitialize data plane thread on every
        test class or test function/method. Session scope should also be Ok,
        however if something goes really wrong in one test module it is safer
        to restart PTF before proceeding running other test modules
        """
    
        # get the eth interfaces from PTF and initialize ifaces_map
        res = ptfhost.command('cat /proc/net/dev')
        ifaces = get_ifaces(res['stdout'])
>       ifaces_map = {int(ifname.replace(ETH_PFX, '')): ifname for ifname in ifaces}

ifaces     = ['eth35', 'eth13', 'eth16', 'eth9', 'eth47', 'eth6', ...]
ptfhost    = <tests.common.devices.ptf.PTFHost object at 0x7f835f1762d0>
request    = <SubRequest 'ptfadapter' for <Function test_bgpmon>>
res        = {'stderr_lines': [], u'cmd': [u'cat', u'/proc/net/dev'], u'end': u'2021-04-10 ...le/2.8/reference_appendices/interpreter_discovery.html for more information.']}

common/plugins/ptfadapter/__init__.py:87: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <listiterator object at 0x7f835d1d13d0>

>   ifaces_map = {int(ifname.replace(ETH_PFX, '')): ifname for ifname in ifaces}
E   ValueError: invalid literal for int() with base 10: '7.100'

.0         = <listiterator object at 0x7f835d1d13d0>
ifname     = 'eth7.100'
```

This is due to some interfaces left over by test_vlan, and not cleaned during teardown.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The new PTF interfaces added during the test are not deleted in teardown if the DUT is not reachable/reponding.

In the present code, DUT and PTF cleanup happens inside one try-catch block. BEcause of this, if DUT cleanup throws exception, PTF cleanup is also skipped.


```
09/04/2021 21:05:43 INFO test_vlan.py:setup_vlan:156: Configure route for remote IP
09/04/2021 21:05:43 DEBUG base.py:_run:63: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/common/devices/multi_asic.py::_run_on_asics#88: [str-s6100-acs-4] AnsibleModule::command, args=["ip route add 200.1.1.6 via 192.168.200.6"], kwargs={}
09/04/2021 21:06:15 DEBUG base.py:_run:82: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/common/devices/multi_asic.py::_run_on_asics#88: [str-s6100-acs-4] AnsibleModule::command Result => {"msg": "Timeout (32s) waiting for privilege escalation prompt: ", "failed": true, "_ansible_no_log": false}
09/04/2021 21:06:15 INFO test_vlan.py:tearDown:193: VLAN test ending ...
09/04/2021 21:06:15 INFO test_vlan.py:tearDown:194: Stop arp_responder
09/04/2021 21:06:15 DEBUG base.py:_run:63: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/vlan/test_vlan.py::tearDown#195: [vms7-1] AnsibleModule::command, args=["supervisorctl stop arp_responder"], kwargs={}
09/04/2021 21:06:17 DEBUG base.py:_run:82: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/vlan/test_vlan.py::tearDown#195: [vms7-1] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["supervisorctl", "stop", "arp_responder"], "end": "2021-04-09 21:05:35.691157", "_ansible_no_log": false, "stdout": "arp_responder: ERROR (not running)", "changed": true, "rc": 0, "start": "2021-04-09 21:05:34.900451", "stderr": "", "delta": "0:00:00.790706", "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "supervisorctl stop arp_responder", "removes": null, "argv": null, "creates": null, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["arp_responder: ERROR (not running)"], "failed": false}
09/04/2021 21:06:17 INFO test_vlan.py:tearDown:197: Delete VLAN intf
09/04/2021 21:06:17 DEBUG base.py:_run:63: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/common/devices/multi_asic.py::_run_on_asics#88: [str-s6100-acs-4] AnsibleModule::command, args=["ip route flush 200.1.1.6"], kwargs={}
09/04/2021 21:06:49 DEBUG base.py:_run:82: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/common/devices/multi_asic.py::_run_on_asics#88: [str-s6100-acs-4] AnsibleModule::command Result => {"msg": "Timeout (32s) waiting for privilege escalation prompt: ", "failed": true, "_ansible_no_log": false}
09/04/2021 21:06:49 ERROR test_vlan.py:tearDown:212: run module command failed, Ansible Results =>
{
    "failed": true, 
    "msg": "Timeout (32s) waiting for privilege escalation prompt: "
}
09/04/2021 21:06:49 DEBUG base.py:_run:63: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/common/devices/multi_asic.py::_run_on_asics#88: [str-s6100-acs-4] AnsibleModule::shell, args=["config reload -y &>/dev/null"], kwargs={"executable": "/bin/bash"}
09/04/2021 21:07:21 DEBUG base.py:_run:82: /var/sonicbld/workspace/NewTests/TEMPLATE_PYTEST_T0_S6100/tests/common/devices/multi_asic.py::_run_on_asics#88: [str-s6100-acs-4] AnsibleModule::shell Result => {"msg": "Timeout (32s) waiting for privilege escalation prompt: ", "failed": true, "_ansible_no_log": false}
```

#### How did you do it?

Separate DUT and PTF cleanup to two different try-catch blocks. Now if DUT cleanup throws exception, PTF cleanup wll still be executed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
