### PR TITLE
added an explicit test skip for test_lag when no LAGs found

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -238,6 +238,14 @@ class LagTest:
             vm_host.no_shutdown(neighbor_intf)
             wait_until(wait_timeout, delay, self.__check_intf_state, vm_host, neighbor_intf, True)
 
+@pytest.fixture(autouse=True, scope='module')
+def skip_if_no_lags(duthosts):
+    def has_lags(dut):
+        lag_facts = dut.lag_facts(host = dut.hostname)['ansible_facts']['lag_facts']
+        return len(lag_facts['names']) > 0
+    some_dut_has_lags = any(has_lags(dut) for dut in duthosts)
+    pytest_require(some_dut_has_lags, 'No LAGs found in any DUT')
+
 @pytest.mark.parametrize("testcase", ["single_lag",
                                       "lacp_rate",
                                       "fallback"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: added an explicit test skip for test_lag when no LAGs found
Fixes # (issue)
- test_lag is failing because of not meet precondition on LAG-less topos - the tests requires LAGs but they're not present. Modified the test to be skipped in such cases instead of failing it


<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Get rid of false bug indication
#### How did you do it?
Checked LAGs list is not empty before running tests
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1 pc/test_lag_2.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
