### PR TITLE
[ test_watchdog_reboot ] Added chassis_db_init exeption in get_pmon_daemons func

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -516,7 +516,7 @@ class SonicHost(AnsibleHostBase):
         @return: dictionary of { service_name1 : state1, ... ... }
         """
         # some services are meant to have a short life span or not part of the daemons
-        exemptions = ['lm-sensors', 'start.sh', 'rsyslogd', 'start', 'dependent-startup']
+        exemptions = ['lm-sensors', 'start.sh', 'rsyslogd', 'start', 'dependent-startup', 'chassis_db_init']
 
         daemons = self.shell('docker exec pmon supervisorctl status', module_ignore_errors=True)['stdout_lines']
 


### PR DESCRIPTION
Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After [`7596`](https://github.com/Azure/sonic-buildimage/pull/7596) have been merged test_watchdog_reboot started failing on check_pmon_daemons. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
TC watchdog_reboot failed
#### How did you do it?
Excluded chassis_db_init  from checking as it is executed only one time and exiting.
#### How did you verify/test it?
Run watchdog_reboot. TC passed
#### Any platform specific information?
SONiC Software Version: SONiC.master.17861-dirty-20210602.081854
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: e50b6fc3
Build date: Wed Jun  2 13:33:37 UTC 2021

Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
