### PR TITLE
[sanity_check]: Change order of mux stop on ToRs

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -438,8 +438,8 @@ def check_mux_simulator(ptf_server_intf, tor_mux_intf, ptfadapter, upper_tor_hos
         # Run tests with upper ToR active
         try:
             # Stop linkmgrd to prevent it from switching over ports
-            lower_tor_host.shell('systemctl stop mux')
             upper_tor_host.shell('systemctl stop mux')
+            lower_tor_host.shell('systemctl stop mux')
 
             toggle_simulator_port_to_upper_tor(tor_mux_intf)
             if check_simulator_read_side(tor_mux_intf) != 1:


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
An upcoming image change will cause the switchover performed during the sanity check to be reversed (since stopping the mux container will trigger a switchover). Since the upper ToR mux container is stopped last, a switchover to make the lower ToR active will be initiated, which has the potential to conflict with with switchover to the upper ToR on the next line.

#### How did you do it?
Stop the mux container on the upper ToR first

#### How did you verify/test it?
Run the sanity check, verify that it is able to pass with the changes described above.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
