### PR TITLE
[doc]: Update KVM Setup for Newer Sonic Image

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -51,12 +51,12 @@ If you want to skip downloading the image when the cEOS image is not imported lo
 You need to prepare a sound SONiC image `sonic-vs.img` in `~/veos-vm/images/`. We don't support to download sound sonic image right now, but for testing, you can also follow the section [Download the sonic-vs image](##download-the-sonic-vs-image) to download an available image and put it into the directory `~/veos-vm/images`
 
 ## Download the sonic-vs image
-To run the tests with a virtual SONiC device, we need a virtual SONiC image. The simplest way to do so is to download a public build from Jenkins.
+To run the tests with a virtual SONiC device, we need a virtual SONiC image. The simplest way to do so is to download the latest succesful build.
 
-1. Download the sonic-vs image from [here](https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image/lastSuccessfulBuild/artifact/target/sonic-vs.img.gz)
+1. Download the sonic-vs image from [here](https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz)
 
 ```
-$ wget https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-image/lastSuccessfulBuild/artifact/target/sonic-vs.img.gz
+$ wget https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz -O sonic-vs.img.gz
 ```
 
 2. Unzip the image and move it into `~/sonic-vm/images/`


### PR DESCRIPTION
Signed-Off by : t-asanguesa@microsoft.com
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: T1 Leaf nodes running the SONiC image previously listed in the KVM Testbed Setup guide were improperly configured for BGP because Jenkins has not been updated in a couple months. The new link fetches the latest successful build. This build can be properly configured.

Changes:
* Updated link from Jenkins to sonic-build.azurewebsites.net
* Updated text relevant to the change in link

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Using the link provided by the KVM Testbed Setup, I deployed SONiC VMs to act as the leaves in the t0 topology. However, this resulted in failed tests reporting that the leaves were not properly configured for BGP.

```
E Failed: neighbor ARISTA04T1 bgp not configured correctly
E neighbor ARISTA03T1 bgp not configured correctly
E neighbor ARISTA02T1 bgp not configured correctly
E neighbor ARISTA01T1 bgp not configured correctly
```

#### How did you do it?
Re-deployed leaf VMs using the latest successful build of `sonic-buildimage` rather than the one provided by Jenkins.

#### How did you verify/test it?
Tests were run after re-deployment and all tests passed.

### Documentation 
Slight changes were made to the KVM Testbed Setup documentation to get rid of the references to Jenkins.

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
