### PR TITLE
[dut utils] protect against empty dut vars

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -19,7 +19,7 @@ def is_supervisor_node(inv_files, hostname):
           logic if possible to derive it from the DUT.
     """
     dut_vars = get_host_visible_vars(inv_files, hostname)
-    if 'card_type' in dut_vars and dut_vars['card_type'] == 'supervisor':
+    if dut_vars and 'card_type' in dut_vars and dut_vars['card_type'] == 'supervisor':
         return True
     return False
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When running test against a none existing dut, e.g. a wrong inventory was chosen, dut_util will throw exception due to host_vars are None, which is not directly helping finding the issue.

#### How did you do it?
Protect against host_var being none or empty.

#### How did you verify/test it?
Run a test with a wrong inventory specified. With the change. there is still an exception, but this time the exception is clear that the host name is not found.

Before the change:
/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:234: in pytest_pycollect_makeitem
    res = list(collector._genfunctions(name, obj))
/usr/local/lib/python2.7/dist-packages/_pytest/python.py:410: in _genfunctions
    self.ihook.pytest_generate_tests(metafunc=metafunc)
/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/usr/local/lib/python2.7/dist-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
conftest.py:913: in pytest_generate_tests
    duts_selected = generate_params_frontend_hostname(metafunc)
conftest.py:698: in generate_params_frontend_hostname
    if is_frontend_node(inv_files, dut):
common/helpers/dut_utils.py:36: in is_frontend_node
    return not is_supervisor_node(inv_files, hostname)
common/helpers/dut_utils.py:22: in is_supervisor_node
    if 'card_type' in dut_vars and dut_vars['card_type'] == 'supervisor':
E   TypeError: argument of type 'NoneType' is not iterable

After the change:
self = <pytest_ansible.host_manager.v28.HostManagerV28 object at 0x7fe887f62190>, item = 'str-s6000-on-4'

    def __getitem__(self, item):
        """Return a ModuleDispatcher instance described the provided `item`."""
        # Handle slicing
        if isinstance(item, slice):
            new_item = "all["
            if item.start is not None:
                new_item += str(item.start)
            new_item += '-'
            if item.stop is not None:
                new_item += str(item.stop)
            item = new_item + ']'
    
        if item in self.__dict__:
            return self.__dict__[item]
        else:
            if not self.has_matching_inventory(item):
>               raise KeyError(item)
E               KeyError: 'str-s6000-on-4'

item       = 'str-s6000-on-4'
self       = <pytest_ansible.host_manager.v28.HostManagerV28 object at 0x7fe887f62190>