### PR TITLE
[voq] Test plan and testcase updates for multiasic

### DIFF
--- a/tests/voq/conftest.py
+++ b/tests/voq/conftest.py
@@ -38,24 +38,6 @@ def all_cfg_facts(duthosts):
     return results
 
 
-@pytest.fixture(scope="module", autouse=True)
-def bgp_redistribute_route_lo(duthosts, all_cfg_facts):
-    for a_host in duthosts.frontend_nodes:
-        for a_asic in a_host.asics:
-            asic_asn = all_cfg_facts[a_host.hostname][a_asic.asic_index]['ansible_facts']['DEVICE_METADATA']['localhost']['bgp_asn']
-            loopbacks = all_cfg_facts[a_host.hostname][a_asic.asic_index]['ansible_facts']['LOOPBACK_INTERFACE']
-            for lb in loopbacks.values():
-                for addr in lb:
-                    if ":" in addr:
-                        send_command = a_asic.get_docker_cmd(
-                            "vtysh -c 'configure terminal' -c 'router bgp {asn}' -c 'address-family ipv6 unicast' -c 'network {addr}'".format(
-                                asn=asic_asn, addr=addr), "bgp")
-                    else:
-                        send_command = a_asic.get_docker_cmd(
-                            "vtysh -c 'configure terminal' -c 'router bgp {asn}' -c 'address-family ipv4 unicast' -c 'network {addr}'".format(asn=asic_asn, addr=addr), "bgp")
-                    a_host.command(send_command)
-
-
 @reset_ansible_local_tmp
 def _get_nbr_macs(nbrhosts, node=None, results=None):
     vm = nbrhosts[node]

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -7,6 +7,8 @@ import random
 
 from tests.ptf_runner import ptf_runner
 
+from tests.common.platform.device_utils import fanout_switch_port_lookup
+
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
@@ -20,8 +22,11 @@ from voq_helpers import asic_cmd, sonic_ping
 from voq_helpers import check_neighbors_are_gone
 from voq_helpers import dump_and_verify_neighbors_on_asic
 from voq_helpers import check_host_arp_table_deleted
+from voq_helpers import get_inband_info
+from voq_helpers import get_ptf_port
+from voq_helpers import get_vm_with_ip
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # lgtm[py/unused-import]
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +35,134 @@ pytestmark = [
 ]
 
 NEW_MAC = "00:01:94:00:00:01"
+
+
+def check_bgp_restored(duthosts, all_cfg_facts):
+    """
+    Checks for bgp neighbors to be established.
+
+    Args:
+        duthosts: duthosts fixture
+        all_cfg_facts: fixture from voq/conftest.py
+
+    Returns:
+        True if all neighbors are established, False if not.
+    """
+    down_nbrs = 0
+    for node in duthosts.frontend_nodes:
+        for asic in node.asics:
+            asic_cfg_facts = all_cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
+            if 'BGP_NEIGHBOR' not in asic_cfg_facts:
+                continue
+
+            if node.is_multi_asic:
+                bgp_facts = node.bgp_facts(instance_id=asic.asic_index)['ansible_facts']
+            else:
+                bgp_facts = node.bgp_facts()['ansible_facts']
+
+            for address in asic_cfg_facts['BGP_NEIGHBOR'].keys():
+                if bgp_facts['bgp_neighbors'][address]['state'] != "established":
+                    logger.info("BGP internal neighbor: %s is down: %s." % (
+                        address, bgp_facts['bgp_neighbors'][address]['state']))
+                    down_nbrs += 1
+    if down_nbrs != 0:
+        logger.warning("Neighbors are still down: %d", down_nbrs)
+        return False
+    else:
+        logger.info("All BGP neighbors are restored.")
+        return True
+
+
+def restore_bgp(duthosts, nbrhosts, all_cfg_facts):
+    """
+    Attempts to restore BGP config.
+
+    Args:
+        duthosts: duthosts fixture
+        nbrhosts: nbrhosts fixture
+        all_cfg_facts: fixture from voq/conftest.py
+
+    """
+    for node in duthosts.frontend_nodes:
+        for asic in node.asics:
+            asic_cfg_facts = all_cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
+            if 'BGP_NEIGHBOR' not in asic_cfg_facts:
+                continue
+
+            if node.is_multi_asic:
+                bgp_facts = node.bgp_facts(instance_id=asic.asic_index)['ansible_facts']
+            else:
+                bgp_facts = node.bgp_facts()['ansible_facts']
+
+            for address in asic_cfg_facts['BGP_NEIGHBOR'].keys():
+                if bgp_facts['bgp_neighbors'][address]['state'] == "established":
+                    logger.info("BGP internal neighbor: %s is established: %s, no action." % (
+                        address, bgp_facts['bgp_neighbors'][address]['state']))
+                else:
+                    logger.info("BGP internal neighbor: %s is not established: %s, will enable" % (
+                        address, bgp_facts['bgp_neighbors'][address]['state']))
+
+                    logger.info(
+                        "Startup neighbor: {} on host {} asic {}".format(address, node.hostname, asic.asic_index))
+                    asnum = asic_cfg_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+                    node.command("sudo config bgp startup neighbor {}".format(address))
+                    if node.is_multi_asic:
+                        node.command(
+                            "docker exec bgp{} vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
+                                asic.asic_index, asnum, address))
+                    else:
+                        node.command(
+                            "docker exec bgp vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
+                                asnum, address))
+
+                    vm_info = get_vm_with_ip(address, nbrhosts)
+                    nbr = nbrhosts[vm_info['vm']]
+                    logger.info(
+                        'enable neighbors {} on neighbor host {}'.format(nbr['conf']['bgp']['peers'],
+                                                                         nbr['host'].hostname))
+
+                    for peer in nbr['conf']['bgp']['peers']:
+                        for neighbor in nbr['conf']['bgp']['peers'][peer]:
+                            nbr['host'].eos_config(
+                                lines=["no neighbor %s shutdown" % neighbor],
+                                parents=['router bgp {}'.format(nbr['conf']['bgp']['asn'])])
+
+                            if ":" in address:
+                                nbr['host'].eos_config(
+                                    lines=["no ipv6 route ::/0 %s " % neighbor])
+                            else:
+                                nbr['host'].eos_config(
+                                    lines=["no ip route 0.0.0.0/0 %s " % neighbor])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def verify_bgp_restored(duthosts, nbrhosts, all_cfg_facts):
+    """
+    After teardown brings up any sessions that are not in case of failure.   Sometimes VMs are not reachable and this
+    needs to be retried over a period of time to restore the config.
+
+    Args:
+        duthosts:  The duthosts fixture
+        nbrhosts: nbrhosts fixture.
+        all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+
+    """
+
+    yield
+
+    restored = False
+    endtime = time.time() + 300
+    while not restored and time.time() < endtime:
+
+        restored = check_bgp_restored(duthosts, all_cfg_facts)
+        if restored:
+            break
+        else:
+            restore_bgp(duthosts, nbrhosts, all_cfg_facts)
+        time.sleep(5)
+    else:
+        logger.error("BGP was never restored.")
+        pytest.fail("BGP was never restored after test_voq_nbr tests ran.")
 
 
 @pytest.fixture(scope="module")
@@ -61,6 +194,9 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
         node_results = []
         for asic in node.asics:
             asic_cfg_facts = cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
