### PR TITLE
[Ansible] Introduce topology `t1-backend`

### DIFF
--- a/ansible/vars/topo_t1-backend.yml
+++ b/ansible/vars/topo_t1-backend.yml
@@ -2,51 +2,51 @@ topology:
   VMs:
     ARISTA01BT0:
       vlans:
-        - 16
+        - 4
       vm_offset: 0
     ARISTA02BT0:
       vlans:
-        - 17
+        - 5
       vm_offset: 1
     ARISTA03BT0:
       vlans:
-        - 18
+        - 6
       vm_offset: 2
     ARISTA04BT0:
       vlans:
-        - 19
+        - 7
       vm_offset: 3
     ARISTA05BT0:
       vlans:
-        - 20
+        - 8
       vm_offset: 4
     ARISTA06BT0:
       vlans:
-        - 21
+        - 9
       vm_offset: 5
     ARISTA07BT0:
       vlans:
-        - 22
+        - 10
       vm_offset: 6
     ARISTA08BT0:
       vlans:
-        - 23
+        - 11
       vm_offset: 7
     ARISTA09BT0:
       vlans:
-        - 24
+        - 12
       vm_offset: 8
     ARISTA10BT0:
       vlans:
-        - 25
+        - 13
       vm_offset: 9
     ARISTA11BT0:
       vlans:
-        - 26
+        - 14
       vm_offset: 10
     ARISTA12BT0:
       vlans:
-        - 27
+        - 15
       vm_offset: 11
 
 configuration_properties:
@@ -61,8 +61,8 @@ configuration_properties:
     tor_subnet_number: 2
     max_tor_subnet_number: 16
     tor_subnet_size: 128
-    vlan_sub_interface_separator: '.'
-    vlan_sub_interface_vlan_id: '10'
+    sub_interface_separator: '.'
+    sub_interface_vlan_id: '10'
   tor:
     swrole: tor
     device_type: BackEndToRRouter
@@ -79,11 +79,6 @@ configuration:
         65100:
         - 10.0.0.32
         - FC00::41
-    vips:
-      ipv4:
-        prefixes:
-          - 200.0.1.0/26
-        asn: 64700
     interfaces:
       Loopback0:
         ipv4: 100.1.0.17/32
@@ -128,11 +123,6 @@ configuration:
         65100:
         - 10.0.0.36
         - FC00::49
-    vips:
-      ipv4:
-        prefixes:
-          - 200.0.1.0/26
-        asn: 64700
     interfaces:
       Loopback0:
         ipv4: 100.1.0.19/32

--- a/ansible/vars/topo_t1-backend.yml
+++ b/ansible/vars/topo_t1-backend.yml
@@ -53,6 +53,7 @@ configuration_properties:
   common:
     dut_asn: 65100
     dut_type: BackEndLeafRouter
+    dut_cluster: PrdStr03
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200

--- a/ansible/vars/topo_t1-str.yml
+++ b/ansible/vars/topo_t1-str.yml
@@ -1,0 +1,342 @@
+topology:
+  VMs:
+    ARISTA01BT0:
+      vlans:
+        - 16
+      vm_offset: 0
+    ARISTA02BT0:
+      vlans:
+        - 17
+      vm_offset: 1
+    ARISTA03BT0:
+      vlans:
+        - 18
+      vm_offset: 2
+    ARISTA04BT0:
+      vlans:
+        - 19
+      vm_offset: 3
+    ARISTA05BT0:
+      vlans:
+        - 20
+      vm_offset: 4
+    ARISTA06BT0:
+      vlans:
+        - 21
+      vm_offset: 5
+    ARISTA07BT0:
+      vlans:
+        - 22
+      vm_offset: 6
+    ARISTA08BT0:
+      vlans:
+        - 23
+      vm_offset: 7
+    ARISTA09BT0:
+      vlans:
+        - 24
+      vm_offset: 8
+    ARISTA10BT0:
+      vlans:
+        - 25
+      vm_offset: 9
+    ARISTA11BT0:
+      vlans:
+        - 26
+      vm_offset: 10
+    ARISTA12BT0:
+      vlans:
+        - 27
+      vm_offset: 11
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: BackEndLeafRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    vlan_sub_interface_separator: '.'
+    vlan_sub_interface_vlan_id: '10'
+  tor:
+    swrole: tor
+    device_type: BackEndToRRouter
+
+configuration:
+  ARISTA01BT0:
+    properties:
+    - common
+    - tor
+    tornum: 1
+    bgp:
+      asn: 64001
+      peers:
+        65100:
+        - 10.0.0.32
+        - FC00::41
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Ethernet1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::22/64
+
+  ARISTA02BT0:
+    properties:
+    - common
+    - tor
+    tornum: 2
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+        - 10.0.0.34
+        - FC00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Ethernet1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::25/64
+
+  ARISTA03BT0:
+    properties:
+    - common
+    - tor
+    tornum: 3
+    bgp:
+      asn: 64003
+      peers:
+        65100:
+        - 10.0.0.36
+        - FC00::49
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Ethernet1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::26/64
+
+  ARISTA04BT0:
+    properties:
+    - common
+    - tor
+    tornum: 4
+    bgp:
+      asn: 64004
+      peers:
+        65100:
+        - 10.0.0.38
+        - FC00::4D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Ethernet1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::29/64
+
+  ARISTA05BT0:
+    properties:
+    - common
+    - tor
+    tornum: 5
+    bgp:
+      asn: 64005
+      peers:
+        65100:
+        - 10.0.0.40
+        - FC00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Ethernet1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::2a/64
+
+  ARISTA06BT0:
+    properties:
+    - common
+    - tor
+    tornum: 6
+    bgp:
+      asn: 64006
+      peers:
+        65100:
+        - 10.0.0.42
+        - FC00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Ethernet1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::2d/64
+
+  ARISTA07BT0:
+    properties:
+    - common
+    - tor
+    tornum: 7
+    bgp:
+      asn: 64007
+      peers:
+        65100:
+        - 10.0.0.44
+        - FC00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Ethernet1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::2e/64
+
+  ARISTA08BT0:
+    properties:
+    - common
+    - tor
+    tornum: 8
+    bgp:
+      asn: 64008
+      peers:
+        65100:
+        - 10.0.0.46
+        - FC00::5D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Ethernet1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::31/64
+
+  ARISTA09BT0:
+    properties:
+    - common
+    - tor
+    tornum: 9
+    bgp:
+      asn: 64009
+      peers:
+        65100:
+        - 10.0.0.48
+        - FC00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Ethernet1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::32/64
+
+  ARISTA10BT0:
+    properties:
+    - common
+    - tor
+    tornum: 10
+    bgp:
+      asn: 64010
+      peers:
+        65100:
+        - 10.0.0.50
+        - FC00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Ethernet1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::35/64
+
+  ARISTA11BT0:
+    properties:
+    - common
+    - tor
+    tornum: 11
+    bgp:
+      asn: 64011
+      peers:
+        65100:
+        - 10.0.0.52
+        - FC00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Ethernet1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::36/64
+
+  ARISTA12BT0:
+    properties:
+    - common
+    - tor
+    tornum: 12
+    bgp:
+      asn: 64012
+      peers:
+        65100:
+        - 10.0.0.54
+        - FC00::6D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Ethernet1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::39/64


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Aim to describe storage backend bt1 switch.
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Few changes:
1. Add three new properties to `configuration_properties.common`:
    * `dut_type` as `BackEndLeafRouter` to imply that the DUT is a bt1.
    * `vlan_sub_interface_separator`
    * `vlan_sub_interface_vlan_id`
