### PR TITLE
fix snmp test phy_entity

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -473,7 +473,7 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_rand_one_per_hwsku_hostn
     pdu_controller.turn_off_outlet(first_outlet)
     assert wait_until(30, 5, check_outlet_status, pdu_controller, first_outlet, False)
     # wait for psud update the database
-    assert wait_until(120, 20, _check_psu_status_after_power_off, duthost, localhost, creds_all_duts[duthost])
+    assert wait_until(120, 20, _check_psu_status_after_power_off, duthost, localhost, creds_all_duts)
 
 
 def _check_psu_status_after_power_off(duthost, localhost, creds_all_duts):


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix for test issue

the test "test_remove_insert_fan_and_check_fan_info" needs to pass to function _check_psu_status_after_power_off the creds of all devices and not from itself.


Test output before the fix:
L0057 ERROR  | Exception caught while checking _check_psu_status_after_power_off: KeyError(<MultiAsicSonicHost> r-tigon-04,) 
L0064 DEBUG  | _check_psu_status_after_power_off is False, wait 20 seconds and check again 
L0052 DEBUG  | Time elapsed: 100.076924 seconds 
L0057 ERROR  | Exception caught while checking _check_psu_status_after_power_off: KeyError(<MultiAsicSonicHost> r-tigon-04,) 
L0064 DEBUG  | _check_psu_status_after_power_off is False, wait 20 seconds and check again 
L0069 DEBUG  | _check_psu_status_after_power_off is still False after 120 seconds, exit with False 


After the change, the test passed


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
test fix
#### How did you do it?

#### How did you verify/test it?
manually
#### Any platform specific information?
any
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
