### PR TITLE
[VLAN] Failed on setup_vlan() when exectue test_vlan.py.

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -134,8 +134,11 @@ def setup_vlan(ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, vlan_ports_
         logger.info("Add members to Vlans")
         for vlan_port in vlan_ports_list:
             for permit_vlanid in vlan_port['permit_vlanid'].keys():
+                is_untagged_member = True if vlan_port['pvid'] == permit_vlanid else False
+                if vlan_port['dev'].startswith("Ethernet") and is_untagged_member is True:
+                    duthost.command('config vlan member del 1000 {port}'.format(port=vlan_port['dev']))
                 duthost.command('config vlan member add {tagged} {id} {port}'.format(
-                    tagged=('--untagged' if vlan_port['pvid'] == permit_vlanid else ''),
+                    tagged=('--untagged' if is_untagged_member is True else ''),
                     id=permit_vlanid,
                     port=vlan_port['dev']
                 ))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Failed on setup_vlan when exectue test_vlan.py.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix issue - Failed on setup_vlan when exectue test_vlan.py. 

The failed reason is that add port which is already an untagged member of VLAN 1000 to new VLAN with untagged, it returns fail on CLI. Thus it is failed on setup_vlan.

#### How did you do it?
The adding port should be removed from VLAN 1000 before it is added to other VLAN with untagged member.

#### How did you verify/test it?
Run test_vlan.py to make sure it can pass.

Test log:
```
johnar@fa6c7e01f5ce:/data/sonic-mgmt/ansible$ cd /data/sonic-mgmt/tests/ && py.test "vlan/test_vlan.py" --host-pattern=2-9_t0 --module-path ../ansible/library/ --testbed_file=testbed.csv --inventory=lab --testbed=2-9_t0 --log-level=INFO --show-capture=stdout --duration=0 -v -o log_cli=true -o log_cli_level=INFO --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.12', 'Platform': 'Linux-4.4.0-87-generic-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.8.0', u'html': u'1.22.1', u'xdist': u'1.28.0', u'ansible': u'2.2.2', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2, repeat-0.8.0, metadata-1.10.0, xdist-1.28.0, html-1.22.1, forked-1.3.0
collected 5 items

vlan/test_vlan.py::test_vlan_tc1_send_untagged
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
02:24:57 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
02:24:57 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
02:25:00 INFO facts_cache.py:write:116: Cached facts "as7726-32x-2.host_visible_vars" to /data/sonic-mgmt/tests/_cache/as7726-32x-2/host_visible_vars.pickle
02:25:00 INFO ptfhost_utils.py:change_mac_addresses:86: Change interface MAC addresses on ptfhost 'ptf2-9'
02:25:01 INFO ptfhost_utils.py:copy_arp_responder_py:117: Copy arp_responder.py to ptfhost 'ptf2-9'
02:25:04 INFO conftest.py:generate_params_dut_hostname:696: DUTs in testbed '2-9_t0' are: ['as7726-32x-2']
02:25:04 INFO conftest.py:creds:388: dut as7726-32x-2 belongs to groups [u'lab', u'sonic', u'sonic_as7726-32x', 'fanout']
02:25:04 INFO conftest.py:creds:400: skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
02:25:04 INFO conftest.py:creds:400: skip empty var file ../ansible/group_vars/all/env.yml
02:25:06 INFO __init__.py:sanity_check:80: Prepare pre-test sanity check
02:25:06 INFO __init__.py:sanity_check:90: Found marker: m.name=topology, m.args=('t0',), m.kwargs={}
02:25:06 INFO __init__.py:sanity_check:114: Skip sanity check according to command line argument or configuration of test script.
02:25:13 INFO test_vlan.py:setup_vlan:106: Shutdown lags, flush IP addresses
02:26:53 INFO test_vlan.py:setup_vlan:116: Add vlans, assign IPs
02:26:55 INFO test_vlan.py:setup_vlan:121: Add members to Vlans
02:27:36 INFO test_vlan.py:setup_vlan:136: Bringup lags
02:28:09 INFO test_vlan.py:setup_vlan:143: Create VLAN intf
02:28:15 INFO test_vlan.py:setup_vlan:146: Configure route for remote IP
02:28:19 INFO test_vlan.py:setup_vlan:154: Copy arp_responder to ptfhost
02:28:23 INFO test_vlan.py:setup_vlan:169: Start arp_responder
02:28:36 INFO __init__.py:loganalyzer:37: Add start marker into DUT syslog
02:28:37 INFO __init__.py:loganalyzer:39: Load config and analyze log
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:300: Test case #1 starting ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:304: Send untagged packet from 28 ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:305: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:37 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 28
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:304: Send untagged packet from 30 ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:305: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:37 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 30
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:304: Send untagged packet from 2 ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:305: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:37 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 2
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:304: Send untagged packet from 1 ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:305: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:37 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 1
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:304: Send untagged packet from 24 ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:305: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:37 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 24
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:304: Send untagged packet from 23 ...
02:28:37 INFO test_vlan.py:test_vlan_tc1_send_untagged:305: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:37 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 23
PASSED                                                                                                                                                                                                      [ 20%]
vlan/test_vlan.py::test_vlan_tc2_send_tagged
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
02:28:41 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
02:28:41 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
02:28:42 INFO __init__.py:loganalyzer:37: Add start marker into DUT syslog
02:28:43 INFO __init__.py:loganalyzer:39: Load config and analyze log
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:319: Test case #2 starting ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(200) packet from 28 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 28
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(100) packet from 28 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 28
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(200) packet from 30 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 30
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(100) packet from 30 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 30
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(200) packet from 2 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 2
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(100) packet from 2 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 2
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(200) packet from 1 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 1
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(100) packet from 1 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 1
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(200) packet from 24 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 24
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(100) packet from 24 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 24
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(200) packet from 23 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 23
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:324: Send tagged(100) packet from 23 ...
02:28:43 INFO test_vlan.py:test_vlan_tc2_send_tagged:325: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:43 INFO test_vlan.py:verify_icmp_packets:267: Verify untagged packets from ports 23
PASSED                                                                                                                                                                                                      [ 40%]
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
02:28:46 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
02:28:46 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
02:28:47 INFO __init__.py:loganalyzer:37: Add start marker into DUT syslog
02:28:48 INFO __init__.py:loganalyzer:39: Load config and analyze log
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:337: Test case #3 starting ...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:347: Send invalid tagged packet  from 28...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:348: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:350: Check on [[30], [2], [1], [24], [23]]...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:347: Send invalid tagged packet  from 30...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:348: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:350: Check on [[28], [2], [1], [24], [23]]...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:347: Send invalid tagged packet  from 2...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:348: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:350: Check on [[28], [30], [1], [24], [23]]...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:347: Send invalid tagged packet  from 1...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:348: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:350: Check on [[28], [30], [2], [24], [23]]...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:347: Send invalid tagged packet  from 24...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:348: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:350: Check on [[28], [30], [2], [1], [23]]...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:347: Send invalid tagged packet  from 23...
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:348: 00:22:00:00:00:02 192.168.0.1 -> ff:ff:ff:ff:ff:ff 192.168.0.2
02:28:48 INFO test_vlan.py:test_vlan_tc3_send_invalid_vid:350: Check on [[28], [30], [2], [1], [24]]...
PASSED                                                                                                                                                                                                      [ 60%]
vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
02:28:51 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
02:28:51 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
02:28:51 INFO __init__.py:loganalyzer:37: Add start marker into DUT syslog
02:28:52 INFO __init__.py:loganalyzer:39: Load config and analyze log
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
02:28:52 INFO test_vlan.py:test_vlan_tc4_tagged_non_broadcast:381: Tagged packet to be sent from port 28 to port 24
02:28:52 INFO test_vlan.py:test_vlan_tc4_tagged_non_broadcast:389: One Way Tagged Packet Transmission Works
02:28:52 INFO test_vlan.py:test_vlan_tc4_tagged_non_broadcast:390: Tagged packet successfully sent from port 28 to port 24
02:28:52 INFO test_vlan.py:test_vlan_tc4_tagged_non_broadcast:394: Tagged packet to be sent from port 24 to port 28
02:28:52 INFO test_vlan.py:test_vlan_tc4_tagged_non_broadcast:402: Two Way Tagged Packet Transmission Works
02:28:52 INFO test_vlan.py:test_vlan_tc4_tagged_non_broadcast:403: Tagged packet successfully sent from port 24 to port 28
PASSED                                                                                                                                                                                                      [ 80%]
vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast
------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
02:28:55 INFO __init__.py:set_default:49: Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
02:28:55 INFO __init__.py:check_test_completeness:139: Test has no defined levels. Continue without test completeness checks
02:28:56 INFO __init__.py:loganalyzer:37: Add start marker into DUT syslog
02:28:57 INFO __init__.py:loganalyzer:39: Load config and analyze log
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
02:28:57 INFO test_vlan.py:test_vlan_tc5_untagged_non_broadcast:434: Untagged packet to be sent from port 28 to port 24
02:28:57 INFO test_vlan.py:test_vlan_tc5_untagged_non_broadcast:442: One Way Untagged Packet Transmission Works
02:28:57 INFO test_vlan.py:test_vlan_tc5_untagged_non_broadcast:443: Untagged packet successfully sent from port 28 to port 24
02:28:57 INFO test_vlan.py:test_vlan_tc5_untagged_non_broadcast:447: Untagged packet to be sent from port 24 to port 28
02:28:57 INFO test_vlan.py:test_vlan_tc5_untagged_non_broadcast:456: Two Way Untagged Packet Transmission Works
02:28:57 INFO test_vlan.py:test_vlan_tc5_untagged_non_broadcast:457: Untagged packet successfully sent from port 24 to port 28
PASSED                                                                                                                                                                                                      [100%]
------------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------------
02:29:00 INFO test_vlan.py:tearDown:183: VLAN test ending ...
02:29:00 INFO test_vlan.py:tearDown:184: Stop arp_responder
02:29:01 INFO test_vlan.py:tearDown:187: Delete VLAN intf
02:32:01 INFO ptfhost_utils.py:copy_arp_responder_py:122: Delete arp_responder.py from ptfhost 'ptf2-9'


============================================================================================= slowest test durations ==============================================================================================
220.36s setup    vlan/test_vlan.py::test_vlan_tc1_send_untagged
185.43s teardown vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast
3.50s teardown vlan/test_vlan.py::test_vlan_tc1_send_untagged
2.88s teardown vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid
2.87s teardown vlan/test_vlan.py::test_vlan_tc2_send_tagged
2.81s teardown vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast
1.67s setup    vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast
1.64s setup    vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid
1.57s setup    vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast
1.53s setup    vlan/test_vlan.py::test_vlan_tc2_send_tagged
0.71s call     vlan/test_vlan.py::test_vlan_tc2_send_tagged
0.63s call     vlan/test_vlan.py::test_vlan_tc1_send_untagged
0.03s call     vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast
0.02s call     vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast
0.02s call     vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid
=========================================================================================== 5 passed in 425.76 seconds ============================================================================================
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7f754da26710>> ignored
johnar@fa6c7e01f5ce:/data/sonic-mgmt/tests$
```