### PR TITLE
Fix ```test_fib``` on t1 testbed

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -172,6 +172,10 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
 @pytest.fixture(scope="session", autouse=True)
 def run_icmp_responder(duthost, ptfhost, tbinfo):
     """Run icmp_responder.py over ptfhost."""
+    # No vlan is avaliable on non-t0 testbed, so skip this fixture 
+    if 't0' not in tbinfo['topo']['type']:
+        yield
+        return
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, ICMP_RESPONDER_PY), dest=OPT_DIR)
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix ```test_fib``` on t1 testbed.
Recent PR #3502 imports autoused fixture ```run_icmp_responder```. However, this fixture doesn't work on non-t0 testbed because ```VLAN_MEMBER``` doesn't exist in running config.
```
    def get_vlan_intfs(self):
        '''
        Get any interfaces belonging to a VLAN
        '''
>       vlan_members_facts = self.get_running_config_facts()['VLAN_MEMBER']
E       KeyError: 'VLAN_MEMBER'
```
This PR addresses the issue by skipping the fixture on non-t0 testbed.

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_fib``` on t1 testbed.

#### How did you do it?
This PR addresses the issue by skipping the fixture on non-t0 testbed.

#### How did you verify/test it?
Verified on SN4600, T1 testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