+
+            if 'BGP_NEIGHBOR' not in asic_cfg_facts:
+                continue
 
             for neighbor in asic_cfg_facts['BGP_NEIGHBOR']:
                 logger.info(
@@ -134,6 +270,12 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
                 if time.time() > endtime:
                     break
 
+
+@pytest.fixture(scope="module")
+def teardown(duthosts, nbrhosts, all_cfg_facts):
+    """
+    Teardown fixture for the module, restore bgp neighbors.
+    """
     yield
 
     # cleanup
@@ -156,6 +298,8 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
         node_results = []
         for asic in node.asics:
             asic_cfg_facts = cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
+            if 'BGP_NEIGHBOR' not in asic_cfg_facts:
+                continue
             logger.info('enable neighbors {} on dut host {}'.format(asic_cfg_facts['BGP_NEIGHBOR'], node.hostname))
             asnum = asic_cfg_facts['DEVICE_METADATA']['localhost']['bgp_asn']
 
@@ -164,13 +308,16 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
                     "Startup neighbor: {} on host {} asic {}".format(neighbor, node.hostname, asic.asic_index))
 
                 node_results.append(node.command("sudo config bgp startup neighbor {}".format(neighbor)))
-                node_results.append(node.command(
-                    "docker exec bgp vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
-                        asnum, neighbor)))
+                if node.is_multi_asic:
+                    node_results.append(node.command(
+                        "docker exec bgp{} vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
+                            asic.asic_index, asnum, neighbor)))
+                else:
+                    node_results.append(node.command(
+                        "docker exec bgp vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
+                            asnum, neighbor)))
 
         results[node.hostname] = node_results
-
-    parallel_run(enable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=120)
 
     # restore neighbors on vms
     @reset_ansible_local_tmp
@@ -191,25 +338,44 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
             'enable neighbors {} on neighbor host {}'.format(node['conf']['bgp']['peers'], node['host'].hostname))
         for peer in node['conf']['bgp']['peers']:
             for neighbor in node['conf']['bgp']['peers'][peer]:
-                node_results.append(node['host'].eos_config(
-                    lines=["no neighbor %s shutdown" % neighbor],
-                    parents=['router bgp {}'.format(node['conf']['bgp']['asn'])],
-                    module_ignore_errors=True)
-                )
-                if ":" in neighbor:
+                try:
                     node_results.append(node['host'].eos_config(
-                        lines=["no ipv6 route ::/0 %s " % neighbor],
-                        module_ignore_errors=True)
+                        lines=["no neighbor %s shutdown" % neighbor],
+                        parents=['router bgp {}'.format(node['conf']['bgp']['asn'])])
                     )
-                else:
+                    if ":" in neighbor:
+                        node_results.append(node['host'].eos_config(
+                            lines=["no ipv6 route ::/0 %s " % neighbor])
+                        )
+                    else:
+                        node_results.append(node['host'].eos_config(
+                            lines=["no ip route 0.0.0.0/0 %s " % neighbor],
+                        )
+                        )
+                except Exception:
+                    logger.warning("Enable of neighbor on VM: %s failed, retrying", node['host'].hostname)
+                    time.sleep(10)
                     node_results.append(node['host'].eos_config(
-                        lines=["no ip route 0.0.0.0/0 %s " % neighbor],
-                        module_ignore_errors=True)
+                        lines=["no neighbor %s shutdown" % neighbor],
+                        parents=['router bgp {}'.format(node['conf']['bgp']['asn'])])
                     )
+                    if ":" in neighbor:
+                        node_results.append(node['host'].eos_config(
+                            lines=["no ipv6 route ::/0 %s " % neighbor],
+                        )
+                        )
+                    else:
+                        node_results.append(node['host'].eos_config(
+                            lines=["no ip route 0.0.0.0/0 %s " % neighbor],
+                        )
+                        )
 
         results[node['host'].hostname] = node_results
 
-    parallel_run(enable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=120)
+    try:
+        parallel_run(enable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=300)
+    finally:
+        parallel_run(enable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=120)
 
 
 def ping_all_dut_local_nbrs(duthosts):
@@ -220,6 +386,7 @@ def ping_all_dut_local_nbrs(duthosts):
         duthosts: An instance of the duthosts fixture.
 
     """
+
     @reset_ansible_local_tmp
     def _ping_all_local_nbrs(node=None, results=None):
         if node is None or results is None:
@@ -231,28 +398,39 @@ def ping_all_dut_local_nbrs(duthosts):
 
         for asic in node.asics:
             cfg_facts = asic.config_facts(source="persistent")['ansible_facts']
-            neighs = cfg_facts['BGP_NEIGHBOR']
+            if 'BGP_NEIGHBOR' in cfg_facts:
+                neighs = cfg_facts['BGP_NEIGHBOR']
+            else:
+                logger.info("No local neighbors for host: %s/%s, skipping", node.hostname, asic.asic_index)
+                continue
+
             for neighbor in neighs:
-                node_results.append(sonic_ping(asic, neighbor))
+                node_results.append(sonic_ping(asic, neighbor, verbose=True))
         results[node.hostname] = node_results
 
     parallel_run(_ping_all_local_nbrs, [], {}, duthosts.frontend_nodes, timeout=120)
 
 
-def ping_all_neighbors(duthosts, neighbors):
+def ping_all_neighbors(duthosts, all_cfg_facts, neighbors):
     """
     Pings all neighbors in the neighbor list from all frontend hosts on the DUT..
 
     Args:
         duthosts: An instance of the duthosts fixture.
+        all_cfg_facts: Fixture from voq/conftest.py
         neighbors: A list of neighbor IP addresses.
 
     """
     for per_host in duthosts.frontend_nodes:
         for asic in per_host.asics:
+            cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+            inband = get_inband_info(cfg_facts)
+            if inband == {}:
+                continue
+
             for neighbor in neighbors:
                 logger.info("Ping %s from %s/%s", neighbor, per_host.hostname, asic.asic_index)
-                sonic_ping(asic, neighbor)
+                sonic_ping(asic, neighbor, verbose=True)
 
 
 @pytest.fixture()
@@ -288,10 +466,13 @@ def poll_neighbor_table_delete(duthosts, neighs, delay=1, poll_time=180):
             logger.info("Poll for ARP clear on host: %s/%s", node.hostname, asic.asic_index)
             node_cleared = False
             while time.time() < endtime and node_cleared is False:
-                arptable = node.switch_arptable()['ansible_facts']
+                if node.is_multi_asic:
+                    arptable = node.switch_arptable(namespace=asic.namespace)['ansible_facts']
+                else:
+                    arptable = node.switch_arptable()['ansible_facts']
                 for nbr in neighs:
                     try:
-                        check_host_arp_table_deleted(node, nbr, arptable)
+                        check_host_arp_table_deleted(node, asic, nbr, arptable)
                     except AssertionError:
                         time.sleep(delay)
                         break
@@ -302,7 +483,7 @@ def poll_neighbor_table_delete(duthosts, neighs, delay=1, poll_time=180):
 
 
 def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
-                            setup, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
+                            setup, teardown, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
     """
     Verify tables, databases, and kernel routes are correctly deleted when the entire neighbor table is cleared.
 
@@ -332,8 +513,11 @@ def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
-
-    neighs = cfg_facts['BGP_NEIGHBOR']
+    if 'BGP_NEIGHBOR' in cfg_facts:
+        neighs = cfg_facts['BGP_NEIGHBOR']
+    else:
+        logger.info("No local neighbors for host: %s/%s, skipping", per_host.hostname, asic.asic_index)
+        return
 
     asic_cmd(asic, "sonic-clear arp")
     asic_cmd(asic, "sonic-clear ndp")
