### PR TITLE
[console][reverse ssh] Add reverse ssh test(conn) for console switch

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -9,7 +9,8 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_console_reversessh_connectivity(duthost, creds):
+@pytest.mark.parametrize("target_line", ["1", "2"])
+def test_console_reversessh_connectivity(duthost, creds, target_line):
     """
     Test reverse SSH are working as expect.
     Verify serial session is available after connect DUT via reverse SSH
@@ -17,13 +18,6 @@ def test_console_reversessh_connectivity(duthost, creds):
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     dutuser = creds['sonicadmin_user']
     dutpass = creds['sonicadmin_password']
-
-    target_line = '1'
-
-    # Ensure the target console line is clear before testing
-    if check_target_line_status(duthost, target_line, "BUSY"):
-        logging.info("Force clear line for testing")
-        duthost.shell('sudo sonic-clear line {}'.format(target_line))
 
     pytest_assert(
         check_target_line_status(duthost, target_line, "IDLE"),

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from pexpect import pxssh
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+def test_console_reversessh_connectivity(duthost):
+    """
+    Test reverse SSH are working as expect.
+    Verify serial session is available after connect DUT via reverse SSH
+    """
+    duthostvars = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars
+    dutip = duthostvars['ansible_host']
+    dutuser = duthostvars['ansible_user']
+    dutpass = duthostvars['ansible_password']
+
+    target_line = 1
+
+    # Ensure the target console line is clear before testing
+    console_facts = duthost.console_facts()['ansible_facts']['console_facts']
+    if console_facts['lines'][target_line]['state'] == "BUSY":
+        duthost.shell('sudo sonic-clear line {}'.format(target_line))
+
+    console_facts = duthost.console_facts()['ansible_facts']['console_facts']
+    pytest_assert(
+        console_facts['lines'][target_line]['state'] == "IDLE",
+        "Target line {} is busy before reverse SSH session start".format(target_line))
+
+    client = pxssh.pxssh()
+    ressh_user = "{}:{}".format(dutuser, target_line)
+    try:
+        client.login(dutip, ressh_user, dutpass)
+
+        # Check the console line state again
+        console_facts = duthost.console_facts()['ansible_facts']['console_facts']
+        pytest_assert(
+            console_facts['lines'][target_line]['state'] == "BUSY",
+            "Target line {} is idle while reverse SSH session is up".format(target_line))
+        
+        # Send escape sequence to exit reverse SSH session
+        client.sendcontrol('a')
+        client.sendcontrol('x')
+    except pxssh.ExceptionPxssh as e:
+        pytest.fail("Not able to do reverse SSH to remote host via DUT")
+
+    console_facts = duthost.console_facts()['ansible_facts']['console_facts']
+    pytest_assert(
+        console_facts['lines'][target_line]['state'] == "IDLE",
+        "Target line {} is busy after exited reverse SSH session".format(target_line))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add reverse SSH Connectivity testing for console switch

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The reverse SSH is a console switch feature to let user connect to a specific console line by reusing the regular SSH ways, for example: `ssh admin:1@duthost`
This PR is for testing the reverse ssh functionality for console switch feature.

#### How did you do it?
- Use `pexpect` module to start a SSH session and then verify if the control plane data is expected
- Test port [1] and [2] based on General Testbed (Both 1 & 2 are attached loopback module)

#### How did you verify/test it?
Line 1 is busy, Line 2 is idle
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================================================================================ test session starts =============================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/internal/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 2 items

console/test_console_reversessh.py::test_console_reversessh_connectivity[1] FAILED                                                                                                                     [ 50%]
console/test_console_reversessh.py::test_console_reversessh_connectivity[2] PASSED                                                                                                                     [100%]

================================================================================================== FAILURES ==================================================================================================

```

Line 1 & 2 are idle (happy path)
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================================================================================ test session starts =============================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/internal/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 2 items

console/test_console_reversessh.py::test_console_reversessh_connectivity[1] PASSED                                                                                                                     [ 50%]
console/test_console_reversessh.py::test_console_reversessh_connectivity[2] PASSED                                                                                                                     [100%]

-------------------------------------------------------------------------- generated xml file: /var/src/internal/tests/logs/tr.xml ---------------------------------------------------------------------------
========================================================================================= 2 passed in 104.72 seconds =========================================================================================
```

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

T0

### Documentation 
Connectivity https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/console/console_test_hld.md#43-reverse-ssh
