### PR TITLE
Improve run_tests.sh to support ignore or include test folders

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -123,7 +123,7 @@ function setup_test_options()
         TEST_CASES=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
     fi
 
-    # Check against $INLUCDE_FOLDERS, filter out test cases not in the specified folders
+    # Check against $INCLUDE_FOLDERS, filter out test cases not in the specified folders
     FINAL_CASES=""
     includes=$(python -c "print '|'.join('''$INCLUDE_FOLDERS'''.split())")
     for test_case in ${TEST_CASES}; do

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -147,6 +147,10 @@ function setup_test_options()
         PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --allow_recover"
     fi
 
+    for skip in ${SKIP_SCRIPTS} ${SKIP_FOLDERS}; do
+        PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --ignore=${skip}"
+    done
+
     if [[ -d ${LOG_PATH} ]]; then
         rm -rf ${LOG_PATH}
     fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -13,6 +13,7 @@ function show_help_and_exit()
     echo "    -E             : exit for any error (default: False)"
     echo "    -f <tb file>   : specify testbed file (default testbed.csv)"
     echo "    -i <inventory> : specify inventory name"
+    echo "    -I <folders>   : specify list of test folders, filter out test cases not in the folders (default: none)"
     echo "    -k <file log>  : specify file log level: error|warning|info|debug (default debug)"
     echo "    -l <cli log>   : specify cli log level: error|warning|info|debug (default warning)"
     echo "    -m <method>    : specify test method group|individual|debug (default group)"
@@ -23,6 +24,7 @@ function show_help_and_exit()
     echo "    -q <n>         : test will stop after <n> failures (default: not stop on failure)"
     echo "    -r             : retain individual file log for suceeded tests (default: remove)"
     echo "    -s <tests>     : specify list of tests to skip (default: none)"
+    echo "    -S <folders>   : specify list of test folders to skip (default: none)"
     echo "    -t <topology>  : specify toplogy: t0|t1|any|combo like t0,any (*)"
     echo "    -u             : bypass util group"
     echo "    -x             : print commands and their arguments as they are executed"
@@ -75,6 +77,7 @@ function setup_environment()
     CLI_LOG_LEVEL='warning'
     EXTRA_PARAMETERS=""
     FILE_LOG_LEVEL='debug'
+    INCLUDE_FOLDERS=""
     INVENTORY="${BASE_PATH}/ansible/lab,${BASE_PATH}/ansible/veos"
     KUBE_MASTER_ID="unset"
     OMIT_FILE_LOG="False"
@@ -120,6 +123,14 @@ function setup_test_options()
         TEST_CASES=$(python -c "print '\n'.join(set('''$all_scripts'''.split()) - set('''$SKIP_SCRIPTS'''.split()))" | sort)
     fi
 
+    # Check against $INLUCDE_FOLDERS, filter out test cases not in the specified folders
+    FINAL_CASES=""
+    includes=$(python -c "print '|'.join('''$INCLUDE_FOLDERS'''.split())")
+    for test_case in ${TEST_CASES}; do
+        FINAL_CASES="${FINAL_CASES} $(echo ${test_case} | grep -E "^(${includes})")"
+    done
+    TEST_CASES=$(python -c "print '\n'.join('''${FINAL_CASES}'''.split())")
+
     PYTEST_COMMON_OPTS="--inventory ${INVENTORY} \
                       --host-pattern ${DUT_NAME} \
                       --testbed ${TESTBED_NAME} \
@@ -135,10 +146,6 @@ function setup_test_options()
     if [[ x"${AUTO_RECOVER}" == x"True" ]]; then
         PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --allow_recover"
     fi
-
-    for skip in ${SKIP_SCRIPTS} ${SKIP_FOLDERS}; do
-        PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} --ignore=${skip}"
-    done
 
     if [[ -d ${LOG_PATH} ]]; then
         rm -rf ${LOG_PATH}
@@ -184,6 +191,7 @@ function run_debug_tests()
     echo "CLI_LOG_LEVEL:         ${CLI_LOG_LEVEL}"
     echo "EXTRA_PARAMETERS:      ${EXTRA_PARAMETERS}"
     echo "FILE_LOG_LEVEL:        ${FILE_LOG_LEVEL}"
+    echo "INCLUDE_FOLDERS:       ${INCLUDE_FOLDERS}"
     echo "INVENTORY:             ${INVENTORY}"
     echo "LOG_PATH:              ${LOG_PATH}"
     echo "OMIT_FILE_LOG:         ${OMIT_FILE_LOG}"
@@ -261,7 +269,7 @@ function run_individual_tests()
 setup_environment
 
 
-while getopts "h?a:b:c:d:e:Ef:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
+while getopts "h?a:b:c:d:e:Ef:i:I:k:l:m:n:oOp:q:rs:S:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -290,6 +298,9 @@ while getopts "h?a:b:c:d:e:Ef:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
             ;;
         i )
             INVENTORY=${OPTARG}
+            ;;
+        I )
+            INCLUDE_FOLDERS="${INCLUDE_FOLDERS} ${OPTARG}"
             ;;
         k )
             FILE_LOG_LEVEL=${OPTARG}
@@ -320,6 +331,9 @@ while getopts "h?a:b:c:d:e:Ef:i:k:l:m:n:oOp:q:rs:t:ux" opt; do
             ;;
         s )
             SKIP_SCRIPTS="${SKIP_SCRIPTS} ${OPTARG}"
+            ;;
+        S )
+            SKIP_FOLDERS="${SKIP_FOLDERS} ${OPTARG}"
             ;;
         t )
             TOPOLOGY=${OPTARG}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently the run_tests.sh tool supports specifying test cases to include or skip. However, it does not
support specifying test folders to include or skip. 

#### How did you do it?
This change added two CLI argument:
* `-S <folders>`: Specify list of test folders to skip. Test cases in the specified folders will be filtered out.
* `-I <folders>`: Specify list of test folders to include. Test cases not in the specified folders will be filtered out.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
