### PR TITLE
[sanity_check]: Fix crash due to invisible fixture

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -403,7 +403,7 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
         logger.info("Checking mux simulator status for PTF interface {}".format(ptf_server_intf))
         ptf_port_index = int(ptf_server_intf.replace('eth', ''))
         recover_all_directions(tor_mux_intf)
-        
+
         upper_tor_intf_mac, upper_tor_mgmt_ip = get_arp_pkt_info(upper_tor_host)
         lower_tor_intf_mac, lower_tor_mgmt_ip = get_arp_pkt_info(lower_tor_host)
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -323,9 +323,63 @@ def get_arp_pkt_info(dut):
     return intf_mac, mgmt_ipv4
 
 
+def mux_sim_check_downstream(active_tor, standby_tor, ptfadapter,
+                     active_tor_ping_tgt_ip, standby_tor_ping_tgt_ip,
+                     active_tor_exp_pkt, standby_tor_exp_pkt,
+                     ptf_port_index, tor_mux_intf):
+    failed = False
+    reason = ''
+    ping_cmd = 'ping -I {} {} -c 1 -W 1; true'
+
+    # Clear ARP tables to start in consistent state
+    active_tor.shell("ip neigh flush all")
+    standby_tor.shell("ip neigh flush all")
+
+    # Ping from both ToRs, expect only message from upper ToR to reach PTF
+    active_tor.shell(ping_cmd.format(tor_mux_intf, active_tor_ping_tgt_ip))
+    try:
+        testutils.verify_packet(ptfadapter, active_tor_exp_pkt, ptf_port_index)
+    except AssertionError:
+        failed = True
+        reason = 'Packet from active ToR {} not received'.format(active_tor)
+        return failed, reason
+
+    standby_tor.shell(ping_cmd.format(tor_mux_intf, standby_tor_ping_tgt_ip))
+    try:
+        testutils.verify_no_packet(ptfadapter, standby_tor_exp_pkt, ptf_port_index)
+    except AssertionError:
+        failed = True
+        reason = 'Packet from standby ToR {} received'.format(standby_tor)
+
+    return failed, reason
+
+
+def mux_sim_check_upstream(upper_tor_host, lower_tor_host, ptfadapter,
+                           ptf_arp_tgt_ip, ptf_arp_pkt, ptf_port_index):
+    # Send dummy ARP packets from PTF to ToR. Ensure that ARP is learned on both ToRs
+    failed = False
+    reason = ''
+    upper_tor_host.shell("ip neigh flush all")
+    lower_tor_host.shell("ip neigh flush all")
+
+    testutils.send_packet(ptfadapter, ptf_port_index, ptf_arp_pkt)
+
+    upper_tor_arp_table = upper_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
+    lower_tor_arp_table = lower_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
+    if ptf_arp_tgt_ip not in upper_tor_arp_table:
+        failed = True
+        reason = 'Packet from PTF not received on upper ToR {}'.format(upper_tor_host)
+        return failed, reason
+
+    if ptf_arp_tgt_ip not in lower_tor_arp_table:
+        failed = True
+        reason = 'Packet from PTF not received on lower ToR {}'.format(lower_tor_host)
+
+    return failed, reason
+
 @pytest.fixture(scope='module')
 def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_host, lower_tor_host, \
