### PR TITLE
[test_fg_ecmp] Fix 'DEFAULT_NAMESPACE' is not defined

### DIFF
--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -7,6 +7,7 @@ import json
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In ecmp/test_fgnhg.py , 'DEFAULT_NAMESPACE' is not defined：
  ```
  def fg_ecmp(ptfhost, duthost, router_mac, net_ports, port_list, ip_to_port, bank_0_port, bank_1_port, prefix_list): 

 

        # Init base test params 

        if isinstance(ipaddress.ip_network(prefix_list[0]), ipaddress.IPv4Network): 

            ipcmd = "ip route" 

        else: 

            ipcmd = "ipv6 route" 

 

        vtysh_base_cmd = "vtysh -c 'configure terminal'" 

>       vtysh_base_cmd = duthost.get_vtysh_cmd_for_namespace(vtysh_base_cmd, DEFAULT_NAMESPACE) 

E       NameError: global name 'DEFAULT_NAMESPACE' is not defined 

```
Summary:
Fixes # (https://github.com/Azure/sonic-mgmt/issues/3323)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix the issue that 'DEFAULT_NAMESPACE' is not defined 

#### How did you do it?
Import  using following line:
`from tests.common.helpers.constants import DEFAULT_NAMESPACE`

#### How did you verify/test it?
Run test_fg_ecmpt test case

#### Any platform specific information?
no

#### Supported testbed topology if it's a new test case?
no

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
