### PR TITLE
Add host name to the file for the extracted logs from the DUT

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -180,7 +180,7 @@ class LogAnalyzer:
                             "unused_expected_regexp": []
                             }
         timestamp = time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())
-        tmp_folder = ".".join((SYSLOG_TMP_FOLDER, timestamp))
+        tmp_folder = ".".join((SYSLOG_TMP_FOLDER, self.ansible_host, timestamp))
         marker = marker.replace(' ', '_')
         self.ansible_loganalyzer.run_id = marker
 

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -180,7 +180,7 @@ class LogAnalyzer:
                             "unused_expected_regexp": []
                             }
         timestamp = time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())
-        tmp_folder = ".".join((SYSLOG_TMP_FOLDER, self.ansible_host, timestamp))
+        tmp_folder = ".".join((SYSLOG_TMP_FOLDER, self.ansible_host.hostname, timestamp))
         marker = marker.replace(' ', '_')
         self.ansible_loganalyzer.run_id = marker
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
With PR https://github.com/Azure/sonic-mgmt/pull/3423, we parallelized the log analyzer for multi-dut setup.

However, we are using the same destination file name for multiple DUTs that under analysis. It is possible
that the 2 fetches stepped on each others toes?

As an example below DUTs str2-7050cx3-acs-06 and str2-7050cx3-acs-07 both have the same destination file for the extracted logs "/tmp/syslog.2021-05-14-01:16:52"


<pre>
14/05/2021 01:16:57 base._run                                L0063 DEBUG  | /var/src/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::save_extracted_log#285: [<b>str2-7050cx3-acs-06</b>] AnsibleModule::fetch, args=[], kwargs={"dest": <b>"/tmp/syslog.2021-05-14-01:16:52"</b>, "src": "/tmp/syslog", "flat": "yes"}
14/05/2021 01:16:58 base._run                                L0082 DEBUG  | /var/src/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::save_extracted_log#285: [<b>str2-7050cx3-acs-07</b>] AnsibleModule::fetch Result => {"changed": true, "_ansible_no_log": false, "remote_md5sum": null, "dest": "<b>/tmp/syslog.2021-05-14-01:16:52</b>", "checksum": "d1bfcc0bf8d935db8cb8c0163fe7f9397ce8261d", "md5sum": "729db59840b409a58b66716b93e58098", "failed": false, "remote_checksum": "d1bfcc0bf8d935db8cb8c0163fe7f9397ce8261d"}
14/05/2021 01:16:58 loganalyzer.analyze                      L0247 DEBUG  | /tmp/syslog.2021-05-14-01:16:52 file content:

14/05/2021 01:16:58 base._run                                L0082 DEBUG  | /var/src/sonic-mgmt/tests/common/plugins/loganalyzer/loganalyzer.py::save_extracted_log#285: [str2-7050cx3-acs-06] AnsibleModule::fetch Result => {"changed": false, "remote_md5sum": null, "dest": "/tmp/syslog.2021-05-14-01:16:52", "checksum": null, "md5sum": null, "_ansible_no_log": false, "failed": true, "file": "/tmp/syslog", "msg": "checksum mismatch", "remote_checksum": "9de888f5fe591891dc43aaac8e696f91051cd8b5"}
</pre>
#### How did you do it?
Made the destination file name distinctive per DUT by include the DUT's hostname along with the timestamp.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
