### PR TITLE
[test_bgp_update_timer] Enable dualtor

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -160,7 +160,7 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
 
 
 @pytest.fixture(scope="module")
-def setup_interfaces(duthost, ptfhost, request, tbinfo):
+def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
     """Setup interfaces for the new BGP peers on PTF."""
 
     def _is_ipv4_address(ip_addr):
@@ -396,7 +396,8 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
     else:
         raise TypeError("Unsupported topology: %s" % tbinfo["topo"]["type"])
 
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    duthost = duthosts[rand_one_dut_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     with setup_func(mg_facts, peer_count) as connections:
         yield connections
 

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -23,6 +23,8 @@ from bgp_helpers import BGP_PLAIN_TEMPLATE
 from bgp_helpers import BGP_NO_EXPORT_TEMPLATE
 from bgp_helpers import DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST, BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+
 
 logger = logging.getLogger(__name__)
 
@@ -219,16 +221,60 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
             if ip_intf["ipv4 address/mask"].split("/")[0] == ip:
                 duthost.shell("config interface %s ip remove %s %s" % (namespace, ip_intf["interface"], ip))
 
+    def _find_vlan_intferface(mg_facts):
+        for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
+            if _is_ipv4_address(vlan_intf["addr"]):
+                return vlan_intf
+        raise ValueError("No Vlan interface defined in T0.")
+
+    def _find_loopback_interface(mg_facts):
+        loopback_intf_name = "Loopback0"
+        for loopback in mg_facts["minigraph_lo_interfaces"]:
+            if loopback["name"] == loopback_intf_name:
+                return loopback
+        raise ValueError("No loopback interface %s defined." % loopback_intf_name)
+
+    @contextlib.contextmanager
+    def _setup_interfaces_dualtor(mg_facts, peer_count):
+        try:
+            connections = []
+            vlan_intf = _find_vlan_intferface(mg_facts)
+            loopback_intf = _find_loopback_interface(mg_facts)
+            vlan_intf_addr = vlan_intf["addr"]
+            vlan_intf_prefixlen = vlan_intf["prefixlen"]
+            loopback_intf_addr = loopback_intf["addr"]
+            loopback_intf_prefixlen = loopback_intf["prefixlen"]
+
+            mux_configs = mux_cable_server_ip(duthost)
+            local_interfaces = random.sample(mux_configs.keys(), peer_count)
+            for local_interface in local_interfaces:
+                connections.append(
+                    {
+                        "local_intf": loopback_intf["name"],
+                        "local_addr": "%s/%s" % (loopback_intf_addr, loopback_intf_prefixlen),
+                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interface],
+                        "neighbor_addr": "%s/%s" % (mux_configs[local_interface]["server_ipv4"].split("/")[0], vlan_intf_prefixlen)
+                    }
+                )
+
+            ptfhost.remove_ip_addresses()
+
+            for conn in connections:
+                ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"],
+                                                  conn["neighbor_addr"]))
+            ptfhost.shell("ip route add %s via %s" % (loopback_intf_addr, vlan_intf_addr))
+            yield connections
+
+        finally:
+            ptfhost.shell("ip route delete %s" % loopback_intf_addr)
+            for conn in connections:
+                ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
+
     @contextlib.contextmanager
     def _setup_interfaces_t0(mg_facts, peer_count):
         try:
             connections = []
-            vlan_intf = None
-            for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
-                if _is_ipv4_address(vlan_intf["addr"]):
-                    break
-            if vlan_intf is None:
-                raise ValueError("No Vlan interface defined in T0.")
+            vlan_intf = _find_vlan_intferface(mg_facts)
             vlan_intf_name = vlan_intf["attachto"]
             vlan_intf_addr = "%s/%s" % (vlan_intf["addr"], vlan_intf["prefixlen"])
             vlan_members = mg_facts["minigraph_vlans"][vlan_intf_name]["members"]
@@ -341,7 +387,9 @@ def setup_interfaces(duthost, ptfhost, request, tbinfo):
                 ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
 
     peer_count = getattr(request.module, "PEER_COUNT", 1)
-    if tbinfo["topo"]["type"] == "t0":
+    if "dualtor" in tbinfo["topo"]["name"]:
+        setup_func = _setup_interfaces_dualtor
+    elif tbinfo["topo"]["type"] == "t0":
         setup_func = _setup_interfaces_t0
     elif tbinfo["topo"]["type"] == "t1":
         setup_func = _setup_interfaces_t1

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -88,7 +88,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga
             dut_asn,
             NEIGHBOR_PORT0,
             neigh_type,
