### PR TITLE
[test_vlan] Fix `test_vlan` non broadcast tests

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -407,7 +407,7 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list):
     transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=dst_mac, dst_mac=src_mac)
 
-    logger.info("Tagged packet to be sent from port {} to port {}".format(src_port, dst_port))
+    logger.info("Tagged packet to be sent from port {} to port {}".format(src_port[0], dst_port))
 
     testutils.send(ptfadapter, src_port[0], transmit_tagged_pkt)
 
@@ -419,9 +419,9 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list):
         raise
     
     logger.info("One Way Tagged Packet Transmission Works")
-    logger.info("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
+    logger.info("Tagged packet successfully sent from port {} to port {}".format(src_port[0], dst_port))
 
-    logger.info("Tagged packet to be sent from port {} to port {}".format(dst_port, src_port))
+    logger.info("Tagged packet to be sent from port {} to port {}".format(dst_port[0], src_port))
 
     testutils.send(ptfadapter, dst_port[0], return_transmit_tagged_pkt)
 
@@ -433,7 +433,7 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list):
         raise
 
     logger.info("Two Way Tagged Packet Transmission Works")
-    logger.info("Tagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
+    logger.info("Tagged packet successfully sent from port {} to port {}".format(dst_port[0], src_port))
 
 
 @pytest.mark.bsl
@@ -462,7 +462,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
 
-    logger.info("Untagged packet to be sent from port {} to port {}".format(src_port, dst_port))
+    logger.info("Untagged packet to be sent from port {} to port {}".format(src_port[0], dst_port))
 
     testutils.send(ptfadapter, src_port[0], transmit_untagged_pkt)
 
@@ -474,9 +474,9 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
         raise
 
     logger.info("One Way Untagged Packet Transmission Works")
-    logger.info("Untagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
+    logger.info("Untagged packet successfully sent from port {} to port {}".format(src_port[0], dst_port))
 
-    logger.info("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))
+    logger.info("Untagged packet to be sent from port {} to port {}".format(dst_port[0], src_port))
 
     testutils.send(ptfadapter, dst_port[0], return_transmit_untagged_pkt)
 
@@ -488,7 +488,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
         raise
 
     logger.info("Two Way Untagged Packet Transmission Works")
-    logger.info("Untagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
+    logger.info("Untagged packet successfully sent from port {} to port {}".format(dst_port[0], src_port))
 
 
 def test_vlan_tc6_tagged_qinq_switch_on_outer_tag(ptfadapter, vlan_ports_list, duthost):

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -9,11 +9,11 @@ import time
 import json
 import itertools
 import logging
-import pprint
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
+
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +23,17 @@ pytestmark = [
     pytest.mark.topology('t0')
 ]
 
+
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     return duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
+
 @pytest.fixture(scope="module")
 def vlan_intfs_list():
     return [ { 'vlan_id': vlan, 'ip': '192.168.{}.1/24'.format(vlan) } for vlan in vlan_id_list  ]
+
 
 @pytest.fixture(scope="module")
 def vlan_ports_list(cfg_facts, ptfhost):
@@ -97,7 +100,6 @@ def create_vlan_interfaces(vlan_ports_list, vlan_intfs_list, duthost, ptfhost):
 @pytest.fixture(scope="module", autouse=True)
 def setup_vlan(ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, vlan_ports_list, vlan_intfs_list, cfg_facts):
     duthost = duthosts[rand_one_dut_hostname]
-
     # --------------------- Setup -----------------------
     try:
         # Generate vlan info
@@ -231,6 +233,7 @@ def setUpArpResponder(vlan_ports_list, ptfhost):
         json.dump(d, file)
     ptfhost.copy(src='/tmp/from_t1.json', dest='/tmp/from_t1.json')
 
+
 def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
                         src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
 
@@ -245,6 +248,7 @@ def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff
                                 ip_ttl=ttl)
     return pkt
 
+
 def build_qinq_packet(outer_vlan_id, vlan_id,
                       src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff:ff:ff",
                       src_ip="192.168.0.1", dst_ip="192.168.0.2", ttl=64):
@@ -256,6 +260,7 @@ def build_qinq_packet(outer_vlan_id, vlan_id,
                              ip_dst=dst_ip,
                              ip_ttl=ttl)
     return pkt
+
 
 def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], device_number=0, timeout=1):
     for port in ports:
@@ -274,6 +279,7 @@ def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], d
         else:
             test.fail("Expected packet was not received on device %d, ports %s.\n"
                     % (device_number, str(port_group)))
