### PR TITLE
[dualtor]Fix test_vxlan_decap on dualtor testbed

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -14,7 +14,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
-
+from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports_to_rand_selected_tor
 pytestmark = [
     pytest.mark.topology('t0')
 ]
@@ -45,6 +45,11 @@ def prepare_ptf(ptfhost, mg_facts, duthost):
     ptfhost.shell("supervisorctl update")
 
     logger.info("Put information needed by the PTF script to the PTF container.")
+
+    vlan_table = duthost.get_running_config_facts()['VLAN']
+    vlan_name = list(vlan_table.keys())[0]
+    vlan_mac = duthost.get_dut_iface_mac(vlan_name)
+    
     vxlan_decap = {
         "minigraph_port_indices": mg_facts["minigraph_ptf_indices"],
         "minigraph_portchannel_interfaces": mg_facts["minigraph_portchannel_interfaces"],
@@ -52,7 +57,8 @@ def prepare_ptf(ptfhost, mg_facts, duthost):
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],
         "minigraph_vlans": mg_facts["minigraph_vlans"],
         "minigraph_vlan_interfaces": mg_facts["minigraph_vlan_interfaces"],
-        "dut_mac": duthost.facts["router_mac"]
+        "dut_mac": duthost.facts["router_mac"],
+        "vlan_mac": vlan_mac
     }
     ptfhost.copy(content=json.dumps(vxlan_decap, indent=2), dest="/tmp/vxlan_decap.json")
 
@@ -146,7 +152,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
         return False, request.param
 
 
-def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost, creds):
+def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost, creds, toggle_all_simulator_ports_to_rand_selected_tor):
     duthost = duthosts[rand_one_dut_hostname]
 
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix ```test_vxlan_decap``` on dualtor testbed.

There are two reasons for the failure of ```test_vxlan_decap``` on dualtor testbed.
1. The MAC address of vlan interface and L2 interfaces are different. We should use correct MAC address for generated packets
2. The DUT selected for testing may not be the active one. A toggle is necessary to ensure that the test are running on active ToR

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_vxlan_decap``` on dualtor testbed.

#### How did you do it?
1. Toggle mux to selected ToR before testing
2. Use correct MAC address for generated packets.

#### How did you verify/test it?
Verified on both T0 and dualtor testbeds. All passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