2. add one new property to `configuration_properties.tor`:
    * `device_type` as `BackEndToRRouter` to imply that the VM is a bt0.
3. Naming the VMs from `ARISTA[0-9]{2}T0` to `ARISTA[0-9]{2}BT0`.


#### How did you verify/test it?
* run `start-topo-vms` and  `add-topo` to deploy this testbed.
```
admin@str2-7050qx-32s-acs-03:~$ show ip int
Interface       Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
--------------  --------  -------------------  ------------  --------------  -------------
Ethernet64.10             10.0.0.32/31         up/up         ARISTA01BT0     10.0.0.33
Ethernet68.10             10.0.0.34/31         up/up         ARISTA02BT0     10.0.0.35
Ethernet72.10             10.0.0.36/31         up/up         ARISTA03BT0     10.0.0.37
Ethernet76.10             10.0.0.38/31         up/up         ARISTA04BT0     10.0.0.39
Ethernet80.10             10.0.0.40/31         up/up         ARISTA05BT0     10.0.0.41
Ethernet84.10             10.0.0.42/31         up/up         ARISTA06BT0     10.0.0.43
Ethernet88.10             10.0.0.44/31         up/up         ARISTA07BT0     10.0.0.45
Ethernet92.10             10.0.0.46/31         up/up         ARISTA08BT0     10.0.0.47
Ethernet96.10             10.0.0.48/31         up/up         ARISTA09BT0     10.0.0.49
Ethernet100.10            10.0.0.50/31         up/up         ARISTA10BT0     10.0.0.51
Ethernet104.10            10.0.0.52/31         up/up         ARISTA11BT0     10.0.0.53
Ethernet108.10            10.0.0.54/31         up/up         ARISTA12BT0     10.0.0.55
admin@str2-7050qx-32s-acs-03:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 40
RIB entries 75, using 14400 bytes of memory
Peers 12, using 261792 KiB of memory
Peer groups 2, using 128 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.33      4  64001         42         52         0      0       0  00:35:07                4  ARISTA01BT0
10.0.0.35      4  64002         41         52         0      0       0  00:35:07                3  ARISTA02BT0
10.0.0.37      4  64003         42         52         0      0       0  00:35:07                4  ARISTA03BT0
10.0.0.39      4  64004         41         52         0      0       0  00:35:07                3  ARISTA04BT0
10.0.0.41      4  64005         41         52         0      0       0  00:35:08                3  ARISTA05BT0
10.0.0.43      4  64006         41         52         0      0       0  00:35:07                3  ARISTA06BT0
10.0.0.45      4  64007         41         52         0      0       0  00:35:07                3  ARISTA07BT0
10.0.0.47      4  64008         41         52         0      0       0  00:35:07                3  ARISTA08BT0
10.0.0.49      4  64009         41         52         0      0       0  00:35:07                3  ARISTA09BT0
10.0.0.51      4  64010         41         52         0      0       0  00:35:07                3  ARISTA10BT0
10.0.0.53      4  64011         41         52         0      0       0  00:35:07                3  ARISTA11BT0
10.0.0.55      4  64012         41         52         0      0       0  00:35:07                3  ARISTA12BT0

Total number of neighbors 12
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
