### PR TITLE
[SNMP][multi-asic]: Modify snmp interfaces test case to support multi-asic platform.

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -17,7 +17,7 @@ def collect_all_facts(duthost, ports_list, namespace=None):
     setup = duthost.interface_facts(namespace=namespace)['ansible_facts']['ansible_interface_facts']
     config_facts = duthost.config_facts(host=duthost.hostname, source="running", namespace=namespace)['ansible_facts']
 
-    if namespace is None or namespace == "":
+    if not namespace:
         sonic_db_cmd = "sonic-db-cli"
     else:
         sonic_db_cmd = "sonic-db-cli -n {}".format(namespace)
@@ -59,8 +59,6 @@ def collect_all_facts(duthost, ports_list, namespace=None):
             oper = duthost.shell('{} STATE_DB HGET "MGMT_PORT_TABLE|{}" "oper_status"'.format(sonic_db_cmd, name), module_ignore_errors=False)
             result[name].update({'operstatus': oper['stdout']})
             result[name].update({'description': config_facts.get(key_word, {})[name].get('description', '')})
-
-             
     return result
 
 def verify_port_snmp(facts, snmp_facts):
@@ -157,6 +155,7 @@ def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_
     for po_name in config_facts.get('PORTCHANNEL', {}):
         assert po_name in snmp_ifnames, "PortChannel not found in SNMP facts."
 
+@pytest.mark.bsl
 def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_per_hwsku_hostname):
     """compare the snmp facts between observed states and target state"""
 

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -7,22 +7,22 @@ pytestmark = [
 ]
 
 
-def collect_all_facts(duthost):
+def collect_all_facts(duthost, namespace):
     """
     Collect all data needed for test per each port from DUT
     :param duthost: DUT host object
     :return: dict with data collected from DUT per each port
     """
     result = {}
-    setup = duthost.setup()['ansible_facts']
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    cmd = 'redis-cli -n 0 --raw hget "PORT_TABLE:{}" "{}"'
+    setup = duthost.interface_facts(namespace=namespace)['ansible_facts']['ansible_interface_facts']
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running", namespace=namespace)['ansible_facts']
+    sonic_db_cmd = "sonic-db-cli -n {} {} HGET {}{}{} {}"
+    net_opersate = "cat /sys/class/net/{}/operstate"
     ports_list = []
     _ = [ports_list.extend(config_facts.get(i, {}).keys())
          for i in ['port_name_to_alias_map', 'PORTCHANNEL', 'MGMT_INTERFACE']]
-
     for name in ports_list:
-        key = 'ansible_{}'.format(name)
+        key = name
         # 6 stands for ethernet-csmacd and 161 stands for ieee8023adLag
         if_type = '161' if name.startswith("PortChannel") else '6'
         if name.startswith("Eth"):
@@ -35,23 +35,32 @@ def collect_all_facts(duthost):
             try:
                 admin = config_facts.get('PORT', {})[name]['admin_status']
             except KeyError:
-                admin = duthost.shell(cmd.format(name, 'admin_status'))['stdout']
+                #admin = duthost.shell(cmd.format(name, 'admin_status'))['stdout']
+                admin = duthost.shell(sonic_db_cmd.format(namespace, "APPL_DB", "PORT_TABLE", ":", name, "admin_status"))['stdout']
             result[portname].update({'adminstatus': admin})
-            oper = duthost.shell(cmd.format(name, 'oper_status'))['stdout']
+            #oper = duthost.shell(cmd.format(name, 'oper_status'))['stdout']
+            oper = duthost.shell(sonic_db_cmd.format(namespace, "APPL_DB", "PORT_TABLE", ":", name, "oper_status"))['stdout']
             result[portname].update({'operstatus': oper})
             result[portname].update({'description': config_facts.get('PORT', {})[name]['description']})
-        else:
+        elif name.startswith("PortChannel"):
             result.setdefault(name, {})
-            key_word = "PORTCHANNEL" if name.startswith("PortChannel") else 'MGMT_PORT'
+            key_word = "PORTCHANNEL"
             result[name].update({'mtu': str(setup[key]['mtu'])})
             result[name].update({'type': if_type})
             result[name].update({'adminstatus': config_facts.get(key_word, {})[name]['admin_status']})
-            if name.startswith("PortChannel"):
-                oper = duthost.shell('redis-cli -n 0 --raw hget "LAG_TABLE:{}" "oper_status"'.format(name))
-            else:
-                oper = duthost.shell('redis-cli -n 6 --raw hget "MGMT_PORT_TABLE|{}" "oper_status"'.format(name))
+            oper = duthost.shell(sonic_db_cmd.format(namespace, "APPL_DB", "LAG_TABLE", ":", name, "oper_status"))
             result[name].update({'operstatus': oper['stdout']})
             result[name].update({'description': config_facts.get(key_word, {})[name].get('description', '')})
