### PR TITLE
[sanity-check] Improve recovery logic - enable neighbor VM health restore

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -116,7 +116,7 @@ class EosHost(AnsibleHostBase):
     def no_shutdown_bgp(self, asn):
         out = self.eos_config(
             lines=['no shut'],
-            parents=['router bgp %s'.format(asn)])
+            parents=['router bgp {}'.format(asn)])
         logging.info('No shut BGP [%s]' % asn)
         return out
 

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -113,6 +113,13 @@ class EosHost(AnsibleHostBase):
         out = self.eos_config(lines=['no agent Rib shutdown'])
         return out
 
+    def no_shutdown_bgp(self, asn):
+        out = self.eos_config(
+            lines=['no shut'],
+            parents=['router bgp %s'.format(asn)])
+        logging.info('No shut BGP [%s]' % asn)
+        return out
+
     def check_bgp_session_state(self, neigh_ips, neigh_desc, state="established"):
         """
         @summary: check if current bgp session equals to the target state

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -12,6 +12,7 @@ from tests.common.plugins.sanity_check import constants
 from tests.common.plugins.sanity_check import checks
 from tests.common.plugins.sanity_check.checks import *
 from tests.common.plugins.sanity_check.recover import recover
+from tests.common.plugins.sanity_check.recover import neighbor_vm_restore
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 
@@ -117,7 +118,7 @@ def do_checks(request, check_items, *args, **kwargs):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def sanity_check(localhost, duthosts, request, fanouthosts, tbinfo):
+def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
     logger.info("Prepare sanity check")
 
     skip_sanity = False
@@ -228,6 +229,9 @@ def sanity_check(localhost, duthosts, request, fanouthosts, tbinfo):
                     if 'host' in failed_result:
                         dut_failed_results[failed_result['host']].append(failed_result)
                 for dut_name, dut_results in dut_failed_results.items():
+                    # Attempt to restore neighbor VM state
+                    neighbor_vm_restore(duthosts[dut_name], nbrhosts, tbinfo)
+                    # Attempt to restore DUT state
                     recover(duthosts[dut_name], localhost, fanouthosts, dut_results, recover_method)
 
                 logger.info("Run sanity check again after recovery")

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -98,3 +98,21 @@ def recover(dut, localhost, fanouthosts, check_results, recover_method):
         reboot_dut(dut, localhost, method["cmd"], wait_time)
     else:
         __recover_with_command(dut, method['cmd'], wait_time)
+
+
+def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    vm_neighbors = mg_facts['minigraph_neighbors']
+    lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+
+    for lag_name in lag_facts['names']:
+        nbr_intf = lag_facts['lags'][lag_name]['po_config']['ports'].keys()[0]
+        peer_device   = vm_neighbors[nbr_intf]['name']
+        nbr_host = nbrhosts[peer_device]['host']
+        intf_list = nbrhosts[peer_device]['conf']['interfaces'].keys()
+        # restore interfaces and portchannels
+        for intf in intf_list:
+            nbr_host.no_shutdown(intf)
+        asn = nbrhosts[peer_device]['conf']['bgp']['asn']
+        # restore BGP session
+        nbr_host.no_shutdown_bgp(asn)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from tests.platform_tests.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, OFFSET_ITEMS, TIME_SPAN_ITEMS
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.plugins.sanity_check.recover import neighbor_vm_restore
 from .args.advanced_reboot_args import add_advanced_reboot_args
 from .args.cont_warm_reboot_args import add_cont_warm_reboot_args
 from .args.normal_reboot_args import add_normal_reboot_args
@@ -320,21 +321,7 @@ def advanceboot_neighbor_restore(duthosts, rand_one_dut_hostname, nbrhosts, tbin
     """
     yield
     duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    vm_neighbors = mg_facts['minigraph_neighbors']
