### PR TITLE
[resume_fanout_ports] Fix dict object has no attribute 'mgmtip' and 'HwSku'

### DIFF
--- a/ansible/roles/test/tasks/resume_fanout_ports.yml
+++ b/ansible/roles/test/tasks/resume_fanout_ports.yml
@@ -13,8 +13,8 @@
       delegate_to: localhost
 
     - set_fact:
-        peer_host: "{{device_info['mgmtip']}}"
-        peer_hwsku: "{{device_info['HwSku']}}"
+        peer_host: "{{device_info[peer_device]['mgmtip']}}"
+        peer_hwsku: "{{device_info[peer_device]['HwSku']}}"
 
     - set_fact:
         intfs_to_exclude: "{{interface}}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Parameter definition is not correct in resume_fanout_ports.yml. Correct it according to the data structure of device_info like below:
```
"device_info": { 
           "switch_host_name": { 
               "HwSku": "MLNX-OS", 
               "ManagementGw": "x.y.z.w", 
               "ManagementIp": "x.y.z.w/24", 
               "Type": "FanoutLeaf", 
               "mgmtip": "x.y.z.w" 
           } 
       },
```
Fixes # https://github.com/Azure/sonic-mgmt/issues/3666

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
Fix issue: Azure#3666

#### How did you do it?
In resume_fanout_ports.yml, change

```
- set_fact:
    peer_host: "{{device_info['mgmtip']}}"
    peer_hwsku: "{{device_info['HwSku']}}"
```
to :
```
- set_fact:
    peer_host: "{{device_info[peer_device]['mgmtip']}}"
   peer_hwsku: "{{device_info[peer_device]['HwSku']}}"
```

#### How did you verify/test it?

1. Make some interfaces shutdown on DUT
2. Run ansible test case: warm_reboot_multi_sad_inboot.yaml
3. Check peer_host and peer_hwsku is set correctly by searching "resume_fanout_ports.yml:15" in test log

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
