### PR TITLE
[vm_set] address add-topo issue observed on ubuntu 20.04.2 LTS

### DIFF
--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -115,7 +115,7 @@ class VlanPort(object):
         with open(CMD_DEBUG_FNAME, 'a') as fp:
             pprint("OUTPUT: %s" % stdout, fp)
 
-        return stdout
+        return stdout.decode('utf-8')
 
 
 def main():


### PR DESCRIPTION
Summary:

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
deploy testbed on server running ubuntu 20.04.2 LTS run into issue.

#### How did you do it?
utf-8 decode the command out. (text=True is not backwards compatible)

#### How did you verify/test it?
add/remove topology on server with ubuntu version 20.04.2 LTS and 18.04.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
