### PR TITLE
[dualtor] Fix test_acl on dualtor testbed

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -20,13 +20,15 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_mod
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
 from tests.common.utilities import wait_until
 from tests.conftest import duthost
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.acl,
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
-    pytest.mark.topology("any")
+    pytest.mark.topology("any"),
+    pytest.mark.usefixtures('toggle_all_simulator_ports_to_rand_selected_tor')
 ]
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -149,10 +151,15 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
                 acl_table_ports[''] += port
 
     vlan_ports = []
+    vlan_mac = duthost.facts["router_mac"]
 
     if topo == "t0":
         vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
                       for ifname in mg_facts["minigraph_vlans"].values()[0]["members"]]
+        
+        vlan_table = duthost.get_running_config_facts()['VLAN']
+        vlan_name = list(vlan_table.keys())[0]
+        vlan_mac = duthost.get_dut_iface_mac(vlan_name)
 
     setup_information = {
         "router_mac": duthost.facts["router_mac"],
@@ -160,7 +167,8 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
         "upstream_port_ids": upstream_port_ids,
         "acl_table_ports": acl_table_ports,
         "vlan_ports": vlan_ports,
-        "topo": topo
+        "topo": topo,
+        "vlan_mac": vlan_mac
     }
 
     logger.info("Gathered variables for ACL test:\n{}".format(pprint.pformat(setup_information)))
@@ -500,10 +508,10 @@ class BaseAclTest(object):
         """Generate a TCP packet for testing."""
         src_ip = src_ip or DEFAULT_SRC_IP[ip_version]
         dst_ip = dst_ip or self.get_dst_ip(direction, ip_version)
-
+        dst_mac = setup["router_mac"] if direction == "uplink->downlink" else setup["vlan_mac"]
         if ip_version == "ipv4":
             pkt = testutils.simple_tcp_packet(
-                eth_dst=setup["router_mac"],
+                eth_dst=dst_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, 0),
                 ip_dst=dst_ip,
                 ip_src=src_ip,
@@ -516,7 +524,7 @@ class BaseAclTest(object):
                 pkt["IP"].proto = proto
         else:
             pkt = testutils.simple_tcpv6_packet(
-                eth_dst=setup["router_mac"],
+                eth_dst=dst_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, 0),
                 ipv6_dst=dst_ip,
                 ipv6_src=src_ip,
@@ -537,10 +545,10 @@ class BaseAclTest(object):
         """Generate a UDP packet for testing."""
         src_ip = src_ip or DEFAULT_SRC_IP[ip_version]
         dst_ip = dst_ip or self.get_dst_ip(direction, ip_version)
-
+        dst_mac = setup["router_mac"] if direction == "uplink->downlink" else setup["vlan_mac"]
         if ip_version == "ipv4":
             return testutils.simple_udp_packet(
-                eth_dst=setup["router_mac"],
+                eth_dst=dst_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, 0),
                 ip_dst=dst_ip,
                 ip_src=src_ip,
@@ -550,7 +558,7 @@ class BaseAclTest(object):
             )
         else:
             return testutils.simple_udpv6_packet(
-                eth_dst=setup["router_mac"],
+                eth_dst=dst_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, 0),
                 ipv6_dst=dst_ip,
                 ipv6_src=src_ip,
@@ -563,10 +571,10 @@ class BaseAclTest(object):
         """Generate an ICMP packet for testing."""
         src_ip = src_ip or DEFAULT_SRC_IP[ip_version]
         dst_ip = dst_ip or self.get_dst_ip(direction, ip_version)
-
+        dst_mac = setup["router_mac"] if direction == "uplink->downlink" else setup["vlan_mac"]
         if ip_version == "ipv4":
             return testutils.simple_icmp_packet(
-                eth_dst=setup["router_mac"],
+                eth_dst=dst_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, 0),
                 ip_dst=dst_ip,
                 ip_src=src_ip,
@@ -576,7 +584,7 @@ class BaseAclTest(object):
             )
         else:
             return testutils.simple_icmpv6_packet(
-                eth_dst=setup["router_mac"],
+                eth_dst=dst_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, 0),
                 ipv6_dst=dst_ip,
                 ipv6_src=src_ip,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix ```test_acl``` on dualtor testbed.

```test_acl``` failed on dualtor testbed because 2 reasons
1. The mac address of Vlan interface and L2 interfaces are different. So we should use different MAC address for upstream packets and downstream packets. For upstream packets, the MAC address of vlan interface should be used. For downstream packets, L2 interface's MAC address should be used.
2. The DUT that are selected for testing should be active.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_acl``` on dualtor testbed.

#### How did you do it?
1. Toggle mux cable to randomly selected DUT;
2. Use different MAC address for upstream packets and downstream packets.

#### How did you verify/test it?
Verified on both dualtor/single tor testbed. All passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
