### PR TITLE
[static]: Fix non-unique MAC addresses

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -6,6 +6,7 @@ import natsort
 import random
 import re
 
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.utilities import wait_until


### PR DESCRIPTION
  Signed-off-by: Vladyslav Morokhovych <vladyslavx.morokhovych@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Set unique MAC addresses on PTF

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Due to non-unique MAC addresses,
after the config reload, first port with the same MAC address will be written to the ARP table 
and the packet will be sent to this port.
This may cause an error, that expected packet arrive at wrong port.

#### How did you do it?
Set unique MAC addresses on PTF by using fixture: `change_mac_addresses`
#### How did you verify/test it?
Run tests on t0 and t0-64 topo
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
