### PR TITLE
[show_interface] Check for namespace when internal intfs need to be displayed

### DIFF
--- a/ansible/library/show_interface.py
+++ b/ansible/library/show_interface.py
@@ -136,7 +136,7 @@ class ShowInterfaceModule(object):
         else:
             try:
                 cli_options = " -n {}".format(namespace) if namespace is not None else ""
-                if include_internal_intfs:
+                if include_internal_intfs and namespace is not None:
                     cli_options += " -d all"
                 intf_status_cmd = "show interface status{}".format(cli_options)
                 rc, self.out, err = self.module.run_command(intf_status_cmd, executable='/bin/bash', use_unsafe_shell=True)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The current code assumes that namespace is always present when the include_internal_intfs option is enabled and the cmd is constructed to display the interface status. Failure was seen when trying to run pytest cases against 201811 branch. In one of the tests, include_internal_intfs was set to True and module run failed because the cmd was unsupported in 201811 branch. To avoid that failure, check for presence of namespace as well along with the current flag to extend the interface cmd options

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran the failing tests on 201811 and it passed