### PR TITLE
[pytest] Improve test_static_route

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -1,17 +1,29 @@
 import pytest
 import json
 import ipaddress
+import time
+import natsort
+import random
+
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.utilities import wait_until
 from tests.common import config_reload
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
-import time
+
 
 pytestmark = [
     pytest.mark.topology('t0'),
     pytest.mark.device_type('vs')
 ]
+
+
+def is_dualtor(tbinfo):
+    """Check if the testbed is dualtor."""
+    return "dualtor" in tbinfo["topo"]["name"]
+
 
 def add_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
     for idx in range(len(nexthop_addrs)):
@@ -20,6 +32,7 @@ def add_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
         else:
             ptfhost.shell("ip addr add {}/{} dev eth{}".format(nexthop_addrs[idx], prefix_len, nexthop_devs[idx]), module_ignore_errors=True)
 
+
 def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
     for idx in range(len(nexthop_addrs)):
         if ipv6:
@@ -27,7 +40,8 @@ def del_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False):
         else:
             ptfhost.shell("ip addr del {}/{} dev eth{}".format(nexthop_addrs[idx], prefix_len, nexthop_devs[idx]), module_ignore_errors=True)
 
-def generate_and_verify_traffic(duthost, ptfadapter, ip_dst, expected_ports, ipv6=False):
+
+def generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, expected_ports, ipv6=False):
     if ipv6:
         pkt = testutils.simple_tcpv6_packet(
             eth_dst=duthost.facts["router_mac"],
@@ -58,10 +72,14 @@ def generate_and_verify_traffic(duthost, ptfadapter, ip_dst, expected_ports, ipv
         exp_pkt.set_do_not_care_scapy(packet.IP, 'ttl')
         exp_pkt.set_do_not_care_scapy(packet.IP, 'chksum')
 
-    testutils.send(ptfadapter, 5, pkt)
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(duthost, tbinfo))
+    ptf_t1_intf_index = int(ptf_t1_intf.strip("eth"))
+    ptfadapter.dataplane.flush()
+    testutils.send(ptfadapter, ptf_t1_intf_index, pkt)
     testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=expected_ports)
 
-def run_static_route_test(duthost, ptfadapter, ptfhost, prefix, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False, config_reload_test=False):
+
+def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False, config_reload_test=False):
     # Add ipaddresses in ptf
     add_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=ipv6)
 
@@ -72,13 +90,13 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, prefix, nexthop_addrs, p
 
         # Check traffic get forwarded to the nexthop
         ip_dst = str(ipaddress.ip_network(unicode(prefix))[1])
-        generate_and_verify_traffic(duthost, ptfadapter, ip_dst, nexthop_devs, ipv6=ipv6)
+        generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
 
         # Config save and reload if specified
         if config_reload_test:
             duthost.shell('config save -y')
             config_reload(duthost)
-            generate_and_verify_traffic(duthost, ptfadapter, ip_dst, nexthop_devs, ipv6=ipv6)
+            generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
 
     finally:
         # Remove static route
@@ -91,43 +109,52 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, prefix, nexthop_addrs, p
         if config_reload_test:
             duthost.shell('config save -y')
 
-def get_vlan_info(duthost, tbinfo, ipv6=False):
+
+def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vlan_intf = mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]
     prefix_len = vlan_intf['prefixlen']
-    vlan_subnet = ipaddress.ip_network(vlan_intf['subnet'])
-    vlan_ports = mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]['attachto']]['members']
-    vlan_ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in vlan_ports]
-    return prefix_len, vlan_subnet, vlan_ptf_ports
 
