### PR TITLE
[dualtor][orchagent] Fix errors when expected tunnel packet headers are not captured properly

### DIFF
--- a/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
@@ -195,5 +195,3 @@ class IpinIPTunnelTest(BaseTest):
                                                     timeout=TIMEOUT)
                 pkt_distribution[self.indice_to_portchannel[dst_ports[idx]]] = pkt_distribution.get(self.indice_to_portchannel[dst_ports[idx]], 0) + 1
             self.check_balance(pkt_distribution, hash_key)
-
-

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -650,7 +650,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
     sport = random.randint(1, 65535) if 'src-port' in hash_key else 1234
     dport = random.randint(1, 65535) if 'dst-port' in hash_key else 80
     dst_mac = duthost.facts["router_mac"]
-    pkt = testutils.simple_tcp_packet(pktlen=128,
+    send_pkt = testutils.simple_tcp_packet(pktlen=128,
                         eth_dst=dst_mac,
                         eth_src=src_mac,
                         dl_vlan_enable=False,
@@ -661,36 +661,31 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
                         tcp_sport=sport,
                         tcp_dport=dport,
                         ip_ttl=64)
-    exp_pkt = mask.Mask(pkt)
+    exp_pkt = mask.Mask(send_pkt)
     exp_pkt.set_do_not_care_scapy(scapyall.Ether, 'dst')
     exp_pkt.set_do_not_care_scapy(scapyall.Ether, "src")
     exp_pkt.set_do_not_care_scapy(scapyall.IP, "ttl")
-    inner_dscp = random.choice(range(0, 33))
-    inner_packet = pkt[IP]
+    exp_pkt.set_do_not_care_scapy(scapyall.IP, "chksum")
+
+    inner_packet = send_pkt[IP]
     inner_packet.ttl = inner_packet.ttl - 1
     exp_tunnel_pkt = testutils.simple_ipv4ip_packet(
         eth_dst=dst_mac,
         eth_src=src_mac,
         ip_src="10.1.0.32",
         ip_dst="10.1.0.33",
-        ip_dscp=inner_dscp,
-        ip_ttl=63,
         inner_frame=inner_packet
     )
+    send_pkt.ttl = 64
     exp_tunnel_pkt[TCP] = inner_packet[TCP]
     exp_tunnel_pkt = mask.Mask(exp_tunnel_pkt)
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.Ether, 'dst')
+    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.Ether, "dst")
     exp_tunnel_pkt.set_do_not_care_scapy(scapyall.Ether, "src")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "ihl")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "tos")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "len")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "id")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "ttl")
-    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "chksum")
+    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "id") # since src and dst changed, ID would change too
+    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "ttl") # ttl in outer packet is set to 255
+    exp_tunnel_pkt.set_do_not_care_scapy(scapyall.IP, "chksum") # checksum would differ as the IP header is not the same
 
-    exp_tunnel_pkt.set_do_not_care(44*8, 2*8) # ignore checking inner packets checksum
-
-    return pkt, exp_pkt, exp_tunnel_pkt
+    return send_pkt, exp_pkt, exp_tunnel_pkt
 
 
 def random_ip(begin, end):
@@ -719,9 +714,9 @@ def count_matched_packets_all_ports(ptfadapter, exp_packet, exp_tunnel_pkt, port
 
         result = testutils.dp_poll(ptfadapter, device_number=device_number, timeout=timeout)
         if isinstance(result, ptfadapter.dataplane.PollSuccess):
-            if (result.port in ports and
-                  (ptf.dataplane.match_exp_pkt(exp_packet, result.packet) or
-                  ptf.dataplane.match_exp_pkt(exp_tunnel_pkt, result.packet))):
+            if ((result.port in ports) and
+                (ptf.dataplane.match_exp_pkt(exp_packet, result.packet) or
+                ptf.dataplane.match_exp_pkt(exp_tunnel_pkt, result.packet))):
                 port_packet_count[result.port] = port_packet_count.get(result.port, 0) + 1
                 packet_count += 1
                 if packet_count == count:
@@ -755,19 +750,20 @@ def check_nexthops_balance(rand_selected_dut,
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), send_packet, count=1)
         # expect ECMP hashing to work and distribute downlink traffic evenly to every nexthop
         all_allowed_ports = expected_downlink_ports + expected_uplink_ports
