### PR TITLE
[pytest]: Allow specifying specific DUT for multi-dut testbeds

### DIFF
--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -41,16 +41,18 @@ class DutHosts(object):
             """ To support hash operator on the DUTs (nodes) in the testbed """
             return list.__hash__()
 
-    def __init__(self, ansible_adhoc, tbinfo):
+    def __init__(self, ansible_adhoc, tbinfo, duts):
         """ Initialize a multi-dut testbed with all the DUT's defined in testbed info.
 
         Args:
             ansible_adhoc: The pytest-ansible fixture
             tbinfo - Testbed info whose "duts" holds the hostnames for the DUT's in the multi-dut testbed.
+            duts - list of DUT hostnames from the `--host-pattern` CLI option. Can be specified if only a subset of 
+                   DUTs in the testbed should be used
 
         """
         # TODO: Initialize the nodes in parallel using multi-threads?
-        self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname) for hostname in tbinfo["duts"]])
+        self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname) for hostname in tbinfo["duts"] if hostname in duts])
         self.supervisor_nodes = self._Nodes([node for node in self.nodes if node.is_supervisor_node()])
         self.frontend_nodes = self._Nodes([node for node in self.nodes if node.is_frontend_node()])
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,7 +8,7 @@ function show_help_and_exit()
     echo "    -a <True|False>: specify if auto-recover is allowed (default: True)"
     echo "    -b <master_id> : specify name of k8s master group used in k8s inventory, format: k8s_vms{msetnumber}_{servernumber}"
     echo "    -c <testcases> : specify test cases to execute (default: none, executed all matched)"
-    echo "    -d <dut name>  : specify DUT name (default: DUT name associated with testbed in testbed file)"
+    echo "    -d <dut name>  : specify comma-separated DUT names (default: DUT name associated with testbed in testbed file)"
     echo "    -e <parameters>: specify extra parameter(s) (default: none)"
     echo "    -E             : exit for any error (default: False)"
     echo "    -f <tb file>   : specify testbed file (default testbed.csv)"


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When using multi-DUT testbeds (dual ToR) it is sometimes desirable to run tests/commands on a specific DUT. Previously, we needed to make local changes to `rand_one_dut_hostname` and similar fixtures to accomplish this

#### How did you do it?
Usage example:
```
./run_tests.sh -n <multi-DUT testbed name> -d <single DUT hostname> ...
```
- Take advantage of the optional `-d` CLI parameter in `run_tests.sh` which maps to the `--host-pattern` CLI option provided by the Ansible pytest plugin
- Instead of always reading the list of DUTs from the testbed file, create a new `get_specified_duts` function to reconcile DUTs from the testbed file with DUTs passed via CLI. 
    - If no DUTs are specified via CLI, the behavior is the same as usual, all DUTs are loaded into the pytest context
    - If one or more DUTs are specified with the `-d` option (comma separated), only these DUTs will be used during tests
    - If a DUT not belonging to the given testbed is passed, the test is preemptively failed

This change should be completely transparent, i.e. if the `-d` option is not used there should be no changes in behavior compared to prior to this change.

#### How did you verify/test it?
- On both single DUT and multi-DUT testbed:
	- Ran tests without specifying specific DUTs, ensured tests passed on all DUTs
	- Ran tests specifying one DUT, ensured tests ran on only the specified and PASSED
	- Ran tests specifying an invalid DUT, ensured tests failed
- On multi-DUT testbed:
	- Ran tests specifying all DUTs belonging to the testbed, ensured tests passed on all DUTs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
