### PR TITLE
[pytest] Get critical processes from the line containing `process_checker`

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -188,7 +188,7 @@ def get_critical_process_from_monit(duthost, container_name):
         return critical_process_list, succeeded
 
     for line in file_content["stdout_lines"]:
-        if "check program" in line:
+        if "process_checker" in line:
             command_line = line.split(" {} ".format(container_name))[1].strip(" \n\"")
             critical_process_list.append(command_line)
 


### PR DESCRIPTION

Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

Initially this pytest script will parse the Monit configuration file of each container to get command lines of critical processes. Specifically this script will parse the line which contains the key string `check program`. For example, one Monit configuration entry of streaming telemetry is:

    `check program telemetry|dialout_client with path "/usr/bin/process_checker telemetry /usr/sbin/dialout_client_cli"`
          `if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles`

This script will get the command line ` /usr/sbin/dialout_client_cli` of critical process `dialout_client`. 
But from 20191130.73 image, we used `memory_checker` in Monit configuration of streaming telemetry to monitor the memory usage:

    `check program container_memory_telemetry with path "/usr/bin/memory_checker telemetry 419430400"`
        `if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service telemetry"`

So the pytest script will parse the `419430400` as command line of a critical process which obviously is wrong.


#### How did you do it?

I used the key string `process_checker` to indicate which line should be parsed.

#### How did you verify/test it?

I tested this change on DuT `str-msn2700-03`.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
