### PR TITLE
[dualtor][orch] Fix TUNNEL config error - use sonic-cfggen to add TUNNEL table to config DB

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -334,18 +334,21 @@ def apply_tunnel_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_pe
 
     dut_loopback = (mock_peer_switch_loopback_ip - 1).ip
 
-    tunnel_key = 'TUNNEL|MuxTunnel0'
     tunnel_params = {
-        'dscp_mode': 'uniform',
-        'dst_ip': dut_loopback,
-        'ecn_mode': 'copy_from_outer',
-        'encap_ecn_mode': 'standard',
-        'ttl_mode': 'pipe',
-        'tunnel_type': 'IPINIP'
+        'TUNNEL': {
+            'MuxTunnel0': {
+                'dscp_mode': 'uniform',
+                'dst_ip': str(dut_loopback),
+                'ecn_mode': 'copy_from_outer',
+                'encap_ecn_mode': 'standard',
+                'ttl_mode': 'pipe',
+                'tunnel_type': 'IPINIP'
+            }
+        }
     }
 
-    for param, value in tunnel_params.items():
-        dut.shell('redis-cli -n 4 HSET "{}" "{}" "{}"'.format(tunnel_key, param, value))
+    dut.copy(content=json.dumps(tunnel_params, indent=2), dest="/tmp/tunnel_params.json")
+    dut.shell("sonic-cfggen -j /tmp/tunnel_params.json --write-to-db")
 
     return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix TUNNEL config error - use sonic-cfggen to add TUNNEL table to config DB 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach

#### What is the motivation for this PR?
While applying tunnel table to configdb, `redis-cli -n 4 HSET`  sets the values incorrectly, this leads to below failure:

```
Apr 30 17:02:56.161416 str2-7050cx3-acs-02 INFO ansible-command: Invoked with creates=None executable=None _uses_shell=True strip_empty_ends=True _raw_params=redis-cli -n 4 HSET "TUNNEL|MuxTunnel0" "encap_ecn_mode" "standard" removes=None argv=None warn=True chdir=None stdin_add_newline=True stdin=None
Apr 30 17:02:45.368535 str2-7050cx3-acs-02 NOTICE acms#root: Waiting for bootstrap cert
Apr 30 17:02:56.350676 str2-7050cx3-acs-02 NOTICE swss#tunnelmgrd: :- doTunnelTask: Peer/Remote IP not configured
Apr 30 17:02:56.351080 str2-7050cx3-acs-02 NOTICE swss#tunnelmgrd: :- doTunnelTask: Tunnel MuxTunnel0 task, op SET
Apr 30 17:02:56.359967 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- setTunnelAttribute: Set attribute dscp_mode with value uniform
Apr 30 17:02:56.360342 str2-7050cx3-acs-02 ERR swss#orchagent: :- addDecapTunnelTermEntries: 10.1.0.32 already exists. Did not create entry.
Apr 30 17:02:56.360498 str2-7050cx3-acs-02 ERR swss#orchagent: :- meta_generic_validation_set: SAI_TUNNEL_ATTR_DECAP_ECN_MODE:SAI_ATTR_VALUE_TYPE_INT32 attr is create only and cannot be modified
Apr 30 17:02:56.360661 str2-7050cx3-acs-02 ERR swss#orchagent: :- setTunnelAttribute: Failed to set attribute ecn_mode with value copy_from_outer
Apr 30 17:02:56.360797 str2-7050cx3-acs-02 ERR swss#orchagent: :- handleSaiSetStatus: Encountered failure in set operation, exiting orchagent, SAI API: SAI_API_TUNNEL, status: SAI_STATUS_INVALID_PARAMETER
Apr 30 17:02:56.361002 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- uninitialize: begin
Apr 30 17:02:56.361157 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- uninitialize: begin
Apr 30 17:02:56.361203 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- ~RedisChannel: join ntf thread begin
Apr 30 17:02:56.361371 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- ~RedisChannel: join ntf thread end
Apr 30 17:02:56.361527 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- clear_local_state: clearing local state
Apr 30 17:02:56.361579 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- meta_init_db: begin
Apr 30 17:02:56.388507 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- meta_init_db: end
Apr 30 17:02:56.388837 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- uninitialize: end
Apr 30 17:02:56.389236 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- stopRecording: stopped recording
Apr 30 17:02:56.389498 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- stopRecording: closed recording file: sairedis.rec
Apr 30 17:02:56.389755 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- uninitialize: end
```
#### How did you do it?
Copy the config into a json file, move the file to device. Then use `sonic-cfggen` to take this json file and write to DB.

#### How did you verify/test it?
Tested the changes, and swss restart is not seen.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
