### PR TITLE
Change to test_techsupport for arm platform and router_mac to lower case

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -194,7 +194,8 @@ class SonicHost(AnsibleHostBase):
             return int(num_asic)
 
     def _get_router_mac(self):
-        return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0].decode("utf-8")
+        return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0].decode(
+            "utf-8").lower()
 
 
     def _get_platform_info(self):

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -370,6 +370,10 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                     add_asic_arg("/{}", cmds.copy_config_cmds, num),
             }
         )
+    # Remove /proc/dma for armh
+    elif duthost.facts["asic_type"] == "marvell":
+        if 'armhf-' in duthost.facts["platform"]:
+            cmds.copy_proc_files.remove("/proc/dma")
 
     return cmds_to_check
 


### PR DESCRIPTION
- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
if sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac returns mac in uppercase it causes fib_test and has_test in ptftests fail as acutal src mac is in lower case

Add check to remove /proc/dma file for arm platforms

#### How did you do it?
modified: tests/common/devices/sonic.py
  Add change to change router_mac to lower case
modified:   tests/show_techsupport/test_techsupport.py
  Add change to remove /proc/dma for arm platform

#### How did you verify/test it?
verified tests run against Nokia-7215

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
