### PR TITLE
[test] Add check neighbors health for SONiC neighbor devices

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -293,8 +293,16 @@ cd sonic-mgmt/tests
 
 2. Run the following command to execute the `bgp_fact` test (including the pre/post setup steps):
 
+If neighbor devices are EOS
+
 ```
 ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.csv -i veos_vtb
+```
+
+If neighbor devices are SONiC
+
+```
+./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.csv -i veos_vtb -e "--neighbor_type=sonic"
 ```
 
 You should see three sets of tests run and pass. You're now set up and ready to use the KVM testbed!

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.devices.local import Localhost
 from tests.common.devices.ptf import PTFHost
 from tests.common.devices.eos import EosHost
+from tests.common.devices.sonic import SonicHost
 from tests.common.devices.fanout import FanoutHost
 from tests.common.devices.k8s import K8sMasterHost
 from tests.common.devices.k8s import K8sMasterCluster
@@ -65,6 +66,10 @@ def pytest_addoption(parser):
 
     # Kubernetes master options
     parser.addoption("--kube_master", action="store", default=None, type=str, help="Name of k8s master group used in k8s inventory, format: k8s_vms{msetnumber}_{servernumber}")
+
+    # neighbor device type
+    parser.addoption("--neighbor_type", action="store", default="eos", type=str, choices=["eos", "sonic"],
+                    help="Neighbor devices type")
 
     ############################
     # pfc_asym options         #
@@ -346,21 +351,31 @@ def k8scluster(k8smasters):
     return k8s_master_cluster
 
 @pytest.fixture(scope="module")
-def nbrhosts(ansible_adhoc, tbinfo, creds):
+def nbrhosts(ansible_adhoc, tbinfo, creds, request):
     """
     Shortcut fixture for getting VM host
     """
 
     vm_base = int(tbinfo['vm_base'][2:])
+    neighbor_type = request.config.getoption("--neighbor_type")
     devices = {}
     for k, v in tbinfo['topo']['properties']['topology']['VMs'].items():
-        devices[k] = {'host': EosHost(ansible_adhoc,
-                                      "VM%04d" % (vm_base + v['vm_offset']),
-                                      creds['eos_login'],
-                                      creds['eos_password'],
-                                      shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
-                                      shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None),
-                      'conf': tbinfo['topo']['properties']['configuration'][k]}
+        if neighbor_type == "eos":
+            devices[k] = {'host': EosHost(ansible_adhoc,
+                                        "VM%04d" % (vm_base + v['vm_offset']),
+                                        creds['eos_login'],
+                                        creds['eos_password'],
+                                        shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
+                                        shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None),
+                        'conf': tbinfo['topo']['properties']['configuration'][k]}
+        elif neighbor_type == "sonic":
+            devices[k] = {'host': SonicHost(ansible_adhoc,
+                                        "VM%04d" % (vm_base + v['vm_offset']),
+                                        ssh_user=creds['sonic_login'] if 'sonic_login' in creds else None,
+                                        ssh_passwd=creds['sonic_password'] if 'sonic_password' in creds else None),
+                        'conf': tbinfo['topo']['properties']['configuration'][k]}
+        else:
+            raise ValueError("Unknown neighbor type %s" % (neighbor_type, ))
     return devices
 
 @pytest.fixture(scope="module")
@@ -430,6 +445,14 @@ def vmhost(ansible_adhoc, request, tbinfo):
 def eos():
     """ read and yield eos configuration """
     with open('eos/eos.yml') as stream:
+        eos = yaml.safe_load(stream)
+        return eos
+
+
+@pytest.fixture(scope='session')
+def sonic():
+    """ read and yield sonic configuration """
+    with open('sonic/sonic.yml') as stream:
         eos = yaml.safe_load(stream)
         return eos
 

--- a/tests/sonic/sonic.yml
+++ b/tests/sonic/sonic.yml
@@ -1,0 +1,2 @@
+# snmp variables
+snmp_rocommunity: public

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -3,6 +3,8 @@ import pytest
 import logging
 
 from common.helpers.assertions import pytest_assert
+from common.devices.eos import EosHost
+from common.devices.sonic import SonicHost
 
 logger = logging.getLogger(__name__)
 
@@ -13,9 +15,9 @@ pytestmark = [
     pytest.mark.topology('util') #special marker
 ]
 
-def check_snmp(hostname, mgmt_addr, localhost, community):
+def check_snmp(hostname, mgmt_addr, localhost, community, is_eos):
     logger.info("Check neighbor {}, mgmt ip {} snmp".format(hostname, mgmt_addr))
