### PR TITLE
[test_pfcwd_function] Fix isBufferInApplDb

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -49,22 +49,22 @@ class PfcCmd(object):
     @staticmethod
     def isBufferInApplDb(asic):
         if not PfcCmd.buffer_model_initialized:
-            PfcCmd.buffer_model = asic.run_redis_cmd(
+            result = asic.run_redis_cmd(
                 argv=[
                     "redis-cli", "-n", "4", "hget",
                     "DEVICE_METADATA|localhost", "buffer_model"
                 ]
             )
-
+            if result:
+                PfcCmd.buffer_model = result[0]
             PfcCmd.buffer_model_initialized = True
             logger.info(
-                "Buffer model is {}, buffer tables will be fetched from {}".
-                    format(
+                "Buffer model is {}, buffer tables will be fetched from {}".format(
                     PfcCmd.buffer_model or "not defined",
                     "APPL_DB" if PfcCmd.buffer_model else "CONFIG_DB"
                 )
             )
-        return PfcCmd.buffer_model
+        return PfcCmd.buffer_model == "dynamic"
 
     @staticmethod
     def counter_cmd(dut, queue_oid, attr):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`isBufferInApplDb` always evaluates to `True` because it doesn't check
the value returned. So `test_pfcwd_mmu_change` will try to modify wrong
table in config db, which will mess up config db.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let `isBufferInApplDb` check the content of `buffer_model` returned, if it is `dynamic`, returns `True`.

#### How did you verify/test it?
Run `test_pfcwd_mmu_change`, save the config db, then diff the config db with the original one.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
