### PR TITLE
[sanity_check]: Enable recover for mux sanity

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -67,7 +67,7 @@ def adaptive_recover(dut, localhost, fanouthosts, check_results, wait_time):
                 action = __recover_interfaces(dut, fanouthosts, result, wait_time)
             elif result['check_item'] == 'services':
                 action = __recover_services(dut, result)
-            elif result['check_item'] in [ 'processes', 'bgp' ]:
+            elif result['check_item'] in [ 'processes', 'bgp', 'mux_simulator' ]:
                 action = 'config_reload'
             else:
                 action = 'reboot'


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
When the mux simulator sanity check failed, it was not triggering any recovery actions.

#### How did you do it?
Add the 'host' field to the check results dictionary
Add 'mux_simulator' to the list of checks that can trigger a config reload

#### How did you verify/test it?
Set the DUT to fail the mux simulator sanity check, and run a test and make sure the check triggers a config reload and passes on the second attempt.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
