### PR TITLE
Fix the mux active/standby change issue for dualtor FIB testing

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -133,7 +133,7 @@ class FibTest(BaseTest):
         self.src_ports = self.test_params.get('src_ports', None)
         if not self.src_ports:
             self.src_ports = [int(port) for port in self.ptf_test_port_map.keys()]
-        
+
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
         self.single_fib = self.test_params.get('single_fib_for_duts', False)
 
@@ -352,13 +352,14 @@ class FibTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
 
         send_packet(self, src_port, pkt)
-        logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
+        logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={}) on port {}'\
             .format(pkt.src,
                     pkt.dst,
                     pkt['IPv6'].src,
                     pkt['IPv6'].dst,
                     sport,
-                    dport))
+                    dport,
+                    src_port))
         logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'\
             .format('any',
                     'any',

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -9,7 +9,9 @@ from datetime import datetime
 import pytest
 import requests
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, change_mac_addresses   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder          # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side
@@ -302,7 +304,6 @@ def set_mux_same_side(tbinfo, mux_server_url):
     return set_mux_side(tbinfo, mux_server_url, random.choice(['upper_tor', 'lower_tor']))
 
 
-@pytest.fixture
 def get_mux_status(tbinfo, mux_server_url):
     if 'dualtor' in tbinfo['topo']['name']:
         res = requests.get(mux_server_url)
@@ -311,13 +312,11 @@ def get_mux_status(tbinfo, mux_server_url):
     return {}
 
 
-@pytest.fixture
-def ptf_test_port_map(ptfhost, tbinfo, disabled_ptf_ports, vlan_ptf_ports, router_macs, vlan_macs, get_mux_status):
+def ptf_test_port_map(ptfhost, tbinfo, mux_server_url, disabled_ptf_ports, vlan_ptf_ports, router_macs, vlan_macs):
     active_dut_map = {}
-    if get_mux_status:
-        for mux_status in get_mux_status.values():
-            active_dut_index = 0 if mux_status['active_side'] == 'upper_tor' else 1
-            active_dut_map[str(mux_status['port_index'])] = active_dut_index
+    for mux_status in get_mux_status(tbinfo, mux_server_url).values():
+        active_dut_index = 0 if mux_status['active_side'] == 'upper_tor' else 1
+        active_dut_map[str(mux_status['port_index'])] = active_dut_index
 
     logger.info('router_macs={}'.format(router_macs))
     logger.info('vlan_macs={}'.format(vlan_macs))
@@ -339,9 +338,9 @@ def ptf_test_port_map(ptfhost, tbinfo, disabled_ptf_ports, vlan_ptf_ports, route
                 target_dut_index = active_dut_map[ptf_port]
                 target_mac = vlan_macs[target_dut_index]
 
-        if not target_dut_index:
-            target_dut_index = int(dut_intf_map.keys()[0])
-        if not target_mac:
+        if target_dut_index is None:
+            target_dut_index = int(dut_intf_map.keys()[0])  # None dualtor, target DUT is always the first and only DUT
+        if target_mac is None:
             target_mac = router_macs[target_dut_index]
         ports_map[ptf_port] = {'target_dut': target_dut_index, 'target_mac': target_mac}
 
@@ -365,8 +364,11 @@ def single_fib_for_duts(tbinfo):
         return True
     return False
 
+
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, True, 1514)])
-def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu, fib_info_files, router_macs, set_mux_random, ptf_test_port_map, ignore_ttl, single_fib_for_duts):
+def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu, set_mux_random, fib_info_files,
+                   tbinfo, mux_server_url, disabled_ptf_ports, vlan_ptf_ports, router_macs, vlan_macs,
+                   ignore_ttl, single_fib_for_duts):
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
     # do not test load balancing for vs platform as kernel 4.9
@@ -384,7 +386,8 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu, fib_info_files, router_ma
                 "fib_test.FibTest",
                 platform_dir="ptftests",
                 params={"fib_info_files": fib_info_files[:3],  # Test at most 3 DUTs
-                        "ptf_test_port_map": ptf_test_port_map,
+                        "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, mux_server_url, disabled_ptf_ports,
+                                                               vlan_ptf_ports, router_macs, vlan_macs),
                         "router_macs": router_macs,
                         "ipv4": ipv4,
                         "ipv6": ipv6,
@@ -444,12 +447,12 @@ def hash_keys(duthost):
             hash_keys.remove('ingress-port')
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
-    # the same packet coming in different asic 
+    # the same packet coming in different asic
     # could egress out of different port
     # the hash_test condition for hash_key == ingress_port will fail
     if duthost.sonichost.is_multi_asic:
         hash_keys.remove('ingress-port')
-    
+
     return hash_keys
 
 
@@ -496,7 +499,9 @@ def ipver(request):
     return request.param
 
 
-def test_hash(fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, router_macs, set_mux_same_side, ptf_test_port_map, ignore_ttl, single_fib_for_duts):
+def test_hash(fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, set_mux_same_side,
+              tbinfo, mux_server_url, disabled_ptf_ports, vlan_ptf_ports, router_macs, vlan_macs,
+              ignore_ttl, single_fib_for_duts):
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.HashTest.{}.{}.log".format(ipver, timestamp)
     logging.info("PTF log file: %s" % log_file)
@@ -506,13 +511,13 @@ def test_hash(fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, router_macs
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-
     ptf_runner(ptfhost,
             "ptftests",
             "hash_test.HashTest",
             platform_dir="ptftests",
             params={"fib_info_files": fib_info_files[:3],   # Test at most 3 DUTs
-                    "ptf_test_port_map": ptf_test_port_map,
+                    "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, mux_server_url, disabled_ptf_ports,
+                                                           vlan_ptf_ports, router_macs, vlan_macs),
                     "hash_keys": hash_keys,
                     "src_ip_range": ",".join(src_ip_range),
                     "dst_ip_range": ",".join(dst_ip_range),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
On dualtor testbed, the active/standby status may be changed while the PTF script is running.
Consequently the PTF script testing FIB may fail.

The reason of active/standby change is that no ICMP responder is running in PTF to simulate
servers. Then status of the muxes are unhealthy and link manager may try to recover the muxes
by switching the active/standby side.

The fix is to start ICMP responder befor the FIB testing to avoid mux active/standby state flapping.

Another logic issue of the FIB testing is getting active side of the DUT index. The issue is fixed
by changing:
```
    if not target_dut_index:
```
to:
```
    if target_dut_index is None:
```
Initializing `target_mac` also has the similiar issue and is fixed in the same way.

The third fix is to change `ptf_test_port_map` and `get_mux_status` from fixture
to function. These two functions depends on fixtures like `set_mux_random`
and `set_mux_same_side`. The execution sequence matters. If they are all
fixtures, changing the sequence of using the fixtures in test function argument
list may affect the test logic and cause issues that are hard to debug.
Making two of them to function calls can avoid this potential vulnerability.

#### How did you do it?
* Start ICMP responder before FIB testing
* Fix the logic issue of getting active side DUT index
* Improve the vulnerability issue of fixture sequence and dependency

#### How did you verify/test it?
Test run the script on both dual ToR and single ToR testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
