### PR TITLE
Dual ToR test cases for verification for DSCP->Q mapping and ECN

### DIFF
--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -9,7 +9,6 @@ from scapy.all import IP, Ether
 from tests.common.dualtor import dual_tor_utils
 from tests.common.utilities import dump_scapy_packet_show_output
 
-
 @pytest.fixture(scope="function")
 def tunnel_traffic_monitor(ptfadapter, tbinfo):
     """Return TunnelTrafficMonitor to verify inter-ToR tunnel traffic."""
@@ -57,7 +56,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
         def _check_ttl(packet):
             """Check ttl field in the packet."""
             outer_ttl, inner_ttl = packet[IP].ttl, packet[IP].payload[IP].ttl
-            logging.debug("Outer packet TTL: %s, inner packet TTL: %s", outer_ttl, inner_ttl)
+            logging.info("Outer packet TTL: %s, inner packet TTL: %s", outer_ttl, inner_ttl)
             if outer_ttl != 255:
                 return "outer packet's TTL expected TTL 255, actual %s" % outer_ttl
             return ""
@@ -72,14 +71,76 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             outer_tos, inner_tos = packet[IP].tos, packet[IP].payload[IP].tos
             outer_dscp, outer_ecn = _disassemble_ip_tos(outer_tos)
             inner_dscp, inner_ecn = _disassemble_ip_tos(inner_tos)
-            logging.debug("Outer packet DSCP: {0:06b}, inner packet DSCP: {1:06b}".format(outer_dscp, inner_dscp))
-            logging.debug("Outer packet ECN: {0:02b}, inner packet ECN: {0:02b}".format(outer_ecn, inner_ecn))
+            logging.info("Outer packet DSCP: {0:06b}, inner packet DSCP: {1:06b}".format(outer_dscp, inner_dscp))
+            logging.info("Outer packet ECN: {0:02b}, inner packet ECN: {0:02b}".format(outer_ecn, inner_ecn))
             check_res = []
             if outer_dscp != inner_dscp:
                 check_res.append("outer packet DSCP not same as inner packet DSCP")
             if outer_ecn != inner_ecn:
                 check_res.append("outer packet ECN not same as inner packet ECN")
             return " ,".join(check_res)
