### PR TITLE
fix test_pfcwd_mmu_change from pfcwd_function

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -28,6 +28,7 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture(scope='function', autouse=True)
 def stop_pfcwd(duthosts, rand_one_dut_hostname):
     """
@@ -40,7 +41,31 @@ def stop_pfcwd(duthosts, rand_one_dut_hostname):
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
+
 class PfcCmd(object):
+    buffer_model_initialized = False
+    buffer_model = None
+
+    @staticmethod
+    def isBufferInApplDb(asic):
+        if not PfcCmd.buffer_model_initialized:
+            PfcCmd.buffer_model = asic.run_redis_cmd(
+                argv=[
+                    "redis-cli", "-n", "4", "hget",
+                    "DEVICE_METADATA|localhost", "buffer_model"
+                ]
+            )
+
+            PfcCmd.buffer_model_initialized = True
+            logger.info(
+                "Buffer model is {}, buffer tables will be fetched from {}".
+                    format(
+                    PfcCmd.buffer_model or "not defined",
+                    "APPL_DB" if PfcCmd.buffer_model else "CONFIG_DB"
+                )
+            )
+        return PfcCmd.buffer_model
+
     @staticmethod
     def counter_cmd(dut, queue_oid, attr):
         """
@@ -115,20 +140,28 @@ class PfcCmd(object):
         logger.info("Retreiving pg profile and dynamic threshold for port: {}".format(port))
 
         asic = dut.get_port_asic_instance(port)
+        if PfcCmd.isBufferInApplDb(asic):
+            db = "0"
+            pg_pattern = "BUFFER_PG_TABLE:{}:3-4"
+        else:
+            db = "4"
+            pg_pattern = "BUFFER_PG|{}|3-4"
+
         pg_profile = asic.run_redis_cmd(
             argv = [
-                "redis-cli", "-n", "4", "HGET", 
-                "BUFFER_PG|{}|3-4".format(port), "profile"
+                "redis-cli", "-n", db, "HGET",
+                pg_pattern.format(port), "profile"
             ]
         )[0].encode("utf-8")[1:-1]
 
         alpha = asic.run_redis_cmd(
             argv = [
-                "redis-cli", "-n", "4", "HGET", pg_profile, "dynamic_th"
+                "redis-cli", "-n", db, "HGET", pg_profile, "dynamic_th"
             ]
         )[0].encode("utf-8")
 
         return pg_profile, alpha
+
 
 class PfcPktCntrs(object):
     """ PFCwd counter retrieval and verifications  """


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
updated method get_mmu_params()
1.  to check whether the buffer configurations are in config db or appl db via checking whether buffer_model exists in DEVICE_METADATA|localhost

2.  fetch the buffer configuration from the config db/appl db accordingly.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
fix tests in pfcwd/test_pfcwd_function.py

previously the  test "test_pfcwd_mmu_change" failed with error:
'>       )[0].encode("utf-8")
E       IndexError: list index out of range'

in method "get_mmu_params"

the reason for it was the "NULL" output in request
asic.run_redis_cmd(
    argv = [
                  "redis-cli", "-n", db, "HGET",
                "BUFFER_PG|{}|3-4".format(port), "profile"
              ]
)


#### How did you verify/test it?
manually


### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
