### PR TITLE
[test_cpu_memory_usage] More descriptive failure messages

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -51,8 +51,15 @@ def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thre
         persist_outstanding_procs.append(pid)
 
     if outstanding_mem_polls or persist_outstanding_procs:
+        failure_message = ""
+
         if outstanding_mem_polls:
-            pytest.fail("System memory usage exceeds {}%".format(memory_threshold))
+            failure_message += "System memory usage exceeds {}%".format(memory_threshold)
+            if persist_outstanding_procs:
+                failure_message += "; "
+
         if persist_outstanding_procs:
-            pytest.fail("Processes that persistently exceed CPU usage ({}%): {}".format(
-                cpu_threshold, [outstanding_procs[p] for p in persist_outstanding_procs]))
+            failure_message += "Processes that persistently exceed CPU usage ({}%): {}".format(
+                cpu_threshold, [outstanding_procs[p] for p in persist_outstanding_procs])
+
+        pytest.fail(failure_message)

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -52,11 +52,7 @@ def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thre
 
     if outstanding_mem_polls or persist_outstanding_procs:
         if outstanding_mem_polls:
-            logging.error("system memory usage exceeds %d%%", memory_threshold)
+            pytest.fail("System memory usage exceeds {}%".format(memory_threshold))
         if persist_outstanding_procs:
-            logging.error(
-                "processes that persistently exceeds cpu usage %d%%: %s",
-                cpu_threshold,
-                [outstanding_procs[p] for p in persist_outstanding_procs]
-            )
-        pytest.fail("system cpu and memory usage check fails")
+            pytest.fail("Processes that persistently exceed CPU usage ({}%): {}".format(
+                cpu_threshold, [outstanding_procs[p] for p in persist_outstanding_procs]))


### PR DESCRIPTION
### Description of PR
Make pytest failure messages more descriptive for test_cpu_memory_usage test case. Rather than logging failure details and failing with a generic failure message, we simply fail with the more descriptive message

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
