### PR TITLE
[rdma] Fix ixia api teardown failure if Session is None

### DIFF
--- a/tests/common/ixia/ixia_fixtures.py
+++ b/tests/common/ixia/ixia_fixtures.py
@@ -194,7 +194,7 @@ def ixia_api(ixia_api_serv_ip,
 
     yield api_session
 
-    if api_session:
+    if api_session and api_session.assistant and api_session.assistant.Session:
         api_session.assistant.Session.remove()
 
 @pytest.fixture(scope = "function")


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Check for the existence of Session object before attempting a removal

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran the test that was failing during teardown and no longer see the errors with the fix