### PR TITLE
[ASCI type] add variation of TD2 lspci signature

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1128,7 +1128,8 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             asic = "th"
         elif "Broadcom Limited Device b971" in output:
             asic = "th2"
-        elif "Broadcom Limited Device b850" in output:
+        elif ("Broadcom Limited Device b850" in output or
+              "Broadcom Limited Broadcom BCM56850" in output):
             asic = "td2"
         elif "Broadcom Limited Device b870" in output:
             asic = "td3"

--- a/tests/platform_tests/broadcom/files/ser_injector.py
+++ b/tests/platform_tests/broadcom/files/ser_injector.py
@@ -327,7 +327,8 @@ def get_asic_name():
         asic = "th"
     elif "Broadcom Limited Device b971" in output:
         asic = "th2"
-    elif "Broadcom Limited Device b850" in output:
+    elif ("Broadcom Limited Device b850" in output or
+          "Broadcom Limited Broadcom BCM56850" in output):
         asic = "td2"
     elif "Broadcom Limited Device b870" in output:
         asic = "td3"


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
SER test is failing on S6000 platform with latest image. Looks like the ASIC type signature is different from what we used to identify TD2.

#### How did you do it?
Add the new variation of TD2 lspci signature.

#### How did you verify/test it?
Run test on S6000