### PR TITLE
Workaround for the announce_routes stuck issue

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -53,7 +53,6 @@ def get_topo_type(topo_name):
     pattern = re.compile(r'^(t0|t1|ptf|fullmesh|dualtor|t2|mgmttor)')
     match = pattern.match(topo_name)
     if not match:
-        logger.warning("Unsupported testbed type - {}".format(topo_name))
         return "unsupported"
     topo_type = match.group()
     if topo_type in ['dualtor', 'mgmttor']:
@@ -81,7 +80,7 @@ def announce_routes(ptf_ip, port, routes):
 
     url = "http://%s:%d" % (ptf_ip, port)
     data = { "commands": ";".join(messages) }
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, timeout=30)
     assert r.status_code == 200
 
 # AS path from Leaf router for T0 topology
@@ -422,17 +421,21 @@ def main():
 
     topo_type = get_topo_type(topo_name)
 
-    if topo_type == "t0":
-        fib_t0(topo, ptf_ip)
-        module.exit_json(changed=True)
-    elif topo_type == "t1":
-        fib_t1_lag(topo, ptf_ip)
-        module.exit_json(changed=True)
-    elif topo_type == "t2":
-        fib_t2_lag(topo, ptf_ip)
-        module.exit_json(changed=True)
-    else:
-        module.exit_json(msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))
+    try:
+        if topo_type == "t0":
+            fib_t0(topo, ptf_ip)
+            module.exit_json(changed=True)
+        elif topo_type == "t1":
+            fib_t1_lag(topo, ptf_ip)
+            module.exit_json(changed=True)
+        elif topo_type == "t2":
+            fib_t2_lag(topo, ptf_ip)
+            module.exit_json(changed=True)
+        else:
+            module.exit_json(msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))
+    except Exception as e:
+        module.fail_json(msg='Announcing routes failed, topo_name={}, topo_type={}, exception={}'\
+            .format(topo_name, topo_type, repr(e)))
 
 
 if __name__ == '__main__':

--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -248,10 +248,12 @@ def main():
         if state == 'started':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, dump_script=dump_script, passive=passive)
             setup_exabgp_supervisord_conf(name)
+            refresh_supervisord(module)
             start_exabgp(module, name)
         elif state == 'restarted':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, dump_script=dump_script, passive=passive)
             setup_exabgp_supervisord_conf(name)
+            refresh_supervisord(module)
             restart_exabgp(module, name)
         elif state == 'present':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, port, dump_script=dump_script, passive=passive)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We observed that the announcing routes step may got stuck ocassionally.
Possibly the stuck happened during HTTP posting to PTF docker to announce
routes. 

#### How did you do it?
This change made some changes to avoid the stuck forever issue.
* Add timeout to the requests.post method.
* Add try...except for the function calls of announcing routes in the
  announce_routes.py module.
* Force the exabgp module to refresh supervisord in case of start and restart.
* Remove the line of referring non-exist logger object in the
  announce_routes.py module.

#### How did you verify/test it?
Tested `testbed-cli.sh restart-ptf` and `testbed-cli.sh announce-routes`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