+
+        @staticmethod
+        def _check_queue(self, packet):
+            """Check queue for encap packet."""
+
+            def _disassemble_ip_tos(tos):
+                return tos >> 2, tos & 0x3
+
+            def derive_queue_id_from_dscp(dscp):
+                """ Derive queue id form DSCP using following mapping
+                      DSCP -> Queue mapping
+                        8          0
+                        5          2
+                        3          3
+                        4          4
+                        46         5
+                        48         6
+                        Rest       1
+                """
+
+                if dscp == 8:
+                    queue = 0
+                elif dscp == 5:
+                    queue = 2
+                elif dscp == 3:
+                    queue = 3
+                elif dscp == 4:
+                    queue = 4
+                elif dscp == 46:
+                    queue = 5
+                elif dscp == 48:
+                    queue = 6
+                else:
+                    queue = 1
+
+                return queue
+
+            outer_tos, inner_tos = packet[IP].tos, packet[IP].payload[IP].tos
+            outer_dscp, outer_ecn = _disassemble_ip_tos(outer_tos)
+            inner_dscp, inner_ecn = _disassemble_ip_tos(inner_tos)
+            logging.info("Outer packet DSCP: {0:06b}, inner packet DSCP: {1:06b}".format(outer_dscp, inner_dscp))
+            check_res = []
+            if outer_dscp != inner_dscp:
+                check_res.append("outer packet DSCP not same as inner packet DSCP")
+            exp_queue = derive_queue_id_from_dscp(outer_dscp)
+
+            time.sleep(10)
+            queue_counter = self.standby_tor.shell('sudo show queue counters | grep "UC"')['stdout']
+            logging.debug('queue_counter:\n{}'.format(queue_counter))
+            result = re.search(r'\S+\s+UC\d\s+10+\s+\S+\s+\S+\s+\S+', queue_counter)
+
+            rec_queue = 0
+            if result != None:
+                output = result.group(0)
+                output_list = output.split()
+                rec_queue = int(output_list[1][2])
+
+            if rec_queue != exp_queue:
+                pytest.fail("the expected Queue : {} not matching with received Queue : {}".format(exp_queue, rec_queue))
+            else:
+                logging.info("the expected Queue : {} matching with received Queue : {}".format(exp_queue, rec_queue))
+            return ""
 
         def __init__(self, standby_tor, active_tor=None, existing=True):
             """
@@ -133,17 +194,20 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             else:
                 self.rec_pkt = Ether(rec_pkt)
                 rec_port = self.listen_ports[port_index]
-                logging.debug("Receive encap packet from PTF interface %s", "eth%s" % rec_port)
-                logging.debug("Encapsulated packet:\n%s", dump_scapy_packet_show_output(self.rec_pkt))
+                logging.info("Receive encap packet from PTF interface %s", "eth%s" % rec_port)
+                logging.info("Encapsulated packet:\n%s", dump_scapy_packet_show_output(self.rec_pkt))
                 if not self.existing:
                     raise RuntimeError("Detected tunnel traffic from host %s." % self.standby_tor.hostname)
                 ttl_check_res = self._check_ttl(self.rec_pkt)
                 tos_check_res = self._check_tos(self.rec_pkt)
+                queue_check_res = self._check_queue(self, self.rec_pkt)
                 check_res = []
                 if ttl_check_res:
                     check_res.append(ttl_check_res)
                 if tos_check_res:
                     check_res.append(tos_check_res)
+                if queue_check_res:
+                    check_res.append(queue_check_res)
                 if check_res:
                     raise ValueError(", ".join(check_res) + ".")
 

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -233,6 +233,11 @@ def test_dscp_to_queue_during_decap_on_active(
     exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
     exp_pkt = build_expected_packet_to_server(encapsulated_packet)
 
+    # Clear queue counters
+    duthost = duthosts[rand_one_dut_hostname]
+    duthost.shell('sonic-clear queuecounters')
+    logging.info("Clearing queue counters before starting traffic")
+
     ptfadapter.dataplane.flush()
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
@@ -273,6 +278,11 @@ def test_dscp_to_queue_during_encap_on_standby(
     iface, _ = rand_selected_interface
 
     exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+
+    # Clear queue counters
+    duthost = duthosts[rand_one_dut_hostname]
+    duthost.shell('sonic-clear queuecounters')
+    logging.info("Clearing queue counters before starting traffic")
 
     ptfadapter.dataplane.flush()
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -1,0 +1,420 @@
+"""
+    Test cases :
+    1. Verification of DSCP -> Q mapping
+        1.1. During packet encapsulation while egressing out of standby and going to T1
+        1.2. During packet decapsulation while egressing out of active and going to server
+    2. ECN marking
+        2.1. During packet encapsulation while egressing out of standby and going to T1
+        2.2. During packet decapsulation while egressing out of active and going to server
+    3. Stamping of ECN marking after packet encapsulation while egressing out of standby and going to T1
+"""
+
+import logging
+import pytest
+import random
+import time
+
+from ptf import mask
+from ptf import testutils
+from scapy.all import Ether, IP
+from tests.common.dualtor.dual_tor_mock import *
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
+from tests.common.dualtor.dual_tor_utils import rand_selected_interface
+from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
+from tests.common.utilities import is_ipv4_address
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder
+from tests.common.fixtures.ptfhost_utils import run_garp_service
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses
+from tests.common.utilities import dump_scapy_packet_show_output
+
+#from tests.saitests.sai_qos_tests import PortEnableDisable
+
+pytestmark = [
+    pytest.mark.topology("t0")
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_common_setup_teardown(
+    apply_mock_dual_tor_tables,
+    apply_mock_dual_tor_kernel_configs,
+    cleanup_mocked_configs,
+    request
+):
+    request.getfixturevalue("run_garp_service")
+
+@pytest.fixture(scope="function")
+def build_encapsulated_ip_packet(
+    rand_selected_interface, 
+    ptfadapter, 
+    rand_selected_dut, 
+    tunnel_traffic_monitor
+):
+    """
+    Build the encapsulated packet to be sent from T1 to ToR.
+    """
+    tor = rand_selected_dut
+    _, server_ips = rand_selected_interface
+    server_ipv4 = server_ips["server_ipv4"].split("/")[0]
+    config_facts = tor.get_running_config_facts()
+    try:
+        peer_ipv4_address = [_["address_ipv4"] for _ in config_facts["PEER_SWITCH"].values()][0]
+    except IndexError:
+        raise ValueError("Failed to get peer ToR address from CONFIG_DB")
+
+    tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback0"]
+                        if is_ipv4_address(_.split("/")[0])][0]
+    tor_ipv4_address = tor_ipv4_address.split("/")[0]
+
+    inner_dscp = random.choice(range(0, 33))
+    inner_ttl = random.choice(range(3, 65))
+    inner_ecn = random.choice(range(0,3))
+
+    inner_packet = testutils.simple_ip_packet(
+        ip_src="1.1.1.1",
+        ip_dst=server_ipv4,
+        ip_dscp=inner_dscp,
+        ip_ttl=inner_ttl,
+        ip_ecn=inner_ecn
+    )[IP]
+    packet = testutils.simple_ipv4ip_packet(
+        eth_dst=tor.facts["router_mac"],
+        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        ip_src=peer_ipv4_address,
+        ip_dst=tor_ipv4_address,
+        ip_dscp=inner_dscp,
+        ip_ttl=255,
+        ip_ecn=inner_ecn,
+        inner_frame=inner_packet
+    )
+    logging.info("the encapsulated packet to send:\n%s", dump_scapy_packet_show_output(packet))
+
+    return packet
+
+@pytest.fixture(scope="function")
+def build_non_encapsulated_ip_packet(
+    rand_selected_interface, 
+    ptfadapter, 
+    rand_selected_dut, 
+    tunnel_traffic_monitor
+):
+    """
+    Build the regular (non encapsulated) packet to be sent from T1 to ToR.
+    """
+    tor = rand_selected_dut
+    _, server_ips = rand_selected_interface
+    server_ipv4 = server_ips["server_ipv4"].split("/")[0]
+    config_facts = tor.get_running_config_facts()
+    try:
+        peer_ipv4_address = [_["address_ipv4"] for _ in config_facts["PEER_SWITCH"].values()][0]
+    except IndexError:
+        raise ValueError("Failed to get peer ToR address from CONFIG_DB")
+
+    tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback0"]
+                        if is_ipv4_address(_.split("/")[0])][0]
+    tor_ipv4_address = tor_ipv4_address.split("/")[0]
+
+    dscp = random.choice(range(0, 33))
+    ttl = random.choice(range(3, 65))
+    ecn = random.choice(range(0,3))
+
+    packet = testutils.simple_ip_packet(
+        eth_dst=tor.facts["router_mac"],
+        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        ip_src="1.1.1.1",
+        ip_dst=server_ipv4,
+        ip_dscp=dscp,
+        ip_ecn=ecn,
+        ip_ttl=ttl
+     )
+    logging.info("the regular IP packet to send:\n%s", dump_scapy_packet_show_output(packet))
+
+    return packet
+
+def get_ptf_server_intf_index(
+    tor, 
+    tbinfo, 
+    iface
+):
+    """
+    Get the index of ptf ToR-facing interface on ptf.
+    """
+    mg_facts = tor.get_extended_minigraph_facts(tbinfo)
+
+    return mg_facts["minigraph_ptf_indices"][iface]
+
+def build_expected_packet_to_server(
+    encapsulated_packet
+):
+    """
+    Build packet expected to be received by server from the tunnel packet.
+    """
+    inner_packet = encapsulated_packet[IP].payload[IP].copy()
+    # use dummy mac address that will be ignored in mask
+    inner_packet = Ether(src="aa:bb:cc:dd:ee:ff", dst="aa:bb:cc:dd:ee:ff") / inner_packet
+    exp_pkt = mask.Mask(inner_packet)
+    exp_pkt.set_do_not_care_scapy(Ether, "dst")
+    exp_pkt.set_do_not_care_scapy(Ether, "src")
+    exp_pkt.set_do_not_care_scapy(IP, "tos")
+    exp_pkt.set_do_not_care_scapy(IP, "ttl")
+    exp_pkt.set_do_not_care_scapy(IP, "chksum")
+
+    return exp_pkt
+
+def derive_queue_id_from_dscp(
+    dscp
+):
+    """  Derive queue id from dscp using followng mapping
+           DSCP -> Queue mapping
+            8          0
+            5          2
+            3          3
+            4          4
+            46         5
+            48         6
+            Rest       1
+    """
+    if dscp == 8:
+        queue = 0
+    elif dscp == 5:
+        queue = 2
+    elif dscp == 3:
+        queue = 3
+    elif dscp == 4:
+        queue = 4
+    elif dscp == 46:
+        queue = 5
+    elif dscp == 48:
+        queue = 6
+    else:
+        queue = 1
+
+    return queue
+
+def get_queue_id_of_received_packet(
+    duthosts, 
+    rand_one_dut_hostname, 
+    rand_selected_interface
+):
+    """
+    Get queue id of the packet received on destination
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    queue_counter = duthost.shell('sudo show queue counters {} | grep "UC"'.format(rand_selected_interface[0]))['stdout']
+    logging.info('queue_counter:\n{}'.format(queue_counter))
+    result = re.search(r'\S+\s+UC\d\s+10+\s+\S+\s+\S+\s+\S+', queue_counter)
+
+    if result is not None:
+        output = result.group(0)
+        output_list = output.split()
+        queue = int(output_list[1][2])
+    else:
+        logging.info("Error occured while fetching queue counters from DUT")
+        return None
+
+    return queue
+
+def verify_ecn_on_received_packet(
+    ptfadapter, 
+    exp_pkt, 
+    exp_ptf_port_index, 
+    exp_ecn
+):
+    """
+    Verify ECN value on the received packet w.r.t expected packet
+    """
+    _, rec_pkt = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index])
+    rec_pkt = Ether(rec_pkt)
+    logging.info("received packet:\n%s", dump_scapy_packet_show_output(rec_pkt))
+
+    if rec_pkt is not None:
+        rec_dscp = rec_pkt[IP].tos >> 2
+        rec_ecn = rec_pkt[IP].tos & 3
+    else:
+        logging.info("No packet recived on expected port")
+        return
+
+    if rec_ecn != exp_ecn:
+        pytest.fail("the expected ECN: {0:02b} not matching with received ECN: {0:02b}".format(exp_ecn, rec_ecn))
+    else:
+        logging.info("the expected ECN: {0:02b} matching with received ECN: {0:02b}".format(exp_ecn, rec_ecn))
+
+def test_dscp_to_queue_during_decap_on_active(
+    apply_active_state_to_orchagent,
+    build_encapsulated_ip_packet,
+    rand_selected_interface, 
+    ptfadapter,
+    tbinfo, 
+    rand_selected_dut, 
+    tunnel_traffic_monitor, 
+    duthosts, 
+    rand_one_dut_hostname
+):
+    """
+    Test if DSCP to Q mapping for inner header is matching with outer header during decap on active
+    """
+    tor = rand_selected_dut
+    encapsulated_packet = build_encapsulated_ip_packet
+    iface, _ = rand_selected_interface
+
+    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+    exp_pkt = build_expected_packet_to_server(encapsulated_packet)
+
+    ptfadapter.dataplane.flush()
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
+
+    exp_tos = encapsulated_packet[IP].payload[IP].tos
+    exp_dscp = exp_tos >> 2
+    exp_queue = derive_queue_id_from_dscp(exp_dscp)
+
+    _, rec_pkt = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index])
+    rec_pkt = Ether(rec_pkt)
+    logging.info("received decap packet:\n%s", dump_scapy_packet_show_output(rec_pkt))
+
+    time.sleep(10)
+    rec_queue = get_queue_id_of_received_packet(duthosts, rand_one_dut_hostname, rand_selected_interface)
+
+    if rec_queue == None or rec_queue != exp_queue:
+        pytest.fail("the expected Queue : {} not matching with received Queue : {}".format(exp_queue, rec_queue))
+    else:
+        logging.info("the expected Queue : {} matching with received Queue : {}".format(exp_queue, rec_queue))
+
+def test_dscp_to_queue_during_encap_on_standby(
+    build_non_encapsulated_ip_packet,
+    rand_selected_interface, ptfadapter,
+    tbinfo, 
+    rand_selected_dut, 
+    tunnel_traffic_monitor, 
+    duthosts, 
+    rand_one_dut_hostname
+):
+    """
+    Test if DSCP to Q mapping for outer header is matching with inner header during encap on standby
+    """
+    rand_selected_dut.shell("/usr/local/bin/write_standby.py")
+
+    tor = rand_selected_dut
+    non_encapsulated_packet = build_non_encapsulated_ip_packet
+    iface, _ = rand_selected_interface
+
+    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+
+    ptfadapter.dataplane.flush()
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
+    with tunnel_traffic_monitor(tor, existing=True):
+       testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=10)
+       time.sleep(2)
+
+def test_ecn_during_decap_on_active(
+    apply_active_state_to_orchagent,
+    build_encapsulated_ip_packet,
+    rand_selected_interface, 
+    ptfadapter,
+    tbinfo, 
+    rand_selected_dut, 
+    tunnel_traffic_monitor
+):
+    """
+    Test if the ECN stamping on inner header is matching with outer during decap on active
+    """
+    tor = rand_selected_dut
+    encapsulated_packet = build_encapsulated_ip_packet
+    iface, _ = rand_selected_interface
+
+    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+    exp_pkt = build_expected_packet_to_server(encapsulated_packet)
+
+    ptfadapter.dataplane.flush()
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
+    time.sleep(10)
+
+    exp_tos = encapsulated_packet[IP].payload[IP].tos
+    exp_ecn = exp_tos & 3
+    verify_ecn_on_received_packet(ptfadapter, exp_pkt, exp_ptf_port_index, exp_ecn)
+
+def test_ecn_during_encap_on_standby(
+    build_non_encapsulated_ip_packet,
+    rand_selected_interface, 
+    ptfadapter,
+    tbinfo, 
+    rand_selected_dut, 
+    tunnel_traffic_monitor
+):
+    """
+    Test if the ECN stamping on outer header is matching with inner during encap on standby
+    """
+    rand_selected_dut.shell("/usr/local/bin/write_standby.py")
+
+    tor = rand_selected_dut
+    non_encapsulated_packet = build_non_encapsulated_ip_packet
+    iface, _ = rand_selected_interface
+
+    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+
+    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+    logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
+    with tunnel_traffic_monitor(tor, existing=True):
+        testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=10)
+        time.sleep(2)
+
+#def test_ecn_marking_during_congestion_on_standby(
+#    duthosts,
+#    rand_one_dut_hostname,
+#    rand_one_dut_portname_oper_up,
+#    rand_one_dut_lossless_prio
+#):
+#    """
+#    Test if the DUT performs ECN marking during congestion on standby at the egress
+#    """
+#    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+#    dut_hostname2, lossless_prio = rand_one_dut_lossless_prio.split('|')
+#    pytest_require(rand_one_dut_hostname == dut_hostname == dut_hostname2,
+#                   "Priority and port are not mapped to the expected DUT")
+#
+#    duthost = duthosts[rand_one_dut_hostname]
+#    lossless_prio = int(lossless_prio)
+#
+#    kmin = 50000
+#    kmax = 51000
+#    pmax = 100
+#    pkt_size = 1024
+#    pkt_cnt = 100
+#
+#    """ Configure WRED/ECN thresholds """
+#    config_result = config_wred(host_ans=duthost,
+#                                kmin=kmin,
+#                                kmax=kmax,
+#                                pmax=pmax)
+#    pytest_assert(config_result is True, 'Failed to configure WRED/ECN at the DUT')
+#
+#    """ Enable ECN marking """
+#    enable_ecn(host_ans=duthost, prio=lossless_prio)
+#
+#    """ Configure PFC threshold to 2 ^ 3 """
+#    config_result = config_ingress_lossless_buffer_alpha(host_ans=duthost,
+#                                                         alpha_log2=3)
+#
+#    pytest_assert(config_result is True, 'Failed to configure PFC threshold to 8')
+#
+#    rand_selected_dut.shell("/usr/local/bin/write_standby.py")
+#
+#    tor = rand_selected_dut
+#    non_encapsulated_packet = build_non_encapsulated_ip_packet
+#    iface, _ = rand_selected_interface
+#
+#    PortEnableDisable.tx_disable(rand_selected_interface)
+#    exp_ptf_port_index = get_ptf_server_intf_index(tor, tbinfo, iface)
+#
+#    ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
+#    logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
+#    testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=10)
+#    time.sleep(5)
+#
+#    exp_tos = encapsulated_packet[IP].payload[IP].tos
+#    exp_ecn = exp_tos & 3
+#    verify_ecn_on_received_packet(ptfadapter, exp_pkt, exp_ptf_port_index, exp_ecn):

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -96,6 +96,22 @@ def get_rx_port(dp, device_number, src_port_id, dst_mac, dst_ip, src_ip):
 
     return result.port
 
