### PR TITLE
[copp] Throttle server send-rate so that DUT does not get overwhelmed

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -40,6 +40,7 @@ class ControlPlaneBaseTest(BaseTest):
     DEFAULT_PRE_SEND_INTERVAL_SEC = 1
     DEFAULT_SEND_INTERVAL_SEC = 10
     DEFAULT_RECEIVE_WAIT_TIME = 3
+    DEFAULT_SERVER_SEND_RATE_LIMIT_PPS = 2000
 
     def __init__(self):
         BaseTest.__init__(self)
@@ -132,6 +133,10 @@ class ControlPlaneBaseTest(BaseTest):
         while datetime.datetime.now() < end_time:
             testutils.send_packet(self, send_intf, packet)
             send_count += 1
+
+            # Depending on the server/platform combination it is possible for the server to
+            # overwhelm the DUT, so we add an artificial delay here to rate-limit the server.
+            time.sleep(1.0 / self.DEFAULT_SERVER_SEND_RATE_LIMIT_PPS)
 
         self.log("Sent out %d packets in %ds" % (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [copp] Throttle server send-rate so that DUT does not get overwhelmed
Fixes https://github.com/Azure/sonic-mgmt/issues/3173

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
It is possible to have a really strong server that sends too much traffic for the DUT to handle on the non-policer COPP test cases.

#### How did you do it?
I added a short delay between sending packets to try to rate-limit the server speed to approx 2-3 times the COPP rate-limit (note: the rate limit is set at 2000 pps but slower servers may still send slightly less than that). This seems like a sufficient amount to clearly differentiate between the policer working and not working.

#### How did you verify/test it?
Ran the test on a variety of server/DUT combinations and it seems to be much more stable than before.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
