### PR TITLE
return none if pdu controller hosts not defined in inventory

### DIFF
--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -18,6 +18,11 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     inv_mgr = duthost.host.options["inventory_manager"]
     pdu_host_list = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
+    if not pdu_host_list:
+        logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create pdu_controller" %
+                     duthost.hostname)
+        yield None
+        return
     pdu_hosts = {}
     for ph in pdu_host_list.split(','):
         var_list = inv_mgr.get_host(ph).get_vars()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR


Summary:
Fixes # (issue)

### Type of change


- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In common/plugins/pdu_controller/__init__.py pdu_controller fixture always assume that pdu controller hosts exists in inventory, I am adding change to handle case where pdu controller hosts is empty 

#### How did you do it?

Add if condition that handles if pdu_host_list is empty when read from inventory

#### How did you verify/test it?
Test when pdu_host list does not exist none is returned 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
