### PR TITLE
[ptf_runner] Enable backend topologies

### DIFF
--- a/ansible/roles/test/files/ptftests/remote.py
+++ b/ansible/roles/test/files/ptftests/remote.py
@@ -4,6 +4,10 @@ Remote platform
 This platform uses physical ethernet interfaces.
 """
 
+ETH_PFX = 'eth'
+SUB_INTF_SEP = '.'
+
+
 def get_ifaces():
     with open('/proc/net/dev') as fp:
         all = fp.read()
@@ -17,13 +21,32 @@ def get_ifaces():
         iface = line.split(':')[0].strip()
 
         # Skip not FP interfaces and vlan interface, like eth1.20
-        if 'eth' not in iface or '.' in iface:
+        if ETH_PFX not in iface:
             continue
         
         ifaces.append(iface)
 
     # Sort before return
     return ifaces
+
+
+def build_ifaces_map(ifaces):
+    """Build interface map for ptf to init dataplane."""
+    sub_ifaces = []
+    iface_map = {}
+    for iface in ifaces:
+        iface_suffix = iface.lstrip(ETH_PFX)
+        if SUB_INTF_SEP in iface_suffix:
+            iface_index = int(iface_suffix.split(SUB_INTF_SEP)[0])
+            sub_ifaces.append((iface_index, iface))
+        else:
+            iface_index = int(iface_suffix)
+            iface_map[(0, iface_index)] = iface
+
+    # override those interfaces that has sub interfaces
+    for i, si in sub_ifaces:
+        iface_map[(0, i)] = si;
+    return iface_map
 
 
 def platform_config_update(config):
@@ -33,6 +56,6 @@ def platform_config_update(config):
     @param config The configuration dictionary to use/update
     """
 
-    remote_port_map = {(0, int(i.replace('eth', ''))) : i for i in get_ifaces()}
+    remote_port_map = build_ifaces_map(get_ifaces())
     config["port_map"] = remote_port_map.copy()
     config["caps_table_idx"] = 0


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For backend topologies with ptf subinterfaces, let `ptf` uses subinterfaces to do IO instead of their original ports.

#### How did you do it?
* modify the port mapping config that is used by `ptf` to initialize `dataplane` interfaces.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
