### PR TITLE
[pfcwd] Fix log message logic to indicate correct db based on buffer model

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -61,7 +61,7 @@ class PfcCmd(object):
             logger.info(
                 "Buffer model is {}, buffer tables will be fetched from {}".format(
                     PfcCmd.buffer_model or "not defined",
-                    "APPL_DB" if PfcCmd.buffer_model else "CONFIG_DB"
+                    "APPL_DB" if PfcCmd.buffer_model == "dynamic" else "CONFIG_DB"
                 )
             )
         return PfcCmd.buffer_model == "dynamic"


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Log message should indicate APPL_DB when buffer_model is dynamic. In case there is no buffer_model defined or buffer_model is traditional, log message should indicate CONFIG_DB

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you verify/test it?
Ran the test and verified that correct msg is printed