### PR TITLE
minigraph: Add the ability to set a per-port speed in the minigraph

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -75,11 +75,11 @@
     delegate_to: localhost
 
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}"
+    port_alias: hwsku="{{ hwsku }}" hostname="{{ inventory_hostname }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
-    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
+    port_alias: hwsku="{{ hwsku }}" hostname="{{ inventory_hostname }}" num_asic="{{ num_asics }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -74,12 +74,17 @@
   - topo_facts: topo={{ topo }} hwsku={{ hwsku }}
     delegate_to: localhost
 
+  - name: get connection graph if defined for dut (ignore any errors)
+    conn_graph_facts: host="{{ inventory_hostname }}" ignore_errors=true
+    delegate_to: localhost
+    ignore_errors: true
+
   - name: find interface name mapping and individual interface speed if defined from dut
-    port_alias: hwsku="{{ hwsku }}" hostname="{{ inventory_hostname }}"
+    port_alias: hwsku="{{ hwsku }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
-    port_alias: hwsku="{{ hwsku }}" hostname="{{ inventory_hostname }}" num_asic="{{ num_asics }}"
+    port_alias: hwsku="{{ hwsku }}" num_asic="{{ num_asics }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -519,6 +519,7 @@ def main():
             filename=dict(required=False),
             filepath=dict(required=False),
             anchor=dict(required=False, type='list'),
+            ignore_errors=dict(required=False, type='bool', default=False),
         ),
         mutually_exclusive=[['host', 'hosts', 'anchor']],
         supports_check_mode=True
@@ -565,7 +566,7 @@ def main():
                 'device_port_vlans': lab_graph.vlanport,
             }
             module.exit_json(ansible_facts=results)
-        succeed, results = build_results(lab_graph, hostnames)
+        succeed, results = build_results(lab_graph, hostnames, m_args['ignore_errors'])
         if succeed:
             module.exit_json(ansible_facts=results)
         else:

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -7,6 +7,7 @@ import subprocess
 from operator import itemgetter
 from itertools import groupby
 from collections import defaultdict
+from devutil import conn_graph_helper
 
 try:
     from sonic_py_common import multi_asic  
@@ -61,7 +62,8 @@ class SonicPortAliasMap():
     Retrieve SONiC device interface port alias mapping and port speed if they are definded
 
     """
-    def __init__(self, hwsku):
+    def __init__(self, hostname, hwsku):
+        self.hostname = hostname
         self.hwsku = hwsku
         return
 
@@ -98,6 +100,9 @@ class SonicPortAliasMap():
         front_panel_asic_ifnames = []
         # All asic names
         asic_if_names = []
+
+        #conn_graph = conn_graph_helper.get_conn_graph_facts([self.hostname])
+        conn_graph = {}
 
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
@@ -142,6 +147,8 @@ class SonicPortAliasMap():
                         aliasmap[alias] = name
                         if (speed_index != -1) and (len(mapping) > speed_index):
                             portspeed[alias] = mapping[speed_index]
+                        elif 'device_conn' in conn_graph and self.hostname in conn_graph['device_conn'] and name in conn_graph['device_conn'][self.hostname]:
+                            portspeed[alias] = conn_graph['device_conn'][self.hostname][name]['speed']
                         if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
                             front_panel_asic_ifnames.append(asicifname)
@@ -155,6 +162,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             hwsku=dict(required=True, type='str'),
+            hostname=dict(required=False, default=None, type='str'),
             num_asic=dict(type='int', required=False),
             include_internal=dict(required=False, type='bool', default=False)
         ),
@@ -166,7 +174,7 @@ def main():
         portmap = {}
         aliasmap = {}
         portspeed = {}
-        allmap = SonicPortAliasMap(m_args['hwsku'])
+        allmap = SonicPortAliasMap(m_args['hostname'], m_args['hwsku'])
         # ASIC interface names of front panel interfaces 
         front_panel_asic_ifnames = []
         # { asic_name: [ asic interfaces] }

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -7,7 +7,6 @@ import subprocess
 from operator import itemgetter
 from itertools import groupby
 from collections import defaultdict
-from devutil import conn_graph_helper
 
 try:
     from sonic_py_common import multi_asic  
@@ -62,8 +61,7 @@ class SonicPortAliasMap():
     Retrieve SONiC device interface port alias mapping and port speed if they are definded
 
     """
