### PR TITLE
[sanity_check]: Run garp service and icmp responder

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -239,4 +239,5 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
 
     yield
 
+    logger.info("Stopping GARP service on PTF host")
     ptfhost.shell('supervisorctl stop garp_service')

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -324,7 +324,7 @@ def get_arp_pkt_info(dut):
 
 
 @pytest.fixture(scope='module')
-def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_host, lower_tor_host, \
+def check_mux_simulator(request, ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_host, lower_tor_host, \
                         recover_all_directions, toggle_simulator_port_to_upper_tor, toggle_simulator_port_to_lower_tor, check_simulator_read_side):
 
     def _check(*args, **kwargs):
@@ -342,6 +342,8 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
                     'failed_reason': '',
                     'check_item': '{} mux simulator'.format(ptf_server_intf)
                 }
+        request.getfixturevalue('run_garp_service')
+        request.getfixturevalue('run_icmp_responder')
 
         logger.info("Checking mux simulator status for PTF interface {}".format(ptf_server_intf))
         ptf_port_index = int(ptf_server_intf.replace('eth', ''))
@@ -456,6 +458,9 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
             return results
 
         logger.info('Finished mux simulator check')
+        upper_tor_host.shell("ip neigh flush all")
+        lower_tor_host.shell("ip neigh flush all")
+
         return results
     return _check
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
During the mux simulator sanity check, there is a chance that linkmgrd will toggle the mux state because it is not receiving a heartbeat. 

#### How did you do it?
Run ICMP responder and GARP service during the sanity check. Also cleanup ARP table after sanity check on DUTs

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
