### PR TITLE
Fix the exabgp dump file growth issue

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+import os
 import re
+import time
 
 DOCUMENTATION = '''
 module:  exabgp
@@ -41,27 +43,7 @@ import sys
 import jinja2
 from ansible.module_utils.basic import *
 
-DEFAULT_DUMP_SCRIPT = "/usr/share/exabgp/dump.py"
 DEFAULT_BGP_LISTEN_PORT = 179
-
-dump_py = '''\
-#!/usr/bin/env python
-
-from sys import stdin
-import json
-import os
-import sys
-
-while True:
-    try:
-        line = stdin.readline()
-        obj = json.loads(line)
-        f = open("/tmp/exabgp-" + obj["neighbor"]["address"]["local"], "a")
-        print >> f, line,
-        f.close()
-    except:
-        continue
-'''
 
 http_api_py = '''\
 from flask import Flask, request
@@ -89,16 +71,20 @@ if __name__ == '__main__':
     app.run(host='0.0.0.0', port=sys.argv[1])
 '''
 
-exabgp_conf_tmpl = '''\
-group exabgp {
+dump_config_tmpl='''\
     process dump {
         encoder json;
         receive {
             parsed;
             update;
         }
-        run /usr/bin/python {{ dump_script }};
+        run /usr/bin/python {dump_script};
     }
+'''
+
+exabgp_conf_tmpl = '''\
+group exabgp {
+{{ dump_config }}
 
     process http-api {
         run /usr/bin/python /usr/share/exabgp/http_api.py {{ port }};
@@ -124,6 +110,10 @@ exabgp_supervisord_conf_tmpl = '''\
 command=/usr/local/bin/exabgp /etc/exabgp/{{ name }}.conf
 stdout_logfile=/tmp/exabgp-{{ name }}.out.log
 stderr_logfile=/tmp/exabgp-{{ name }}.err.log
+stdout_logfile_maxbytes=10000000
+stdout_logfile_backups=2
+stderr_logfile_maxbytes=10000000
+stderr_logfile_backups=2
 redirect_stderr=false
 autostart=true
 autorestart=true
@@ -172,23 +162,28 @@ def restart_exabgp(module, name):
 def stop_exabgp(module, name):
     exec_command(module, cmd="supervisorctl stop exabgp-%s" % name, ignore_error=True)
 
-def setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, auto_flush=True, group_updates=True, dump_script=DEFAULT_DUMP_SCRIPT, passive=False):
+def setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, auto_flush=True, group_updates=True, dump_script=None, passive=False):
     try:
         os.mkdir("/etc/exabgp", 0755)
     except OSError:
         pass
 
+    dump_config = ""
+    if dump_script:
+        dump_config = dump_config_tmpl.format(dump_script=dump_script)
+
     t = jinja2.Template(exabgp_conf_tmpl)
-    data = t.render(name=name, \
-                    router_id=router_id, \
-                    local_ip=local_ip, \
-                    peer_ip=peer_ip, \
-                    local_asn=local_asn, \
-                    peer_asn=peer_asn, \
-                    port=port, \
-                    auto_flush=auto_flush, \
-                    group_updates=group_updates, \
-                    dump_script=dump_script, passive=passive,
+    data = t.render(name=name,
+                    router_id=router_id,
+                    local_ip=local_ip,
+                    peer_ip=peer_ip,
+                    local_asn=local_asn,
+                    peer_asn=peer_asn,
+                    port=port,
+                    auto_flush=auto_flush,
+                    group_updates=group_updates,
+                    dump_config=dump_config,
+                    passive=passive,
                     listen_port=DEFAULT_BGP_LISTEN_PORT)
     with open("/etc/exabgp/%s.conf" % name, 'w') as out_file:
         out_file.write(data)
@@ -198,7 +193,6 @@ def remove_exabgp_conf(name):
         os.remove("/etc/exabgp/%s.conf" % name)
     except Exception:
         pass
-
 
 def setup_exabgp_supervisord_conf(name):
     t = jinja2.Template(exabgp_supervisord_conf_tmpl)
@@ -212,14 +206,11 @@ def remove_exabgp_supervisord_conf(name):
     except Exception:
         pass
 
-def setup_exabgp_processor(use_default_dump_script):
+def setup_exabgp_processor():
     try:
         os.mkdir("/usr/share/exabgp", 0755)
     except OSError:
         pass
-    if use_default_dump_script:
-        with open(DEFAULT_DUMP_SCRIPT, 'w') as out_file:
-            out_file.write(dump_py)
     with open("/usr/share/exabgp/http_api.py", 'w') as out_file:
         out_file.write(http_api_py)
 
@@ -234,7 +225,7 @@ def main():
             local_asn=dict(required=False, type='int'),
             peer_asn=dict(required=False, type='int'),
             port=dict(required=False, type='int', default=5000),
-            dump_script=dict(required=False, type='str', default=DEFAULT_DUMP_SCRIPT),
+            dump_script=dict(required=False, type='str', default=None),
             passive=dict(required=False, type='bool', default=False)
         ),
         supports_check_mode=False)
