### PR TITLE
[rdma] Enable minigraph generation for breakout 7050

### DIFF
--- a/ansible/group_vars/sonic/breakout_speed.yml
+++ b/ansible/group_vars/sonic/breakout_speed.yml
@@ -1,0 +1,6 @@
+breakout_speed:
+  Arista-7050-QX-32S:
+    Ethernet1: 10000
+    Ethernet2: 10000
+    Ethernet3: 10000
+    Ethernet4: 1000

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -20,8 +20,8 @@
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
 {% elif (breakout_speed is defined) and (hwsku in breakout_speed) and (port_alias[index] in breakout_speed[hwsku].keys()) %}
           <Speed>{{ breakout_speed[hwsku][port_alias[index]] }}</Speed>
-{% elif device_conn[port_alias_map[port_alias[index]]] is defined %}
-          <Speed>{{ device_conn[port_alias_map[port_alias[index]]]['speed'] }}</Speed>
+{% elif device_conn[inventory_hostname][port_alias_map[port_alias[index]]] is defined %}
+          <Speed>{{ device_conn[inventory_hostname][port_alias_map[port_alias[index]]]['speed'] }}</Speed>
 {% else %}
           <Speed>{{ iface_speed }}</Speed>
 {% endif %}

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -18,8 +18,10 @@
           <Priority>0</Priority>
 {% if port_speed[port_alias[index]] is defined %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
-{% elif device_conn[inventory_hostname][port_alias[index]] is defined %}
-          <Speed>{{ device_conn[inventory_hostname][port_alias[index]]['speed'] }}</Speed>
+{% elif (breakout_speed is defined) and (hwsku in breakout_speed) and (port_alias[index] in breakout_speed[hwsku].keys()) %}
+          <Speed>{{ breakout_speed[hwsku][port_alias[index]] }}</Speed>
+{% elif device_conn[port_alias_map[port_alias[index]]] is defined %}
+          <Speed>{{ device_conn[port_alias_map[port_alias[index]]]['speed'] }}</Speed>
 {% else %}
           <Speed>{{ iface_speed }}</Speed>
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the current tgen topology, the connection graph includes only the links connected to the traffic generator. Hence the 10G links are not defined. The current logic for defining the speed for interfaces in the minigraph follows the order below 
1. get the speed from port_config.ini.
2. if not obtained from 1, then get it from connection graph
3. if not obtained from 2, then set the value of 'iface_speed'
We will be setting the speed incorrectly to 40G (condition 3 kicks in) for the 10G links because no speed is defined in port_config.ini for this SKU and 2) is also not satisfied for the reason stated above. 
To overcome this problem, added a new file where link-speed mappings can be defined for each sku, if needed and use that info as well in the minigraph generation to define the correct speed for a link.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

#### How did you verify/test it?
Successfully generated minigraph for the 7050 breakout sku with the changes and ensured that the speeds for the links were set as desired.
