### PR TITLE
[advance-reboot] Create summarized report of reboot timing data

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1111,10 +1111,6 @@ class ReloadTest(BaseTest):
             longest_downtime = (self.no_routing_stop - self.no_routing_start).total_seconds()
         else:
             longest_downtime = "N/A"
-        if self.no_routing_stop and self.reboot_start:
-            reboot_time = (self.no_routing_stop - self.reboot_start).total_seconds()
-        else:
-            reboot_time = "0:00:00"
         if self.total_disrupt_time:
             # Add total downtime (calculated in physical warmboot test using packet disruptions)
             total_downtime = self.total_disrupt_time

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -766,6 +766,8 @@ class ReloadTest(BaseTest):
         self.no_cp_replies = None
         self.upper_replies = []
         self.routing_always = False
+        self.total_disrupt_packets = None
+        self.total_disrupt_time = None
         self.ssh_jobs = []
         for addr in self.ssh_targets:
             q = Queue.Queue(1)
@@ -1113,14 +1115,15 @@ class ReloadTest(BaseTest):
             reboot_time = (self.no_routing_stop - self.reboot_start).total_seconds()
         else:
             reboot_time = "0:00:00"
-        if 'warm-reboot' in self.reboot_type and not self.kvm_test:
+        if self.total_disrupt_time:
             # Add total downtime (calculated in physical warmboot test using packet disruptions)
             total_downtime = self.total_disrupt_time
         else:
             total_downtime = "N/A"
         self.report["longest_downtime"] = longest_downtime
-        self.report["reboot_time"] = reboot_time
         self.report["total_downtime"] = total_downtime
+        self.report["lost_packets"] = self.total_disrupt_packets\
+            if self.total_disrupt_packets else "N/A"
         with open(self.report_file_name, 'w') as reportfile:
             json.dump(self.report, reportfile)
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -171,7 +171,7 @@ def analyze_syslog(duthost, messages, result, first_occurence_times):
                 datetime.strptime(timestamps["Stopped"], FMT)).total_seconds()
         elif "Start" in timestamps and "End" in timestamps:
             timings["reboot_time"] = (datetime.strptime(timestamps["End"], FMT) -\
-            datetime.strptime(timestamps["Start"], FMT)).total_seconds()
+                datetime.strptime(timestamps["Start"], FMT)).total_seconds()
 
     result["processing_time"].update(service_restart_times)
     result["first_occurence"] = first_occurence_times

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -119,8 +119,8 @@ def analyze_syslog(duthost, messages, result, first_occurence_times):
         "INIT_VIEW|End": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*switched ASIC to INIT VIEW.*'),
         "APPLY_VIEW|Start": re.compile(r'.*swss#orchagent.*notifySyncd.*sending syncd.*APPLY_VIEW.*'),
         "APPLY_VIEW|End": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*switched ASIC to APPLY VIEW.*'),
-        "FINALIZER|Start":  re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
-        "FINALIZER|End":  re.compile(r'.*WARMBOOT_FINALIZER.*Finalizing warmboot.*')
+        "FINALIZER|Start": re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
+        "FINALIZER|End": re.compile(r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)")
     }
 
     def service_time_check(message, status):
@@ -296,11 +296,12 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
     report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),\
         "../logs/platform_tests/")))
     report_file_path = report_file_dir + "/" + report_file_name
+    summary_file_path = report_file_dir + "/" + summary_file_name
     if not os.path.exists(report_file_dir):
         os.makedirs(report_file_dir)
     with open(report_file_path, 'w') as fp:
         json.dump(analyze_result, fp, indent=4)
-    with open(summary_file_name, 'w') as fp:
+    with open(summary_file_path, 'w') as fp:
         json.dump(result_summary, fp, indent=4)
 
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -82,6 +82,23 @@ def get_state_times(timestamp, state, state_times):
     return {state_name: state_dict}
 
 
+def get_report_summary(analyze_result, reboot_type):
+    processing_times = analyze_result.get("processing_time", {})
+    first_occurences = analyze_result.get("first_occurence", {})
+    processing_times_summary = dict()
+    for entity, time_data in processing_times.items():
+        processing_times_summary.update({entity.lower(): str(time_data["reboot_time"])})
+    for entity, time_data in first_occurences.items():
+        processing_times_summary.update({entity.lower(): str(time_data["time_since_reboot"])})
+    result_summary = {
+        "reboot_type": reboot_type,
+        "reboot_time": str(analyze_result.get("reboot_time", {}).get("reboot_time")),
+        "dataplane": {k: str(v) for k,v in analyze_result.get("dataplane", {}).items()},
+        "processing_time": processing_times_summary
+    }
+    return result_summary
+
+
 def analyze_syslog(duthost, messages, result, first_occurence_times):
     service_restart_times = dict()
     if not messages:
