### PR TITLE
[report-uploader] Upload advanced-reboot timing data to Kusto

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -29,6 +29,8 @@ import os
 
 from collections import defaultdict
 from datetime import datetime
+from utilities import TestResultJSONValidationError
+from utilities import validate_json_file
 
 import defusedxml.ElementTree as ET
 
@@ -77,10 +79,6 @@ REQUIRED_TESTCASE_JSON_FIELDS = ["result", "error", "summary"]
 
 class JUnitXMLValidationError(Exception):
     """Expected errors that are thrown while validating the contents of the JUnit XML file."""
-
-
-class TestResultJSONValidationError(Exception):
-    """Expected errors that are trhown while validating the contents of the Test Result JSON file."""
 
 
 def validate_junit_xml_stream(stream):
@@ -458,19 +456,7 @@ def validate_junit_json_file(path):
             - The provided file is unparseable
             - The provided file is missing required fields
     """
-    if not os.path.exists(path):
-        print(f"{path} not found")
-        sys.exit(1)
-
-    if not os.path.isfile(path):
-        print(f"{path} is not a JSON file")
-        sys.exit(1)
-
-    try:
-        with open(path) as f:
-            test_result_json = json.load(f)
-    except Exception as e:
-        raise TestResultJSONValidationError(f"Could not load JSON file {path}: {e}") from e
+    test_result_json = validate_json_file(path)
 
     _validate_json_metadata(test_result_json)
     _validate_json_summary(test_result_json)

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -85,3 +85,41 @@
                                                                                   {"column":"ReportId","Properties":{"path":"$.id"}},
                                                                                   {"column":"TestbedName","Properties":{"path":"$.testbed"}},
                                                                                   {"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}}]'
+
+###############################################################################
+# REBOOT REPORT TABLE SETUP                                                   #
+# 1. Create a RebootTimingData table to store reboot test timings             #
+# 2. Add a JSON mapping for the table                                         #
+###############################################################################
+// Create table command
+////////////////////////////////////////////////////////////
+.create table ['RebootTimingData']  (['RebootTime']:string, ['RebootType']:string, ['DataplaneLongestDowntime']:string,
+                                    ['DataplaneLostPackets']:string, ['DataplaneTotalDowntime']:string, ['ProcessingTimeDefaultRouteSet']:string,
+                                    ['ProcessingTimeSaiSwitchCreate']:string, ['ProcessingTimeLagReady']:string, ['ProcessingTimeBgp']:string,
+                                    ['ProcessingTimeSyncd']:string, ['ProcessingTimeRadv']:string, ['ProcessingTimeFirstNeighborEntry']:string,
+                                    ['ProcessingTimeInitView']:string, ['ProcessingTimeFinalizer']:string, ['ProcessingTimePortInit']:string,
+                                    ['ProcessingTimeTeamd']:string, ['ProcessingTimeGbsyncd']:string, ['ProcessingTimeSwss']:string,
+                                    ['ProcessingTimeApplyView']:string)
+
+
+// Create mapping command
+////////////////////////////////////////////////////////////
+.create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDatamapping' '[{"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
+                                                                                    {"column":"RebootType", "Properties":{"Path":"$[\'reboot_type\']"}},
+                                                                                    {"column":"DataplaneLongestDowntime", "Properties":{"Path":"$[\'dataplane\'][\'longest_downtime\']"}},
+                                                                                    {"column":"DataplaneLostPackets", "Properties":{"Path":"$[\'dataplane\'][\'lost_packets\']"}},
+                                                                                    {"column":"DataplaneTotalDowntime", "Properties":{"Path":"$[\'dataplane\'][\'total_downtime\']"}},
+                                                                                    {"column":"ProcessingTimeDefaultRouteSet", "Properties":{"Path":"$[\'processing_time\'][\'default_route_set\']"}},
+                                                                                    {"column":"ProcessingTimeSaiSwitchCreate", "Properties":{"Path":"$[\'processing_time\'][\'sai_switch_create\']"}},
+                                                                                    {"column":"ProcessingTimeLagReady", "Properties":{"Path":"$[\'processing_time\'][\'lag_ready\']"}},
+                                                                                    {"column":"ProcessingTimeBgp", "Properties":{"Path":"$[\'processing_time\'][\'bgp\']"}},
+                                                                                    {"column":"ProcessingTimeSyncd", "Properties":{"Path":"$[\'processing_time\'][\'syncd\']"}},
+                                                                                    {"column":"ProcessingTimeRadv", "Properties":{"Path":"$[\'processing_time\'][\'radv\']"}},
+                                                                                    {"column":"ProcessingTimeFirstNeighborEntry", "Properties":{"Path":"$[\'processing_time\'][\'first_neighbor_entry\']"}},
+                                                                                    {"column":"ProcessingTimeInitView", "Properties":{"Path":"$[\'processing_time\'][\'init_view\']"}},
+                                                                                    {"column":"ProcessingTimeFinalizer", "Properties":{"Path":"$[\'processing_time\'][\'finalizer\']"}},
+                                                                                    {"column":"ProcessingTimePortInit", "Properties":{"Path":"$[\'processing_time\'][\'port_init\']"}},
+                                                                                    {"column":"ProcessingTimeTeamd", "Properties":{"Path":"$[\'processing_time\'][\'teamd\']"}},
+                                                                                    {"column":"ProcessingTimeGbsyncd", "Properties":{"Path":"$[\'processing_time\'][\'gbsyncd\']"}},
+                                                                                    {"column":"ProcessingTimeSwss", "Properties":{"Path":"$[\'processing_time\'][\'swss\']"}},
+                                                                                    {"column":"ProcessingTimeApplyView", "Properties":{"Path":"$[\'processing_time\'][\'apply_view\']"}}]'

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -94,16 +94,20 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RawRebootTimingData']  (ReportId: string, ['ProcessingTime']:dynamic, ['FirstOccurence']:dynamic, ['RebootTime']:dynamic, ['Dataplane']:dynamic)
+.create table ['RawRebootTimingData']  (ReportId: string,
+                                    ['Controlplane']:dynamic, ['Dataplane']:dynamic, ['OffsetFromKexec']:dynamic,
+                                    ['TimeSpan']:dynamic, ['RebootTime']:dynamic)
 
 // Create mapping command
 ////////////////////////////////////////////////////////////
 .create table ['RawRebootTimingData'] ingestion json mapping 'RawRebootTimingDataMapping' '[
-                                                                                {"column":"ReportId","Properties":{"path":"$.id"}},
-                                                                                {"column":"ProcessingTime", "Properties":{"Path":"$[\'processing_time\']"}},
-                                                                                {"column":"FirstOccurence", "Properties":{"Path":"$[\'first_occurence\']"}},
-                                                                                {"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
-                                                                                {"column":"Dataplane", "Properties":{"Path":"$[\'dataplane\']"}}]'
+                                                            {"column":"ReportId","Properties":{"path":"$.id"}},
+                                                            {"column":"OffsetFromKexec", "Properties":{"Path":"$[\'offset_from_kexec\']"}},
+                                                            {"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
+                                                            {"column":"Controlplane", "Properties":{"Path":"$[\'controlplane\']"}},
+                                                            {"column":"Dataplane", "Properties":{"Path":"$[\'dataplane\']"}},
+                                                            {"column":"TimeSpan", "Properties":{"Path":"$[\'time_span\']"}}]'
+
 
 ###############################################################################
 # REBOOT REPORT TABLE SETUP                                                   #
@@ -112,33 +116,47 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData']  (ReportId: string, ['RebootTime']:string, ['RebootType']:string, ['DataplaneLongestDowntime']:string,
-                                    ['DataplaneLostPackets']:string, ['DataplaneTotalDowntime']:string, ['ProcessingTimeDefaultRouteSet']:string,
-                                    ['ProcessingTimeSaiSwitchCreate']:string, ['ProcessingTimeLagReady']:string, ['ProcessingTimeBgp']:string,
-                                    ['ProcessingTimeSyncd']:string, ['ProcessingTimeRadv']:string, ['ProcessingTimeFirstNeighborEntry']:string,
-                                    ['ProcessingTimeInitView']:string, ['ProcessingTimeFinalizer']:string, ['ProcessingTimePortInit']:string,
-                                    ['ProcessingTimeTeamd']:string, ['ProcessingTimeGbsyncd']:string, ['ProcessingTimeSwss']:string,
-                                    ['ProcessingTimeApplyView']:string)
-
+.create table ['RebootTimingData'] (ReportId: string, ['RebootType']:string,
+                                    ['ControlplaneArpPing']:string, ['ControlplaneDowntime']:string, ['DataplaneLostPackets']:string, ['DataplaneDowntime']:string,
+                                    ['OffsetFromKexecDatabase']:string, ['OffsetFromKexecFinalizer']:string, ['OffsetFromKexecInitView']:string, ['OffsetFromKexecSyncdCreateSwitch']:string,
+                                    ['OffsetFromKexecPortInit']:string, ['OffsetFromKexecPortReady']:string, ['OffsetFromKexecSaiCreateSwitch']:string, ['OffsetFromKexecNeighborEntry']:string,
+                                    ['OffsetFromKexecDefaultRouteSet']:string, ['OffsetFromKexecLagReady']:string, ['OffsetFromKexecApplyView']:string, ['TimeSpanRadv']:string,
+                                    ['TimeSpanSyncd']:string, ['TimeSpanBgp']:string, ['TimeSpanPortInit']:string, ['TimeSpanSwss']:string, ['TimeSpanTeamd']:string,
+                                    ['TimeSpanDatabase']:string, ['TimeSpanSyncdCreateSwitch']:string, ['TimeSpanSaiCreateSwitch']:string, ['TimeSpanApplyView']:string,
+                                    ['TimeSpanInitView']:string, ['TimeSpanNeighborEntry']:string, ['TimeSpanPortReady']:string, ['TimeSpanFinalizer']:string, ['TimeSpanLagReady']:string)
 
 // Create mapping command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDataMapping' '[{"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
-                                                                                    {"column":"RebootType", "Properties":{"Path":"$[\'reboot_type\']"}},
-                                                                                    {"column":"DataplaneLongestDowntime", "Properties":{"Path":"$[\'dataplane\'][\'longest_downtime\']"}},
-                                                                                    {"column":"DataplaneLostPackets", "Properties":{"Path":"$[\'dataplane\'][\'lost_packets\']"}},
-                                                                                    {"column":"DataplaneTotalDowntime", "Properties":{"Path":"$[\'dataplane\'][\'total_downtime\']"}},
-                                                                                    {"column":"ProcessingTimeDefaultRouteSet", "Properties":{"Path":"$[\'processing_time\'][\'default_route_set\']"}},
-                                                                                    {"column":"ProcessingTimeSaiSwitchCreate", "Properties":{"Path":"$[\'processing_time\'][\'sai_switch_create\']"}},
-                                                                                    {"column":"ProcessingTimeLagReady", "Properties":{"Path":"$[\'processing_time\'][\'lag_ready\']"}},
-                                                                                    {"column":"ProcessingTimeBgp", "Properties":{"Path":"$[\'processing_time\'][\'bgp\']"}},
-                                                                                    {"column":"ProcessingTimeSyncd", "Properties":{"Path":"$[\'processing_time\'][\'syncd\']"}},
-                                                                                    {"column":"ProcessingTimeRadv", "Properties":{"Path":"$[\'processing_time\'][\'radv\']"}},
-                                                                                    {"column":"ProcessingTimeFirstNeighborEntry", "Properties":{"Path":"$[\'processing_time\'][\'first_neighbor_entry\']"}},
-                                                                                    {"column":"ProcessingTimeInitView", "Properties":{"Path":"$[\'processing_time\'][\'init_view\']"}},
-                                                                                    {"column":"ProcessingTimeFinalizer", "Properties":{"Path":"$[\'processing_time\'][\'finalizer\']"}},
-                                                                                    {"column":"ProcessingTimePortInit", "Properties":{"Path":"$[\'processing_time\'][\'port_init\']"}},
-                                                                                    {"column":"ProcessingTimeTeamd", "Properties":{"Path":"$[\'processing_time\'][\'teamd\']"}},
-                                                                                    {"column":"ProcessingTimeGbsyncd", "Properties":{"Path":"$[\'processing_time\'][\'gbsyncd\']"}},
-                                                                                    {"column":"ProcessingTimeSwss", "Properties":{"Path":"$[\'processing_time\'][\'swss\']"}},
-                                                                                    {"column":"ProcessingTimeApplyView", "Properties":{"Path":"$[\'processing_time\'][\'apply_view\']"}}]'
+.create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDataMapping' '[
+                                                            {"column":"ReportId","Properties":{"path":"$.id"}},
+                                                            {"column":"OffsetFromKexecDatabase", "Properties":{"Path":"$[\'offset_from_kexec\'][\'database\']"}},
+                                                            {"column":"OffsetFromKexecFinalizer", "Properties":{"Path":"$[\'offset_from_kexec\'][\'finalizer\']"}},
+                                                            {"column":"OffsetFromKexecPortInit", "Properties":{"Path":"$[\'offset_from_kexec\'][\'port_init\']"}},
+                                                            {"column":"OffsetFromKexecInitView", "Properties":{"Path":"$[\'offset_from_kexec\'][\'init_view\']"}},
+                                                            {"column":"OffsetFromKexecSyncdCreateSwitch", "Properties":{"Path":"$[\'offset_from_kexec\'][\'syncd_create_switch\']"}},
+                                                            {"column":"OffsetFromKexecDefaultRouteSet", "Properties":{"Path":"$[\'offset_from_kexec\'][\'default_route_set\']"}},
+                                                            {"column":"OffsetFromKexecLagReady", "Properties":{"Path":"$[\'offset_from_kexec\'][\'lag_ready\']"}},
+                                                            {"column":"OffsetFromKexecPortReady", "Properties":{"Path":"$[\'offset_from_kexec\'][\'port_ready\']"}},
+                                                            {"column":"OffsetFromKexecSaiCreateSwitch", "Properties":{"Path":"$[\'offset_from_kexec\'][\'sai_create_switch\']"}},
+                                                            {"column":"OffsetFromKexecNeighborEntry", "Properties":{"Path":"$[\'offset_from_kexec\'][\'neighbor_entry\']"}},
+                                                            {"column":"OffsetFromKexecApplyView", "Properties":{"Path":"$[\'offset_from_kexec\'][\'apply_view\']"}},
+                                                            {"column":"ControlplaneArpPing", "Properties":{"Path":"$[\'controlplane\'][\'arp_ping\']"}},
+                                                            {"column":"ControlplaneDowntime", "Properties":{"Path":"$[\'controlplane\'][\'downtime\']"}},
+                                                            {"column":"TimeSpanRadv", "Properties":{"Path":"$[\'time_span\'][\'radv\']"}},
+                                                            {"column":"TimeSpanSyncd", "Properties":{"Path":"$[\'time_span\'][\'syncd\']"}},
+                                                            {"column":"TimeSpanBgp", "Properties":{"Path":"$[\'time_span\'][\'bgp\']"}},
+                                                            {"column":"TimeSpanPortInit", "Properties":{"Path":"$[\'time_span\'][\'port_init\']"}},
+                                                            {"column":"TimeSpanSwss", "Properties":{"Path":"$[\'time_span\'][\'swss\']"}},
+                                                            {"column":"TimeSpanTeamd", "Properties":{"Path":"$[\'time_span\'][\'teamd\']"}},
+                                                            {"column":"TimeSpanDatabase", "Properties":{"Path":"$[\'time_span\'][\'database\']"}},
+                                                            {"column":"TimeSpanSyncdCreateSwitch", "Properties":{"Path":"$[\'time_span\'][\'syncd_create_switch\']"}},
+                                                            {"column":"TimeSpanSaiCreateSwitch", "Properties":{"Path":"$[\'time_span\'][\'sai_create_switch\']"}},
+                                                            {"column":"TimeSpanApplyView", "Properties":{"Path":"$[\'time_span\'][\'apply_view\']"}},
+                                                            {"column":"TimeSpanInitView", "Properties":{"Path":"$[\'time_span\'][\'init_view\']"}},
+                                                            {"column":"TimeSpanNeighborEntry", "Properties":{"Path":"$[\'time_span\'][\'neighbor_entry\']"}},
+                                                            {"column":"TimeSpanPortReady", "Properties":{"Path":"$[\'time_span\'][\'port_ready\']"}},
+                                                            {"column":"TimeSpanFinalizer", "Properties":{"Path":"$[\'time_span\'][\'finalizer\']"}},
+                                                            {"column":"TimeSpanLagReady", "Properties":{"Path":"$[\'time_span\'][\'lag_ready\']"}},
+                                                            {"column":"RebootType", "Properties":{"Path":"$[\'reboot_type\']"}},
+                                                            {"column":"DataplaneLostPackets", "Properties":{"Path":"$[\'dataplane\'][\'lost_packets\']"}},
+                                                            {"column":"DataplaneDowntime", "Properties":{"Path":"$[\'dataplane\'][\'downtime\']"}}]'

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -86,6 +86,24 @@
                                                                                   {"column":"TestbedName","Properties":{"path":"$.testbed"}},
                                                                                   {"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}}]'
 
+
+###############################################################################
+# RAW REBOOT REPORT TABLE SETUP                                               #
+# 1. Create a RawRebootTimingData table to store reboot test timings          #
+# 2. Add a JSON mapping for the table                                         #
+###############################################################################
+// Create table command
+////////////////////////////////////////////////////////////
+.create table ['RawRebootTimingData']  (['ProcessingTime']:dynamic, ['FirstOccurence']:dynamic, ['RebootTime']:dynamic, ['Dataplane']:dynamic)
+
+// Create mapping command
+////////////////////////////////////////////////////////////
+.create table ['RawRebootTimingData'] ingestion json mapping 'RawRebootTimingDataMapping' '[
+                                                                                {"column":"ProcessingTime", "Properties":{"Path":"$[\'processing_time\']"}},
+                                                                                {"column":"FirstOccurence", "Properties":{"Path":"$[\'first_occurence\']"}},
+                                                                                {"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
+                                                                                {"column":"Dataplane", "Properties":{"Path":"$[\'dataplane\']"}}]'
+
 ###############################################################################
 # REBOOT REPORT TABLE SETUP                                                   #
 # 1. Create a RebootTimingData table to store reboot test timings             #
@@ -104,7 +122,7 @@
 
 // Create mapping command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDatamapping' '[{"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
+.create table ['RebootTimingData'] ingestion json mapping 'RebootTimingDataMapping' '[{"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
                                                                                     {"column":"RebootType", "Properties":{"Path":"$[\'reboot_type\']"}},
                                                                                     {"column":"DataplaneLongestDowntime", "Properties":{"Path":"$[\'dataplane\'][\'longest_downtime\']"}},
                                                                                     {"column":"DataplaneLostPackets", "Properties":{"Path":"$[\'dataplane\'][\'lost_packets\']"}},

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -94,11 +94,12 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RawRebootTimingData']  (['ProcessingTime']:dynamic, ['FirstOccurence']:dynamic, ['RebootTime']:dynamic, ['Dataplane']:dynamic)
+.create table ['RawRebootTimingData']  (ReportId: string, ['ProcessingTime']:dynamic, ['FirstOccurence']:dynamic, ['RebootTime']:dynamic, ['Dataplane']:dynamic)
 
 // Create mapping command
 ////////////////////////////////////////////////////////////
 .create table ['RawRebootTimingData'] ingestion json mapping 'RawRebootTimingDataMapping' '[
+                                                                                {"column":"ReportId","Properties":{"path":"$.id"}},
                                                                                 {"column":"ProcessingTime", "Properties":{"Path":"$[\'processing_time\']"}},
                                                                                 {"column":"FirstOccurence", "Properties":{"Path":"$[\'first_occurence\']"}},
                                                                                 {"column":"RebootTime", "Properties":{"Path":"$[\'reboot_time\']"}},
@@ -111,7 +112,7 @@
 ###############################################################################
 // Create table command
 ////////////////////////////////////////////////////////////
-.create table ['RebootTimingData']  (['RebootTime']:string, ['RebootType']:string, ['DataplaneLongestDowntime']:string,
+.create table ['RebootTimingData']  (ReportId: string, ['RebootTime']:string, ['RebootType']:string, ['DataplaneLongestDowntime']:string,
                                     ['DataplaneLostPackets']:string, ['DataplaneTotalDowntime']:string, ['ProcessingTimeDefaultRouteSet']:string,
                                     ['ProcessingTimeSaiSwitchCreate']:string, ['ProcessingTimeLagReady']:string, ['ProcessingTimeBgp']:string,
                                     ['ProcessingTimeSyncd']:string, ['ProcessingTimeRadv']:string, ['ProcessingTimeFirstNeighborEntry']:string,

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -60,12 +60,11 @@ class ReportDBConnector(ABC):
         """
 
     @abstractmethod
