### PR TITLE
[mgmttor] Fix issue where announce_route module failed to read mgmttor topo

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -50,13 +50,14 @@ IPV6_BASE_PORT = 6000
 
 
 def get_topo_type(topo_name):
-    pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2)')
+    pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2|mgmttor)')
     match = pattern.match(topo_name)
     if not match:
-        raise Exception("Unsupported testbed type - {}".format(topo_name))
+        logger.warning("Unsupported testbed type - {}".format(topo_name))
+        return "unsupported"
     topo_type = match.group()
-    if 'dualtor' in topo_type:
-        # set dualtor topology type to 't0' to avoid adding it in each test script.
+    if tb_type in ['dualtor', 'mgmttor']:
+        # set dualtor/ topology type to 't0' to avoid adding it in each test script.
         topo_type = 't0'
     return topo_type
 

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -56,7 +56,7 @@ def get_topo_type(topo_name):
         logger.warning("Unsupported testbed type - {}".format(topo_name))
         return "unsupported"
     topo_type = match.group()
-    if tb_type in ['dualtor', 'mgmttor']:
+    if topo_type in ['dualtor', 'mgmttor']:
         # set dualtor/ topology type to 't0' to avoid adding it in each test script.
         topo_type = 't0'
     return topo_type

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -57,7 +57,7 @@ def get_topo_type(topo_name):
         return "unsupported"
     topo_type = match.group()
     if topo_type in ['dualtor', 'mgmttor']:
-        # set dualtor/ topology type to 't0' to avoid adding it in each test script.
+        # set dualtor/mgmttor topology type to 't0' to avoid adding it in each test script.
         topo_type = 't0'
     return topo_type
 

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -210,7 +210,7 @@ class TestbedInfo(object):
             logger.warning("Unsupported testbed type - {}".format(topo_name))
             return "unsupported"
         tb_type = match.group()
-        if 'dualtor' in tb_type or tb_type in ['mgmttor']:
+        if tb_type in ['mgmttor', 'dualtor']:
             # certain testbed types are in 't0' category with different names.
             tb_type = 't0'
         return tb_type


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix issue where announce_route module failed to read mgmttor topo.
The issue is same with https://github.com/Azure/sonic-mgmt/pull/3553

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Testbed includes the 'mgmttor' will cause test case failed due to couldn't parse the testbed_type

#### How did you do it?
Update testbed_type parsing logic

#### How did you verify/test it?
Remove & Add topo.
KVM test also verified: 
```
TASK [vm_set : Announce routes] ************************************************
Saturday 29 May 2021  03:16:31 +0000 (0:00:02.675)       0:03:06.802 ********** 
included: /var/src/s/ansible/roles/vm_set/tasks/announce_routes.yml for STR-ACS-VSERV-01
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
