### PR TITLE
fix arp_neighbor_noptf for multi asic devices

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -30,22 +30,33 @@ class TestNeighborMacNoPtf:
         6: {"intfIp": "fe00::1/64", "NeighborIp": "fe00::2"},
     }	
 
-    def count_routes(self, host, prefix):
+    def count_routes(self, asichost, prefix):
         # Counts routes in ASIC_DB with a given prefix
-        num = host.shell(
-                'sonic-db-cli ASIC_DB eval "return #redis.call(\'keys\', \'{}:{{\\"dest\\":\\"{}*\')" 0'.format(ROUTE_TABLE_NAME, prefix),
+        num = asichost.shell(
+                '{} ASIC_DB eval "return #redis.call(\'keys\', \'{}:{{\\"dest\\":\\"{}*\')" 0'.format(asichost.sonic_db_cli,ROUTE_TABLE_NAME, prefix),
                 module_ignore_errors=True, verbose=True)['stdout']
         return int(num)
 
+    def _check_no_bgp_routes_asic(self, asichost):
+        # Checks that there are no routes installed by BGP in ASIC_DB by filtering out all local routes installed on asic
+        localv6 = self.count_routes(asichost, "fc") + self.count_routes(asichost, "fe")
+        localv4 = self.count_routes(asichost, "10.") + self.count_routes(asichost, "192.168.0.")
+        #these routes are present only on multi asic device, on single asic platform they will be zero
+        internal = self.count_routes(asichost, "8.") + self.count_routes(asichost, "2603")
+        allroutes = self.count_routes(asichost, "")
+        logger.info("asic[{}] localv4 routes {} localv6 routes {} internalv4 {} allroutes {}".format(asichost.asic_index, localv4, localv6, internal, allroutes))
+        bgp_routes_asic = allroutes - localv6 - localv4 - internal - DEFAULT_ROUTE_NUM
+
+        return bgp_routes_asic
+
     def _check_no_bgp_routes(self, duthost):
-        # Checks that there are no routes installed by BGP in ASIC_DB by filtering out all local routes installed on testbeds
-        localv6 = self.count_routes(duthost, "fc") + self.count_routes(duthost, "fe")
-        localv4 = self.count_routes(duthost, "10.") + self.count_routes(duthost, "192.168.0.")
-        allroutes = self.count_routes(duthost, "")
-        bgproutes = allroutes - localv6 - localv4 - DEFAULT_ROUTE_NUM
-
-        return bgproutes == 0
-
+        bgp_routes = 0
+        # Checks that there are no routes installed by BGP in ASIC_DB by filtering out all local routes installed on testbed
+        for asic in duthost.asics:
+            bgp_routes += self._check_no_bgp_routes_asic(asic)
+        
+        return bgp_routes == 0
+            
     @pytest.fixture(scope="module", autouse=True)
     def setupDutConfig(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         """

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -33,15 +33,15 @@ class TestNeighborMacNoPtf:
     def count_routes(self, asichost, prefix):
         # Counts routes in ASIC_DB with a given prefix
         num = asichost.shell(
-                '{} ASIC_DB eval "return #redis.call(\'keys\', \'{}:{{\\"dest\\":\\"{}*\')" 0'.format(asichost.sonic_db_cli,ROUTE_TABLE_NAME, prefix),
+                '{} ASIC_DB eval "return #redis.call(\'keys\', \'{}:{{\\"dest\\":\\"{}*\')" 0'.format(asichost.sonic_db_cli, ROUTE_TABLE_NAME, prefix),
                 module_ignore_errors=True, verbose=True)['stdout']
         return int(num)
 
-    def _check_no_bgp_routes_asic(self, asichost):
-        # Checks that there are no routes installed by BGP in ASIC_DB by filtering out all local routes installed on asic
+    def _get_bgp_routes_asic(self, asichost):
+        # Get the routes installed by BGP in ASIC_DB by filtering out all local routes installed on asic
         localv6 = self.count_routes(asichost, "fc") + self.count_routes(asichost, "fe")
         localv4 = self.count_routes(asichost, "10.") + self.count_routes(asichost, "192.168.0.")
-        #these routes are present only on multi asic device, on single asic platform they will be zero
+        # these routes are present only on multi asic device, on single asic platform they will be zero
         internal = self.count_routes(asichost, "8.") + self.count_routes(asichost, "2603")
         allroutes = self.count_routes(asichost, "")
         logger.info("asic[{}] localv4 routes {} localv6 routes {} internalv4 {} allroutes {}".format(asichost.asic_index, localv4, localv6, internal, allroutes))
@@ -53,7 +53,7 @@ class TestNeighborMacNoPtf:
         bgp_routes = 0
         # Checks that there are no routes installed by BGP in ASIC_DB by filtering out all local routes installed on testbed
         for asic in duthost.asics:
-            bgp_routes += self._check_no_bgp_routes_asic(asic)
+            bgp_routes += self._get_bgp_routes_asic(asic)
         
         return bgp_routes == 0
             


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshminarasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Closes #3671

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x ] 201911

### Approach
#### What is the motivation for this PR?
This change fixes the issue https://github.com/Azure/sonic-mgmt/issues/3671

#### How did you do it?
Add support to the count_routes for all the asics

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
