### PR TITLE
[start-vms] protect against none type

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -259,7 +259,7 @@ class VMTopology(object):
                 fp_br_name = OVS_FP_BRIDGE_TEMPLATE % (vm, fp_num)
                 self.create_ovs_bridge(fp_br_name, self.fp_mtu)
 
-        if 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
+        if self.topo and 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
             # We have a KVM based virtual chassis, need to create bridge for midplane and inband.
             self.create_ovs_bridge(VS_CHASSIS_INBAND_BRIDGE_NAME, self.fp_mtu)
             self.create_ovs_bridge(VS_CHASSIS_MIDPLANE_BRIDGE_NAME, self.fp_mtu)
@@ -486,7 +486,7 @@ class VMTopology(object):
                 injected_iface = INJECTED_INTERFACES_TEMPLATE % (self.vm_set_name, ptf_index)
                 self.bind_ovs_ports(br_name, self.duts_fp_ports[self.duts_name[dut_index]][str(vlan_index)], injected_iface, vm_iface, disconnect_vm)
 
-        if 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
+        if self.topo and 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
             # We have a KVM based virtaul chassis, bind the midplane and inband ports
             self.bind_vs_dut_ports(VS_CHASSIS_INBAND_BRIDGE_NAME, self.topo['DUT']['vs_chassis']['inband_port'])
             self.bind_vs_dut_ports(VS_CHASSIS_MIDPLANE_BRIDGE_NAME, self.topo['DUT']['vs_chassis']['midplane_port'])
@@ -500,7 +500,7 @@ class VMTopology(object):
                 vm_iface = OVS_FP_TAP_TEMPLATE % (self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                 self.unbind_ovs_ports(br_name, vm_iface)
 
-        if 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
+        if self.topo and 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
             # We have a KVM based virtaul chassis, unbind the midplane and inband ports
             self.unbind_vs_dut_ports(VS_CHASSIS_INBAND_BRIDGE_NAME, self.topo['DUT']['vs_chassis']['inband_port'])
             self.unbind_vs_dut_ports(VS_CHASSIS_MIDPLANE_BRIDGE_NAME, self.topo['DUT']['vs_chassis']['midplane_port'])


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
start vm on server failed:

#### How did you do it?
When self.topo is none, following if statement is not safe:

The full traceback is:
WARNING: The below traceback may *not* be related to the actual failure.
  File "/tmp/ansible_vm_topology_payload_pPqW60/__main__.py", line 1038, in main
    net.create_bridges()
  File "/tmp/ansible_vm_topology_payload_pPqW60/__main__.py", line 262, in create_bridges
    if 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### How did you verify/test it?
start vms on a server