### PR TITLE
[advanced-reboot] Initialize report template for IO test results

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -221,6 +221,7 @@ def analyze_sairedis_rec(messages, result, offset_from_kexec):
 
 
 def get_data_plane_report(analyze_result, reboot_type):
+    report = {"controlplane": {"arp_ping": "", "downtime": ""}, "dataplane": {"lost_packets": "", "downtime": ""}}
     files = glob.glob('/tmp/{}-reboot-report.json'.format(reboot_type))
     if files:
         filepath = files[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
If for some reason, test does not generate dataplane and controlplane report, Pytest script will throw error.

#### How did you do it?
Handle the missing report by initializing an empty template.

#### How did you verify/test it?
tbd

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
