### PR TITLE
[201811] minigraph: Fix issue of alias name vs sonic name being used for populating the speed

### DIFF
--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -17,8 +17,8 @@
           <Priority>0</Priority>
 {% if port_speed[port_alias[index]] is defined %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
-{% elif device_conn[inventory_hostname][port_alias[index]] is defined %}
-          <Speed>{{ device_conn[inventory_hostname][port_alias[index]]['speed'] }}</Speed>
+{% elif device_conn[port_alias_map[port_alias[index]]] is defined %}
+          <Speed>{{ device_conn[port_alias_map[port_alias[index]]]['speed'] }}</Speed>
 {% else %}
           <Speed>{{ iface_speed }}</Speed>
 {% endif %}


### PR DESCRIPTION
### Description of PR

For filling in the speed of the port, when reading `device_conn`, the Sonic name needs to be used for reading into the dict, not the alias name.

Also, Indexing by the hostname isn't required for 201811, since the returned structure gets rid of that "layer" if the hostname exists in that data structure.

Signed-off-by: Saikrishna Arcot <saiarcot895@gmail.com>

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Testing

Verified by generating a minigraph for 7050QX-32S-S4Q31 and checking to make sure the first four ports have the correct speed.