-def test_static_route(duthost, ptfadapter, ptfhost, tbinfo):
-    prefix_len, vlan_subnet, vlan_ptf_ports = get_vlan_info(duthost, tbinfo)
-    run_static_route_test(duthost, ptfadapter, ptfhost, "1.1.1.0/24", 
-        [str(vlan_subnet[11])], prefix_len, [vlan_ptf_ports[0]])
-
-def test_static_route_ecmp(duthost, ptfadapter, ptfhost, tbinfo):
-    prefix_len, vlan_subnet, vlan_ptf_ports = get_vlan_info(duthost, tbinfo)
-    if len(vlan_ptf_ports) >= 3:
-        nexthops = [str(vlan_subnet[20 + idx]) for idx in range(3)]
-        intfs = vlan_ptf_ports[0:3]
+    if is_dualtor(tbinfo):
+        server_ips = mux_cable_server_ip(duthost)
+        vlan_intfs = natsort.natsorted(server_ips.keys())
+        nexthop_devs = [mg_facts["minigraph_ptf_indices"][_] for _ in vlan_intfs]
+        server_ip_key = "server_ipv6" if ipv6 else "server_ipv4"
+        nexthop_addrs = [server_ips[_][server_ip_key].split("/")[0] for _ in vlan_intfs]
     else:
-        nexthops = [str(vlan_subnet[20 + idx]) for idx in range(len(vlan_ptf_ports))]
-        intfs = vlan_ptf_ports[0:len(vlan_ptf_ports)]
-    run_static_route_test(duthost, ptfadapter, ptfhost, "2.2.2.0/24", 
-        nexthops, prefix_len, intfs, config_reload_test=True)
+        vlan_subnet = ipaddress.ip_network(vlan_intf['subnet'])
+        vlan_ports = mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]['attachto']]['members']
+        vlan_ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in vlan_ports]
+        nexthop_devs = vlan_ptf_ports
+        nexthop_addrs = [str(vlan_subnet[i + 2]) for i in range(len(nexthop_devs))]
+    count = min(count, len(nexthop_devs))
+    indices = random.sample(list(range(len(nexthop_devs))), k=count)
+    return prefix_len, [nexthop_addrs[_] for _ in indices], [nexthop_devs[_] for _ in indices]
 
-def test_static_route_ipv6(duthost, ptfadapter, ptfhost, tbinfo):
-    prefix_len, vlan_subnet, vlan_ptf_ports = get_vlan_info(duthost, tbinfo, ipv6=True)
-    run_static_route_test(duthost, ptfadapter, ptfhost, "2000:1::/64", 
-        [str(vlan_subnet[11])], prefix_len, [vlan_ptf_ports[0]], ipv6=True)
 
-def test_static_route_ecmp_ipv6(duthost, ptfadapter, ptfhost, tbinfo):
-    prefix_len, vlan_subnet, vlan_ptf_ports = get_vlan_info(duthost, tbinfo, ipv6=True)
-    if len(vlan_ptf_ports) >= 3:
-        nexthops = [str(vlan_subnet[20 + idx]) for idx in range(3)]
-        intfs = vlan_ptf_ports[0:3]
-    else:
-        nexthops = [str(vlan_subnet[20 + idx]) for idx in range(len(vlan_ptf_ports))]
-        intfs = vlan_ptf_ports[0:len(vlan_ptf_ports)]
-    run_static_route_test(duthost, ptfadapter, ptfhost, "2000:2::/64", 
-        nexthops, prefix_len, intfs, ipv6=True, config_reload_test=True)
+def test_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo)
+    run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "1.1.1.0/24",
+                          nexthop_addrs, prefix_len, nexthop_devs)
+
+
+def test_static_route_ecmp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo, count=3)
+    run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2.2.2.0/24",
+                          nexthop_addrs, prefix_len, nexthop_devs, config_reload_test=True)
+
+
+def test_static_route_ipv6(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo, ipv6=True)
+    run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2000:1::/64",
+                          nexthop_addrs, prefix_len, nexthop_devs, ipv6=True)
+
+
+def test_static_route_ecmp_ipv6(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo, ipv6=True, count=3)
+    run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2000:2::/64",
+                          nexthop_addrs, prefix_len, nexthop_devs, ipv6=True, config_reload_test=True)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Improve `test_static_route`

#### How did you do it?
1. support dualtor testbed.
2. rename `get_vlan_info` to `get_nexthops` to reflect its functionality
to select nexthops from the vlan subnet.
3. for `generate_and_verify_traffic`, using t1 ptf interface to send
packets.

#### How did you verify/test it?
run `test_static_route`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
