### PR TITLE
[add-topo] Fix regex to get fp port number

### DIFF
--- a/ansible/roles/eos/tasks/veos.yml
+++ b/ansible/roles/eos/tasks/veos.yml
@@ -2,7 +2,7 @@
   set_fact: ansible_user="root" ansible_password={{ eos_root_password }}
 
 - name: Get VM front panel interface number
-  shell: virsh domiflist {{ inventory_hostname }} | grep -E "^{{ inventory_hostname }}-t" | wc -l
+  shell: virsh domiflist {{ inventory_hostname }} | grep -E "^\s*{{ inventory_hostname }}-t" | wc -l
   register: fp_num
   delegate_to: "{{ VM_host[0] }}"
   become: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For VM host server with Libvirt newer versions(`6.0.0` tested), `virsh domiflist` outputs contains extra blank space before each line, so that
`fp_num` will be 0 and `bp_ifname` will be 1 in such case, the final `startup-config` for the VM will look like:
```
interface Ethernet1
 no switchport
 no shutdown
 ip address 10.0.0.41/31
 ipv6 enable
 ipv6 address fc00::52/126
 ipv6 nd ra suppress
 no shutdown
!
interface Loopback0
 description LOOPBACK
 ip address 100.1.0.21/32
 ipv6 enable
 ipv6 address 2064:100::15/128
 ipv6 nd ra suppress
 no shutdown
!
!
interface Ethernet1
 description backplane
 no switchport
 no shutdown
 ip address 10.10.246.21/24
 ipv6 enable
 ipv6 address fc0a::2a/64
 ipv6 nd ra suppress
 no shutdown
```
the backplane config will be applied to `Ethernet1` at last.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fix the `startup-config` error due to the wrong fp ports number.

#### How did you do it?
Add extra blank line match in the fp port regex.

#### How did you verify/test it?
run `add-topo`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
