### PR TITLE
Fix ```test_monit```

### DIFF
--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -62,7 +62,7 @@ def check_monit_last_output(duthost):
         else:
             return "/usr/bin/lldpmgrd' is not running in host" in monit_last_output
     else:
-        pytes.fail("Failed to get Monit last output of process 'lldpmgrd'!")
+        pytest.fail("Failed to get Monit last output of process 'lldpmgrd'!")
 
 
 def test_monit_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
@@ -77,10 +77,12 @@ def test_monit_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         None.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    monit_status_result = duthost.shell("sudo monit status", module_ignore_errors=True)
-
-    exit_code = monit_status_result["rc"]
-    pytest_assert(exit_code == 0, "Monit is either not running or not configured correctly")
+    def _monit_status():
+        monit_status_result = duthost.shell("sudo monit status", module_ignore_errors=True)
+        return monit_status_result["rc"] == 0
+    # Monit is configured with start delay = 300s, hence we wait up to 320s here 
+    pytest_assert(wait_until(320, 20, _monit_status), 
+                    "Monit is either not running or not configured correctly")
 
 
 def test_monit_reporting_message(duthosts, enum_rand_one_per_hwsku_frontend_hostname, disable_lldp):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
```test_monit``` began to fail with following error
```
exit_code = monit_status_result["rc"]
>       pytest_assert(exit_code == 0, "Monit is either not running or not configured correctly")
E       Failed: Monit is either not running or not configured correctly
```
The root cause is test cases running before this one will restart ```monit``` status, and it will take up to ```300``` seconds for ```monit``` to be reloaded. 
This PR addressed the issue by adding a ```wait_until``` logic.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_monit```.

#### How did you do it?
This PR addressed the issue by adding a ```wait_until``` logic.

#### How did you verify/test it?
Verified by running ```test_monit``` after ```test_memory_checker```, which will restart ```monit``` service.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
