### PR TITLE
Skip running tests if pretest failed

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -370,7 +370,7 @@ setup_test_options
 if [[ x"${TEST_METHOD}" != x"debug" && x"${BYPASS_UTIL}" == x"False" ]]; then
     RESULT=0
     prepare_dut || RESULT=$?
-    if [[ ${RESULT}!=0 ]]; then
+    if [[ ${RESULT} != 0 ]]; then
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         echo "!!!!!  Prepare DUT failed, skip testing  !!!!!"
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -368,7 +368,14 @@ fi
 setup_test_options
 
 if [[ x"${TEST_METHOD}" != x"debug" && x"${BYPASS_UTIL}" == x"False" ]]; then
-    prepare_dut
+    RESULT=0
+    prepare_dut || RESULT=$?
+    if [[ ${RESULT}!=0 ]]; then
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        echo "!!!!!  Prepare DUT failed, skip testing  !!!!!"
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        exit ${RESULT}
+    fi
 fi
 
 RC=0


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When we use the run_tests.sh tool to run test, it may run some pretests
to prepare DUT. In case pretests failed, its highly possible that the
DUT is not in good status. There would be no point continue running
rest of the tests that may take many hours to complete.

#### How did you do it?
This change enhanced the run_tests.sh script to skip running tests if
pretest failed.

#### How did you verify/test it?
Shutdown the portchannel of a neighbor VM. Use the run_tests.sh to run scripts. Do not bypass pretest.
The run_tests.sh script exit early as soon as prepare DUT failed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
