### PR TITLE
multi asic changes for IP decap test

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -22,6 +22,22 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+@pytest.fixture(scope='module')
+def config_facts(duthosts):
+    cfg_facts = {}
+    for duthost in duthosts:
+        cfg_facts[duthost.hostname] = []
+        for asic in duthost.asics:
+            if asic.is_it_backend():
+                continue
+            asic_cfg_facts = asic.config_facts(source='running')['ansible_facts']
+            cfg_facts[duthost.hostname].append(asic_cfg_facts)
+    return cfg_facts
+
+
+@pytest.fixture(scope='module')
+def minigraph_facts(duthosts, tbinfo):
+    return duthosts.get_extended_minigraph_facts(tbinfo)
 
 def get_fib_info(duthost, cfg_facts, mg_facts):
     """Get parsed FIB information from redis DB.
@@ -44,41 +60,55 @@ def get_fib_info(duthost, cfg_facts, mg_facts):
             }
     """
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-    duthost.shell("redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(timestamp))
-    duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
-
-    po = cfg_facts.get('PORTCHANNEL', {})
-    ports = cfg_facts.get('PORT', {})
-
     fib_info = {}
-    with open("/tmp/fib/{}/tmp/fib.{}.txt".format(duthost.hostname, timestamp)) as fp:
-        fib = json.load(fp)
-        for k, v in fib.items():
-            skip = False
+    for asic_index, asic_cfg_facts in  enumerate(cfg_facts):
 
-            prefix = k.split(':', 1)[1]
-            ifnames = v['value']['ifname'].split(',')
-            nh = v['value']['nexthop']
+        asic = duthost.asic_instance(asic_index)
 
-            oports = []
-            for ifname in ifnames:
-                if po.has_key(ifname):
-                    oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
-                else:
-                    if ports.has_key(ifname):
-                        oports.append([str(mg_facts['minigraph_ptf_indices'][ifname])])
+        asic.shell("{} redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(asic.ns_arg, timestamp))
+        duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
+
+        po = asic_cfg_facts.get('PORTCHANNEL', {})
+        ports = asic_cfg_facts.get('PORT', {})
+
+
+        with open("/tmp/fib/{}/tmp/fib.{}.txt".format(duthost.hostname, timestamp)) as fp:
+            fib = json.load(fp)
+            for k, v in fib.items():
+                skip = False
+
+                prefix = k.split(':', 1)[1]
+                ifnames = v['value']['ifname'].split(',')
+                nh = v['value']['nexthop']
+
+                oports = []
+                for ifname in ifnames:
+                    if po.has_key(ifname):
+                        # ignore the prefix, if the prefix nexthop is not a frontend port
+                        if 'members' in po[ifname]:
+                            if 'role' in ports[po[ifname]['members'][0]] and ports[po[ifname]['members'][0]]['role'] == 'Int':
+                                skip = True
+                            else:
+                                oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
                     else:
-                        logger.info("Route point to non front panel port {}:{}".format(k, v))
-                        skip = True
+                        if ports.has_key(ifname):
+                            if 'role' in ports[ifname] and ports[ifname]['role'] == 'Int':
+                                skip = True
+                            else:
+                                oports.append([str(mg_facts['minigraph_ptf_indices'][ifname])])
+                        else:
+                            logger.info("Route point to non front panel port {}:{}".format(k, v))
+                            skip = True
 
-            # skip direct attached subnet
-            if nh == '0.0.0.0' or nh == '::' or nh == "":
-                skip = True
+                # skip direct attached subnet
+                if nh == '0.0.0.0' or nh == '::' or nh == "":
+                    skip = True
 
-            if not skip:
-                fib_info[prefix] = oports
-            else:
-                fib_info[prefix] = []
+                if not skip:
+                    if prefix in fib_info:
+                        fib_info[prefix] += oports
+                    else:
+                        fib_info[prefix] = oports
     return fib_info
 
 
@@ -102,7 +132,7 @@ def prepare_ptf(duthost, ptfhost, cfg_facts, mg_facts):
 
 
 @pytest.fixture(scope="module")
-def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
+def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost, config_facts, minigraph_facts):
     duthost = duthosts[rand_one_dut_hostname]
 
     # Initialize parameters
@@ -116,20 +146,21 @@ def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
 
     # The hostvars dict has definitions defined in ansible/group_vars/sonic/variables
     hostvars = duthost.host.options["variable_manager"]._hostvars[duthost.hostname]
-    sonic_hwsku = duthost.facts["hwsku"]
-    mellanox_hwskus = hostvars["mellanox_hwskus"]
+    sonic_hwsku = duthost.sonichost.facts["hwsku"]
+    mellanox_hwskus = hostvars.get("mellanox_hwskus", [])
 
     if sonic_hwsku in mellanox_hwskus:
         dscp_mode = "uniform"
         ecn_mode = "standard"
 
     # Gather some facts
-    cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")["ansible_facts"]
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    cfg_facts = config_facts[duthost.hostname]
+    mg_facts  = minigraph_facts[duthost.hostname]
 
     lo_ip = None
     lo_ipv6 = None
-    for addr in cfg_facts["LOOPBACK_INTERFACE"]["Loopback0"]:
+    # Loopback0 ip is same on all asic
+    for addr in cfg_facts[0]["LOOPBACK_INTERFACE"]["Loopback0"]:
         ip = IPNetwork(addr).ip
         if ip.version == 4 and not lo_ip:
             lo_ip = ip
@@ -139,8 +170,8 @@ def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
 
     vlan_ip = None
     vlan_ipv6 = None
-    if "VLAN_INTERFACE" in cfg_facts:
-        for addr in cfg_facts["VLAN_INTERFACE"]["Vlan1000"]:
+    if "VLAN_INTERFACE" in cfg_facts[0]:
+        for addr in cfg_facts[0]["VLAN_INTERFACE"]["Vlan1000"]:
             ip = IPNetwork(addr).ip
             if ip.version == 4 and not vlan_ip:
                 vlan_ip = ip
@@ -173,18 +204,24 @@ def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
         "dscp_mode": dscp_mode,
         "ecn_mode": ecn_mode,
         "ttl_mode": ttl_mode,
+        "ignore_ttl": True if duthost.sonichost.is_multi_asic else False,
+        "max_internal_hops": 3 if duthost.sonichost.is_multi_asic else 0,
     }
 
