### PR TITLE
[IPinIP] Update dscp mode to uniform

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -106,7 +106,11 @@ def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     # Initialize parameters
-    dscp_mode = "pipe"
+    if "201811" in duthost.os_version or "201911" in duthost.os_version:
+        dscp_mode = "pipe"
+    else:
+        dscp_mode = "uniform"
+
     ecn_mode = "copy_from_outer"
     ttl_mode = "pipe"
 


### PR DESCRIPTION
Summary:
Decap test is modified to use dscp mode as uniform instead of pipe. This is based on following PR:

https://github.com/Azure/sonic-buildimage/pull/7234


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
dscp mode to be uniform

#### How did you do it?

#### How did you verify/test it?
Run test

#### Any platform specific information?
Applicable to non-mellanox platforms.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
