### PR TITLE
Fix PTF ipv6 link local address

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -11,5 +11,8 @@ for INTF in ${INTF_LIST}; do
     MAC="${PREFIX}${SUFFIX}"
 
     echo "Update ${INTF} MAC address: ${ADDR}->$MAC"
+    # bringing the device down/up to trigger ipv6 link local address change
+    ip link set dev ${INTF} down
     ip link set dev ${INTF} address ${MAC}
+    ip link set dev ${INTF} up
 done

--- a/ansible/roles/vm_set/files/change_mac.sh
+++ b/ansible/roles/vm_set/files/change_mac.sh
@@ -1,0 +1,1 @@
+../../test/files/helpers/change_mac.sh

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -208,6 +208,10 @@
       max_fp_num: "{{ max_fp_num }}"
     become: yes
 
+  - name: Change MAC address for PTF interfaces
+    include_tasks: ptf_change_mac.yml
+    when: topo != 'fullmesh'
+
   - name: Send arp ping packet to gw for flusing the ARP table
     command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
     become: yes

--- a/ansible/roles/vm_set/tasks/ptf_change_mac.yml
+++ b/ansible/roles/vm_set/tasks/ptf_change_mac.yml
@@ -1,0 +1,23 @@
+---
+- name: Include variables for PTF containers
+  include_vars:
+    dir: "{{ playbook_dir }}/group_vars/ptf_host/"
+
+- name: Set ptf host
+  set_fact:
+    ptf_host: "ptf_{{ vm_set_name }}"
+    ptf_host_ip: "{{ ptf_ip.split('/')[0] }}"
+
+- name: Add ptf host
+  add_host:
+    hostname: "{{ ptf_host }}"
+    ansible_user: "{{ ptf_host_user }}"
+    ansible_ssh_host: "{{ ptf_host_ip }}"
+    ansible_ssh_pass: "{{ ptf_host_pass }}"
+    ansible_python_interpreter: "/usr/bin/python"
+    groups:
+      - ptf_host
+
+- name: Change PTF interface MAC addresses
+  script: change_mac.sh
+  delegate_to: "{{ ptf_host }}"

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -72,6 +72,10 @@
       max_fp_num: "{{ max_fp_num }}"
     become: yes
 
+  - name: Change MAC address for PTF interfaces
+    include_tasks: ptf_change_mac.yml
+    when: topo != 'fullmesh'
+
   - name: Send arp ping packet to gw for flusing the ARP table
     command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
     become: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Previously, `change_mac.sh` doesn't bring down the interface before changing the interface hardware address, the ipv6 link local address thus has no change.

#### How did you do it?
1. Bring down the interface before the hardware address change, then bring it up afterward.
2. Call the script `change_mac.sh` in `add-topo` and `restart-ptf` after initializing the PTF.

#### How did you verify/test it?
* run `testbed-cli.sh add-topo`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
