### PR TITLE
[pytest] Test the feature of memory checker.

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -1,0 +1,201 @@
+"""
+Test the feature of memory checker.
+"""
+import logging
+from multiprocessing.pool import ThreadPool
+
+import pytest
+
+from pkg_resources import parse_version
+from tests.common.utilities import wait_until
+from tests.common.helpers.dut_utils import check_container_state
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_require
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+CONTAINER_STOP_THRESHOLD_SECS = 200
+CONTAINER_RESTART_THRESHOLD_SECS = 180
+CONTAINER_CHECK_INTERVAL_SECS = 1
+
+
+@pytest.fixture(autouse=True, scope="module")
+def modify_monit_config_and_restart(duthost):
+    """Backup Monit configuration file, then customize and restart it before testing. Restore original
+    Monit configuration file and restart it after testing.
+
+    Args:
+        duthost: Hostname of DuT.
+
+    Returns:
+        None.
+    """
+    logger.info("Back up Monit configuration file ...")
+    duthost.shell("sudo cp -f /etc/monit/monitrc /tmp/")
+
+    logger.info("Modifying Monit config to eliminate start delay and decrease interval ...")
+    duthost.shell("sudo sed -i 's/set daemon 60/set daemon 10/' /etc/monit/monitrc")
+    duthost.shell("sudo sed -i '/with start delay 300/s/^./#/' /etc/monit/monitrc")
+
+    logger.info("Restart Monit service ...")
+    duthost.shell("sudo systemctl restart monit")
+
+    yield
+
+    logger.info("Restore original Monit configuration ...")
+    duthost.shell("sudo mv -f /tmp/monitrc /etc/monit/")
+
+    logger.info("Restart Monit service ...")
+    duthost.shell("sudo systemctl restart monit")
+
+
+def install_stress_utility(duthost, container_name):
+    """Installs the 'stress' utility in container before testing.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container_name: Name of container.
+
+    Retuerns:
+        None.
+    """
+    logger.info("Installing 'stress' utility in '{}' container ...".format(container_name))
+
+    install_cmd_result = duthost.shell("docker exec {} bash -c 'export http_proxy=http://100.127.20.21:8080 \
+                                        && export https_proxy=http://100.127.20.21:8080 \
+                                        && apt-get install stress -y'".format(container_name))
+
+    exit_code = install_cmd_result["rc"]
+    pytest_assert(exit_code == 0, "Failed to install 'stress' utility!")
+    logger.info("'stress' utility was installed.")
+
+
+def remove_stress_utility(duthost, container_name):
+    """Removes the 'stress' utility from container after testing.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container_name: Name of container.
+
+    Retuerns:
+        None.
+    """
+    logger.info("Removing 'stress' utility on device ...")
+    remove_cmd_result = duthost.shell("docker exec {} apt-get remove stress -y".format(container_name))
+    exit_code = remove_cmd_result["rc"]
+    pytest_assert(exit_code == 0, "Failed to remove 'stress' utility!")
+    logger.info("'stress' utility was removed.")
+
+
+def eatup_memory(duthost, container_name):
+    """Eats up more than 400MB memory in specified container.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container_name: Name of container.
+
+    Retuerns:
+        None.
+    """
+    logger.info("Executing command 'stress -m 4' in '{}' container ...".format(container_name))
+    duthost.shell("docker exec {} stress -m 4".format(container_name), module_ignore_errors=True)
+
+
+def eatup_memory_and_restart_container(duthost, container_name):
+    """Invokes the 'stress' utility to eat up more than 400MB memory asynchronously and checkes
+    whether the container can be restarted or not.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container_name: Name of container.
+
+    Retuerns:
+        None.
+
+    """
+    thread_pool = ThreadPool()
+
+    thread_pool.apply_async(eatup_memory, (duthost, container_name))
+
+    logger.info("Waiting '{}' container to be stopped ...".format(container_name))
+    stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
+                         CONTAINER_CHECK_INTERVAL_SECS,
+                         check_container_state, duthost, container_name, False)
+    pytest_assert(stopped, "Failed to stop '{}' container!".format(container_name))
+    logger.info("'{}' container is stopped.".format(container_name))
+
+    logger.info("Waiting '{}' container to be restarted ...".format(container_name))
+    stopped = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
+                         CONTAINER_CHECK_INTERVAL_SECS,
+                         check_container_state, duthost, container_name, True)
+    pytest_assert(stopped, "Failed to restart '{}' container!".format(container_name))
+    logger.info("'{}' container is restarted.".format(container_name))
+
+
+def check_critical_processes(duthost, container_name):
+    """Checks whether the critical processes are running after container was restarted.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container_name: Name of container.
+
+    Retuerns:
+        None.
+    """
+    status_result = duthost.critical_process_status(container_name)
+    if status_result["status"] is False or len(status_result["exited_critical_process"]) > 0:
+        return False
+
+    return True
+
+
+def postcheck_critical_processes(duthost, container_name):
+    """Checks whether the critical processes are running after container was restarted.
+
+    Args:
+        duthost: The AnsibleHost object of DuT.
+        container_name: Name of container.
+
+    Retuerns:
+        None.
+    """
+    logger.info("Checking running status of critical processes in '{}' container ..."
+                .format(container_name))
+    is_succeeded = wait_until(CONTAINER_RESTART_THRESHOLD_SECS, CONTAINER_CHECK_INTERVAL_SECS,
+                              check_critical_processes, duthost, container_name)
+    if not is_succeeded:
+        pytest.fail("Not all critical processes in '{}' container are running!"
+                    .format(container_name))
+    logger.info("All critical processes in '{}' container are running.".format(container_name))
+
+
+def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """Checks whether the telemetry container can be restarted or not if the memory
+    usage of it is beyond 400MB.
+
+    Args:
+        duthosts: The fixture returns list of DuTs.
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture randomly pick up
+        a frontend DuT from testbed.
+
+    Returns:
+        None.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    # TODO: Currently we only test 'telemetry' container and need extend this
+    # testing on all containers after the feature 'memory_checker' is fully implemented.
+    container_name = "telemetry"
+
+    pytest_require(("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
+                   or parse_version(duthost.kernel_version) > parse_version("4.9.0"),
+                   "Test is not supported for 20191130.70 and older image versions!")
+
+    install_stress_utility(duthost, container_name)
+    eatup_memory_and_restart_container(duthost, container_name)
+    remove_stress_utility(duthost, container_name)
+    postcheck_critical_processes(duthost, container_name)

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -98,7 +98,7 @@ def consume_memory(duthost, container_name, vm_workers):
     Args:
         duthost: The AnsibleHost object of DuT.
         container_name: Name of container.
-        vm_workers: Nnumber of workers which does the spinning on malloc()/free()
+        vm_workers: Number of workers which does the spinning on malloc()/free()
           to consume memory.
 
     Returns:
@@ -109,13 +109,13 @@ def consume_memory(duthost, container_name, vm_workers):
 
 
 def consume_memory_and_restart_container(duthost, container_name, vm_workers):
-    """Invokes the 'stress' utility to consume memory more than threshold asynchronously and checkes
-    whether the container can be stopped and restarted.
+    """Invokes the 'stress' utility to consume memory more than the threshold asynchronously
+    and checks whether the container can be stopped and restarted.
 
     Args:
         duthost: The AnsibleHost object of DuT.
         container_name: Name of container.
-        vm_workers: Nnumber of workers which does the spinning on malloc()/free()
+        vm_workers: Number of workers which does the spinning on malloc()/free()
           to consume memory.
 
     Returns:
@@ -126,14 +126,14 @@ def consume_memory_and_restart_container(duthost, container_name, vm_workers):
 
     thread_pool.apply_async(consume_memory, (duthost, container_name, vm_workers))
 
-    logger.info("Waiting '{}' container to be stopped ...".format(container_name))
+    logger.info("Waiting for '{}' container to be stopped ...".format(container_name))
     stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
                          CONTAINER_CHECK_INTERVAL_SECS,
                          check_container_state, duthost, container_name, False)
     pytest_assert(stopped, "Failed to stop '{}' container!".format(container_name))
     logger.info("'{}' container is stopped.".format(container_name))
 
-    logger.info("Waiting '{}' container to be restarted ...".format(container_name))
+    logger.info("Waiting for '{}' container to be restarted ...".format(container_name))
     restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
                            CONTAINER_CHECK_INTERVAL_SECS,
                            check_container_state, duthost, container_name, True)
@@ -168,7 +168,7 @@ def postcheck_critical_processes(duthost, container_name):
     Returns:
         None.
     """
