### PR TITLE
[ptfadapter] Enable backend topologies

### DIFF
--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -72,6 +72,25 @@ def get_ifaces(netdev_output):
     return ifaces
 
 
+def get_ifaces_map(ifaces):
+    """Get interface map."""
+    sub_ifaces = []
+    iface_map = {}
+    for iface in ifaces:
+        iface_suffix = iface.lstrip(ETH_PFX)
+        if "." in iface_suffix:
+            iface_index = int(iface_suffix.split(".")[0])
+            sub_ifaces.append((iface_index, iface))
+        else:
+            iface_index = int(iface_suffix)
+            iface_map[iface_index] = iface
+
+    # override those interfaces that has sub interface
+    for i, si in sub_ifaces:
+        iface_map[i] = si
+    return iface_map
+
+
 @pytest.fixture(scope='module')
 def ptfadapter(ptfhost, tbinfo, request):
     """return ptf test adapter object.
@@ -85,7 +104,7 @@ def ptfadapter(ptfhost, tbinfo, request):
     # get the eth interfaces from PTF and initialize ifaces_map
     res = ptfhost.command('cat /proc/net/dev')
     ifaces = get_ifaces(res['stdout'])
-    ifaces_map = {int(ifname.replace(ETH_PFX, '')): ifname for ifname in ifaces}
+    ifaces_map = get_ifaces_map(ifaces)
 
     # generate supervisor configuration for ptf_nn_agent
     ptfhost.host.options['variable_manager'].extra_vars.update({


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
For those backend topologies (`t0-backend` and `t1-backend`), ptf interfaces have sub interfaces created and `ptfadapter` fixture fails to parse them. This patch is to enable `ptfadapter` parse those sub interfaces.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enable `ptfadapter` for backend topologies.

#### How did you do it?
Run `ptf_nn_agent.py` with subinterfaces instead for backend topologies:

#### How did you verify/test it?
* previous `ptf_nn_agent` start command:
```
command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 0@tcp://0.0.0.0:10900 -i 0-0@eth0 -i 0-1@eth1 -i 0-2@eth2
```
* now
```
command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 0@tcp://0.0.0.0:10900 -i 0-0@eth0.1000 -i 0-1@eth1.1000 -i 0-2@eth2.1000
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
