### PR TITLE
[Vrf] Enhance test_vrf to support t0-64 topology

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -336,7 +336,7 @@ def gen_vrf_neigh_file(vrf, ptfhost, render_file):
     ptfhost.template(src="vrf/vrf_neigh.j2", dest=render_file)
 
 def gen_specific_neigh_file(dst_ips, dst_ports, render_file, ptfhost):
-    dst_ports = [str(port[0]) for port in dst_ports]
+    dst_ports = [str(port) for port_list in dst_ports for port in port_list]
     tmp_file = tempfile.NamedTemporaryFile()
     for ip in dst_ips:
         tmp_file.write('{} [{}]\n'.format(ip, ' '.join(dst_ports)))

--- a/tests/vrf/vrf_fib.j2
+++ b/tests/vrf/vrf_fib.j2
@@ -5,7 +5,7 @@
 {%- endmacro %}
 
 {# defualt route#}
-{% if testbed_type == 't0' %}
+{% if testbed_type == 't0' or testbed_type == 't0-64' %}
 0.0.0.0/0 {{ gen_dst_ports(dst_intfs) }}
 ::/0 {{ gen_dst_ports(dst_intfs) }}
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR should enhance **test_vrf** to support **t0-64** topology. Main problem was that **vrf_fib.j2** jinga template was skipped for any other topology that **t0** and list of routes wasn't generated which lead to errors like below: 
```
E                   "======================================================================", 
E                   "ERROR: fib_test.FibTest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"ptftests/fib_test.py\", line 411, in runTest", 
E                   "    self.check_ip_ranges()", 
E                   "  File \"ptftests/fib_test.py\", line 155, in check_ip_ranges", 
E                   "    self.check_balancing(covered_ip_ranges, dut_index, ipv4)", 
E                   "  File \"ptftests/fib_test.py\", line 191, in check_balancing", 
E                   "    src_port, exp_port_list, next_hop = self.get_src_and_exp_ports(dst_ip)", 
E                   "  File \"ptftests/fib_test.py\", line 161, in get_src_and_exp_ports", 
E                   "    next_hop = self.fibs[active_dut_index][dst_ip]", 
E                   "  File \"ptftests/fib.py\", line 71, in __getitem__", 
E                   "    return self._ipv4_lpm_dict[str(ip)]", 
E                   "  File \"ptftests/lpm.py\", line 77, in __getitem__", 
E                   "    return self._subnet_tree[key]", 
E                   "  File \"/usr/local/lib/python2.7/dist-packages/SubnetTree.py\", line 157, in __getitem__", 
E                   "    return _SubnetTree.SubnetTree___getitem__(self, cidr)", 
E                   "KeyError: '241.117.237.245'", 
E                   "", 
E                   "----------------------------------------------------------------------", 
E                   "Ran 1 test in 0.009s", 
E                   "", 
E                   "FAILED (errors=1)"
```
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Add support for t0-64 topology
#### How did you do it?

#### How did you verify/test it?
Run **test_vrf** on **t0** and **t0-64** topology.
#### Any platform specific information?
```
SONiC Software Version: SONiC.202012.13712-dirty-20210505.090601
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: 6060da3a
Build date: Wed May  5 16:33:59 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
