### PR TITLE
[sonic fanout] make sure sonic fanout hostname type is str

### DIFF
--- a/tests/common/cache/facts_cache.py
+++ b/tests/common/cache/facts_cache.py
@@ -172,7 +172,7 @@ def _get_default_zone(function, func_args, func_kargs):
     hostname = None
     if func_args:
         hostname = getattr(func_args[0], "hostname", None)
-    if not hostname or not isinstance(hostname, str):
+    if not hostname or type(hostname) not in [ str, unicode ]:
         raise ValueError("Failed to get attribute 'hostname' of type string from instance of type %s."
                          % type(func_args[0]))
     zone = hostname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,8 +370,8 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
         for dut_host, value in dev_conn.items():
             for dut_port in value.keys():
                 fanout_rec = value[dut_port]
-                fanout_host = fanout_rec['peerdevice']
-                fanout_port = fanout_rec['peerport']
+                fanout_host = str(fanout_rec['peerdevice'])
+                fanout_port = str(fanout_rec['peerport'])
 
                 if fanout_host in fanout_hosts.keys():
                     fanout = fanout_hosts[fanout_host]


### PR DESCRIPTION
### Description of PR

Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
DUT with SONiC fanout are unable to run tests requires fanout information, e.g. link_flap, lag_2.

#### How did you do it?

By default, the fanout hostname is AnsibleUnsafeText. This causes cache lookup module to fail. Force the type to str to avoid later surprises.

At the same time, relax the cache check to allow unicode too.

#### How did you verify/test it?

run link_flap and lag_2 on dut with sonic fanout.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
