### PR TITLE
Skip drop_counter test cases that require mellanox fanout

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -12,6 +12,7 @@ import ptf.packet as packet
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.utilities import get_inventory_files
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"
@@ -45,7 +46,9 @@ def fanouthost(request, duthosts, rand_one_dut_hostname, localhost):
             # Import fanout configuration handler based on vendor name
             if "mellanox" in file_name:
                 module = importlib.import_module("..fanout.{0}.{0}_fanout".format(file_name.strip(".py")), __name__)
-                fanout = module.FanoutHandler(duthost, localhost)
+                fanout = module.FanoutHandler(duthost, localhost, get_inventory_files(request))
+                if not fanout.is_mellanox:
+                    fanout = None
                 break
 
     yield fanout

--- a/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
+++ b/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
@@ -47,7 +47,7 @@ class FanoutHandler(BaseFanoutHandler):
             dut_facts = self.ansible_localhost.conn_graph_facts(host=duthost.hostname, filepath=LAB_CONNECTION_GRAPH_PATH)["ansible_facts"]
         except RunAnsibleModuleFail as e:
             if  "cannot find info for" in e.results['msg']:
-                return None
+                return
             else:
                 raise e
 

--- a/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
+++ b/tests/drop_packets/fanout/mellanox/mellanox_fanout.py
@@ -1,11 +1,14 @@
 import os
 import pytest
 from ..fanout_base import BaseFanoutHandler
+from tests.common.errors import RunAnsibleModuleFail
+from ansible.inventory.manager import InventoryManager
+from ansible.parsing.dataloader import DataLoader
 
 MAX_OPENFLOW_RULE_ID = 65535
-RUN_ANSIBLE_PLAYBOOK = "cd {ansible_path}; ansible-playbook {playbook} -i lab -l {fanout_host} --extra-vars \"{extra_vars}\" -vvvvv"
+RUN_ANSIBLE_PLAYBOOK = "cd {ansible_path}; ansible-playbook {playbook} -i {inventory} -l {fanout_host} --extra-vars \"{extra_vars}\" -vvvvv"
 # Ansible config files
-LAB_CONNECTION_GRAPH = os.path.normpath((os.path.join(os.path.dirname(__file__), "../../../../ansible/files/lab_connection_graph.xml")))
+LAB_CONNECTION_GRAPH_PATH = os.path.normpath((os.path.join(os.path.dirname(__file__), "../../../../ansible/files")))
 ANSIBLE_ROOT = os.path.normpath((os.path.join(__file__, "../../../../../ansible")))
 # Ansible playbook which executes Jinja template
 ANSIBLE_PLAYBOOK = os.path.join(os.path.dirname(__file__), "exec_template.yml")
@@ -13,16 +16,57 @@ ANSIBLE_PLAYBOOK = os.path.join(os.path.dirname(__file__), "exec_template.yml")
 DEL_RULE_TEMPLATE = os.path.join(os.path.dirname(__file__), "mlnx_del_of_rule.j2")
 
 
+def is_mellanox_devices(hwsku):
+    """
+    A helper function to check if a given sku is Mellanox device
+    """
+    hwsku = hwsku.lower()
+    return 'mellanox' in hwsku \
+        or 'msn' in hwsku \
+        or 'mlnx' in hwsku
+
+def find_inventory_file(hostname, inventory_files):
+    """
+    Find correct inventory file for given host
+    """
+    for inventory_file in inventory_files:
+        dataloader = DataLoader()
+        inv_mgr = InventoryManager(loader=dataloader, sources=inventory_files)
+        if hostname in inv_mgr.hosts.keys():
+            return inventory_file
+    return None
 class FanoutHandler(BaseFanoutHandler):
-    def __init__(self, duthost, localhost):
+    def __init__(self, duthost, localhost, inventory_files):
         self.initialized = False
         self.rule_id = MAX_OPENFLOW_RULE_ID
+        self.is_mellanox = False
+
         # Ansible localhost fixture which calls ansible playbook on the local host
         self.ansible_localhost = localhost
