### PR TITLE
[pdu] address a few PDU/PSU related issues

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -144,6 +144,18 @@ def get_dut_psu_line_pattern(dut):
     if "201811" in dut.os_version or "201911" in dut.os_version:
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
     else:
+        """
+        Changed the pattern to match space (s+) and noen space (S+) only.
+        w+ cannot match following examples properly:
+
+        example 1:
+            PSU 1  PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
+            PSU 2  PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
+        example 2:
+            PSU 1  N/A      N/A               12.05           3.38        40.62  OK        green
+            PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
+
+        """
         psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
     return psu_line_pattern
 

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -140,17 +140,20 @@ def get_psu_num(dut):
     return psu_num
 
 
-def check_vendor_specific_psustatus(dut, psu_status_line):
+def get_dut_psu_line_pattern(dut):
+    if "201811" in dut.os_version or "201911" in dut.os_version:
+        psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
+    else:
+        psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+    return psu_line_pattern
+
+
+def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
     """
     @summary: Vendor specific psu status check
     """
     if dut.facts["asic_type"] in ["mellanox"]:
         from .mellanox.check_sysfs import check_psu_sysfs
-
-        if "201811" in dut.os_version or "201911" in dut.os_version:
-            psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
-        else:
-            psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
 
         psu_match = psu_line_pattern.match(psu_status_line)
         psu_id = psu_match.group(1)
@@ -169,13 +172,18 @@ def turn_all_outlets_on(pdu_ctrl):
 
 
 def check_all_psu_on(dut, psu_test_results):
+    """
+        @summary: check all PSUs are in 'OK' status.
+        @param dut: dut host instance.
+        @param psu_test_results: dictionary of all PSU names, values are not important.
+    """
     power_off_psu_list = []
 
     if "201811" in dut.os_version or "201911" in dut.os_version:
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
             fields = line.split()
-            psu_test_results[fields[1]] = False
+            psu_test_results[fields[1]] = line
             if " ".join(fields[2:]) == "NOT OK":
                 power_off_psu_list.append(fields[1])
     else:
@@ -183,6 +191,7 @@ def check_all_psu_on(dut, psu_test_results):
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS_JSON)
         psu_info_list = json.loads(cli_psu_status["stdout"])
         for psu_info in psu_info_list:
+            psu_test_results[psu_info['name']] = psu_info
             if psu_info["status"] == "NOT OK":
                 power_off_psu_list.append(psu_info["index"])
 
@@ -194,13 +203,13 @@ def check_all_psu_on(dut, psu_test_results):
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_PSU_ABSENCE], indirect=True)
-def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, pdu_controller, ignore_particular_error_log):
+def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_hostname, pdu_controller, ignore_particular_error_log):
     """
     @summary: Turn off/on PSU and check PSU status using 'show platform psustatus'
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
+    psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
     psu_num = get_psu_num(duthost)
     pytest_require(psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
@@ -231,11 +240,11 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, pd
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
-            pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output")
-            fields = line.split()
-            if fields[2] != "OK":
-                psu_under_test = fields[1]
-            check_vendor_specific_psustatus(duthost, line)
+            psu_match = psu_line_pattern.match(line)
+            pytest_assert(psu_match, "Unexpected PSU status output")
+            if psu_match.group(2) != "OK":
+                psu_under_test = psu_match.group(1)
+            check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
         pytest_assert(psu_under_test is not None, "No PSU is turned off")
 
         logging.info("Turn on outlet {}".format(outlet))
@@ -244,11 +253,11 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, rand_one_dut_hostname, pd
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
-            pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output")
-            fields = line.split()
-            if fields[1] == psu_under_test:
-                pytest_assert(fields[2] == "OK", "Unexpected PSU status after turned it on")
-            check_vendor_specific_psustatus(duthost, line)
+            psu_match = psu_line_pattern.match(line)
+            pytest_assert(psu_match, "Unexpected PSU status output")
+            if psu_match.group(1) == psu_under_test:
+                pytest_assert(psu_match.group(2) == "OK", "Unexpected PSU status after turned it on")
+            check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
 
         psu_test_results[psu_under_test] = True
 
@@ -330,11 +339,11 @@ def check_thermal_control_load_invalid_file(duthost, file_name):
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_PSU_ABSENCE], indirect=True)
-def test_thermal_control_psu_absence(duthosts, rand_one_dut_hostname, pdu_controller, mocker_factory, ignore_particular_error_log):
+def test_thermal_control_psu_absence(duthosts, enum_rand_one_per_hwsku_hostname, pdu_controller, mocker_factory, ignore_particular_error_log):
     """
     @summary: Turn off/on PSUs, check thermal control is working as expect.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     psu_num = get_psu_num(duthost)
     
     pytest_require(psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
@@ -397,13 +406,13 @@ def turn_off_outlet_and_check_thermal_control(dut, pdu_ctrl, outlet, mocker):
     time.sleep(5)
 
     psu_under_test = None
-    psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
+    psu_line_pattern = get_dut_psu_line_pattern(duthost)
     cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
     for line in cli_psu_status["stdout_lines"][2:]:
-        pytest_assert(psu_line_pattern.match(line), "Unexpected PSU status output")
-        fields = line.split()
-        if fields[2] != "OK":
-            psu_under_test = fields[1]
+        psu_match = psu_line_pattern.match(line)
+        pytest_assert(psu_match, "Unexpected PSU status output")
+        if psu_match.group(2) != "OK":
+            psu_under_test = psu_match.group(1)
 
     pytest_assert(psu_under_test is not None, "No PSU is turned off")
     logging.info('Wait and check all FAN speed turn to 100%...')

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -145,7 +145,7 @@ def get_dut_psu_line_pattern(dut):
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
     else:
         """
-        Changed the pattern to match space (s+) and noen space (S+) only.
+        Changed the pattern to match space (s+) and non-space (S+) only.
         w+ cannot match following examples properly:
 
         example 1:

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -186,7 +186,7 @@ def _power_off_reboot_helper(kwargs):
         pdu_ctrl.turn_on_outlet(outlet)
 
 
-def test_power_off_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, xcvr_skip_list, pdu_controller, power_off_delay):
+def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, conn_graph_facts, xcvr_skip_list, pdu_controller, power_off_delay):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object
@@ -196,7 +196,7 @@ def test_power_off_reboot(duthosts, rand_one_dut_hostname, localhost, conn_graph
     @param pdu_controller: The python object of psu controller
     @param power_off_delay: Pytest parameter. The delay between turning off and on the PSU
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     pdu_ctrl = pdu_controller
     if pdu_ctrl is None:
         pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)


### PR DESCRIPTION
### Description of PR


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PDU/PSU related tests are failing.

#### How did you do it?
1. Use enum_rand_one_per_hwsku_hostname in tests requires PDU controller

   PDU controller is picked with enum_rand_one_per_hwsku_hostname. 
   The tests requires PDU controller needs to use the same enumerator
   to make sure that the operation is towards the expected PDU.

2. Generate PSU output match pattern according to image version.

   Check PSU status from the pattern match results.

   Update PSU pattern to match space and non-space only. w+ is not a good
   pattern, we have serial numbers with '-', and 'N/A' in output, neither will match w+.

3. Populate PSU status and return to caller of check_all_psu_on.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How did you verify/test it?
Run reboot_test.py (power off), and test_platform_info.py (pdu and psu test cases)