### PR TITLE
[platform][cli] Add optional attributes to show platfrom summary test

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -51,13 +51,13 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
     summary_dict = util.parse_colon_speparated_lines(summary_output_lines)
     expected_fields = set(["Platform", "HwSKU", "ASIC"])
     actual_fields = set(summary_dict.keys())
-    new_field = set(["ASIC Count"])
+    new_field = set(["ASIC Count", "Serial Number", "Hardware Revision", "Model Number"])
 
     missing_fields = expected_fields - actual_fields
     pytest_assert(len(missing_fields) == 0, "Output missing fields: {} on '{}'".format(repr(missing_fields), duthost.hostname))
 
     unexpected_fields = actual_fields - expected_fields
-    pytest_assert(((unexpected_fields == new_field) or len(unexpected_fields) == 0),
+    pytest_assert(((unexpected_fields.issubset(new_field)) or len(unexpected_fields) == 0),
                   "Unexpected fields in output: {}  on '{}'".format(repr(unexpected_fields), duthost.hostname))
 
     # Testing for missing values


### PR DESCRIPTION
### Description of PR
Made the `test_show_platform_summary` test tolerant of the new fields in the CLI output of `show platform summary` 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

CLI output of `show platform summary` has new fields and needs to be added as acceptable. 

#### How did you do it?

Added new fields from `show platform summary` to optional field set in the `test_show_platform_summary` test

#### How did you verify/test it?

Ran test test_show_platform_summary and passed

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

N/A Platform Test

### Documentation 

N/A Simple alignment with new CLI output
