### PR TITLE
Skip static route test for 201911 or older images

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -12,12 +12,20 @@ from tests.common import config_reload
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
+from pkg_resources import parse_version
 
 
 pytestmark = [
     pytest.mark.topology('t0'),
     pytest.mark.device_type('vs')
 ]
+
+
+def skip_201911_and_older(duthost):
+    """ Skip the current test if the DUT version is 201911 or older.
+    """
+    if parse_version(duthost.kernel_version) <= parse_version('4.9.0'):
+        pytest.skip("Test not supported for 201911 images or older. Skipping the test")
 
 
 def is_dualtor(tbinfo):
@@ -134,6 +142,7 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
 
 def test_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo)
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "1.1.1.0/24",
                           nexthop_addrs, prefix_len, nexthop_devs)
@@ -141,6 +150,7 @@ def test_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfad
 
 def test_static_route_ecmp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo, count=3)
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2.2.2.0/24",
                           nexthop_addrs, prefix_len, nexthop_devs, config_reload_test=True)
@@ -148,6 +158,7 @@ def test_static_route_ecmp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
 
 def test_static_route_ipv6(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo, ipv6=True)
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2000:1::/64",
                           nexthop_addrs, prefix_len, nexthop_devs, ipv6=True)
@@ -155,6 +166,7 @@ def test_static_route_ipv6(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
 
 def test_static_route_ecmp_ipv6(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, ptfhost, tbinfo):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs = get_nexthops(duthost, tbinfo, ipv6=True, count=3)
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2000:2::/64",
                           nexthop_addrs, prefix_len, nexthop_devs, ipv6=True, config_reload_test=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip static route test for 201911 or older images
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Skip static route test for 201911 or older images to avoid false alarm.

#### How did you do it?
Check the kernel version at the be beginning of static route tests and skip if the DUT is 201911 or older. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