@@ -149,20 +166,22 @@ def analyze_syslog(duthost, messages, result, first_occurence_times):
             datetime.strptime(timestamps["Starting"], FMT)).total_seconds() \
                 if "Started" in timestamps and "Starting" in timestamps else None
 
-        timings["reboot_time"] = (datetime.strptime(timestamps["Started"], FMT) -\
-            datetime.strptime(timestamps["Stopped"], FMT)).total_seconds() \
-                if "Started" in timestamps and "Stopped" in timestamps else None
+        if "Started" in timestamps and "Stopped" in timestamps:
+            timings["reboot_time"] = (datetime.strptime(timestamps["Started"], FMT) -\
+                datetime.strptime(timestamps["Stopped"], FMT)).total_seconds()
+        elif "Start" in timestamps and "End" in timestamps:
+            timings["reboot_time"] = (datetime.strptime(timestamps["End"], FMT) -\
+            datetime.strptime(timestamps["Start"], FMT)).total_seconds()
 
-    files = glob.glob('/tmp/*-report.json')
-    if files:
-        filepath = files[0]
-        with open(filepath) as json_file:
-            report = json.load(json_file)
-
-    result["Services"] = service_restart_times
+    result["processing_time"].update(service_restart_times)
     result["first_occurence"] = first_occurence_times
-    result["dataplane"] = report
-    result["reboot_start"] = reboot_time
+    finalizer_end_time = service_restart_times.get("FINALIZER",{}).get("timestamp",{}).get("End")
+    result["reboot_time"] = {
+        "timestamp": {"Start": reboot_time, "End": finalizer_end_time},
+        "reboot_time": (datetime.strptime(finalizer_end_time, FMT) -\
+            datetime.strptime(reboot_time, FMT)).total_seconds() \
+                if finalizer_end_time and reboot_time != "N/A" else "N/A"
+    }
 
     return result
 
@@ -190,12 +209,21 @@ def analyze_sairedis_rec(messages, result, first_occurence_times):
 
     for _, timings in sai_redis_state_times.items():
         timestamps = timings["timestamp"]
-        if "Stopped" in timestamps and "Started" in timestamps:
-            timings["time"] = (datetime.strptime(timestamps["Stopped"], FMT) -\
-                datetime.strptime(timestamps["Started"], FMT)).total_seconds() \
+        if "Start" in timestamps and "End" in timestamps:
+            timings["reboot_time"] = (datetime.strptime(timestamps["End"], FMT) -\
+                datetime.strptime(timestamps["Start"], FMT)).total_seconds()
 
-    result["sairedis_state"] = sai_redis_state_times
+    result["processing_time"].update(sai_redis_state_times)
     result["first_occurence"] = first_occurence_times
+
+
+def get_data_plane_report(analyze_result, reboot_type):
+    files = glob.glob('/tmp/{}-reboot-report.json'.format(reboot_type))
+    if files:
+        filepath = files[0]
+        with open(filepath) as json_file:
+            report = json.load(json_file)
+    analyze_result["dataplane"] = report
 
 
 @pytest.fixture()