@@ -379,7 +563,7 @@ def select_neighbors(port_cfg, cfg_facts):
 
 
 def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
-                            setup, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
+                            setup, teardown, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
     """
     Verify tables, databases, and kernel routes are correctly deleted when a single neighbor adjacency is cleared.
 
@@ -406,8 +590,11 @@ def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
-
-    neighs = cfg_facts['BGP_NEIGHBOR']
+    if 'BGP_NEIGHBOR' in cfg_facts:
+        neighs = cfg_facts['BGP_NEIGHBOR']
+    else:
+        logger.info("No local neighbors for host: %s/%s, skipping", per_host.hostname, asic.asic_index)
+        return
 
     eth_cfg = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
     pos_cfg = cfg_facts['PORTCHANNEL_INTERFACE'] if 'PORTCHANNEL_INTERFACE' in cfg_facts else {}
@@ -474,8 +661,11 @@ def change_mac_ptf(ptfhost, intf, mac):
     ptfhost.shell("ifconfig {} up".format(intf))
 
 
-def check_arptable_mac(host, neighbor, mac, checkstate=True):
-    arptable = host.switch_arptable()['ansible_facts']
+def check_arptable_mac(host, asic, neighbor, mac, checkstate=True):
+    if host.is_multi_asic:
+        arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+    else:
+        arptable = host.switch_arptable()['ansible_facts']
 
     if ':' in neighbor:
         table = arptable['arptable']['v6']
@@ -490,22 +680,25 @@ def check_arptable_mac(host, neighbor, mac, checkstate=True):
         return table[neighbor]['macaddress'] == mac
 
 
-def check_arptable_state(host, neighbor, state):
-    arptable = host.switch_arptable()['ansible_facts']
+def check_arptable_state(host, asic, neighbor, state):
+    if host.is_multi_asic:
+        arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+    else:
+        arptable = host.switch_arptable()['ansible_facts']
 
     if ':' in neighbor:
         table = arptable['arptable']['v6']
     else:
         table = arptable['arptable']['v4']
 
-    logger.info("Poll neighbor: %s, mac: %s, state: %s", neighbor, table[neighbor]['macaddress'],
+    logger.info("Poll neighbor: %s, mac: %s, current state: %s", neighbor, table[neighbor]['macaddress'],
                 table[neighbor]['state'])
 
     return table[neighbor]['state'] == state
 
 
 def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
-                                setup, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
+                                setup, teardown, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
     """
     Verify tables, databases, and kernel routes are correctly updated when the MAC address of a neighbor changes
     and is updated via request/reply exchange.
@@ -540,7 +733,12 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
     asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
-    neighs = cfg_facts['BGP_NEIGHBOR']
+    if 'BGP_NEIGHBOR' in cfg_facts:
+        neighs = cfg_facts['BGP_NEIGHBOR']
+    else:
+        logger.info("No local neighbors for host: %s/%s, skipping", per_host.hostname, asic.asic_index)
+        return
+
     eth_cfg = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
     if eth_cfg == {}:
         pytest.skip("Can't run this test without any IP interfaces on ethernet ports")
@@ -561,14 +759,13 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
     original_mac = nbrinfo['mac']
 
     for neighbor in nbr_to_test:
-
         # Check neighbor on local linecard
         logger.info("*" * 60)
         logger.info("Verify initial neighbor: %s, port %s", neighbor, local_port)
-        pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac, checkstate=False),
+        pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, asic, neighbor, original_mac, checkstate=False),
                       "MAC {} didn't change in ARP table".format(original_mac))
         sonic_ping(asic, neighbor, verbose=True)
-        pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac),
+        pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, asic, neighbor, original_mac),
                       "MAC {} didn't change in ARP table".format(original_mac))
 
     dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, nbr_to_test, nbrhosts, all_cfg_facts, nbr_macs)
@@ -582,18 +779,18 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             if ":" in neighbor:
                 logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
                 asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
-            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, NEW_MAC, checkstate=False),
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, asic, neighbor, NEW_MAC, checkstate=False),
                           "MAC {} didn't change in ARP table".format(NEW_MAC))
 
             sonic_ping(asic, neighbor, verbose=True)
-            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, NEW_MAC),
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, asic, neighbor, NEW_MAC),
                           "MAC {} didn't change in ARP table".format(NEW_MAC))
             logger.info("Verify neighbor after mac change: %s, port %s", neighbor, local_port)
             check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
 
         logger.info("Ping neighbors: %s from all line cards", nbr_to_test)
 
-        ping_all_neighbors(duthosts, nbr_to_test)
+        ping_all_neighbors(duthosts, all_cfg_facts, nbr_to_test)
 
     finally:
         logger.info("-" * 60)
@@ -603,15 +800,16 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             if ":" in neighbor:
                 logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
                 asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
-            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac, checkstate=False),
-                          "MAC {} didn't change in ARP table".format(original_mac))
+            pytest_assert(
+                wait_until(60, 2, check_arptable_mac, per_host, asic, neighbor, original_mac, checkstate=False),
+                "MAC {} didn't change in ARP table".format(original_mac))
             sonic_ping(asic, neighbor, verbose=True)
-            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, neighbor, original_mac),
+            pytest_assert(wait_until(60, 2, check_arptable_mac, per_host, asic, neighbor, original_mac),
                           "MAC {} didn't change in ARP table".format(original_mac))
 
         dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, nbr_to_test, nbrhosts, all_cfg_facts, nbr_macs)
 
-    ping_all_neighbors(duthosts, nbr_to_test)
+    ping_all_neighbors(duthosts, all_cfg_facts, nbr_to_test)
 
 
 class LinkFlap(object):
@@ -668,10 +866,10 @@ class LinkFlap(object):
         """
         logger.info("Bring up link: %s/%s <-> %s/%s", fanout.hostname, fanport, dut.hostname, dut_intf)
         fanout.no_shutdown(fanport)
-        pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'up'),
-                      "dut port {} didn't go down as expected".format(dut_intf))
+        pytest_assert(wait_until(60, 1, self.check_intf_status, dut, dut_intf, 'up'),
+                      "dut port {} didn't go up as expected".format(dut_intf))
 
-    def localport_admindown(self, dut, dut_intf):
+    def localport_admindown(self, dut, asic, dut_intf):
         """
         Admins down a port on the DUT and polls for oper status to be down.
 
@@ -684,11 +882,14 @@ class LinkFlap(object):
 
         """
         logger.info("Admin down port %s/%s", dut.hostname, dut_intf)
-        dut.shutdown(dut_intf)
+        if dut.is_multi_asic:
+            asic.shutdown_interface(dut_intf)
+        else:
+            dut.shutdown(dut_intf)
         pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'down'),
                       "dut port {} didn't go down as expected".format(dut_intf))
 
-    def localport_adminup(self, dut, dut_intf):
+    def localport_adminup(self, dut, asic, dut_intf):
         """
         Admins up a port on the DUT and polls for oper status to be up.
 
@@ -701,7 +902,11 @@ class LinkFlap(object):
 
         """
         logger.info("Admin up port %s/%s", dut.hostname, dut_intf)
-        dut.no_shutdown(dut_intf)
+        if dut.is_multi_asic:
+            asic.startup_interface(dut_intf)
+        else:
+            dut.no_shutdown(dut_intf)
+
         pytest_assert(wait_until(30, 1, self.check_intf_status, dut, dut_intf, 'up'),
                       "dut port {} didn't go up as expected".format(dut_intf))
 
@@ -719,7 +924,7 @@ def pick_ports(cfg_facts):
 
     """
     intfs = {}
