### PR TITLE
Fix log error in check fan fault status

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -36,7 +36,7 @@ def check_sysfs(dut):
         if platform_data["fans"]["hot_swappable"]:
             assert fan_info['status'] == '1', "Fan {} status {} is not 1".format(fan_id, fan_info['status'])
 
-        assert fan_info['fault'] == '0', "Fan {} fault status {} is not 1".format(fan_id, fan_info['fault'])
+        assert fan_info['fault'] == '0', "Fan {} fault status {} is not 0".format(fan_id, fan_info['fault'])
 
     if not _is_fan_speed_in_range(sysfs_facts):
         sysfs_fan_config = [generate_sysfs_fan_config(platform_data)]


### PR DESCRIPTION
### Description of PR

Summary: Fix the error log during check fan fault status
Fixes # Fix the error log during check fan fault status

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
the log msg is not correct
#### How did you do it?
change the "Fan {} fault status {} is not 1" to "Fan {} fault status {} is not 0"
#### How did you verify/test it?
run the testcase which call this function "check_sysfs"
#### Any platform specific information?
no