-    def upload_reboot_report(self, reboot_timing_dict: Dict, path_name: str = "", report_guid: str = "") -> None:
+    def upload_reboot_report(self, path_name: str = "", report_guid: str = "") -> None:
         """Upload reboot test report to the back-end data store.
 
         Args:
-            reboot_timing_dict: reboot test results stored in dictionary
-            path_name: Path 
+            path_name: Path to reboot report/summary file
             report_guid: A randomly generated UUID that is used to query for a specific test run across tables.
         """
 
@@ -160,7 +159,7 @@ class KustoConnector(ReportDBConnector):
         pdu_status_data = {"data": pdu_output}
         self._ingest_data(self.RAW_PDU_STATUS_TABLE, pdu_status_data)
 
-    def upload_reboot_report(self, reboot_timing_dict: Dict, path_name: str = "", report_guid: str = "") -> None:
+    def upload_reboot_report(self, path_name: str = "", report_guid: str = "") -> None:
         reboot_timing_data = {
             "id": report_guid
         }

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -41,9 +41,13 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         report_guid = str(uuid.uuid4())
         for path_name in args.path_list:
             is_reboot_report = "reboot_report" in path_name
+            if "reboot_summary" in path_name:
+                report_type = "summary"
+            elif "reboot_report" in path_name:
+                report_type = "detailed"
             if is_reboot_report:
                 test_result_json = validate_json_file(path_name)
