### PR TITLE
[arp] Add support of t0-64 topology for test_arp_dualtor

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -1,9 +1,7 @@
 import logging
 import pytest
-import time
 
 from .args.wr_arp_args import add_wr_arp_args
-from .arp_utils import collect_info, get_po
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -36,10 +34,13 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     external_ports = [p for p in mg_facts['minigraph_ports'].keys() if 'BP' not in p]
     ports = list(sorted(external_ports, key=lambda item: int(item.replace('Ethernet', ''))))
 
-    portchannel_members = []
-    for _, v in config_facts['PORTCHANNEL_MEMBER'].items():
-        portchannel_members += v.keys()
-    ports_for_test = [x for x in ports if x not in portchannel_members]
+    if 'PORTCHANNEL_MEMBER' in config_facts:
+        portchannel_members = []
+        for _, v in config_facts['PORTCHANNEL_MEMBER'].items():
+            portchannel_members += v.keys()
+        ports_for_test = [x for x in ports if x not in portchannel_members]
+    else:
+        ports_for_test = ports
 
     # Select two interfaces for testing which are not in portchannel
     intf1 = ports_for_test[0]

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -29,41 +29,29 @@ def config_facts(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 
 @pytest.fixture(scope="module")
-def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):
+def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo, config_facts):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.asic_instance(enum_frontend_asic_index)
     mg_facts = asic.get_extended_minigraph_facts(tbinfo)
     external_ports = [p for p in mg_facts['minigraph_ports'].keys() if 'BP' not in p]
     ports = list(sorted(external_ports, key=lambda item: int(item.replace('Ethernet', ''))))
-    # Select port index 0 & 1 two interfaces for testing
-    intf1 = ports[0]
-    intf2 = ports[1]
+
+    portchannel_members = []
+    for _, v in config_facts['PORTCHANNEL_MEMBER'].items():
+        portchannel_members += v.keys()
+    ports_for_test = [x for x in ports if x not in portchannel_members]
+
+    # Select two interfaces for testing which are not in portchannel
+    intf1 = ports_for_test[0]
+    intf2 = ports_for_test[1]
     logger.info("Selected ints are {0} and {1}".format(intf1, intf2))
 
     intf1_indice = mg_facts['minigraph_ptf_indices'][intf1]
     intf2_indice = mg_facts['minigraph_ptf_indices'][intf2]
 
-    po1 = get_po(mg_facts, intf1)
-    po2 = get_po(mg_facts, intf2)
-
-    if po1 is not None:
-        asic.config_portchannel_member(po1, intf1, "del")
-        collect_info(duthost)
-        asic.startup_interface(intf1)
-        collect_info(duthost)
-    
-    if po2 is not None:
-        asic.config_portchannel_member(po2, intf2, "del")
-        collect_info(duthost)
-        asic.startup_interface(intf2)
-        collect_info(duthost)
-
     asic.config_ip_intf(intf1, "10.10.1.2/28", "add")
     asic.config_ip_intf(intf2, "10.10.1.20/28", "add")
 
-    if (po1 is not None) or (po2 is not None):
-        time.sleep(40)
-    
     yield intf1, intf2, intf1_indice, intf2_indice
 
     asic.config_ip_intf(intf1, "10.10.1.2/28", "remove")


### PR DESCRIPTION
  Signed-off-by: Vladyslav Morokhovych <vladyslavx.morokhovych@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add support of t0-64 and t0-64-32 topology for `test_arp_dualtor`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Fails of `test_arp_dualtor` when run on t0-64 topology.
When port that selected for tests was portchannel member
test delete this port from portchannel but do not add to VLAN and leave it in routed state.

#### How did you do it?
Change how ports are selecting for test in `conftest.py`.
After change, select ports for test that are not members of portchannel .

#### How did you verify/test it?
run `test_arp_dualtor` on t0, t0-64 and t0-64-32:

```
PASSED arp/test_arp_dualtor.py::test_arp_garp_enabled
PASSED arp/test_arp_dualtor.py::test_proxy_arp[v4]
PASSED arp/test_arp_dualtor.py::test_proxy_arp[v6]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
