### PR TITLE
Fixing generic config reload option to use force if supported

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -1,6 +1,5 @@
 import time
 import logging
-from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -52,8 +52,9 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
             ' or '.join(['"{}"'.format(src) for src in config_sources])
         ))
 
+    cmd = 'config reload -y &>/dev/null'
     if config_force_option_supported(duthost):
-        wait_until(300, 20, config_system_checks_passed, duthost)
+        cmd = 'config reload -y -f &>/dev/null'
 
     logger.info('reloading {}'.format(config_source))
 
@@ -71,6 +72,6 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         duthost.shell('config save -y')
 
     if config_source == 'config_db':
-        duthost.shell('config reload -y &>/dev/null', executable="/bin/bash")
+        duthost.shell(cmd, executable="/bin/bash")
 
     time.sleep(wait)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
With the introduction of system checks for config reload, without the system being stable, config reload will not proceed. However many tests in the sonic-mgmt test suite use config reload to recover the system for the test cases where they intentionally kill or stop a docker or process. Hence in order to support those these and not to have any impact on the existing tests, the config_reload API will use -f option if supported.


#### How did you do it?
Added logic to do force config reload if supported

#### How did you verify/test it?
Ran few tests that use config reload for clean up after killing tasks (e.g. container_checker/test_container_checker.py)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
