### PR TITLE
[console][reverse ssh] Add reverse ssh test(force interrupt) for console switch

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -44,6 +44,49 @@ def test_console_reversessh_connectivity(duthost, creds, target_line):
         wait_until(10, 1, check_target_line_status, duthost, target_line, "IDLE"),
         "Target line {} is busy after exited reverse SSH session".format(target_line))
 
+@pytest.mark.parametrize("target_line", ["1", "2"])
+def test_console_reversessh_force_interrupt(duthost, creds, target_line):
+    """
+    Test reverse SSH are working as expect.
+    Verify active serial session can be shut by DUT
+    """
+    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    dutuser = creds['sonicadmin_user']
+    dutpass = creds['sonicadmin_password']
+
+    pytest_assert(
+        check_target_line_status(duthost, target_line, "IDLE"),
+        "Target line {} is busy before reverse SSH session start".format(target_line))
+
+    ressh_user = "{}:{}".format(dutuser, target_line)
+    try:
+        client = pexpect.spawn('ssh {}@{}'.format(ressh_user, dutip))
+        client.expect('[Pp]assword:')
+        client.sendline(dutpass)
+
+        # Check the console line state again
+        pytest_assert(
+            check_target_line_status(duthost, target_line, "BUSY"),
+            "Target line {} is idle while reverse SSH session is up".format(target_line))
+    except Exception as e:
+        pytest.fail("Not able to do reverse SSH to remote host via DUT")
+
+    try:
+        # Force clear line from DUT
+        duthost.shell('sudo sonic-clear line {}'.format(target_line))
+    except Exception as e:
+        pytest.fail("Not able to do clear line for DUT")
+
+    # Check the session ended within 5s and the line state is idle
+    pytest_assert(
+        wait_until(5, 1, check_target_line_status, duthost, target_line, "IDLE"),
+        "Target line {} not toggle to IDLE state after force clear command sent")
+
+    try:
+        client.expect("Picocom was killed")
+    except Exception as e:
+        pytest.fail("Console session not exit correctly: {}".format(str(e)))
+
 def check_target_line_status(duthost, line, expect_status):
     console_facts = duthost.console_facts()['ansible_facts']['console_facts']
     return console_facts['lines'][line]['state'] == expect_status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add reverse ssh test(force interrupt) for console switch

Signed-off-by: Jing Kan jika@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Verify active serial session can be shut by DUT

#### How did you do it?
Connect DUT serial port A via reverse SSH then connect to DUT and clear port A

#### How did you verify/test it?
Run the test on physical DUT:
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/internal/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 4 items

console/test_console_reversessh.py::test_console_reversessh_connectivity[1] PASSED [ 25%]
console/test_console_reversessh.py::test_console_reversessh_connectivity[2] PASSED [ 50%]
console/test_console_reversessh.py::test_console_reversessh_force_interrupt[1] PASSED [ 75%]
console/test_console_reversessh.py::test_console_reversessh_force_interrupt[2] PASSED [100%]

----------- generated xml file: /var/src/internal/tests/logs/tr.xml ------------
========================== 4 passed in 140.24 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Force Interrupt https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/console/console_test_hld.md#43-reverse-ssh
