### PR TITLE
[dualtor][orch] Fix errors in MUX_CABLE table to config DB: add one-shot config

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -363,19 +363,21 @@ def apply_mux_cable_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock
 
     server_ipv4_base_addr, server_ipv6_base_addr = mock_server_base_ip_addr
 
-    keys_inserted = []
-
-    cmds = []
+    mux_cable_params = dict()
     for i, intf in enumerate(tor_mux_intfs):
         server_ipv4 = str(server_ipv4_base_addr + i)
         server_ipv6 = str(server_ipv6_base_addr + i)
-        key = 'MUX_CABLE|{}'.format(intf)
-        keys_inserted.append(key)
-        cmds.append('redis-cli -n 4 HSET "{}" "server_ipv4" "{}"'.format(key, server_ipv4))
-        cmds.append('redis-cli -n 4 HSET "{}" "server_ipv6" "{}"'.format(key, server_ipv6))
-        cmds.append('redis-cli -n 4 HSET "{}" "state" "auto"'.format(key))
-    dut.shell_cmds(cmds=cmds)
+        mux_cable_params.update(
+            {intf: {
+                'server_ipv4':server_ipv4,
+                'server_ipv6':server_ipv6,
+                'state': 'auto'
+                }
+            })
 
+    mux_cable_params = {'MUX_CABLE': mux_cable_params}
+    dut.copy(content=json.dumps(mux_cable_params, indent=2), dest="/tmp/mux_cable_params.json")
+    dut.shell("sonic-cfggen -j /tmp/mux_cable_params.json --write-to-db")
     return
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When configuring `MUX_CABLE` table in config_db, all interfaces are configured individually (for ipv4, ipv6 and state), and this leads to overwriting these values iteratively.
In syslog, `logic error` is seen coming from orchagent:
```
Apr 28 13:30:13.422313 str2-7050cx3-acs-02 INFO ansible-shell_cmds: Invoked with continue_on_fail=True cmds=['redis-cli -n 4 HSET "MUX_CABLE|Ethernet4" "server_ipv4" "192.168.0.2/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet4" "server_ipv6" "fc02:1000::2/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet4" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet8" "server_ipv4" "192.168.0.3/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet8" "server_ipv6" "fc02:1000::3/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet8" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet12" "server_ipv4" "192.168.0.4/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet12" "server_ipv6" "fc02:1000::4/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet12" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet16" "server_ipv4" "192.168.0.5/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet16" "server_ipv6" "fc02:1000::5/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet16" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet20" "server_ipv4" "192.168.0.6/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet20" "server_ipv6" "fc02:1000::6/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet20" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet24" "server_ipv4" "192.168.0.7/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet24" "server_ipv6" "fc02:1000::7/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet24" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet28" "server_ipv4" "192.168.0.8/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet28" "server_ipv6" "fc02:1000::8/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet28" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet32" "server_ipv4" "192.168.0.9/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet32" "server_ipv6" "fc02:1000::9/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet32" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet36" "server_ipv4" "192.168.0.10/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet36" "server_ipv6" "fc02:1000::a/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet36" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet40" "server_ipv4" "192.168.0.11/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet40" "server_ipv6" "fc02:1000::b/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet40" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet44" "server_ipv4" "192.168.0.12/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet44" "server_ipv6" "fc02:1000::c/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet44" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet48" "server_ipv4" "192.168.0.13/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet48" "server_ipv6" "fc02:1000::d/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet48" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet52" "server_ipv4" "192.168.0.14/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet52" "server_ipv6" "fc02:1000::e/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet52" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet56" "server_ipv4" "192.168.0.15/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet56" "server_ipv6" "fc02:1000::f/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet56" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet60" "server_ipv4" "192.168.0.16/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet60" "server_ipv6" "fc02:1000::10/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet60" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet64" "server_ipv4" "192.168.0.17/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet64" "server_ipv6" "fc02:1000::11/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet64" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet68" "server_ipv4" "192.168.0.18/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet68" "server_ipv6" "fc02:1000::12/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet68" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet72" "server_ipv4" "192.168.0.19/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet72" "server_ipv6" "fc02:1000::13/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet72" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet76" "server_ipv4" "192.168.0.20/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet76" "server_ipv6" "fc02:1000::14/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet76" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet80" "server_ipv4" "192.168.0.21/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet80" "server_ipv6" "fc02:1000::15/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet80" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet84" "server_ipv4" "192.168.0.22/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet84" "server_ipv6" "fc02:1000::16/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet84" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet88" "server_ipv4" "192.168.0.23/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet88" "server_ipv6" "fc02:1000::17/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet88" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet92" "server_ipv4" "192.168.0.24/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet92" "server_ipv6" "fc02:1000::18/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet92" "state" "auto"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet96" "server_ipv4" "192.168.0.25/32"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet96" "server_ipv6" "fc02:1000::19/128"', 'redis-cli -n 4 HSET "MUX_CABLE|Ethernet96" "state" "auto"']


Apr 28 13:30:13.606080 str2-7050cx3-acs-02 ERR swss#orchagent: :- doTask: Logic error: _Map_base::at
```

