### PR TITLE
[dualtor] Add Loopback3

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -43,7 +43,7 @@ class DualTorParser:
             loopback_ips[dut]['ipv4'] = self.vm_config['DUT']['loopback']['ipv4'][dut_num]
             loopback_ips[dut]['ipv6'] = self.vm_config['DUT']['loopback']['ipv6'][dut_num] 
 
-            for loopback_num in range(1, 3): # Generate two additional loopback IPs, Loopback1 and Loopback2
+            for loopback_num in range(1, 4): # Generate two additional loopback IPs, Loopback1 and Loopback2
                 loopback_key = 'loopback{}'.format(loopback_num)
                 loopback_dict = {}
                 loopback_dict['ipv4'] = self.vm_config['DUT'][loopback_key]['ipv4'][dut_num]

--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -43,7 +43,7 @@ class DualTorParser:
             loopback_ips[dut]['ipv4'] = self.vm_config['DUT']['loopback']['ipv4'][dut_num]
             loopback_ips[dut]['ipv6'] = self.vm_config['DUT']['loopback']['ipv6'][dut_num] 
 
-            for loopback_num in range(1, 4): # Generate two additional loopback IPs, Loopback1 and Loopback2
+            for loopback_num in range(1, 4): # Generate two additional loopback IPs, Loopback1, Loopback2, and Loopback3
                 loopback_key = 'loopback{}'.format(loopback_num)
                 loopback_dict = {}
                 loopback_dict['ipv4'] = self.vm_config['DUT'][loopback_key]['ipv4'][dut_num]

--- a/ansible/vars/topo_dualtor-120.yml
+++ b/ansible/vars/topo_dualtor-120.yml
@@ -221,6 +221,13 @@ topology:
       ipv6:
         - FC00:1::36/128
         - FC00:1::36/128
+    loopback3:
+      ipv4:
+        - 10.1.0.38/32
+        - 10.1.0.39/32
+      ipv6:
+        - FC00:1::38/128
+        - FC00:1::39/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_dualtor-56.yml
+++ b/ansible/vars/topo_dualtor-56.yml
@@ -125,6 +125,13 @@ topology:
       ipv6:
         - FC00:1::36/128
         - FC00:1::36/128
+    loopback3:
+      ipv4:
+        - 10.1.0.38/32
+        - 10.1.0.39/32
+      ipv6:
+        - FC00:1::38/128
+        - FC00:1::39/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_dualtor.yml
+++ b/ansible/vars/topo_dualtor.yml
@@ -77,6 +77,13 @@ topology:
       ipv6:
         - FC00:1::36/128
         - FC00:1::36/128
+    loopback3:
+      ipv4:
+        - 10.1.0.38/32
+        - 10.1.0.39/32
+      ipv6:
+        - FC00:1::38/128
+        - FC00:1::39/128
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add `Loopback3` that could be used in SLB testcase.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes #3278 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
ToRs need `Loopback3` to talk to BGP SLBs.

#### How did you do it?
Add `Loopback3`

#### How did you verify/test it?
Run `testbed-cli deploy-mg`
```
admin@str2-7050cx3-acs-08:~$ show ip interface
Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ------------  --------------  -------------
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
Loopback1                  10.1.0.34/32         up/up         N/A             N/A
Loopback2                  10.1.0.36/32         up/up         N/A             N/A
Loopback3                  10.1.0.38/32         up/up         N/A             N/A
PortChannel0001            10.0.0.56/31         up/up         ARISTA01T1      10.0.0.57
PortChannel0002            10.0.0.58/31         up/up         ARISTA02T1      10.0.0.59
PortChannel0003            10.0.0.60/31         up/up         ARISTA03T1      10.0.0.61
PortChannel0004            10.0.0.62/31         up/up         ARISTA04T1      10.0.0.63
Vlan1000                   192.168.0.1/21       up/up         N/A             N/A
docker0                    240.127.1.1/24       up/down       N/A             N/A
eth0                       10.3.147.22/23       up/up         N/A             N/A
lo                         127.0.0.1/16         up/up         N/A             N/A
tun0                       10.1.0.38/32         up/up         N/A             N/A
```
```
admin@str2-7050cx3-acs-09:~$ show ip interface
Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ------------  --------------  -------------
Loopback0                  10.1.0.33/32         up/up         N/A             N/A
Loopback1                  10.1.0.35/32         up/up         N/A             N/A
Loopback2                  10.1.0.36/32         up/up         N/A             N/A
Loopback3                  10.1.0.39/32         up/up         N/A             N/A
PortChannel0001            10.0.1.56/31         up/up         ARISTA01T1      10.0.1.57
PortChannel0002            10.0.1.58/31         up/up         ARISTA02T1      10.0.1.59
PortChannel0003            10.0.1.60/31         up/up         ARISTA03T1      10.0.1.61
PortChannel0004            10.0.1.62/31         up/up         ARISTA04T1      10.0.1.63
Vlan1000                   192.168.0.1/21       up/up         N/A             N/A
docker0                    240.127.1.1/24       up/down       N/A             N/A
eth0                       10.3.147.20/23       up/up         N/A             N/A
lo                         127.0.0.1/16         up/up         N/A             N/A
tun0                       10.1.0.39/32         up/up         N/A             N/A
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
