### PR TITLE
Fix ipfwd on dualtor testbed.

### DIFF
--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -2,7 +2,6 @@ import pytest
 from ipaddress import ip_address
 import logging
 import json
-import ipaddress
 import time
 
 logger = logging.getLogger(__name__)
@@ -82,10 +81,10 @@ def arptable_on_switch(asic_host, mg_facts):
         switch_arptable = asic_host.switch_arptable()['ansible_facts']
         for intf in mg_facts['minigraph_portchannel_interfaces']:
             peer_addr = intf['peer_addr']
-            if ipaddress.ip_address(peer_addr).version == 4 and peer_addr not in switch_arptable['arptable']['v4']:
+            if ip_address(peer_addr).version == 4 and peer_addr not in switch_arptable['arptable']['v4']:
                 all_rebuilt = False
                 break
-            if ipaddress.ip_address(peer_addr).version == 6 and peer_addr not in switch_arptable['arptable']['v6']:
+            if ip_address(peer_addr).version == 6 and peer_addr not in switch_arptable['arptable']['v6']:
                 all_rebuilt = False
                 break
         if all_rebuilt:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix ```ipfwd``` on dualtor testbed.
The root cause for failure of ```ipfwd/test_dip_sip.py``` 
```
    def get_lag_facts(dut, lag_facts, switch_arptable, mg_facts, ignore_lags, enum_frontend_asic_index, key='src'):
    ......
                            selected_lag_facts[key + '_router_ipv4'] = intf['addr']
                            selected_lag_facts[key + '_host_ipv4'] = intf['peer_addr']
>                           selected_lag_facts[key + '_host_mac'] = switch_arptable['arptable']['v4'][intf['peer_addr']]['macaddress']
E                           KeyError: u'10.0.0.57'
```
is because ```check_mux_simulator``` in ```sanity_check``` will flush arp table. As a result, ```get_lag_facts``` failed to get mac address for neigh and raised ```KeyError```.
This PR fix the issue by waiting some time (70 seconds) for arp table being rebuilt.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```ipfwd``` on dualtor testbed.

#### How did you do it?
This PR fix the issue by waiting some time (70 seconds) for arp table being rebuilt.

#### How did you verify/test it?
Verified on both dualtor and single tor testbed. All test case passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
No.