#### How did you do it?
Use sonic-cfggen to configure MUX_CABLE table at once with json file (which contains config for each interface).

#### How did you verify/test it?
Tested with the fix and orchagent errors are not seen.
The ` addDecapTunnelTermEntries` error that still appears is acceptable and needs a image modification to change it to WARNING.

```
May  3 17:42:31.978203 str2-7050cx3-acs-02 INFO ansible-command: Invoked with creates=None executable=None _uses_shell=True strip_empty_ends=True _raw_params=sonic-cfggen -j /tmp/mux_cable_params.json --write-to-db removes=None argv=None warn=True chdir=None stdin_add_newline=True stdin=None
May  3 17:42:32.642636 str2-7050cx3-acs-02 INFO ansible-config_facts: Invoked with source=running host=str2-7050cx3-acs-02 namespace=None filename=None
May  3 17:42:33.434960 str2-7050cx3-acs-02 INFO ansible-stat: Invoked with checksum_algorithm=sha1 get_checksum=True follow=False path=/tmp/tunnel_params.json get_md5=None get_mime=True get_attributes=True
May  3 17:42:33.654101 str2-7050cx3-acs-02 INFO ansible-file: Invoked with directory_mode=None force=False remote_src=None _original_basename=tmpydidVw path=/tmp/tunnel_params.json owner=None follow=True group=None unsafe_writes=None setype=None content=NOT_LOGGING_PARAMETER serole=None selevel=None state=file dest=/tmp/tunnel_params.json access_time=None access_time_format=%Y%m%d%H%M.%S modification_time=None regexp=None src=None seuser=None recurse=False _diff_peek=None delimiter=None mode=None modification_time_format=%Y%m%d%H%M.%S attributes=None backup=None
May  3 17:42:34.052050 str2-7050cx3-acs-02 INFO ansible-command: Invoked with creates=None executable=None _uses_shell=True strip_empty_ends=True _raw_params=sonic-cfggen -j /tmp/tunnel_params.json --write-to-db removes=None argv=None warn=True chdir=None stdin_add_newline=True stdin=None
May  3 17:42:34.295407 str2-7050cx3-acs-02 NOTICE swss#tunnelmgrd: :- doTunnelTask: Peer/Remote IP not configured
May  3 17:42:34.295758 str2-7050cx3-acs-02 NOTICE swss#tunnelmgrd: :- doTunnelTask: Tunnel MuxTunnel0 task, op SET
May  3 17:42:34.300060 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- addDecapTunnel: Create overlay loopback router interface oid:6000000000711
May  3 17:42:34.305027 str2-7050cx3-acs-02 ERR swss#orchagent: :- addDecapTunnelTermEntries: 10.1.0.32 already exists. Did not create entry.
May  3 17:42:34.305027 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- doTask: Tunnel(s) added to ASIC_DB.
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
