### PR TITLE
[pytes] Get techsupport dump file name from the last line of the 'stdout'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -523,10 +523,8 @@ def collect_techsupport_on_dut(request, a_dut):
     # "function" scope
     testname = request.node.name
     if request.config.getoption("--collect_techsupport") and request.node.rep_call.failed:
-        res = a_dut.shell(
-            "generate_dump -s \"-2 hours\"", module_ignore_errors=True
-        )
-        fname = res['stdout']
+        res = a_dut.shell("generate_dump -s \"-2 hours\"")
+        fname = res['stdout_lines'][-1]
         a_dut.fetch(src=fname, dest="logs/{}".format(testname))
         tar = tarfile.open("logs/{}/{}/{}".format(testname, a_dut.hostname, fname))
         for m in tar.getmembers():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -523,7 +523,9 @@ def collect_techsupport_on_dut(request, a_dut):
     # "function" scope
     testname = request.node.name
     if request.config.getoption("--collect_techsupport") and request.node.rep_call.failed:
-        res = a_dut.shell("generate_dump -s \"-2 hours\"")
+        res = a_dut.shell(
+            "generate_dump -s \"-2 hours\"", module_ignore_errors=True
+        )
         fname = res['stdout']
         a_dut.fetch(src=fname, dest="logs/{}".format(testname))
         tar = tarfile.open("logs/{}/{}/{}".format(testname, a_dut.hostname, fname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
'generate_dump' command to collect techsupport can sometimes print messages when some file doesn't exist, or a commandis not found or a command is timed out.

e.g. ""Command: show queue counters timedout after 5 minutes"

In such cases use the last line from 'stdout' to get the dump filename. Currently it assumes that 'stdout' always contains a single line with the dump filename.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Make extracting dump filename robust.

#### How did you do it?
Always read the last line for the filename

#### How did you verify/test it?
Tested on sonic-mgmt pytest

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
