### PR TITLE
[dualtor] Import fixture 'change_mac_addresses' and restart mux-simulator

### DIFF
--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -4,7 +4,7 @@ import time
 
 from tests.common.dualtor.dual_tor_utils import get_crm_nexthop_counter # lgtm[py/unused-import]
 from tests.common.helpers.assertions import pytest_assert as py_assert
-from tests.common.fixtures.ptfhost_utils import run_garp_service
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service
 
 
 CRM_POLL_INTERVAL = 1
@@ -57,6 +57,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def common_setup_teardown(request, tbinfo):
+def common_setup_teardown(request, tbinfo, vmhost):
     if 'dualtor' in tbinfo['topo']['name']:
         request.getfixturevalue('run_garp_service')
+        vmhost.shell('systemctl restart mux-simulator')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

The dualtor/conftest.py has an importing issue of dependent fixture. All
dualtor tests failed because of this.

#### How did you do it?
This PR fixed the importing issue. Another change is to always
restart the mux-simulator server before each test.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
