### PR TITLE
[platform][api] skip new get_revision tests if version 201811 / 201911 / 202012

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -5,6 +5,7 @@ import collections
 import inspect
 import ipaddress
 import logging
+import pytest
 import six
 import sys
 import threading
@@ -21,6 +22,16 @@ from tests.common.cache import FactsCache
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
+
+
+def skip_version(duthost, version_list):
+    """
+    @summary: Skip current test if any given version keywords are in os_version
+    @param duthost: The DUT
+    @param version_list: A list of incompatible versions
+    """
+    if any(version in duthost.os_version for version in version_list):
+        pytest.skip("DUT has version {} and test supports {}".format(duthost.os_version, ", ".join(version_list)))
 
 
 def wait(seconds, msg=""):

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -5,14 +5,14 @@ import collections
 import inspect
 import ipaddress
 import logging
-import pytest
+import re
 import six
 import sys
 import threading
 import time
-import re
-
 from io import BytesIO
+
+import pytest
 from ansible.parsing.dataloader import DataLoader
 from ansible.inventory.manager import InventoryManager
 from ansible.vars.manager import VariableManager

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -31,7 +31,7 @@ def skip_version(duthost, version_list):
     @param version_list: A list of incompatible versions
     """
     if any(version in duthost.os_version for version in version_list):
-        pytest.skip("DUT has version {} and test supports {}".format(duthost.os_version, ", ".join(version_list)))
+        pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(version_list)))
 
 
 def wait(seconds, msg=""):

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -8,6 +8,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, module
 from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_visible_vars
+from tests.common.utilities import skip_version
 
 from platform_api_test_base import PlatformApiTestBase
 
@@ -129,6 +130,8 @@ class TestChassisApi(PlatformApiTestBase):
         self.compare_value_with_device_facts(duthost, 'serial', serial)
 
     def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_version(duthost, ["201811", "201911", "202012"])
         revision = chassis.get_revision(platform_api_conn)
         pytest_assert(revision is not None, "Unable to retrieve chassis serial number")
         pytest_assert(isinstance(revision, STRING_TYPE), "Chassis serial number appears incorrect")

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -6,6 +6,7 @@ import yaml
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, psu
+from tests.common.utilities import skip_version
 from tests.platform_tests.cli.util import get_skip_mod_list
 from platform_api_test_base import PlatformApiTestBase
 
@@ -103,6 +104,8 @@ class TestPsuApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_version(duthost, ["201811", "201911", "202012"])
         for i in range(self.num_psus):
             revision = psu.get_revision(platform_api_conn, i)
             if self.expect(revision is not None, "Unable to retrieve PSU {} serial number".format(i)):


### PR DESCRIPTION
### Description of PR
Added utility function to skip tests on specific versions of SONiC and implemented this in the `get_revision()` tests in `test_chassis` and `test_psu` that are currently failing on older versions.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Tests are failing on 201811 / 201911 / 202012 which don't have the `get_revision` platform API call defined.

#### How did you do it?
Added a utility which uses the DUT  `os_version` to check the version of SONiC against a given list of incompatible versions. 

#### How did you verify/test it?
Run test and verify skip on pre `202106` versions. 

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Platform test, no topo. 

### Documentation 
Bugfix, no additional docs. 
