### PR TITLE
[test_unknown_mac] Fix issue with MAC being present in FDB after fdb flush

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -128,6 +128,8 @@ def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_ho
     logger.info("Populate ARP entry for dest port")
     ptfhost.command("ifconfig eth{} {}".format(setup['ptf_dst_port'], setup['vlan']['ips'][0]))
     ptfhost.command("ping {} -c 3".format(setup['vlan']['addr']))
+    # Wait 5 seconds for secondary ARP before proceeding to clear FDB
+    time.sleep(5)
 
     yield
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test uses ping command from PTF to populate ARP on DUT, then clears FDB to emulate unknown_mac behavior.
Partial output of tcpdump during ping:
```
09:24:16.707355 ARP, Request who-has 192.168.0.1 tell 192.168.0.2, length 28
09:24:16.708029 ARP, Reply 192.168.0.1 is-at fc:bd:67:62:4b:60, length 46
09:24:16.708059 IP 192.168.0.2 > 192.168.0.1: ICMP echo request, id 1875, seq 1, length 64
09:24:16.708478 IP 192.168.0.1 > 192.168.0.2: ICMP echo reply, id 1875, seq 1, length 64
09:24:17.707817 IP 192.168.0.2 > 192.168.0.1: ICMP echo request, id 1875, seq 2, length 64
09:24:17.708237 IP 192.168.0.1 > 192.168.0.2: ICMP echo reply, id 1875, seq 2, length 64
09:24:18.731876 IP 192.168.0.2 > 192.168.0.1: ICMP echo request, id 1875, seq 3, length 64
09:24:18.732507 IP 192.168.0.1 > 192.168.0.2: ICMP echo reply, id 1875, seq 3, length 64
09:24:21.747609 ARP, Request who-has 192.168.0.2 tell 192.168.0.1, length 46
09:24:21.747652 ARP, Reply 192.168.0.2 is-at 40:a6:b7:22:af:18, length 28
```
There is a secondary unicast ARP request from DUT 5 seconds after start to verify that ARP entry is still valid.
FDB clear command is executed between ping start and this secondary ARP. This causes removed FDB entry to be re-added, resulting in test failing with following error:
`Failed: 40:a6:b7:22:af:18 present in FDB`
#### How did you do it?
Added 5 second timeout after ping command.
#### How did you verify/test it?
Run pfc/test_unknown_mac.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
