### PR TITLE
[Mellanox] Removed invalid sensors path for msn2100 and msn2010

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -945,8 +945,6 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -1040,8 +1038,6 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
-        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_crit
       - - coretemp-isa-0000/Core 1/temp3_input


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Removed invalid sensors path for msn2100 and msn2010
Fixes # (issue): fix for test case "platform_tests/test_sensors.py"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
It is fix for test case "platform_tests/test_sensors.py".

#### How did you do it?
Removed invalid sensor path for specific platforms

#### How did you verify/test it?
Executed test case  "platform_tests/test_sensors.py"

#### Any platform specific information?
Related to platforms:
x86_64-mlnx_msn2100-r0
x86_64-mlnx_msn2010-r0

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
