### PR TITLE
[arp]: Ignore case when comparing MAC addresses

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -133,7 +133,7 @@ def test_arp_garp_enabled(duthosts, enum_rand_one_per_hwsku_frontend_hostname, g
     vlan_intfs = config_facts['VLAN_INTERFACE'].keys()
 
     switch_arptable = duthost.switch_arptable()['ansible_facts']
-    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'] == arp_src_mac)
+    pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['macaddress'].lower() == arp_src_mac.lower())
     pytest_assert(switch_arptable['arptable']['v4'][arp_request_ip]['interface'] in vlan_intfs)
 
 
@@ -188,12 +188,12 @@ def test_proxy_arp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_pt
         dut_macs = []
 
         for vlan_details in vlans.values():
-            dut_macs.append(vlan_details['mac'])
+            dut_macs.append(vlan_details['mac'].lower())
     else:
         router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
         dut_macs = [router_mac]
 
     pytest_assert(ping_addr in neighbor_table.keys())
-    pytest_assert(neighbor_table[ping_addr]['macaddress'] in dut_macs)
+    pytest_assert(neighbor_table[ping_addr]['macaddress'].lower() in dut_macs)
     pytest_assert(neighbor_table[ping_addr]['interface'] == ptf_intf_name)
     pytest_assert(neighbor_table[ping_addr]['state'].lower() not in ['failed', 'incomplete'])


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The proxy ARP test can fail because the MAC addresses being compared are allowed to use both upper and lower case letters.

#### How did you do it?
Use the `lower()` string method to ensure that all MACs are converted to lower case before comparison

#### How did you verify/test it?
Run the dual ToR ARP tests and verify that they pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
