### PR TITLE
[mgmttor] add support for testbed type mgmttor

### DIFF
--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -204,14 +204,14 @@ class TestbedInfo(object):
                       explicit_start=True, Dumper=IncIndentDumper)
 
     def get_testbed_type(self, topo_name):
-        pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2|tgen)')
+        pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2|tgen|mgmttor)')
         match = pattern.match(topo_name)
         if match == None:
-            raise Exception("Unsupported testbed type - {}".format(topo_name))
+            logger.warning("Unsupported testbed type - {}".format(topo_name))
+            return "unsupported"
         tb_type = match.group()
-        if 'dualtor' in tb_type:
-            # augment dualtor topology type to 't0' to avoid adding it
-            # everywhere.
+        if 'dualtor' in tb_type or tb_type in ['mgmttor']:
+            # certain testbed types are in 't0' category with different names.
             tb_type = 't0'
         return tb_type
 


### PR DESCRIPTION
Summary:

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
marked one testbed as 'mgmttor' and all nightly tests are failing.

#### How did you do it?
Relax the testbed name check, return 'unsupported' when no match.
Generate warning so that it would be noticed and fixed. Also a
mistake won't cause other testbeds to fail nightly tests.

#### How did you verify/test it?
run test used to fail. see the warning and test proceeds on unaffected testbed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
