### PR TITLE
[rdma] Disable loganalyzer for pfc reboot testcases

### DIFF
--- a/tests/ixia/pfc/test_pfc_pause_lossless.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossless.py
@@ -126,6 +126,7 @@ def test_pfc_pause_multi_lossless_prio(ixia_api,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True)
 
+@pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
 def test_pfc_pause_single_lossless_prio_reboot(ixia_api,
                                                ixia_testbed_config,
@@ -194,6 +195,7 @@ def test_pfc_pause_single_lossless_prio_reboot(ixia_api,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True)
 
+@pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
 def test_pfc_pause_multi_lossless_prio_reboot(ixia_api,
                                               ixia_testbed_config,

--- a/tests/ixia/pfc/test_pfc_pause_lossy.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossy.py
@@ -126,6 +126,7 @@ def test_pfc_pause_multi_lossy_prio(ixia_api,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False)
 
+@pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
 def test_pfc_pause_single_lossy_prio_reboot(ixia_api,
                                             ixia_testbed_config,
@@ -194,6 +195,7 @@ def test_pfc_pause_single_lossy_prio_reboot(ixia_api,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False)
 
+@pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
 def test_pfc_pause_multi_lossy_prio_reboot(ixia_api,
                                            ixia_testbed_config,


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Loganalyzer needs to be disabled for reboot scenarios to avoid test flakiness

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
