### PR TITLE
Restart ptf_nn_agent when reiniting ptfadapter

### DIFF
--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -105,7 +105,7 @@ def ptfadapter(ptfhost, tbinfo, request):
     # Force a restart of ptf_nn_agent to ensure that it is in good status.
     ptfhost.command('supervisorctl restart ptf_nn_agent')
 
-    with PtfTestAdapter(tbinfo['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys()) as adapter:
+    with PtfTestAdapter(tbinfo['ptf_ip'], DEFAULT_PTF_NN_PORT, 0, ifaces_map.keys(), ptfhost) as adapter:
         if not request.config.option.keep_payload:
             override_ptf_functions()
             node_id = request.module.__name__

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -8,7 +8,7 @@ import ptf.mask as mask
 from ptf.base_tests import BaseTest
 from ptf.dataplane import DataPlane, DataPlanePortNN
 from tests.common.utilities import wait_until
-
+import logging
 
 class PtfAdapterNNConnectionError(Exception):
 
@@ -29,7 +29,7 @@ class PtfTestAdapter(BaseTest):
     # the number of currently established connections
     NN_STAT_CURRENT_CONNECTIONS = 201
 
-    def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set):
+    def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptfhost):
         """ initialize PtfTestAdapter
         :param ptf_ip: PTF host IP
         :param ptf_nn_port: PTF nanomessage agent port
@@ -41,6 +41,7 @@ class PtfTestAdapter(BaseTest):
         super(PtfTestAdapter, self).__init__()
         self.payload_pattern = ""
         self.connected = False
+        self.ptfhost = ptfhost
         self._init_ptf_dataplane(ptf_ip, ptf_nn_port, device_num, ptf_port_set)
 
     def __enter__(self):
@@ -55,19 +56,12 @@ class PtfTestAdapter(BaseTest):
 
     def _check_ptf_nn_agent_availability(self, socket_addr):
         """Verify the nanomsg socket address exposed by ptf_nn_agent is available."""
-        # Bypass connection checker temporarily to workaround ptfadapter connection issue
-        # As per doc from nanomsg, there is no reliable interface to identify the connection status
-        # We also noticed that the connection checker was failing because reinit can't teardown the established 
-        # connection occasionally, so below checker will fail. 
-        return True
-        """
         sock = nnpy.Socket(nnpy.AF_SP, nnpy.PAIR)
         sock.connect(socket_addr)
         try:
             return wait_until(1, 0.2, lambda:sock.get_statistic(self.NN_STAT_CURRENT_CONNECTIONS) == 1)
         finally:
             sock.close()
-        """
 
     def _init_ptf_dataplane(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptf_config=None):
         """
@@ -124,6 +118,7 @@ class PtfTestAdapter(BaseTest):
             for injector in DataPlanePortNN.packet_injecters.values():
                 injector.socket.close()
             DataPlanePortNN.packet_injecters.clear()
+        
         self.connected = False
 
     def reinit(self, ptf_config=None):
@@ -134,6 +129,13 @@ class PtfTestAdapter(BaseTest):
         :param ptf_config: PTF configuration dictionary
         """
         self.kill()
+
+        # Restart ptf_nn_agent to close any TCP connection from the server side
+        logging.info("Restarting ptf_nn_agent")
+        self.ptfhost.command('supervisorctl reread')
+        self.ptfhost.command('supervisorctl update')
+        self.ptfhost.command('supervisorctl restart ptf_nn_agent')
+
         self._init_ptf_dataplane(self.ptf_ip, self.ptf_nn_port, self.device_num, self.ptf_port_set, ptf_config)
 
     def update_payload(self, pkt):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
We found that ```ptfadapter``` failed to tear down the TCP connection with ```ptf_nn_agent``` in ```reinit```. As a result, the following ```_check_ptf_nn_agent_availability``` will report a connection error.
This PR restarts ```ptf_nn_agent``` on ```ptf``` to close TCP connection from the server side to ensure no connection is established after ```self.kill``` .

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix the ```ptfadapter``` connection issue.

#### How did you do it?
This PR restarts ```ptf_nn_agent``` on ```ptf``` to close TCP connection from the server side to ensure no connection is established after ```self.kill``` .

#### How did you verify/test it?
The change has been running in personal nightly test for several days, and all ```fdb``` and ```ipfwd``` test cases passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