-    duthost.copy(content=decap_conf_template.render(**decap_conf_vars), dest="/tmp/decap_conf.json")
-    duthost.shell("docker cp /tmp/decap_conf.json swss:/decap_conf.json")
-    duthost.shell('docker exec swss sh -c "swssconfig /decap_conf.json"')
+    duthost.copy(content=decap_conf_template.render(
+        **decap_conf_vars), dest="/tmp/decap_conf.json")
+    for asic_id in duthost.get_frontend_asic_ids():
+        duthost.shell("docker cp /tmp/decap_conf.json swss{}:/decap_conf.json"
+                      .format(asic_id if asic_id is not None else ""))
+        duthost.shell('docker exec swss{} sh -c "swssconfig /decap_conf.json"'
+                      .format(asic_id if asic_id is not None else ""))
 
     # Prepare PTFf docker
     prepare_ptf(duthost, ptfhost, cfg_facts, mg_facts)
 
     setup_info = {
         "src_ports": ",".join([str(port) for port in src_ports]),
-        "router_mac": cfg_facts["DEVICE_METADATA"]["localhost"]["mac"],
+        "router_mac": cfg_facts[0]["DEVICE_METADATA"]["localhost"]["mac"],
         "vlan_ip": str(vlan_ip) if vlan_ip else "",
         "vlan_ipv6": str(vlan_ipv6) if vlan_ipv6 else "",
     }
@@ -195,9 +232,13 @@ def setup_teardown(request, tbinfo, duthosts, rand_one_dut_hostname, ptfhost):
 
     # Remove decap configuration
     decap_conf_vars["op"] = "DEL"
