### PR TITLE
[dualtor][orchagent]Fix bugs on mocked single tor

### DIFF
--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -55,8 +55,8 @@ def test_active_tor_remove_neighbor_downstream_active(
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send traffic to server %s from ptf t1 interface %s", server_ipv4, ptf_t1_intf)
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, vmhost, test_params["selected_port"],
-        conn_graph_facts, exp_pkt, existing=True
+        tor, ptfhost, vmhost, tbinfo, test_params["selected_port"],
+        conn_graph_facts, exp_pkt, existing=True, is_mocked=is_mocked_dualtor(tbinfo)
     )
     tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
@@ -64,8 +64,8 @@ def test_active_tor_remove_neighbor_downstream_active(
 
     logging.info("send traffic to server %s after removing neighbor entry", server_ipv4)
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, vmhost, test_params["selected_port"],
-        conn_graph_facts, exp_pkt, existing=False
+        tor, ptfhost, vmhost, tbinfo, test_params["selected_port"],
+        conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)
     )    # for real dualtor testbed, leave the neighbor restoration to garp service
     flush_neighbor_ct = flush_neighbor(tor, server_ipv4, restore=is_t0_mocked_dualtor)
     with crm_neighbor_checker(tor), stop_garp(ptfhost), flush_neighbor_ct, tunnel_monitor, server_traffic_monitor:
@@ -73,8 +73,8 @@ def test_active_tor_remove_neighbor_downstream_active(
 
     logging.info("send traffic to server %s after neighbor entry is restored", server_ipv4)
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, vmhost, test_params["selected_port"],
-        conn_graph_facts, exp_pkt, existing=True
+        tor, ptfhost, vmhost, tbinfo, test_params["selected_port"],
+        conn_graph_facts, exp_pkt, existing=True, is_mocked=is_mocked_dualtor(tbinfo)
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -242,8 +242,8 @@ def test_standby_tor_remove_neighbor_downstream_standby(
     logging.info("send traffic to server %s after removing neighbor entry", server_ipv4)
     tunnel_monitor.existing = False
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, vmhost, test_params["selected_port"],
-        conn_graph_facts, exp_pkt, existing=False
+        tor, ptfhost, vmhost, tbinfo, test_params["selected_port"],
+        conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)
     )
     # for real dualtor testbed, leave the neighbor restoration to garp service
     flush_neighbor_ct = flush_neighbor(tor, server_ipv4, restore=is_t0_mocked_dualtor)
@@ -275,8 +275,8 @@ def test_downstream_standby_mux_toggle_active(
     def monitor_tunnel_and_server_traffic(torhost, expect_tunnel_traffic=True, expect_server_traffic=True):
         tunnel_monitor = tunnel_traffic_monitor(tor, existing=True)
         server_traffic_monitor = ServerTrafficMonitor(
-            torhost, vmhost, test_params["selected_port"],
-            conn_graph_facts, exp_pkt, existing=False
+            torhost, ptfhost, vmhost, tbinfo, test_params["selected_port"],
+            conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)
         )
         tunnel_monitor.existing = expect_tunnel_traffic
         server_traffic_monitor.existing = expect_server_traffic


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add few fixes:
1. for mac move, enabling garp before test execution for mocked testbed.
2. Make `ServerTrafficMonitor` support mocked single tor testbed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
1. for mac move, the single tor doesn't create arp entry when receiving GARP packets.
2. for `ServerTrafficMonitor`, it fails to dump vlan interface on the server for mocked single tor testbed because the vlan interface is injected to the ptf docker net namespace and invisible to the server.

#### How did you do it?
1. for mac move, enable `arp_accept` flag before running the test on single tor testbed.
2. for `ServerTrafficMonitor`, let's make it simply dump packet inside the ptf container for single tor testbed.

#### How did you verify/test it?
```
dualtor/test_orchagent_mac_move.py::test_mac_move PASSED                                                                                                                                       [100%]
dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active PASSED                                                                                      [100%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby PASSED                                                                                   [100%]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
