### PR TITLE
[advanced-reboot] Fix for "SSH threads haven’t finished for 300 seconds"

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -121,11 +121,16 @@ class Arista(object):
         samples[cur_time] = sample
 
         while not (quit_enabled and v4_routing_ok and v6_routing_ok):
-            cmd = self.queue.get()
-            if cmd == 'quit':
-                self.log('quit command received')
-                quit_enabled = True
-                continue
+            cmd = None
+            # quit command was received, we don't process next commands
+            # but wait for v4_routing_ok and v6_routing_ok
+            if not quit_enabled:
+                cmd = self.queue.get()
+                self.log('Command received: cmd={}'.format(cmd))
+                if cmd == 'quit':
+                    quit_enabled = True
+                    continue
+
             cur_time = time.time()
             info = {}
             debug_info = {}


### PR DESCRIPTION
This is due to "quit" command received but v4_routing_ok or
v6_routing_ok is not true, than we will wait forever in
self.queue.get(). What we need to do is to retry this loop without
fetching command (we are quiting, no more commands are expected) until
v4_routing_ok and v6_routing_ok are true or timeout will be reached.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [advanced-reboot] Fix for "SSH threads haven’t finished for 300 seconds"
Fixes https://github.com/Azure/sonic-mgmt/issues/2601

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?

To fix failure - "SSH threads haven’t finished for 300 seconds".

#### How did you do it?

Fix a bug, that will cause SSH thread to stuck forever.

#### How did you verify/test it?

Ran the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
