### PR TITLE
[rdma] Enable test runs on tgen topology

### DIFF
--- a/ansible/veos
+++ b/ansible/veos
@@ -27,6 +27,8 @@ all:
           - t0-116
           - dualtor
           - dualtor-56
+          - tgen-t0-3
+          - tgen-t1-3-lag
       children:
         server_1:
         server_2:

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -204,7 +204,7 @@ class TestbedInfo(object):
                       explicit_start=True, Dumper=IncIndentDumper)
 
     def get_testbed_type(self, topo_name):
-        pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2)')
+        pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2|tgen)')
         match = pattern.match(topo_name)
         if match == None:
             raise Exception("Unsupported testbed type - {}".format(topo_name))


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Include 'tgen' to the supported testbed types and topologies

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To enable RDMA test runs on the new 'tgen' topology