### PR TITLE
Improve advanced reboot test to support multiple VLANs

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1,5 +1,5 @@
 #
-# ptf --test-dir ptftests fast-reboot --qlen=1000 --platform remote -t 'verbose=True;dut_username="admin";dut_hostname="10.0.0.243";reboot_limit_in_seconds=30;portchannel_ports_file="/tmp/portchannel_interfaces.json";vlan_ports_file="/tmp/vlan_interfaces.json";ports_file="/tmp/ports.json";dut_mac="4c:76:25:f5:48:80";default_ip_range="192.168.0.0/16";vlan_ip_range="172.0.0.0/22";arista_vms="[\"10.0.0.200\",\"10.0.0.201\",\"10.0.0.202\",\"10.0.0.203\"]"' --platform-dir ptftests --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
+# ptf --test-dir ptftests fast-reboot --qlen=1000 --platform remote -t 'verbose=True;dut_username="admin";dut_hostname="10.0.0.243";reboot_limit_in_seconds=30;portchannel_ports_file="/tmp/portchannel_interfaces.json";vlan_ports_file="/tmp/vlan_interfaces.json";ports_file="/tmp/ports.json";dut_mac="4c:76:25:f5:48:80";default_ip_range="192.168.0.0/16";vlan_ip_range="{\"Vlan100\": \"172.0.0.0/22\"}";arista_vms="[\"10.0.0.200\",\"10.0.0.201\",\"10.0.0.202\",\"10.0.0.203\"]"' --platform-dir ptftests --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre
 #
 #
 # This test checks that DUT is able to make FastReboot procedure
@@ -137,7 +137,6 @@ class ReloadTest(BaseTest):
         self.check_param('vlan_ports_file', '', required=True)
         self.check_param('ports_file', '', required=True)
         self.check_param('dut_mac', '', required=True)
-        self.check_param('dut_vlan_ip', '', required=True)
         self.check_param('default_ip_range', '', required=True)
         self.check_param('vlan_ip_range', '', required=True)
         self.check_param('lo_prefix', '10.1.0.32/32', required=False)
@@ -253,19 +252,29 @@ class ReloadTest(BaseTest):
 
         return port_indices
 
-    def read_portchannel_ports(self):
-        content = self.read_json('portchannel_ports_file')
+    def read_vlan_portchannel_ports(self):
+        portchannel_content = self.read_json('portchannel_ports_file')
+        portchannel_names = [pc['name'] for pc in portchannel_content.values()]
+
+        vlan_content = self.read_json('vlan_ports_file')
+
+        ports_per_vlan = dict()
+        pc_in_vlan = []
+        for vlan in self.vlan_ip_range.keys():
+            ports_in_vlan = []
+            for ifname in vlan_content[vlan]['members']:
+                if ifname in portchannel_names:
+                    pc_in_vlan.append(ifname)
+                else:
+                    ports_in_vlan.append(self.port_indices[ifname])
+            ports_per_vlan[vlan] = ports_in_vlan
+
         pc_ifaces = []
-        for pc in content.values():
-            pc_ifaces.extend([self.port_indices[member] for member in pc['members']])
+        for pc in portchannel_content.values():
+            if not pc['name'] in pc_in_vlan:
+                pc_ifaces.extend([self.port_indices[member] for member in pc['members']])
 
-        return pc_ifaces
-
-    def read_vlan_ports(self):
-        content = self.read_json('vlan_ports_file')
-        if len(content) > 1:
-            raise Exception("Too many vlans")
-        return [self.port_indices[ifname] for ifname in content.values()[0]['members']]
+        return ports_per_vlan, pc_ifaces
 
     def check_param(self, param, default, required = False):
         if param not in self.test_params:
@@ -317,19 +326,21 @@ class ReloadTest(BaseTest):
 
     def generate_vlan_servers(self):
         vlan_host_map = defaultdict(dict)
-        vlan_ip_range = self.test_params['vlan_ip_range']
+        self.nr_vl_pkts = 0
+        for vlan, prefix in self.vlan_ip_range.items():
+            if not self.ports_per_vlan[vlan]:
+                continue
+            _, mask = prefix.split('/')
+            n_hosts = min(2**(32 - int(mask)) - 3, self.max_nr_vl_pkts)
 
-        _, mask = vlan_ip_range.split('/')
-        n_hosts = min(2**(32 - int(mask)) - 3, self.max_nr_vl_pkts)
+            for counter, i in enumerate(xrange(2, n_hosts + 2)):
+                mac = self.VLAN_BASE_MAC_PATTERN.format(counter)
+                port = self.ports_per_vlan[vlan][i % len(self.ports_per_vlan[vlan])]
+                addr = self.host_ip(prefix, i)
 
