### PR TITLE
[Mellanox] Align PSU fan name convention change with production code

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -85,7 +85,7 @@ FAN_NAMING_RULE = {
         "led_orange": "led_fan{}_orange"
     },
     "psu_fan": {
-        "name": "psu_{}_fan_1",
+        "name": "psu{}_fan1",
         "speed": "psu{}_fan1_speed_get",
         "power_status": "psu{}_pwr_status",
         "max_speed": "psu_fan_max",
@@ -793,6 +793,7 @@ class RandomFanStatusMocker(CheckMockerResultMixin, FanStatusMocker):
         naming_rule = FAN_NAMING_RULE['psu_fan']
         if self.mock_helper.is_201911():
             led_color = ''
+            naming_rule['name'] = 'psu_{}_fan_1'
         else:
             led_color = 'green'
         for index in range(1, psu_count + 1):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Align psu fan name convention change with production code

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Production code has changed PSU fan name convention from psu_{psu_index}_fan_{fan_index} to psu{psu_index}_fan{fan_index}, need to align this change with test case.

#### How did you do it?

For 201911, keep PSU name psu_{psu_index}_fan_{fan_index}; for other, change PSU fan name convention to psu{psu_index}_fan{fan_index} 

#### How did you verify/test it?

Manually run test case "test_show_platform_fanstatus_mocked"

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
