### PR TITLE
Watchdog reboot test was skipped on master

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -105,6 +105,10 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
         reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
+        if reboot_type == REBOOT_TYPE_WATCHDOG:
+            res = duthost.command('python -c \"import sonic_platform\"',module_ignore_errors=True)
+            if res['failed']:
+                reboot_command = "python3 -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\""
         if timeout == 0:
             timeout = reboot_ctrl['timeout']
         if wait == 0:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -104,11 +104,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     hostname = duthost.hostname
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
-        reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
         if reboot_type == REBOOT_TYPE_WATCHDOG:
-            res = duthost.command('python -c \"import sonic_platform\"', module_ignore_errors=True)
-            if res['failed']:
-                reboot_command = "python3 -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\""
+            res = duthost.command('python -c \"import sonic_platform\"',module_ignore_errors=True)
+            reboot_command = "python{} -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\"".format('3' if res['failed'] else '2')
+            logger.info('reboot command : {}'.format(reboot_command))
+        else:
+            reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
         if timeout == 0:
             timeout = reboot_ctrl['timeout']
         if wait == 0:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -106,7 +106,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
         reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
         if reboot_type == REBOOT_TYPE_WATCHDOG:
-            res = duthost.command('python -c \"import sonic_platform\"',module_ignore_errors=True)
+            res = duthost.command('python -c \"import sonic_platform\"', module_ignore_errors=True)
             if res['failed']:
                 reboot_command = "python3 -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\""
         if timeout == 0:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -67,7 +67,7 @@ reboot_ctrl_dict = {
         "test_reboot_cause_only": False
     },
     REBOOT_TYPE_WATCHDOG: {
-        "command": "python -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\"",
+        "command": "watchdogutil arm -s 5",
         "timeout": 300,
         "wait": 120,
         "cause": "Watchdog",
@@ -104,12 +104,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     hostname = duthost.hostname
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
-        if reboot_type == REBOOT_TYPE_WATCHDOG:
-            res = duthost.command('python -c \"import sonic_platform\"', module_ignore_errors=True)
-            reboot_command = "python{} -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\"".format('3' if res['failed'] else '2')
-            logger.info('reboot command : {}'.format(reboot_command))
-        else:
-            reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
+        reboot_command = reboot_ctrl['command'] if reboot_type != REBOOT_TYPE_POWEROFF else None
         if timeout == 0:
             timeout = reboot_ctrl['timeout']
         if wait == 0:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -105,7 +105,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     try:
         reboot_ctrl    = reboot_ctrl_dict[reboot_type]
         if reboot_type == REBOOT_TYPE_WATCHDOG:
-            res = duthost.command('python -c \"import sonic_platform\"',module_ignore_errors=True)
+            res = duthost.command('python -c \"import sonic_platform\"', module_ignore_errors=True)
             reboot_command = "python{} -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog().arm(5); exit()\"".format('3' if res['failed'] else '2')
             logger.info('reboot command : {}'.format(reboot_command))
         else:

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -236,10 +236,9 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, 
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    test_watchdog_supported = "watchdogutil status"
 
-    watchdog_supported = duthost.command(test_watchdog_supported,module_ignore_errors=True)
-    if "" != watchdog_supported["stderr"] or "" == watchdog_supported["stdout"]:
+    watchdogutil_status_result = duthost.command("watchdogutil status", module_ignore_errors=True)
+    if "" != watchdogutil_status_result["stderr"] or "" == watchdogutil_status_result["stdout"]:
         pytest.skip("Watchdog is not supported on this DUT, skip this test case")
 
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -236,7 +236,7 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, 
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    py_res = duthost.command("python -c \"import sonic_platform\"",module_ignore_errors=True)
+    py_res = duthost.command("python -c \"import sonic_platform\"", module_ignore_errors=True)
     test_watchdog_supported = "python{} -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog(); exit()\"".format('3' if py_res['failed'] else '2')
 
     watchdog_supported = duthost.command(test_watchdog_supported,module_ignore_errors=True)["stderr"]

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -236,11 +236,10 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, 
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    py_res = duthost.command("python -c \"import sonic_platform\"", module_ignore_errors=True)
-    test_watchdog_supported = "python{} -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog(); exit()\"".format('3' if py_res['failed'] else '2')
+    test_watchdog_supported = "watchdogutil status"
 
-    watchdog_supported = duthost.command(test_watchdog_supported,module_ignore_errors=True)["stderr"]
-    if "" != watchdog_supported:
+    watchdog_supported = duthost.command(test_watchdog_supported,module_ignore_errors=True)
+    if "" != watchdog_supported["stderr"] or "" == watchdog_supported["stdout"]:
         pytest.skip("Watchdog is not supported on this DUT, skip this test case")
 
     reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, REBOOT_TYPE_WATCHDOG)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -236,7 +236,8 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost, 
     @summary: This test case is to perform reboot via watchdog and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    test_watchdog_supported = "python -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog(); exit()\""
+    py_res = duthost.command("python -c \"import sonic_platform\"",module_ignore_errors=True)
+    test_watchdog_supported = "python{} -c \"import sonic_platform.platform as P; P.Platform().get_chassis().get_watchdog(); exit()\"".format('3' if py_res['failed'] else '2')
 
     watchdog_supported = duthost.command(test_watchdog_supported,module_ignore_errors=True)["stderr"]
     if "" != watchdog_supported:


### PR DESCRIPTION
…emoved.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Watchdog reboot test was skipped on master since sonic_platform python2 package has been removed.

#### How did you do it?
Check if the sonic_platform python2 package is available or not and import the sonic_platform python3 package if not.
#### How did you verify/test it?
Run tests/platform_test/test_reboot.py on 201911 and master and check if the test_watchdog_reboot is not skipped and passed without an error.
#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
