### PR TITLE
[mux_sim]: Add recovery method

### DIFF
--- a/tests/common/dualtor/constants.py
+++ b/tests/common/dualtor/constants.py
@@ -10,6 +10,7 @@ DROP = "drop"
 OUTPUT = "output"
 FLAP_COUNTER = "flap_counter"
 CLEAR_FLAP_COUNTER = "clear_flap_counter"
+RESET = "reset"
 
 MUX_SIM_ALLOWED_DISRUPTION_SEC = 5
 CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC = 120

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -5,7 +5,7 @@ import urllib2
 
 from tests.common import utilities
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT, FLAP_COUNTER, CLEAR_FLAP_COUNTER
+from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT, FLAP_COUNTER, CLEAR_FLAP_COUNTER, RESET
 
 __all__ = ['check_simulator_read_side', 'mux_server_url', 'url', 'recover_all_directions', 'set_drop', 'set_output', 'toggle_all_simulator_ports_to_another_side', \
            'toggle_all_simulator_ports_to_lower_tor', 'toggle_all_simulator_ports_to_random_side', 'toggle_all_simulator_ports_to_upper_tor', \
@@ -55,7 +55,7 @@ def url(mux_server_url, duthost, tbinfo):
         """
         if not interface_name:
             if action:
-                # Only for flap_counter or clear_flap_counter
+                # Only for flap_counter, clear_flap_counter, or reset
                 return mux_server_url + "/{}".format(action)
             return mux_server_url
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -388,3 +388,17 @@ def simulator_clear_flap_counters(url):
     data = {"port_to_clear": "all"}
     pytest_assert(_post(server_url, data), "Failed to clear flap counter for all ports")
 
+@pytest.fixture
+def reset_simulator_port(url):
+
+    def _reset_simulator_port(interface_name):
+        server_url = url(interface_name=interface_name, action=RESET) 
+        pytest_assert(_post(server_url, {}))
+
+    return _reset_simulator_port
+
+@pytest.fixture
+def reset_all_simulator_ports(url):
+
+    server_url = url(action=RESET)
+    pytest_assert(_post(server_url, {}))


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
It is possible for the OVS flow configurations used by the mux simulator to become stuck in a bad state.

#### How did you do it?
* In the mux simulator, infer the interface to device mapping (which interface is associated with NIC, upper tor, and lower tor) by sorting the output from `ovs-vsctl list-ports` instead of assuming that the output is in the correct order
* In the mux simulator, add methods to reset flows from the NIC and from the ToR side
    * For the NIC, delete all flows originating from the NIC interface and add a new flow from the NIC which outputs to both ToR interfaces
    * For the ToR side, delete all flows originating from either ToR interface and add a new flow from a randomly selected ToR interface which outputs to the NIC interface
    * Add a wrapper method to reset both ToR and NIC flows for a single interface
  	* Add handlers to enable reset of all flows for a VM set with a single POST request
* In mux_simulator_control, add fixtures to reset a single port and all ports for a given testbed

#### How did you verify/test it?
* Use the new tools to recover a testbed with broken flow configurations, and verify that the configuration is correct afterward
* Also verify that the mux state on a dual ToR testbed changes from 'unknown' to either 'active' or 'standby'

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
