### PR TITLE
[Sub-ports] Added setting of parent ports by using pytest option

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -36,6 +36,14 @@ def pytest_addoption(parser):
         help="Max numbers of sub-ports for test_max_numbers_of_sub_ports test case",
     )
 
+    parser.addoption(
+        "--range_of_parent_port",
+        action="store",
+        type=str,
+        default='1-2',
+        help="Range of parent ports for creating sub-ports",
+    )
+
 
 @pytest.fixture(params=['port', 'port_in_lag'])
 def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
@@ -65,6 +73,10 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
     """
     sub_ports_config = {}
     max_numbers_of_sub_ports = request.config.getoption("--max_numbers_of_sub_ports")
+
+    first_interface_index, last_interface_index = request.config.getoption("--range_of_parent_port").split('-')
+    interface_ranges = range(int(first_interface_index), int(last_interface_index) + 1)
+
     vlan_ranges_dut = range(10, 50, 10)
     vlan_ranges_ptf = range(10, 50, 10)
 
@@ -84,7 +96,6 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
             vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
             vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)
 
-    interface_ranges = range(1, 3)
     ip_subnet = u'172.16.0.0/16'
     prefix = 30
     subnet = ipaddress.ip_network(ip_subnet)


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added setting of parent ports range for creating sub-ports by using `--range_of_parent_port` pytest option.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
L3 subport test cases are failed on t0-64 topology due to assertion error:
```
AssertionError: Did not receive expected packet on any of ports [1] for device 0.
```
Error reproduces due to the wrong range of parent ports for those topologies. So should be implemented setting of parent ports range by using pytest option.
#### How did you do it?
Added new pytest option `--range_of_parent_port` to conftest.py module.
#### How did you verify/test it?
Run test. Test passed.
`py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library sub_port_interfaces --range_of_parent_port='6-8'`
#### Any platform specific information?
SONiC Software Version: SONiC.master.162-dirty-20210331.125032
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: ecaf97d8
Build date: Wed Mar 31 13:09:26 UTC 2021
Platform: x86_64-arista_7170_32cd
HwSKU: Arista-7170-32CD-C32
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
