### PR TITLE
[restapi] Use Loopback IP for default VXLAN tunnel

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -25,8 +25,8 @@ This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN membe
 '''
 def test_data_path(construct_url, vlan_members):
     # Create Default VxLan Tunnel
-    params = '{"ip_addr": "10.3.152.32"}'
-    logger.info("Creating Default VxLan Tunnel with ip_addr: 10.3.152.32")
+    params = '{"ip_addr": "10.1.0.32"}'
+    logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
     r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)
     pytest_assert(r.status_code == 204)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use Loopback IP for default VXLAN tunnel
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