-    def __init__(self, hostname, hwsku):
-        self.hostname = hostname
+    def __init__(self, hwsku):
         self.hwsku = hwsku
         return
 
@@ -100,9 +98,6 @@ class SonicPortAliasMap():
         front_panel_asic_ifnames = []
         # All asic names
         asic_if_names = []
-
-        #conn_graph = conn_graph_helper.get_conn_graph_facts([self.hostname])
-        conn_graph = {}
 
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
@@ -147,8 +142,6 @@ class SonicPortAliasMap():
                         aliasmap[alias] = name
                         if (speed_index != -1) and (len(mapping) > speed_index):
                             portspeed[alias] = mapping[speed_index]
-                        elif 'device_conn' in conn_graph and self.hostname in conn_graph['device_conn'] and name in conn_graph['device_conn'][self.hostname]:
-                            portspeed[alias] = conn_graph['device_conn'][self.hostname][name]['speed']
                         if role == "Ext" and (asic_name_index != -1) and (len(mapping) > asic_name_index):
                             asicifname = mapping[asic_name_index]
                             front_panel_asic_ifnames.append(asicifname)
@@ -162,7 +155,6 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             hwsku=dict(required=True, type='str'),
-            hostname=dict(required=False, default=None, type='str'),
             num_asic=dict(type='int', required=False),
             include_internal=dict(required=False, type='bool', default=False)
         ),
@@ -174,7 +166,7 @@ def main():
         portmap = {}
         aliasmap = {}
         portspeed = {}
-        allmap = SonicPortAliasMap(m_args['hostname'], m_args['hwsku'])
+        allmap = SonicPortAliasMap(m_args['hwsku'])
         # ASIC interface names of front panel interfaces 
         front_panel_asic_ifnames = []
         # { asic_name: [ asic interfaces] }

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -16,11 +16,10 @@
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>
           <Priority>0</Priority>
-{% set speed_option = port_speed | length %}
-{% if speed_option == 0 %}
-          <Speed>{{ iface_speed }}</Speed>
-{% else %}
+{% if port_speed[port_alias[index]] is defined %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
+{% else %}
+          <Speed>{{ iface_speed }}</Speed>
 {% endif %}
         </a:EthernetInterface>
 {% endfor %}

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -18,6 +18,8 @@
           <Priority>0</Priority>
 {% if port_speed[port_alias[index]] is defined %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
+{% elif device_conn[inventory_hostname][port_alias[index]] is defined %}
+          <Speed>{{ device_conn[inventory_hostname][port_alias[index]]['speed'] }}</Speed>
 {% else %}
           <Speed>{{ iface_speed }}</Speed>
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <saiarcot895@gmail.com>

### Description of PR

In the case of devices with mixed port speeds, the speed for each port
has to be individually specified in the minigraph, and a single speed
for the entire device cannot be used. Instead, read the connection
graph, which contains the speed for each individual link, and use the
speed specified there for each port.

The speed specified in the connection graph is used only if
port_config.ini doesn't have a speed specified there. If there is a speed
specified there, then that is used.

If no speed is specified in port_config.ini, and there's no speed specified
for the port in the connection graph, then the speed in the inventory
yaml file is used.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

  ### Testing done

Generated minigraph with and without this change for most of our internal testbeds (str and str2), as well as `vms-s6000-t0`. Verified that all of the generated minigraphs remained the same with this change, and that there are no minigraphs that are not getting successfully generated that were getting generated before this change.

Also verified that with a non-default speed in the connection graph data (i.e. a speed for one port that was different than the speed for the other ports), that speed correctly got populated in the minigraph.