+        try:
+            dut_facts = self.ansible_localhost.conn_graph_facts(host=duthost.hostname, filepath=LAB_CONNECTION_GRAPH_PATH)["ansible_facts"]
+        except RunAnsibleModuleFail as e:
+            if  "cannot find info for" in e.results['msg']:
+                return None
+            else:
+                raise e
 
-        dut_facts = self.ansible_localhost.conn_graph_facts(host=duthost.hostname, filename=LAB_CONNECTION_GRAPH)["ansible_facts"]
         self.fanout_host = dut_facts["device_conn"][duthost.hostname]["Ethernet0"]["peerdevice"]
-        fanout_facts = self.ansible_localhost.conn_graph_facts(host=self.fanout_host, filename=LAB_CONNECTION_GRAPH)["ansible_facts"]
+        try:   
+            fanout_facts = self.ansible_localhost.conn_graph_facts(host=self.fanout_host, filepath=LAB_CONNECTION_GRAPH_PATH)["ansible_facts"]
+        except RunAnsibleModuleFail as e:
+            if  "cannot find info for" in e.results['msg']:
+                return
+            else:
+                raise e
+
+        fanout_sku = fanout_facts['device_info'][self.fanout_host]['HwSku']
+        if not is_mellanox_devices(fanout_sku):
+            return
+
+        self.fanout_inventory_file = find_inventory_file(self.fanout_host, inventory_files)
+        if not self.fanout_inventory_file:
+            return
 
         self.fanout_trunk_port = None
         for iface, iface_info in fanout_facts["device_port_vlans"][self.fanout_host].items():
@@ -31,6 +75,8 @@ class FanoutHandler(BaseFanoutHandler):
                 break
         else:
             raise Exception("Unable to identify Fanout Trunk port")
+        
+        self.is_mellanox = True
 
     def update_config(self, **kwargs):
         """
@@ -44,7 +90,7 @@ class FanoutHandler(BaseFanoutHandler):
             for key, value in kwargs.items():
                 extra_vars += "{}={} ".format(key, value)
 
-            add_flow = RUN_ANSIBLE_PLAYBOOK.format(ansible_path=ANSIBLE_ROOT, playbook=ANSIBLE_PLAYBOOK,
+            add_flow = RUN_ANSIBLE_PLAYBOOK.format(ansible_path=ANSIBLE_ROOT, playbook=ANSIBLE_PLAYBOOK, inventory=self.fanout_inventory_file,
                                                         fanout_host=self.fanout_host, extra_vars=extra_vars)
 
             res = self.ansible_localhost.shell(add_flow)
@@ -62,7 +108,7 @@ class FanoutHandler(BaseFanoutHandler):
     def restore_config(self):
         """ Delete openflow rule to clear previous configuration """
         if self.initialized:
-            del_flow = RUN_ANSIBLE_PLAYBOOK.format(ansible_path=ANSIBLE_ROOT, playbook=ANSIBLE_PLAYBOOK,
+            del_flow = RUN_ANSIBLE_PLAYBOOK.format(ansible_path=ANSIBLE_ROOT, playbook=ANSIBLE_PLAYBOOK, inventory=self.fanout_inventory_file,
                                                         fanout_host=self.fanout_host,
                                                         extra_vars="rule_id={} template_path={}".format(self.rule_id,
                                                                                                 DEL_RULE_TEMPLATE))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to add a check for the type of fanout switch and skip ```test_equal_smac_dmac_drop```, ```test_multicast_smac_drop``` and ```test_non_routable_igmp_pkts``` if the fanout switch is not mellanox, since these 3 test cases require mellanox fanout switch.

Besides, the ```inventory``` and ```connection_graph``` file are hardcoded before. This part is also updated in this PR. 

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
This PR is to skip ```drop_counter``` test cases that require mellanox fanout

#### How did you do it?
Add a check for the type of fanout switch and skip ```test_equal_smac_dmac_drop```, ```test_multicast_smac_drop``` and ```test_non_routable_igmp_pkts``` if the fanout switch is not mellanox.

#### How did you verify/test it?
Verified on SN4600, T0 testbed. The fanout switch is not ```Mellanox``` devices, and the 3 test  cases were skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