@@ -210,6 +238,13 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         rand_one_dut_hostname: hostname of a randomly selected DUT
     """
     duthost = duthosts[rand_one_dut_hostname]
+    test_name = request.node.name
+    if "warm" in test_name:
+        reboot_type = "warm"
+    elif "fast" in test_name:
+        reboot_type = "fast"
+    else:
+        reboot_type = "unknown"
     # Currently, advanced reboot test would skip for kvm platform if the test has no device_type marker for vs.
     # Doing the same skip logic in this fixture to avoid running loganalyzer without the test executed
     if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
@@ -217,7 +252,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         if 'vs' not in device_marks:
             pytest.skip('Testcase not supported for kvm')
 
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="test_advanced_reboot", 
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="test_advanced_reboot_{}".format(test_name),
                     additional_files={'/var/log/swss/sairedis.rec': 'recording on: /var/log/swss/sairedis.rec'})
     marker = loganalyzer.init()
     loganalyzer.load_common_config()
@@ -235,7 +270,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
     yield
 
     result = loganalyzer.analyze(marker, fail=False)
-    analyze_result = dict()
+    analyze_result = {"processing_time": dict()}
     first_occurence_times = dict()
     for key, messages in result["expect_messages"].items():
         if "syslog" in key:
@@ -245,15 +280,19 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
 
     for marker, time_data in analyze_result["first_occurence"].items():
         marker_start_time = time_data.get("timestamp", {}).get("Start")
-        reboot_start_time = analyze_result["reboot_start"]
-        if reboot_start_time != "N/A" and marker_start_time:
+        reboot_start_time = analyze_result.get("reboot_time", {}).get("timestamp", {}).get("Start")
+        if reboot_start_time and reboot_start_time != "N/A" and marker_start_time:
             time_data["time_since_reboot"] = (datetime.strptime(marker_start_time, FMT) -\
                 datetime.strptime(reboot_start_time, FMT)).total_seconds()
         else:
             time_data["time_since_reboot"] = "N/A"
 
+    get_data_plane_report(analyze_result, reboot_type)
+    result_summary = get_report_summary(analyze_result, reboot_type)
     logging.info(json.dumps(analyze_result, indent=4))
+    logging.info(json.dumps(result_summary, indent=4))
     report_file_name = request.node.name + "_report.json"
+    summary_file_name = request.node.name + "_summary.json"
     report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),\
         "../logs/platform_tests/")))
     report_file_path = report_file_dir + "/" + report_file_name
@@ -261,6 +300,8 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         os.makedirs(report_file_dir)
     with open(report_file_path, 'w') as fp:
         json.dump(analyze_result, fp, indent=4)
+    with open(summary_file_name, 'w') as fp:
+        json.dump(result_summary, fp, indent=4)
 
 
 def pytest_addoption(parser):

--- a/tests/platform_tests/templates/expect_boot_messages
+++ b/tests/platform_tests/templates/expect_boot_messages
@@ -5,6 +5,8 @@ r, ".* NOTICE admin: Stopped.* swss.* service.*"
 r, ".* NOTICE root: (Stopping|Stopped|Starting|Started).* (swss|syncd|gbsyncd).* service.*"
 r, ".* NOTICE root: WARMBOOT_FINALIZER : Wait for database to become ready.*"
 r, ".* NOTICE root: WARMBOOT_FINALIZER : Finalizing warmboot.*"
+r, ".* NOTICE root: WARMBOOT_FINALIZER : warmboot is not enabled.*"
+
 r, ".* NOTICE swss#portsyncd.*main: PortInitDone"
 r, ".* NOTICE teamd#tlm_teamd.*try_add_lag: The LAG 'PortChannel.*' has been added.*"
 r, ".* NOTICE swss#orchagent.*notifySyncd.*sending syncd: INIT_VIEW.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Create a summarized version of advanced-reboot timing data.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The timestamps in the detailed version of reboot-timing-data aren't necessarily useful in data plotting. Also not all the entities have Starting/Stopping data. This leads to inconsistent data being uploaded, and some columns have no values.

Create a summary (along with a detailed report) version of the advanced-reboot timing data.
The summarized version contains the time-taken data, and not the timestamps. This is useful in making kusto table and queries simpler.
The detailed version will still be generated and can be used for further analysis.

#### How did you do it?

#### How did you verify/test it?

Tested warm reboot in  KVM, physical testbeds. Sample reports:

**Physical warm**:
```
{
    "processing_time": {
        "default_route_set": "19982517.2243", 
        "sai_switch_create": "0.004269", 
        "radv": "81.117343", 
        "first_neighbor_entry": "19982516.0746", 
        "init_view": "12.975441", 
        "bgp": "65.291994", 
        "finalizer": "143.468494", 
        "port_init": "47.989596", 
        "lag_ready": "106.051827", 
        "teamd": "48.962493", 
        "syncd": "35.944287", 
        "swss": "54.877092", 
        "apply_view": "10.55414"
    }, 
    "reboot_time": "161.989634", 
    "reboot_type": "warm", 
    "dataplane": {
        "total_downtime": "15.32117486", 
        "lost_packets": "2858", 
        "longest_downtime": "0.505247"
    }
}
```
**Physical fast**
```
{
    "processing_time": {
        "default_route_set": "69.93171", 
        "sai_switch_create": "11.904239", 
        "radv": "73.579099", 
        "first_neighbor_entry": "61.836979", 
        "init_view": "5.386714", 
        "bgp": "54.634928", 
        "finalizer": "1.257536", 
        "port_init": "58.190113", 
        "lag_ready": "39.282395", 
        "teamd": "56.61588", 
        "syncd": "37.662354", 
        "swss": "43.406041", 
        "apply_view": "0.001785"
    }, 
    "reboot_time": "19.044175", 
    "reboot_type": "fast", 
    "dataplane": {
        "total_downtime": "N/A", 
        "lost_packets": "N/A", 
        "longest_downtime": "29.357011"
    }
}
```

**KVM warm**
```
{
    "processing_time": {
        "default_route_set": "51.141763", 
        "sai_switch_create": "0.004053", 
        "radv": "82.097353", 
        "first_neighbor_entry": "49.378104", 
        "init_view": "2.608553", 
        "bgp": "70.735566", 
        "finalizer": "137.445965", 
        "port_init": "45.515821", 
        "lag_ready": "113.225831", 
        "teamd": "53.771907", 
        "gbsyncd": "39.780869", 
        "syncd": "42.76827", 
        "swss": "61.36063", 
        "apply_view": "13.652175"
    }, 
    "reboot_time": "169.345454", 
    "reboot_type": "warm", 
    "dataplane": {
        "total_downtime": "N/A", 
        "lost_packets": "N/A", 
        "longest_downtime": "132.277659"
    }
}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
