### PR TITLE
Removed ARP validation in case interface operational status turns down due to peer interface going down

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -326,9 +326,6 @@ def test_no_egress_drop_on_down_link(do_test, ptfadapter, duthosts, rand_one_dut
     ip_dst = rif_port_down
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], ip_dst, pkt_fields["ipv4_src"])
 
-    arp_info = duthost.shell("show arp")["stdout"]
-    pytest_assert(ip_dst not in arp_info.split(), "ARP entry is not cleared")
-
     pkt = testutils.simple_tcp_packet(
         eth_dst=ports_info["dst_mac"],  # DUT port
         eth_src=ports_info["src_mac"],  # PTF port


### PR DESCRIPTION
### Description of PR
Removed ARP validation in case interface operational status turns down due to peer interface going down

Summary: following the discussion in https://github.com/Azure/sonic-buildimage/issues/6856 test should not assume ARP is clear when peer port going down. Following that, ARP validation is removed.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix test failure due to wrong assumption of ARP table clear on peer interface down. 

#### How did you do it?
Removed ARP validation

#### How did you verify/test it?
Executed test case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
