### PR TITLE
Fix test_fdb_mac_expire on dualtor testbed.

### DIFF
--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -200,7 +200,7 @@ class TestFdbMacExpire:
             self.__loadSwssConfig(duthost)
         self.__deleteTmpSwitchConfig(duthost)
 
-    def testFdbMacExpire(self, request, tbinfo, duthost, ptfhost):
+    def testFdbMacExpire(self, request, tbinfo, rand_selected_dut, ptfhost):
         """
             TestFdbMacExpire Verifies FDb aging timer is respected
 
@@ -211,7 +211,7 @@ class TestFdbMacExpire:
             Args:
                 request (Fixture): pytest request object
                 tbinfo (Fixture, dict): Map containing testbed information
-                duthost (AnsibleHost): Device Under Test (DUT)
+                rand_selected_dut (AnsibleHost): Device Under Test (DUT)
                 ptfhost (AnsibleHost): Packet Test Framework (PTF)
 
             Returns:
@@ -226,7 +226,7 @@ class TestFdbMacExpire:
 
         testParams = {
             "testbed_type": tbinfo["topo"]["name"],
-            "router_mac": duthost.facts["router_mac"],
+            "router_mac": rand_selected_dut.facts["router_mac"],
             "fdb_info": self.FDB_INFO_FILE,
             "dummy_mac_prefix": self.DUMMY_MAC_PREFIX,
         }
@@ -236,10 +236,10 @@ class TestFdbMacExpire:
         time.sleep(fdbAgingTime)
 
         count = 0
-        dummyMacCount = self.__getFdbTableCount(duthost, self.DUMMY_MAC_PREFIX)
+        dummyMacCount = self.__getFdbTableCount(rand_selected_dut, self.DUMMY_MAC_PREFIX)
         while count * self.POLLING_INTERVAL_SEC < fdbAgingTime and dummyMacCount != 0:
             time.sleep(self.POLLING_INTERVAL_SEC)
-            dummyMacCount = self.__getFdbTableCount(duthost, self.DUMMY_MAC_PREFIX)
+            dummyMacCount = self.__getFdbTableCount(rand_selected_dut, self.DUMMY_MAC_PREFIX)
             count += 1
             logger.info(
                 "MAC table entries count: {0}, after {1} sec".format(


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix ```test_fdb_mac_expire``` on dualtor testbed.
The test code ```testFdbMacExpire``` always uses the first dut for testing, which is unexpected. Instead, we should run test on the pre randomly selected dut.

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_fdb_mac_expire``` on dualtor testbed.

#### How did you do it?
Use ```rand_selected_dut``` for testing.

#### How did you verify/test it?
Verified on a dualtor testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
dualtor specified.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
