### PR TITLE
[ARP] Add delay after removing interfae from PortChannel

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -59,12 +59,14 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
         if po1:
             asic.config_portchannel_member(po1, intf1, "del")
+            time.sleep(5)
             collect_info(duthost)
             asic.startup_interface(intf1)
             collect_info(duthost)
 
         if po2:
             asic.config_portchannel_member(po2, intf2, "del")
+            time.sleep(5)
             collect_info(duthost)
             asic.startup_interface(intf2)
             collect_info(duthost)


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
ARP test often fails after removing interface from PortChannel.

Immediately after removing interface (Ethernet0 in our case) from LAG we execute CLI commands that try to reconfigure this interface and add IP address.
Reconfiguring on Linux and SDK level requires some time and we often face with problem that on linux level device is already reconfigured, but we not yet reconfigured on SDK. So we working with interface (Ethernet0) as with routed interface but it actually still a part of LAG. Orcagent terminates and test fails.

#### How did you do it?
Added sleep delay after `sudo config portchannel member del PortChannel0002 Ethernet0`. It will guarantee that for next CLI commands Ethernet0 will be simple routed interface , not member of LAG

#### How did you verify/test it?
run ARP test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t1-lag

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