-        ptf_port_count, result_packet = count_matched_packets_all_ports(ptfadapter,
+        ptf_port_count = count_matched_packets_all_ports(ptfadapter,
                                             exp_packet=exp_pkt,
                                             exp_tunnel_pkt=exp_tunnel_pkt,
                                             ports=all_allowed_ports,
-                                            timeout=0.01,
+                                            timeout=0.1,
                                             count=1)
 
         for ptf_idx, pkt_count in ptf_port_count.items():
             port_packet_count[ptf_idx] = port_packet_count.get(ptf_idx, 0) + pkt_count
 
     logging.info("Received packets in ports: {}".format(str(port_packet_count)))
+    expect_packet_num = 10000 // nexthops_count
     for downlink_int in expected_downlink_ports:
-        expect_packet_num = 10000 // len(expected_downlink_ports)
+        # ECMP validation:
         pkt_num_lo = expect_packet_num * (1.0 - 0.25)
         pkt_num_hi = expect_packet_num * (1.0 + 0.25)
         count = port_packet_count.get(downlink_int, 0)
@@ -778,11 +774,20 @@ def check_nexthops_balance(rand_selected_dut,
 
     if len(downlink_ints) < nexthops_count:
         # Some nexthop is now connected to standby mux, and the packets will be sent towards portchanel ints
-        # Verify that the packets are also sent to uplinks (in case of standby MUX)
+        # Hierarchical ECMP validation (in case of standby MUXs):
+        # Step 1: Calculate total uplink share.
+        total_uplink_share = expect_packet_num * (nexthops_count - len(expected_downlink_ports))
+        # Step 2: Divide uplink share among all uplinks
+        expect_packet_num = total_uplink_share // len(expected_uplink_ports)
+        # Step 3: Check if uplink distribution (hierarchical ECMP) is balanced
         for uplink_int in expected_uplink_ports:
+            pkt_num_lo = expect_packet_num * (1.0 - 0.25)
+            pkt_num_hi = expect_packet_num * (1.0 + 0.25)
             count = port_packet_count.get(uplink_int, 0)
             logging.info("Packets received on uplink port {}: {}".format(uplink_int, count))
-            pt_assert(count > 0, "Packets not sent on uplink ports {}".format(uplink_int))
+            if count < pkt_num_lo or count > pkt_num_hi:
+                balance = False
+                pt_assert(balance, "Hierarchical ECMP failed: packets not evenly distributed on uplink port {}".format(uplink_int))
 
 
 def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num = 100, drop = False):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix dualtor-orchagent test errors when tunnel packets are not captured on expected interfaces. Also, remove ignore bits set on most of the packet fields.
Fixes: https://github.com/Azure/sonic-buildimage/issues/8084

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In the present utilitities, the expected tunnel packets are either not captured, or are masked entirely which leads to false-negatives.

#### How did you do it?
Use `simple_ipv4ip_packet` to create tunnel packet, and remove the wildcarded masks from most of the packet headers.

Correct the ttl value in the inner packet.
Ignore checksum, as the modified ttl will change checksum.

#### How did you verify/test it?
Tested eCMP nexthop on single tor device, and the tunnel packets are captured on the portchannel interfaces.


```
06:21:40 dual_tor_utils.add_nexthop_routes        L1032 INFO   | Route added to str2-7050cx3-acs-02: ip route replace 1.1.1.2/32 nexthop via 192.168.0.3 nexthop via 192.168.0.25 nexthop via 192.168.0.2 nexthop via 192.168.0.24
06:21:40 test_orchagent_active_tor_downstream.tes L0107 INFO   | Verify traffic to this route destination is distributed to four server ports
06:21:41 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [2, 24, 1, 23]
06:21:41 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:21:43 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:23:25 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {24: 2533, 1: 2526, 2: 2430, 23: 2459}
06:23:25 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 2: 2430
06:23:25 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 24: 2533
06:23:25 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 1: 2526
06:23:25 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2459

06:23:25 test_orchagent_active_tor_downstream.tes L0114 INFO   | Simulate 192.168.0.3 mux state change to Standby
06:23:25 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying standby state to orchagent
06:23:27 test_orchagent_active_tor_downstream.tes L0118 INFO   | Verify traffic to this route destination is distributed to 3 server ports and 1 tunnel nexthop
06:23:29 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [24, 1, 23]
06:23:29 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:23:30 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:25:15 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {1: 2446, 23: 2539, 24: 2491, 28: 603, 29: 591, 30: 640, 31: 639}
06:25:15 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 24: 2491
06:25:15 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 1: 2446
06:25:15 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2539
06:25:15 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 603
06:25:15 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 640
06:25:15 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 591
06:25:15 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 639

06:25:15 test_orchagent_active_tor_downstream.tes L0114 INFO   | Simulate 192.168.0.25 mux state change to Standby
06:25:15 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying standby state to orchagent
06:25:17 test_orchagent_active_tor_downstream.tes L0118 INFO   | Verify traffic to this route destination is distributed to 2 server ports and 2 tunnel nexthop
06:25:18 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [1, 23]
06:25:18 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:25:19 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:27:00 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {1: 2480, 23: 2525, 28: 1207, 29: 1225, 30: 1227, 31: 1292}
06:27:00 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 1: 2480
06:27:00 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2525
06:27:00 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 1207
06:27:00 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 1227
06:27:00 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 1225
06:27:00 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 1292

06:27:00 test_orchagent_active_tor_downstream.tes L0114 INFO   | Simulate 192.168.0.2 mux state change to Standby
06:27:00 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying standby state to orchagent
06:27:02 test_orchagent_active_tor_downstream.tes L0118 INFO   | Verify traffic to this route destination is distributed to 1 server ports and 3 tunnel nexthop
06:27:03 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [23]
06:27:03 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:27:04 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:28:45 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {23: 2461, 28: 1890, 29: 1911, 30: 1852, 31: 1838}
06:28:45 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2461
06:28:45 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 1890
06:28:45 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 1852
06:28:45 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 1911
06:28:45 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 1838

06:28:45 test_orchagent_active_tor_downstream.tes L0114 INFO   | Simulate 192.168.0.24 mux state change to Standby
06:28:45 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying standby state to orchagent
06:28:48 test_orchagent_active_tor_downstream.tes L0118 INFO   | Verify traffic to this route destination is distributed to 0 server ports and 4 tunnel nexthop
06:28:49 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports []
06:28:49 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:28:51 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:30:34 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {28: 2527, 29: 2477, 30: 2446, 31: 2501}
06:30:34 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 2527
06:30:34 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 2446
06:30:34 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 2477
06:30:34 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 2501

06:30:34 test_orchagent_active_tor_downstream.tes L0124 INFO   | Simulate 192.168.0.24 mux state change back to Active
06:30:34 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying active state to orchagent
06:30:37 test_orchagent_active_tor_downstream.tes L0127 INFO   | Verify traffic to this route destination is distributed to 1 server ports and 3 tunnel nexthop
06:30:38 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [23]
06:30:38 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:30:39 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:32:21 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {23: 2546, 28: 1847, 29: 1866, 30: 1888, 31: 1805}
06:32:21 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2546
06:32:21 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 1847
06:32:21 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 1888
06:32:21 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 1866
06:32:21 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 1805

06:32:21 test_orchagent_active_tor_downstream.tes L0124 INFO   | Simulate 192.168.0.2 mux state change back to Active
06:32:21 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying active state to orchagent
06:32:23 test_orchagent_active_tor_downstream.tes L0127 INFO   | Verify traffic to this route destination is distributed to 2 server ports and 2 tunnel nexthop
06:32:24 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [1, 23]
06:32:24 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:32:26 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:34:07 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {1: 2473, 23: 2513, 28: 1246, 29: 1219, 30: 1213, 31: 1281}
06:34:07 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 1: 2473
06:34:07 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2513
06:34:07 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 1246
06:34:07 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 1213
06:34:07 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 1219
06:34:07 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 1281

06:34:07 test_orchagent_active_tor_downstream.tes L0124 INFO   | Simulate 192.168.0.25 mux state change back to Active
06:34:07 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying active state to orchagent
06:34:10 test_orchagent_active_tor_downstream.tes L0127 INFO   | Verify traffic to this route destination is distributed to 3 server ports and 1 tunnel nexthop
06:34:11 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [24, 1, 23]
06:34:11 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:34:12 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:35:56 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {1: 2450, 23: 2483, 24: 2546, 28: 614, 29: 601, 30: 620, 31: 642}
06:35:56 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 24: 2546
06:35:56 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 1: 2450
06:35:56 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2483
06:35:56 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 28: 614
06:35:56 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 30: 620
06:35:56 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 29: 601
06:35:56 dual_tor_utils.check_nexthops_balance    L0783 INFO   | Packets received on uplink port 31: 642

06:35:56 test_orchagent_active_tor_downstream.tes L0124 INFO   | Simulate 192.168.0.3 mux state change back to Active
06:35:56 dual_tor_mock.set_dual_tor_state_to_orch L0065 INFO   | Applying active state to orchagent
06:35:58 test_orchagent_active_tor_downstream.tes L0127 INFO   | Verify traffic to this route destination is distributed to 4 server ports and 0 tunnel nexthop
06:35:59 dual_tor_utils.check_nexthops_balance    L0744 INFO   | Expecting packets in downlink ports [2, 24, 1, 23]
06:35:59 dual_tor_utils.check_nexthops_balance    L0745 INFO   | Expecting packets in uplink ports [28, 30, 29, 31]
06:36:00 dual_tor_utils.get_t1_ptf_ports          L0150 INFO   | Using portchannel ports ['eth28'] on PTF for DUT str2-7050cx3-acs-02
06:37:42 dual_tor_utils.check_nexthops_balance    L0766 INFO   | Received packets in ports: {24: 2482, 1: 2503, 2: 2490, 23: 2478}
06:37:42 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 2: 2490
06:37:42 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 24: 2482
06:37:42 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 1: 2503
06:37:42 dual_tor_utils.check_nexthops_balance    L0773 INFO   | Packets received on downlink port 23: 2478

06:37:42 dual_tor_utils.remove_static_routes      L1039 INFO   | Removing dual ToR peer switch static route
PASSED                                                                   
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
