### PR TITLE
[interfaces] skip vlan interface mac check on dualtor testbeds

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -36,9 +36,11 @@ def test_interfaces(duthosts, enum_frontend_dut_hostname, tbinfo, enum_asic_inde
     verify_ip_address(host_facts, mg_facts['minigraph_vlan_interfaces'])
     verify_ip_address(host_facts, mg_facts['minigraph_lo_interfaces'])
 
+    topo = tbinfo["topo"]["name"]
     router_mac = duthost.facts['router_mac']
     verify_mac_address(host_facts, mg_facts['minigraph_portchannel_interfaces'], router_mac)
-    verify_mac_address(host_facts, mg_facts['minigraph_vlan_interfaces'], router_mac)
+    if "dualtor" not in topo:
+        verify_mac_address(host_facts, mg_facts['minigraph_vlan_interfaces'], router_mac)
     verify_mac_address(host_facts, mg_facts['minigraph_interfaces'], router_mac)
 
 def verify_port(host_facts, ports):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
interface test fails on dualtor testbeds when checking vlan macs against switch mac. On dualtor testbed, this check will fail by design.

#### How did you do it?
Skip vlan mac checking if the topology is dualtor.

#### How did you verify/test it?
Run test on a dualtor testbed and passed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
