### PR TITLE
[Sensor] Support Skip List of Sensors for a specific SONiC branch

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -149,6 +149,8 @@ sensors_checks:
 
     psu_skips: {}
 
+    sensor_skip_version: {}
+
   x86_64-dell_z9100_c2538-r0:
     alarms:
       fan:
@@ -276,6 +278,8 @@ sensors_checks:
 
     psu_skips: {}
 
+    sensor_skip_version: {}
+
   x86_64-dell_s6000_s1220-r0:
     alarms:
       fan:
@@ -350,6 +354,7 @@ sensors_checks:
         skip_list:
         - dni_dps460-i2c-1-59
         - ltc4215-i2c-11-42
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn2700-r0:
     alarms:
@@ -507,6 +512,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn2740-r0:
     alarms:
@@ -675,6 +681,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn2410-r0:
     alarms:
@@ -856,6 +863,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn2100-r0:
     alarms:
@@ -964,6 +972,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn2010-r0:
     alarms:
@@ -1057,6 +1066,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn3700-r0:
     alarms:
@@ -1267,6 +1277,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn3700c-r0:
     alarms:
@@ -1467,6 +1478,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn3800-r0:
     alarms:
@@ -1738,6 +1750,7 @@ sensors_checks:
         side: left
         skip_list:
         - dps460-i2c-4-59
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn4700-r0:
     alarms:
@@ -2036,6 +2049,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn4700-r0-a1:
     alarms:
@@ -2260,6 +2274,19 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version:
+      201911:
+        skip_list:
+        - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in1)/curr1_alarm
+        - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Pwr (in1)/power1_alarm
+        - mp2975-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in1)/curr1_alarm
+        - mp2975-i2c-5-64/PMIC-2 PSU 12V Rail Pwr (in1)/power1_alarm
+        - mp2975-i2c-5-66/PMIC-3 PSU 12V Rail Curr (in1)/curr1_alarm
+        - mp2975-i2c-5-66/PMIC-3 PSU 12V Rail Pwr (in1)/power1_alarm
+        - mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail Curr (in1)/curr1_alarm
+        - mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail Pwr (in1)/power1_alarm
+        - mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail Curr (in1)/curr1_alarm
+        - mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail Pwr (in1)/power1_alarm
 
   x86_64-arista_7050_qx32:
     alarms:
@@ -2339,6 +2366,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-arista_7260cx3_64:
     alarms:
@@ -2428,6 +2456,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-ingrasys_s9100-r0:
     alarms:
@@ -2478,6 +2507,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-ingrasys_s8900_54xc-r0:
     alarms:
@@ -2528,6 +2558,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-ingrasys_s8900_64xc-r0:
     alarms:
@@ -2586,6 +2617,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-ingrasys_s8810_32q-r0:
     alarms:
@@ -2639,6 +2671,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-ingrasys_s9130_32x-r0:
     alarms:
@@ -2690,6 +2723,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-accton_wedge100bf_65x-r0:
     alarms:
@@ -2733,6 +2767,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-accton_wedge100bf_32x-r0:
     alarms:
@@ -2776,6 +2811,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-arista_7060_cx32s:
     alarms:
@@ -2845,6 +2881,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-accton_as7712_32x-r0:
     alarms:
@@ -2918,6 +2955,7 @@ sensors_checks:
         side: left
         skip_list:
         - ym2651-i2c-11-5b
+    sensor_skip_version: {}
 
   x86_64-cel_seastone-r0:
     alarms:
@@ -3097,6 +3135,7 @@ sensors_checks:
       - lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
       - lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-arista_7170_64c:
     alarms:
@@ -3183,6 +3222,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-cel_e1031-r0:
     alarms:
@@ -3208,6 +3248,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-arista_7050_qx32s:
     alarms:
@@ -3291,6 +3332,7 @@ sensors_checks:
       - pmbus-i2c-5-58/Power supply 2 sensor/temp3_input
 
     psu_skips: {}
+    sensor_skip_version: {}
 
   et6448m:
     alarms:
@@ -3325,6 +3367,7 @@ sensors_checks:
       - adt7473-i2c-0-2e/+3.3V/in2_input
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
   
   armhf-nokia_ixs7215_52x-r0:
     alarms:
@@ -3359,6 +3402,7 @@ sensors_checks:
       - adt7473-i2c-0-2e/+3.3V/in2_input
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-juniper_qfx5210-r0:
     alarms:
@@ -3430,6 +3474,7 @@ sensors_checks:
         side: left
         skip_list:
         - ym2851-i2c-9-58
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn3420-r0:
     alarms:
@@ -3621,6 +3666,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn4410-r0:
     alarms:
@@ -3922,6 +3968,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn4600c-r0:
     alarms:
@@ -4211,6 +4258,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn4600-r0:
     alarms:
@@ -4533,6 +4581,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 
   x86_64-mlnx_msn4600-r0-a1:
     alarms:
@@ -4780,4 +4829,5 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
+    sensor_skip_version: {}
 

--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -149,7 +149,7 @@ sensors_checks:
 
     psu_skips: {}
 
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-dell_z9100_c2538-r0:
     alarms:
@@ -278,7 +278,7 @@ sensors_checks:
 
     psu_skips: {}
 
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-dell_s6000_s1220-r0:
     alarms:
@@ -354,7 +354,7 @@ sensors_checks:
         skip_list:
         - dni_dps460-i2c-1-59
         - ltc4215-i2c-11-42
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn2700-r0:
     alarms:
@@ -512,7 +512,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn2740-r0:
     alarms:
@@ -681,7 +681,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn2410-r0:
     alarms:
@@ -863,7 +863,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn2100-r0:
     alarms:
@@ -972,7 +972,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn2010-r0:
     alarms:
@@ -1066,7 +1066,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn3700-r0:
     alarms:
@@ -1277,7 +1277,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn3700c-r0:
     alarms:
@@ -1478,7 +1478,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn3800-r0:
     alarms:
@@ -1750,7 +1750,7 @@ sensors_checks:
         side: left
         skip_list:
         - dps460-i2c-4-59
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4700-r0:
     alarms:
@@ -2049,7 +2049,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4700-r0-a1:
     alarms:
@@ -2274,7 +2274,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version:
+    sensor_skip_per_version:
       201911:
         skip_list:
         - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in1)/curr1_alarm
@@ -2366,7 +2366,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-arista_7260cx3_64:
     alarms:
@@ -2456,7 +2456,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-ingrasys_s9100-r0:
     alarms:
@@ -2507,7 +2507,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-ingrasys_s8900_54xc-r0:
     alarms:
@@ -2558,7 +2558,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-ingrasys_s8900_64xc-r0:
     alarms:
@@ -2617,7 +2617,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-ingrasys_s8810_32q-r0:
     alarms:
@@ -2671,7 +2671,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-ingrasys_s9130_32x-r0:
     alarms:
@@ -2723,7 +2723,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-accton_wedge100bf_65x-r0:
     alarms:
@@ -2767,7 +2767,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-accton_wedge100bf_32x-r0:
     alarms:
@@ -2811,7 +2811,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-arista_7060_cx32s:
     alarms:
@@ -2881,7 +2881,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-accton_as7712_32x-r0:
     alarms:
@@ -2955,7 +2955,7 @@ sensors_checks:
         side: left
         skip_list:
         - ym2651-i2c-11-5b
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-cel_seastone-r0:
     alarms:
@@ -3135,7 +3135,7 @@ sensors_checks:
       - lm75b-i2c-6-49/Front-panel temp sensor 2/temp1_input
       - lm75b-i2c-7-4a/ASIC temp sensor/temp1_input
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-arista_7170_64c:
     alarms:
@@ -3222,7 +3222,7 @@ sensors_checks:
       temp: []
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-cel_e1031-r0:
     alarms:
@@ -3248,7 +3248,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-arista_7050_qx32s:
     alarms:
@@ -3332,7 +3332,7 @@ sensors_checks:
       - pmbus-i2c-5-58/Power supply 2 sensor/temp3_input
 
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   et6448m:
     alarms:
@@ -3367,7 +3367,7 @@ sensors_checks:
       - adt7473-i2c-0-2e/+3.3V/in2_input
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
   
   armhf-nokia_ixs7215_52x-r0:
     alarms:
@@ -3402,7 +3402,7 @@ sensors_checks:
       - adt7473-i2c-0-2e/+3.3V/in2_input
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-juniper_qfx5210-r0:
     alarms:
@@ -3474,7 +3474,7 @@ sensors_checks:
         side: left
         skip_list:
         - ym2851-i2c-9-58
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn3420-r0:
     alarms:
@@ -3666,7 +3666,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4410-r0:
     alarms:
@@ -3968,7 +3968,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4600c-r0:
     alarms:
@@ -4258,7 +4258,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4600-r0:
     alarms:
@@ -4581,7 +4581,7 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4600-r0-a1:
     alarms:
@@ -4829,5 +4829,5 @@ sensors_checks:
       power: []
       temp: []
     psu_skips: {}
-    sensor_skip_version: {}
+    sensor_skip_per_version: {}
 

--- a/ansible/library/sensors_facts.py
+++ b/ansible/library/sensors_facts.py
@@ -93,7 +93,7 @@ class SensorsModule(object):
         self.collect_sensors()
         self.parse_sensors()
         self.psu_check()
-        self.version_skip_check()
+        self.sensor_skip_check()
         self.check_alarms()
         self.module.exit_json(ansible_facts={'sensors': self.facts})
 
@@ -168,14 +168,14 @@ class SensorsModule(object):
 
         return
 
-    def version_skip_check(self):
+    def sensor_skip_check(self):
         """
         Check that if some sensors need to be skipped on the DUT.
         If the image version on DUT match, we set up self.skip_sensors_attr set,
         which should be skipped during checks
         """
 
-        for version, attrs in self.checks['sensor_skip_version'].items():
+        for version, attrs in self.checks['sensor_skip_per_version'].items():
             if version == self.os_version:
                 for attr in attrs['skip_list']:
                     self.skip_sensors_attr.add(attr)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?

With different versions of SONiC images, due to the kernel driver version difference, the supported sensor or sensor attributes list could also be different.  To make the sensor test case be adapted to this situation, extended the sensor_facts to support a skip sensor list on a specific SONiC image version.

A sensor skip list will be added to  sku-sensors-data.yml which defined the sensors or sensor attributes that should be skipped in a specific version. Sensor_facts will parse it, if the DUT image version match, the set of sensors will be added to the skip list, a warning message will be printed out but the test case will not fail.

#### How did you do it?

Add a sensor skip list to sku-sensors-data.yml. e.g:

    sensor_skip_per_version:
          201911:
            skip_list:
            - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in1)/curr1_alarm
            - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Pwr (in1)/power1_alarm
            - mp2975-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in1)/curr1_alarm
            - mp2975-i2c-5-64/PMIC-2 PSU 12V Rail Pwr (in1)/power1_alarm
            - mp2975-i2c-5-66/PMIC-3 PSU 12V Rail Curr (in1)/curr1_alarm
            - mp2975-i2c-5-66/PMIC-3 PSU 12V Rail Pwr (in1)/power1_alarm
            - mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail Curr (in1)/curr1_alarm
            - mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail Pwr (in1)/power1_alarm
            - mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail Curr (in1)/curr1_alarm
            - mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail Pwr (in1)/power1_alarm

in the sensor_facts module, add a new function to get the SONiC image version, the new added list will also be parsed. If the image version match, the sensors will be added to the skip list. When checking the alarm, these sensors will be skipped but a warning message will be printed out.

    10:29:59 test_sensors.test_sensors                L0050 WARNING| Sensor warnings:
    [
        "sensor attributes [mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in1)/curr1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-62/PMIC-1 PSU 12V Rail Pwr (in1)/power1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in1)/curr1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-64/PMIC-2 PSU 12V Rail Pwr (in1)/power1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-66/PMIC-3 PSU 12V Rail Curr (in1)/curr1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-66/PMIC-3 PSU 12V Rail Pwr (in1)/power1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail Curr (in1)/curr1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail Pwr (in1)/power1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail Curr (in1)/curr1_alarm] is absent in version 201911", 
        "sensor attributes [mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail Pwr (in1)/power1_alarm] is absent in version 201911"
    ]

#### How did you verify/test it?

run sensor test with different versions of SONiC image.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