+
 
 def verify_icmp_packets(ptfadapter, vlan_ports_list, vlan_port, vlan_id):
     untagged_pkt = build_icmp_packet(0)
@@ -310,6 +316,7 @@ def verify_icmp_packets(ptfadapter, vlan_ports_list, vlan_port, vlan_id):
                                     pkt=masked_tagged_pkt,
                                     ports=tagged_dst_ports,
                                     portchannel_ports=tagged_dst_pc_ports)
+
 
 @pytest.mark.bsl
 def test_vlan_tc1_send_untagged(ptfadapter, vlan_ports_list):
@@ -348,6 +355,7 @@ def test_vlan_tc2_send_tagged(ptfadapter, vlan_ports_list):
             testutils.send(ptfadapter, vlan_port["port_index"][0], pkt)
             verify_icmp_packets(ptfadapter, vlan_ports_list, vlan_port, permit_vlanid)
 
+
 @pytest.mark.bsl
 def test_vlan_tc3_send_invalid_vid(ptfadapter, vlan_ports_list):
     """
@@ -372,8 +380,9 @@ def test_vlan_tc3_send_invalid_vid(ptfadapter, vlan_ports_list):
         logger.info("Check on " + str(dst_ports) + "...")
         testutils.verify_no_packet_any(ptfadapter, masked_invalid_tagged_pkt, dst_ports)
 
+
 @pytest.mark.bsl
-def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
+def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list):
     """
     Test case #4
     Send packets w/ src and dst specified over tagged ports in vlan
@@ -381,50 +390,51 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     """
     vlan_ids = vlan_ports_list[0]['permit_vlanid'].keys()
     tagged_test_vlan = vlan_ids[0]
-    untagged_test_vlan = vlan_ids[1]
 
     ports_for_test = []
 
     for vlan_port in vlan_ports_list:
         if vlan_port['pvid'] != tagged_test_vlan:
-            ports_for_test.append(vlan_port['port_index'][0])
-
+            ports_for_test.append(vlan_port['port_index'])
 
     #take two tagged ports for test
     src_port = ports_for_test[0]
     dst_port = ports_for_test[-1]
 
-    src_mac = ptfadapter.dataplane.get_mac(0, src_port)
-    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port)
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
+    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
     transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_tagged_pkt = build_icmp_packet(vlan_id=tagged_test_vlan, src_mac=dst_mac, dst_mac=src_mac)
 
-    logger.info ("Tagged packet to be sent from port {} to port {}".format(src_port, dst_port))
+    logger.info("Tagged packet to be sent from port {} to port {}".format(src_port, dst_port))
 
-    testutils.send(ptfadapter, src_port, transmit_tagged_pkt)
+    testutils.send(ptfadapter, src_port[0], transmit_tagged_pkt)
 
-    result_dst_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=dst_port,
-                                      timeout=1, exp_pkt=transmit_tagged_pkt)
+    try:
+        testutils.verify_packets_any(ptfadapter, transmit_tagged_pkt, ports=dst_port)
+    except Exception as detail:
+        if "Did not receive expected packet on any of ports" in str(detail):
+            logger.error("Expected packet was not received")
+        raise
+    
+    logger.info("One Way Tagged Packet Transmission Works")
+    logger.info("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
 
-    if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
-        logger.info ("One Way Tagged Packet Transmission Works")
-        logger.info ("Tagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
-    else:
-        pytest.fail("Expected packet was not received")
+    logger.info("Tagged packet to be sent from port {} to port {}".format(dst_port, src_port))
 
-    logger.info ("Tagged packet to be sent from port {} to port {}".format(dst_port, src_port))
+    testutils.send(ptfadapter, dst_port[0], return_transmit_tagged_pkt)
 
-    testutils.send(ptfadapter, dst_port, return_transmit_tagged_pkt)
+    try:
+        testutils.verify_packets_any(ptfadapter, return_transmit_tagged_pkt, ports=src_port)
+    except Exception as detail:
+        if "Did not receive expected packet on any of ports" in str(detail):
+            logger.error("Expected packet was not received")
+        raise
 
-    result_src_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=src_port,
-                                      timeout=1, exp_pkt=return_transmit_tagged_pkt)
+    logger.info("Two Way Tagged Packet Transmission Works")
+    logger.info("Tagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
 
-    if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
-        logger.info ("Two Way Tagged Packet Transmission Works")
-        logger.info ("Tagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
-    else:
-        pytest.fail("Expected packet was not received")
 
 @pytest.mark.bsl
 def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
@@ -435,50 +445,50 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     """
     vlan_ids = vlan_ports_list[0]['permit_vlanid'].keys()
     tagged_test_vlan = vlan_ids[0]
