### PR TITLE
[psu] share the PSU line pattern across tests

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -25,3 +25,23 @@ def fanout_switch_port_lookup(fanout_switches, dut_name, dut_port):
             return fanout, fanout.host_to_fanout_port_map[dut_host_port]
 
     return None, None
+
+
+def get_dut_psu_line_pattern(dut):
+    if "201811" in dut.os_version or "201911" in dut.os_version:
+        psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
+    else:
+        """
+        Changed the pattern to match space (s+) and non-space (S+) only.
+        w+ cannot match following examples properly:
+
+        example 1:
+            PSU 1  PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
+            PSU 2  PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
+        example 2:
+            PSU 1  N/A      N/A               12.05           3.38        40.62  OK        green
+            PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
+
+        """
+        psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+    return psu_line_pattern

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -19,6 +19,7 @@ import util
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
+from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
 
 pytestmark = [
@@ -176,10 +177,7 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))
     psu_status_output_lines = duthost.command(cmd)["stdout_lines"]
 
-    if "201811" in duthost.os_version or "201911" in duthost.os_version:
-        psu_line_pattern = re.compile(r"PSU\s+\d+\s+(OK|NOT OK|NOT PRESENT)")
-    else:
-        psu_line_pattern = re.compile(r"PSU\s+\d+\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+    psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
     # Check that all PSUs are showing valid status and also at least one PSU is OK
     num_psu_ok = 0
@@ -187,7 +185,7 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     for line in psu_status_output_lines[2:]:
         psu_match = psu_line_pattern.match(line)
         pytest_assert(psu_match, "Unexpected PSU status output: '{}' on '{}'".format(line, duthost.hostname))
-        psu_status = psu_match.group(1)
+        psu_status = psu_match.group(2)
         if psu_status == "OK":
             num_psu_ok += 1
 

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -6,7 +6,6 @@ https://github.com/Azure/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import json
 import logging
-import re
 import time
 
 import pytest

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -14,6 +14,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
+from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from thermal_control_test_helper import *
 
 pytestmark = [
@@ -138,26 +139,6 @@ def get_psu_num(dut):
         pytest_assert(False, "Unable to get the number of PSUs using command '{}' with exception {}".format(cmd_num_psu, repr(e)))
 
     return psu_num
-
-
-def get_dut_psu_line_pattern(dut):
-    if "201811" in dut.os_version or "201911" in dut.os_version:
-        psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
-    else:
-        """
-        Changed the pattern to match space (s+) and non-space (S+) only.
-        w+ cannot match following examples properly:
-
-        example 1:
-            PSU 1  PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
-            PSU 2  PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
-        example 2:
-            PSU 1  N/A      N/A               12.05           3.38        40.62  OK        green
-            PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
-
-        """
-        psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
-    return psu_line_pattern
 
 
 def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
platform_tests/cli/test_show_platform.py::test_show_platform_psustatus is failing because the PSU output line regex is wrong. This issue was addressed for platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus before.

#### How did you do it?
Share the PSU out line regex between tests.

#### How did you verify/test it?
run platform_tests/cli/test_show_platform.py::test_show_platform_psustatus, passes with change.
run platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus, passes before/after change.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
