### PR TITLE
[Ansible] Add `restart-ptf` to `testbed-cli.sh`

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1193,6 +1193,8 @@ def main():
                 net.unbind_fp_ports()
                 net.add_injected_fp_ports_to_docker()
                 net.bind_fp_ports()
+                net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
+
             if hostif_exists:
                 net.add_host_ports()
         elif cmd == 'connect-vms' or cmd == 'disconnect-vms':

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -1,40 +1,85 @@
-- name: Remove ptf docker container ptf_{{ vm_set_name }}
-  docker_container:
-    name: ptf_{{ vm_set_name }}
-    state: absent
-  become: yes
+- name: set "PTF" container type, by default
+  set_fact:
+    container_type: "PTF"
 
-- name: Create ptf container ptf_{{ vm_set_name }}
-  docker_container:
-    name: ptf_{{ vm_set_name }}
-    image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
-    pull: yes
-    state: started
-    restart: yes
-    network_mode: none
-    detach: True
-    capabilities:
-      - net_admin
-    privileged: yes
-  become: yes
+- name: Restart the ptf container
+  block:
+  - name: Set default value for ptf_imagetag
+    set_fact:
+      ptf_imagetag: "latest"
+    when: ptf_imagetag is not defined
 
-- name: Set front panel/mgmt port for dut
-  include_tasks: get_dut_port.yml
+  - name: Remove ptf container ptf_{{ vm_set_name }}
+    docker_container:
+      name: ptf_{{ vm_set_name }}
+      state: absent
+    become: yes
 
-- name: Renumber topology {{ topo }} to VMs. base vm = {{ VM_base }}
-  vm_topology:
-    cmd: "renumber"
-    vm_set_name: "{{ vm_set_name }}"
-    topo: "{{ topology }}"
-    vm_names: "{{ VM_hosts }}"
-    vm_base: "{{ VM_base }}"
-    ptf_mgmt_ip_addr: "{{ ptf_ip }}"
-    ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
-    ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
-    ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
-    mgmt_bridge: "{{ mgmt_bridge }}"
-    dut_fp_ports: "{{ dut_fp_ports }}"
-    dut_mgmt_port: "{{ dut_mgmt_port }}"
-    fp_mtu: "{{ fp_mtu_size }}"
-    max_fp_num: "{{ max_fp_num }}"
-  become: yes
+  - name: Create ptf container ptf_{{ vm_set_name }}
+    docker_container:
+      name: ptf_{{ vm_set_name }}
+      image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
+      pull: yes
+      state: started
+      restart: yes
+      network_mode: none
+      detach: True
+      capabilities:
+        - net_admin
+      privileged: yes
+    become: yes
+
+  - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}
+    command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.conf.all.disable_ipv6=0
+    become: yes
+
+  - name: Get dut ports
+    include_tasks: get_dut_port.yml
+    loop: "{{ duts_name.split(',') }}"
+    loop_control:
+      loop_var: dut_name
+
+  - name: Create vlan ports for dut
+    include_tasks: create_dut_port.yml
+    when: external_port is defined
+    loop: "{{ duts_name.split(',') }}"
+    loop_control:
+      loop_var: dut_name
+
+  - debug: msg="{{ duts_fp_ports }}"
+  - debug: msg="{{ duts_mgmt_port }}"
+
+  - name: Renumber topology {{ topo }} to VMs. base vm = {{ VM_base }}
+    vm_topology:
+      cmd: "renumber"
+      vm_set_name: "{{ vm_set_name }}"
+      topo: "{{ topology }}"
+      vm_names: "{{ VM_hosts }}"
+      vm_base: "{{ VM_base }}"
+      vm_type: "{{ vm_type }}"
+      ptf_mgmt_ip_addr: "{{ ptf_ip }}"
+      ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
+      ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
+      ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
+      ptf_bp_ip_addr: "{{ ptf_bp_ip }}"
+      ptf_bp_ipv6_addr: "{{ ptf_bp_ipv6 }}"
+      mgmt_bridge: "{{ mgmt_bridge }}"
+      duts_fp_ports: "{{ duts_fp_ports }}"
+      duts_mgmt_port: "{{ duts_mgmt_port }}"
+      duts_name: "{{ duts_name.split(',') }}"
+      fp_mtu: "{{ fp_mtu_size }}"
+      max_fp_num: "{{ max_fp_num }}"
+    become: yes
+
+  - name: Send arp ping packet to gw for flusing the ARP table
+    command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
+    become: yes
+
+  - name: Start ptf_tgen service
+    include_tasks: start_ptf_tgen.yml
+    when: topo == 'fullmesh'
+
+  - name: Start PTF portchannel service
+    include_tasks: ptf_portchannel.yml
+
+  when: container_type == "PTF"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -312,6 +312,22 @@ function renumber_topo
   echo Done
 }
 
+function restart_ptf
+{
+  topology=$1
+  passwd=$2
+  shift
+  shift
+
+  read_file ${topology}
+
+  echo "Restart ptf for testbed '${vm_set_name}'"
+
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6"$@
+
+  echo Done 
+}
+
 function refresh_dut
 {
   topology=$1
@@ -569,6 +585,8 @@ case "${subcmd}" in
                  setup_k8s_vms $@
                ;;
   destroy-master) stop_k8s_vms $@
+               ;;
+  restart-ptf) restart_ptf $@
                ;;
   *)           usage
                ;;


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add `restart-ptf` to restart ptf docker container by adding new function
`restart_ptf` to `testbed-cli.sh`, it basically does the same thing as
`renumber_topo` without setting out fanout switch.

Also fix some bugs of `vm_topology.py` and `renumber_topo.yml`:
1. Add back plane port when renumbering topology.
2. Call `create_dut_port.yml` to setup vlan virtual interfaces before
`vm_topology`.
3. Add needed steps for other testbeds like `fullmesh`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Support restarting ptf docker container.

#### How did you do it?
Add `restart-ptf` to restart ptf docker container by adding new function
`restart_ptf` to `testbed-cli.sh`, it basically does the same thing as
`renumber_topo` without setting out fanout switch.

Also fix some bugs of `vm_topology.py` and `renumber_topo.yml`:
1. Add back plane port when renumbering topology.
2. Call `create_dut_port.yml` to setup vlan virtual interfaces before
`vm_topology`.
3. Add needed steps for other testbeds like `fullmesh`.

#### How did you verify/test it?
* tested it over t0, dualtor.
```
./testbed-cli.sh restart-ptf vms20-t0-7050cx3-2 password.txt
./testbed-cli.sh restart-ptf vms21-dual-t0-7050-3 password.txt
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