-    lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-
-    for lag_name in lag_facts['names']:
-        nbr_intf = lag_facts['lags'][lag_name]['po_config']['ports'].keys()[0]
-        peer_device   = vm_neighbors[nbr_intf]['name']
-        nbr_host = nbrhosts[peer_device]['host']
-        intf_list = nbrhosts[peer_device]['conf']['interfaces'].keys()
-        # restore interfaces and portchannels
-        for intf in intf_list:
-            nbr_host.no_shutdown(intf)
-        asn = nbrhosts[peer_device]['conf']['bgp']['asn']
-        # restore BGP session
-        nbr_host.no_shutdown_bgp(asn)
+    neighbor_vm_restore(duthost, nbrhosts, tbinfo)
 
 
 def pytest_addoption(parser):

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -33,7 +33,7 @@ def test_warm_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     advancedReboot.runRebootTestcase()
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad(request, get_advanced_reboot):
+def test_warm_reboot_sad(request, get_advanced_reboot, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path
 
@@ -60,7 +60,7 @@ def test_warm_reboot_sad(request, get_advanced_reboot):
     )
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_multi_sad(request, get_advanced_reboot):
+def test_warm_reboot_multi_sad(request, get_advanced_reboot, advanceboot_neighbor_restore):
     '''
     Warm reboot with multi sad path
 
@@ -117,7 +117,7 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
     )
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
+def test_warm_reboot_sad_bgp(request, get_advanced_reboot, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad (bgp)
 
@@ -139,7 +139,7 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
     )
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
+def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path (lag member)
 
@@ -170,7 +170,7 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
     )
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_lag(request, get_advanced_reboot):
+def test_warm_reboot_sad_lag(request, get_advanced_reboot, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path (lag)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable the recovery logic to restore neighbor VMs ports and BGP state to `no shutdown`
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Present recovery logic after sanity check failure does not help if the neighbor VMs are in bad state (down ports, bgp session).
This leads to all the tests failing at test_setup as the testbed remains unhealthy.

How can neighbors be in bad state?
In SAD testcases for test_warm_reboot, the interfaces, LAGs and BGP sessions are shutdown in neighbor (T1) VMs.
If the test script (advanced-reboot.py) crashes or the test abruptly fails, the neighbor VMs will still be in bad state. This will cause consecutive testcases to start failing.

#### How did you do it?
Add neighbor restore attempt to recovery script that runs as part of sanity checks.
Also, add a teardown logic in a fixture which will restore all the interfaces, LAGs and BGP sessions on T1 neighbors.

#### How did you verify/test it?
Tested a few cases (down links, Portchannels and BGP) - after the abrupt test exist, the teardown function restores the neighbors back to a good state.
```
---------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------
21:18:20 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet2]
21:18:24 eos.no_shutdown                          L0077 INFO   | No shut interface [Port-Channel1]
21:18:27 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet1]
21:18:31 eos.no_shutdown                          L0077 INFO   | No shut interface [Loopback0]
21:18:35 eos.no_shutdown_bgp                      L0120 INFO   | No shut BGP 4200064600
21:18:39 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet2]
21:18:42 eos.no_shutdown                          L0077 INFO   | No shut interface [Port-Channel1]
21:18:46 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet1]
21:18:50 eos.no_shutdown                          L0077 INFO   | No shut interface [Loopback0]
21:18:53 eos.no_shutdown_bgp                      L0120 INFO   | No shut BGP 4200064600
21:18:57 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet2]
21:19:01 eos.no_shutdown                          L0077 INFO   | No shut interface [Port-Channel1]
21:19:04 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet1]
21:19:08 eos.no_shutdown                          L0077 INFO   | No shut interface [Loopback0]
21:19:12 eos.no_shutdown_bgp                      L0120 INFO   | No shut BGP 4200064600
21:19:16 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet2]
21:19:19 eos.no_shutdown                          L0077 INFO   | No shut interface [Port-Channel1]
21:19:23 eos.no_shutdown                          L0077 INFO   | No shut interface [Ethernet1]
21:19:27 eos.no_shutdown                          L0077 INFO   | No shut interface [Loopback0]
21:19:30 eos.no_shutdown_bgp                      L0120 INFO   | No shut BGP 4200064600
21:19:30 duthost_utils._backup_and_restore_config L0030 INFO   | Restore /etc/sonic/config_db.json with /etc/sonic/config_db.json.before_test_function on str2-7260cx3-acs-9
21:19:31 advanced_reboot.tearDown                 L0538 INFO   | Running test tear down
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
