### PR TITLE
[subport] Make ptf cleanup an autouse fixture

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -254,7 +254,7 @@ def reload_dut_config(request, duthost, define_sub_ports_configuration):
     duthost.shell('sudo config load -y /etc/sonic/config_db.json')
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def reload_ptf_config(request, ptfhost, define_sub_ports_configuration):
     """
     PTF's configuration reload on teardown


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In recent nightly runs, we see ptf cleanup not happening for some testbeds when subport tests have been run.  Though the ptf cleanup should happen as per the code flow, making the ptf cleanup fixture 'autouse' 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

#### How did you verify/test it?
Ran one of the subport tests and the ptf cleanup is called as expected