-    intfs.update(cfg_facts['INTERFACE'])
+    intfs.update(cfg_facts.get('INTERFACE', {}))
     if "PORTCHANNEL_INTERFACE" in cfg_facts:
         intfs.update(cfg_facts['PORTCHANNEL_INTERFACE'])
 
@@ -739,7 +944,7 @@ def pick_ports(cfg_facts):
 class TestNeighborLinkFlap(LinkFlap):
 
     def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
-                                        all_cfg_facts, setup, nbrhosts, nbr_macs, established_arp):
+                                        all_cfg_facts, setup, teardown, nbrhosts, nbr_macs, established_arp):
         """
         Verify tables, databases, and kernel routes are correctly deleted when the DUT port is admin down/up.
 
@@ -772,7 +977,11 @@ class TestNeighborLinkFlap(LinkFlap):
         asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
         cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
-        neighs = cfg_facts['BGP_NEIGHBOR']
+        if 'BGP_NEIGHBOR' in cfg_facts:
+            neighs = cfg_facts['BGP_NEIGHBOR']
+        else:
+            logger.info("No local neighbors for host: %s/%s, skipping", per_host.hostname, asic.asic_index)
+            return
 
         intfs, intfs_to_test = pick_ports(cfg_facts)
 
@@ -784,20 +993,97 @@ class TestNeighborLinkFlap(LinkFlap):
 
             logger.info("Testing neighbors: %s on intf: %s", neighbors, intf)
 
-            self.localport_admindown(per_host, intf)
+            self.localport_admindown(per_host, asic, intf)
             try:
                 check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
             finally:
-                self.localport_adminup(per_host, intf)
+                self.localport_adminup(per_host, asic, intf)
 
             for neighbor in neighbors:
                 sonic_ping(asic, neighbor)
 
             for neighbor in neighbors:
-                pytest_assert(wait_until(60, 2, check_arptable_state, per_host, neighbor, "REACHABLE"),
+                pytest_assert(wait_until(60, 2, check_arptable_state, per_host, asic, neighbor, "REACHABLE"),
                               "STATE for neighbor {} did not change to reachable".format(neighbor))
 
             dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighbors, nbrhosts, all_cfg_facts, nbr_macs)
+
+    def test_front_panel_linkflap_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+                                       all_cfg_facts,
+                                       fanouthosts, setup, teardown, nbrhosts, established_arp):
+        """
+        Verify tables, databases, and kernel routes are correctly deleted when the front panel port flaps.
+
+        Test Steps
+        * Admin down interface on fanout to cause LOS on DUT.
+        * On local linecard:
+            * Verify ARP/NDP entries are removed from CLI for neighbors on down port.
+            * Verify table entries in ASIC, AppDb are removed for addresses on down port.
+        * On Supervisor card:
+            * Verify Chassis App DB entry are removed for only the cleared address.  Entries for addresses on other line cards
+            should still be present.
+        * On remote linecards:
+            * Verify table entries in ASICDB, APPDB, and host ARP table are removed for cleared addresses.
+            * Verify kernel routes for cleared address are deleted.
+        * Admin interface up, verify recreation after restarting traffic.
+
+        Args:
+            duthosts: duthosts fixture.
+            enum_rand_one_per_hwsku_frontend_hostname: frontend iteration fixture.
+            enum_asic_index: asic iteration fixture.
+            all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
+            fanouthosts: fanouthosts fixture.
+            setup: setup fixture for this module.
+            nbrhosts: nbrhosts fixture.
+            established_arp: Fixture to establish ARP to all neighbors.
+
+        """
+        if fanouthosts == {}:
+            pytest.skip("Fanouthosts fixture did not return anything, this test case can not run.")
+
+        per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
+
+        if 'BGP_NEIGHBOR' in cfg_facts:
+            neighs = cfg_facts['BGP_NEIGHBOR']
+        else:
+            logger.info("No local neighbors for host: %s/%s, skipping", per_host.hostname, asic.asic_index)
+            return
+
+        intfs, intfs_to_test = pick_ports(cfg_facts)
+
+        logger.info("Will test interfaces: %s", intfs_to_test)
+
+        for intf in intfs_to_test:
+            local_ips = [i.split("/")[0] for i in intfs[intf].keys()]  # [u'2064:100::2/64', u'100.0.0.2/24']
+            neighbors = [n for n in neighs if neighs[n]['local_addr'] in local_ips]
+            logger.info("Testing neighbors: %s on intf: %s", neighbors, intf)
+
+            if "portchannel" in intf.lower():
+                pc_cfg = cfg_facts['PORTCHANNEL_MEMBER']
+                pc_members = pc_cfg[intf]
+                logger.info("Portchannel members %s: %s", intf, pc_members.keys())
+                portbounce_list = pc_members.keys()
+            else:
+                portbounce_list = [intf]
+
+            try:
+                for lport in portbounce_list:
+                    fanout, fanport = fanout_switch_port_lookup(fanouthosts, per_host.hostname, lport)
+                    logger.info("fanout port: %s %s, host: %s", fanout, fanport, fanout.host)
+                    self.linkflap_down(fanout, fanport, per_host, lport)
+
+                for neighbor in neighbors:
+                    check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
+
+            finally:
+                for lport in portbounce_list:
+                    fanout, fanport = fanout_switch_port_lookup(fanouthosts, per_host.hostname, lport)
+                    self.linkflap_up(fanout, fanport, per_host, lport)
+
+            for neighbor in neighbors:
+                check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
 
 
 class TestGratArp(object):
@@ -829,7 +1115,7 @@ class TestGratArp(object):
         logger.info("Grat packet sent.")
 
     def test_gratarp_macchange(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
-                               ptfhost, tbinfo, nbrhosts, setup, all_cfg_facts, established_arp):
+                               ptfhost, tbinfo, nbrhosts, setup, teardown, all_cfg_facts, established_arp):
         """
         Verify tables, databases, and kernel routes are correctly updated when a unsolicited ARP packet changes
         the MAC address of learned neighbor.
