### PR TITLE
Changed CRM_UPDATE_TIME from 4 to 15 seconds to increase stability of the test

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -23,7 +23,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 CRM_POLLING_INTERVAL = 1
-CRM_UPDATE_TIME = 4
+CRM_UPDATE_TIME = 15
 SONIC_RES_UPDATE_TIME = 50
 
 THR_VERIFY_CMDS = OrderedDict([


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Increase stability of crm test on having in /var/log/syslog expected message by log_analyzer

crm_interface = ('PortChannel0001', 'PortChannel0002') 
crm_stats_nexthop_available = 184674 
crm_stats_nexthop_used = 4 
duthost    = <tests.common.devices.MultiAsicSonicHost object at 0x7f8eb54f0210> 
duthosts   = <tests.common.devices.DutHosts object at 0x7f8eb54f0190> 
get_nexthop_stats = 'redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_ipv4_nexthop_used crm_stats_ipv4_nexthop_available' 
ip_ver     = '4' 
neighbours_num = 1847 
new_crm_stats_nexthop_available = 180980 
new_crm_stats_nexthop_used = 1851 
nexthop    = '2.2.2.2' 
nexthop_add_cmd = 'ip neigh replace 2.2.2.2 lladdr 11:22:33:44:55:66 dev PortChannel0001' 
nexthop_del_cmd = 'ip neigh del 2.2.2.2 lladdr 11:22:33:44:55:66 dev PortChannel0001' 
rand_one_dut_hostname = 'r-tigris-04' 
used_percent = 0 


crm/test_crm.py:509: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
crm/test_crm.py:241: in verify_thresholds 
    time.sleep(CRM_UPDATE_TIME)    <==============================Here is sleep to wait for log_analyzer
common/plugins/loganalyzer/loganalyzer.py:75: in __exit__ 
    self.analyze(self._markers.pop(), fail=self.fail) 
common/plugins/loganalyzer/loganalyzer.py:254: in analyze 
    self._verify_log(analyzer_summary) 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
self = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f8eb3b455a0> 
result = {'expect_messages': {'/tmp/syslog.2021-04-29-00:00:26': []}, 'match_files': {'/tmp/syslog.2021-04-29-00:00:26': {'expe... {'/tmp/syslog.2021-04-29-00:00:26': []}, 'total': {'expected_match': 0, 'expected_missing_match': 1, 'match': 0}, ...} 


    def _verify_log(self, result): 
        """ 
        Verify that total match and expected missing match equals to zero or raise exception otherwise. 
        Verify that expected_match is not equal to zero when there is configured expected regexp in self.expect_regex list 
        """ 
        if not result: 
            raise LogAnalyzerError("Log analyzer failed - no result.") 
        if result["total"]["match"] != 0 or result["total"]["expected_missing_match"] != 0: 
>           raise LogAnalyzerError(result) 
E           LogAnalyzerError: {'match_messages': {'/tmp/syslog.2021-04-29-00:00:26': []}, 'total': {'expected_match': 0, 'expected_missing_match': 1, 'match': 0}, 'match_files': {'/tmp/syslog.2021-04-29-00:00:26': {'expected_match': 0, 'match': 0}}, 'expect_messages': {'/tmp/syslog.2021-04-29-00:00:26': []}, 'unused_expected_regexp': ['.* THRESHOLD_EXCEEDED .*']} 

 

result     = {'expect_messages': {'/tmp/syslog.2021-04-29-00:00:26': []}, 'match_files': {'/tmp/syslog.2021-04-29-00:00:26': {'expe... {'/tmp/syslog.2021-04-29-00:00:26': []}, 'total': {'expected_match': 0, 'expected_missing_match': 1, 'match': 0}, ...} 

self       = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7f8eb3b455a0> 
#### How did you do it?

#### How did you verify/test it?
You can see here that expected message was on the switch 00:00:33, but was expected to occur at 00:00:26

/var/log/syslog.162.gz:30:Apr 29 00:00:12.694865 r-tigris-04 WARNING swss#orchagent: :- checkCrmThresholds: IPV4_NEXTHOP THRESHOLD_EXCEEDED for TH_FREE 1% Used count 1851 free count 180984
/var/log/syslog.162.gz:69:Apr 29 00:00:33.013988 r-tigris-04 WARNING swss#orchagent: message repeated 9 times: [ :- checkCrmThresholds: IPV4_NEXTHOP THRESHOLD_EXCEEDED for TH_FREE 1% Used count 1851 free count 180984]


executed the test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
