### PR TITLE
[installer] create swap file when memory is low

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -36,12 +36,41 @@ def exec_command(module, cmd, ignore_error=False, msg="executing command"):
     return rc, out, err
 
 
+# Return available disk size in MB
 def get_disk_free_size(module, partition):
     _, out, _   = exec_command(module, cmd="df -BM --output=avail %s" % partition,
                          msg="checking disk available size")
     avail = int(out.split('\n')[1][:-1])
 
     return avail
+
+# Return total/available memory size in MB, 0, 0 means failed to get the sizes
+def get_memory_sizes(module):
+    _, out, _   = exec_command(module, cmd="free -m", msg="checking memory total/free sizes")
+    lines = out.split('\n')
+    if len(lines) < 2:
+        return 0, 0
+
+    fields = lines[1].split()
+    if len(fields) < 3:
+        return 0, 0
+
+    total, avail = int(fields[1]), int(fields[-1])
+    return total, avail
+
+
+def setup_swap_if_necessary(module):
+    df = get_disk_free_size(module, '/host')
+    mem, mf = get_memory_sizes(module)
+    if df < 4000 or mem == 0 or mf == 0:
+        # Disk free space low or failed to obtain memory information
+        return
+
+    if mem < 2048 or mf < 1200:
+        # Memory size or available amount is low, there is risk of OOM during new
+        # image installation. Create a temporary swap file.
+        exec_command(module, cmd="sudo rm -f {0}; sudo fallocate -l 1G {0}; sudo chmod 600 {0}; sudo mkswap {0}; sudo swapon {0}".format('/host/swapfile'),
+                     msg="Create a temporary swap file")
 
 
 def reduce_installed_sonic_images(module):
@@ -147,6 +176,7 @@ def main():
         reduce_installed_sonic_images(module)
         if new_image_url or save_as:
             free_up_disk_space(module, disk_used_pcent)
+            setup_swap_if_necessary(module)
             install_new_sonic_image(module, new_image_url, save_as)
     except:
         err = str(sys.exc_info())


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some device has small amount of memory, these devices might trigger OOM during new image installation.

#### How did you do it?
Create a temporary swap file during installation when needed.

This change is a work-around, the change needs to be ported to sonic-installer.

#### How did you verify/test it?
Tested image installation on a device with 2G memory, before this change, the installation would trigger OOM and device would hang. With the change, installation succeeded.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
