### PR TITLE
[201811] Revert ansible syntax changes and clean up t0-35 topo definition

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -90,17 +90,17 @@
   - name: find all interface indexes mapping connecting to VM
     set_fact:
       interface_to_vms: "{{ interface_to_vms|default({}) | combine({ item.key: item.value['interface_indexes'] }) }}"
-    with_dict: "{{ vm_topo_config['vm'] }}"
+    with_dict: vm_topo_config['vm']
 
   - name: find all interface indexes connecting to VM
     set_fact:
       ifindex_to_vms: "{{ ifindex_to_vms|default([]) }} + {{ item.value['interface_indexes']}}"
-    with_dict: "{{ vm_topo_config['vm'] }}"
+    with_dict: vm_topo_config['vm']
 
   - name: find all interface names
     set_fact:
       intf_names: "{{ intf_names | default({}) | combine({item.key: port_alias[item.value[0]|int:item.value[-1]|int+1] }) }}"
-    with_dict: "{{ interface_to_vms }}"
+    with_dict: interface_to_vms
 
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2

--- a/ansible/vars/topo_t0-35.yml
+++ b/ansible/vars/topo_t0-35.yml
@@ -56,37 +56,12 @@ topology:
       vlans:
         - 34
       vm_offset: 3
-  DUT:
-    vlan_configs:
-      default_vlan_config: one_vlan_a
-      one_vlan_a:
-        Vlan1000:
-          id: 1000
-          intfs: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
-          prefix: 192.168.0.1/21
-          prefix_v6: fc02:1000::1/64
-          tag: 1000
-      two_vlan_a:
-        Vlan100:
-          id: 100
-          intfs: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-          prefix: 192.168.100.1/21
-          prefix_v6: fc02:100::1/64
-          tag: 100
-        Vlan200: 
-          id: 200
-          intfs: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
-          prefix: 192.168.200.1/21
-          prefix_v6: fc02:200::1/64
-          tag: 200
 
 configuration_properties:
   common:
     dut_asn: 65100
     dut_type: ToRRouter
     swrole: leaf
-    nhipv4: 10.10.246.254
-    nhipv6: FC0A::FF
     podset_number: 200
     tor_number: 16
     tor_subnet_number: 2
@@ -94,8 +69,10 @@ configuration_properties:
     tor_subnet_size: 128
     spine_asn: 65534
     leaf_asn_start: 64600
-    tor_asn_start: 65500
+    tor_asn_start: 65100
     failure_rate: 0
+    nhipv4: 10.10.246.100
+    nhipv6: FC0A::C9
 
 configuration:
   ARISTA01T1:
@@ -118,7 +95,7 @@ configuration:
         ipv6: fc00::72/126
     bp_interface:
       ipv4: 10.10.246.29/24
-      ipv6: fc0a::1d/64
+      ipv6: fc0a::3a/64
 
   ARISTA02T1:
     properties:
@@ -140,7 +117,7 @@ configuration:
         ipv6: fc00::76/126
     bp_interface:
       ipv4: 10.10.246.30/24
-      ipv6: fc0a::1e/64
+      ipv6: fc0a::3d/64
 
   ARISTA03T1:
     properties:
@@ -162,7 +139,7 @@ configuration:
         ipv6: fc00::7a/126
     bp_interface:
       ipv4: 10.10.246.31/24
-      ipv6: fc0a::1f/64
+      ipv6: fc0a::3e/64
 
   ARISTA04T1:
     properties:
@@ -184,4 +161,4 @@ configuration:
         ipv6: fc00::7e/126
     bp_interface:
       ipv4: 10.10.246.32/24
-      ipv6: fc0a::20/64
+      ipv6: fc0a::41/64


### PR DESCRIPTION
### Description of PR

Revert some changes made in 1511ae6ff30190a74d8eef2e8d763a6a04f8c34e related to the ansible syntax used for `with_dict`, as those changes are not actually needed in this branch.

Also modify the t0-35 topo to more closely match the t0 topo definition in this branch.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach

#### How did you verify/test it?

Verified by using these changes to deploy a minigraph and run some tests on an internal testbed.
