### PR TITLE
[pfc_asym] Fixed 'deploy_pfc_gen' fixture

### DIFF
--- a/tests/common/fixtures/pfc_asym.py
+++ b/tests/common/fixtures/pfc_asym.py
@@ -24,9 +24,10 @@ ARP_RESPONDER_CONF = os.path.join(TESTS_ROOT, "templates/arp_responder.conf.j2")
 def get_fanout(fanout_graph_facts, setup):
     for fanout_host_name, value in fanout_graph_facts.items():
         for _, ports in value["device_conn"].items():
-            for fanout_inf, peer_info in ports.items():
-                if peer_info["peerport"] == setup["ptf_test_params"]["server_ports"][0]["dut_name"]:
-                    return fanout_host_name
+            for attr, attr_info in ports.items():
+                if attr == "peerport":
+                    if attr_info == setup["ptf_test_params"]["server_ports"][0]["dut_name"]:
+                        return fanout_host_name
     return None
 
 
@@ -112,15 +113,13 @@ def pfc_storm_runner(fanouthosts, fanout_graph_facts, pfc_storm_template, setup)
             dev_conn = fanout_graph_facts[fanout_host_name]["device_conn"]
             plist = []
             if self.server_ports:
-                for _, val in dev_conn.items():
-                    p = ",".join([key for key, value in val.items() if value["peerport"] in self.used_server_ports])
-                    if p:
-                        plist.append(p)
+                p = ",".join([iface for iface, value in dev_conn.items() if value["peerport"] in self.used_server_ports])
+                if p:
+                    plist.append(p)
             if self.non_server_port:
-                for _, val in dev_conn.items():
-                    p = ",".join([key for key, value in val.items() if value["peerport"] in self.used_non_server_port])
-                    if p:
-                        plist.append(p)
+                p = ",".join([iface for iface, value in dev_conn.items() if value["peerport"] in self.used_non_server_port])
+                if p:
+                    plist.append(p)
             params["pfc_fanout_interface"] += ",".join([key for key in plist])
             fanout_host.exec_template(ansible_root=ANSIBLE_ROOT, ansible_playbook=RUN_PLAYBOOK, inventory=setup["fanout_inventory"], \
                 **params)


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix usage of `fanout_graph_facts` data in `deploy_pfc_gen` fixture
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Motivation is to fix usage of `fanout_graph_facts` fixture by `deploy_pfc_gen` fixture located in  `common/fixtures/pfc_asym.py` module.
Some time ago there was a change in the `fanout_graph_facts` fixture, added by this commit - https://github.com/Azure/sonic-mgmt/commit/cd3864b0f05ba05163b919434ee7b291f4d66a7d

But `common/fixtures/pfc_asym.py` module was not aligned to this changes.

#### How did you do it?
Updated code to use new dictionary structure in the `common/fixtures/pfc_asym.py` module.

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
