### PR TITLE
Fix test_sub_port_interfaces

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -84,12 +84,12 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
             vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
             vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)
 
-    interface_ranges = range(1, 3)
+    interface_num = 2
     ip_subnet = u'172.16.0.0/16'
     prefix = 30
     subnet = ipaddress.ip_network(ip_subnet)
 
-    config_port_indices, ptf_ports = get_port(duthost, ptfhost, interface_ranges, request.param)
+    config_port_indices, ptf_ports = get_port(duthost, ptfhost, interface_num, request.param)
 
     subnets = [i for i, _ in zip(subnet.subnets(new_prefix=22), config_port_indices)]
 

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -1,5 +1,4 @@
 import os
-from sys import path_importer_cache
 import time
 
 from collections import OrderedDict
@@ -417,9 +416,10 @@ def get_port(duthost, ptfhost, interface_num, port_type):
         portchannel_members += v.keys()
 
     config_vlan_members = cfg_facts['port_index_map']
+    port_status = cfg_facts['PORT']
     config_port_indices = {}
     for k, v in config_vlan_members.items():
-        if k not in portchannel_members:
+        if k not in portchannel_members and cfg_facts['PORT'][k].get('admin_status', 'down') == 'up':
             config_port_indices[v] = k
             if len(config_port_indices) == interface_num:
                 break

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -1,4 +1,5 @@
 import os
+from sys import path_importer_cache
 import time
 
 from collections import OrderedDict
@@ -7,7 +8,7 @@ import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
 
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 
 
@@ -302,13 +303,15 @@ def create_lag_port(duthost, config_port_indices):
         Dictonary of lag ports on the DUT
     """
     lag_port_map = {}
-    for port_index, port_name in config_port_indices.items():
-        lag_port = 'PortChannel{}'.format(port_index)
+    portchannel_idx = 1
+    for _, port_name in config_port_indices.items():
+        lag_port = 'PortChannel{}'.format(portchannel_idx)
         remove_ip_from_port(duthost, port_name)
         remove_member_from_vlan(duthost, '1000', port_name)
         duthost.shell('config portchannel add {}'.format(lag_port))
         duthost.shell('config portchannel member add {} {}'.format(lag_port, port_name))
-        lag_port_map[port_index] = lag_port
+        lag_port_map[portchannel_idx] = lag_port
+        portchannel_idx += 1
 
     return lag_port_map
 
@@ -395,24 +398,38 @@ def check_namespace(ptfhost, name_of_namespace):
     return name_of_namespace in out
 
 
-def get_port(duthost, ptfhost, interface_ranges, port_type):
+def get_port(duthost, ptfhost, interface_num, port_type):
     """
     Get port configurations from DUT and PTF
 
     Args:
         duthost: DUT host object
         ptfhost: PTF host object
-        interface_ranges: numbers of ports
+        interface_num: number of ports
         port_type: Type of port
 
     Returns:
         Tuple with port configurations of DUT and PTF
     """
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    portchannel_members = []
+    for _, v in cfg_facts['PORTCHANNEL_MEMBER'].items():
+        portchannel_members += v.keys()
+
     config_vlan_members = cfg_facts['port_index_map']
-    config_port_indices = {v: k for k, v in cfg_facts['port_index_map'].items() if k in config_vlan_members and v in interface_ranges}
+    config_port_indices = {}
+    for k, v in config_vlan_members.items():
+        if k not in portchannel_members:
+            config_port_indices[v] = k
+            if len(config_port_indices) == interface_num:
+                break
+
+    pytest_require(len(config_port_indices) == interface_num, "No port for testing")
+    
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
-    ptf_ports = {port_id: ptf_ports_available_in_topo[port_id] for port_id in interface_ranges}
+    ptf_ports = {}
+    for k in config_port_indices.keys():
+            ptf_ports[k] = ptf_ports_available_in_topo[k]
 
     if 'port_in_lag' in port_type:
         lag_port_map = create_lag_port(duthost, config_port_indices)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to stabilize ```test_sub_port_interfaces``` on some platform.
There are two major reasons for test failure of ```test_sub_port_interfaces```
1. The ports selected for testing may be members of PortChannels. Adding such ports into other PortChannel or adding sub ports for such ports will cause exception.
2. The length of name of ```PortChannel + sub port tag``` might exceed 15, which is not allowed.

This PR addresses these 2 issues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to stabilize ```test_sub_port_interfaces``` on some platform.

#### How did you do it?
1. Ensure interfaces selected for testing are not members of other portchannels.
2. Shorten the name of added portchannel.

#### How did you verify/test it?
Verified on SN4600 testbed. All cases passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
