### PR TITLE
[lldpctl_facts]: Ignore unknown tlvs

### DIFF
--- a/ansible/library/lldpctl_facts.py
+++ b/ansible/library/lldpctl_facts.py
@@ -16,6 +16,8 @@ def gather_lldp(module, lldpctl_docker_cmd, skip_interface_pattern_list):
     lldp_entries = output.splitlines()
     skip_interface_pattern_str = "(?:% s)" % '|'.join(skip_interface_pattern_list) if skip_interface_pattern_list else None
     for entry in lldp_entries:
+        if 'unknown-tlv' in entry:
+            continue
         if entry.startswith("lldp"):
             path, value = entry.strip().split("=", 1)
             path = path.split(".")


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The output of `lldpctl -f keyvalue` can sometimes contain more than one unknown TLVs, which can cause `gather_lldp` to crash. A previous patch/fix for this issue applied to `/usr/bin/lldpctl` on the SONiC host no longer works because of multi-ASIC compatibility changes (the executable on the host is no longer invoked, instead the `lldpctl` executable inside each lldp container is called directly).

#### How did you do it?
In `gather_lldp` ignore any lines with unknown TLVs

#### How did you verify/test it?
Run the LLDP test and the SNMP LLDP tests on a testbed that was experiencing the unknown TLV issue. Verify both tests pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
