### PR TITLE
[test_snmp_phy_entity] Fix wrong funciton name and input argument

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -453,7 +453,7 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_rand_one_per_hwsku_hostn
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     if not pdu_controller:
         pytest.skip('psu_controller is None, skipping this test')
-    outlet_status = pdu_controller.get_psu_status()
+    outlet_status = pdu_controller.get_outlet_status()
     if len(outlet_status) < 2:
         pytest.skip('At least 2 PSUs required for rest of the testing in this case')
 
@@ -484,7 +484,7 @@ def _check_psu_status_after_power_off(duthost, localhost, creds_all_duts):
     :param creds_all_duts: Credential for snmp
     :return: True if sensor information is removed from mib
     """
-    mib_info = get_entity_mib(duthost, localhost, creds_all_duts[duthost])
+    mib_info = get_entity_mib(duthost, localhost, creds_all_duts)
     keys = redis_get_keys(duthost, STATE_DB, PSU_KEY_TEMPLATE.format('*'))
     power_off_psu_found = False
     for key in keys:
@@ -531,7 +531,7 @@ def test_remove_insert_fan_and_check_fan_info(duthosts, enum_rand_one_per_hwsku_
     # Ignore the test if the platform does not have fans (e.g Line card)
     if not keys:
         pytest.skip('Fan information does not exist in DB, skipping this test')
-    mib_info = get_entity_mib(duthost, localhost, creds_all_duts[duthost])
+    mib_info = get_entity_mib(duthost, localhost, creds_all_duts)
     for key in keys:
         fan_info = redis_hgetall(duthost, STATE_DB, key)
         if fan_info['presence'] == 'True':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1, In test_snmp_phy_entity.py, below line calling non-existing function "get_psu_status()"
`pdu_controller.get_psu_status()`
should be:
`pdu_controller.get_outlet_status()`

2, In test_snmp_phy_entity.py, below line calling wrong argument " creds_all_duts[duthost]" 
 `mib_info = get_entity_mib(duthost, localhost, creds_all_duts[duthost])`
should be:
 `mib_info = get_entity_mib(duthost, localhost, creds_all_duts)`


Summary:
Fixes # (https://github.com/Azure/sonic-mgmt/issues/3328)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix https://github.com/Azure/sonic-mgmt/issues/3328
#### How did you do it?
Correct the function name and argument

#### How did you verify/test it?
Run test_snmp_phy_entity test case

#### Any platform specific information?
no

#### Supported testbed topology if it's a new test case?
no

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
