### PR TITLE
skip test_server_failure for non dualtor t0 topo

### DIFF
--- a/tests/dualtor/test_server_failure.py
+++ b/tests/dualtor/test_server_failure.py
@@ -10,13 +10,14 @@ pytestmark = [
     pytest.mark.usefixtures('run_garp_service', 'run_icmp_responder')
 ]
 
+@pytest.fixture(autouse=True, scope='module')
+def skip_if_non_dualtor_topo(tbinfo):
+    pytest_require('dualtor' in tbinfo['topo']['name'], "Only run on dualtor testbed")
 
 def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_counter, simulator_server_down, toggle_simulator_port_to_upper_tor, loganalyzer):
     """
     Verify that mux cable is not toggled excessively.
     """
-    pytest_require('dualtor' in tbinfo['topo']['name'], 
-                    "Only run on dualtor testbed")
 
     for analyzer in list(loganalyzer.values()):
         analyzer.ignore_regex.append(r".*ERR swss#orchagent: :- setState: State transition from active to active is not-handled")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: skip test server failure for non dualtor t0 topo
Fixes # (issue)
- test_server_failure seems to expect topo in a form 't0-dualtor' so module has t0 mark, but the test fails for usual t0 topo when a corresponding fixture extracts MUX-connected servers list. Therefore test was modified in order to check for required topo before other test fixture launch
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Skip test for not supported topo
#### How did you do it?
Corrected a check on supported topo, skipped for unsupported "t0"
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0 dualtor/test_server_failure.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
