### PR TITLE
Add back the support of pytest option "--host-pattern all"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,9 @@ def get_specified_duts(request):
     testbed_duts = tbinfo['duts']
 
     host_pattern = request.config.getoption("--host-pattern")
+    if host_pattern=='all':
+        return testbed_duts
+
     if ';' in host_pattern:
         specified_duts = host_pattern.replace('[', '').replace(']', '').split(';')
     else:
@@ -245,7 +248,7 @@ def rand_one_dut_hostname(request):
     """
     dut_hostnames = generate_params_dut_hostname(request)
     if len(dut_hostnames) > 1:
-        dut_hostnames = random.sample(dut_hostnames, 1) 
+        dut_hostnames = random.sample(dut_hostnames, 1)
     logger.info("Randomly select dut {} for testing".format(dut_hostnames[0]))
     return dut_hostnames[0]
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
PR #3327 broke the support of pytest option "--host-pattern all". A specific DUT hostname must be provided. 

#### How did you do it?
This change is to add back the support of specifying pytest option "--host-pattern all" to match all DUTs of current testbed.

#### How did you verify/test it?
Tested pytest option:
* "--host-pattern vlab-01"
* "--host-pattern all"
* "--host-pattern nonexist"

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
