### PR TITLE
[port_utils] Update port_utils to match new z9332f port aliases

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -25,6 +25,7 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
     elif hwsku == "Force10-Z9100":
         for i in range(0, 128, 4):
             port_alias_to_name_map["hundredGigE1/%d" % (i / 4 + 1)] = "Ethernet%d" % i
+    # TODO: Come up with a generic formula for generating etp style aliases based on number of ports and lanes
     elif hwsku == "DellEMC-Z9332f-M-O16C64":
         # 100G ports
         s100G_ports = [x for x in range(0, 96, 2)] + [x for x in range(128, 160, 2)]
@@ -36,20 +37,20 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
         s10G_ports = [x for x in range(256, 258)]
 
         for i in s100G_ports:
-            alias = "hundredGigE1/{}/{}".format(((i + 8) // 8), ((i // 2) % 4) + 1)
+            alias = "etp{}{}".format(((i + 8) // 8), chr(ord('a') + (i // 2) % 4))
             port_alias_to_name_map[alias] = "Ethernet{}".format(i)
         for i in s400G_ports:
-            alias = "fourhundredGigE1/{}".format((i // 8) + 1)
+            alias = "etp{}".format((i // 8) + 1)
             port_alias_to_name_map[alias] = "Ethernet{}".format(i)
         for i in s10G_ports:
-            alias = "tenGigE1/{}".format(33 if i == 256 else 34)
+            alias = "etp{}".format(33 if i == 256 else 34)
             port_alias_to_name_map[alias] = "Ethernet{}".format(i)
     elif hwsku == "DellEMC-Z9332f-O32":
         for i in range(0, 256, 8):
-            alias = "fourhundredGigE1/{}".format((i // 8) + 1)
+            alias = "etp{}".format((i // 8) + 1)
             port_alias_to_name_map[alias] = "Ethernet{}".format(i)
         for i in range(256, 258):
-            alias = "tenGigE1/{}".format(33 if i == 256 else 34)
+            alias = "etp{}".format(33 if i == 256 else 34)
             port_alias_to_name_map[alias] = "Ethernet{}".format(i)
     elif hwsku == "Arista-7050-QX32":
         for i in range(1, 25):


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
A recent PR in sonic-buildimage updated the z9332f platform to use `etp` style aliases, so port_utils needs to be updated.

#### How did you do it?
Changed the formulas to use `etp` instead of `hundredGig...`.

#### How did you verify/test it?
Ran code locally to verify the correct port aliases are generated.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