@@ -863,17 +1149,17 @@ class TestGratArp(object):
 
         """
         self.ptfhost = ptfhost
-        devices = {}
-        for k, v in tbinfo['topo']['properties']['topology']['VMs'].items():
-            devices[k] = {'vlans': v['vlans']}
-        logger.info("devices: %s", devices)
 
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
         asic = duthost.asics[enum_asic_index if enum_asic_index is not None else 0]
         cfg_facts = all_cfg_facts[duthost.hostname][asic.asic_index]['ansible_facts']
 
-        neighs = cfg_facts['BGP_NEIGHBOR']
+        if 'BGP_NEIGHBOR' in cfg_facts:
+            neighs = cfg_facts['BGP_NEIGHBOR']
+        else:
+            logger.info("No local neighbors for host: %s/%s, skipping", duthost.hostname, asic.asic_index)
+            return
 
         eth_cfg = cfg_facts['INTERFACE'] if 'INTERFACE' in cfg_facts else {}
         if eth_cfg == {}:
@@ -896,16 +1182,17 @@ class TestGratArp(object):
 
             nbrinfo = get_neighbor_info(neighbor, nbrhosts)
 
-            # 0.1@1 = dut_index.dut_port@ptfport
-            tb_port = devices[nbrinfo['vm']]['vlans'][0].split("@")[1]
+            tb_port = get_ptf_port(duthosts,
+                                   all_cfg_facts[duthost.hostname][asic.asic_index]['ansible_facts'],
+                                   tbinfo, duthost, local_port)[0]
             original_mac = nbrinfo['mac']
 
             logger.info("*" * 60)
             logger.info("Verify initial neighbor: %s, port %s", neighbor, local_port)
-            logging.info("%s port %s is on ptf port: %s", duthost.hostname, local_port, tb_port)
+            logger.info("%s port %s is on ptf port: %s", duthost.hostname, local_port, tb_port)
             logger.info("-" * 60)
             sonic_ping(asic, neighbor)
-            pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, original_mac),
+            pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, asic, neighbor, original_mac),
                           "MAC {} didn't change in ARP table".format(original_mac))
 
             check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
@@ -914,16 +1201,16 @@ class TestGratArp(object):
                 change_mac(nbrhosts[nbrinfo['vm']], nbrinfo['shell_intf'], NEW_MAC)
                 self.send_grat_pkt(NEW_MAC, neighbor, int(tb_port))
 
-                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, NEW_MAC, checkstate=False),
-                              "MAC {} didn't change in ARP table".format(NEW_MAC))
+                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, asic, neighbor, NEW_MAC, checkstate=False),
+                              "MAC {} didn't change in ARP table of neighbor {}".format(NEW_MAC, neighbor))
                 try:
                     sonic_ping(asic, neighbor)
                 except AssertionError:
                     logging.info("No initial response from ping, begin poll to see if ARP table responds.")
-                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, NEW_MAC, checkstate=True),
-                              "MAC {} didn't change in ARP table".format(NEW_MAC))
+                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, asic, neighbor, NEW_MAC, checkstate=True),
+                              "MAC {} didn't change in ARP table of neighbor {}".format(NEW_MAC, neighbor))
                 check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
-                ping_all_neighbors(duthosts, [neighbor])
+                ping_all_neighbors(duthosts, all_cfg_facts, [neighbor])
             finally:
                 logger.info("Will Restore ethernet mac on neighbor: %s, port %s, vm %s", neighbor,
                             nbrinfo['shell_intf'], nbrinfo['vm'])
@@ -932,11 +1219,12 @@ class TestGratArp(object):
                 if ":" in neighbor:
                     logger.info("Force neighbor solicitation to workaround long IPV6 timer.")
                     asic_cmd(asic, "ndisc6 %s %s" % (neighbor, local_port))
-                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, original_mac, checkstate=False),
-                              "MAC {} didn't change in ARP table".format(original_mac))
+                pytest_assert(
+                    wait_until(60, 2, check_arptable_mac, duthost, asic, neighbor, original_mac, checkstate=False),
+                    "MAC {} didn't change in ARP table".format(original_mac))
                 sonic_ping(asic, neighbor, verbose=True)
-                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, neighbor, original_mac),
+                pytest_assert(wait_until(60, 2, check_arptable_mac, duthost, asic, neighbor, original_mac),
                               "MAC {} didn't change in ARP table".format(original_mac))
 
             check_one_neighbor_present(duthosts, duthost, asic, neighbor, nbrhosts, all_cfg_facts)
-            ping_all_neighbors(duthosts, [neighbor])
+            ping_all_neighbors(duthosts, all_cfg_facts, [neighbor])

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -9,12 +9,13 @@ from tests.common.helpers.redis import AsicDbCli, AppDbCli, VoqDbCli
 logger = logging.getLogger(__name__)
 
 
-def check_host_arp_table(host, neighbor_ip, neighbor_mac, interface, state, arptable=None):
+def check_host_arp_table(host, asic, neighbor_ip, neighbor_mac, interface, state, arptable=None):
     """
     Validates the ARP table of a host by running ip neigh for a single neighbor.
 
     Args:
-        host: instance of SonicHost to run the arp show.
+        host: instance of SonicHost to use.
+        asic: instance of SonicAsic to run the arp show.
         neighbor_ip: IP address of the neighbor to verify.
         neighbor_mac: MAC address expected in the show command output.
         interface: Port expected in the show command output.
