### PR TITLE
[lldp]: Fix of a fake test pass

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -23,11 +23,14 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, co
 
     config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
     lldpctl_facts = duthost.lldpctl_facts(asic_instance_id=enum_frontend_asic_index, skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
-    for k, v in lldpctl_facts['lldpctl'].items():
-        # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
-        assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
-        # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
-        assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
+    if not lldpctl_facts['lldpctl'].items():
+        pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
+    else:
+        for k, v in lldpctl_facts['lldpctl'].items():
+            # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
+            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
+            # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
+            assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
 
 
 def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, eos,
@@ -48,7 +51,8 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
     dut_system_description = res['stdout']
     lldpctl_facts = duthost.lldpctl_facts(asic_instance_id=enum_frontend_asic_index, skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
     config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    
+    if not lldpctl_facts['lldpctl'].items():
+        pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
     # We use the MAC of mgmt port to generate chassis ID as LLDPD dose. 
     # To be compatible with PR #3331, we keep using router MAC on T2 devices
     switch_mac = ""

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -25,12 +25,11 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, co
     lldpctl_facts = duthost.lldpctl_facts(asic_instance_id=enum_frontend_asic_index, skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
     if not lldpctl_facts['lldpctl'].items():
         pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
-    else:
-        for k, v in lldpctl_facts['lldpctl'].items():
-            # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
-            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
-            # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
-            assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
+    for k, v in lldpctl_facts['lldpctl'].items():
+        # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
+        assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
+        # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
+        assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
 
 
 def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, eos,


### PR DESCRIPTION
Signed-off-by: Vladyslav Morokhovych <vladyslavx.morokhovych@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix issue when DUT didn't get any LLDP neighbors but TC still passed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
When DUT didn't get any LLDP neighbors (`lldpctl_facts['lldpctl']` are empty) and test go to:
`for k, v in lldpctl_facts['lldpctl'].items():`
there is no checks are performed during the test and it give us a fake pass of test
#### How did you do it?
Added check if `lldpctl_facts['lldpctl'].items()` are empty, and provide an fail with the appropriate comment
#### How did you verify/test it?
lldp/test_lldp.py::test_lldp PASSED                                                                                                                                                                                                         
lldp/test_lldp.py::test_lldp_neighbor PASSED 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
