### PR TITLE
[crm] only set ARP cache limit setting when needed

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -339,9 +339,21 @@ def increase_arp_cache(duthost, max_value, ip_ver, test_name):
         res = duthost.shell(get_cmd.format(ip_ver, thresh_id))
         if res["rc"] != 0:
             logger.warning("Unable to get kernel ARP cache size: \n{}".format(res))
-        else:
-            # Add cleanup step to restore ARP cache
-            RESTORE_CMDS[test_name].append("sysctl -w " + res["stdout"].replace(" ", ""))
+            continue
+
+        try:
+            # Sample output: net.ipv4.neigh.default.gc_thresh1 = 1024
+            cur_th = int(res["stdout"].split()[-1])
+        except:
+            logger.warning("Unable to determin kernel ARP cache size: \n{}".format(res))
+            continue
+
+        if cur_th >= max_value + 100:
+            logger.info("Skipping setting ARP cache size to {}, current {}".format(max_value, res['stdout']))
+            continue
+
+        # Add cleanup step to restore ARP cache
+        RESTORE_CMDS[test_name].append("sysctl -w " + res["stdout"].replace(" ", ""))
         cmd = set_cmd.format(ip_ver, thresh_id, max_value + 100)
         duthost.shell(cmd)
         logger.info("{}".format(cmd))

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -344,7 +344,7 @@ def increase_arp_cache(duthost, max_value, ip_ver, test_name):
         try:
             # Sample output: net.ipv4.neigh.default.gc_thresh1 = 1024
             cur_th = int(res["stdout"].split()[-1])
-        except:
+        except ValueError:
             logger.warning("Unable to determin kernel ARP cache size: \n{}".format(res))
             continue
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -345,7 +345,7 @@ def increase_arp_cache(duthost, max_value, ip_ver, test_name):
             # Sample output: net.ipv4.neigh.default.gc_thresh1 = 1024
             cur_th = int(res["stdout"].split()[-1])
         except ValueError:
-            logger.warning("Unable to determin kernel ARP cache size: \n{}".format(res))
+            logger.warning("Unable to determine kernel ARP cache size: \n{}".format(res))
             continue
 
         if cur_th >= max_value + 100:


### PR DESCRIPTION
Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

SONiC already set ARP cache limit quit high, test shouldn't need to increase according to its needs unless the threshold is
actually lower then needed.

#### How did you do it?

Skip ARP cache limit setting if the current limit is higher than requested limit.

#### How did you verify/test it?

Run crm test and watch ARP limit never changes during tests.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
