### PR TITLE
[sFlow] Fix sFlow on 201911 image

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -109,11 +109,13 @@ def config_dut_ports(duthost, ports, vlan):
 def get_ifindex(duthost, port):
      ifindex = duthost.shell('cat /sys/class/net/%s/ifindex' %port)['stdout']
      return ifindex
- 
+
 # ----------------------------------------------------------------------------------
 
 def get_port_index(duthost, port):
-    index = duthost.shell("python3 -c \"from swsssdk import port_util; print(port_util.get_index_from_str(\'{}\'))\"".format(port))['stdout']
+    py_version = 'python' if '201911' in duthost.os_version else 'python3'
+    cmd = "{} -c \"from swsssdk import port_util; print(port_util.get_index_from_str(\'{}\'))\""
+    index = duthost.shell(cmd.format(py_version, port))['stdout']
     return index
 
 # ----------------------------------------------------------------------------------
@@ -125,7 +127,7 @@ def config_sflow_agent(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     duthost.shell("config sflow agent-id del") # Remove any existing agent-id
     duthost.shell("config sflow agent-id add Loopback0")
-    yield   
+    yield
     duthost.shell("config sflow agent-id del")
 
 # ----------------------------------------------------------------------------------
@@ -502,7 +504,7 @@ class TestReboot():
         partial_ptf_runner(
               enabled_sflow_interfaces=var['sflow_ports'].keys(),
               active_collectors="['collector0','collector1']" )
-        
+
     def testWarmreboot(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):
 
         config_sflow(duthost,sflow_status='enable')


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: sFlow test cases fail on **201911** images, when using command `python3 -c \"from swsssdk import port_util; print(port_util.get_index_from_str(\'{}\'))\` with **ImportError**: 
` "ImportError: No module named 'swsssdk'"`

This PR ensures that proper version of python will be used when executing command. 
On 201911 image its python, on master or 202012 images its python3. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix sFlow TCs on 201911 image
#### How did you do it?
Use proper version of python to execute command
#### How did you verify/test it?
Run sFlow on 201911 and 202012 image.
#### Any platform specific information?
```
SONiC Software Version: SONiC.201911.263-dirty-20210413.071124
Distribution: Debian 9.13
Kernel: 4.9.0-14-2-amd64
Build commit: b375053a
Build date: Tue Apr 13 07:18:53 UTC 2021
Built by: johnar@worker-s2fb0c0
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
