### PR TITLE
Test cases for RADV IPv6 router advertisement

### DIFF
--- a/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
+++ b/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
@@ -217,9 +217,8 @@ class RadvSolicitedRATest(DataplaneBaseTest):
         logging.info("Sending ICMPv6 router solicitation on PTF port:eth%s",
                      self.ptf_port_index)
         ret = testutils.send_packet(self, self.ptf_port_index, self.rs_packet)
-        assert(len(self.rs_packet) == ret,
-               "Failed to send ICMPv6 router solicitation on PTF port:eth%s",
-               self.ptf_port_index)
+        assert len(self.rs_packet) == ret, \
+               "Failed to send ICMPv6 router solicitation on PTF eth%s".format(self.ptf_port_index)
 
     """
     @summary: Verify the received solicited RA packet from the router/DUT

--- a/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
+++ b/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
@@ -1,0 +1,240 @@
+# Packet Test Framework imports
+import ptf
+import scapy
+import logging
+import ptf.testutils as testutils
+from ptf import config
+from ptf.base_tests import BaseTest
+from ptf.mask import Mask
+
+ALL_NODES_MULTICAST_MAC_ADDRESS = '33:33:00:00:00:01'
+ALL_ROUTERS_MULTICAST_MAC_ADDRESS = '33:33:00:00:00:02'
+ALL_NODES_IPV6_MULTICAST_ADDRESS = 'ff02::1'
+ALL_ROUTERS_IPV6_MULTICAST_ADDRESS = 'ff02::2'
+ICMPV6_SOLICITED_RA_TIMEOUT = 1
+
+class DataplaneBaseTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+
+    def setUp(self):
+        # Filter for ICMPv6 RA packets
+        def is_icmpv6_ra(pkt_str):
+            try:
+                pkt = scapy.layers.l2.Ether(pkt_str)
+                return (scapy.layers.inet6.IPv6 in pkt and scapy.layers.inet6.ICMPv6ND_RA in pkt)
+            except:
+                return False
+
+        self.dataplane = ptf.dataplane_instance
+        self.dataplane.flush()
+        testutils.add_filter(is_icmpv6_ra)
+
+        if config["log_dir"] is not None:
+            filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
+            self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config["log_dir"] is not None:
+            self.dataplane.stop_pcap()
+        testutils.reset_filters()
+
+    """
+    @summary: Creates an ICMPv6 router advertisement packet with ICMPv6 prefix option
+
+    """
+    def create_icmpv6_router_advertisement_packet(self, dst_mac, dst_ip, src_mac, src_ip):
+        ether = scapy.layers.l2.Ether(dst=dst_mac, src=src_mac)
+        ip6 = scapy.layers.inet6.IPv6(src=src_ip, dst=dst_ip, fl=0, tc=0, hlim=255)
+        icmp6 = scapy.layers.inet6.ICMPv6ND_RA(code=0, M=1, O=0)
+        #NOTE: Test expects RA packet to contain route prefix as the first option
+        icmp6 /= scapy.layers.inet6.ICMPv6NDOptPrefixInfo(type=3, len=4)
+        rapkt = ether / ip6 / icmp6
+        return rapkt
+
+    """
+    @summary: Mask off fields we don't care about matching in RA packet
+    Match following fields of RA packet:-
+        1. Eth src and dest
+        2. Link local IPv6 src and dest
+        3. IP6 hop limit = 255
+        4. ICMPv6 RA type == 134 and code == 0
+        5. Flag M == 1 and O == 0
+        6. ICMPv6 prefix option (i.e type == 3 and len == 4)
+
+    """
+    def mask_off_dont_care_ra_packet_fields(self, rapkt):
+        masked_rapkt = Mask(rapkt)
+        masked_rapkt.set_ignore_extra_bytes()
+
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.IPv6, "version")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.IPv6, "tc")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.IPv6, "fl")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.IPv6, "plen")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.IPv6, "nh")
+
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "cksum")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "chlim")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "H")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "prf")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "P")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "res")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "routerlifetime")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "reachabletime")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6ND_RA, "retranstimer")
+
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "prefixlen")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "L")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "A")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "R")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "res1")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "validlifetime")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo,
+                                    "preferredlifetime")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "res2")
+        masked_rapkt.set_do_not_care_scapy(scapy.layers.inet6.ICMPv6NDOptPrefixInfo, "prefix")
+
+        return masked_rapkt
+
+"""
+@summary: This test is to validate the unsolicted router advertisements sent on
+the VLAN network of the ToR. In this test we listen on the first PTF port
+(Eg eth0) for any RA messages.
+
+"""
+
+class RadvUnSolicitedRATest(DataplaneBaseTest):
+    def __init__(self):
+        DataplaneBaseTest.__init__(self)
+
+    def setUp(self):
+        DataplaneBaseTest.setUp(self)
+
+        self.test_params = testutils.test_params_get()
+
+        self.hostname = self.test_params['hostname']
+        self.downlink_vlan_mac = self.test_params['downlink_vlan_mac']
+        self.downlink_vlan_ip6 = self.test_params['downlink_vlan_ip6']
+        self.ptf_port_index = int(self.test_params['ptf_port_index'])
+        self.ptf_port_mac = self.dataplane.get_mac(0, self.ptf_port_index)
+        self.radv_max_ra_interval = int(self.test_params['max_ra_interval'])
+
+        rapkt = self.create_icmpv6_router_advertisement_packet(
+                                                src_mac=self.downlink_vlan_mac,
+                                                dst_mac=ALL_NODES_MULTICAST_MAC_ADDRESS,
+                                                src_ip=self.downlink_vlan_ip6,
+                                                dst_ip=ALL_NODES_IPV6_MULTICAST_ADDRESS)
+        self.masked_rapkt = self.mask_off_dont_care_ra_packet_fields(rapkt)
+
+
+    def tearDown(self):
+        DataplaneBaseTest.tearDown(self)
+
+    """
+    @summary: Verify received RA packet
+
+    """
+
+    def verify_periodic_router_advertisement(self):
+        testutils.verify_packet(
+                                self,
+                                self.masked_rapkt,
+                                self.ptf_port_index,
+                                self.radv_max_ra_interval+1)
+        logging.info("Received unsolicited RA from:%s on PTF eth%d",
+                                                            self.downlink_vlan_ip6,
+                                                            self.ptf_port_index)
+
+
+    def runTest(self):
+        count = 5
+        while count > 0:
+            self.verify_periodic_router_advertisement()
+            count = count - 1
+
+"""
+@summary: This test validates the solicited router advertisement sent on the VLAN network of the ToR
+We simulate the ToR sending the ICMPv6 router solicitation packet through one of the PTF port (eg eth0)
+
+"""
+
+class RadvSolicitedRATest(DataplaneBaseTest):
+    def __init__(self):
+        DataplaneBaseTest.__init__(self)
+
+    def setUp(self):
+        DataplaneBaseTest.setUp(self)
+
+        self.test_params = testutils.test_params_get()
+
+        self.hostname = self.test_params['hostname']
+        self.downlink_vlan_mac = self.test_params['downlink_vlan_mac']
+        self.downlink_vlan_ip6 = self.test_params['downlink_vlan_ip6']
+        self.ptf_port_index = int(self.test_params['ptf_port_index'])
+        self.ptf_port_mac = self.dataplane.get_mac(0, self.ptf_port_index)
+        self.ptf_port_ip6 = self.test_params['ptf_port_ip6']
+        self.radv_max_ra_interval = int(self.test_params['max_ra_interval'])
+
+        rapkt = self.create_icmpv6_router_advertisement_packet(
+                                    src_mac=self.downlink_vlan_mac,
+                                    dst_mac=self.ptf_port_mac,
+                                    src_ip=self.downlink_vlan_ip6,
+                                    dst_ip=self.ptf_port_ip6)
+
+        self.masked_rapkt = self.mask_off_dont_care_ra_packet_fields(rapkt)
+        self.rs_packet = self.create_icmpv6_router_solicitation_packet()
+
+    def tearDown(self):
+        DataplaneBaseTest.tearDown(self)
+
+
+    """
+    @summary: Creates a solicited RA packet originating from PTF port
+
+    """
+    def create_icmpv6_router_solicitation_packet(self):
+        ether = scapy.layers.l2.Ether(
+                            dst=ALL_ROUTERS_MULTICAST_MAC_ADDRESS,
+                            src=self.ptf_port_mac)
+        ip6 = scapy.layers.inet6.IPv6(
+                                    dst=ALL_ROUTERS_IPV6_MULTICAST_ADDRESS,
+                                    src=self.ptf_port_ip6,
+                                    fl=0,
+                                    tc=0,
+                                    hlim=255)
+        icmp6 = scapy.layers.inet6.ICMPv6ND_RS(code=0, res=0)
+        rspkt = ether / ip6 / icmp6
+        return rspkt
+
+    """
+    @summary: Sends ICMPv6 router solicitation packet on PTF port
+
+    """
+    def ptf_send_icmpv6_router_solicitation(self):
+        logging.info("Sending ICMPv6 router solicitation on PTF port:eth%s",
+                                                                self.ptf_port_index)
+        ret = testutils.send_packet(self, self.ptf_port_index, self.rs_packet)
+        assert(len(self.rs_packet) == ret,
+                "Failed to send ICMPv6 router solicitation on PTF port:eth%s",
+                        self.ptf_port_index)
+
+    """
+    @summary: Verify the received solicited RA packet from the router/DUT
+
+    """
+    def verify_solicited_router_advertisement(self):
+        testutils.verify_packet(
+                                self,
+                                self.masked_rapkt,
+                                self.ptf_port_index,
+                                ICMPV6_SOLICITED_RA_TIMEOUT)
+        logging.info("Received solicited RA from:%s on PTF eth%d",
+                                                            self.downlink_vlan_ip6,
+                                                            self.ptf_port_index)
+
+    def runTest(self):
+        count = 5
+        while count > 0:
+            self.ptf_send_icmpv6_router_solicitation()
+            self.verify_solicited_router_advertisement()
+            count = count - 1

--- a/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
+++ b/ansible/roles/test/files/ptftests/radv_ipv6_ra_test.py
@@ -31,7 +31,7 @@ class DataplaneBaseTest(BaseTest):
             try:
                 pkt = Ether(pkt_str)
                 return (IPv6 in pkt and RA in pkt)
-            except:
+            except Exception:
                 return False
 
         self.dataplane = ptf.dataplane_instance

--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -1,0 +1,158 @@
+import ipaddress
+import pytest
+import time
+import logging
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.ptf_runner import ptf_runner
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('vs')
+]
+
+RADV_CONF_FILE = '/etc/radvd.conf'
+RADV_MIN_RA_INTERVAL = 3
+RADV_MAX_RA_INTERVAL = 4
+
+"""
+@summary: This fixture collects the data related to downlink VLAN port(s) and
+the connected PTF port(s) required to setup the RADV tests
+
+"""
+
+@pytest.fixture(scope="module")
+def radv_test_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+    dhcp_relay_data_list = []
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    # RADVd is configured for each VLAN interface
+    vlan_dict = mg_facts['minigraph_vlans']
+    vlan_interfaces_list = []
+    for vlan_iface_name, vlan_info_dict in vlan_dict.items():
+        # Gather information about the downlink VLAN interface this relay agent is listening on
+        downlink_vlan_iface = {}
+        downlink_vlan_iface['name'] = vlan_iface_name
+
+        # Obtain the link-local IPv6 address of the DUT's downlink VLAN interface
+        downlink_vlan_iface['mac'] = duthost.get_dut_iface_mac(vlan_iface_name)
+        cmd = "ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'".format(vlan_iface_name)
+        res = duthost.shell(cmd)
+        ip6 = ipaddress.IPv6Address(unicode(res['stdout']))
+        pytest_assert(ip6.is_link_local,
+                "ip6 address:{} of {} is not a link-local address".format(str(ip6), downlink_vlan_iface['name']))
+        downlink_vlan_iface['ip6'] = str(ip6)
+
+        # Obtain link-local IPv6 address of the connected PTF port (Eg eth0)
+        # This PTF port maps to the first member of the TOR's VLAN
+        ptf_port = {}
+        ptf_port['port_idx'] = mg_facts['minigraph_ptf_indices'][vlan_info_dict['members'][0]]
+        ptf_port['name'] = "eth" + str(ptf_port['port_idx'])
+        cmd = "ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'".format(ptf_port['name'])
+        res = ptfhost.shell(cmd)
+        ip6 = ipaddress.IPv6Address(unicode(res['stdout']))
+        pytest_assert(ip6.is_link_local,
+                "ip6 address:{} of {} is not a link-local address".format(str(ip6), ptf_port['name']))
+        ptf_port['ip6'] = str(ip6)
+
+        vlan_intf_data = {}
+        vlan_intf_data['downlink_vlan_intf'] = downlink_vlan_iface
+        vlan_intf_data['ptf_port'] = ptf_port
+        vlan_interfaces_list.append(vlan_intf_data)
+
+    return vlan_interfaces_list
+
+"""
+@summary: Updates min/max RA interval in RADVd's config file
+
+"""
+
+def dut_update_ra_interval(duthost, ra, interval):
+    logging.info("Updating %s to %d in RADVd's config file:%s", ra, int(interval), RADV_CONF_FILE)
+    cmd = "sed -ie 's/\(.*\)\({}\) \([[:digit:]]\+\)/\\1\\2 {}/' {}".format(ra, interval, RADV_CONF_FILE)
+    duthost.shell("docker exec radv {}".format(cmd))
+
+"""
+@summary: A fixture that updates the RADVd's periodic RA update intervals and restores the
+intervals to old values after the test
+
+"""
+@pytest.fixture
+def dut_update_radv_periodic_ra_interval(duthost):
+    pytest_assert(duthost.is_service_fully_started('radv'), "radv service not running")
+
+    cmd = 'docker exec radv [ -f {} ] && echo "1" || echo "0"'.format(RADV_CONF_FILE)
+    pytest_assert(u'1' == duthost.shell(cmd)["stdout"], "radv conf file {} NOT found".format(RADV_CONF_FILE))
+
+    cmd = "grep 'MinRtrAdvInterval' {}".format(RADV_CONF_FILE)
+    cmd += " | sed -e 's/.*\(MinRtrAdvInterval\) \([[:digit:]]\+\)\;/\\2/;'"
+    curr_min_ra_interval = duthost.shell('docker exec radv {}'.format(cmd))["stdout"]
+
+    cmd = "grep 'MaxRtrAdvInterval' {}".format(RADV_CONF_FILE)
+    cmd += " | sed -e 's/.*\(MaxRtrAdvInterval\) \([[:digit:]]\+\)\;/\\2/;'"
+    curr_max_ra_interval = duthost.shell('docker exec radv {}'.format(cmd))["stdout"]
+
+    dut_update_ra_interval(duthost, "MinRtrAdvInterval", RADV_MIN_RA_INTERVAL)
+    dut_update_ra_interval(duthost, "MaxRtrAdvInterval", RADV_MAX_RA_INTERVAL)
+
+    # Notify RADVd to read the updated RA intervals
+    logging.info("Notifying RADVd to read the updated config file:%s", RADV_CONF_FILE)
+    duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
+
+    yield
+    # Restore the RA interval back to original values
+    dut_update_ra_interval(duthost, "MinRtrAdvInterval", curr_min_ra_interval)
+    dut_update_ra_interval(duthost, "MaxRtrAdvInterval", curr_max_ra_interval)
+    duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
+    logging.info("Successfully restored RADVd's config back to original")
+
+"""
+@summary: Test validates the RADVd's periodic router advertisement sent on each VLAN interface
+
+"""
+
+def test_radv_router_advertisement(dut_update_radv_periodic_ra_interval, duthost, ptfhost, radv_test_setup):
+    for vlan_intf in radv_test_setup:
+        # Run the RADV test on the PTF host
+        logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
+                                                vlan_intf['downlink_vlan_intf']['name'],
+                                                vlan_intf['ptf_port']['port_idx'])
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "radv_ipv6_ra_test.RadvUnSolicitedRATest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "downlink_vlan_mac": vlan_intf['downlink_vlan_intf']['mac'],
+                           "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
+                           "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
+                           "max_ra_interval": RADV_MAX_RA_INTERVAL},
+                   log_file="/tmp/radv_ipv6_ra_test.RadvUnSolicitedRATest.log")
+
+"""
+@summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
+
+"""
+
+def test_solicited_router_advertisement(ptfhost, duthost, radv_test_setup):
+
+    for vlan_intf in radv_test_setup:
+        # Run the RADV solicited RA test on the PTF host
+        logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
+                                                        vlan_intf['downlink_vlan_intf']['name'],
+                                                        vlan_intf['ptf_port']['port_idx'])
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "radv_ipv6_ra_test.RadvSolicitedRATest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "downlink_vlan_mac": vlan_intf['downlink_vlan_intf']['mac'],
+                           "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
+                           "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
+                           "ptf_port_ip6": vlan_intf['ptf_port']['ip6'],
+                           "max_ra_interval": RADV_MAX_RA_INTERVAL},
+                   log_file="/tmp/radv_ipv6_ra_test.RadvSolicitedRATest.log")

--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -1,13 +1,12 @@
 import ipaddress
-import pytest
-import time
 import logging
+import time
+
+import pytest
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
-from tests.ptf_runner import ptf_runner
-from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+from tests.ptf_runner import ptf_runner
 
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -15,8 +14,9 @@ pytestmark = [
 ]
 
 RADV_CONF_FILE = '/etc/radvd.conf'
-RADV_MIN_RA_INTERVAL = 3
-RADV_MAX_RA_INTERVAL = 4
+RADV_BACKUP_CONF_FILE = '/tmp/radvd.conf'
+RADV_MIN_RA_INTERVAL_SECS = 3
+RADV_MAX_RA_INTERVAL_SECS = 4
 
 """
 @summary: This fixture collects the data related to downlink VLAN port(s) and
