### PR TITLE
Fix wrong inventory file issue for testbed-cli.sh announce-routes

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -369,7 +369,7 @@ function announce_routes
 
   read_file $topology
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i "$inv_name" testbed_announce_routes.yml --vault-password-file="$passfile" \
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_announce_routes.yml --vault-password-file="$passfile" \
       -l "$server" -e vm_set_name="$vm_set_name" -e topo="$topo" -e ptf_ip="$ptf_ip" $@
 
   echo done


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The `testbed-cli.sh announce-routes` tool uses the inventory file embedded in testbed file.
For VS setup, by default file vtestbed.csv is used. The inventory file embedded in it is veos_vtb.
This works for VS setup because test server is defined in veos_vtb. For physical test setups,
this does not always work. The inventory file in testbed.csv (column inv_name) may not has
test server information. This will cause 'testbed-cli.sh announce-routes' not working for
physical setups.

#### How did you do it?

The fix is to always use $vmfile as inventory file internally when run 'testbed-cli.sh announce-routes'.
Then it works for both physical and VS setup. When we use the testbed-cli.sh tool for VS setup,
we usually need to specify vmfile using option like "-m veos_vtb".

#### How did you verify/test it?
Run `testbed-cli.sh announce-routes` for both VS setup and physical testbeds using different testbed and inventory files.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
