### PR TITLE
[SNMP] Modify test_snmp_psu_status

### DIFF
--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -1,6 +1,9 @@
 import pytest
+from tests.common.helpers.assertions import pytest_assert
 
 PSU_STATUS_OK = 2
+PSU_STATUS_FUNCTIONING_FAIL = 7
+PSU_STATUS_MODULE_MISSING = 8
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -23,11 +26,27 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
 @pytest.mark.bsl
 def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, localhost, creds_all_duts):
     duthost = duthosts[enum_supervisor_dut_hostname]
-
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-
     snmp_facts = localhost.snmp_facts(host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"])['ansible_facts']
 
-    for k, v in snmp_facts['snmp_psu'].items():
-        if int(v['operstatus']) != PSU_STATUS_OK:
-            pytest.fail("PSU {} operstatus is not OK!".format(k))
+    psus_on = 0
+    msg = "Unexpected operstatus results {} != {} for PSU {}"
+
+    for psu_indx, operstatus in snmp_facts['snmp_psu'].items():
+        get_presence = duthost.shell("redis-cli -n 6 hget 'PSU_INFO|PSU {}' presence".format(psu_indx))
+        get_status = duthost.shell("redis-cli -n 6 hget 'PSU_INFO|PSU {}' status".format(psu_indx))
+        status = get_status['stdout'] == 'true'
+        presence = get_presence['stdout'] == 'true'
+
+        if presence and status:
+            pytest_assert(int(operstatus['operstatus']) == PSU_STATUS_OK,
+                          msg.format(operstatus['operstatus'], PSU_STATUS_OK, psu_indx))
+            psus_on += 1
+        elif presence and not status:
+            pytest_assert(int(operstatus['operstatus']) == PSU_STATUS_FUNCTIONING_FAIL,
+                          msg.format(operstatus['operstatus'], PSU_STATUS_FUNCTIONING_FAIL, psu_indx))
+        elif not presence:
+            pytest_assert(int(operstatus['operstatus']) == PSU_STATUS_MODULE_MISSING,
+                          msg.format(operstatus['operstatus'], PSU_STATUS_MODULE_MISSING, psu_indx))
+
+    pytest_assert(psus_on >= 1, "At least one PSU should be with operstatus OK")


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Test case `test_snmp_psu_status` expects that all `PSUs `on DUT will have `operstate OK`, but it doesn't count if DUT for example have only one PSU plugged in, in such case test will fail. Goal of this PR is to modify `test_snmp_psu_status ` to compare **snmp** information about PSU with PSU information that was gathered from DUT, and verify that it is as expected and that at least one PSU is with status OK. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Modify test_snmp_psu_status to correctly verify proper work of snmp. 
#### How did you do it?
Modify test_snmp_psu_status
#### How did you verify/test it?
Run test case on t0, t1 topo: 
`snmp/test_snmp_psu.py::test_snmp_psu_status  PASSED`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.15330-dirty-20210516.082409
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: ea803257
Build date: Sun May 16 14:02:33 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
