### PR TITLE
Make verify_mac_address more robust

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -52,7 +52,7 @@ def verify_mac_address(host_facts, intfs, router_mac):
         else:
             ifname = intf['name']
 
-        pytest_assert(host_facts[ifname]['macaddress'] == router_mac, \
+        pytest_assert(host_facts[ifname]['macaddress'].lower() == router_mac.lower(), \
                 "interface {} mac address {} does not match router mac {}".format(ifname, host_facts[ifname]['macaddress'], router_mac))
 
 def verify_ip_address(host_facts, intfs):


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
```test_interface``` failed on some testbed because the mac address retrieved from ```config_db``` is in upper case, while the mac address in system is in lower case. The reason for the diff is unclear yet.
```
pytest_assert(host_facts[ifname]['macaddress'] == router_mac, \
>                   "interface {} mac address {} does not match router mac {}".format(ifname, host_facts[ifname]['macaddress'], router_mac))
E           Failed: interface PortChannel0001 mac address 1c:34:da:1d:e4:00 does not match router mac 1C:34:DA:1D:E4:00
```

This PR convert the str to lower case before comparison to make the logic more robust.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to update ```verify_mac_address```.

#### How did you do it?
Convert to lower case before comparison.

#### How did you verify/test it?
Verified on SN4600, test case can pass.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
