### PR TITLE
[crm] skip clear percentage threashold check while percentage is 0

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -258,7 +258,7 @@ def verify_thresholds(duthost, asichost, **kwargs):
                 kwargs["th_hi"] = used_percent
                 loganalyzer.expect_regex = [EXPECT_EXCEEDED]
             elif key == "clear_percentage":
-                if used_percent >= 100:
+                if used_percent >= 100 or used_percent < 1:
                     logger.warning("The used percentage for {} is {} and verification for clear_percentage is skipped" \
                                .format(kwargs["crm_cli_res"], used_percent))
                     continue


### PR DESCRIPTION
What is the motivation for this PR?
To fix the failures in clear percentage threshold check while percentage is 0

How did you do it?
SWSS print warning log for THRESHOLD_EXCEEDED and THRESHOLD_CLEAR coupled. So if the test case need to skip check one, it also needs to skip the other.

How did you verify/test it?
Run test_crm.py, it should pass.

Signed-off-by: Kevin Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
