### PR TITLE
[interface_facts] Fix import error due to multi_asic module not present in certain branches 

### DIFF
--- a/ansible/library/interface_facts.py
+++ b/ansible/library/interface_facts.py
@@ -18,7 +18,12 @@ import json
 
 from ansible.module_utils.basic import *
 from collections import defaultdict
-from sonic_py_common import multi_asic
+try:
+    from sonic_py_common import multi_asic
+    NAMESPACE_LIST = multi_asic.get_namespace_list()
+except ImportError:
+    NAMESPACE_LIST = ['']
+
 
 INTF_IP_GET_INFO_SCRIPT = "/tmp/gather_intf_ip_info.py"
 DOCUMENTATION = '''
@@ -313,7 +318,7 @@ def main():
     cmd_prefix = ''
     cmd = '/usr/bin/python {}'.format(INTF_IP_GET_INFO_SCRIPT)
 
-    for namespace in multi_asic.get_namespace_list():
+    for namespace in NAMESPACE_LIST:
         if namespace_passed and namespace != namespace_passed:
             continue
         # If the user passed a namespace parameter invoke that script with the cmd_prefix


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When running a few pytest cases against 201811 branch, interface_facts module complains of multi_asic import since that is not available in 201811 branch.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran the failing pytest case with the change against 201811 branch and it passed
