### PR TITLE
[Platform API] Use correct key name, 'psus'

### DIFF
--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -63,7 +63,7 @@ class TestPsuFans(PlatformApiTestBase):
         expected_value = None
 
         if duthost.facts.get("chassis"):
-            expected_psus = duthost.facts.get("chassis").get("psu")
+            expected_psus = duthost.facts.get("chassis").get("psus")
             if expected_psus:
                 expected_fans = expected_psus[psu_idx].get("fans")
                 if expected_fans:


### PR DESCRIPTION
Platform facts in platform.json are currently expected to use plural keys (e.g., "psus").