### PR TITLE
Move 'get_disabled_container_list' to dut_utils.py

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -11,6 +11,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common import config_reload
+from tests.common.helpers.dut_utils import get_disabled_container_list
 
 logger = logging.getLogger(__name__)
 
@@ -151,23 +152,6 @@ def get_program_info(duthost, container_name, program_name):
                     .format(program_name, program_status, program_pid))
 
     return program_status, program_pid
-
-
-def get_disabled_container_list(duthost):
-    """
-    @summary: Get the container/service names which are disabled
-    @return: A list includes the names of disabled containers/services
-    """
-    disabled_containers = []
-
-    container_status, succeeded = duthost.get_feature_status()
-    pytest_assert(succeeded, "Failed to get status ('enabled'|'disabled') of containers. Exiting...")
-
-    for container_name, status in container_status.items():
-        if status == "disabled":
-            disabled_containers.append(container_name)
-
-    return disabled_containers
 
 
 def is_container_running(duthost, container_name):

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -180,4 +180,3 @@ def get_disabled_container_list(duthost):
             disabled_containers.append(container_name)
 
     return disabled_containers
-    

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -159,3 +159,25 @@ def get_program_info(duthost, container_name, program_name):
                     .format(program_name, program_status, program_pid))
 
     return program_status, program_pid
+
+
+def get_disabled_container_list(duthost):
+    """Gets the container/service names which are disabled.
+
+    Args:
+        duthost: Host DUT.
+
+    Return:
+        A list includes the names of disabled containers/services
+    """
+    disabled_containers = []
+
+    container_status, succeeded = duthost.get_feature_status()
+    pytest_assert(succeeded, "Failed to get status ('enabled'|'disabled') of containers. Exiting...")
+
+    for container_name, status in container_status.items():
+        if "disabled" in status:
+            disabled_containers.append(container_name)
+
+    return disabled_containers
+    

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -15,6 +15,7 @@ from tests.common.helpers.dut_utils import is_hitting_start_limit
 from tests.common.helpers.dut_utils import is_container_running
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
+from tests.common.helpers.dut_utils import get_disabled_container_list
 
 logger = logging.getLogger(__name__)
 
@@ -82,27 +83,6 @@ def update_monit_service(duthost):
     duthost.shell("sudo mv -f /tmp/sonic-host /etc/monit/conf.d/")
     logger.info("Restart the Monit service and delay monitoring for 5 minutes.")
     duthost.shell("sudo systemctl restart monit")
-
-
-def get_disabled_container_list(duthost):
-    """Gets the container/service names which are disabled.
-
-    Args:
-        duthost: Host DUT.
-
-    Return:
-        A list includes the names of disabled containers/services
-    """
-    disabled_containers = []
-
-    container_status, succeeded = duthost.get_feature_status()
-    pytest_assert(succeeded, "Failed to get status ('enabled'|'disabled') of containers. Exiting...")
-
-    for container_name, status in container_status.items():
-        if "disabled" in status:
-            disabled_containers.append(container_name)
-
-    return disabled_containers
 
 
 def check_all_critical_processes_status(duthost):


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Util ```get_disabled_container_list``` is duplicated defined in both ```test_container_autorestart``` and ```test_container_check```.
This PR move ```get_disabled_container_list``` definiton to dut_utils.py, and fix ```always_disabled``` issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to move ```get_disabled_container_list``` definiton to dut_utils.py, and fix ```always_disabled``` issue.

#### How did you do it?
Please see code.

#### How did you verify/test it?
Verified on SN4600c.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
