### PR TITLE
[wr-arp] Fix auth errors in test_wr_arp - enable alt_password connection mechanism

### DIFF
--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -193,7 +193,11 @@ class ArpTest(BaseTest):
         self.dut_ssh = self.get_param('dut_ssh')
         self.dut_username = self.get_param('dut_username')
         self.dut_password = self.get_param('dut_password')
-        self.dut_connection = DeviceConnection(self.dut_ssh, username=self.dut_username, password=self.dut_password)
+        self.dut_alt_password=self.get_param('alt_password')
+        self.dut_connection = DeviceConnection(self.dut_ssh,
+                                            username=self.dut_username,
+                                            password=self.dut_password,
+                                            alt_password=self.dut_alt_password)
         self.how_long = int(self.get_param('how_long', required=False, default=300))
 
         if not os.path.isfile(config):

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -197,6 +197,7 @@ class TestWrArp:
         dutIp = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
         logger.info('Warm-Reboot Control-Plane assist feature')
+        sonicadmin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
         ptf_runner(
             ptfhost,
             'ptftests',
@@ -209,6 +210,7 @@ class TestWrArp:
                 'dut_ssh' : dutIp,
                 'dut_username': creds['sonicadmin_user'],
                 'dut_password': creds['sonicadmin_password'],
+                "alt_password": sonicadmin_alt_password,
                 'config_file' : VXLAN_CONFIG_FILE,
                 'how_long' : testDuration,
             },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix authentication errors seen in test_wr_arp script running on master images.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Test `test_wr_arp` currently fails due to:
```
E                   "======================================================================", 
E                   "FAIL: wr_arp.ArpTest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"ptftests/wr_arp.py\", line 278, in runTest", 
E                   "    self.assertTrue(False, \"Timed out waiting for warm reboot\")", 
E                   "AssertionError: Timed out waiting for warm reboot", 
E                   "", 
E                   "----------------------------------------------------------------------", 

```

This is due to the fact that DUT paramiko connection does not try alt_password.

#### How did you do it?
Add retry with alt_password if the default password connection fails inside `wr_arp` script.

#### How did you verify/test it?
Tested on physical devices running 202012 and on master image. The test passes with the fix.

```
-------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------
22:43:43 test_wr_arp.testWrArp                    L0199 INFO   | Warm-Reboot Control-Plane assist feature
PASSED                                                                                                                                                                                                                              [100%]
------------------------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------------------------
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