-            is_quagga=is_quagga or is_dualtor
+            is_multihop=is_quagga or is_dualtor
         ),
         BGPNeighbor(
             duthost,
@@ -100,7 +100,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga
             dut_asn,
             NEIGHBOR_PORT1,
             neigh_type,
-            is_quagga=is_quagga or is_dualtor
+            is_multihop=is_quagga or is_dualtor
         )
     )
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -10,6 +10,11 @@ from scapy.all import sniff, IP
 from scapy.contrib import bgp
 from tests.common.helpers.bgp import BGPNeighbor
 
+
+from tests.common.dualtor.mux_simulator_control import mux_server_url
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+
+
 pytestmark = [
     pytest.mark.topology("any"),
 ]
@@ -43,14 +48,21 @@ def log_bgp_updates(duthost, iface, save_path):
 
 
 @pytest.fixture
-def is_quagga(duthost):
+def is_quagga(duthosts, rand_one_dut_hostname):
     """Return True if current bgp is using Quagga."""
+    duthost = duthosts[rand_one_dut_hostname]
     show_res = duthost.shell("vtysh -c 'show version'")
     return "Quagga" in show_res["stdout"]
 
 
 @pytest.fixture
-def common_setup_teardown(duthost, is_quagga, ptfhost, setup_interfaces):
+def is_dualtor(tbinfo):
+    return "dualtor" in tbinfo["topo"]["name"]
+
+
+@pytest.fixture
+def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces):
+    duthost = duthosts[rand_one_dut_hostname]
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
     conn0, conn1 = setup_interfaces
     dut_asn = mg_facts["minigraph_bgp_asn"]
@@ -76,7 +88,7 @@ def common_setup_teardown(duthost, is_quagga, ptfhost, setup_interfaces):
             dut_asn,
             NEIGHBOR_PORT0,
             neigh_type,
-            is_quagga=is_quagga
+            is_quagga=is_quagga or is_dualtor
         ),
         BGPNeighbor(
             duthost,
@@ -88,7 +100,7 @@ def common_setup_teardown(duthost, is_quagga, ptfhost, setup_interfaces):
             dut_asn,
             NEIGHBOR_PORT1,
             neigh_type,
-            is_quagga=is_quagga
+            is_quagga=is_quagga or is_dualtor
         )
     )
 
@@ -118,7 +130,8 @@ def constants(is_quagga, setup_interfaces):
     return _constants
 
 
-def test_bgp_update_timer(common_setup_teardown, constants, duthost):
+def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_dut_hostname,
+                          toggle_all_simulator_ports_to_rand_selected_tor):
 
     def bgp_update_packets(pcap_file):
         """Get bgp update packets from pcap file."""
@@ -141,6 +154,8 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthost):
             return bgp_fields["withdrawn_len"] > 0 and _route in bgp_fields["withdrawn"]
         else:
             return False
+
+    duthost = duthosts[rand_one_dut_hostname]
 
     n0, n1 = common_setup_teardown
     try:

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -23,7 +23,7 @@ class BGPNeighbor(object):
 
     def __init__(self, duthost, ptfhost, name,
                  neighbor_ip, neighbor_asn,
-                 dut_ip, dut_asn, port, neigh_type, is_quagga=False):
+                 dut_ip, dut_asn, port, neigh_type, is_multihop=False):
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.ptfip = ptfhost.mgmt_ip
@@ -34,7 +34,7 @@ class BGPNeighbor(object):
         self.peer_asn = dut_asn
         self.port = port
         self.type = neigh_type
-        self.is_quagga = is_quagga
+        self.is_multihop = is_multihop
 
     def start_session(self):
         """Start the BGP session."""
@@ -75,7 +75,7 @@ class BGPNeighbor(object):
         if not wait_tcp_connection(self.ptfhost, self.ptfip, self.port):
             raise RuntimeError("Failed to start BGP neighbor %s" % self.name)
 
-        if self.is_quagga:
+        if self.is_multihop:
             allow_ebgp_multihop_cmd = (
                 "vtysh "
                 "-c 'configure terminal' "

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -144,7 +144,7 @@ def bgp_neighbors(upper_tor_host, lower_tor_host, ptfhost, setup_interfaces):
             conn["local_asn"],
             conn["exabgp_port"],
             conn["neighbor_type"],
-            is_quagga=is_quagga
+            is_multihop=is_quagga
         )
     return neighbors
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
`test_bgp_update_timer` fails for dualtor testbeds.

#### How did you do it?
1. make the test compatible for the multiple-DUTs testbed.
2. let the DUT uses loopback instead of VLAN interface to start BGP sessions.
3. choose ip addresses in the VLAN subnet(`192.168.0.0/21`) for ptf interfaces from the mux configs.

#### How did you verify/test it?
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer PASSED                                                                                                                                     [100%]

===================================================================================== 1 passed in 196.89 seconds =====================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
