### PR TITLE
[test_curl] Fix mvrf test_curl

### DIFF
--- a/tests/mvrf/temp_http_server.py
+++ b/tests/mvrf/temp_http_server.py
@@ -25,3 +25,4 @@ if __name__ == "__main__":
     # This script will exit after 2 * httpd.timeout seconds in worst case that no request is received at all.
     httpd.handle_request()  # For testing http port open
     httpd.handle_request()  # For GET request from client
+    httpd.handle_request()  # For second GET request from client issued by cmd ip vrf exec mgmt curl


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
**mvrf/test_mgmtvrf.py::TestMvrfOutbound::test_curl** fails on `master` image when trying to get string trough mvrf from http server on ptf:  `curl: (7) Failed to connect to <ip> port <port_num>: Connection refused`
Although when started server manually on ptf and tried to get string from DUT everything was successful. 

As it turned out **master** image use `sudo ip vrf exec mgmt curl` which sends 2 GET requests, when **201911** image use `sudo cgexec -g l3mdev:mgmt curl` which sends 1 GET request, when server is limited to handle 2 request:
**1. For testing http port open
2. For GET request from client**

And as a result it fails to connect to the server and get string needed for test on master image. This PR should increase server limit to handle 3 request.
Fixes # (issue)
Output of **temp_http_server.py** on **master** image:
```
[15/Apr/2021 12:07:35] "GET / HTTP/1.1" 200 
[15/Apr/2021 12:07:35] "GET / HTTP/1.1" 200
```

Output on **201911** image: 
`[15/Apr/2021 15:15:11] "GET / HTTP/1.1" 200`


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix test_curl and make it pass on master images. 
#### How did you do it?
Increase server limit to handle 3 request.
#### How did you verify/test it?
Run test_curl on master and 201911 images.
`mvrf/test_mgmtvrf.py::TestMvrfOutbound::test_curl PASSED`
#### Any platform specific information?
```
SONiC.master.173-dirty-20210412.105046
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: 7df4c0ad
Build date: Mon Apr 12 11:01:38 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
