### PR TITLE
[201811] Port changes for 7050QX-32S-S4Q31 into 201811 branch

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -69,6 +69,11 @@
     connection: local
     when: "VM_topo | bool"
 
+  - name: get connection graph if defined for dut (ignore any errors)
+    conn_graph_facts: host="{{ inventory_hostname }}"
+    connection: local
+    ignore_errors: true
+
   - name: find interface name mapping and individual interface speed if defined
     port_alias: hwsku="{{ hwsku }}"
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -90,17 +90,17 @@
   - name: find all interface indexes mapping connecting to VM
     set_fact:
       interface_to_vms: "{{ interface_to_vms|default({}) | combine({ item.key: item.value['interface_indexes'] }) }}"
-    with_dict: vm_topo_config['vm']
+    with_dict: "{{ vm_topo_config['vm'] }}"
 
   - name: find all interface indexes connecting to VM
     set_fact:
       ifindex_to_vms: "{{ ifindex_to_vms|default([]) }} + {{ item.value['interface_indexes']}}"
-    with_dict: vm_topo_config['vm']
+    with_dict: "{{ vm_topo_config['vm'] }}"
 
   - name: find all interface names
     set_fact:
       intf_names: "{{ intf_names | default({}) | combine({item.key: port_alias[item.value[0]|int:item.value[-1]|int+1] }) }}"
-    with_dict: interface_to_vms
+    with_dict: "{{ interface_to_vms }}"
 
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -15,11 +15,12 @@
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>
           <Priority>0</Priority>
-{% set speed_option = port_speed | length %}
-{% if speed_option == 0 %}
-          <Speed>{{ iface_speed }}</Speed>
-{% else %}
+{% if port_speed[port_alias[index]] is defined %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
+{% elif device_conn[inventory_hostname][port_alias[index]] is defined %}
+          <Speed>{{ device_conn[inventory_hostname][port_alias[index]]['speed'] }}</Speed>
+{% else %}
+          <Speed>{{ iface_speed }}</Speed>
 {% endif %}
         </a:EthernetInterface>
 {% endfor %}

--- a/ansible/vars/topo_t0-35.yml
+++ b/ansible/vars/topo_t0-35.yml
@@ -1,0 +1,187 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+    - 26
+    - 27
+    - 28
+    - 29
+    - 30
+  disabled_host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 28
+    - 29
+    - 30
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 31
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 32
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 33
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 34
+      vm_offset: 3
+  DUT:
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+          prefix: 192.168.100.1/21
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200: 
+          id: 200
+          intfs: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+          prefix: 192.168.200.1/21
+          prefix_v6: fc02:200::1/64
+          tag: 200
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64


### PR DESCRIPTION

### Description of PR

Summary:
Port changes made for bringing up 7050QX-32S-S4Q31 from the master branch to the 201811 branch.

This PR includes the minigraph generation changes and the new topology.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Testing

Verified that at least one of the current setups successfully generated the same minigraph.
