### PR TITLE
[advance-reboot] Store timing data into a json file for warm/fast reboot

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -63,7 +63,7 @@ def bring_up_dut_interfaces(request, duthosts, rand_one_dut_hostname, tbinfo):
             duthost.no_shutdown(ifname=port)
 
 @pytest.fixture()
-def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname):
+def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
     """
     Advance reboot log analysis.
     This fixture starts log analysis at the beginning of the test. At the end,
@@ -146,6 +146,14 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname):
             service_restart_times.update(report)
     result = service_restart_times
     logging.info(json.dumps(result, indent=4))
+    report_file_name = request.node.name + "_report.json"
+    report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),\
+        "../logs/platform_tests/")))
+    report_file_path = report_file_dir + "/" + report_file_name
+    if not os.path.exists(report_file_dir):
+        os.makedirs(report_file_dir)
+    with open(report_file_path, 'w') as fp:
+        json.dump(result, fp, indent=4)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Create and store advance_reboot timing data into a json file
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Create a JSON file with the advance reboot timing results, and store it inside log dir.

#### What is the motivation for this PR?
For better visibility of the reboot timing data

#### How did you do it?

#### How did you verify/test it?
Tested on local KVM device.


```
sonic-mgmt/tests/logs/platform_tests$ ls -ltrh
total 8.0K
-rw-r--r-- 1 2.2K Apr 21 01:14 test_warm_reboot_report.json
-rw-r--r-- 1 699 Apr 21 01:14 test_advanced_reboot.py::test_warm_reboot.xml

sonic-mgmt/tests/logs/platform_tests$ cat test_warm_reboot_report.json 
{
    "bgp": {
        "timestamp": {
            "Stopping": "Apr 21 01:10:27.747367", 
            "Starting": "Apr 21 01:11:45.631139", 
            "Stopped": "Apr 21 01:10:32.246328", 
            "Started": "Apr 21 01:11:47.365673"
        }, 
        "start_time": 1.734534, 
        "stop_time": 4.498961, 
        "reboot_time": 75.119345
    }, 
    "radv": {
        "timestamp": {
            "Stopping": "Apr 21 01:10:26.627260", 
            "Starting": "Apr 21 01:11:50.641653", 
            "Stopped": "Apr 21 01:10:27.714121", 
            "Started": "Apr 21 01:11:52.677034"
        }, 
        "start_time": 2.035381, 
        "Stopping count": 2, 
        "stop_time": 1.086861, 
        "reboot_time": 84.962913
    }, 
    "longest_downtime": 135.503178, 
    "teamd": {
        "timestamp": {
            "Stopping": "Apr 21 01:10:45.446116", 
            "Starting": "Apr 21 01:11:49.044496", 
            "Stopped": "Apr 21 01:10:53.021880", 
            "Started": "Apr 21 01:11:50.315265"
        }, 
        "start_time": 1.270769, 
        "stop_time": 7.575764, 
        "reboot_time": 57.293385
    }, 
    "gbsyncd": {
        "timestamp": {
            "Stopping": "Apr 21 01:11:08.110040", 
            "Starting": "Apr 21 01:11:49.066814", 
            "Stopped": "Apr 21 01:11:08.711633", 
            "Started": "Apr 21 01:11:50.419748"
        }, 
        "start_time": 1.352934, 
        "stop_time": 0.601593, 
        "reboot_time": 41.708115
    }, 
    "syncd": {
        "timestamp": {
            "Stopping": "Apr 21 01:10:53.078079", 
            "Starting": "Apr 21 01:11:49.053465", 
            "Stopped": "Apr 21 01:11:05.041681", 
            "Started": "Apr 21 01:11:50.553223"
        }, 
        "start_time": 1.499758, 
        "stop_time": 11.963602, 
        "reboot_time": 45.511542
    }, 
    "swss": {
        "timestamp": {
            "Stopping": "Apr 21 01:10:42.398795", 
            "Starting": "Apr 21 01:11:47.404536", 
            "Stopped": "Apr 21 01:10:43.543723", 
            "Started": "Apr 21 01:11:49.015813"
        }, 
        "start_time": 1.611277, 
        "stop_time": 1.144928, 
        "reboot_time": 65.47209
    }, 
    "reboot_time": 138.215828
}

sonic-mgmt/tests/logs/platform_tests$ 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
