### PR TITLE
[multi-asic] test_po_update.py to support multi-asic

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -843,25 +843,6 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
 
         return nbinfo[str(neighbor_ip)]
 
-    def get_bgp_statistic(self, stat):
-        """
-        Get the named bgp statistic
-
-        Args: stat - name of statistic
-
-        Returns: statistic value or None if not found
-
-        """
-        ret = None
-        bgp_facts = self.bgp_facts()['ansible_facts']
-        if stat in bgp_facts['bgp_statistics']:
-            ret = bgp_facts['bgp_statistics'][stat]
-        return ret
-
-    def check_bgp_statistic(self, stat, value):
-        val = self.get_bgp_statistic(stat)
-        return val == value
-
     def get_bgp_neighbors(self):
         """
         Get a diction of BGP neighbor states

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -484,3 +484,22 @@ class SonicAsic(object):
         if pcs is not None and portchannel in pcs:
             return True
         return False
+
+    def get_bgp_statistic(self, stat):
+        """
+        Get the named bgp statistic
+
+        Args: stat - name of statistic
+
+        Returns: statistic value or None if not found
+
+        """
+        ret = None
+        bgp_facts = self.bgp_facts()['ansible_facts']
+        if stat in bgp_facts['bgp_statistics']:
+            ret = bgp_facts['bgp_statistics'][stat]
+        return ret
+
+    def check_bgp_statistic(self, stat, value):
+        val = self.get_bgp_statistic(stat)
+        return val == value

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -40,12 +40,12 @@ def get_portchannel_in_ns(mg_facts, namespace):
     return None
 
 
-def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index, tbinfo):
+def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):
     """
     test port channel add/deletion as well ip address configuration
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
+    namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
     namespace_prefix = '-n ' + namespace if namespace else ''
     asichost = duthost.asic_instance_from_namespace(namespace)
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_po_update.py to support multi-asic
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
test_po_update.py to support multi-asic

#### How did you do it?
Updated the testcase to pass the asic_index to run this tests in various namespaces. If we don't find a valid port channel in the namesapce ( as here for back end asic's ) skip the test.

#### How did you verify/test it?

Run on single asic and multi-asic platforms.

```
jujoseph@f7cb8ab178ad:/var/mgmt/Networking-acs-sonic-mgmt/tests$ ./run_tests.sh -d str-s6000-acs-8 -n vms12-t1-lag-1 -i ../ansible/str -f ../ansible/testbed.csv -c pc/test_po_update.py -u -e "--disable_loganalyzer --skip_sanity"; ./run_tests.sh -d str2-n-acs-1 -n vms17-t1-n-acs-1 -i ../ansible/str2 -f ../ansible/testbed.csv -c pc/test_po_update.py -u -e "--disable_loganalyzer --skip_sanity"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/mgmt/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 1 item                                                                                                                                                                                                                                               

pc/test_po_update.py::test_po_update[str-s6000-acs-8-None] PASSED                                                                                                                                                                                        [100%]

------------------------------------------------------------------------------------------ generated xml file: /var/mgmt/Networking-acs-sonic-mgmt/tests/logs/tr.xml -------------------------------------------------------------------------------------------
================================================================================================================== 1 passed in 349.52 seconds ==================================================================================================================
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/mgmt/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 6 items                                                                                                                                                                                                                                              

pc/test_po_update.py::test_po_update[str2-n-acs-1-0] PASSED                                                                                                                                                                                          [ 16%]
pc/test_po_update.py::test_po_update[str2-n-acs-1-1] PASSED                                                                                                                                                                                          [ 33%]
pc/test_po_update.py::test_po_update[str2-n-acs-1-2] PASSED                                                                                                                                                                                          [ 50%]
pc/test_po_update.py::test_po_update[str2-n-acs-1-3] PASSED                                                                                                                                                                                          [ 66%]
pc/test_po_update.py::test_po_update[str2-n-acs-1-4] SKIPPED                                                                                                                                                                                         [ 83%]
pc/test_po_update.py::test_po_update[str2-n-acs-1-5] SKIPPED                                                                                                                                                                                         [100%]

------------------------------------------------------------------------------------------ generated xml file: /var/mgmt/Networking-acs-sonic-mgmt/tests/logs/tr.xml -------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [2] /var/mgmt/Networking-acs-sonic-mgmt/tests/pc/test_po_update.py:61: Skip test due to there is no portchannel present from minigraph.
============================================================================================================ 4 passed, 2 skipped in 399.04 seconds =============================================================================================================


	   

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
