### PR TITLE
[Asible] Enable deployment of t0-backend

### DIFF
--- a/ansible/library/vlan_config.py
+++ b/ansible/library/vlan_config.py
@@ -58,6 +58,9 @@ def main():
             if 'mac' in vlan_param:
                 vlan_configs[vlan]['mac'] = vlan_param['mac']
 
+            if 'type' in vlan_param:
+                vlan_configs[vlan]['type'] = vlan_param['type']
+
     except Exception as e:
         module.fail_json(msg = traceback.format_exc())
     else:

--- a/ansible/roles/eos/templates/t0-backend-leaf.j2
+++ b/ansible/roles/eos/templates/t0-backend-leaf.j2
@@ -1,0 +1,167 @@
+{% set host = configuration[hostname] %}
+{% set ip_interfaces = [] %}
+{% set create_vlan_sub_interfaces = props['device_type'] in ['BackEndToRRouter', 'BackEndLeafRouter'] %}
+{% if create_vlan_sub_interfaces %}
+{% set sub_interface_separator = props['sub_interface_separator'] %}
+{% set sub_interface_vlan_id = props['sub_interface_vlan_id'] %}
+{% endif %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+{% set is_loopback = true %}
+ description LOOPBACK
+ no shutdown
+{% else %}
+{% set is_loopback = false %}
+ no switchport
+ no shutdown
+{% endif %}
+{% if iface['ipv4'] is defined %}
+{% if create_vlan_sub_interfaces and not is_loopback %}
+{{ ip_interfaces.append(name) }}
+{% else %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 nd ra suppress
+{% if create_vlan_sub_interfaces and not is_loopback %}
+{{ ip_interfaces.append(name) }}
+{% else %}
+ ipv6 address {{ iface['ipv6'] }}
+{% endif %}
+{% endif %}
+!
+{% endfor %}
+!
+{% for name in ip_interfaces|unique %}
+{% set iface = host['interfaces'][name] %}
+{% set vlan_sub_intf = name + sub_interface_separator + sub_interface_vlan_id %}}
+interface {{ vlan_sub_intf }}
+ no switchport
+ no shutdown
+ encapsulation dot1q vlan {{ sub_interface_vlan_id }}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+ graceful-restart restart-time {{ bgp_gr_timer }}
+ graceful-restart
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -485,6 +485,7 @@ class VMTopology(object):
         vlan_sub_iface_name = iface_name + vlan_separator + vlan_id
         VMTopology.cmd("nsenter -t %s -n ip link add link %s name %s type vlan id %s" % (self.pid, iface_name, vlan_sub_iface_name, vlan_id))
         VMTopology.cmd("nsenter -t %s -n ip link set %s up" % (self.pid, vlan_sub_iface_name))
+        self.update()
 
     def remove_dut_if_from_docker(self, iface_name, dut_iface):
 
@@ -513,6 +514,7 @@ class VMTopology(object):
         vlan_sub_iface_name = iface_name + vlan_separator + vlan_id
         if vlan_sub_iface_name in self.cntr_ifaces:
             VMTopology.cmd("nsenter -t %s -n ip link del %s" % (self.pid, vlan_sub_iface_name))
+        self.update()
 
     def add_veth_if_to_docker(self, ext_if, int_if, create_vlan_subintf=False, **kwargs):
         """Create vethernet devices (ext_if, int_if) and put int_if into the ptf docker."""

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -121,7 +121,12 @@
           <AttachTo>{{ vlan_intf_str }}</AttachTo>
           <NoDhcpRelay>False</NoDhcpRelay>
           <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
+{% if 'type' in vlan_param %}
+{% if vlan_param['type']|lower == 'tagged'%}
+          <Type>Tagged</Type>
+{% else %}
           <Type i:nil="true"/>
+{% endif %}
 {% set dhcp_servers_str=';'.join(dhcp_servers) %}
           <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
           <VlanID>{{ vlan_param['id'] }}</VlanID>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -127,6 +127,7 @@
 {% else %}
           <Type i:nil="true"/>
 {% endif %}
+{% endif %}
 {% set dhcp_servers_str=';'.join(dhcp_servers) %}
           <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
           <VlanID>{{ vlan_param['id'] }}</VlanID>

--- a/ansible/veos
+++ b/ansible/veos
@@ -26,6 +26,7 @@ all:
           - t0-64-32
           - t0-80
           - t0-116
+          - t0-backend
           - dualtor
           - dualtor-56
           - cable-test

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -24,6 +24,7 @@ all:
           - t0-64
           - t0-64-32
           - t0-116
+          - t0-backend
           - dualtor
           - dualtor-56
           - dualtor-120


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Support `t0-backend` add-topo and deploy-mg.

#### How did you do it?
1. for `add-topo`, modify `vm_topology` to create sub interfaces on `PTF` for enabled vlan interfaces defined in `t0-backend` topology.
2. for `deploy-mg`, modify minigraph templates to check and add `VLAN` type.

#### How did you verify/test it?
* run `add-topo` and `deploy-mg`
* bgp up and running
```
admin@str2-7050qx-32s-acs-03:/etc/sonic$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6419
RIB entries 9623, using 1847616 bytes of memory
Peers 12, using 261792 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       2411       2411         0      0       0  00:06:57             4800  ARISTA01BT1
10.0.0.59      4  64600       2413      11575         0      0       0  00:08:00             4800  ARISTA02BT1
10.0.0.61      4  64600       2411       2411         0      0       0  00:06:57             4800  ARISTA03BT1
10.0.0.63      4  64600       2411       2411         0      0       0  00:06:57             4800  ARISTA04BT1
10.0.0.65      4  64600       2411       2411         0      0       0  00:06:57             4800  ARISTA05BT1
10.0.0.67      4  64600       2411       2411         0      0       0  00:06:57             4800  ARISTA06BT1
10.0.0.69      4  64600       2413      11575         0      0       0  00:08:01             4800  ARISTA07BT1
10.0.0.71      4  64600       2412      11574         0      0       0  00:07:59             4800  ARISTA08BT1
10.0.0.73      4  64600       2413      11575         0      0       0  00:08:01             4800  ARISTA09BT1
10.0.0.75      4  64600       2411       2411         0      0       0  00:06:57             4800  ARISTA10BT1
10.0.0.77      4  64600       2413      11575         0      0       0  00:08:01             4800  ARISTA11BT1
10.0.0.79      4  64600       2413      11575         0      0       0  00:08:01             4800  ARISTA12BT1

Total number of neighbors 12
```
* vlan config
```
admin@str2-7050qx-32s-acs-03:/etc/sonic$ show vlan config
Name        VID  Member      Mode
--------  -----  ----------  ------
Vlan1000   1000  Ethernet4   tagged
Vlan1000   1000  Ethernet8   tagged
Vlan1000   1000  Ethernet12  tagged
Vlan1000   1000  Ethernet16  tagged
Vlan1000   1000  Ethernet20  tagged
Vlan1000   1000  Ethernet24  tagged
Vlan1000   1000  Ethernet28  tagged
Vlan1000   1000  Ethernet32  tagged
Vlan1000   1000  Ethernet36  tagged
Vlan1000   1000  Ethernet40  tagged
Vlan1000   1000  Ethernet44  tagged
Vlan1000   1000  Ethernet48  tagged
Vlan1000   1000  Ethernet52  tagged
Vlan1000   1000  Ethernet56  tagged
Vlan1000   1000  Ethernet60  tagged
Vlan1000   1000  Ethernet64  tagged
Vlan1000   1000  Ethernet68  tagged
Vlan1000   1000  Ethernet72  tagged
Vlan1000   1000  Ethernet76  tagged
```
* ping `192.168.0.100`(assigned to ptf interface `eth4.1000`) from DUT and verify IO.
```
admin@str2-7050qx-32s-acs-03:/etc/sonic$ ping 192.168.0.100 -c 1
PING 192.168.0.100 (192.168.0.100) 56(84) bytes of data.
64 bytes from 192.168.0.100: icmp_seq=1 ttl=64 time=0.236 ms

--- 192.168.0.100 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.236/0.236/0.236/0.000 ms
```
```
root@1e21e5eacfed:/# ifconfig eth4.1000
eth4.1000: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
        inet 192.168.0.100  netmask 255.255.248.0  broadcast 192.168.7.255
        inet6 fe80::9a03:9bff:fe03:2204  prefixlen 64  scopeid 0x20<link>
        ether 98:03:9b:03:22:04  txqueuelen 1000  (Ethernet)
        RX packets 25  bytes 2156 (2.1 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 44  bytes 3760 (3.6 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
root@1e21e5eacfed:/# tcpdump -i eth4 -nev
tcpdump: listening on eth4, link-type EN10MB (Ethernet), capture size 262144 bytes
07:18:34.134676 c0:d6:82:ef:0f:0f > 98:03:9b:03:22:04, ethertype 802.1Q (0x8100), length 102: vlan 1000, p 0, ethertype IPv4, (tos 0x0, ttl 64, id 12794, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.0.1 > 192.168.0.100: ICMP echo request, id 12537, seq 1, length 64
07:18:34.134722 98:03:9b:03:22:04 > c0:d6:82:ef:0f:0f, ethertype 802.1Q (0x8100), length 102: vlan 1000, p 0, ethertype IPv4, (tos 0x0, ttl 64, id 62861, offset 0, flags [none], proto ICMP (1), length 84)
    192.168.0.100 > 192.168.0.1: ICMP echo reply, id 12537, seq 1, length 64
^C
2 packets captured
2 packets received by filter
0 packets dropped by kernel
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
