### PR TITLE
dhcp pytest: add back but skip the unicast mac testcase

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -178,6 +178,9 @@ class DHCPTest(DataplaneBaseTest):
         discover_packet[scapy.Ether].dst = dst_mac
         discover_packet[scapy.IP].sport = src_port
 
+        if dst_mac != BROADCAST_MAC:
+            discover_packet[scapy.IP].dst = self.switch_loopback_ip
+
         return discover_packet
 
     def create_dhcp_discover_relayed_packet(self):
@@ -289,6 +292,9 @@ class DHCPTest(DataplaneBaseTest):
 
         request_packet[scapy.Ether].dst = dst_mac
         request_packet[scapy.IP].sport = src_port
+
+        if dst_mac != BROADCAST_MAC:
+            discover_packet[scapy.IP].dst = self.switch_loopback_ip
 
         return request_packet
 

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -180,6 +180,7 @@ class DHCPTest(DataplaneBaseTest):
 
         if dst_mac != self.BROADCAST_MAC:
             discover_packet[scapy.IP].dst = self.switch_loopback_ip
+            discover_packet[scapy.IP].src = self.client_ip
 
         return discover_packet
 
@@ -295,6 +296,7 @@ class DHCPTest(DataplaneBaseTest):
 
         if dst_mac != self.BROADCAST_MAC:
             discover_packet[scapy.IP].dst = self.switch_loopback_ip
+            discover_packet[scapy.IP].src = self.client_ip
 
         return request_packet
 

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -295,8 +295,8 @@ class DHCPTest(DataplaneBaseTest):
         request_packet[scapy.IP].sport = src_port
 
         if dst_mac != self.BROADCAST_MAC:
-            discover_packet[scapy.IP].dst = self.switch_loopback_ip
-            discover_packet[scapy.IP].src = self.client_ip
+            request_packet[scapy.IP].dst = self.switch_loopback_ip
+            request_packet[scapy.IP].src = self.client_ip
 
         return request_packet
 

--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -178,7 +178,7 @@ class DHCPTest(DataplaneBaseTest):
         discover_packet[scapy.Ether].dst = dst_mac
         discover_packet[scapy.IP].sport = src_port
 
-        if dst_mac != BROADCAST_MAC:
+        if dst_mac != self.BROADCAST_MAC:
             discover_packet[scapy.IP].dst = self.switch_loopback_ip
 
         return discover_packet
@@ -293,7 +293,7 @@ class DHCPTest(DataplaneBaseTest):
         request_packet[scapy.Ether].dst = dst_mac
         request_packet[scapy.IP].sport = src_port
 
-        if dst_mac != BROADCAST_MAC:
+        if dst_mac != self.BROADCAST_MAC:
             discover_packet[scapy.IP].dst = self.switch_loopback_ip
 
         return request_packet

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -292,6 +292,35 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
+@pytest.mark.skip(reason="skip the unicast mac testcase which will fail in a multi-Vlan setting")
+def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
+    """Test DHCP relay functionality on T0 topology with unicast mac
+       Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
+    """
+    testing_mode, duthost = testing_config
+
+    for dhcp_relay in dut_dhcp_relay_data:
+        # Run the DHCP relay test on the PTF host
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "dhcp_relay_test.DHCPTest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                           "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'][0]),
+                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": duthost.facts["router_mac"],
+                           "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                           "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
+                           "testing_mode": testing_mode},
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+
+
 def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology with random source port (sport)
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -298,7 +298,7 @@ def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_route
     """
     testing_mode, duthost = testing_config
 
-    if testing_mode == DUAL_TOR_MODE:
+    if len(dut_dhcp_relay_data) > 1:
         pytest.skip("skip the unicast mac testcase in the multi-Vlan setting")
 
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -292,7 +292,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-@pytest.mark.skip(reason="skip the unicast mac testcase which will fail in a multi-Vlan setting")
+@pytest.mark.skipif(testing_config[0] == DUAL_TOR_MODE, reason="skip the unicast mac testcase in the multi-Vlan setting")
 def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology with unicast mac
        Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -292,12 +292,14 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-@pytest.mark.skipif(testing_config[0] == DUAL_TOR_MODE, reason="skip the unicast mac testcase in the multi-Vlan setting")
 def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
     """Test DHCP relay functionality on T0 topology with unicast mac
        Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
     """
     testing_mode, duthost = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        pytest.skip("skip the unicast mac testcase in the multi-Vlan setting")
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host


### PR DESCRIPTION
dhcp pytest: add back but skip the unicast mac testcase

This is a follow-up with [this PR](https://github.com/Azure/sonic-mgmt/pull/3268)