-                kusto_db.upload_reboot_report(test_result_json, report_guid)
+                kusto_db.upload_reboot_report(test_result_json, report_type, report_guid)
             else:
                 if args.json:
                     test_result_json = validate_junit_json_file(path_name)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -39,9 +39,8 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         tracking_id = args.external_id if args.external_id else ""
         report_guid = str(uuid.uuid4())
         for path_name in args.path_list:
-            is_reboot_report = "test_warm_reboot" in path_name or "test_fast_reboot" in path_name
-            if is_reboot_report:
-                kusto_db.upload_reboot_report(test_result_json, path_name, report_guid)
+            if "reboot_summary" in path_name or "reboot_report" in path_name:
+                kusto_db.upload_reboot_report(path_name, report_guid)
             else:
                 if args.json:
                     test_result_json = validate_junit_json_file(path_name)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -9,7 +9,6 @@ from junit_xml_parser import (
     parse_test_result
 )
 from report_data_storage import KustoConnector
-from utilities import validate_json_file
 
 
 def _run_script():
@@ -40,14 +39,9 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         tracking_id = args.external_id if args.external_id else ""
         report_guid = str(uuid.uuid4())
         for path_name in args.path_list:
-            is_reboot_report = "reboot_report" in path_name
-            if "reboot_summary" in path_name:
-                report_type = "summary"
-            elif "reboot_report" in path_name:
-                report_type = "detailed"
+            is_reboot_report = "test_warm_reboot" in path_name or "test_fast_reboot" in path_name
             if is_reboot_report:
