### PR TITLE
[qos] enable QoS test on dualtor topology

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -15,7 +15,7 @@ class QosSaiBase:
     """
         QosSaiBase contains collection of pytest fixtures that ready the tesbed for QoS SAI test cases.
     """
-    SUPPORTED_T0_TOPOS = ["t0", "t0-64", "t0-116", "dualtor-56"]
+    SUPPORTED_T0_TOPOS = ["t0", "t0-64", "t0-116", "dualtor-56", "dualtor"]
     SUPPORTED_T1_TOPOS = {"t1-lag", "t1-64-lag"}
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["td2", "th", "th2", "spc1", "spc2", "spc3", "td3"]
@@ -460,7 +460,7 @@ class QosSaiBase:
 
             testPortIds = sorted(dutPortIps.keys())
         else:
-            raise Exception("Unsupported testbed type - {}".format(topo))
+            pytest.skip("Unsupported testbed type - {}".format(topo))
 
         # restore currently assigned IPs
         testPortIps.update(dutPortIps)


### PR DESCRIPTION
### Description of PR

Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
qos test is failing on dualtor topology. It was enabled for dualtor-56 but not for dualtor.

#### How did you do it?
Add 'dualtor' to supported list.
For topologies that are not on the supported list. Skip the test instead of failing.

#### How did you verify/test it?
Tested the skip change first. Making sure the tests are skipping instead of failing.
Then added 'dualtor' to run tests and run into passes and legit failures.