-    logger.info("Checking running status of critical processes in '{}' container ..."
+    logger.info("Checking the running status of critical processes in '{}' container ..."
                 .format(container_name))
     is_succeeded = wait_until(CONTAINER_RESTART_THRESHOLD_SECS, CONTAINER_CHECK_INTERVAL_SECS,
                               check_critical_processes, duthost, container_name)
@@ -180,7 +180,8 @@ def postcheck_critical_processes(duthost, container_name):
 
 def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Checks whether the telemetry container can be restarted or not if the memory
-    usage of it is beyond 400MB.
+    usage of it is beyond the threshold. The `stress` utility is leveraged as
+    the memory stressing tool.
 
     Args:
         duthosts: The fixture returns list of DuTs.
@@ -191,8 +192,9 @@ def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         None.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # TODO: Currently we only test 'telemetry' container and number of vm_workers is hard coded.
-    # I will extend this testing on all containers after the feature 'memory_checker' is fully implemented.
+    # TODO: Currently we only test 'telemetry' container which has the memory threshold 400MB
+    # and number of vm_workers is hard coded. We will extend this testing on all containers after
+    # the feature 'memory_checker' is fully implemented.
     container_name = "telemetry"
     vm_workers = 4
 


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR aims to test the feature of memory checker in 20191130.73 and newer image version. Currently this pytest script only tests the feature on streaming telemetry container and will extend this test to all other containers once this feature is fully implemented.

#### How did you do it?
I implemented this test according to the following steps:
1. Installs `stress` utility in container under testing.
2. Invokes `stress` utility to eat up the amount of memory which is larger than the threshold.
3. Waits for the container to be stopped and restarted
4. Checks whether all critical processes in container are running

#### How did you verify/test it?
I tested this feature on the testbed `str-msn2700-01`.

    18:30:05 test_memory_checker.modify_monit_config_ L0038 INFO | Back up Monit configuration file ...
    18:30:06 test_memory_checker.modify_monit_config_ L0041 INFO | Modifying Monit config to eliminate start delay and decrease interval ...
    18:30:07 test_memory_checker.modify_monit_config_ L0045 INFO | Restart Monit service ...
    18:30:10 __init__.loganalyzer L0047 INFO | Log analyzer is disabled
    -------------------------------- live log call ---------------------------------
    18:30:10 test_memory_checker.install_stress_utili L0067 INFO | Installing 'stress' utility in 'telemetry' container ...
    18:30:15 test_memory_checker.install_stress_utili L0075 INFO | 'stress' utility was installed.
    18:30:15 test_memory_checker.consume_memory_and_r L0129 INFO | Waiting 'telemetry' container to be stopped ...
    18:30:15 test_memory_checker.consume_memory L0107 INFO | Executing command 'stress -m 4' in 'telemetry' container ...
    18:32:27 test_memory_checker.consume_memory_and_r L0134 INFO | 'telemetry' container is stopped.
    18:32:27 test_memory_checker.consume_memory_and_r L0136 INFO | Waiting 'telemetry' container to be restarted ...
    18:32:30 test_memory_checker.consume_memory_and_r L0141 INFO | 'telemetry' container is restarted.
    18:32:30 test_memory_checker.remove_stress_utilit L0088 INFO | Removing 'stress' utility from 'telemetry' container ...
    18:32:41 test_memory_checker.remove_stress_utilit L0092 INFO | 'stress' utility was removed.
    18:32:41 test_memory_checker.postcheck_critical_p L0172 INFO | Checking running status of critical processes in 'telemetry' container ...
    18:32:44 sonic.critical_process_status L0456 INFO | ====== supervisor process status for service telemetry ======
    18:32:44 test_memory_checker.postcheck_critical_p L0178 INFO | All critical processes in 'telemetry' container are running.
    PASSED [100%]
    ------------------------------ live log teardown -------------------------------
    18:32:44 test_memory_checker.modify_monit_config_ L0050 INFO | Restore original Monit configuration ...
    18:32:45 test_memory_checker.modify_monit_config_ L0053 INFO | Restart Monit service ...
    18:32:46 __init__.sanity_check L0249 INFO | No post-test check is required. Done post-test sanity check

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
