### PR TITLE
Restart mux simulator with PTF

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -9,6 +9,12 @@
       ptf_imagetag: "latest"
     when: ptf_imagetag is not defined
 
+  - name: Stop mux simulator
+    include_tasks: control_mux_simulator.yml
+    vars:
+      mux_simulator_action: stop
+    when: "'dualtor' in topo"
+
   - name: Remove ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}
@@ -87,5 +93,11 @@
     when:
       - topo != 'fullmesh'
       - not 'ptf' in topo
+
+  - name: Start mux simulator
+    include_tasks: control_mux_simulator.yml
+    vars:
+      mux_simulator_action: start
+    when: "'dualtor' in topo"
 
   when: container_type == "PTF"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When PTF is restarted, it would be better to restart the mux simulator
service as well to include the latest mux simulator changes.

#### How did you do it?
Restart mux simulator together with restarting PTF.

#### How did you verify/test it?
Run 'testbed-cli.sh restart-ptf'.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
