### PR TITLE
Use supervisorctl to restart the thermalctl processes on pmon docker

### DIFF
--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -255,7 +255,7 @@ def restart_thermal_control_daemon(dut):
     :param dut: DUT object representing a SONiC switch under test.
     :return:
     """
-    logging.info('Restarting thermal control daemon...')
+    logging.info('Restarting thermal control daemon on {}...'.format(dut.hostname))
     find_thermalctld_pid_cmd = 'docker exec -i pmon bash -c \'pgrep -f thermalctld\' | sort'
     output = dut.shell(find_thermalctld_pid_cmd)
     assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
@@ -265,37 +265,15 @@ def restart_thermal_control_daemon(dut):
     # use subprocess to call ethtool to do initialization.
     # So we check here thermalcltd must have at least 2 processes.
     assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
-    pid_0 = int(output["stdout_lines"][0].strip())
-    pid_1 = int(output["stdout_lines"][1].strip())
-    # find and kill the parent process
-    pid_to_kill = pid_0 if pid_0 < pid_1 else pid_1
-    logging.info('Killing old thermal control daemon with pid: {}'.format(pid_to_kill))
-    kill_thermalctld_cmd = 'docker exec -i pmon bash -c \'kill {}\''.format(pid_to_kill)
-    output = dut.command(kill_thermalctld_cmd)  # kill thermalctld and wait supervisord auto reboot thermalctld
-    assert output["rc"] == 0, "Run command '%s' failed" % kill_thermalctld_cmd
 
-    # make sure thermalctld has restarted
-    max_wait_time = 30
-    while max_wait_time > 0:
-        max_wait_time -= 1
+    restart_thermalctl_cmd = "docker exec -i pmon bash -c 'supervisorctl restart thermalctld'"
+    output = dut.shell(restart_thermalctl_cmd)
+    if output["rc"] == 0:
         output = dut.shell(find_thermalctld_pid_cmd)
-        assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
-        if len(output["stdout_lines"]) != 2:
-            time.sleep(1)
-            continue
-
-        new_pid_0 = int(output["stdout_lines"][0].strip())
-        new_pid_1 = int(output["stdout_lines"][1].strip())
-        parent_pid = new_pid_0 if new_pid_0 < new_pid_1 else new_pid_1
-
-        if parent_pid == pid_to_kill:
-            logging.info('Old thermal control daemon is still alive, waiting...')
-            time.sleep(1)
-            continue
-        else:
-            logging.info('New pid of thermal control daemon is {}'.format(parent_pid))
-            return
-
+        assert output["rc"] == 0, "Run command '{}' failed after restart of thermalctld on {}".format(find_thermalctld_pid_cmd, dut.hostname)
+        assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
+        logging.info("thermalctld processes restarted successfully on {}".format(dut.hostname))
+        return
     # try restore by config reload...
     config_reload(dut)
     assert 0, 'Wait thermal control daemon restart failed'


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
On pmon docker there are typically 2 thermalctl processes. One being the
parent process of the other. In order to restart the thermalctl process,
the existing code would assume that the process with the smallest pid is
the parent process. This is not always the case.
#### How did you do it?
A cleaner way is to user superivosorctl to restart the thermalctl processes
```
docker exec -i pmon bash -c 'supervisorctl restart thermalctl'
```
Modified the function "restart_thermal_control_daemon" in thermal_control_test_helpers.py with the above methodology to restart the thermalctl processes in the pmon docker

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
