### PR TITLE
[fib] Fix incorrect prefix/nh list generation for single_asic device

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -124,6 +124,9 @@ def get_fib_info(duthost, cfg_facts, mg_facts):
                         fib_info[prefix] += oports
                     else:
                         fib_info[prefix] = oports
+                # For single_asic device, add empty list for directly connected subnets
+                elif skip and not duthost.is_multi_asic:
+                    fib_info[prefix] = []
 
     return fib_info
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_basic_fib failing due to incorrect fib_info generation on single_asic devices. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR [3214](https://github.com/Azure/sonic-mgmt/pull/3214) introduced multi-asic support for fib test.
test_basic_fib fails on single-asic devices with the following error:
`"AssertionError: Received expected packet on port 13 for device 0, but it should have arrived on one of these ports: [28, 29, 30, 31].`

This occurs due to prefixes for directly connected subnets not being added to fib_info_file.
E.g. we have following entry on DUT:
``` 
  "ROUTE_TABLE:192.168.0.0/21": {
    "expireat": 1618578926.178756, 
    "ttl": -0.001, 
    "type": "hash", 
    "value": {
      "ifname": "Vlan1000", 
      "nexthop": "0.0.0.0"
    }
  }
```
Previously, we added entry for `192.168.0.0/21` to fib_info with nexthop '[]' and skipped this range later during the test.
Now this entry is skipped from the start and not added to fib_info. 
This results in IP range for subnet 192.168.0.0/21 (or any other directly connected subnet) being considered a part of IP range for previous subnet:
_Expected IP range:_
```
169.255.0.0 - 192.167.255.255
192.168.0.0 - 192.168.7.255
192.168.8.0 - 192.168.8.127
```
_Actual IP range:_
```
169.255.0.0 - 192.168.7.255
192.168.8.0 - 192.168.8.127
```
### How did you do it?
For single-asic devices, skipped prefixes are now added to fib_info file with nexthop '[]'.
#### How did you verify/test it?
Run test_basic_fib
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.173-dirty-20210412.032545
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: 7df4c0ad
Build date: Mon Apr 12 10:15:05 UTC 2021
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