@@ -250,7 +241,7 @@ def main():
     dump_script = module.params['dump_script']
     passive = module.params['passive']
 
-    setup_exabgp_processor(dump_script==DEFAULT_DUMP_SCRIPT)
+    setup_exabgp_processor()
 
     result = {}
     try:

--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -78,7 +78,7 @@ dump_config_tmpl='''\
             parsed;
             update;
         }
-        run /usr/bin/python {dump_script};
+        run /usr/bin/python {{ dump_script }};
     }
 '''
 
@@ -170,7 +170,7 @@ def setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, p
 
     dump_config = ""
     if dump_script:
-        dump_config = dump_config_tmpl.format(dump_script=dump_script)
+        dump_config = jinja2.Template(dump_config_tmpl).render(dump_script=dump_script)
 
     t = jinja2.Template(exabgp_conf_tmpl)
     data = t.render(name=name,

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -23,7 +23,7 @@
     ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
     ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
 
-- name: Start exabgp processes for IPv4 on PTF
+- name: (Re)start exabgp processes for IPv4 on PTF
   exabgp:
     name: "{{ vm_item.key }}"
     state: "restarted"
@@ -40,7 +40,7 @@
     loop_var: vm_item
   delegate_to: "{{ ptf_host }}"
 
-- name: Start exabgp processes for IPv6 on PTF
+- name: (Re)start exabgp processes for IPv6 on PTF
   exabgp:
     name: "{{ vm_item.key }}-v6"
     state: "restarted"
@@ -59,7 +59,7 @@
 
 - name: Wait for exabgp to (re)start
   pause:
-    seconds: "{{ 2 * [topology['VMs']|dict2items|length, 10] | min }}"
+    seconds: "{{ 2 * topology['VMs']|dict2items|length }}"
 
 - name: Verify that exabgp processes for IPv4 are started
   wait_for:

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -26,7 +26,7 @@
 - name: Start exabgp processes for IPv4 on PTF
   exabgp:
     name: "{{ vm_item.key }}"
-    state: "started"
+    state: "restarted"
     router_id: "{{ ptf_local_ipv4 }}"
     local_ip: "{{ ptf_local_ipv4 }}"
     peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv4.split('/')[0] }}"
@@ -43,7 +43,7 @@
 - name: Start exabgp processes for IPv6 on PTF
   exabgp:
     name: "{{ vm_item.key }}-v6"
-    state: "started"
+    state: "restarted"
     router_id: "{{ ptf_local_ipv4 }}"
     local_ip: "{{ ptf_local_ipv6 }}"
     peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv6.split('/')[0] }}"
@@ -56,6 +56,10 @@
   loop_control:
     loop_var: vm_item
   delegate_to: "{{ ptf_host }}"
+
+- name: Wait for exabgp to (re)start
+  pause:
+    seconds: "{{ 2 * [topology['VMs']|dict2items|length, 10] | min }}"
 
 - name: Verify that exabgp processes for IPv4 are started
   wait_for:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The exabgp processes running in PTF docker will dump any route changes to files under /tmp folder.
The dumped content includes announced routes and routes change from neighbor VMs. In case of T1 topology,
DUT learns most of the routes from T2 VMs. The routes are propagated to T0 VMs by DUT. The T0 VMs will then
propagate the routes to the exabgp processes in PTF docker. If BGP on DUT is restarted, DUT will withdraw and
announce the routes to T0 VMs. Then the T0 VMs will withdraw and announce the routes to PTF docker. All the
activities are recorded to dump file. Consequently the dump file will grow infinitely unless the PTF docker is
recreated and eventually cause no disk space issue.

#### How did you do it?
The dump file indeed is not required for announcing routes from PTF to VMs. This change deprecated the default
dumping function. With this change, by default there will be no dump unless the exabgp module is called with
argument 'dump_script'. The 'dump_script' argument is currently used by the BGP monitoring tests.

Other changes:
* Enabled log rotation for exabgp processes
* Restart exabgp process during announce routes if exabgp processes are already running

#### How did you verify/test it?
Tested:
* remove add topo
* announce routes
* bgp/test_bgpmon.py
* bgp/test_bgp_facts.py
* bgp/test_bgp_speaker.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