-    duthost.copy(content=decap_conf_template.render(**decap_conf_vars), dest="/tmp/decap_conf.json")
-    duthost.shell("docker cp /tmp/decap_conf.json swss:/decap_conf.json")
-    duthost.shell('docker exec swss sh -c "swssconfig /decap_conf.json"')
+    duthost.copy(content=decap_conf_template.render(
+        **decap_conf_vars), dest="/tmp/decap_conf.json")
+    for asic_id in duthost.get_frontend_asic_ids():
+        duthost.shell("docker cp /tmp/decap_conf.json swss{}:/decap_conf.json"
+                      .format(asic_id if asic_id is not None else ""))
+        duthost.shell('docker exec swss{} sh -c "swssconfig /decap_conf.json"'
+                      .format(asic_id if asic_id is not None else ""))
 
 
 def test_decap(setup_teardown, tbinfo, ptfhost):
@@ -222,6 +263,8 @@ def test_decap(setup_teardown, tbinfo, ptfhost):
                         "ttl_mode": setup_info["ttl_mode"],
                         "src_ports": setup_info["src_ports"],
                         "router_mac": setup_info["router_mac"],
+                        "ignore_ttl": setup_info["ignore_ttl"],
+                        "max_internal_hops": setup_info["max_internal_hops"],
                         "fib_info": FIB_INFO_DEST,
                         },
                 qlen=PTFRUNNER_QLEN,


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshminarasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Change the IP decap tests to support multi asic platforms
#### How did you do it?
The following changes are done to support IP decap tests for multi asic platforms
 - Change the test to get configuration for every asic and build the FIB table with external nexthops
 -  Add to optional params to the IP decap PTF test
    - `ignore_ttl`: The Param is used to mask the ttl value in the expected packets. The param is `False` in single asic devices
     - `max_internal_hops`: The param indicate the internal hop a packet might take in multi asic devices.  On single ASIC device this param is `0`
     
#### How did you verify/test it?
Verify the test passed on single and multi asic testbed

