### PR TITLE
[common]: Fix of get_port_map

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -115,18 +115,10 @@ def get_port_map(dut, asic_index=None):
     @return: a dictionary containing the port map
     """
     logging.info("Retrieving port mapping from DUT")
-    # copy the helper to DUT
-    src_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'files/getportmap.py')
-    dest_path = os.path.join('/usr/share/sonic/device', dut.facts['platform'], 'plugins/getportmap.py')
-    dut.copy(src=src_path, dest=dest_path)
-
-    # execute command on the DUT to get portmap
-    get_portmap_cmd = "docker exec pmon python /usr/share/sonic/platform/plugins/getportmap.py -asicid {}".format(asic_index)
-    portmap_json_string = dut.command(get_portmap_cmd)["stdout"]
-
-    # parse the json
-    port_mapping = json.loads(portmap_json_string)
-    assert port_mapping, "Retrieve port mapping from DUT failed"
+    namespace = dut.get_namespace_from_asic_id(asic_index)
+    config_facts = dut.config_facts(host=dut.hostname, source="running",namespace=namespace)['ansible_facts']
+    port_mapping = config_facts['port_index_map']
+    for k,v in port_mapping.items():
+        port_mapping[k] = [v]
 
     return port_mapping
-

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -3,7 +3,6 @@ Helper script for checking status of interfaces
 
 This script contains re-usable functions for checking status of interfaces on SONiC.
 """
-import json
 import logging
 from transceiver_utils import all_transceivers_detected
 


### PR DESCRIPTION

  Signed-off-by: Vladyslav Morokhovych <vladyslavx.morokhovych@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Patch with fix for `get_port_map` in `interface_utils.py` 
According to [Porting Guide](https://github.com/Azure/SONiC/wiki/Porting-Guide): `plugins/getportmap.py` and `port_config.ini` are deprecated, but was used in `get_port_map`
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
 
Deprecation of 
- plugins/getportmap.py
- port_config.ini ( In favor of the use of platform.json and hwsku.json )

#### How did you do it?
Change `get_port_map` in `interface_utils.py` 
Switched from using `getportmap.py` and `port_config.ini`  
to retrieving port mapping from `config_facts` depending on asic
#### How did you verify/test it?
Run `sfp` tests, `test_reboot.py`, `test_sequential_restart.py` on t0, t0-64-32 and t1
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
