### PR TITLE
[M0 topologies] reduce the podset count of M0 topology to 30

### DIFF
--- a/ansible/vars/topo_mgmttor.yml
+++ b/ansible/vars/topo_mgmttor.yml
@@ -143,7 +143,7 @@ configuration_properties:
     dut_asn: 65100
     dut_type: MgmtTsToR
     swrole: leaf
-    podset_number: 200
+    podset_number: 30
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16

--- a/ansible/vars/topo_t0-52.yml
+++ b/ansible/vars/topo_t0-52.yml
@@ -94,7 +94,7 @@ configuration_properties:
     dut_asn: 65100
     dut_type: ToRRouter
     swrole: leaf
-    podset_number: 200
+    podset_number: 30
     tor_number: 16
     tor_subnet_number: 2
     max_tor_subnet_number: 16


### PR DESCRIPTION
Summary:

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
M0 devices deployed with topo-52 or topo-mgmttor crashes at start up due to ASIC doesn't have enough memory to hold regular amount of routes.

#### How did you do it?
Reduce number of routes announcing to the DUT.

#### How did you verify/test it?
remove-topo/add-topo and verify the route count drops and DUT no longer crash.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