-        for counter, i in enumerate(xrange(2, n_hosts + 2)):
-            mac = self.VLAN_BASE_MAC_PATTERN.format(counter)
-            port = self.vlan_ports[i % len(self.vlan_ports)]
-            addr = self.host_ip(vlan_ip_range, i)
+                vlan_host_map[port][addr] = mac     # For simplicity, assuming there is no overlapped ports between vlans
 
-            vlan_host_map[port][addr] = mac
-
-        self.nr_vl_pkts = n_hosts
+            self.nr_vl_pkts += n_hosts
 
         return vlan_host_map
 
@@ -494,13 +505,15 @@ class ReloadTest(BaseTest):
     def setUp(self):
         self.fails['dut'] = set()
         self.port_indices = self.read_port_indices()
-        self.portchannel_ports = self.read_portchannel_ports()
-        self.vlan_ports = self.read_vlan_ports()
+        self.vlan_ip_range = json.loads(self.test_params['vlan_ip_range'])
+        self.ports_per_vlan, self.portchannel_ports = self.read_vlan_portchannel_ports()
+        self.vlan_ports = []
+        for ports in self.ports_per_vlan.values():
+            self.vlan_ports += ports
         if self.sad_oper:
             self.build_peer_mapping()
             self.test_params['vlan_if_port'] = self.build_vlan_if_port_mapping()
 
-        self.vlan_ip_range = self.test_params['vlan_ip_range']
         self.default_ip_range = self.test_params['default_ip_range']
 
         self.limit = datetime.timedelta(seconds=self.test_params['reboot_limit_in_seconds'])
@@ -704,16 +717,17 @@ class ReloadTest(BaseTest):
         self.ping_dut_packet = str(packet)
 
     def generate_arp_ping_packet(self):
-        vlan_ip_range = self.test_params['vlan_ip_range']
+        vlan = next(k for k, v in self.ports_per_vlan.items() if v)
+        vlan_ip_range = self.vlan_ip_range[vlan]
 
-        vlan_port_canadiates = range(len(self.vlan_ports))
+        vlan_port_canadiates = range(len(self.ports_per_vlan[vlan]))
         vlan_port_canadiates.remove(0) # subnet prefix
         vlan_port_canadiates.remove(1) # subnet IP on dut
         src_idx  = random.choice(vlan_port_canadiates)
         vlan_port_canadiates.remove(src_idx)
         dst_idx  = random.choice(vlan_port_canadiates)
-        src_port = self.vlan_ports[src_idx]
-        dst_port = self.vlan_ports[dst_idx]
+        src_port = self.ports_per_vlan[vlan][src_idx]
+        dst_port = self.ports_per_vlan[vlan][dst_idx]
         src_addr = self.host_ip(vlan_ip_range, src_idx)
         dst_addr = self.host_ip(vlan_ip_range, dst_idx)
         src_mac  = self.hex_to_mac(self.vlan_host_map[src_port][src_addr])

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -64,6 +64,7 @@ import scapy.all as scapyall
 import itertools
 from device_connection import DeviceConnection
 import multiprocessing
+import ast
 
 from arista import Arista
 import sad_path as sp
@@ -505,7 +506,7 @@ class ReloadTest(BaseTest):
     def setUp(self):
         self.fails['dut'] = set()
         self.port_indices = self.read_port_indices()
-        self.vlan_ip_range = json.loads(self.test_params['vlan_ip_range'])
+        self.vlan_ip_range = ast.literal_eval(self.test_params['vlan_ip_range'])
         self.ports_per_vlan, self.portchannel_ports = self.read_vlan_portchannel_ports()
         self.vlan_ports = []
         for ports in self.ports_per_vlan.values():

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -412,7 +412,7 @@ class ReloadTest(BaseTest):
         vlan_content = self.read_json('vlan_ports_file')
         
         vlan_if_port = []
-        for vlan in self.vlan_ip_range.keys():
+        for vlan in self.vlan_ip_range:
             for ifname in vlan_content[vlan]['members']:
                 if ifname not in portchannel_names:
                     vlan_if_port.append((ifname, self.port_indices[ifname]))

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -32,6 +32,7 @@ import pickle
 from operator import itemgetter
 import scapy.all as scapyall
 import enum
+import ast
 
 class Arista(object):
     DEBUG = False
@@ -43,7 +44,8 @@ class Arista(object):
         self.password = password
         self.conn = None
         self.arista_prompt = None
