### PR TITLE
[Mellanox][QoS] Release the margin in PFCXon and PFCXoff test to 3 for all Mellanox platforms

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -146,8 +146,7 @@ class QosParamMellanox(object):
         xoff['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp
         # One motivation of margin is to tolerance the deviation.
         # We need a larger margin on SPC2/3
-        if self.asic_type != 'spc1':
-            xoff['pkts_num_margin'] = 3
+        xoff['pkts_num_margin'] = 3
         self.qos_params_mlnx[self.speed_cable_len]['xoff_1'].update(xoff)
         self.qos_params_mlnx[self.speed_cable_len]['xoff_2'].update(xoff)
 
@@ -155,10 +154,7 @@ class QosParamMellanox(object):
         xon['pkts_num_trig_pfc'] = pkts_num_trig_pfc
         xon['pkts_num_dismiss_pfc'] = pkts_num_dismiss_pfc + self.extra_margin
         xon['pkts_num_hysteresis'] = pkts_num_hysteresis + 16
-        if self.asic_type == 'spc2':
-            xon['pkts_num_margin'] = 2
-        elif self.asic_type == 'spc3':
-            xon['pkts_num_margin'] = 3
+        xon['pkts_num_margin'] = 3
         self.qos_params_mlnx['xon_1'].update(xon)
         self.qos_params_mlnx['xon_2'].update(xon)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Originally, we tried to maintain the margin in an as-accurate-as-possible approach.
However, this introduced some noise when the buffer parameters were changed.
This time we found in the PFCXoff test margin 2 wasn't enough to tolerance the deviation after buffer configuration was upgraded for 2km cable support.
In order to avoid the noise, we would like to release the margin to 3 for all Mellanox platforms.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How did you do it?
Release the margin to 3.

#### How did you verify/test it?
Run regression test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