@@ -27,7 +27,6 @@ the connected PTF port(s) required to setup the RADV tests
 @pytest.fixture(scope="module")
 def radv_test_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    dhcp_relay_data_list = []
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
@@ -89,25 +88,20 @@ def dut_update_radv_periodic_ra_interval(duthost):
     cmd = 'docker exec radv [ -f {} ] && echo "1" || echo "0"'.format(RADV_CONF_FILE)
     pytest_assert(u'1' == duthost.shell(cmd)["stdout"], "radv conf file {} NOT found".format(RADV_CONF_FILE))
 
-    cmd = "grep 'MinRtrAdvInterval' {}".format(RADV_CONF_FILE)
-    cmd += " | sed -e 's/.*\(MinRtrAdvInterval\) \([[:digit:]]\+\)\;/\\2/;'"
-    curr_min_ra_interval = duthost.shell('docker exec radv {}'.format(cmd))["stdout"]
+    # Take backup of original radvd.conf before updating
+    duthost.shell('docker exec radv cp {} {}'.format(RADV_CONF_FILE, RADV_BACKUP_CONF_FILE))
 
-    cmd = "grep 'MaxRtrAdvInterval' {}".format(RADV_CONF_FILE)
-    cmd += " | sed -e 's/.*\(MaxRtrAdvInterval\) \([[:digit:]]\+\)\;/\\2/;'"
-    curr_max_ra_interval = duthost.shell('docker exec radv {}'.format(cmd))["stdout"]
-
-    dut_update_ra_interval(duthost, "MinRtrAdvInterval", RADV_MIN_RA_INTERVAL)
-    dut_update_ra_interval(duthost, "MaxRtrAdvInterval", RADV_MAX_RA_INTERVAL)
+    dut_update_ra_interval(duthost, "MinRtrAdvInterval", RADV_MIN_RA_INTERVAL_SECS)
+    dut_update_ra_interval(duthost, "MaxRtrAdvInterval", RADV_MAX_RA_INTERVAL_SECS)
 
     # Notify RADVd to read the updated RA intervals
     logging.info("Notifying RADVd to read the updated config file:%s", RADV_CONF_FILE)
     duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
 
     yield
