### PR TITLE
Fix warmboot pipeline - use DUT name instead of testbed name in pytest

### DIFF
--- a/tests/pipelines/cont-warmboot.yml
+++ b/tests/pipelines/cont-warmboot.yml
@@ -89,7 +89,7 @@ stages:
               pytest platform_tests/test_cont_warm_reboot.py \
                     --continuous_reboot_count=$CONTINUOUS_REBOOT_COUNT \
                     --continuous_reboot_delay=$CONTINUOUS_REBOOT_DELAY \
-                    --testbed=$(tbname) --host-pattern=$(tbname) --inventory=/data/sonic-mgmt/ansible/veos_vtb \
+                    --testbed=$(tbname) --host-pattern=$(dut) --inventory=/data/sonic-mgmt/ansible/veos_vtb \
                     --testbed_file=/data/sonic-mgmt/ansible/vtestbed.csv --module-path=/data/sonic-mgmt/ansible/library \
                     --show-capture=no --log-cli-level=INFO  \
                     --image_location=$IMAGE_LOCATION --image_list=$IMAGE_LIST \
@@ -150,3 +150,4 @@ stages:
         testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'
         testRunTitle: kvmtest
       condition: succeededOrFailed()
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
Fix warmboot pipeline - use DUT name instead of testbed name in pytest

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
After latest enhancements, the pytest command in warmboot pipeline has started failing with:
```
        if any([dut not in testbed_duts for dut in specified_duts]):
>           pytest.fail("One of the specified DUTs {} does not belong to the testbed {}".format(specified_duts, tbname))
E           Failed: One of the specified DUTs ['vms-kvm-t0'] does not belong to the testbed vms-kvm-t0

conftest.py:201: Failed
```
https://dev.azure.com/mssonic/build/_build/results?buildId=11178&view=logs&j=917c1508-19c3-53d5-10ca-59367f40e278&t=ee91ab2a-89fc-53fe-e8a3-d4d569b7f2e0

#### How did you do it?
Fix the DUT name argument in the pytest cmd.

#### How did you verify/test it?
Tested locally on a KVM.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