**Output from single asic testbed**
```
./run_tests.sh -d str-a7170-acs-1 -n vms13-t0-a7170 -c decap/test_decap.py -i /data/repos/files/veos_vtb -f /data/repos/files/vtestbed.csv -l INFO -k debug -m individual -u -t t1,any
 -e '--deep_clean  --skip_sanity --disable_loganalyzer '
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is
now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
================================================================================= test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/public/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

decap/test_decap.py::test_decap
------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------
09:49:45 __init__.set_default                     L0049 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
09:49:45 __init__.check_test_completeness         L0139 INFO   | Test has no defined levels. Continue without test completeness checks
09:49:45 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/vms13-t0-a7170/tbinfo.pickle" failed with exception: IOError(2, 'No such file or directory')
09:49:45 facts_cache.write                        L0114 INFO   | Create cache dir /data/repos/public/sonic-mgmt/tests/_cache/vms13-t0-a7170
09:49:45 facts_cache.write                        L0120 INFO   | Cached facts "vms13-t0-a7170.tbinfo" to /data/repos/public/sonic-mgmt/tests/_cache/vms13-t0-a7170/tbinfo.pickle
09:49:45 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1/basic_facts.pickle" failed with exception: IOError(2, 'No such file or directory')
09:49:48 facts_cache.write                        L0114 INFO   | Create cache dir /data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1
09:49:48 facts_cache.write                        L0120 INFO   | Cached facts "str-a7170-acs-1.basic_facts" to /data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1/basic_facts.pickle
09:49:49 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1/host_visible_vars.pickle" failed with exception: IOError(2, 'No such file or directory')
09:49:49 facts_cache.write                        L0120 INFO   | Cached facts "str-a7170-acs-1.host_visible_vars" to /data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1/host_visible_vars.pickle
09:49:50 ptfhost_utils.change_mac_addresses       L0101 INFO   | Change interface MAC addresses on ptfhost 'ptf-04'
09:49:50 ptfhost_utils.copy_ptftests_directory    L0061 INFO   | Copy PTF test files to PTF host 'ptf-04'
09:50:11 ptfhost_utils.remove_ip_addresses        L0115 INFO   | Remove existing IPs on ptfhost 'ptf-04'
09:50:12 conftest.generate_params_dut_hostname    L0786 INFO   | Using DUTs ['str-a7170-acs-1'] in testbed 'vms13-t0-a7170'
09:50:12 conftest.rand_one_dut_hostname           L0252 INFO   | Randomly select dut str-a7170-acs-1 for testing
09:50:12 conftest.creds_on_dut                    L0445 INFO   | dut str-a7170-acs-1 belongs to groups [u'sonic', 'fanout']
09:50:12 conftest.creds_on_dut                    L0457 INFO   | skip empty var file ../ansible/group_vars/all/env.yml
09:50:12 conftest.creds_on_dut                    L0457 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
09:50:13 __init__.sanity_check                    L0121 INFO   | Prepare sanity check
09:50:13 __init__.sanity_check                    L0131 INFO   | Found marker: m.name=topology, m.args=('any',), m.kwargs={}
09:50:13 __init__.sanity_check                    L0157 INFO   | Skip sanity check according to command line argument or configuration of test script.
09:50:14 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1/mg_facts.pickle" failed with exception: IOError(2, 'No such file or directory')
09:50:15 facts_cache.write                        L0120 INFO   | Cached facts "str-a7170-acs-1.mg_facts" to /data/repos/public/sonic-mgmt/tests/_cache/str-a7170-acs-1/mg_facts.pickle
09:50:15 test_decap.setup_teardown                L0169 INFO   | lo_ip=10.1.0.32, lo_ipv6=fc00:1::32
09:50:15 test_decap.setup_teardown                L0180 INFO   | vlan_ip=192.168.0.1, vlan_ipv6=fc02:1000::1
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc00:1::32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nexthop': u'::'}}
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fe80::/64:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nexthop': u'::'}}
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc02:1000::/64:{u'type': u'hash', u'value': {u'ifname': u'Vlan1000', u'nexthop': u'::'}}
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:192.168.0.0/21:{u'type': u'hash', u'value': {u'ifname': u'Vlan1000', u'nexthop': u'0.0.0.0'}}
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:10.1.0.32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nexthop': u'0.0.0.0'}}
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc00:2::/64:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop': u'::'}}
09:50:21 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:10.64.246.0/23:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop': u'0.0.0.0'}}
09:50:22 test_decap.setup_teardown                L0229 INFO   | {
  "ecn_mode": "copy_from_outer",
  "vlan_ip": "192.168.0.1",
  "vlan_ipv6": "fc02:1000::1",
  "dscp_mode": "pipe",
  "ignore_ttl": false,
  "lo_ipv6": "fc00:1::32",
  "router_mac": "74:83:ef:8d:d8:1b",
  "lo_ip": "10.1.0.32",
  "max_internal_hops": 0,
  "outer_ipv6": true,
  "outer_ipv4": true,
  "inner_ipv4": true,
  "inner_ipv6": true,
  "ttl_mode": "pipe",
  "src_ports": "0,1,4,5,6,7,8,9,10,11,12,13,14,15,16,17,20,21,22,23,24,25,26,27,28,29,30,31,32,36,37,38,39,40,41,42,48,52,53,54,55,56,57,58",
  "op": "SET"
}
09:50:22 __init__.loganalyzer                     L0047 INFO   | Log analyzer is disabled
PASSED                                                                                                                                                                           [100%]
---------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------
09:52:17 ptfhost_utils.remove_ip_addresses        L0120 INFO   | Remove IPs to restore ptfhost 'ptf-04'
09:52:17 ptfhost_utils.copy_ptftests_directory    L0066 INFO   | Delete PTF test files from PTF host 'ptf-04'

-------------------------------------------------- generated xml file: /data/repos/public/sonic-mgmt/tests/logs/decap/test_decap.xml ---------------------------------------------------
============================================================================== 1 passed in 152.90 seconds ==============================================================================
```

