### PR TITLE
Fix importing issue for test report uploading

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -6,11 +6,15 @@ import uuid
 
 from abc import ABC, abstractmethod
 from azure.kusto.data import KustoConnectionStringBuilder
-from azure.kusto.ingest import (
-    KustoIngestClient,
-    IngestionProperties,
-    DataFormat,
-)
+
+try:
+    from azure.kusto.ingest import KustoIngestClient
+except ImportError:
+    from azure.kusto.ingest import QueuedIngestClient as KustoIngestClient
+
+from azure.kusto.ingest import IngestionProperties
+from azure.kusto.ingest import DataFormat
+
 from datetime import datetime
 from typing import Dict, List
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The test report uploading script depends on an older version of azure.kusto.ingest package. The latest
azure.kusto.ingest package introduced a break change:
    https://github.com/Azure/azure-kusto-python/pull/270

This would cause importing issue running the test report uploading script if the azure.kusto.ingest
is upgraded. Currently the issue was not exposed yet because the sonic-mgmt docker used in
testing still has older version of the azure.kusto.ingest package. If upgrade sonic-mgmt docker
to latest version, the importing issue will be hit.

#### How did you do it?
The fix is to wrap the importing in try...except. If ImportError exception is raised, try to import
class name in newer version of azure.kusto.ingest package. Then the test result uploading script
can be  backward compatible.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