+        else:
+            result.setdefault(name, {})
+            result[name].update({'mtu': str(setup[key]['mtu'])})
+            result[name].update({'type': if_type})
+            result[name].update({'adminstatus': config_facts.get(key_word, {})[name]['admin_status']})
+            oper = duthost.shell(net_opersate.format(name))
+            result[name].update({'operstatus': oper['stdout']})
+            result[name].update({'description': config_facts.get(key_word, {})[name].get('description', '')})
+
+             
     return result
 
 def verify_port_snmp(facts, snmp_facts):
@@ -62,12 +71,15 @@ def verify_port_snmp(facts, snmp_facts):
     :return: Dict with unequal snmp_facts
     """
     missed = {}
-    for _, port_snmp in snmp_facts['snmp_interfaces'].items():
-        port_name = port_snmp['name']
+    import pdb; pdb.set_trace()
+    snmp_port_map = { snmp_facts['snmp_interfaces'][idx]['name'] : idx for idx in snmp_facts['snmp_interfaces'] }
+
+    for port_name in facts:
+        idx = snmp_port_map[port_name]
+        port_snmp = snmp_facts['snmp_interfaces'][idx]
         compare = ['operstatus', 'adminstatus', 'mtu', 'description', 'type']
         missed.setdefault(port_name, {})
         for field in compare:
-            # Skip MTU on mgmt port for now, due to not implemented in Sonic for mgmt port
             if field == 'mtu' and port_name.startswith('eth0'):
                 continue
             elif facts[port_name][field] != port_snmp[field]:
@@ -82,10 +94,12 @@ def verify_port_ifindex(snmp_facts, results):
     :return: dict with unequal snmp_facts per port
     """
     unique = []
-    for port_index, port_snmp in snmp_facts['snmp_interfaces'].items():
-        port_name = port_snmp['name']
+    snmp_port_map = { snmp_facts['snmp_interfaces'][idx]['name'] : idx for idx in snmp_facts['snmp_interfaces'] }
+    for port_name in results:
+        idx = snmp_port_map[port_name]
+        port_snmp = snmp_facts['snmp_interfaces'][idx]
         unique.append(port_snmp['ifindex'])
-        if int(port_index) - 1 != int(port_snmp['ifindex']):
+        if int(idx) - 1 != int(port_snmp['ifindex']):
             results[port_name].update({'ifindex': port_snmp['ifindex']})
     if len(unique) != len(set(unique)):
         pytest.fail("Ifindex MIB values are not unique {}".format(unique))
