### PR TITLE
[rdma] Avoid add-topo failure when no VMs are associated with a testbed entry

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -121,12 +121,15 @@
 
         - name: Extract VM names from the inventory
           set_fact: VM_hosts={{ groups[current_server] | filter_by_prefix('VM') | sort }}
+          when: VM_base|length > 0
 
         - name: Generate vm list of target VMs
           set_fact: VM_targets={{ VM_hosts | filter_vm_targets(topology['VMs'], VM_base) }}
-          when: topology['VMs'] is defined
+          when:
+            - topology['VMs'] is defined
+            - VM_base|length > 0
       run_once: True
       delegate_to: localhost
 
   roles:
-    - { role: eos, when: topology.VMs is defined and inventory_hostname in VM_targets } # role eos will be executed in any case, and when will evaluate with every task
+    - { role: eos, when: topology.VMs is defined and VM_targets is defined and inventory_hostname in VM_targets } # role eos will be executed in any case, and when will evaluate with every task


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Testbed entry using tgen topologies will no have a VM specified in them. Without this change, add-topo fails

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran add-topo successfully with this change


