### PR TITLE
[Mellanox][platform] Adjust test case according to get_fan_direction update

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -322,8 +322,11 @@ class FanDrawerData:
     Data mocker of a FAN drawer.
     """
 
-    # FAN direction sys fs path.
-    FAN_DIR_PATH = '/run/hw-management/thermal/fan{}_dir'
+    # FAN direction sys fs path available in 201911 and later
+    FAN_DIR_PATH_ALL_FANS = '/run/hw-management/system/fan_dir'
+
+    # FAN direction sys fs path available in 202012 and later
+    FAN_DIR_PATH_PER_FAN = '/run/hw-management/thermal/fan{}_dir'
 
     def __init__(self, mock_helper, naming_rule, index):
         """
@@ -335,6 +338,10 @@ class FanDrawerData:
         self.index = index
         self.helper = mock_helper
         self.platform_data = get_platform_data(self.helper.dut)
+        if "201911" in self.helper.dut.os_version:
+            self.mock_fan_direction = self.mock_fan_direction_fan_dir_for_all_fans
+        else:
+            self.mock_fan_direction = self.mock_fan_direction_fan_dir_per_fan
         if self.platform_data['fans']['hot_swappable']:
             self.name = 'drawer{}'.format(index)
         else:
@@ -382,14 +389,14 @@ class FanDrawerData:
         else:
             self.mocked_presence = 'Present'
 
-    def mock_fan_direction(self, direction):
+    def mock_fan_direction_fan_dir_per_fan(self, direction):
         """
-        Mock direction of this FAN with given direction value.
+        Mock direction of this FAN with given direction value for the image where there is a fan_dir for each fan
         :param direction: Direction value. 1 means intake, 0 means exhaust.
         :return:
         """
         try:
-            _ = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH.format(self.index)))
+            _ = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH_PER_FAN.format(self.index)))
         except SysfsNotExistError as e:
             self.mocked_direction = NOT_AVAILABLE
             return
@@ -401,7 +408,28 @@ class FanDrawerData:
             fan_dir_value = 0
             self.mocked_direction = 'exhaust'
 
-        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH.format(self.index), fan_dir_value)
+        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH_PER_FAN.format(self.index), fan_dir_value)
+
+    def mock_fan_direction_fan_dir_for_all_fans(self, direction):
+        """
+        Mock direction of this FAN with given direction value for the image where there is only a fan_dir for all fans
+        :param direction: Direction value. 1 means intake, 0 means exhaust.
+        :return:
+        """
+        try:
+            fan_dir_bits = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH_ALL_FANS))
+        except SysfsNotExistError as e:
+            self.mocked_direction = NOT_AVAILABLE
+            return
+
+        if direction:
+            fan_dir_bits = fan_dir_bits | (1 << (self.index - 1))
+            self.mocked_direction = 'intake'
+        else:
+            fan_dir_bits = fan_dir_bits & ~(1 << (self.index - 1))
+            self.mocked_direction = 'exhaust'
+
+        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH_ALL_FANS, fan_dir_bits)
 
     def get_status_led(self):
         """

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -323,7 +323,7 @@ class FanDrawerData:
     """
 
     # FAN direction sys fs path.
-    FAN_DIR_PATH = '/run/hw-management/system/fan_dir'
+    FAN_DIR_PATH = '/run/hw-management/thermal/fan{}_dir'
 
     def __init__(self, mock_helper, naming_rule, index):
         """
@@ -389,19 +389,19 @@ class FanDrawerData:
         :return:
         """
         try:
-            fan_dir_bits = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH))
+            fan_dir_bits = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH.format(self.index)))
         except SysfsNotExistError as e:
             self.mocked_direction = NOT_AVAILABLE
             return
 
         if direction:
-            fan_dir_bits = fan_dir_bits | (1 << (self.index - 1))
+            fan_dir_bits = 1
             self.mocked_direction = 'intake'
         else:
-            fan_dir_bits = fan_dir_bits & ~(1 << (self.index - 1))
+            fan_dir_bits = 0
             self.mocked_direction = 'exhaust'
 
-        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH, fan_dir_bits)
+        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH.format(self.index), fan_dir_bits)
 
     def get_status_led(self):
         """

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -389,7 +389,7 @@ class FanDrawerData:
         :return:
         """
         try:
-            fan_dir_value = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH.format(self.index)))
+            _ = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH.format(self.index)))
         except SysfsNotExistError as e:
             self.mocked_direction = NOT_AVAILABLE
             return

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -389,19 +389,19 @@ class FanDrawerData:
         :return:
         """
         try:
-            fan_dir_bits = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH.format(self.index)))
+            fan_dir_value = int(self.helper.read_value(FanDrawerData.FAN_DIR_PATH.format(self.index)))
         except SysfsNotExistError as e:
             self.mocked_direction = NOT_AVAILABLE
             return
 
         if direction:
-            fan_dir_bits = 1
+            fan_dir_value = 1
             self.mocked_direction = 'intake'
         else:
-            fan_dir_bits = 0
+            fan_dir_value = 0
             self.mocked_direction = 'exhaust'
 
-        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH.format(self.index), fan_dir_bits)
+        self.helper.mock_value(FanDrawerData.FAN_DIR_PATH.format(self.index), fan_dir_value)
 
     def get_status_led(self):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adjust test case according to get_fan_direction update
This PR depends on Azure/sonic-buildimage#7386

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Adjust test case according to get_fan_direction update

#### How did you do it?
Replace the old way to mock fan direction with the new way.
- The old way: fan direction is fetched via reading `/var/run/hw-management/system/fan_dir`, supported on Spetrum-2/3 platforms.
- The new way: fan direction is fetched via reading `/var/run/hw-management/thermal/fanX_dir`, supported on all platforms.

#### How did you verify/test it?
Run regression test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
