### PR TITLE
Fix the dualtor orchagent stress test for single ToR

### DIFF
--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -156,6 +156,8 @@ def test_change_mux_state(
 
     # Apply mux active state
     load_swss_config(dut, _swss_path(SWSS_MUX_STATE_ACTIVE_CONFIG_FILE))
+    load_swss_config(dut, _swss_path(SWSS_MUX_STATE_STANDBY_CONFIG_FILE))
+    load_swss_config(dut, _swss_path(SWSS_MUX_STATE_ACTIVE_CONFIG_FILE))
 
     wait(3, 'extra wait for initial CRMs to be updated')
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
The dualtor orchagent stress test can be executed on single ToR with mock.
While executing on single ToR, due to limitation of mock, IP route to peer
switch is not yet present in routing table if just the SWSS_MUX_STATE_ACTIVE_CONFIG_FILE
config is applied. After the SWSS_MUX_STATE_STANDBY_CONFIG_FILE config
is applied, then the IP route to peer will be present in routing table. This will
consume 1 extra ipv4_nexthop resource. That's why CRM resource usages
before and after loading of the SWSS_MUX_STATE_STANDBY_CONFIG_FILE config
are different and the test failed on single ToR.

#### How did you do it?
The fix is to firstly apply SWSS_MUX_STATE_ACTIVE_CONFIG_FILE,
SWSS_MUX_STATE_STANDBY_CONFIG_FILE, and then
SWSS_MUX_STATE_ACTIVE_CONFIG_FILE. Collect CRM usage.
Then load the configs to change mux state multiple times and
collect CRM usage again. Compare the usage to see if there
is any CRM resource leak.

#### How did you verify/test it?
Run dualtor/test_orch_stress.py on both dualToR and single ToR testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
