### PR TITLE
   [psu] Just valid the mandatory fields of show PSU CLI

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -43,5 +43,5 @@ def get_dut_psu_line_pattern(dut):
             PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
 
         """
-        psu_line_pattern = re.compile(r"PSU\s+(\d+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
+        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT)\s+(green|amber|red|off)")
     return psu_line_pattern


### PR DESCRIPTION
    What is the motivation for this PR?
    Some fields in the output of "show platform psustatus" are based on the vendor's specific implementation, such as 'Model', 'Serial'. Those fields may include spaces characters which will cause the pattern check failed.  Additionally, sometimes vendor may need to add some more fields for the output of this CLI, which will also cause the pattern match to fail.
    As those fields are not mandatory for the test cases, so we don't need to validate all of them. Just focus on the fields we are needed.

    How did you do it?
    Just valid the mandatory fields of the "show platform psustatus"

    How did you verify/test it?
    run platform_tests/cli/test_show_platform.py::test_show_platform_psustatus, passes with change.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
