### PR TITLE
Fix ```test_route_perf```

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -95,17 +95,21 @@ def generate_intf_neigh(duthost, num_neigh, ip_version):
     # Generate interfaces and neighbors
     intf_neighs = []
     str_intf_nexthop = {'ifname':'', 'nexthop':''}
-    for idx_neigh in range(num_neigh):
+
+    idx_neigh = 0
+    for itfs_name in up_interfaces:
+        if not itfs_name.startswith("PortChannel") and interfaces[itfs_name]['vlan'].startswith("PortChannel"):
+            continue
         if ip_version == 4:
             intf_neigh = {
-                'interface' : up_interfaces[idx_neigh % len(up_interfaces)],
+                'interface' : itfs_name,
                 'ip' : '10.%d.0.1/24' % (idx_neigh + 1),
                 'neighbor' : '10.%d.0.2' % (idx_neigh + 1),
                 'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
             }
         else:
             intf_neigh = {
-                'interface' : up_interfaces[idx_neigh % len(up_interfaces)],
+                'interface' : itfs_name,
                 'ip' : '%x::1/64' % (0x2000 + idx_neigh),
                 'neighbor' : '%x::2' % (0x2000 + idx_neigh),
                 'mac' : '54:54:00:ad:48:%0.2x' % idx_neigh
@@ -118,6 +122,9 @@ def generate_intf_neigh(duthost, num_neigh, ip_version):
         else:
             str_intf_nexthop['ifname'] += ',' + intf_neigh['interface']
             str_intf_nexthop['nexthop'] += ',' + intf_neigh['neighbor']
+        idx_neigh += 1
+        if idx_neigh == num_neigh:
+            break
 
     return intf_neighs, str_intf_nexthop
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix ```test_route_perf```.

Test case ``` test_route_perf``` failed on some platform (Like SN4600) because the added nexthop is a member of PortChannel. 
```orchagent``` will crash with following errors.

```
May 24 12:53:13.138090 str-msn4600c-acs-02 ERR syncd#SDK: [SAI_UTILS.ERR] mlnx_sai_utils.c[858]- check_port_type_attr: Port LAG member object id 16b0000000001 is not supported by attr id 2
May 24 12:53:13.138121 str-msn4600c-acs-02 ERR syncd#SDK: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_INVALID_PORT_NUMBER
May 24 12:53:13.138441 str-msn4600c-acs-02 ERR syncd#SDK: :- processQuadEvent: attr: SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID: oid:0x3000000000010
May 24 12:53:13.138441 str-msn4600c-acs-02 ERR syncd#SDK: :- processQuadEvent: attr: SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS: 1C:34:DA:1D:E4:00
May 24 12:53:13.138470 str-msn4600c-acs-02 ERR syncd#SDK: :- processQuadEvent: attr: SAI_ROUTER_INTERFACE_ATTR_TYPE: SAI_ROUTER_INTERFACE_TYPE_PORT
May 24 12:53:13.138470 str-msn4600c-acs-02 ERR syncd#SDK: :- processQuadEvent: attr: SAI_ROUTER_INTERFACE_ATTR_PORT_ID: oid:0x100000000095f
May 24 12:53:13.138491 str-msn4600c-acs-02 ERR syncd#SDK: :- processQuadEvent: attr: SAI_ROUTER_INTERFACE_ATTR_MTU: 9100
May 24 12:53:13.138667 str-msn4600c-acs-02 ERR swss#orchagent: :- create: create status: SAI_STATUS_INVALID_PORT_NUMBER
May 24 12:53:13.138667 str-msn4600c-acs-02 ERR swss#orchagent: :- addRouterIntfs: Failed to create router interface Ethernet8, rv:-9
May 24 12:53:13.139181 str-msn4600c-acs-02 INFO swss#/supervisord: orchagent terminate called after throwing an instance of 'std::runtime_error'
May 24 12:53:13.139181 str-msn4600c-acs-02 INFO swss#/supervisord: orchagent   what():  Failed to create router interface.
```
This PR fixes the issue by skipping interfaces that are already in PortChannels.

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_route_perf```.

#### How did you do it?
This PR fixes the issue by skipping interfaces that are already in PortChannels.

#### How did you verify/test it?
Verified on SN4600, both T0 and T1 testbeds. All test case passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
