### PR TITLE
[qos] Skip test when test port set is empty

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -5,7 +5,7 @@ import re
 import yaml
 
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file    # lgtm[py/unused-import]
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from tests.common.system_utils import docker
 
@@ -434,6 +434,7 @@ class QosSaiBase:
                 # The last port is used for up link from DUT switch
                 testPortIds -= {len(mgFacts["minigraph_ptf_indices"]) - 1}
             testPortIds = sorted(testPortIds)
+            pytest_require(len(testPortIds) != 0, "Skip test since no ports are available for testing")
 
             # get current DUT port IPs
             dutPortIps = {}


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We skip lag interfaces on Mellanox devices since packet aging enable/disable cannot be done on lag member ports. Hence some mellanox skus on topologies like "t1-64-lag" will not have any ports selected for the test. In such cases, the test should be skipped

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Made the testPortIds empty and verified that the tests were skipped