### PR TITLE
[dualtor] Add downstream standby mux toggle with route to server added

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -25,7 +25,9 @@ __all__ = [
     'mock_server_ip_mac_map',
     'set_dual_tor_state_to_orchagent',
     'del_dual_tor_state_from_orchagent',
-    'is_t0_mocked_dualtor'
+    'is_t0_mocked_dualtor',
+    'is_mocked_dualtor',
+    'set_mux_state'
 ]
 
 logger = logging.getLogger(__name__)
@@ -127,6 +129,22 @@ def _apply_dual_tor_state_to_orchagent(dut, state, tor_mux_intfs):
     set_dual_tor_state_to_orchagent(dut, state, tor_mux_intfs)
     yield
     del_dual_tor_state_from_orchagent(dut, state, tor_mux_intfs)
+
+
+def is_mocked_dualtor(tbinfo):
+    return 'dualtor' not in tbinfo['topo']['name']
+
+
+def set_mux_state(dut, tbinfo, state, itfs, toggle_all_simulator_ports):
+    if is_mocked_dualtor(tbinfo):
+        set_dual_tor_state_to_orchagent(dut, state, itfs)
+    else:
+        dut_index = tbinfo['duts'].index(dut.hostname)
+        if dut_index == 0 and state == 'active' or dut_index == 1 and state == 'standby':
+            side = 'upper_tor'
+        else:
+            side = 'lower_tor'
+        toggle_all_simulator_ports(side)
 
 
 @pytest.fixture(scope='module')

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -591,7 +591,7 @@ def mux_cable_server_ip(dut):
     return json.loads(mux_cable_config)
 
 
-def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, standby_tor_ip, target_server_ip, target_server_port, ptf_portchannel_indices):
+def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, standby_tor_ip, selected_port, target_server_ip, target_server_port, ptf_portchannel_indices):
     """
     Function for testing traffic distribution among all avtive T1.
     A test script will be running on ptf to generate traffic to standby interface, and the traffic will be forwarded to

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -38,10 +38,6 @@ def clear_portstat(dut):
     dut.shell("portstat -c")
 
 
-def is_mocked_dualtor(tbinfo):
-    return 'dualtor' not in tbinfo['topo']['name']
-
-
 @pytest.fixture(scope='module', autouse=True)
 def test_cleanup(rand_selected_dut):
     """
@@ -51,23 +47,11 @@ def test_cleanup(rand_selected_dut):
     config_reload(rand_selected_dut)
 
 
-def set_mux_state(dut, tbinfo, state, itfs, toggle_all_simulator_ports):
-    if is_mocked_dualtor(tbinfo):
-        set_dual_tor_state_to_orchagent(dut, state, [itfs])
-    else:
-        dut_index = tbinfo['duts'].index(dut.hostname)
-        if dut_index == 0 and state == 'active' or dut_index == 1 and state == 'standby':
-            side = 'upper_tor'
-        else:
-            side = 'lower_tor'
-        toggle_all_simulator_ports(side)
-
-
 def test_standby_tor_upstream_mux_toggle(rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface, toggle_all_simulator_ports, set_crm_polling_interval):
     itfs, ip = rand_selected_interface
     PKT_NUM = 100
     # Step 1. Set mux state to standby and verify traffic is dropped by ACL rule and drop counters incremented
-    set_mux_state(rand_selected_dut, tbinfo, 'standby', itfs, toggle_all_simulator_ports)
+    set_mux_state(rand_selected_dut, tbinfo, 'standby', [itfs], toggle_all_simulator_ports)
     # Wait sometime for mux toggle
     time.sleep(PAUSE_TIME)
     crm_facts0 = rand_selected_dut.get_crm_facts()
@@ -87,7 +71,7 @@ def test_standby_tor_upstream_mux_toggle(rand_selected_dut, tbinfo, ptfadapter, 
                 "RX_DRP for {} is expected to increase by {} actually {}".format(itfs, PKT_NUM, drop_counter))
 
     # Step 2. Toggle mux state to active, and verify traffic is not dropped by ACL and fwd-ed to uplinks; verify CRM show and no nexthop objects are stale