**Output from Multi asic testbed**
```
+ ./run_tests.sh -d str-sonic-acs-2 -n vms13-t1-lag-2 -c decap/test_decap.py -i /data/repos/files/veos_vtb -f /data/repos/files/vtestbed.csv -l INFO -k debug -u -m individual -t t1,any
 -e '--skip_sanity --deep_clean --disable_loganalyzer  '
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is
now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
================================================================================= test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/public/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

decap/test_decap.py::test_decap
------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------
09:02:02 __init__.set_default                     L0049 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
09:02:02 __init__.check_test_completeness         L0139 INFO   | Test has no defined levels. Continue without test completeness checks
09:02:02 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/vms13-t1-lag-2/tbinfo.pickle" failed with exception: IOErro
r(2, 'No such file or directory')
09:02:02 facts_cache.write                        L0114 INFO   | Create cache dir /data/repos/public/sonic-mgmt/tests/_cache/vms13-t1-lag-2
09:02:02 facts_cache.write                        L0120 INFO   | Cached facts "vms13-t1-lag-2.tbinfo" to /data/repos/public/sonic-mgmt/tests/_cache/vms13-t1-lag-2/tbinfo.pickle
09:02:02 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2/basic_facts.pickle" failed with exception:
IOError(2, 'No such file or directory')
09:02:07 facts_cache.write                        L0114 INFO   | Create cache dir /data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2
09:02:07 facts_cache.write                        L0120 INFO   | Cached facts "str-sonic-acs-2.basic_facts" to /data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2/basic_facts.pi
ckle
09:02:12 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2/host_visible_vars.pickle" failed with excep
tion: IOError(2, 'No such file or directory')
09:02:12 facts_cache.write                        L0120 INFO   | Cached facts "str-sonic-acs-2.host_visible_vars" to /data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2/host_vis
ible_vars.pickle
09:02:12 ptfhost_utils.change_mac_addresses       L0101 INFO   | Change interface MAC addresses on ptfhost 'ptf-05'
09:02:14 ptfhost_utils.copy_ptftests_directory    L0061 INFO   | Copy PTF test files to PTF host 'ptf-05'
09:02:41 ptfhost_utils.remove_ip_addresses        L0115 INFO   | Remove existing IPs on ptfhost 'ptf-05'
09:02:42 conftest.generate_params_dut_hostname    L0786 INFO   | Using DUTs ['str-sonic-acs-2'] in testbed 'vms13-t1-lag-2'
09:02:42 conftest.rand_one_dut_hostname           L0252 INFO   | Randomly select dut str-sonic-acs-2 for testing
09:02:42 conftest.creds_on_dut                    L0445 INFO   | dut str-sonic-acs-2 belongs to groups [u'sonic', 'fanout']
09:02:42 conftest.creds_on_dut                    L0457 INFO   | skip empty var file ../ansible/group_vars/all/env.yml
09:02:42 conftest.creds_on_dut                    L0457 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
09:02:44 __init__.sanity_check                    L0121 INFO   | Prepare sanity check
09:02:44 __init__.sanity_check                    L0131 INFO   | Found marker: m.name=topology, m.args=('any',), m.kwargs={}
09:02:44 __init__.sanity_check                    L0157 INFO   | Skip sanity check according to command line argument or configuration of test script.
09:02:50 facts_cache.read                         L0093 INFO   | Load cache file "/data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2/mg_facts.pickle" failed with exception: IOE
rror(2, 'No such file or directory')
09:02:51 facts_cache.write                        L0120 INFO   | Cached facts "str-sonic-acs-2.mg_facts" to /data/repos/public/sonic-mgmt/tests/_cache/str-sonic-acs-2/mg_facts.pickle
09:02:51 test_decap.setup_teardown                L0169 INFO   | lo_ip=10.1.0.32, lo_ipv6=fc00:1::32
09:02:51 test_decap.setup_teardown                L0180 INFO   | vlan_ip=None, vlan_ipv6=None
09:03:03 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:2603:10e2:400:::{u'type': u'hash', u'value': {u'ifname': u'Loopback4096
', u'nexthop': u'::'}}
09:03:03 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc00:1::32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nex
thop': u'::'}}
09:03:03 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fe80::/64:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop':
 u'::'}}
09:03:03 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fd00::/80:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop':
 u'::'}}
09:03:03 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:8.0.0.0:{u'type': u'hash', u'value': {u'ifname': u'Loopback4096', u'nex
thop': u'0.0.0.0'}}
09:03:03 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:10.1.0.32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nex$
hop': u'0.0.0.0'}}
09:03:07 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:8.0.0.1:{u'type': u'hash', u'value': {u'ifname': u'Loopback4096', u'ne$
thop': u'0.0.0.0'}}
09:03:07 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc00:1::32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'ne$
thop': u'::'}}
09:03:07 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fe80::/64:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop'$
 u'::'}}
09:03:07 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fd00::/80:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop'$
 u'::'}}
09:03:07 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:10.1.0.32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nex$
hop': u'0.0.0.0'}}
09:03:07 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:2603:10e2:400::1:{u'type': u'hash', u'value': {u'ifname': u'Loopback40$
6', u'nexthop': u'::'}}
09:03:11 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc00:1::32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'ne$
thop': u'::'}}
09:03:11 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fe80::/64:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop'$
 u'::'}}
09:03:11 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fd00::/80:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop'$
 u'::'}}
09:03:11 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:8.0.0.2:{u'type': u'hash', u'value': {u'ifname': u'Loopback4096', u'ne$
thop': u'0.0.0.0'}}
09:03:11 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:10.1.0.32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nex$
hop': u'0.0.0.0'}}
09:03:11 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:2603:10e2:400::2:{u'type': u'hash', u'value': {u'ifname': u'Loopback40$
6', u'nexthop': u'::'}}
09:03:14 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:2603:10e2:400::3:{u'type': u'hash', u'value': {u'ifname': u'Loopback40$
6', u'nexthop': u'::'}}
09:03:15 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:8.0.0.3:{u'type': u'hash', u'value': {u'ifname': u'Loopback4096', u'nex
thop': u'0.0.0.0'}}
09:03:15 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fc00:1::32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'nex
thop': u'::'}}
09:03:15 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fe80::/64:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop':
 u'::'}}
09:03:15 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:fd00::/80:{u'type': u'hash', u'value': {u'ifname': u'eth0', u'nexthop':
 u'::'}}
09:03:15 test_decap.get_fib_info                  L0100 INFO   | Route point to non front panel port ROUTE_TABLE:10.1.0.32:{u'type': u'hash', u'value': {u'ifname': u'Loopback0', u'next
hop': u'0.0.0.0'}}
09:03:15 test_decap.setup_teardown                L0229 INFO   | {
  "ecn_mode": "copy_from_outer",
  "vlan_ip": "",
  "vlan_ipv6": "",
  "dscp_mode": "pipe",
  "ignore_ttl": true,
  "lo_ipv6": "fc00:1::32",
  "router_mac": "00:be:75:3a:ef:50",
  "lo_ip": "10.1.0.32",
  "max_internal_hops": 3,
  "outer_ipv6": true,
  "outer_ipv4": true,
  "inner_ipv4": true,
  "inner_ipv6": true,
  "ttl_mode": "pipe",
  "src_ports": "0,1,4,5,16,17,20,21,34,36,37,38,39,42,44,45,46,47,50,52,53,54,55,58,60,61,62,63",
  "op": "SET"
}
09:03:15 __init__.loganalyzer                     L0047 INFO   | Log analyzer is disabled
PASSED                                                                                                                                                                           [100%]
---------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------
09:05:28 ptfhost_utils.remove_ip_addresses        L0120 INFO   | Remove IPs to restore ptfhost 'ptf-05'
09:05:28 ptfhost_utils.copy_ptftests_directory    L0066 INFO   | Delete PTF test files from PTF host 'ptf-05'


-------------------------------------------------- generated xml file: /data/repos/public/sonic-mgmt/tests/logs/decap/test_decap.xml ---------------------------------------------------
============================================================================== 1 passed in 206.32 seconds ==============================================================================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
