### PR TITLE
[pfc] test_unknown_mac use correct MAC when sending packet

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -222,6 +222,7 @@ class TrafficSendVerify(object):
         self.exp_pkts = list()
         self.pkt_map = dict()
         self.pre_rx_drops = dict()
+        self.dut_mac = duthost.facts['router_mac']
 
     def _constructPacket(self):
         """
@@ -232,7 +233,7 @@ class TrafficSendVerify(object):
             udp_dport = random.randint(0, 65535)
             src_port = self.ptf_pc_ports[pc_info][0]
             src_ip = self.ptf_pc_ports[pc_info][2]
-            pkt = testutils.simple_udp_packet(eth_dst=self.arp_entry[self.dst_ip],
+            pkt = testutils.simple_udp_packet(eth_dst=self.dut_mac,
                                                         eth_src=self.ptfadapter.dataplane.get_mac(0, src_port),
                                                         ip_dst=self.dst_ip,
                                                         ip_src=src_ip,
@@ -243,7 +244,7 @@ class TrafficSendVerify(object):
                                                        )
             self.pkts.append(pkt)
             tmp_pkt = testutils.simple_udp_packet(eth_dst=self.arp_entry[self.dst_ip],
-                                                  eth_src=self.ptfadapter.dataplane.get_mac(0, src_port),
+                                                  eth_src=self.dut_mac,
                                                   ip_dst=self.dst_ip,
                                                   ip_src=src_ip,
                                                   ip_tos = self.dscp << 2,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_unknown_mac sending packets with incorrect MAC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
Packets sent during test_unknown_mac are always dropped, even if FDB table is not cleared. 
This occurs due to incorrect MAC address of generated packets - destination MAC was set to MAC of expected port on PTF. Since packets are sent from PTF ports mapped to portchannels, DUT always drops these packets.
#### How did you do it?
Replaced destination MAC of sent packet and source MAC of expected packet with DUT MAC. 
#### How did you verify/test it?
Run pfc/test_unknown_mac
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
