### PR TITLE
Fix test_lldp

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -31,7 +31,7 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, co
 
 
 def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, eos,
-                       collect_techsupport_all_duts, loganalyzer, enum_frontend_asic_index):
+                       collect_techsupport_all_duts, loganalyzer, enum_frontend_asic_index, tbinfo):
     """ verify LLDP information on neighbors """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
@@ -48,7 +48,11 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
     dut_system_description = res['stdout']
     lldpctl_facts = duthost.lldpctl_facts(asic_instance_id=enum_frontend_asic_index, skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
     config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
- 
+    
+    # LLDPD use mac address of eth0 to generate chassis ID.
+    mgmt_alias = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_mgmt_interface"]["alias"]
+    mgmt_mac = duthost.get_dut_iface_mac(mgmt_alias)
+
     nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
 
     for k, v in lldpctl_facts['lldpctl'].items():
@@ -64,7 +68,7 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_name'] == duthost.hostname
         # Verify the published DUT chassis id field is not empty
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_chassis_id'] == \
-               "0x%s" % (duthost.facts['router_mac'].replace(':', ''))
+               "0x%s" % (mgmt_mac.replace(':', ''))
         # Verify the published DUT system description field is correct
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_desc'] == dut_system_description
         # Verify the published DUT port id field is correct


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3490 
The MAC address of ```eth0``` and front panel interfaces are different on some devices. The ```lldpd``` daemon uses the MAC address of ```eth0``` to generate chassis ID, while test script does a comparison between chassis ID and ```router_mac```. This is the root cause of test failure on some platform.

This PR addresses the issue by changing ```router_mac``` to the MAC address of ```eth0``` when make the verification.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_lldp```.

#### How did you do it?
This PR addresses the issue by changing ```router_mac``` to the MAC address of ```eth0``` when make the verification.

#### How did you verify/test it?
Verified on SN4600. The test case will pass.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