-                        recover_all_directions, toggle_simulator_port_to_upper_tor, toggle_simulator_port_to_lower_tor, check_simulator_read_side):
+                    recover_all_directions, toggle_simulator_port_to_upper_tor, toggle_simulator_port_to_lower_tor, check_simulator_read_side):
 
     def _check(*args, **kwargs):
         """
@@ -343,21 +397,19 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
                     'check_item': '{} mux simulator'.format(ptf_server_intf)
                 }
 
+        failed = False
+        reason = ''
+
         logger.info("Checking mux simulator status for PTF interface {}".format(ptf_server_intf))
         ptf_port_index = int(ptf_server_intf.replace('eth', ''))
         recover_all_directions(tor_mux_intf)
         
-        # Stop linkmgrd to prevent it from switching over ports
-        lower_tor_host.shell('systemctl stop mux')
-        upper_tor_host.shell('systemctl stop mux')
-
         upper_tor_intf_mac, upper_tor_mgmt_ip = get_arp_pkt_info(upper_tor_host)
         lower_tor_intf_mac, lower_tor_mgmt_ip = get_arp_pkt_info(lower_tor_host)
 
         upper_tor_ping_tgt_ip = '10.10.10.1'
         lower_tor_ping_tgt_ip = '10.10.10.2'
         ptf_arp_tgt_ip = '10.10.10.3'
-        ping_cmd = 'ping -I {} {} -c 1 -W 1; true'
 
         upper_tor_exp_pkt = testutils.simple_arp_packet(eth_dst='ff:ff:ff:ff:ff:ff',
                                                         eth_src=upper_tor_intf_mac,
@@ -374,107 +426,63 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
                                                 ip_snd=ptf_arp_tgt_ip,
                                                 arp_op=2)
 
-        # Clear ARP tables to start in consistent state
-        upper_tor_host.shell("ip neigh flush all")
-        lower_tor_host.shell("ip neigh flush all")
 
         # Run tests with upper ToR active
-        toggle_simulator_port_to_upper_tor(tor_mux_intf)
-
-        if check_simulator_read_side(tor_mux_intf) != 1:
-            results['failed'] = True
-            results['failed_reason'] = 'Unable to switch active link to upper ToR'
-            return results
-
-        # Ping from both ToRs, expect only message from upper ToR to reach PTF
-        upper_tor_host.shell(ping_cmd.format(tor_mux_intf, upper_tor_ping_tgt_ip))
         try:
-            testutils.verify_packet(ptfadapter, upper_tor_exp_pkt, ptf_port_index)
-        except AssertionError:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from active upper ToR not received'
-            return results
+            # Stop linkmgrd to prevent it from switching over ports
+            lower_tor_host.shell('systemctl stop mux')
+            upper_tor_host.shell('systemctl stop mux')
 
-        lower_tor_host.shell(ping_cmd.format(tor_mux_intf, lower_tor_ping_tgt_ip))
-        try:
-            testutils.verify_no_packet(ptfadapter, lower_tor_exp_pkt, ptf_port_index)
-        except AssertionError:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from standby lower ToR received'
-            return results
+            toggle_simulator_port_to_upper_tor(tor_mux_intf)
+            if check_simulator_read_side(tor_mux_intf) != 1:
+                failed = True
+                reason = 'Unable to switch active link to upper ToR'
 
-        # Send dummy ARP packets from PTF to ToR. Ensure that ARP is learned on both ToRs
-        upper_tor_host.shell("ip neigh flush all")
-        lower_tor_host.shell("ip neigh flush all")
-        testutils.send_packet(ptfadapter, ptf_port_index, ptf_arp_pkt)
+            if not failed:
+                failed, reason = mux_sim_check_downstream(upper_tor_host, lower_tor_host,
+                    ptfadapter, upper_tor_ping_tgt_ip, lower_tor_ping_tgt_ip,
+                    upper_tor_exp_pkt, lower_tor_exp_pkt, ptf_port_index, tor_mux_intf)
 
-        upper_tor_arp_table = upper_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
-        lower_tor_arp_table = lower_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
-        if ptf_arp_tgt_ip not in upper_tor_arp_table:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from PTF not received on active upper ToR'
-            return results
+            
+            if not failed:
+                failed, reason = mux_sim_check_upstream(upper_tor_host, lower_tor_host,
+                    ptfadapter, ptf_arp_tgt_ip, ptf_arp_pkt, ptf_port_index)
 
-        if ptf_arp_tgt_ip not in lower_tor_arp_table:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from PTF not received on standby lower ToR'
-            return results
+            # Repeat all tests with lower ToR active
+            if not failed:
+                toggle_simulator_port_to_lower_tor(tor_mux_intf)
+                if check_simulator_read_side(tor_mux_intf) != 2:
+                    failed = True
+                    reason = 'Unable to switch active link to lower ToR'
 
-        # Repeat all tests with lower ToR active
-        toggle_simulator_port_to_lower_tor(tor_mux_intf)
-        if check_simulator_read_side(tor_mux_intf) != 2:
-            results['failed'] = True
-            results['failed_reason'] = 'Unable to switch active link to lower ToR'
-            return results
+            if not failed:
+                failed, reason = mux_sim_check_downstream(lower_tor_host, upper_tor_host,
+                    ptfadapter, lower_tor_ping_tgt_ip, upper_tor_ping_tgt_ip,
+                    lower_tor_exp_pkt, upper_tor_exp_pkt, ptf_port_index, tor_mux_intf)
 
-        lower_tor_host.shell(ping_cmd.format(tor_mux_intf, lower_tor_ping_tgt_ip))
-        try:
-            testutils.verify_packet(ptfadapter, lower_tor_exp_pkt, ptf_port_index)
-        except AssertionError:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from active lower ToR not received'
-            return results
+            if not failed:
+                failed, reason = mux_sim_check_upstream(upper_tor_host, lower_tor_host,
+                    ptfadapter, ptf_arp_tgt_ip, ptf_arp_pkt, ptf_port_index)
 
-        upper_tor_host.shell(ping_cmd.format(tor_mux_intf, upper_tor_ping_tgt_ip))
-        try:
-            testutils.verify_no_packet(ptfadapter, upper_tor_exp_pkt, ptf_port_index)
-        except AssertionError:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from standby upper ToR received'
-            return results
+            logger.info('Finished mux simulator check')
+        finally:
+            upper_tor_host.shell("ip neigh flush all")
+            lower_tor_host.shell("ip neigh flush all")
 
-        upper_tor_host.shell("ip neigh flush all")
-        lower_tor_host.shell("ip neigh flush all")
-        testutils.send_packet(ptfadapter, ptf_port_index, ptf_arp_pkt)
+            cmds = [
+                'systemctl reset-failed mux',
+                'systemctl start mux'
+            ]
 
-        upper_tor_arp_table = upper_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
-        lower_tor_arp_table = lower_tor_host.switch_arptable()['ansible_facts']['arptable']['v4']
-        if ptf_arp_tgt_ip not in upper_tor_arp_table:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from PTF not received on standby upper ToR'
-            return results
+            lower_tor_host.shell_cmds(cmds=cmds)
+            upper_tor_host.shell_cmds(cmds=cmds)
 
-        if ptf_arp_tgt_ip not in lower_tor_arp_table:
-            results['failed'] = True
-            results['failed_reason'] = 'Packet from PTF not received on active lower ToR'
-            return results
-
-        logger.info('Finished mux simulator check')
-        upper_tor_host.shell("ip neigh flush all")
-        lower_tor_host.shell("ip neigh flush all")
+        results['failed'] = failed
+        results['failed_reason'] = reason
 
         return results
 
-    yield _check
-
-    cmds = [
-        'systemctl reset-failed mux',
-        'systemctl start mux'
-    ]
-
-    lower_tor_host.shell_cmds(cmds=cmds)
-    upper_tor_host.shell_cmds(cmds=cmds)
-
+    return _check
 
 @pytest.fixture(scope="module")
 def check_monit(duthosts):

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -335,7 +335,7 @@ def mux_sim_check_downstream(active_tor, standby_tor, ptfadapter,
     active_tor.shell("ip neigh flush all")
     standby_tor.shell("ip neigh flush all")
 
-    # Ping from both ToRs, expect only message from upper ToR to reach PTF
+    # Ping from both ToRs, expect only message from active ToR to reach PTF
     active_tor.shell(ping_cmd.format(tor_mux_intf, active_tor_ping_tgt_ip))
     try:
         testutils.verify_packet(ptfadapter, active_tor_exp_pkt, ptf_port_index)
@@ -442,7 +442,6 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
                 failed, reason = mux_sim_check_downstream(upper_tor_host, lower_tor_host,
                     ptfadapter, upper_tor_ping_tgt_ip, lower_tor_ping_tgt_ip,
                     upper_tor_exp_pkt, lower_tor_exp_pkt, ptf_port_index, tor_mux_intf)
-
             
             if not failed:
                 failed, reason = mux_sim_check_upstream(upper_tor_host, lower_tor_host,
@@ -466,10 +465,8 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
 
             logger.info('Finished mux simulator check')
         finally:
-            upper_tor_host.shell("ip neigh flush all")
-            lower_tor_host.shell("ip neigh flush all")
-
             cmds = [
+                'ip neigh flush all',
                 'systemctl reset-failed mux',
                 'systemctl start mux'
             ]


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Dual ToR testbeds running non dual ToR specific tests with the sanity check enabled will have the sanity check crash, since the mux simulator sanity check was recently update to use the `run_garp_service` fixture. This fixture is not imported/visible in most tests, thus the test would fail at the sanity check.

#### How did you do it?
The `run_garp_service` fixture was used to prevent linkmgrd from preventing unwanted switchovers. The alternative to this was to simply stop linkmgrd entirely, and restart it after the sanity check ends

Also, refactored the test into shorter methods for code quality/readability.

#### How did you verify/test it?
Run a non-dual ToR test on a dual ToR testbed, verified the sanity check passed. 
Run a dual ToR test on a dual ToR testbed, verified the sanity check passed.


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
