### PR TITLE
[port_utils] Update the 10G breakout ports for Arista-7050-QX-32S in the port alias map

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -68,7 +68,9 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
         for i in range(25, 33):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % ((i - 1) * 4)
     elif hwsku == "Arista-7050-QX-32S":
-        for i in range(5, 29):
+        for i in range(0, 4):
+            port_alias_to_name_map["Ethernet1/%d" % (i + 1)] = "Ethernet%d" % i
+        for i in range(6, 29):
             port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 5) * 4)
         for i in range(29, 37):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % ((i - 5) * 4)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Arista-7050-QX-32s is now mapped to Arista-7050-QX-S4Q31. Hence the 10G ports need to be included in the port map definition

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

#### How did you verify/test it?
Ran add-topo successfully. Prior to this fix, failure was seen in conn_graph_facts