### PR TITLE
Fix ```test_arpall``` on t1-lag topo

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -1,7 +1,9 @@
 import logging
 import pytest
+import time
 
 from .args.wr_arp_args import add_wr_arp_args
+from .arp_utils import collect_info, get_po
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -33,18 +35,43 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     mg_facts = asic.get_extended_minigraph_facts(tbinfo)
     external_ports = [p for p in mg_facts['minigraph_ports'].keys() if 'BP' not in p]
     ports = list(sorted(external_ports, key=lambda item: int(item.replace('Ethernet', ''))))
+    po1 = None
+    po2 = None
+    if tbinfo['topo']['type'] == 't0':
+        if 'PORTCHANNEL_MEMBER' in config_facts:
+            portchannel_members = []
+            for _, v in config_facts['PORTCHANNEL_MEMBER'].items():
+                portchannel_members += v.keys()
+            ports_for_test = [x for x in ports if x not in portchannel_members]
+        else:
+            ports_for_test = ports
 
-    if 'PORTCHANNEL_MEMBER' in config_facts:
-        portchannel_members = []
-        for _, v in config_facts['PORTCHANNEL_MEMBER'].items():
-            portchannel_members += v.keys()
-        ports_for_test = [x for x in ports if x not in portchannel_members]
+        # Select two interfaces for testing which are not in portchannel
+        intf1 = ports_for_test[0]
+        intf2 = ports_for_test[1]
     else:
-        ports_for_test = ports
+        # Select port index 0 & 1 two interfaces for testing
+        intf1 = ports[0]
+        intf2 = ports[1]
 
-    # Select two interfaces for testing which are not in portchannel
-    intf1 = ports_for_test[0]
-    intf2 = ports_for_test[1]
+        po1 = get_po(mg_facts, intf1)
+        po2 = get_po(mg_facts, intf2)
+
+        if po1:
+            asic.config_portchannel_member(po1, intf1, "del")
+            collect_info(duthost)
+            asic.startup_interface(intf1)
+            collect_info(duthost)
+
+        if po2:
+            asic.config_portchannel_member(po2, intf2, "del")
+            collect_info(duthost)
+            asic.startup_interface(intf2)
+            collect_info(duthost)
+
+        if po1 or po2:
+            time.sleep(40)
+
     logger.info("Selected ints are {0} and {1}".format(intf1, intf2))
 
     intf1_indice = mg_facts['minigraph_ptf_indices'][intf1]
@@ -58,6 +85,11 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     asic.config_ip_intf(intf1, "10.10.1.2/28", "remove")
     asic.config_ip_intf(intf2, "10.10.1.20/28", "remove")
 
+    if tbinfo['topo']['type'] != 't0':
+        if po1:
+            asic.config_portchannel_member(po1, intf1, "add")
+        if po2:
+            asic.config_portchannel_member(po2, intf2, "add")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes ```test_arpall``` on t1-lag topo.
```test_arpall``` began to fail on ```t1-lag``` topo with below error
```
        # Select two interfaces for testing which are not in portchannel
>       intf1 = ports_for_test[0]
E       IndexError: list index out of range
```
It's because PR #3578 updated the logic for selecting ports for testing. However, there is no up port that is not in PortChannels on ```t1-lag``` topo, since all ports are members of PortChannels.

This PR addressed the issue by applying original logic to non-T0 topo, while maintain the updated logic for T0 topo.

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_arpall``` on t1-lag topo.

#### How did you do it?
This PR addressed the issue by applying original logic to non-T0 topo, while maintain the updated logic for T0 topo.

#### How did you verify/test it?
Verified on SN4600, T1 topo. All test cases in ```test_arpall``` passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
