### PR TITLE
[test_lag_2] Fix logic error in checking the wrong module name

### DIFF
--- a/ansible/library/lag_facts.py
+++ b/ansible/library/lag_facts.py
@@ -48,7 +48,7 @@ class LagModule(object):
         self.get_po_names()
         for po,ns in self.lag_names.items():
             self.lags[po] = {}
-            if 'multi_asic' in sys.modules:
+            if 'sonic_py_common' in sys.modules:
                 ns_id = multi_asic.get_asic_id_from_name(ns) if ns else ''
             else:
                 ns_id = ''
@@ -70,7 +70,7 @@ class LagModule(object):
                 self.module.fail_json(msg=fail_msg)
             else:
                 for po in out.split():
-                    if 'multi_asic' in sys.modules and multi_asic.is_port_channel_internal(po):
+                    if 'sonic_py_common' in sys.modules and multi_asic.is_port_channel_internal(po):
                         continue
                     self.lag_names[po] = ns
         return


### PR DESCRIPTION
### Description of PR

This change is to fix a regression that got committed in
04e73e768e865a027bf48297573b5d5c95df40a5. It was checking to see that
the multi_asic python module was loaded or not (to determine if this is
running on an older image or current image. This is incorrect, and it
should have been checking for the sonic_py_common module instead.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach

#### How did you verify/test it?

Run only the `single_lag` testcase defined in `tests/pc/test_lag_2.py` on a 6-ASIC board running the 201911 image.

