### PR TITLE
[pdu controller] Support define PDU info from connection graph

### DIFF
--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -49,10 +49,12 @@ class PduManager():
         """
         self.controllers = []
 
-    def _update_outlets(self, outlets, pdu_index):
-        for outlet in outlets:
-            outlet['pdu_index'] = pdu_index
-            outlet['pdu_name'] = self.controllers[pdu_index]['psu_peer']['peerdevice']
+    def _update_outlets(self, outlets, pdu_index, controller_index=None):
+        for outlet_idx, outlet in enumerate(outlets):
+            outlet['pdu_index'] = pdu_index + outlet_idx
+            if controller_index is None:
+                controller_index = pdu_index
+            outlet['pdu_name'] = self.controllers[controller_index]['psu_peer']['peerdevice']
 
     def add_controller(self, psu_name, psu_peer, pdu_vars):
         """
@@ -96,12 +98,19 @@ class PduManager():
         }
         next_index = len(self.controllers)
         self.controllers.append(pdu)
-        if not shared_pdu:
-            controller = get_pdu_controller(pdu_ip, pdu_vars)
-            if not controller:
-                logger.warning('Failed creating pdu controller: {}'.format(psu_peer))
-                return
-            outlets = controller.get_outlet_status(hostname=self.dut_hostname)
+
+        outlet = None
+        if 'peerport' in psu_peer and psu_peer['peerport'] != 'probing':
+            outlet = psu_peer['peerport'] if psu_peer['peerport'].startswith('.') else '.' + psu_peer['peerport']
+
+        if not (shared_pdu and outlet is None):
+            if controller is None:
+                controller = get_pdu_controller(pdu_ip, pdu_vars)
+                if not controller:
+                    logger.warning('Failed creating pdu controller: {}'.format(psu_peer))
+                    return
+
+            outlets = controller.get_outlet_status(hostname=self.dut_hostname, outlet=outlet)
             self._update_outlets(outlets, next_index)
             pdu['outlets'] = outlets
             pdu['controller'] = controller
@@ -163,10 +172,10 @@ class PduManager():
             status = status + outlets
         else:
             # collect all status
-            for pdu_index, controller in enumerate(self.controllers):
-                if len(controller['outlets']) > 0:
-                    outlets = controller['controller'].get_outlet_status(hostname=self.dut_hostname)
-                    self._update_outlets(outlets, pdu_index)
+            for controller_index, controller in enumerate(self.controllers):
+                for outlet in controller['outlets']:
+                    outlets = controller['controller'].get_outlet_status(outlet=outlet['outlet_id'])
+                    self._update_outlets(outlets, outlet['pdu_index'], controller_index)
                     status = status + outlets
 
         return status
@@ -186,7 +195,7 @@ def _merge_dev_link(devs, links):
         for key, val in info.items():
             if key not in ret[host]:
                 ret[host][key] = {}
-            ret[host][key].update(val)
+            ret[host][key]=dict(ret[host][key], **val)
 
     return ret
 


### PR DESCRIPTION
    What is the motivation for this PR?
    1. Support get the PDU status using 'peerport' field defined in connection graph
    2. Fix the bug while two PSU port connect to the same PDU server
    3. Workaround for the dict.update() issue which causes to update the other dicts in the same list unexpectedly

    How did you do it?
    1. Input outlet param for get_outlet_status() function
    2. Update the second PDU controller's outlets info as well while shared_pdu is true
    3. using dict(old, **new) to take replace of old.update(new)

    How did you verify/test it?
    By using "devutil -a pdu_status" to verify it with both from connection graphand inventory

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
