### PR TITLE
[Ansible] Fix `restart-ptf`

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -82,4 +82,10 @@
   - name: Start PTF portchannel service
     include_tasks: ptf_portchannel.yml
 
+  - name: Announce routes
+    include_tasks: announce_routes.yml
+    when:
+      - topo != 'fullmesh'
+      - not 'ptf' in topo
+
   when: container_type == "PTF"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -15,6 +15,7 @@ function usage
   echo "    $0 [options] announce-routes <topo-name> <vault-password-file>"
   echo "    $0 [options] (gen-mg | deploy-mg | test-mg) <topo-name> <inventory> <vault-password-file>"
   echo "    $0 [options] (create-master | destroy-master) <k8s-server-name> <vault-password-file>"
+  echo "    $0 [options] restart-ptf <topo-name> <vault-password-file>"
   echo
   echo "Options:"
   echo "    -t <tbfile>     : testbed CSV file name (default: 'testbed.csv')"
@@ -62,6 +63,7 @@ function usage
   echo "        by default, data acl is enabled"
   echo "To create Kubernetes master on a server: $0 -m k8s_ubuntu create-master 'k8s-server-name'  ~/.password"
   echo "To destroy Kubernetes master on a server: $0 -m k8s_ubuntu destroy-master 'k8s-server-name' ~/.password"
+  echo "To restart ptf defined in testbed: $0 restart-ptf 'topo-name' ~/.password"
   echo
   echo "You should define your topology in testbed CSV file"
   echo


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Add few fixes for `restart-ptf`:

1. add announce route to `renumber_topo.yml`.
2. add missing help page for `restart-ptf` in `testbed-cli.sh`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
`exabgp` processes on ptf are not restored after `restart-ptf`

#### How did you do it?
1. add announce route to `renumber_topo.yml`.
2. add missing help page for `restart-ptf` in `testbed-cli.sh`.

#### How did you verify/test it?
```
# ./testbed-cli.sh restart-ptf vms6-t1-7060 password.txt
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