@@ -24,7 +25,10 @@ def check_host_arp_table(host, neighbor_ip, neighbor_mac, interface, state, arpt
     """
 
     if arptable is None:
-        arptable = host.switch_arptable()['ansible_facts']
+        if host.is_multi_asic:
+            arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+        else:
+            arptable = host.switch_arptable()['ansible_facts']
 
     if ':' in neighbor_ip:
         table = arptable['arptable']['v6']
@@ -41,7 +45,7 @@ def check_host_arp_table(host, neighbor_ip, neighbor_mac, interface, state, arpt
                   "table state %s is not %s" % (table[neighbor_ip]['state'].lower(), state.lower()))
 
 
-def check_host_arp_table_deleted(host, neighbor_ip, arptable=None):
+def check_host_arp_table_deleted(host, asic, neighbor_ip, arptable=None):
     """
     Verifies the ARP entry is deleted.
 
@@ -52,7 +56,11 @@ def check_host_arp_table_deleted(host, neighbor_ip, arptable=None):
 
     """
     if arptable is None:
-        arptable = host.switch_arptable()['ansible_facts']
+        if host.is_multi_asic:
+            arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+        else:
+            arptable = host.switch_arptable()['ansible_facts']
+
     logger.debug("ARP: %s", arptable)
     if ':' in neighbor_ip:
         table = arptable['arptable']['v6']
@@ -123,7 +131,7 @@ def check_local_neighbor(host, asic, neighbor_ip, neighbor_mac, interface):
     pytest_assert(":{}:".format(interface) in neighbor_key, "Port for %s does not match" % neighbor_key)
 
     # verify linux arp table
-    check_host_arp_table(host, neighbor_ip, neighbor_mac, interface, 'REACHABLE')
+    check_host_arp_table(host, asic, neighbor_ip, neighbor_mac, interface, 'REACHABLE')
 
     return {'neighbor_key': neighbor_key, 'encap_index': asic_dict['encap_index']}
 
@@ -272,10 +280,14 @@ def check_voq_remote_neighbor(host, asic, neighbor_ip, neighbor_mac, interface, 
     appdb = AppDbCli(asic)
     neighbor_key = appdb.get_neighbor_key_by_ip(neighbor_ip)
     pytest_assert(":{}:".format(interface) in neighbor_key, "Port for %s does not match" % neighbor_key)
-    appdb.get_and_check_key_value(neighbor_key, inband_mac, field="neigh")
-
-    # verify linux arp table
-    check_host_arp_table(host, neighbor_ip, inband_mac, interface, 'PERMANENT')
+    if host.get_facts()['asic_type'] == "vs":
+        appdb.get_and_check_key_value(neighbor_key, neighbor_mac, field="neigh")
+        # verify linux arp table
+        check_host_arp_table(host, asic, neighbor_ip, neighbor_mac, interface, 'PERMANENT')
+    else:
+        appdb.get_and_check_key_value(neighbor_key, inband_mac, field="neigh")
+        # verify linux arp table
+        check_host_arp_table(host, asic, neighbor_ip, inband_mac, interface, 'PERMANENT')
 
     # verify linux route entry
     check_neighbor_kernel_route(host, asic.asic_index, neighbor_ip, interface)
@@ -332,13 +344,39 @@ def check_voq_neighbor_on_sup(sup, slot, asic, port, neighbor, encap_index, mac)
     logger.info("Neigh key: %s, slotnum: %s", neigh_key, slot)
     pytest_assert("|%s|" % slot in neigh_key,
                   "Slot for %s does not match %s" % (neigh_key, slot))
-    pytest_assert("|%s|" % port in neigh_key,
+    pytest_assert("|%s:" % port in neigh_key or "|%s|" % port in neigh_key,
                   "Port for %s does not match %s" % (neigh_key, port))
     pytest_assert("|%s|" % asic in neigh_key,
                   "Asic for %s does not match %s" % (neigh_key, asic))
 
     voqdb.get_and_check_key_value(neigh_key, mac, field="neigh")
     voqdb.get_and_check_key_value(neigh_key, encap_index, field="encap_index")
+
+
+def get_eos_mac(nbr, nbr_intf):
+    """
+    Gets the MAC address of and interface from an EOS host.
+
+    Args:
+        nbr: The element for the neighbor from nbrhosts fixture.
+        nbr_intf: The interface name on the neighbor to retrieve the MAC
+
+    Returns:
+        A dictionary with the mac address and shell interface name.
+    """
+    if "port-channel" in nbr_intf.lower():
+        # convert Port-Channel1 to po1
+        shell_intf = "po" + nbr_intf[-1]
+    else:
+        # convert Ethernet1 to eth1
+        shell_intf = "eth" + nbr_intf[-1]
+
+    output = nbr['host'].command("ip addr show dev %s" % shell_intf)
+    # 8: Ethernet0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 ...
+    #     link/ether a6:69:05:fd:da:5f brd ff:ff:ff:ff:ff:ff
+
+    mac = output['stdout_lines'][1].split()[1]
+    return {'mac': mac, "shell_intf": shell_intf}
 
 
 def get_neighbor_info(neigh_ip, nbrhosts):
@@ -384,7 +422,7 @@ def get_sonic_mac(host, asicnum, port):
         cmd = "sudo ip netns exec {} ip link show {}".format(ns, port)
     output = host.command(cmd)
     mac = output['stdout_lines'][1].split()[1]
-    logger.debug("host: %s, asic: %d, port: %s, mac: %s", host.hostname, asicnum, port, mac)
+    logger.info("host: %s, asic: %d, port: %s, mac: %s", host.hostname, asicnum, port, mac)
     return mac
 
 
@@ -439,6 +477,28 @@ def get_inband_info(cfg_facts):
     return ret
 
 
+def get_vm_with_ip(neigh_ip, nbrhosts):
+    """
+    Finds the EOS VM and port with a specific IP Address.
+
+    Args:
+        neigh_ip: IP address to find.
+        nbrhosts: nbrhosts fixture.
+
+    Returns:
+        A dictionary with the vm index for nbrhosts, and port name.
+    """
+    for a_vm in nbrhosts:
+        for port, a_intf in nbrhosts[a_vm]['conf']['interfaces'].iteritems():
+            if 'ipv4' in a_intf and a_intf['ipv4'].split("/")[0] == neigh_ip:
+                return {"vm": a_vm, "port": port}
+            if 'ipv6' in a_intf and a_intf['ipv6'].split("/")[0].lower() == neigh_ip.lower():
+                return {"vm": a_vm, "port": port}
+    logger.error("Could not find vm connected to neighbor IP: %s", neigh_ip)
+    logger.info("nbrhosts: {}".format(json.dumps(nbrhosts, indent=4)))
+    return None
+
+
 def get_port_by_ip(cfg_facts, ipaddr):
     """
     Returns the port which has a given IP address from the dut config.
@@ -457,7 +517,7 @@ def get_port_by_ip(cfg_facts, ipaddr):
         iptype = "ipv4"
 
     intf = {}
-    intf.update(cfg_facts['INTERFACE'])
+    intf.update(cfg_facts.get('INTERFACE', {}))
     if "PORTCHANNEL_INTERFACE" in cfg_facts:
         intf.update(cfg_facts['PORTCHANNEL_INTERFACE'])
     for a_intf in intf:
@@ -507,54 +567,6 @@ def find_system_port(dev_sysports, slot, asic_index, hostif):
     raise KeyError("Could not find system port for {}/{}/{}".format(slot, asic_index, hostif))
 
 
-def get_vm_with_ip(neigh_ip, nbrhosts):
-    """
-    Finds the EOS VM and port with a specific IP Address.
-
-    Args:
-        neigh_ip: IP address to find.
-        nbrhosts: nbrhosts fixture.
-
-    Returns:
-        A dictionary with the vm index for nbrhosts, and port name.
-    """
-    for a_vm in nbrhosts:
-        for port, a_intf in nbrhosts[a_vm]['conf']['interfaces'].iteritems():
-            if 'ipv4' in a_intf and a_intf['ipv4'].split("/")[0] == neigh_ip:
-                return {"vm": a_vm, "port": port}
-            if 'ipv6' in a_intf and a_intf['ipv6'].split("/")[0].lower() == neigh_ip.lower():
-                return {"vm": a_vm, "port": port}
-    logger.error("Could not find vm connected to neighbor IP: %s", neigh_ip)
-    logger.info("nbrhosts: {}".format(json.dumps(nbrhosts, indent=4)))
-    return None
-
-
-def get_eos_mac(nbr, nbr_intf):
-    """
-    Gets the MAC address of and interface from an EOS host.
-
-    Args:
-        nbr: The element for the neighbor from nbrhosts fixture.
-        nbr_intf: The interface name on the neighbor to retrieve the MAC
-
-    Returns:
-        A dictionary with the mac address and shell interface name.
-    """
-    if "port-channel" in nbr_intf.lower():
-        # convert Port-Channel1 to po1
-        shell_intf = "po" + nbr_intf[-1]
-    else:
-        # convert Ethernet1 to eth1
-        shell_intf = "eth" + nbr_intf[-1]
-
-    output = nbr['host'].command("ip addr show dev %s" % shell_intf)
-    # 8: Ethernet0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 ...
-    #     link/ether a6:69:05:fd:da:5f brd ff:ff:ff:ff:ff:ff
-
-    mac = output['stdout_lines'][1].split()[1]
-    return {'mac': mac, "shell_intf": shell_intf}
-
-
 def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts):
     """
     Verifies a single neighbor entry is present in a voq system on local and remote sonic instances.
@@ -584,13 +596,8 @@ def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all
 
     # Check neighbor on local linecard
     local_port = get_port_by_ip(cfg_facts, local_ip)
-    show_intf = asic.show_interface(command="status")['ansible_facts']
     if local_port is None:
         logger.error("Did not find port for this neighbor %s, must skip", local_ip)
-        return
-
-    if show_intf['int_status'][local_port]['oper_state'] == "down":
-        logger.error("Port is down, must skip interface: %s, IP: %s", local_port, local_ip)
         return
 
     neigh_mac = get_neighbor_info(neighbor, nbrhosts)['mac']
@@ -601,16 +608,21 @@ def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all
     logger.info("Local_dict: %s", local_dict)
 
     # Check the same neighbor entry on the supervisor nodes
-    if "portchannel" in local_port.lower():
+    if "portchannel" in local_port.lower() or per_host.is_multi_asic:
         slotname = cfg_facts['DEVICE_METADATA']['localhost']['hostname']
         asicname = cfg_facts['DEVICE_METADATA']['localhost']['asic_name']
     else:
         sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
         slotname = sysport_info['slot']
         asicname = sysport_info['asic']
-    for sup in duthosts.supervisor_nodes:
-        check_voq_neighbor_on_sup(sup, slotname, asicname, local_port,
+
+    if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
+        check_voq_neighbor_on_sup(per_host, slotname, asicname, local_port,
                                   neighbor, local_dict['encap_index'], neigh_mac)
+    else:
+        for sup in duthosts.supervisor_nodes:
+            check_voq_neighbor_on_sup(sup, slotname, asicname, local_port,
+                                      neighbor, local_dict['encap_index'], neigh_mac)
 
     # Check the neighbor entry on each remote linecard
     for rem_host in duthosts.frontend_nodes:
@@ -621,6 +633,10 @@ def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all
                 continue
             rem_cfg_facts = all_cfg_facts[rem_host.hostname][rem_asic.asic_index]['ansible_facts']
             remote_inband_info = get_inband_info(rem_cfg_facts)
+            if remote_inband_info == {}:
+                logger.info("No inband configuration on this asic: %s/%s, will be skipped.", rem_host.hostname,
+                            rem_asic.asic_index)
+                continue
             remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
             check_voq_remote_neighbor(rem_host, rem_asic, neighbor, neigh_mac, remote_inband_info['port'],
                                       local_dict['encap_index'], remote_inband_mac)
@@ -642,7 +658,12 @@ def check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs):
         for asic in per_host.asics:
             logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
             cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
-            neighs = cfg_facts['BGP_NEIGHBOR']
+            logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
+            if 'BGP_NEIGHBOR' in cfg_facts:
+                neighs = cfg_facts['BGP_NEIGHBOR']
+            else:
+                logger.info("No local neighbors for host: %s/%s, skipping", per_host.hostname, asic.asic_index)
+                continue
 
             dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs.keys(),
                                               nbrhosts, all_cfg_facts, nbr_macs)
@@ -677,10 +698,17 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
     app_dump = appdb.dump_neighbor_table()
 
     encaps = {}
-    arptable = per_host.switch_arptable()['ansible_facts']
+    if per_host.is_multi_asic:
+        arptable = per_host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+    else:
+        arptable = per_host.switch_arptable()['ansible_facts']
 
     if len(duthosts.supervisor_nodes) == 1:
         voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
+        voq_dump = voqdb.dump_neighbor_table()
+    elif per_host.is_multi_asic:
+        # look on linecard for pizzabox multiasic
+        voqdb = VoqDbCli(per_host)
         voq_dump = voqdb.dump_neighbor_table()
     else:
         voq_dump = {}
@@ -690,7 +718,11 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
         neigh_mac = nbr_macs[nbr_vm['vm']][nbr_vm['port']]
         local_ip = neighs[neighbor]['local_addr']
         local_port = get_port_by_ip(cfg_facts, local_ip)
-        sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
+        if 'slot_num' in per_host.facts:
+            sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
+        else:
+            sysport_info = {'slot': cfg_facts['DEVICE_METADATA']['localhost']['hostname'],
+                            'asic': cfg_facts['DEVICE_METADATA']['localhost']['asic_name']}
 
         # Validate the asic db entries
         for entry in asic_dump:
@@ -729,12 +761,11 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
             fail_cnt += 1
 
         # Validate the arp table entries
-        check_host_arp_table(per_host, neighbor, neigh_mac, local_port, 'REACHABLE', arptable=arptable)
+        check_host_arp_table(per_host, asic, neighbor, neigh_mac, local_port, 'REACHABLE', arptable=arptable)
 
         # supervisor checks
         for entry in voq_dump:
-            matchstr = '|%s' % neighbor
-            if entry.endswith(matchstr):
+            if entry.endswith('|%s' % neighbor) or entry.endswith(':%s' % neighbor):
 
                 if "portchannel" in local_port.lower():
                     slotname = cfg_facts['DEVICE_METADATA']['localhost']['hostname']
@@ -746,7 +777,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
                 logger.debug("Neigh key: %s, slotnum: %s", entry, slotname)
                 pytest_assert("|%s|" % slotname in entry,
                               "Slot for %s does not match %s" % (entry, slotname))
-                pytest_assert("|%s|" % local_port in entry,
+                pytest_assert("|%s:" % local_port in entry or "|%s|" % local_port in entry,
                               "Port for %s does not match %s" % (entry, local_port))
                 pytest_assert("|%s|" % asicname in entry,
                               "Asic for %s does not match %s" % (entry, asicname))
@@ -768,11 +799,12 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
     return {'encaps': encaps, 'fail_cnt': fail_cnt}
 
 
-def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_cfg_facts, nbrhosts, nbr_macs):
+def check_all_neighbors_present_remote(local_host, rem_host, rem_asic, neighs, encaps, all_cfg_facts, nbrhosts, nbr_macs):
     """
     Dumps and verifies all neighbors on a remote host.
 
     Args:
+        local_host: MultiAsicSonicHost instance where the neighs are ingressing (eBGP into)
         rem_host: MultiAsicSonicHost instance to check.
         rem_asic: SonicAsic instance to check.
         neighs: List of neighbors to verify.  (IP address strings)
@@ -788,6 +820,9 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
 
     rem_cfg_facts = all_cfg_facts[rem_host.hostname][rem_asic.asic_index]['ansible_facts']
     remote_inband_info = get_inband_info(rem_cfg_facts)
+    if remote_inband_info == {}:
+        logger.info("No inband configuration on this asic: %s/%s, will be skipped.", rem_host.hostname, rem_asic.asic_index)
+        return {'fail_cnt': 0}
     remote_inband_mac = get_sonic_mac(rem_host, rem_asic.asic_index, remote_inband_info['port'])
     fail_cnt = 0
 
@@ -797,18 +832,19 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
     docker = "bgp"
     if rem_host.facts["num_asic"] > 1:
         docker = "bgp" + str(rem_asic.asic_index)
+
     v4_output = rem_host.command("docker exec " + docker + " vtysh -c \"show ip route kernel json\"")
     v6_output = rem_host.command("docker exec " + docker + " vtysh -c \"show ipv6 route kernel json\"")
     v4_parsed = json.loads(v4_output["stdout"])
     v6_parsed = json.loads(v6_output["stdout"])
 
     # kernel routes
-    if rem_host.facts["num_asic"] == 1:
+    if rem_host.is_multi_asic:
+        v4cmd = "ip netns exec {} ip -4 route show scope link".format(rem_asic.namespace)
+        v6cmd = "ip netns exec {} ip -6 route show".format(rem_asic.namespace)
+    else:
         v4cmd = "ip -4 route show scope link"
         v6cmd = "ip -6 route show"
-    else:
-        v4cmd = "ip netns exec asic{} ip -4 route show scope link"
-        v6cmd = "ip netns exec asic{} ip -6 route show"
 
     v4_kern = rem_host.command(v4cmd)['stdout_lines']
     v6_kern = rem_host.command(v6cmd)['stdout_lines']
@@ -820,9 +856,16 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
     appdb = AppDbCli(rem_asic)
     app_dump = appdb.dump_neighbor_table()
 
-    arptable = rem_host.switch_arptable()['ansible_facts']
+    if rem_host.is_multi_asic:
+        arptable = rem_host.switch_arptable(namespace=rem_asic.namespace)['ansible_facts']
+    else:
+        arptable = rem_host.switch_arptable()['ansible_facts']
 
     for neighbor in neighs:
