### PR TITLE
[qos] Add qos params for breakout 7050 and enable test run

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -227,6 +227,64 @@ qos_params:
                 pkts_num_trig_ingr_drp: 5164
                 pkts_num_fill_egr_min: 0
                 cell_size: 208
+            breakout:
+                pkts_num_leak_out: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4780
+                    pkts_num_trig_ingr_drp: 5046
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 4780
+                    pkts_num_trig_ingr_drp: 5046
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4780
+                    pkts_num_trig_ingr_drp: 5046
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 5046
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 4780
+                    pkts_num_trig_ingr_drp: 5046
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 208
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4780
+                    pkts_num_dismiss_pfc: 18
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 4780
+                    pkts_num_dismiss_pfc: 18
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 6
+                    pkts_num_trig_pfc: 4780
+                    packet_size: 64
+                    cell_size: 208
         40000_40m:
             pkts_num_leak_out: 48
             xoff_1:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -54,6 +54,8 @@ class TestQosSai(QosSaiBase):
         'Arista-7050CX3-32S-C32'
     ]
 
+    BREAKOUT_SKUS = ['Arista-7050-QX-32S']
+
     def testParameter(
         self, duthost, dutConfig, dutQosConfig, ingressLosslessProfile,
         ingressLossyProfile, egressLosslessProfile
@@ -87,7 +89,10 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
-        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        if dutTestParams['hwsku'] in self.BREAKOUT_SKUS:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+        else:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({
@@ -135,9 +140,12 @@ class TestQosSai(QosSaiBase):
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         if xonProfile in dutQosConfig["param"][portSpeedCableLength].keys():
-            qosConfig = dutQosConfig["param"][portSpeedCableLength] 
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]
         else:
-            qosConfig = dutQosConfig["param"]
+            if dutTestParams['hwsku'] in self.BREAKOUT_SKUS:
+                qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+            else:
+                qosConfig = dutQosConfig["param"]
 
 
         dst_port_count = set([
@@ -393,7 +401,7 @@ class TestQosSai(QosSaiBase):
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
         else:
             qosConfig = dutQosConfig["param"]
- 
+
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -530,7 +538,10 @@ class TestQosSai(QosSaiBase):
         if pgProfile in dutQosConfig["param"][portSpeedCableLength].keys():
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
         else:
-            qosConfig = dutQosConfig["param"]
+            if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and pgProfile in dutQosConfig["param"][portSpeedCableLength]["breakout"].keys():
+                qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+            else:
+                qosConfig = dutQosConfig["param"]
 
         if "wm_pg_shared_lossless" in pgProfile:
             pktsNumFillShared = qosConfig[pgProfile]["pkts_num_trig_pfc"]
@@ -582,7 +593,10 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
-        qosConfig = dutQosConfig["param"][portSpeedCableLength]
+        if dutTestParams['hwsku'] in self.BREAKOUT_SKUS:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+        else:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -631,8 +645,11 @@ class TestQosSai(QosSaiBase):
         """
         portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
 
-        if queueProfile == "wm_q_shared_lossless": 
-            qosConfig = dutQosConfig["param"][portSpeedCableLength] 
+        if queueProfile == "wm_q_shared_lossless":
+            if dutTestParams['hwsku'] in self.BREAKOUT_SKUS:
+                qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+            else:
+                qosConfig = dutQosConfig["param"][portSpeedCableLength]
             triggerDrop = qosConfig[queueProfile]["pkts_num_trig_ingr_drp"]
         else:
             if queueProfile in dutQosConfig["param"][portSpeedCableLength].keys():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Arista-7050-QX-32S has 4 10G ports and 31 40G ports. Shared space is different from the 32 port SKU and new parameters need to be added for the qos test run. The testcases have also been modified to consume this information

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

#### How did you verify/test it?
Ran the qos sai test with the new values on breakout 7050 and it passed