### PR TITLE
[console] Add udevrule port mapping test for console switch

### DIFF
--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -11,7 +11,7 @@ def test_console_driver(duthost):
     Test console driver are well installed.
     Verify ttyUSB(0-47) are presented in DUT
     """
-    out = duthost.shell('ls /dev/ttyUSB*', module_ignore_errors=True)['stdout']v
+    out = duthost.shell('ls /dev/ttyUSB*', module_ignore_errors=True)['stdout']
     ttys = set(out.split())
     pytest_assert(len(ttys) > 0, "No virtual tty devices been created by console driver")
 

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
@@ -12,12 +11,10 @@ def test_console_driver(duthost):
     Test console driver are well installed.
     Verify ttyUSB(0-47) are presented in DUT
     """
-    out = duthost.shell('ls /dev/ttyUSB*')['stdout']
-    pytest_assert(
-        "No such file or directory" not in out,
-        "No virtual tty devices been created by console driver")
-
+    out = duthost.shell('ls /dev/ttyUSB*', module_ignore_errors=True)['stdout']v
     ttys = set(out.split())
+    pytest_assert(len(ttys) > 0, "No virtual tty devices been created by console driver")
+
     for i in range(48):
         expected_virtual_tty = "/dev/ttyUSB{}".format(i)
         pytest_assert(

--- a/tests/console/test_console_udevrule.py
+++ b/tests/console/test_console_udevrule.py
@@ -11,14 +11,12 @@ def test_console_port_mapping(duthost):
     Test udev rule are working as expect.
     Verify C0-(1-48) are presented in DUT
     """
-    out = duthost.shell('ls /dev/C0-*')['stdout']
-    pytest_assert(
-        "No such file or directory" not in out,
-        "No console tty devices been created by udev rule")
-
+    out = duthost.shell('ls /dev/C0-*', module_ignore_errors=True)['stdout']
     ttys = set(out.split())
+    pytest_assert(len(ttys) > 0, "No console tty devices been created by udev rule")
+
     for i in range(1, 49):
-        expected_virtual_tty = "/dev/C0-{}".format(i)
+        expected_console_tty = "/dev/C0-{}".format(i)
         pytest_assert(
-            expected_virtual_tty in ttys,
-            "Expected console device [{}] not found.".format(expected_virtual_tty))
+            expected_console_tty in ttys,
+            "Expected console device [{}] not found.".format(expected_console_tty))

--- a/tests/console/test_console_udevrule.py
+++ b/tests/console/test_console_udevrule.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+def test_console_port_mapping(duthost):
+    """
+    Test udev rule are working as expect.
+    Verify C0-(1-48) are presented in DUT
+    """
+    out = duthost.shell('ls /dev/C0-*')['stdout']
+    pytest_assert(
+        "No such file or directory" not in out,
+        "No console tty devices been created by udev rule")
+
+    ttys = set(out.split())
+    for i in range(1, 49):
+        expected_virtual_tty = "/dev/C0-{}".format(i)
+        pytest_assert(
+            expected_virtual_tty in ttys,
+            "Expected console device [{}] not found.".format(expected_virtual_tty))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[console] Add udevrule port mapping test for console switch
- Add new test case for testing udev rule status
- Fix issue where the test failed unexpected if no device exists

Signed-off-by: Jing Kan jika@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add test to verify if udev rule are working on console switch enabled device.

#### How did you do it?
Add new test case to check if `/dev/C0-*` devices been created by udev rule.

#### How did you verify/test it?
Run test on physical DUT:
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/internal/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

console/test_console_udevrule.py::test_console_port_mapping PASSED       [100%]

----------- generated xml file: /var/src/internal/tests/logs/tr.xml ------------
========================== 1 passed in 79.55 seconds ===========================
```

Unbind usb devices to check if no device exists:
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/internal/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

console/test_console_udevrule.py::test_console_port_mapping FAILED       [100%]

=================================== FAILURES ===================================
__________________________ test_console_port_mapping ___________________________

duthost = <MultiAsicSonicHost> str-e1031-acs-3

    def test_console_port_mapping(duthost):
        """
        Test udev rule are working as expect.
        Verify C0-(1-48) are presented in DUT
        """
        out = duthost.shell('ls /dev/C0-*', module_ignore_errors=True)['stdout']
        ttys = set(out.split())
>       pytest_assert(len(ttys) > 0, "No console tty devices been created by udev rule")
E       Failed: No console tty devices been created by udev rule

duthost    = <MultiAsicSonicHost> str-e1031-acs-3
out        = u''
ttys       = set([])

console/test_console_udevrule.py:16: Failed
----------- generated xml file: /var/src/internal/tests/logs/tr.xml ------------
=========================== short test summary info ============================
FAILED console/test_console_udevrule.py::test_console_port_mapping - Failed: ...
========================== 1 failed in 80.79 seconds ===========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/console/console_test_hld.md#42-udev-rule-test
Case: Port Mapping