### PR TITLE
[test_interface]: verify the interface mac equal to the router mac

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -36,9 +36,24 @@ def test_interfaces(duthosts, enum_frontend_dut_hostname, tbinfo, enum_asic_inde
     verify_ip_address(host_facts, mg_facts['minigraph_vlan_interfaces'])
     verify_ip_address(host_facts, mg_facts['minigraph_lo_interfaces'])
 
+    router_mac = duthost.facts['router_mac']
+    verify_mac_address(host_facts, mg_facts['minigraph_portchannel_interfaces'], router_mac)
+    verify_mac_address(host_facts, mg_facts['minigraph_vlan_interfaces'], router_mac)
+    verify_mac_address(host_facts, mg_facts['minigraph_interfaces'], router_mac)
+
 def verify_port(host_facts, ports):
     for port in ports:
         pytest_assert(host_facts[port]['active'], "interface {} is not active".format(port))
+
+def verify_mac_address(host_facts, intfs, router_mac):
+    for intf in intfs:
+        if intf.has_key('attachto'):
+            ifname = intf['attachto']
+        else:
+            ifname = intf['name']
+
+        pytest_assert(host_facts[ifname]['macaddress'] == router_mac, \
+                "interface {} mac address {} does not match router mac {}".format(ifname, host_facts[ifname]['macaddress'], router_mac))
 
 def verify_ip_address(host_facts, intfs):
     for intf in intfs:

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -47,7 +47,7 @@ def verify_port(host_facts, ports):
 
 def verify_mac_address(host_facts, intfs, router_mac):
     for intf in intfs:
-        if intf.has_key('attachto'):
+        if 'attachto' in intf:
             ifname = intf['attachto']
         else:
             ifname = intf['name']


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
verify the interface mac equal to the router mac

#### How did you do it?
add validiation for interface mac

#### How did you verify/test it?
test locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