-    untagged_test_vlan = vlan_ids[1]
 
     ports_for_test = []
 
     for vlan_port in vlan_ports_list:
         if vlan_port['pvid'] != tagged_test_vlan:
-            ports_for_test.append(vlan_port['port_index'][0])
+            ports_for_test.append(vlan_port['port_index'])
 
     #take two tagged ports for test
     src_port = ports_for_test[0]
     dst_port = ports_for_test[-1]
 
-    src_mac = ptfadapter.dataplane.get_mac(0, src_port)
-    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port)
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port[0]) 
+    dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
     transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
     return_transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=dst_mac, dst_mac=src_mac)
 
-    logger.info ("Untagged packet to be sent from port {} to port {}".format(src_port, dst_port))
+    logger.info("Untagged packet to be sent from port {} to port {}".format(src_port, dst_port))
 
-    testutils.send(ptfadapter, src_port, transmit_untagged_pkt)
+    testutils.send(ptfadapter, src_port[0], transmit_untagged_pkt)
 
-    result_dst_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=dst_port,
-                                      timeout=1, exp_pkt=transmit_untagged_pkt)
+    try:
+        testutils.verify_packets_any(ptfadapter, transmit_untagged_pkt, ports=dst_port)
+    except Exception as detail:
+        if "Did not receive expected packet on any of ports" in str(detail):
+            logger.error("Expected packet was not received")
+        raise
 
-    if isinstance(result_dst_if, ptfadapter.dataplane.PollSuccess):
-        logger.info ("One Way Untagged Packet Transmission Works")
-        logger.info ("Untagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
-    else:
-        pytest.fail("Expected packet was not received")
+    logger.info("One Way Untagged Packet Transmission Works")
+    logger.info("Untagged packet successfully sent from port {} to port {}".format(src_port, dst_port))
 
-    logger.info ("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))
+    logger.info("Untagged packet to be sent from port {} to port {}".format(dst_port, src_port))
 
-    testutils.send(ptfadapter, dst_port, return_transmit_untagged_pkt)
+    testutils.send(ptfadapter, dst_port[0], return_transmit_untagged_pkt)
 
-    result_src_if = testutils.dp_poll(ptfadapter, device_number=0, port_number=src_port,
-                                      timeout=1, exp_pkt=return_transmit_untagged_pkt)
+    try:
+        testutils.verify_packets_any(ptfadapter, return_transmit_untagged_pkt, ports=src_port)
+    except Exception as detail:
+        if "Did not receive expected packet on any of ports" in str(detail):
+            logger.error("Expected packet was not received")
+        raise
 
-
-    if isinstance(result_src_if, ptfadapter.dataplane.PollSuccess):
-        logger.info ("Two Way Untagged Packet Transmission Works")
-        logger.info ("Untagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
-    else:
-        pytest.fail("Expected packet was not received")
+    logger.info("Two Way Untagged Packet Transmission Works")
+    logger.info("Untagged packet successfully sent from port {} to port {}".format(dst_port, src_port))
 
 
 def test_vlan_tc6_tagged_qinq_switch_on_outer_tag(ptfadapter, vlan_ports_list, duthost):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For the following two testcases:
* `test_vlan_tc4_tagged_non_broadcast`
* `test_vlan_tc4_untagged_non_broadcast`
The chosen test interface could be a portchannel that has multiple
ports, so that the packet verification should check all the portchannel
member ports.

So to improve those tests:
1. use `verify_packets_any` to check all ports in `dest_port`.
2. format the code to enforce PEP8.
3. remove unused variables, imports, etc.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
For the following two testcases:
* `test_vlan_tc4_tagged_non_broadcast`
* `test_vlan_tc4_untagged_non_broadcast`
The chosen test interface could be a portchannel that has multiple
ports, so that the packet verification should check all the portchannel
member ports.

#### How did you do it?
1. use `verify_packets_any` to check all ports in `dest_port`.
2. format the code to enforce PEP8.
3. remove unused variables, imports, etc.

#### How did you verify/test it?
* run over testbeds has portchannels with multiple member ports
```
vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast PASSED                                                                                                                                   [ 50%]
vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast PASSED                                                                                                                                 [100%]

============================================================================== 2 passed, 4 deselected in 415.40 seconds ==============================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
