### PR TITLE
log exception/backtrace when a process run in parallel fails

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -5,8 +5,7 @@ import shutil
 import tempfile
 import signal
 import traceback
-from multiprocessing import Process, Manager
-import multiprocessing as mp
+from multiprocessing import Process, Manager, Pipe
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 
 logger = logging.getLogger(__name__)
@@ -21,7 +20,7 @@ class SonicProcess(Process):
     """
     def __init__(self, *args, **kwargs):
         Process.__init__(self, *args, **kwargs)
-        self._pconn, self._cconn = mp.Pipe()
+        self._pconn, self._cconn = Pipe()
         self._exception = None
 
     def run(self):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently when a Process run via parallel_run function in parallel.py fails because of an exception, we
are only able to get the exit code, and fail a test. We have to dig through the debug test logs to
figure out why the process failed to find the exception.

#### How did you do it?

By wrapping the multiprocessing.Process class in SonicProcess class, we can catch the exception when the Process is run by
enclosing the run call in a try/catch block and storing the exception. parallel_run would then create instances of SonicProcess instead of Process.
If any of the SonicProcess has an non-zero exit code, we can get the actual exception and log it.

#### How did you verify/test it?
Ran sanity check where we have an exception in a log message (using hostname1 instead of hostname). Here is the output in the log
```
ERROR    tests.common.helpers.parallel:parallel.py:119 Process _check_interfaces_on_dut--<MultiAsicSonicHost>board7 had exit code 1 and exception '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'hostname1' and traceback Traceback (most recent call last):
  File "/data/tests/common/helpers/parallel.py", line 24, in run
    Process.run(self)
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/data/tests/common/helpers/parallel.py", line 142, in wrapper
    target(*args, **kwargs)
  File "/data/tests/common/plugins/sanity_check/checks.py", line 129, in _check_interfaces_on_dut
    logger.info("Checking interfaces status on %s..." % dut.hostname1)
  File "/data/tests/common/devices/multi_asic.py", line 237, in __getattr__
    return getattr(self.sonichost, attr)  # For backward compatibility
  File "/data/tests/common/devices/base.py", line 50, in __getattr__
    "'%s' object has no attribute '%s'" % (self.__class__, module_name)
AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'hostname1'

```

Example exception raised by an ansible module (changed the ansible library 'show_ip_interface' to send 'show ip interface1' instead of 'show ip interface'):

```
ERROR    tests.common.helpers.parallel:parallel.py:119 Process _check_interfaces_on_dut--<MultiAsicSonicHost> board7 had exit code 1 and exception run module show_ip_interface failed, Ansible Results =>
{
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "namespace": null
        }
    }, 
    "msg": "Command failed rc = 2, out = , err = Usage: show ip [OPTIONS] COMMAND [ARGS]...\nTry \"show ip -h\" for help.\n\nError: No such command \"interfaces1\".\n"
} and traceback Traceback (most recent call last):
  File "/data/tests/common/helpers/parallel.py", line 24, in run
    Process.run(self)
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/data/tests/common/helpers/parallel.py", line 142, in wrapper
    target(*args, **kwargs)
  File "/data/tests/common/plugins/sanity_check/checks.py", line 154, in _check_interfaces_on_dut
    down_ports += _find_down_ports(asic, phy_interfaces, ip_interfaces)
  File "/data/tests/common/plugins/sanity_check/checks.py", line 113, in _find_down_ports
    down_ports = _find_down_ip_ports(dut, ip_interfaces) + \
  File "/data/tests/common/plugins/sanity_check/checks.py", line 91, in _find_down_ip_ports
    ip_intf_facts = dut.show_ip_interface()['ansible_facts']['ip_interfaces']
  File "/data/tests/common/devices/sonic_asic.py", line 144, in show_ip_interface
    return self.sonichost.show_ip_interface(*module_args, **complex_args)
  File "/data/tests/common/devices/base.py", line 89, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
RunAnsibleModuleFail: run module show_ip_interface failed, Ansible Results =>
{
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "namespace": null
        }
    }, 
    "msg": "Command failed rc = 2, out = , err = Usage: show ip [OPTIONS] COMMAND [ARGS]...\nTry \"show ip -h\" for help.\n\nError: No such command \"interfaces1\".\n"
}

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
