### PR TITLE
[multi-asic]: Add additional tests to be run for multi-asic t1-lag testbed

### DIFF
--- a/tests/pipelines/multi_asic_201911.yml
+++ b/tests/pipelines/multi_asic_201911.yml
@@ -146,17 +146,17 @@ stages:
       condition: succeededOrFailed()
     
     - publish: $(Build.ArtifactStagingDirectory)/kvmdump
-      artifact: sonic-buildimage.kvmtest.$(tbtype).memdump@$(System.JobAttempt)
+      artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}.memdump@$(System.JobAttempt)
       displayName: "Archive sonic kvm memdump"
       condition: failed()
     
     - publish: $(Build.ArtifactStagingDirectory)/logs
-      artifact: sonic-buildimage.kvmtest.$(tbtype).log@$(System.JobAttempt)
+      artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}.log@$(System.JobAttempt)
       displayName: "Archive sonic kvm logs"
       condition: succeededOrFailed()
     
     - task: PublishTestResults@2
       inputs:
         testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'
-        testRunTitle: kvmtest.$(tbtype)
+        testRunTitle: kvmtest.${{ parameters.tbtype }}
       condition: succeededOrFailed()

--- a/tests/pipelines/multi_asic_201911.yml
+++ b/tests/pipelines/multi_asic_201911.yml
@@ -77,16 +77,41 @@ stages:
         rm -rf $(Build.ArtifactStagingDirectory)/*
         parent_dir="/data/sonic-mgmt"
         tests="test_interfaces.py \
+        monit/test_monit_status.py \
         bgp/test_bgp_fact.py \
+        bgp/test_bgp_allow_list.py \
+        bgp/test_bgp_multipath_relax.py \
+        bgp/test_bgp_bbr.py \
+        bgp/test_bgp_bounce.py \
+        bgp/test_bgp_update_timer.py \
+        bgp/test_traffic_shift.py \
+        cacl/test_ebtables_application.py \
+        cacl/test_cacl_application.py \
+        cacl/test_cacl_function.py \
         lldp/test_lldp.py \
+        ntp/test_ntp.py \
+        pc/test_po_cleanup.py \
+        pc/test_po_update.py \
         route/test_default_route.py \
+        route/test_default_route.py \
+        snmp/test_snmp_cpu.py \
+        snmp/test_snmp_interfaces.py \
+        snmp/test_snmp_lldp.py \
         snmp/test_snmp_pfc_counters.py \
         snmp/test_snmp_queue.py \
         snmp/test_snmp_loopback.py \
         snmp/test_snmp_default_route.py \
+        syslog/test_syslog.py \
         tacacs/test_rw_user.py \
         tacacs/test_ro_user.py \
-        tacacs/test_jit_user.py"
+        tacacs/test_jit_user.py \
+        test_features.py \
+        test_procdockerstatsd.py \
+        iface_namingmode/test_iface_namingmode.py \
+        platform_tests/test_cpu_memory_usage.py \
+        bgp/test_bgpmon.py \
+        container_checker/test_container_checker.py \
+        process_monitoring/test_critical_process_monitoring.py"
         CMD="cd $parent_dir/tests; \
         export ANSIBLE_CONFIG=$parent_dir/ansible ANSIBLE_LIBRARY=$parent_dir/ansible; \
         ./run_tests.sh -c \"$tests\" -d ${{ parameters.dut }} -f $(testbed_file) -i $(inventory) -n ${{ parameters.tbname }} -e --disable_loganalyzer -u"


### PR DESCRIPTION

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Currently we are testing a small subset of test cases on multi-asic testbed.
After having this run a few times and observing the stability, more test cases can be added to run on multi-asic t1-lag testing.

#### How did you do it?
Add additional testcases to be run on multi-asic t1-lag testbed.

#### How did you verify/test it?
Azure pipeline is created to run this script periodically.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
