### PR TITLE
[pretest] remove older logs from /var/log/ for better log_analyzer analysis

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -34,6 +34,12 @@ def test_cleanup_testbed(duthosts, enum_dut_hostname, request, ptfhost):
         # Remove old dump files.
         duthost.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")
 
+        # delete other log files that are more than a day old,
+        # this step is needed to remove some backup files or the debug files added by users
+        # which can create issue for log-analyzer
+        duthost.shell("sudo find /var/log/ -mtime +1 '*.gz' | sudo xargs rm -f",
+            module_ignore_errors=True, executable="/bin/bash")
+
     # Cleanup rsyslog configuration file that might have damaged by test_syslog.py
     if ptfhost:
         ptfhost.shell("if [[ -f /etc/rsyslog.conf ]]; then mv /etc/rsyslog.conf /etc/rsyslog.conf.orig; uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -37,7 +37,7 @@ def test_cleanup_testbed(duthosts, enum_dut_hostname, request, ptfhost):
         # delete other log files that are more than a day old,
         # this step is needed to remove some backup files or the debug files added by users
         # which can create issue for log-analyzer
-        duthost.shell("sudo find /var/log/ -mtime +1 '*.gz' | sudo xargs rm -f",
+        duthost.shell("sudo find /var/log/ -mtime +1 | sudo xargs rm -f",
             module_ignore_errors=True, executable="/bin/bash")
 
     # Cleanup rsyslog configuration file that might have damaged by test_syslog.py


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove more than one day logs from /var/log dir inside DUT. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
Before tests, some DUTs can have much older files which are not removed as part of present cleanup steps.
These files lead to issues with log_analyzer processing. Examples include backup files and user created debug files:

`/var/log/swss/sairedis.rec.1.gz-2021031300.backup`


#### How did you do it?
Added an extra step for files cleanup as part of test_pretest::test_cleanup_testbed

#### How did you verify/test it?
With modification, the backup and older files are removed from /var/log dir

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
