### PR TITLE
Platform tests: remove autouse=True from loganalyzer fixture

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -62,7 +62,7 @@ def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):
         for port in ports:
             duthost.no_shutdown(ifname=port)
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname):
     """
     Advance reboot log analysis.

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -10,7 +10,7 @@ pytestmark = [
 ]
 
 @pytest.mark.usefixtures('get_advanced_reboot')
-def test_fast_reboot(request, get_advanced_reboot):
+def test_fast_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     '''
     Fast reboot test case is run using advacned reboot test fixture
 
@@ -22,7 +22,7 @@ def test_fast_reboot(request, get_advanced_reboot):
 
 @pytest.mark.usefixtures('get_advanced_reboot')
 @pytest.mark.device_type('vs')
-def test_warm_reboot(request, get_advanced_reboot):
+def test_warm_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     '''
     Warm reboot test case is run using advacned reboot test fixture
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove autouse of `advanceboot_loganalyzer` fixture from platform_tests.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
All the platform tests are automatically using function scoped fixture `advanceboot_loganalyzer`.
Limit the use of `advanceboot_loganalyzer` fixture only for fast and warm reboot tests.

#### How did you do it?
Removed autouse=True
Added fixture for test_warm_reboot, and test_fast_reboot.

#### How did you verify/test it?
Tested test_warm_Reboot on KVM switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