+        neighbor_mac_on_dut = remote_inband_mac
+        if rem_host.get_facts()['asic_type'] == 'vs':
+            # For vs platform, the mac programmed will be remote asic's mac as required for datapath to work.
+            neighbor_mac_on_dut = local_host.get_facts()['router_mac']
         logger.info("Check remote host: %s, asic: %s, for neighbor %s", rem_host.hostname, rem_asic.asic_index,
                     neighbor)
         nbr_vm = get_vm_with_ip(neighbor, nbrhosts)
@@ -864,7 +907,7 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
         for entry in app_dump:
             matchstr = ':%s' % neighbor
             if entry.endswith(matchstr):
-                if remote_inband_mac.lower() != app_dump[entry]['value']['neigh'].lower():
+                if neighbor_mac_on_dut.lower() != app_dump[entry]['value']['neigh'].lower():
                     logger.error("App neighbor macs for %s do not match: %s != %s", neighbor, remote_inband_mac.lower(),
                                  app_dump[entry]['value']['neigh'].lower())
                     fail_cnt += 1
@@ -879,7 +922,8 @@ def check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps, all_c
             fail_cnt += 1
 
         # Verify ARP table
-        check_host_arp_table(rem_host, neighbor, remote_inband_mac, remote_inband_info['port'], 'PERMANENT',
+
+        check_host_arp_table(rem_host, rem_asic, neighbor, neighbor_mac_on_dut, remote_inband_info['port'], 'PERMANENT',
                              arptable=arptable)
 
         # Verify routing tables
@@ -940,7 +984,7 @@ def dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs, nbrhosts
             if rem_host == per_host and rem_asic == asic:
                 # skip remote check on local host
                 continue
-            ret = check_all_neighbors_present_remote(rem_host, rem_asic, neighs, encaps,
+            ret = check_all_neighbors_present_remote(per_host, rem_host, rem_asic, neighs, encaps,
                                                      all_cfg_facts, nbrhosts, nbr_macs)
             fail_cnt += ret['fail_cnt']
 
@@ -1026,7 +1070,10 @@ def check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
     asicdb_neigh_table = asicdb.dump_neighbor_table()
     app_neigh_table = appdb.dump_neighbor_table()
 
-    arptable = per_host.switch_arptable()['ansible_facts']
+    if per_host.is_multi_asic:
+        arptable = per_host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+    else:
+        arptable = per_host.switch_arptable()['ansible_facts']
 
     if len(duthosts.supervisor_nodes) == 1:
         voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
@@ -1038,7 +1085,7 @@ def check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
         logger.info("Checking ARP/NDP for %s is deleted from host: %s, asic: %s", neighbor, per_host.hostname,
                     asic.asic_index)
         # check local host
-        check_host_arp_table_deleted(per_host, neighbor, arptable)
+        check_host_arp_table_deleted(per_host, asic, neighbor, arptable)
 
         for entry in asicdb_neigh_table.keys():
             search = '"ip":"%s"' % neighbor
@@ -1065,14 +1112,22 @@ def check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
                 logger.info("Remote host checks of ARP/NDP for %s are deleted from host: %s, asic: %s", neighbor,
                             rem_host.hostname,
                             rem_asic.asic_index)
-
+                rem_cfg_facts = all_cfg_facts[rem_host.hostname][rem_asic.asic_index]['ansible_facts']
+                remote_inband_info = get_inband_info(rem_cfg_facts)
+                if remote_inband_info == {}:
+                    logger.info("No inband configuration on this ASIC: %s/%s, skipping", rem_host.hostname,
+                                rem_asic.asic_index)
+                    continue
                 asicdb = AsicDbCli(rem_asic)
                 appdb = AppDbCli(rem_asic)
                 asicdb_neigh_table = asicdb.dump_neighbor_table()
                 app_neigh_table = appdb.dump_neighbor_table()
-                arptable = per_host.switch_arptable()['ansible_facts']
+                if per_host.is_multi_asic:
+                    arptable = rem_host.switch_arptable(namespace=rem_asic.namespace)['ansible_facts']
+                else:
+                    arptable = rem_host.switch_arptable()['ansible_facts']
 
-                check_host_arp_table_deleted(rem_host, neighbor, arptable)
+                check_host_arp_table_deleted(rem_host, rem_asic, neighbor, arptable)
 
                 for entry in asicdb_neigh_table.keys():
                     search = '"ip":"%s"' % neighbor
@@ -1083,8 +1138,6 @@ def check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
                     if entry.endswith(":" + neighbor):
                         raise AssertionError("Found neighbor %s in app: %s", neighbor, entry)
 
-                rem_cfg_facts = all_cfg_facts[rem_host.hostname][rem_asic.asic_index]['ansible_facts']
-                remote_inband_info = get_inband_info(rem_cfg_facts)
                 check_neighbor_kernel_route(rem_host, rem_asic.asic_index, neighbor, remote_inband_info['port'],
                                             present=False)
 
@@ -1184,3 +1237,39 @@ def eos_ping(eos, ipaddr, count=2, timeout=3, interface=None, size=None, ttl=Non
         raise AssertionError("Ping failed: %s" % output['parsed'])
 
     return output
+
+
+def get_ptf_port(duthosts, cfg_facts, tbinfo, dut, dut_port):
+    """
+    Gets the port or ports of the PTF connected to a specific dut port.
+
+    Args:
+        duthosts: The duthosts fixture.
+        cfg_facts: The config facts for the requested dut.
+        tbinfo: The tbinfo fixture.
+        dut: The duthost (frontend node) the port is on.
+        dut_port: The port of the dut the needed PTF is connected to.
+
+    Returns:
+        A list of ports connected to a dut port.  Single element list if dutport
+        is ethernet, multiple elements if dutport is portchannel.  The port numbers
+        are ints.
+
+    """
+
+    # get the index of the frontend node to index into the tbinfo dictionary.
+    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+
+    if "portchannel" in dut_port.lower():
+        pc_cfg = cfg_facts['PORTCHANNEL_MEMBER']
+        pc_members = pc_cfg[dut_port]
+        logger.info("Portchannel members %s: %s", dut_port, pc_members.keys())
+        port_list = pc_members.keys()
+    else:
+        port_list = [dut_port]
+
+    ret = []
+    for port in port_list:
+        ret.append(mg_facts['minigraph_ptf_indices'][port])
+
+    return ret

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -25,10 +25,7 @@ def check_host_arp_table(host, asic, neighbor_ip, neighbor_mac, interface, state
     """
 
     if arptable is None:
-        if host.is_multi_asic:
-            arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
-        else:
-            arptable = host.switch_arptable()['ansible_facts']
+        arptable = asic.switch_arptable()['ansible_facts']
 
     if ':' in neighbor_ip:
         table = arptable['arptable']['v6']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### VoQ test cases updates for multiasic
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Updates VoQ test plan and test scripts for multiasic line cards.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To run the init, neighbor and IP forwarding tests on chassis with multiasic linecards.

#### How did you do it?

Scripts in tests/voq were enhanced to handle multiasic cards:

* All test cases were changed so that ASICs with no neighbors or router interfaces will be skipped.
* The HIDE_INTERNAL route map is let in place and tests in ipfwd script that are affected by it are removed.
* CLI and database checks where enhanced to look in the correct namespace on multiasic cards.

Other enhancements:
* Neighbor script cleanup was enhanced be more robust when restoring configuration.
* PTF port selection was centralized and now uses minigraph.
* TTL checks were made optional for running ipfwd script on VS testbed.
* Test plan was updated with these changes.

#### How did you verify/test it?
Ran test suite on VoQ chassis.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
T2

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