@@ -100,8 +114,10 @@ def verify_snmp_speed(facts, snmp_facts, results):
     :return: Updated dict with unequal snmp_facts
     """
     speed, high_speed = "speed", "ifHighSpeed"
-    for _, port_snmp in snmp_facts['snmp_interfaces'].items():
-        port_name = port_snmp['name']
+    snmp_port_map = { snmp_facts['snmp_interfaces'][idx]['name'] : idx for idx in snmp_facts['snmp_interfaces'] }
+    for port_name in results:
+        idx = snmp_port_map[port_name]
+        port_snmp = snmp_facts['snmp_interfaces'][idx]
         if port_name.startswith('Eth'):
             speed_to_bps = facts[port_name][speed] * 1000000
             if speed_to_bps > int(port_snmp[speed]):
@@ -159,14 +175,15 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     for name in config_facts.get('MGMT_INTERFACE', {}):
         assert name in snmp_ifnames, "Management Interface not found in SNMP facts."
 
-def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts):
+def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts, enum_asic_index):
     """Verify correct behaviour of port MIBs ifIndex, ifMtu, ifSpeed,
        ifAdminStatus, ifOperStatus, ifAlias, ifHighSpeed, ifType """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"])['ansible_facts']
 
-    dut_facts = collect_all_facts(duthost)
+    dut_facts = collect_all_facts(duthost, namespace)
     ports_snmps = verify_port_snmp(dut_facts, snmp_facts)
     speed_snmp = verify_snmp_speed(dut_facts, snmp_facts, ports_snmps)
     result = verify_port_ifindex(snmp_facts, speed_snmp)

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -176,8 +176,7 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     # is implemented for multi-asic platform
     if duthost.num_asics() == 1:
         ports_list = []
-        _ = [ports_list.extend(config_facts.get(i, {}).keys())
-             for i in ['MGMT_INTERFACE']]
+        ports_list.extend(config_facts.get('MGMT_INTERFACE', {}).keys())
         dut_facts = collect_all_facts(duthost, ports_list)
         ports_snmps = verify_port_snmp(dut_facts, snmp_facts)
         speed_snmp = verify_snmp_speed(dut_facts, snmp_facts, ports_snmps)
@@ -194,8 +193,8 @@ def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, localh
     config_facts = duthost.config_facts(host=duthost.hostname, source="persistent", namespace=namespace)['ansible_facts']
 
     ports_list = []
-    _ = [ports_list.extend(config_facts.get(i, {}).keys())
-         for i in ['port_name_to_alias_map', 'PORTCHANNEL']]
+    for i in ['port_name_to_alias_map', 'PORTCHANNEL']:
+        ports_list.extend(config_facts.get(i, {}).keys())
 
     dut_facts = collect_all_facts(duthost, ports_list, namespace)
     ports_snmps = verify_port_snmp(dut_facts, snmp_facts)

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -16,8 +16,6 @@ def collect_all_facts(duthost, ports_list, namespace=None):
     result = {}
     setup = duthost.interface_facts(namespace=namespace)['ansible_facts']['ansible_interface_facts']
     config_facts = duthost.config_facts(host=duthost.hostname, source="running", namespace=namespace)['ansible_facts']
-    sonic_db_cmd = "sonic-db-cli -n {} {} HGET {}{}{} {}"
-    net_opersate = "cat /sys/class/net/{}/operstate"
     ports_list = []
 
     if namespace is None or namespace == "":

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -19,7 +19,7 @@ def collect_all_facts(duthost, namespace=None):
     sonic_db_cmd = "sonic-db-cli -n {} {} HGET {}{}{} {}"
     net_opersate = "cat /sys/class/net/{}/operstate"
     ports_list = []
-    if namespace == None:
+    if namespace is None:
         namespace = ""
     if namespace == "":
         _ = [ports_list.extend(config_facts.get(i, {}).keys())


### PR DESCRIPTION
- Modify test_snmp_interfaces_mibs to support namespace
for multi-asic platform.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Modify the newly added test_snmp_interfaces_mib to support multi-asic platform.
#### How did you do it?
- Modify the test_snmp_interfaces_mib function to run for all asic namespaces.
- Modify functions to check ports/mtu to compare data in snmp facts against config_facts.

#### How did you verify/test it?
Ran test case on multi-asic platform.
pytest --testbed=vms-kvm-four-asic-t1-lag --inventory=veos_vtb --testbed_file=vtestbed.csv --host-pattern=vlab-08 --module-path=../ansible/library "snmp/test_snmp_interfaces.py" --show-capture=no --disable_loganalyzer --skip_sanity -v
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
===================================================================== test session starts ======================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.17', 'Platform': 'Linux-5.4.0-1031-azure-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.9.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist': u'1.28.0', u'html': u'1.22.1', u'forked': u'1.3.0', u'metadata': u'1.10.0'}}
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: metadata-1.10.0, forked-1.3.0, html-1.22.1, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
collected 9 items                                                                                                                                              

snmp/test_snmp_interfaces.py::test_snmp_interfaces[vlab-08-0] PASSED                                                                                     [ 11%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces_mibs[vlab-08-0] PASSED                                                                                [ 22%]
snmp/test_snmp_interfaces.py::test_snmp_mgmt_interface[vlab-08] PASSED                                                                                   [ 33%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces[vlab-08-1] PASSED                                                                                     [ 44%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces_mibs[vlab-08-1] PASSED                                                                                [ 55%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces[vlab-08-2] PASSED                                                                                     [ 66%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces_mibs[vlab-08-2] PASSED                                                                                [ 77%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces[vlab-08-3] PASSED                                                                                     [ 88%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces_mibs[vlab-08-3] PASSED                                                                                [100%]

======================================================================= warnings summary =======================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================== 9 passed, 1 warnings in 1140.50 seconds ============================================================


Test result of single asic VS:
pytest --testbed=vms-kvm-t0 --inventory=veos_vtb --testbed_file=vtestbed.csv --host-pattern=vlab-01 --module-path=../ansible/library "snmp/test_snmp_interfaces.py" --show-capture=no --disable_loganalyzer --skip_sanity -v
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================ test session starts =============================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.17', 'Platform': 'Linux-5.4.0-66-generic-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.10.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist': u'1.28.0', u'html': u'1.22.1', u'forked': u'1.3.0', u'metadata': u'1.11.0'}}
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: xdist-1.28.0, html-1.22.1, repeat-0.9.1, forked-1.3.0, metadata-1.11.0, ansible-2.2.2
collected 3 items                                                                                                                                                                                            

snmp/test_snmp_interfaces.py::test_snmp_interfaces[vlab-01-None] PASSED                                                                                                                                [ 33%]
snmp/test_snmp_interfaces.py::test_snmp_interfaces_mibs[vlab-01-None] PASSED                                                                                                                           [ 66%]
snmp/test_snmp_interfaces.py::test_snmp_mgmt_interface[vlab-01] PASSED                                                                                                                                 [100%]

============================================================================================== warnings summary ==============================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
