### PR TITLE
[console] Add driver test for Console Switch

### DIFF
--- a/ansible/library/console_facts.py
+++ b/ansible/library/console_facts.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+
+DOCUMENTATION = '''
+module:         console_facts
+version_added:  "2.0"
+author:         Jing Kan (jika@microsoft.com)
+short_description: Retrieve console information from Quagga
+description:
+    - Retrieve console feature information from CONFIG_DB
+    - Retrieve console status from show line command
+    - Retrieved facts will be inserted into the 'console_facts' key
+'''
+
+class ConsoleModule(object):
+    LINE_INDEX = 0
+    BAUD_INDEX = 1
+    FLCT_INDEX = 2
+    RDEV_INDEX = 5
+
+    STATUS_BUSY = "BUSY"
+    STATUS_IDLE = "IDLE"
+
+    STATUS_INDICATOR = "*"
+    FLCT_ENABLED_TEXT = "Enabled"
+
+    def __init__(self, hostname, config_facts, include_remote_device_mapping = True):
+        self.include_remote_device_mapping = include_remote_device_mapping
+        self.module = AnsibleModule(argument_spec = dict())
+
+    def run(self):
+        """
+            Main method of the class
+        """
+        self.module.exit_json(ansible_facts = {
+            'console_facts' : self.get_console_facts()
+        })
+
+    def get_console_facts(self):
+        """
+        Retrieve console facts
+        """
+        facts = {
+            "enabled" : self.get_console_feature_status()
+        }
+
+        if facts["enabled"]:
+            facts["lines"] = self.get_console_lines_status()
+            if self.include_remote_device_mapping:
+                facts["remote_device_mapping"] = self.build_remote_device_mapping()
+
+    def get_console_feature_status(self):
+        """
+        Retrieve console feature information
+        """
+        rt, out, err = module.run_command('sonic-db-cli CONFIG_DB HGET CONSOLE_SWITCH|console_mgmt enabled')
+        if rt != 0:
+            self.module.fail_json("Failed to get console feature status, rt={}, out={}, err={}".format(rt, out, err))
+        return True if out.contains("yes") else False
+
+    def get_console_lines_status(self):
+        """
+        Retrieve detailed console status
+        """
+        fields_line_index = 1
+        skip_lines = 2
+        max_fields = 6
+        result = {}
+
+        # We only parse configured lines
+        cmd = "show line -b"
+        rt, out, err = self.module.run_command(cmd)
+        if rt != 0:
+            module.fail_json(msg = "Failed to get line information! {}".format(err))
+
+        # Parse show line outputs
+        lines = out.splitlines()
+        if len(lines) == 0:
+            module.fail_json(msg = "Failed to parse header from show line outputs")
+            return None
+
+        try:
+            # 1. Extract field mask line according by fileds line
+            fields_line = lines[fields_line_index]
+
+            for line in lines[skip_lines:]:
+                # 2. Extract fields for each line
+                fields = []
+                field = ""
+                for i in range(len(fields_line)):
+                    if i == len(line):
+                        break
+                    mask = fields_line[i]
+                    if mask == '-':
+                        field += line[i]
+                    elif len(field) > 0:
+                        fields.append(field.strip())
+                        field = ""
+                if len(field) > 0:
+                    fields.append(field.strip())
+
+                # 3. Construct line status
+                line_status = {}
+                line_status['state'] = self.STATUS_BUSY if field[self.LINE_INDEX].contains(self.STATUS_INDICATOR) else self.STATUS_IDLE
+                line_status['baud_rate'] = int(field[self.BAUD_INDEX])
+                line_status['flow_control'] = True if field[self.FLCT_INDEX] == self.FLCT_ENABLED_TEXT else False
+                if len(field) >= self.RDEV_INDEX:
+                    line_status['remote_device'] = field[self.RDEV_INDEX]
+                result[field[self.LINE_INDEX].lstrip(self.STATUS_INDICATOR)] = line_status
+            return result
+        except Exception as e:
+            module.fail_json(msg = "Failed to parse header from [{}] outputs: {}".format(cmd, str(e)))
+
+    def build_remote_device_mapping(self, lines):
+        """
+        Build the mapping between remote device and line number
+        """
+        mapping = {}
+        for line_num, line_status in lines:
+            if "remote_device" in line_status and line_status["remote_device"]:
+                mapping[line_status["remote_device"]] = line_num
+
+def main():
+    console_module = ConsoleModule()
+    console_module.run()
+
+from ansible.module_utils.basic import *
+if __name__ == "__main__":
+    main()

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,0 +1,12 @@
+import logging
+import pytest
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_if_console_feature_disabled(console_facts):
+    if not console_facts['enabled']:
+        pytest.skip("Skip test due to the console switch feature is not enabled for current DUT.")
+    yield
+
+@pytest.fixture(scope='module')
+def console_facts(duthost):
+    return duthost.console_facts()['ansible_facts']['console_facts']

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -14,7 +14,7 @@ def test_console_driver(duthost):
     """
     out = duthost.shell('ls /dev/ttyUSB*')['stdout']
     pytest_assert(
-        not out.contains("No such file or directory"),
+        "No such file or directory" not in out,
         "No virtual tty devices been created by console driver")
 
     ttys = set(out.split())

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -1,0 +1,25 @@
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+def test_console_driver(duthost):
+    """
+    Test console driver are well installed.
+    Verify ttyUSB(0-47) are presented in DUT
+    """
+    out = duthost.shell('ls /dev/ttyUSB*')['stdout']
+    pytest_assert(
+        not out.contains("No such file or directory"),
+        "No virtual tty devices been created by console driver")
+
+    ttys = set(out.split())
+    for i in range(48):
+        expected_virtual_tty = "/dev/ttyUSB{}".format(i)
+        pytest_assert(
+            expected_virtual_tty in ttys,
+            "Expected virtual tty device [{}] not found.".format(expected_virtual_tty))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add driver test for Console Switch.
- Add a new Ansible Module to extract console related status from DUT
- Add a new test case to verify if the console switch driver is working as expect

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To verify if the console switch driver installed properly and works as expect.

#### How did you do it?
Verify if virtual tty devices are created by driver.

#### How did you verify/test it?

Run test with physical DUT:
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/internal/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

console/test_console_driver.py::test_console_driver PASSED                                                                                                                                      [100%]

----------------------------------------------------------------------- generated xml file: /var/src/internal/tests/logs/tr.xml -----------------------------------------------------------------------
====================================================================================== 1 passed in 79.33 seconds ======================================================================================
```

#### Any platform specific information?
This test case only capable for console switch feature enabled DUT.

#### Supported testbed topology if it's a new test case?
T0 (management device)

### Documentation 
https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/console/console_test_hld.md#41-driver-test