### PR TITLE
Delay 5 seconds before checking 'Successfully created ACL rule' log message

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -403,7 +403,8 @@ class BaseAclTest(object):
             loganalyzer.expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
             with loganalyzer:
                 self.setup_rules(duthost, acl_table, ip_version)
-
+                time.sleep(5)
+                
             self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo)
 
             assert self.check_rule_counters(duthost), "Rule counters should be ready!"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes failure of ```test_acl``` on some platforms.
We noticed that ```test_acl``` failed on some platform with following backtrace
```
try:
            loganalyzer.expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
            with loganalyzer:
                self.setup_rules(duthost, acl_table, ip_version)
    
            self.post_setup_hook(duthost, localhost, populate_vlan_arp_entries, tbinfo)
    
            assert self.check_rule_counters(duthost), "Rule counters should be ready!"
    
        except LogAnalyzerError as err:
            # Cleanup Config DB if rule creation failed
            logger.error("ACL rule application failed, attempting to clean-up...")
            self.teardown_rules(duthost)
>           raise err
E           LogAnalyzerError: {'match_messages': {'/tmp/syslog.str2-7050cx3-acs-01.2021-06-18-05:40:37': []}, 'total': {'expected_match': 0, 'expected_missing_match': 1, 'match': 0}, 'match_files': {'/tmp/syslog.str2-7050cx3-acs-01.2021-06-18-05:40:37': {'expected_match': 0, 'match': 0}}, 'expect_messages': {'/tmp/syslog.str2-7050cx3-acs-01.2021-06-18-05:40:37': []}, 'unused_expected_regexp': ['.*Successfully created ACL rule.*']}
```
Actually, the ACL rules were created successfully, and the expected logs were printed out a bit later. The reason for the latency is unclear yet.

This PR addressed the issue by adding a delay (5 seconds) before verifying logs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fixes failure of ```test_acl``` on some platforms.

#### How did you do it?
This PR addressed the issue by adding a delay (5 seconds) before verifying logs.

#### How did you verify/test it?
Verified on Arista-7050, and all test cases in ```test_acl``` passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