-    # Restore the RA interval back to original values
-    dut_update_ra_interval(duthost, "MinRtrAdvInterval", curr_min_ra_interval)
-    dut_update_ra_interval(duthost, "MaxRtrAdvInterval", curr_max_ra_interval)
+    # Restore the original radvd.conf file
+    duthost.shell('docker exec radv cp {} {}'.format(RADV_BACKUP_CONF_FILE, RADV_CONF_FILE))
+    duthost.shell('docker exec radv rm -f {}'.format(RADV_BACKUP_CONF_FILE))
     duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
     logging.info("Successfully restored RADVd's config back to original")
 
@@ -130,7 +124,7 @@ def test_radv_router_advertisement(dut_update_radv_periodic_ra_interval, duthost
                            "downlink_vlan_mac": vlan_intf['downlink_vlan_intf']['mac'],
                            "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
                            "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
-                           "max_ra_interval": RADV_MAX_RA_INTERVAL},
+                           "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
                    log_file="/tmp/radv_ipv6_ra_test.RadvUnSolicitedRATest.log")
 
 """
@@ -154,5 +148,5 @@ def test_solicited_router_advertisement(ptfhost, duthost, radv_test_setup):
                            "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
                            "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
                            "ptf_port_ip6": vlan_intf['ptf_port']['ip6'],
-                           "max_ra_interval": RADV_MAX_RA_INTERVAL},
+                           "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
                    log_file="/tmp/radv_ipv6_ra_test.RadvSolicitedRATest.log")


### PR DESCRIPTION
### Description of PR
Added new test cases to test RADV IPv6 router advertisement

Summary:
Fixes #3294 

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911


#### What is the motivation for this PR?
Fixes #3294 

#### How did you do it?
1. Verify the DUT is sending unsolicited RA at certain intervals on each VLAN interface
2. Verify the DUT sends solicited RA for every ICMPv6 router solicitation

#### How did you verify/test it?
Verified testcases running pytest on T0 topology

#### Supported testbed topology if it's a new test case?
T0 topology

