### PR TITLE
Fix the PTF default gateway flushed issue

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -126,7 +126,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
                 module_ignore_errors=True)
             )
         results[node['host'].hostname] = node_results
-    
+
     results = parallel_run(configure_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
 
     check_results(results)
@@ -146,7 +146,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
         # Disable graceful restart in case of failure
         parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
         pytest.fail(err_msg)
-    
+
     yield
 
     results = parallel_run(restore_nbr_gr, (), {}, nbrhosts.values(), timeout=120)
@@ -454,7 +454,7 @@ def bgpmon_setup_teardown(ptfhost, duthost, localhost, setup_interfaces):
 
     # Flush neighbor and route in advance to avoid possible "RTNETLINK answers: File exists"
     ptfhost.shell("ip neigh flush to %s nud permanent" % dut_lo_addr)
-    ptfhost.shell("ip route flush match %s" % dut_lo_addr + "/32")
+    ptfhost.shell("ip route del %s" % dut_lo_addr + "/32", module_ignore_errors=True)
 
     # Add the route to DUT loopback IP  and the interface router mac
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (dut_lo_addr, duthost.facts["router_mac"], connection["neighbor_intf"]))
@@ -471,5 +471,5 @@ def bgpmon_setup_teardown(ptfhost, duthost, localhost, setup_interfaces):
     ptfhost.file(path=CUSTOM_DUMP_SCRIPT_DEST, state="absent")
     ptfhost.file(path=DUMP_FILE, state="absent")
     # Remove the route to DUT loopback IP  and the interface router mac
-    ptfhost.shell("ip route flush match %s" % dut_lo_addr + "/32")
+    ptfhost.shell("ip route del %s" % dut_lo_addr + "/32")
     ptfhost.shell("ip neigh flush to %s nud permanent" % dut_lo_addr)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
In tests/bgp/conftest.py, the bgpmon_setup_teardown fixture is to setup and teardown
configurations for BGP monitoring. To avoid configurations left over by other incompleted
tests, some code were added to cleanup ip neighbor and route before config change.
However, the command used for clearing ip route is:
    ptfhost.shell("ip route flush match %s" % dut_lo_addr + "/32")
This will cause the mgmt default gateway being flushed too.

#### How did you do it?
This fix is to change the command from 'ip route flush' to 'ip route del' which does not
have such side effect.

#### How did you verify/test it?
Test run tests/bgp/test_bgp_allow_list.py. Then check routes on the PTF docker after testing is completed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