-    res = localhost.snmp_facts(host=mgmt_addr, version='v2c', is_eos=True, community=community)
+    res = localhost.snmp_facts(host=mgmt_addr, version='v2c', is_eos=is_eos, community=community)
     try:
         snmp_data = res['ansible_facts']
     except:
@@ -45,14 +47,33 @@ def check_eos_facts(hostname, mgmt_addr, host):
 
     return "neighbor {} has no management address {}".format(hostname, mgmt_ip)
 
-def check_bgp_facts(hostname, host):
+def check_sonic_facts(hostname, mgmt_addr, host):
+    logger.info("Check neighbor {} eos facts".format(hostname))
+    res = host.facts
+    logger.info("facts: {}".format(json.dumps(res, indent=4)))
+    mgmt_addrs = host.facts['mgmt_interface']
+    if len(mgmt_addrs) == 0:
+        return "there is no management interface in neighbor {}".format(hostname)
+    for addr in mgmt_addrs:
+        if addr == mgmt_addr:
+            return
+    return "neighbor {} has no management address {}".format(hostname, mgmt_ip)
+
+def check_eos_bgp_facts(hostname, host):
     logger.info("Check neighbor {} bgp facts".format(hostname))
     res = host.eos_command(commands=['show ip bgp sum'])
     logger.info("bgp: {}".format(res))
     if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
         return "neighbor {} bgp not configured correctly".format(hostname)
 
-def test_neighbors_health(duthosts, localhost, nbrhosts, eos, enum_frontend_dut_hostname):
+def check_sonic_bgp_facts(hostname, host):
+    logger.info("Check neighbor {} bgp facts".format(hostname))
+    res = host.command('vtysh -c "show ip bgp sum"')
+    logger.info("bgp: {}".format(res))
+    if not res.has_key('stdout_lines') or u'Unicast Summary' not in "\n".join(res['stdout_lines']):
+        return "neighbor {} bgp not configured correctly".format(hostname)
+
+def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_frontend_dut_hostname):
     """Check each neighbor device health"""
 
     fails = []
@@ -74,18 +95,38 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, enum_frontend_dut_
             # The server neighbors need to be skipped too.
             continue
 
-        failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'])
-        if failmsg:
+        nbrhost = nbrhosts[k]['host']
+
+        if isinstance(nbrhost, EosHost):
+            failmsg = check_snmp(k, v['mgmt_addr'], localhost, eos['snmp_rocommunity'], True)
+            if failmsg:
+                fails.append(failmsg)
+
+            failmsg = check_eos_facts(k, v['mgmt_addr'], nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+            failmsg = check_eos_bgp_facts(k, nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+        elif isinstance(nbrhost, SonicHost):
+            failmsg = check_snmp(k, v['mgmt_addr'], localhost, sonic['snmp_rocommunity'], False)
+            if failmsg:
+                fails.append(failmsg)
+
+            failmsg = check_sonic_facts(k, v['mgmt_addr'], nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+            failmsg = check_sonic_bgp_facts(k, nbrhost)
+            if failmsg:
+                fails.append(failmsg)
+
+        else:
+            failmsg = "neighbor type {} is unknown".format(k)
             fails.append(failmsg)
 
-        eoshost = nbrhosts[k]['host']
-        failmsg = check_eos_facts(k, v['mgmt_addr'], eoshost)
-        if failmsg:
-            fails.append(failmsg)
-
-        failmsg = check_bgp_facts(k, eoshost)
-        if failmsg:
-            fails.append(failmsg)
 
     # TODO: check link, bgp, etc. on
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
./run_tests.sh -E -n vms-kvm-t0 -d vlab-01 -c test_nbr_health.py -f vtestbed.csv -i veos_vtb -e "--neighbor_type=sonic"


Summary:
Add test for neighbor health if the neighbor devices are SONiC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To check the neighbor health if the neighbor devices are SONiC

#### How did you do it?

Add a command argument of pytest to indicate the neighbor device type so that we can choose different flow when we check the neighbor health.

#### How did you verify/test it?

1. Build the SONiC neighbor testbed to follow the [KVM Testbed Setup](https://github.com/Azure/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md)

```bash
./testbed-cli.sh -m veos_vtb -n 4 -k vsonic start-vms server_1 password.txt
./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k vsonic add-topo vms-kvm-t0 password.txt
./testbed-cli.sh -t vtestbed.csv -m veos_vtb deploy-mg vms-kvm-t0 veos_vtb password.txt
```

2. Run neighbor health test

```bash
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.csv -i veos_vtb -e "--neighbor_type=sonic"
```

3. All test should be pass

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

None

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