-    set_mux_state(rand_selected_dut, tbinfo, 'active', itfs, toggle_all_simulator_ports)
+    set_mux_state(rand_selected_dut, tbinfo, 'active', [itfs], toggle_all_simulator_ports)
     # Wait sometime for mux toggle
     time.sleep(PAUSE_TIME)
     # Verify packets are not go up
@@ -100,7 +84,7 @@ def test_standby_tor_upstream_mux_toggle(rand_selected_dut, tbinfo, ptfadapter, 
                             drop=False)
 
     # Step 3. Toggle mux state to standby, and verify traffic is dropped by ACL; verify CRM show and no nexthop objects are stale
-    set_mux_state(rand_selected_dut, tbinfo, 'standby', itfs, toggle_all_simulator_ports)
+    set_mux_state(rand_selected_dut, tbinfo, 'standby', [itfs], toggle_all_simulator_ports)
      # Wait sometime for mux toggle
     time.sleep(PAUSE_TIME)
     # Verify packets are not go up again


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: New dualtor orch testcase: add downstream standby mux toggle with route to server added
Fixes: https://github.com/Azure/sonic-mgmt/issues/3275

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Check standby/active forwarding with 1) Standby MUX toggle 2) Route to server (standby neighbor) added.

#### How did you do it?
New testcase.

#### How did you verify/test it?

