### PR TITLE
[pdu controller] Allow to define pdu_host info in conngraph

### DIFF
--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -18,15 +18,14 @@ def pdu_controller(duthosts, enum_rand_one_per_hwsku_hostname, conn_graph_facts,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     inv_mgr = duthost.host.options["inventory_manager"]
     pdu_host_list = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
-    if not pdu_host_list:
-        logging.info("No 'pdu_host' is defined in inventory file for '%s'. Unable to create pdu_controller" %
-                     duthost.hostname)
-        yield None
-        return
     pdu_hosts = {}
-    for ph in pdu_host_list.split(','):
-        var_list = inv_mgr.get_host(ph).get_vars()
-        pdu_hosts[ph] = var_list
+    if pdu_host_list:
+        for ph in pdu_host_list.split(','):
+            var_list = inv_mgr.get_host(ph).get_vars()
+            pdu_hosts[ph] = var_list
+    else:
+        logging.debug("No 'pdu_host' is defined in inventory file for '%s'." %
+                     duthost.hostname)
 
     controller = pdu_manager_factory(duthost.hostname, pdu_hosts, conn_graph_facts, pdu)
 


### PR DESCRIPTION
Don't return fail until checking the pdu_host in both of inventory and conngraph.

Signed-off-by: Shengkai Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
