### PR TITLE
[dualtor][orchagent] Add mac move testcases

### DIFF
--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -1,0 +1,120 @@
+import logging
+import pytest
+import random
+
+from ptf import testutils
+from tests.common.dualtor.dual_tor_mock import *
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
+from tests.common.dualtor.dual_tor_utils import crm_neighbor_checker
+from tests.common.dualtor.dual_tor_utils import build_packet_to_server
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
+from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder
+from tests.common.fixtures.ptfhost_utils import run_garp_service
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses
+from tests.common.utilities import dump_scapy_packet_show_output
+
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.usefixtures('apply_mock_dual_tor_tables',
+                            'apply_mock_dual_tor_kernel_configs',
+                            'run_garp_service',
+                            'run_icmp_responder')
+]
+
+
+NEW_NEIGHBOR = "192.168.0.100"
+
+
+@pytest.fixture(scope="function")
+def announce_new_neighbor(ptfadapter, rand_selected_dut, tbinfo):
+    """Utility fixture to announce new neighbor from a mux port."""
+
+    def _announce_new_neighbor_gen():
+        """Generator to announce the neighbor to a different interface at each iteration."""
+        for dut_iface in dut_ifaces:
+            update_iface_func = yield dut_iface
+            if callable(update_iface_func):
+                update_iface_func(dut_iface)
+            ptf_iface = dut_to_ptf_intf_map[dut_iface]
+            ptf_iface_mac = ptfadapter.dataplane.ports[(0, ptf_iface)].mac()
+            garp_packet = testutils.simple_arp_packet(
+                eth_src=ptf_iface_mac,
+                hw_snd=ptf_iface_mac,
+                ip_snd=NEW_NEIGHBOR,
+                ip_tgt=NEW_NEIGHBOR,
+                arp_op=2
+            )
+            logging.info(
+                "GARP packet to announce new neighbor %s to mux interface %s:\n%s",
+                NEW_NEIGHBOR, dut_iface, dump_scapy_packet_show_output(garp_packet)
+            )
+            testutils.send(ptfadapter, int(ptf_iface), garp_packet, count=5)
+            # let the generator stops here to allow the caller to execute testings
+            yield
+
+    dut_to_ptf_intf_map = rand_selected_dut.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
+    mux_configs = mux_cable_server_ip(rand_selected_dut)
+    dut_ifaces = mux_configs.keys()
+    random.shuffle(dut_ifaces)
+    return _announce_new_neighbor_gen()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_arp(duthosts):
+    """Cleanup arp entries after test."""
+    yield
+    for duthost in duthosts:
+        duthost.shell("sonic-clear arp")
+
+
+def test_mac_move(
+    announce_new_neighbor, apply_active_state_to_orchagent,
+    conn_graph_facts, ptfadapter,
+    rand_selected_dut, set_crm_polling_interval,
+    tbinfo, tunnel_traffic_monitor, vmhost
+):
+    tor = rand_selected_dut
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    ptf_t1_intf_index = int(ptf_t1_intf.strip("eth"))
+
+    # new neighbor learnt on an active port
+    test_port = next(announce_new_neighbor)
+    announce_new_neighbor.send(None)
+    logging.info("let new neighbor learnt on active port %s", test_port)
+    pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
+    server_traffic_monitor = ServerTrafficMonitor(
+        tor, vmhost, test_port,
+        conn_graph_facts, exp_pkt, existing=True
+    )
+    with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
+        testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
+
+    # mac move to a standby port
+    test_port = next(announce_new_neighbor)
+    announce_new_neighbor.send(lambda iface: set_dual_tor_state_to_orchagent(tor, "standby", [iface]))
+    logging.info("mac move to a standby port %s", test_port)
+    pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=True)
+    server_traffic_monitor = ServerTrafficMonitor(
+        tor, vmhost, test_port,
+        conn_graph_facts, exp_pkt, existing=False
+    )
+    with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
+        testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
+
+    # mac move to another active port
+    test_port = next(announce_new_neighbor)
+    announce_new_neighbor.send(None)
+    logging.info("mac move to another active port %s", test_port)
+    pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
+    server_traffic_monitor = ServerTrafficMonitor(
+        tor, vmhost, test_port,
+        conn_graph_facts, exp_pkt, existing=True
+    )
+    with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
+        testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3276

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Verify those mac move scenarios:
1. if a new neighbor(in the VLAN subnet) is learned on an active port, the traffic to the new neighbor will be directly forwarded to the neighbor.
2. if the mac moves from an active port to another standby port, verify the traffic is directed back to T1s to the active ToR.
3. if the mac moves back to another active port, verify the traffic is directly forwarded.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add:
1. `test_mac_move.py::test_mac_move`

#### How did you verify/test it?
```
dualtor/test_mac_move.py::test_mac_move PASSED                                                                                                                                                 [100%]

===================================================================================== 1 passed in 79.14 seconds ======================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
