### PR TITLE
[test_pfcwd_warm_reboot] Fix test dependency from odd/even days

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -27,7 +27,7 @@ def pytest_addoption(parser):
                      help='PFC WD storm restore interval')
     parser.addoption('--fake-storm', action='store', type=bool, default=True,
                      help='Fake storm for most ports instead of using pfc gen')
-    parser.addoption('--two-queues', action='store_true', default=False,
+    parser.addoption('--two-queues', action='store_true', default=True,
                      help='Run test with sending traffic to both queues [3, 4]')
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -27,6 +27,8 @@ def pytest_addoption(parser):
                      help='PFC WD storm restore interval')
     parser.addoption('--fake-storm', action='store', type=bool, default=True,
                      help='Fake storm for most ports instead of using pfc gen')
+    parser.addoption('--two-queues', action='store_true', default=False,
+                     help='Run test with sending traffic to both queues [3, 4]')
 
 @pytest.fixture(scope="module", autouse=True)
 def skip_pfcwd_test_dualtor(tbinfo):
@@ -34,6 +36,23 @@ def skip_pfcwd_test_dualtor(tbinfo):
         pytest.skip("Pfcwd tests skipped on dual tor testbed")
 
     yield
+
+
+@pytest.fixture(scope="module")
+def two_queues(request):
+    """
+    Enable/Disable sending traffic to queues [4, 3]
+    By default send to queue 4
+
+    Args:
+        request: pytest request object
+        duthosts: AnsibleHost instance for multi DUT
+        rand_one_dut_hostname: hostname of DUT
+
+    Returns:
+        two_queues: False/True
+    """
+    return request.config.getoption('--two-queues')
 
 
 @pytest.fixture(scope="module")

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -107,7 +107,8 @@ class SetupPfcwdFunc(object):
         """
         self.pfc_wd = dict()
         self.pfc_wd['queue_indices'] = [4]
-        if (self.seed % 2) != 0:
+        if self.two_queues:
+            # Will send traffic for (queues 4 and 3) per each port
             self.pfc_wd['queue_indices'].append(3)
         self.pfc_wd['test_pkt_count'] = 100
         self.pfc_wd['frames_number'] = 10000000000000
@@ -431,7 +432,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                         PfcCmd.set_storm_status(self.dut, self.oid_map[(port, queue)], "disabled")
 
     def pfcwd_wb_helper(self, fake_storm, testcase_actions, setup_pfc_test, fanout_graph_facts, ptfhost,
-                        duthost, localhost, fanouthosts):
+                        duthost, localhost, fanouthosts, two_queues):
         """
         Helper method that initializes the vars and starts the test execution
 
@@ -455,7 +456,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         self.neighbors = setup_info['neighbors']
         dut_facts = self.dut.facts
         self.peer_dev_list = dict()
-        self.seed = int(datetime.datetime.today().day)
+        self.two_queues = two_queues
         self.storm_handle = dict()
         bitmask = 0
         storm_deferred = 0
@@ -520,7 +521,8 @@ class TestPfcwdWb(SetupPfcwdFunc):
         """
         yield request.param
 
-    def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts, rand_one_dut_hostname, localhost, fanouthosts):
+    def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, fanout_graph_facts, ptfhost, duthosts,
+                      rand_one_dut_hostname, localhost, fanouthosts, two_queues):
         """
         Tests PFCwd warm reboot with various testcase actions
 
@@ -546,4 +548,4 @@ class TestPfcwdWb(SetupPfcwdFunc):
         duthost = duthosts[rand_one_dut_hostname]
         logger.info("--- {} ---".format(TESTCASE_INFO[testcase_action]['desc']))
         self.pfcwd_wb_helper(fake_storm, TESTCASE_INFO[testcase_action]['test_sequence'], setup_pfc_test,
-                             fanout_graph_facts, ptfhost, duthost, localhost, fanouthosts)
+                             fanout_graph_facts, ptfhost, duthost, localhost, fanouthosts, two_queues)

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -107,7 +107,7 @@ class SetupPfcwdFunc(object):
         """
         self.pfc_wd = dict()
         self.pfc_wd['queue_indices'] = [4]
-        if self.two_queues:
+        if self.two_queues and (self.seed % 2) != 0:
             # Will send traffic for (queues 4 and 3) per each port
             self.pfc_wd['queue_indices'].append(3)
         self.pfc_wd['test_pkt_count'] = 100
@@ -456,6 +456,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         self.neighbors = setup_info['neighbors']
         dut_facts = self.dut.facts
         self.peer_dev_list = dict()
+        self.seed = int(datetime.datetime.today().day)
         self.two_queues = two_queues
         self.storm_handle = dict()
         bitmask = 0


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  **test_pfcwd_warm_reboot** behavior depends from the day of test execution, if it is **even** or **odd** day. 

```
self.seed = int(datetime.datetime.today().day)

self.pfc_wd['queue_indices'] = [4]
if (self.seed % 2) != 0:
    self.pfc_wd['queue_indices'].append(3)
```

This impacts test behavior which could make debug of a test more difficult, because test depending from the day will send traffic to 4 queue or to both queues 4 and 3. Added optional parameter `--two-queues` to choose when test should be executed with sending traffic to both queues. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix test dependency from odd/even days
#### How did you do it?
Added optional parameter `--two-queues`
#### How did you verify/test it?
Run test with optional parameter and without it 
#### Any platform specific information?
```
SONiC Software Version: SONiC.201911.267-dirty-20210424.082658
Distribution: Debian 9.13
Kernel: 4.9.0-14-2-amd64
Build commit: a754e4b1
Build date: Sat Apr 24 08:36:35 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
