### PR TITLE
[pfc-wd] Fixed test case "test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change" cleanup to prevent broken config_db.json

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -119,9 +119,15 @@ class PfcCmd(object):
         """
         logger.info("Updating dynamic threshold for {} to {}".format(profile, value))
         asic = dut.get_port_asic_instance(port)
+
+        if PfcCmd.isBufferInApplDb(asic):
+            db = "0"
+        else:
+            db = "4"
+
         asic.run_redis_cmd(
             argv = [
-                "redis-cli", "-n", "4", "HSET", profile, "dynamic_th", value
+                "redis-cli", "-n", db, "HSET", profile, "dynamic_th", value
             ]
         )
 


### PR DESCRIPTION
[pfc-wd] Fixed test case "test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change" cleanup to prevent broken config_db.json

Signed-off-by: Petro Pikh <petrop@nvidia.com>


Summary:  Fixed cleanup for test case "test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change". Without this fix - when do "config save -y" after test execution - config_db.json will be broken.
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
After execution of test case "test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change" and command "config save -y" config_db.json was broken.

#### How did you do it?
Change test case logic to do set in correct redis instance

#### How did you verify/test it?
Executed test case "test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change" and did command "config save -y" - checked generated config_db.json file.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

