### PR TITLE
[apiserver] Replace dot notation with bracket notation for dict variables

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -41,21 +41,27 @@
 
     - debug:
         msg: "[ WARNING ] Keysight API server container is already running hence not deploying again."
-      when: >
-        keysight_api_server_container_status.exists
-        and keysight_api_server_container_status.container['State']['Status'] == 'running'
+      when:
+        - keysight_api_server_container_status['exists']
+        - keysight_api_server_container_status['container']['State']['Status'] == 'running'
 
     - name: Start Keysight API Server container
       block:
+        - name: Assign rest port
+          set_fact:
+            rest_port: secret_group_vars['ixia_api_server']['rest_port']
+          when:
+            - secret_group_vars is defined
+            - secret_group_vars['ixia_api_server'] is defined
+            - secret_group_vars['ixia_api_server']['rest_port'] is defined
+
         - name: default secret_group_vars if not defined
           set_fact:
-            secret_group_vars:
-              ixia_api_server:
-                rest_port: 443
+            rest_port: 443
           when: >
             secret_group_vars is not defined
-            or secret_group_vars.ixia_api_server is not defined
-            or secret_group_vars.ixia_api_server.rest_port is not defined
+            or secret_group_vars['ixia_api_server'] is not defined
+            or secret_group_vars['ixia_api_server']['rest_port'] is not defined
 
         - name: Pull and start Keysight API Server container
           docker_container:
@@ -64,7 +70,7 @@
             pull: yes
             state: started
             restart: no
-            published_ports: "{{ secret_group_vars.ixia_api_server.rest_port }}:443"
+            published_ports: "{{ rest_port }}:443"
             detach: True
             capabilities:
               - net_admin
@@ -83,9 +89,9 @@
           become: yes
 
       when: >
-        not keysight_api_server_container_status.exists
-        or (keysight_api_server_container_status.exists
-        and keysight_api_server_container_status.container['State']['Status'] != 'running')
+        not keysight_api_server_container_status['exists']
+        or (keysight_api_server_container_status['exists']
+        and keysight_api_server_container_status['container']['State']['Status'] != 'running')
 
   when: container_type == "API-SERVER"
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
API server deployment was failing with the following error
TASK [vm_set : Pull and start Keysight API Server container] ***********************************************************************************************
task path: /var/nejo/Networking-acs-sonic-mgmt/ansible/roles/vm_set/tasks/add_topo.yml:55
Tuesday 25 May 2021  18:07:29 +0000 (0:00:00.039)       0:01:05.763 ***********
fatal: [STR2-ACS-SERV-20]: FAILED! => {
    "msg": "The field 'remote_user' has an invalid value, which includes an undefined variable. The error was: 'dict object' has no attribute 'vm_host'"
}

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

#### How did you do it?
Use brackets to access dictionary variables instead of dot notation

#### How did you verify/test it?
Ran add-topo successfully with the change