### PR TITLE
Added allure_server plugin

### DIFF
--- a/tests/common/plugins/allure_server/README.md
+++ b/tests/common/plugins/allure_server/README.md
@@ -1,0 +1,24 @@
+#### Allure server plugin usage example
+
+Below is described possibility of allure_server plugin usage.
+
+##### Structure
+allure_server plugin allows to upload allure report data to allure server
+
+Plugin parse pytest arguments:
+- "allure_server_addr" - Allure server address: IP/domain name, by default None
+- "allure_server_port" - Allure server port, by default 5050
+- "allure_server_project_id" - Allure server project ID, by default current timestamp used as project ID
+
+
+##### How it works
+By default if no allure server related atgs provided - plugin will do nothing.
+
+If provided "allure_server_addr" option provided - then plugin will check if "allure_report_dir" option provided and then
+it will do:
+- create project on allure server(if does not exist)
+- upload results to allure server
+- generate report on allure server
+
+Finally you will see allure report url in test logs.
+Example: "Allure report URL: http://1.2.3.4:5050/allure-docker-service/projects/162159947324/reports/1/index.html"

--- a/tests/common/plugins/allure_server/__init__.py
+++ b/tests/common/plugins/allure_server/__init__.py
@@ -1,0 +1,133 @@
+import time
+import logging
+import os
+import requests
+import base64
+
+logger = logging.getLogger()
+
+
+def pytest_addoption(parser):
+    """
+    Parse pytest options
+    :param parser: pytest buildin
+    """
+    parser.addoption('--allure_server_addr', action='store', default=None, help='Allure server address: IP/domain name')
+    parser.addoption('--allure_server_port', action='store', default=5050, help='Allure server port')
+    parser.addoption('--allure_server_project_id', action='store', default=None, help='Allure server project ID')
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    Pytest hook which are executed after all tests before exist from program
+    :param session: pytest buildin
+    :param exitstatus: pytest buildin
+    """
+    if not session.config.getoption("--collectonly"):
+        allure_server_addr = session.config.option.allure_server_addr
+        allure_server_port = session.config.option.allure_server_port
+        allure_server_project_id = session.config.option.allure_server_project_id
+
+        if allure_server_addr:
+            allure_report_dir = session.config.option.allure_report_dir
+            if allure_report_dir:
+                try:
+                    allure_server_odb = AllureServer(allure_server_addr, allure_server_port, allure_report_dir,
+                                                     allure_server_project_id)
+                    allure_server_odb.generate_allure_report()
+                except Exception as err:
+                    logger.error('Failed to upload allure report to server. Allure report not available. '
+                                 '\nError: {}'.format(err))
+            else:
+                logger.error('PyTest argument "--alluredir" not provided. Impossible to generate Allure report')
+
+
+def get_time_stamp_str():
+    """
+    This method return string with current time
+    :return: string, example: 16063138520755782
+    """
+    current_time = time.time()
+    current_time_without_dot = str(current_time).replace('.', '')
+    return current_time_without_dot
+
+
+class AllureServer:
+    def __init__(self, allure_server_ip, allure_server_port, allure_report_dir, project_id=None):
+        self.allure_report_dir = allure_report_dir
+        self.base_url = 'http://{}:{}/allure-docker-service'.format(allure_server_ip, allure_server_port)
+        self.project_id = project_id if project_id else get_time_stamp_str()
+        self.http_headers = {'Content-type': 'application/json'}
+
+    def generate_allure_report(self):
+        """
+        This method creates new project(if need) on allure server, uploads test results to server and generates report
+        """
+        self.create_project_on_allure_server()
+        self.upload_results_to_allure_server()
+        self.generate_report_on_allure_server()
+
+    def create_project_on_allure_server(self):
+        """
+        This method creates new project(if need) on allure server
+        """
+        data = {'id': self.project_id}
+        url = self.base_url + '/projects'
+
+        if requests.get(url + '/' + self.project_id).status_code != 200:
+            logger.info('Creating project {} on allure server'.format(self.project_id))
+            response = requests.post(url, json=data, headers=self.http_headers)
+            if response.raise_for_status():
+                logger.error('Failed to create project on allure server, error: {}'.format(response.content))
+        else:
+            logger.info('Allure project {} already exist on server. No need to create project'.format(self.project_id))
+
+    def upload_results_to_allure_server(self):
+        """
+        This method uploads files from allure results folder to allure server
+        """
+        data = {'results': self.get_allure_files_content()}
+        url = self.base_url + '/send-results?project_id=' + self.project_id
+
+        logger.info('Sending allure results to allure server')
+        response = requests.post(url, json=data, headers=self.http_headers)
+        if response.raise_for_status():
+            logger.error('Failed to upload results to allure server, error: {}'.format(response.content))
+
+    def get_allure_files_content(self):
+        """
+        This method creates a list all files under allure report folder
+        :return: list with allure folder content, example [{'file1': 'file content'}, {'file2': 'file2 content'}]
+        """
+        files = os.listdir(self.allure_report_dir)
+        results = []
+
+        for file in files:
+            result = {}
+            file_path = self.allure_report_dir + "/" + file
+            if os.path.isfile(file_path):
+                try:
+                    with open(file_path, "rb") as f:
+                        content = f.read()
+                        if content.strip():
+                            b64_content = base64.b64encode(content)
+                            result['file_name'] = file
+                            result['content_base64'] = b64_content.decode('UTF-8')
+                            results.append(result)
+                finally:
+                    f.close()
+        return results
+
+    def generate_report_on_allure_server(self):
+        """
+        This method would generate the report on the remote allure server and display the report URL in the log
+        """
+        logger.info('Generating report on allure server')
+        url = self.base_url + '/generate-report?project_id=' + self.project_id
+        response = requests.get(url, headers=self.http_headers)
+
+        if response.raise_for_status():
+            logger.error('Failed to generate report on allure server, error: {}'.format(response.content))
+        else:
+            report_url = response.json()['data']['report_url']
+            logger.info('Allure report URL: {}'.format(report_url))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,8 @@ pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.log_section_start',
                   'tests.common.plugins.custom_fixtures',
                   'tests.common.dualtor',
-                  'tests.vxlan')
+                  'tests.vxlan',
+                  'tests.common.plugins.allure_server')
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
### Description of PR
Added allure_server plugin which will allow to upload allure reports to allure server.
Plugin by default doing nothing. In case when provided "allure_server_addr" - we will try to upload test results to allure server.

Signed-off-by: Petro Pikh petrop@nvidia.com

Summary: Added allure_server plugin
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Allure reports can be stored locally or can be used by Jenkins plugin. In case when you do not use Jenkins and do not need to store report locally we can use allure-server(https://github.com/fescobar/allure-docker-service). This plugin allows to upload allure reports to allure-server.

#### How did you do it?
Added additional plugin to pytest which by default doing nothing

#### How did you verify/test it?
Executed pytest tests with and without option "allure_server_addr"

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
Added README.md file in plugin folder.
