### PR TITLE
Fix ‘_ns_arg’ exception in get_active_ip_interfaces

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -259,7 +259,7 @@ class SonicAsic(object):
             Dict of Interfaces and their IPv4 address
         """
         ip_ifs = self.show_ip_interface()["ansible_facts"]["ip_interfaces"]
-        return self.sonichost.active_ip_interfaces(ip_ifs, self._ns_arg)
+        return self.sonichost.active_ip_interfaces(ip_ifs, self.ns_arg)
 
     def bgp_drop_rule(self, ip_version, state="present"):
         """


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR fixed exception in ```get_active_ip_interfaces``` caused by ```_ns_arg``` (A typo?).
```
def get_active_ip_interfaces(self):
        """
        Return a dict of active IP (Ethernet or PortChannel) interfaces, with
        interface and peer IPv4 address.
    
        Returns:
            Dict of Interfaces and their IPv4 address
        """
        ip_ifs = self.show_ip_interface()["ansible_facts"]["ip_interfaces"]
>       return self.sonichost.active_ip_interfaces(ip_ifs, self._ns_arg)
E       AttributeError: 'SonicAsic' object has no attribute '_ns_arg'

```  
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix exception in ```get_active_ip_interfaces``` caused by ```_ns_arg``` .
#### How did you do it?

#### How did you verify/test it?
Verified on SN4600c, T1 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