-        self.v4_routes = [test_params['vlan_ip_range'], test_params['lo_prefix']]
+        self.v4_routes = list(ast.literal_eval(test_params['vlan_ip_range']).values())
+        self.v4_routes.append(test_params['lo_prefix'])
         self.v6_routes = [test_params['lo_v6_prefix']]
         self.fails = set()
         self.info = set()

--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -51,7 +51,7 @@
     - name: Set PTF test params
       set_fact:
         dut_mac: "{{ ansible_Ethernet0['macaddress'] }}"
-        vlan_ip_range: "{{ minigraph_vlan_interfaces[0]['subnet'] }}"
+        vlan_ip_range: "{ '{{ minigraph_vlan_interfaces[0]['attachto'] }}': '{{ minigraph_vlan_interfaces[0]['subnet'] }}' }"
         lo_v6_prefix: "{{ minigraph_lo_interfaces | map(attribute='addr') | ipv6 | first | ipsubnet(64) }}"
 
     - name: Remove existing ip from ptf host

--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -60,9 +60,8 @@
         - vlan_ports_file=\"/tmp/vlan_interfaces.json\"
         - ports_file=\"/tmp/ports.json\"
         - dut_mac='{{ dut_mac }}'
-        - dut_vlan_ip='192.168.0.1'
         - default_ip_range='192.168.100.0/18'
-        - vlan_ip_range='{{ vlan_ip_range }}'
+        - vlan_ip_range=\"{{ vlan_ip_range }}\"
         - lo_v6_prefix='{{ lo_v6_prefix }}'
         - arista_vms=\"['{{ vm_hosts | list | join("','") }}']\"
         - preboot_files='{{ preboot_files }}'

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -158,8 +158,11 @@ class AdvancedReboot:
 
         self.rebootData['dut_hostname'] = self.mgFacts['minigraph_mgmt_interface']['addr']
         self.rebootData['dut_mac'] = self.duthost.facts['router_mac']
-        self.rebootData['vlan_ip_range'] = self.mgFacts['minigraph_vlan_interfaces'][0]['subnet']
-        self.rebootData['dut_vlan_ip'] = self.mgFacts['minigraph_vlan_interfaces'][0]['addr']
+        vlan_ip_range = dict()
+        for vlan in self.mgFacts['minigraph_vlan_interfaces']:
+            if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
+                vlan_ip_range[vlan['attachto']] = vlan['subnet']
+        self.rebootData['vlan_ip_range'] = json.dumps(vlan_ip_range)
 
         self.rebootData['dut_username'] = self.creds['sonicadmin_user']
         self.rebootData['dut_password'] = self.creds['sonicadmin_password']
@@ -494,7 +497,6 @@ class AdvancedReboot:
                 "vlan_ports_file" : self.rebootData['vlan_interfaces_file'],
                 "ports_file" : self.rebootData['ports_file'],
                 "dut_mac" : self.rebootData['dut_mac'],
-                "dut_vlan_ip" : self.rebootData['dut_vlan_ip'],
                 "default_ip_range" : self.rebootData['default_ip_range'],
                 "vlan_ip_range" : self.rebootData['vlan_ip_range'],
                 "lo_v6_prefix" : self.rebootData['lo_v6_prefix'],

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -115,6 +115,10 @@ def ptf_params(duthost, creds, tbinfo, upgrade_type):
             attr['mgmt_addr'] for dev, attr in mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
         ]
     sonicadmin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
+    vlan_ip_range = dict()
+    for vlan in mgFacts['minigraph_vlan_interfaces']:
+        if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
+            vlan_ip_range[vlan['attachto']] = vlan['subnet']
     ptf_params = {
         "verbose": False,
         "dut_username": creds.get('sonicadmin_user'),
@@ -127,9 +131,8 @@ def ptf_params(duthost, creds, tbinfo, upgrade_type):
         "vlan_ports_file": TMP_VLAN_FILE,
         "ports_file": TMP_PORTS_FILE,
         "dut_mac": duthost.facts["router_mac"],
-        "dut_vlan_ip": "192.168.0.1",
         "default_ip_range": "192.168.100.0/18",
-        "vlan_ip_range": mg_facts['minigraph_vlan_interfaces'][0]['subnet'],
+        "vlan_ip_range": json.dumps(vlan_ip_range),
         "lo_v6_prefix": lo_v6_prefix,
         "arista_vms": vm_hosts,
         "setup_fdb_before_test": True,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve advanced reboot test to support multiple VLANs and the scenario with portchannel in VLAN
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The current advanced reboot tests only support the scenario with one vlan and no portchannel in vlans. This PR aims to improve the test cases to cover broader scenarios.

#### How did you do it?
Update advanced reboot to take account of multiple VLANs and ignore portchannel ports in VLANs.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