-                test_result_json = validate_json_file(path_name)
-                kusto_db.upload_reboot_report(test_result_json, report_type, report_guid)
+                kusto_db.upload_reboot_report(test_result_json, path_name, report_guid)
             else:
                 if args.json:
                     test_result_json = validate_junit_json_file(path_name)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import sys
+import uuid
 
 from junit_xml_parser import (
     validate_junit_json_file,
@@ -8,6 +9,7 @@ from junit_xml_parser import (
     parse_test_result
 )
 from report_data_storage import KustoConnector
+from utilities import validate_json_file
 
 
 def _run_script():
@@ -35,16 +37,20 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
     kusto_db = KustoConnector(args.db_name)
 
     if args.category == "test_result":
+        tracking_id = args.external_id if args.external_id else ""
+        report_guid = str(uuid.uuid4())
         for path_name in args.path_list:
-            if args.json:
-                test_result_json = validate_junit_json_file(path_name)
+            is_reboot_report = "reboot_report" in path_name
+            if is_reboot_report:
+                test_result_json = validate_json_file(path_name)
+                kusto_db.upload_reboot_report(test_result_json, report_guid)
             else:
-                roots = validate_junit_xml_path(path_name)
-                test_result_json = parse_test_result(roots)
-
-            tracking_id = args.external_id if args.external_id else ""
-
-            kusto_db.upload_report(test_result_json, tracking_id)
+                if args.json:
+                    test_result_json = validate_junit_json_file(path_name)
+                else:
+                    roots = validate_junit_xml_path(path_name)
+                    test_result_json = parse_test_result(roots)
+                kusto_db.upload_report(test_result_json, tracking_id, report_guid)
     elif args.category == "reachability":
         reachability_data = []
         for path_name in args.path_list:

--- a/test_reporting/utilities.py
+++ b/test_reporting/utilities.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import json
+
+
+class TestResultJSONValidationError(Exception):
+    """Expected errors that are trhown while validating the contents of the Test Result JSON file."""
+
+
+def validate_json_file(path):
+    if not os.path.exists(path):
+        print(f"{path} not found")
+        sys.exit(1)
+    if not os.path.isfile(path):
+        print(f"{path} is not a JSON file")
+        sys.exit(1)
+
+    try:
+        with open(path) as f:
+            test_result_json = json.load(f)
+    except Exception as e:
+        raise TestResultJSONValidationError(f"Could not load JSON file {path}: {e}") from e
+
+    return test_result_json


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add new tables and reporting mechanism to upload reboot test results to Kusto DB.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To upstream advanced-reboot timing data to Kusto. This would enable fast/easy lookup and tracking the progress/regressions.

#### How did you do it?
Added a new table `RebootTimingData` and mapping for the below json.
Added a new method to enable reboot result upload.

Sample Json data that is mapped to newly created table:
```
{
    "offset_from_kexec": {
        "database": "35.892342", 
        "finalizer": "35.913938", 
        "init_view": "47.25007", 
        "syncd_create_switch": "46.856395", 
        "port_init": "56.016975", 
        "lag_ready": "123.15247", 
        "port_ready": "88.131799", 
        "sai_create_switch": "51.49355", 
        "neighbor_entry": "59.788826", 
        "default_route_set": "64.926464", 
        "apply_view": "78.962488"
    }, 
    "controlplane": {
        "arp_ping": "", 
        "downtime": "126.81416"
    }, 
    "time_span": {
        "radv": "87.051703", 
        "bgp": "77.473141", 
        "syncd": "47.588903", 
        "swss": "68.047943", 
        "teamd": "60.166329", 
        "database": "37.356888", 
        "syncd_create_switch": "3.822214", 
        "sai_create_switch": "0.008182", 
        "apply_view": "9.152629", 
        "init_view": "4.231182", 
        "neighbor_entry": "4.423869", 
        "port_init": "2.958689", 
        "port_ready": "1.052344", 
        "finalizer": "138.202517", 
        "lag_ready": "0.212124"
    }, 
    "reboot_type": "warm", 
    "dataplane": {
        "lost_packets": "", 
        "downtime": "136.309334"
    }
}
```

#### How did you verify/test it?
Table and mapping created successfully on Kusto.
Ingested a sample data to the table using Jenkins job.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
