### PR TITLE
[test_port_toggle] using minigraph neighbors ports to toggle

### DIFF
--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -34,8 +34,8 @@ def port_toggle(duthost, tbinfo, ports=None, wait_time_getter=None, wait_after_p
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     if not ports:
-        logger.info("No ports specified, toggling all minigraph ports")
-        ports = mg_facts["minigraph_ports"].keys()
+        logger.info("No ports specified, toggling all minigraph neighbors ports")
+        ports = mg_facts["minigraph_neighbors"].keys()
 
     if not wait_time_getter:
         wait_time_getter = default_port_toggle_wait_time


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Using "minigraph_neighbors" ports to toggle instead of "minigraph_ports".
The "minigraph_neighbors" ports it is a dictionary with one port to neighbor, but "minigraph_ports" can include few splitted ports to one neighbor.
The verification logic didn't changed, still using "minigraph_neighbors" ports.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
Adaptation test to t0-56 topology


#### How did you verify/test it?
Manually testing