Tested on physical dualtor testbed:
```
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
18:57:43 facts_cache.read                         L0093 INFO   | Load cache file "/var/src/Networking-acs-sonic-mgmt/tests/_cache/str2-7050cx3-acs-11/mg_facts.pickle" failed with exception: IOError(2, 'No such file or directory')
18:57:43 facts_cache.write                        L0120 INFO   | Cached facts "str2-7050cx3-acs-11.mg_facts" to /var/src/Networking-acs-sonic-mgmt/tests/_cache/str2-7050cx3-acs-11/mg_facts.pickle
18:57:48 test_orchagent_standby_tor_downstream.bu L0218 INFO   | the packet destinated to server 192.168.0.9:
###[ Ethernet ]###
  dst       = 94:8e:d3:04:eb:28
  src       = 9a:69:d5:62:2a:00
  type      = 0x800
###[ IP ]###
     version   = 4
     ihl       = None
     tos       = 0x20
     len       = None
     id        = 1
     flags     = 
     frag      = 0
     ttl       = 36
     proto     = hopopt
     chksum    = None
     src       = 1.1.1.1
     dst       = 192.168.0.9
     \options   \
###[ Raw ]###
        load      = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./0123456789:;<=>?@A'

18:57:49 dual_tor_utils.get_t1_ptf_ports          L0145 INFO   | Using portchannel ports ['eth56', 'eth57'] on PTF for DUT str2-7050cx3-acs-10
18:57:49 test_orchagent_standby_tor_downstream.te L0327 INFO   | Stage 1: Verify Standby Forwarding
18:57:49 test_orchagent_standby_tor_downstream.te L0328 INFO   | Step 1.1: Add route to a nexthop which is a standby Neighbor
18:57:49 mux_simulator_control._toggle_all_simula L0272 INFO   | Toggle all ports to "lower_tor"
18:57:56 test_orchagent_standby_tor_downstream.ad L0098 INFO   | Applying route on str2-7050cx3-acs-10 to dst 192.168.0.9
18:57:58 test_orchagent_standby_tor_downstream.ad L0118 INFO   | Route added to str2-7050cx3-acs-10: ip route replace 192.168.0.9/32 nexthop via 192.168.0.9 
18:57:58 test_orchagent_standby_tor_downstream.te L0331 INFO   | Step 1.2: Verify traffic to this route dst is forwarded to Active ToR and equally distributed
18:57:58 dual_tor_utils.check_tunnel_balance      L0622 INFO   | run ptf test for verifying IPinIP tunnel balance
18:57:58 dual_tor_utils.check_tunnel_balance      L0625 INFO   | PTF log file: /tmp/ip_in_ip_tunnel_test.2021-04-16-18:57:58.log
19:06:04 server_traffic_utils.__exit__            L0104 INFO   | the expected packet:
0000   94 8E D3 04 EB 28 9A 69  D5 62 2A 00 08 00 45 20   .....(.i.b*...E 
0010   00 56 00 01 00 00 24 00  D3 D4 01 01 01 01 C0 A8   .V....$.........
0020   00 09 00 01 02 03 04 05  06 07 08 09 0A 0B 0C 0D   ................
0030   0E 0F 10 11 12 13 14 15  16 17 18 19 1A 1B 1C 1D   ................
0040   1E 1F 20 21 22 23 24 25  26 27 28 29 2A 2B 2C 2D   .. !"#$%&'()*+,-
0050   2E 2F 30 31 32 33 34 35  36 37 38 39 3A 3B 3C 3D   ./0123456789:;<=
0060   3E 3F 40 41                                        >?@A
mask = 00 00 00 00 00 00 00 00  00 00 00 00 ff ff ff 00
0010   ff ff ff ff ff ff 00 ff  00 00 ff ff ff ff ff ff
0020   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0030   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0040   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0050   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0060   ff ff ff ff  

19:06:04 server_traffic_utils.__exit__            L0106 INFO   | received 10 matched packets
19:06:04 server_traffic_utils.__exit__            L0110 INFO   | display the most recent matched captured packet:
dst        : DestMACField         = '12:08:92:ca:29:12' (None)
src        : SourceMACField       = '00:aa:bb:cc:dd:ee' (None)
type       : XShortEnumField      = 2048            (0)
--
version    : BitField             = 4L              (4)
ihl        : BitField             = 5L              (None)
tos        : XByteField           = 32              (0)
len        : ShortField           = 86              (None)
id         : ShortField           = 1               (1)
flags      : FlagsField           = 0L              (0)
frag       : BitField             = 0L              (0)
ttl        : ByteField            = 34              (64)
proto      : ByteEnumField        = 0               (0)
chksum     : XShortField          = 54740           (None)
src        : Emph                 = '1.1.1.1'       (None)
dst        : Emph                 = '192.168.0.9'   ('127.0.0.1')
options    : PacketListField      = []              ([])
--
load       : StrField             = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./0123456789:;<=>?@A' ('')

19:06:04 test_orchagent_standby_tor_downstream.te L0335 INFO   | Stage 2: Verify Active Forwarding
19:06:04 test_orchagent_standby_tor_downstream.te L0336 INFO   | Step 2.1: Simulate Mux state change to active
19:06:04 mux_simulator_control._toggle_all_simula L0272 INFO   | Toggle all ports to "upper_tor"
19:06:13 test_orchagent_standby_tor_downstream.te L0338 INFO   | Step 2.2: Verify traffic to this route dst is forwarded directly to server
19:06:18 server_traffic_utils.__exit__            L0104 INFO   | the expected packet:
0000   94 8E D3 04 EB 28 9A 69  D5 62 2A 00 08 00 45 20   .....(.i.b*...E 
0010   00 56 00 01 00 00 24 00  D3 D4 01 01 01 01 C0 A8   .V....$.........
0020   00 09 00 01 02 03 04 05  06 07 08 09 0A 0B 0C 0D   ................
0030   0E 0F 10 11 12 13 14 15  16 17 18 19 1A 1B 1C 1D   ................
0040   1E 1F 20 21 22 23 24 25  26 27 28 29 2A 2B 2C 2D   .. !"#$%&'()*+,-
0050   2E 2F 30 31 32 33 34 35  36 37 38 39 3A 3B 3C 3D   ./0123456789:;<=
0060   3E 3F 40 41                                        >?@A
mask = 00 00 00 00 00 00 00 00  00 00 00 00 ff ff ff 00
0010   ff ff ff ff ff ff 00 ff  00 00 ff ff ff ff ff ff
0020   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0030   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0040   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0050   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0060   ff ff ff ff  

19:06:18 server_traffic_utils.__exit__            L0106 INFO   | received 10 matched packets
19:06:18 server_traffic_utils.__exit__            L0110 INFO   | display the most recent matched captured packet:
dst        : DestMACField         = '12:08:92:ca:29:12' (None)
src        : SourceMACField       = '00:aa:bb:cc:dd:ee' (None)
type       : XShortEnumField      = 2048            (0)
--
version    : BitField             = 4L              (4)
ihl        : BitField             = 5L              (None)
tos        : XByteField           = 32              (0)
len        : ShortField           = 86              (None)
id         : ShortField           = 1               (1)
flags      : FlagsField           = 0L              (0)
frag       : BitField             = 0L              (0)
ttl        : ByteField            = 35              (64)
proto      : ByteEnumField        = 0               (0)
chksum     : XShortField          = 54484           (None)
src        : Emph                 = '1.1.1.1'       (None)
dst        : Emph                 = '192.168.0.9'   ('127.0.0.1')
options    : PacketListField      = []              ([])
--
load       : StrField             = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./0123456789:;<=>?@A' ('')

19:06:19 test_orchagent_standby_tor_downstream.te L0341 INFO   | Stage 3: Verify Standby Forwarding Again
19:06:19 test_orchagent_standby_tor_downstream.te L0342 INFO   | Step 3.1: Simulate Mux state change to standby
19:06:19 mux_simulator_control._toggle_all_simula L0272 INFO   | Toggle all ports to "lower_tor"
19:06:27 test_orchagent_standby_tor_downstream.te L0344 INFO   | Step 3.2: Verify traffic to this route dst is now redirected back to Active ToR and equally distributed
19:06:32 server_traffic_utils.__exit__            L0104 INFO   | the expected packet:
0000   94 8E D3 04 EB 28 9A 69  D5 62 2A 00 08 00 45 20   .....(.i.b*...E 
0010   00 56 00 01 00 00 24 00  D3 D4 01 01 01 01 C0 A8   .V....$.........
0020   00 09 00 01 02 03 04 05  06 07 08 09 0A 0B 0C 0D   ................
0030   0E 0F 10 11 12 13 14 15  16 17 18 19 1A 1B 1C 1D   ................
0040   1E 1F 20 21 22 23 24 25  26 27 28 29 2A 2B 2C 2D   .. !"#$%&'()*+,-
0050   2E 2F 30 31 32 33 34 35  36 37 38 39 3A 3B 3C 3D   ./0123456789:;<=
0060   3E 3F 40 41                                        >?@A
mask = 00 00 00 00 00 00 00 00  00 00 00 00 ff ff ff 00
0010   ff ff ff ff ff ff 00 ff  00 00 ff ff ff ff ff ff
0020   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0030   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0040   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0050   ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff
0060   ff ff ff ff  

19:06:32 server_traffic_utils.__exit__            L0106 INFO   | received 10 matched packets
19:06:32 server_traffic_utils.__exit__            L0110 INFO   | display the most recent matched captured packet:
dst        : DestMACField         = '12:08:92:ca:29:12' (None)
src        : SourceMACField       = '00:aa:bb:cc:dd:ee' (None)
type       : XShortEnumField      = 2048            (0)
--
version    : BitField             = 4L              (4)
ihl        : BitField             = 5L              (None)
tos        : XByteField           = 32              (0)
len        : ShortField           = 86              (None)
id         : ShortField           = 1               (1)
flags      : FlagsField           = 0L              (0)
frag       : BitField             = 0L              (0)
ttl        : ByteField            = 34              (64)
proto      : ByteEnumField        = 0               (0)
chksum     : XShortField          = 54740           (None)
src        : Emph                 = '1.1.1.1'       (None)
dst        : Emph                 = '192.168.0.9'   ('127.0.0.1')
options    : PacketListField      = []              ([])
--
load       : StrField             = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./0123456789:;<=>?@A' ('')

19:06:32 dual_tor_utils.check_tunnel_balance      L0622 INFO   | run ptf test for verifying IPinIP tunnel balance
19:06:32 dual_tor_utils.check_tunnel_balance      L0625 INFO   | PTF log file: /tmp/ip_in_ip_tunnel_test.2021-04-16-19:06:32.log
19:14:47 test_orchagent_standby_tor_downstream.re L0125 INFO   | Removing dual ToR peer switch static route
PASSED  
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
