### PR TITLE
Skip show_techsupport test when DATAACL doesn't exist.

### DIFF
--- a/ansible/library/acl_facts.py
+++ b/ansible/library/acl_facts.py
@@ -221,7 +221,7 @@ def merge_acl_table_and_rule(all_config):
     for table in acl_tables:
         acl_tables[table]['rules'] = {}
 
-    for rule in all_config['ACL_RULE']:
+    for rule in all_config.get('ACL_RULE', {}):
         rule_expanded = rule.split('|')
         if len(rule_expanded) == 2:
             table_name = rule_expanded[0]

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -12,7 +12,7 @@ from tests.common.utilities import wait_until
 
 from log_messages import *
 
-import tech_support_cmds as cmds
+import tech_support_cmds as cmds 
 
 logger = logging.getLogger(__name__)
 
@@ -295,8 +295,8 @@ def test_techsupport(request, config, duthosts, enum_rand_one_per_hwsku_frontend
 
 
 def add_asic_arg(format_str, cmds_list, asic_num):
-    """
-    Add ASIC specific arg using the supplied string formatter
+    """ 
+    Add ASIC specific arg using the supplied string formatter 
 
     New commands are added for each ASIC. In case of a regex
     paramter, new regex is created for each ASIC.
@@ -331,9 +331,9 @@ def add_asic_arg(format_str, cmds_list, asic_num):
 @pytest.fixture(scope='function')
 def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
-    Prepare a list of commands to be expected in the
-    show techsupport output. All the expected commands are
-    categorized into groups.
+    Prepare a list of commands to be expected in the 
+    show techsupport output. All the expected commands are 
+    categorized into groups. 
 
     For multi ASIC platforms, command strings are generated based on
     the number of ASICs.
@@ -365,11 +365,11 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     if duthost.facts["asic_type"] == "broadcom":
         cmds_to_check.update(
             {
-                "broadcom_cmd_bcmcmd":
+                "broadcom_cmd_bcmcmd": 
                     add_asic_arg(" -n {}", cmds.broadcom_cmd_bcmcmd, num),
-                "broadcom_cmd_misc":
+                "broadcom_cmd_misc": 
                     add_asic_arg("{}", cmds.broadcom_cmd_misc, num),
-                "copy_config_cmds":
+                "copy_config_cmds": 
                     add_asic_arg("/{}", cmds.copy_config_cmds, num),
             }
         )
@@ -378,8 +378,8 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 
 def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist):
-    """
-    Check commands within a group against the command list
+    """ 
+    Check commands within a group against the command list 
 
     Returns: list commands not found
     """

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -6,13 +6,13 @@ import time
 import logging
 
 from random import randint
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import wait_until
 
 from log_messages import *
 
-import tech_support_cmds as cmds 
+import tech_support_cmds as cmds
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +122,9 @@ def acl(duthosts, enum_rand_one_per_hwsku_frontend_hostname, acl_setup):
     :return:
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    acl_facts = duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]
+    pytest_require(ACL_TABLE_NAME in acl_facts, "{} acl table not exists")
+
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='acl')
     loganalyzer.load_common_config()
 
@@ -292,8 +295,8 @@ def test_techsupport(request, config, duthosts, enum_rand_one_per_hwsku_frontend
 
 
 def add_asic_arg(format_str, cmds_list, asic_num):
-    """ 
-    Add ASIC specific arg using the supplied string formatter 
+    """
+    Add ASIC specific arg using the supplied string formatter
 
     New commands are added for each ASIC. In case of a regex
     paramter, new regex is created for each ASIC.
@@ -328,9 +331,9 @@ def add_asic_arg(format_str, cmds_list, asic_num):
 @pytest.fixture(scope='function')
 def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
-    Prepare a list of commands to be expected in the 
-    show techsupport output. All the expected commands are 
-    categorized into groups. 
+    Prepare a list of commands to be expected in the
+    show techsupport output. All the expected commands are
+    categorized into groups.
 
     For multi ASIC platforms, command strings are generated based on
     the number of ASICs.
@@ -362,11 +365,11 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     if duthost.facts["asic_type"] == "broadcom":
         cmds_to_check.update(
             {
-                "broadcom_cmd_bcmcmd": 
+                "broadcom_cmd_bcmcmd":
                     add_asic_arg(" -n {}", cmds.broadcom_cmd_bcmcmd, num),
-                "broadcom_cmd_misc": 
+                "broadcom_cmd_misc":
                     add_asic_arg("{}", cmds.broadcom_cmd_misc, num),
-                "copy_config_cmds": 
+                "copy_config_cmds":
                     add_asic_arg("/{}", cmds.copy_config_cmds, num),
             }
         )
@@ -375,8 +378,8 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 
 def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist):
-    """ 
-    Check commands within a group against the command list 
+    """
+    Check commands within a group against the command list
 
     Returns: list commands not found
     """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
1. Skip ```show_techsupport``` test when DATAACL doesn't exist.
2. Fix exception in ```acl_facts``` library when no ```ACL_RULE``` in ```config_db```.

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to skip ```show_techsupport``` test when DATAACL doesn't exist, and an exception in ```acl_facts``` is fixed at the same time.

#### How did you do it?
Add a check for existence of ```DATAACL```.

#### How did you verify/test it?
Verified on a dualtor testbed (with ```DATAACL```) and a T0 testbed (without ```DATAACL```). All passed.
 
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