+class PortEnableDisable(sai_base_test.ThriftInterfaceDataPlane):
+    def tx_disable(self, dst_port_id):
+        sai_base_test.ThriftInterfaceDataPlane.setUp(self)
+        time.sleep(5)
+        switch_init(self.client)
+
+        asic_type = self.test_params['sonic_asic_type']
+        sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
+
+    def tx_enable(self, dst_port_id):
+        sai_base_test.ThriftInterfaceDataPlane.setUp(self)
+        time.sleep(5)
+        switch_init(self.client)
+
+        asic_type = self.test_params['sonic_asic_type']
+        sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -96,6 +96,7 @@ def get_rx_port(dp, device_number, src_port_id, dst_mac, dst_ip, src_ip):
 
     return result.port
 
+
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -96,23 +96,6 @@ def get_rx_port(dp, device_number, src_port_id, dst_mac, dst_ip, src_ip):
 
     return result.port
 
-class PortEnableDisable(sai_base_test.ThriftInterfaceDataPlane):
-    def tx_disable(self, dst_port_id):
-        sai_base_test.ThriftInterfaceDataPlane.setUp(self)
-        time.sleep(5)
-        switch_init(self.client)
-
-        asic_type = self.test_params['sonic_asic_type']
-        sai_thrift_port_tx_disable(self.client, asic_type, [dst_port_id])
-
-    def tx_enable(self, dst_port_id):
-        sai_base_test.ThriftInterfaceDataPlane.setUp(self)
-        time.sleep(5)
-        switch_init(self.client)
-
-        asic_type = self.test_params['sonic_asic_type']
-        sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])
-
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
     def setUp(self):
         sai_base_test.ThriftInterfaceDataPlane.setUp(self)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Verify DSCP->Q mapping and ECN marking in dual ToR scenario

#### How did you do it?
Added test cases to verify DSCP -> Q mapping and ECN marking during encap/decap of packets on active/standby ToR.

#### How did you verify/test it?
Verified on single ToR mocked as dual ToR

#### Any platform specific information?
dual ToR

#### Supported testbed topology if it's a new test case?
T0

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
