### PR TITLE
[fanout] Update errdisable detect cause from link-flap to link-change

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -1,4 +1,5 @@
 !
+no errdisable detect cause link-flap
 no errdisable detect cause link-change
 !
 no schedule tech-support

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -1,5 +1,5 @@
 !
-no errdisable detect cause link-flap
+no errdisable detect cause link-change
 !
 no schedule tech-support
 !
@@ -87,7 +87,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }}
  no shutdown
 !
 # LACP packets pass through

--- a/ansible/roles/fanout/templates/arista_7260_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260_deploy.j2
@@ -2,7 +2,7 @@
 ! boot system flash:/EOS-4.15.1FX-7260QX.swi
 !
 !
-no errdisable detect cause link-flap
+no errdisable detect cause link-change
 !
 no schedule tech-support
 !
@@ -54,7 +54,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }}
  no shutdown
 !
 # LACP packets pass through

--- a/ansible/roles/fanout/templates/arista_7260_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260_deploy.j2
@@ -2,6 +2,7 @@
 ! boot system flash:/EOS-4.15.1FX-7260QX.swi
 !
 !
+no errdisable detect cause link-flap
 no errdisable detect cause link-change
 !
 no schedule tech-support

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -1,4 +1,5 @@
 !
+no errdisable detect cause link-flap
 no errdisable detect cause link-change
 !
 no schedule tech-support

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -1,5 +1,5 @@
 !
-no errdisable detect cause link-flap
+no errdisable detect cause link-change
 !
 no schedule tech-support
 !
@@ -60,7 +60,7 @@ vrf definition management
    speed forced 10gfull
    no shutdown
 !
-{% endfor %}   
+{% endfor %}
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
@@ -110,7 +110,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info[inventory_hostname]["ManagementIp"] }} 
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }}
  no shutdown
 !
 # LACP packets pass through


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
On later version of EOS, command "no errdisable detect cause link-flap" has been
deprecated. On some older version of EOS, both link-flap and link-change are supported.
However, they are mutually exclusive. On even older version of EOS, only `no errdisable
detect cause link-flap` is supported.

#### How did you do it?
This change added the "no errdisable detect cause link-change" command to related fanout
deploy templates. While deploying a fanout switch, command `no errdisable detect
cause link-flap` is firstly executed. Then the `no errdisable detect cause link-change` command
is executed. On EOS versions support only one of them, the valid one will be kept in running
config. On EOS versions support both of them, the newer one will be kept in running config.

#### How did you verify/test it?
Manually test the commands sequence on different EOS versions.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
