### PR TITLE
[dut_utils]: Search list of running containers to check status

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -43,8 +43,8 @@ def is_container_running(duthost, container_name):
     Returns:
         Boolean value. True represents the container is running
     """
-    result = duthost.shell("docker inspect -f \{{\{{.State.Running\}}\}} {}".format(container_name))
-    return result["stdout_lines"][0].strip() == "true"
+    running_containers = duthost.shell(r"docker ps -f 'status=running' --format '\{\{.Names\}\}'")['stdout']
+    return container_name in running_containers
 
 
 def check_container_state(duthost, container_name, should_be_running):

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -43,7 +43,7 @@ def is_container_running(duthost, container_name):
     Returns:
         Boolean value. True represents the container is running
     """
-    running_containers = duthost.shell(r"docker ps -f 'status=running' --format '\{\{.Names\}\}'")['stdout']
+    running_containers = duthost.shell(r"docker ps -f 'status=running' --format \{\{.Names\}\}")['stdout_lines']
     return container_name in running_containers
 
 


### PR DESCRIPTION

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Previously, when checking the state of a container that did not exist on a device, the `is_container_running` method would raise an exception since the command run on the DUT would return an error.

#### How did you do it?
Instead of explicitly inspecting the state of a specific container, obtain a list of all currently running containers and check if the target container is present.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
