### PR TITLE
[Ansible] Migrate from Python 2.x to Python 3.x given Python 2.x has reached EOL for long time

### DIFF
--- a/ansible/devutil/inv_helpers.py
+++ b/ansible/devutil/inv_helpers.py
@@ -127,7 +127,7 @@ class HostManager():
         res["console_user"] = {}
         res["console_password"] = {}
 
-        for k, v in console_login_creds.iteritems():
+        for k, v in console_login_creds.items():
             res["console_user"][k] = v["user"]
             res["console_password"][k] = v["passwd"]
 

--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -74,10 +74,10 @@ def create_maps(config):
         for idx, val in enumerate(port_name_list_sorted):
             port_index_map[val] = idx
 
-        port_name_to_alias_map = { name : v['alias'] if 'alias' in v else '' for name, v in config["PORT"].iteritems()}
+        port_name_to_alias_map = { name : v['alias'] if 'alias' in v else '' for name, v in config["PORT"].items()}
 
         # Create inverse mapping between port name and alias
-        port_alias_to_name_map = {v: k for k, v in port_name_to_alias_map.iteritems()}
+        port_alias_to_name_map = {v: k for k, v in port_name_to_alias_map.items()}
 
     return {
     'port_name_to_alias_map' : port_name_to_alias_map,

--- a/ansible/library/fabric_info.py
+++ b/ansible/library/fabric_info.py
@@ -59,10 +59,10 @@ def main():
                      'ip6_prefix': next_v6addr + "/" + v6pfx[-1] }
             fabric_info.append( data )
         module.exit_json(ansible_facts={'fabric_info': fabric_info})
-    except (IOError, OSError), e:
+    except (IOError, OSError) as e:
         fail_msg = "IO error" + str(e)
         module.fail_json(msg=fail_msg)
-    except Exception, e:
+    except Exception as e:
         fail_msg = "failed to find the correct fabric asic info " + str(e)
         module.fail_json(msg=fail_msg)
 

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -241,7 +241,7 @@ def parse_png(png, hname):
                             elif node.tag == str(QName(ns, "EndDevice")):
                                 mgmt_dev = node.text
 
-    for k, v in neighbors.iteritems():
+    for k, v in neighbors.items():
          v['namespace'] = neighbors_namespace[k]
 
     return (neighbors, devices, console_dev, console_port, mgmt_dev, mgmt_port)
@@ -603,7 +603,7 @@ def parse_xml(filename, hostname, asic_name=None):
     port_alias_to_name_map, port_alias_asic_map = get_port_alias_to_name_map(hwsku, asic_id)
 
     # Create inverse mapping between port name and alias
-    port_name_to_alias_map = {v: k for k, v in port_alias_to_name_map.iteritems()}
+    port_name_to_alias_map = {v: k for k, v in port_alias_to_name_map.items()}
 
     for child in root:
         if asic_name is None:
@@ -628,7 +628,7 @@ def parse_xml(filename, hostname, asic_name=None):
 
     # Associate Port Channel to namespace
     try:
-        for pckey, pcval in pcs.iteritems():
+        for pckey, pcval in pcs.items():
             pcval['namespace'] = neighbors[pcval['members'][0]]['namespace']
     except Exception as e:
         print >> sys.stderr, "Warning: PortChannel " + pckey + " has no member ports."

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -247,7 +247,7 @@ def main():
             # is not passed.
             try: 
                 num_asic = multi_asic.get_num_asics()
-            except Exception, e:
+            except Exception as e:
                 num_asic = 1
 
         switchid = 0
@@ -286,10 +286,10 @@ def main():
                                         'front_panel_asic_ifnames': front_panel_asic_ifnames,
                                         'asic_if_names': asic_if_names,
                                         'sysports': sysports})
-    except (IOError, OSError), e:
+    except (IOError, OSError) as e:
         fail_msg = "IO error" + str(e)
         module.fail_json(msg=fail_msg)
-    except Exception, e:
+    except Exception as e:
         fail_msg = "failed to find the correct port config for "+m_args['hwsku'] + str(e)
         module.fail_json(msg=fail_msg)
 

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -143,7 +143,7 @@ class ParseTestbedTopoinfo():
                         line['ptf_ipv6'], line['ptf_netmask_v6'] = \
                             _cidr_to_ip_mask(line["ptf_ipv6"])
 
-                    line['duts'] = line['dut'].translate(str.maketrans("", ""), "[] ").split(';')
+                    line['duts'] = line['dut'].translate(str.maketrans("", "", "[] ")).split(';')
                     line['duts_map'] = {dut: line['duts'].index(dut) for dut in line['duts']}
                     del line['dut']
 

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -3,7 +3,6 @@ import os
 import traceback
 import ipaddr as ipaddress
 import csv
-import string
 import yaml
 
 from collections import defaultdict
@@ -144,7 +143,7 @@ class ParseTestbedTopoinfo():
                         line['ptf_ipv6'], line['ptf_netmask_v6'] = \
                             _cidr_to_ip_mask(line["ptf_ipv6"])
 
-                    line['duts'] = line['dut'].translate(string.maketrans("", ""), "[] ").split(';')
+                    line['duts'] = line['dut'].translate(str.maketrans("", ""), "[] ").split(';')
                     line['duts_map'] = {dut: line['duts'].index(dut) for dut in line['duts']}
                     del line['dut']
 

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -151,20 +151,20 @@ class ParseTestbedTopoinfo():
             vmconfig[vm]['bgp_ipv6'] = [None] * dut_num
             vmconfig[vm]['bgp_asn'] = topo_definition['configuration'][vm]['bgp']['asn']
             for ipstr in topo_definition['configuration'][vm]['bgp']['peers'][dut_asn]:
-                ip = ipaddress.ip_address(ipstr.decode('utf8'))
+                ip = ipaddress.ip_address(ipstr)
                 for dut_index in range(0, dut_num):
                     if ip.version == 4:
                         # Each VM might not be connected to all the DUT's, so check if this VM is a peer to DUT at dut_index
                         if vmconfig[vm]['peer_ipv4'][dut_index]:
                             ipsubnet_str = vmconfig[vm]['peer_ipv4'][dut_index]+'/'+vmconfig[vm]['ipv4mask'][dut_index]
-                            ipsubnet = ipaddress.ip_interface(ipsubnet_str.decode('utf8'))
+                            ipsubnet = ipaddress.ip_interface(ipsubnet_str)
                             if ip in ipsubnet.network:
                                 vmconfig[vm]['bgp_ipv4'][dut_index] = ipstr.upper()
                     elif ip.version == 6:
                         # Each VM might not be connected to all the DUT's, so check if this VM is a peer to DUT at dut_index
                         if vmconfig[vm]['peer_ipv6'][dut_index]:
                             ipsubnet_str = vmconfig[vm]['peer_ipv6'][dut_index]+'/'+vmconfig[vm]['ipv6mask'][dut_index]
-                            ipsubnet = ipaddress.ip_interface(ipsubnet_str.decode('utf8'))
+                            ipsubnet = ipaddress.ip_interface(ipsubnet_str)
                             if ip in ipsubnet.network:
                                 vmconfig[vm]['bgp_ipv6'][dut_index] = ipstr.upper()
         return vmconfig

--- a/ansible/linkstate/scripts/ptf_proxy.py
+++ b/ansible/linkstate/scripts/ptf_proxy.py
@@ -144,7 +144,7 @@ def generate_vm_port_mapping(vm_base):
     return vm_ports, vm_list
 
 def merge(fanout_mappings, fanout_name_2_ip, vm_mappings):
-    return {(fanout_name_2_ip[fanout_name], fanout_port) : vm_mappings[dut_port]  for (fanout_name, fanout_port), dut_port in fanout_mappings.iteritems() if dut_port in vm_mappings}
+    return {(fanout_name_2_ip[fanout_name], fanout_port) : vm_mappings[dut_port]  for (fanout_name, fanout_port), dut_port in fanout_mappings.items() if dut_port in vm_mappings}
 
 def generate_x_table(base_vm, dut):
     devices, dut_ports, mapping, fanout_name_2_ip = parse_lab_connection_graph('lab_connection_graph.xml', dut)

--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -111,7 +111,7 @@ def filter_vm_targets(values, topology, vm_base):
 
     result = []
     base = values.index(vm_base)
-    for hostname, attr in topology.iteritems():
+    for hostname, attr in topology.items():
         if base + attr['vm_offset'] >= len(values):
             continue
         result.append(values[base + attr['vm_offset']])
@@ -153,7 +153,7 @@ def extract_hostname(values, topology, vm_base, inventory_hostname):
 
     hash = {}
     base = values.index(vm_base)
-    for hostname, attr in topology.iteritems():
+    for hostname, attr in topology.items():
         if base + attr['vm_offset'] >= len(values):
             continue
         if inventory_hostname == values[base + attr['vm_offset']]:

--- a/ansible/roles/test/files/acstests/IP_decap_test.py
+++ b/ansible/roles/test/files/acstests/IP_decap_test.py
@@ -136,9 +136,9 @@ class DecapPacketTest(BaseTest, RouterUtility):
         default_route_ports =[]
         unicast_ip = 'none'
         unicast_dst_port = []
-        print self.route_info.iteritems()
+        print self.route_info.items()
         #running on the routes_info file and extractin ECMP route and unicast route
-        for prefix, port_index_list in self.route_info.iteritems():
+        for prefix, port_index_list in self.route_info.items():
             dest_ip_addr = prefix.split("/")[0]
 			
             if (self.is_ipv6_address(dest_ip_addr)): 

--- a/ansible/roles/test/files/acstests/router_utils.py
+++ b/ansible/roles/test/files/acstests/router_utils.py
@@ -69,7 +69,7 @@ class RouterUtility():
         is_valid_ipv6 = True
         try :
             ip = ipaddress.IPv6Address(unicode(ipaddr))
-        except Exception, e:
+        except Exception as e:
             is_valid_ipv6 = False
 
         return is_valid_ipv6

--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -439,7 +439,7 @@ class DecapPacketTest(BaseTest):
 
                 try:
                     self.run_encap_combination_test(outer_pkt_type, inner_pkt_type)
-                except AssertionError, e:
+                except AssertionError as e:
                     error = e
                     # print error, but continue to test others encap traffic combinations
                     print "\n{}:\n{}".format(encap_combination, error)

--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -69,7 +69,7 @@ class ControlPlaneBaseTest(BaseTest):
 
         self.my_mac = {}
         self.peer_mac = {}
-        for port_id, port in self.dataplane.ports.iteritems():
+        for port_id, port in self.dataplane.ports.items():
             if port_id[0] == 0:
                 self.my_mac[port_id[1]] = port.mac()
             elif port_id[0] == 1:

--- a/ansible/roles/test/files/ptftests/fg_ecmp_test.py
+++ b/ansible/roles/test/files/ptftests/fg_ecmp_test.py
@@ -180,7 +180,7 @@ class FgEcmpTest(BaseTest):
 
         elif self.test_case == 'initial_hash_check':
             self.log("Ensure that flow to port map is maintained when the same flow is re-sent...")
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -193,7 +193,7 @@ class FgEcmpTest(BaseTest):
         elif self.test_case == 'hash_check_warm_boot':
             self.log("Ensure that flow to port map is maintained when the same flow is re-sent...")
             total_flood_pkts = 0
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -209,7 +209,7 @@ class FgEcmpTest(BaseTest):
 
         elif self.test_case == 'bank_check':
             self.log("Send the same flows once again and verify that they end up on the same bank...")
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -229,7 +229,7 @@ class FgEcmpTest(BaseTest):
                 withdraw_port_grp = self.exp_port_set_one
             else:
                 withdraw_port_grp = self.exp_port_set_two
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -251,7 +251,7 @@ class FgEcmpTest(BaseTest):
                 add_port_grp = self.exp_port_set_one
             else:
                 add_port_grp = self.exp_port_set_two
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -271,7 +271,7 @@ class FgEcmpTest(BaseTest):
                 active_port_grp = self.exp_port_set_two
             else:
                 active_port_grp = self.exp_port_set_one
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -292,7 +292,7 @@ class FgEcmpTest(BaseTest):
             else:
                 active_port_grp = self.exp_port_set_one
 
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.net_ports)
                 else:
@@ -312,7 +312,7 @@ class FgEcmpTest(BaseTest):
         elif self.test_case == 'net_port_hashing':
             self.log("Send packets destined to network ports and ensure hash distribution is as expected")
 
-            for src_ip, port in tuple_to_port_map[self.dst_ip].iteritems():
+            for src_ip, port in tuple_to_port_map[self.dst_ip].items():
                 if self.inner_hashing:
                     in_port = random.choice(self.serv_ports)
                 else:

--- a/ansible/roles/test/files/ptftests/populate_fdb.py
+++ b/ansible/roles/test/files/ptftests/populate_fdb.py
@@ -86,7 +86,7 @@ class PopulateFdb(BaseTest):
             Returns:
                 mac (int): integer representation of MAC address
         """
-        return int(mac.translate(None, ":.- "), 16)
+        return int(mac.translate(str.maketrans("", "", ":.- ")), 16)
 
     def __convertMacToStr(self, mac):
         """

--- a/ansible/roles/test/files/ptftests/vrf_test.py
+++ b/ansible/roles/test/files/ptftests/vrf_test.py
@@ -86,7 +86,7 @@ class FwdTest(FibTest):
         else:
             entries = self.fwd_dict.ipv6
 
-        for ip_range, next_hop in entries.iteritems():
+        for ip_range, next_hop in entries.items():
             self.check_ip_range(ip_range, next_hop, ipv4)
 
     #---------------------------------------------------------------------

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -524,7 +524,7 @@ def write_result_file(run_id, out_dir, analysis_result_per_file, messages_regex_
     expected_lines_total = []
 
     with open(out_dir + "/result.loganalysis." + run_id + ".log", 'w') as out_file:
-        for key, val in analysis_result_per_file.iteritems():
+        for key, val in analysis_result_per_file.items():
             matching_lines, expected_lines = val
 
             out_file.write("\n-----------Matches found in file:'%s'-----------\n" % key)
@@ -577,7 +577,7 @@ def write_summary_file(run_id, out_dir, analysis_result_per_file, unused_regex_m
     out_file.write("\nLOG ANALYSIS SUMMARY\n")
     total_match_cnt = 0
     total_expect_cnt = 0
-    for key, val in analysis_result_per_file.iteritems():
+    for key, val in analysis_result_per_file.items():
         matching_lines, expecting_lines = val
 
         file_match_cnt = len(matching_lines)

--- a/ansible/roles/test/templates/acl_ranges_table.j2
+++ b/ansible/roles/test/templates/acl_ranges_table.j2
@@ -3,7 +3,7 @@
         "ACL_TABLE:ACL_Testbed_Range_Test_Table": {
             "policy_desc" : "This_table_contains_rules_needed_for_the_testbed_ranges_test",
             "type" : "L3",
-            "ports" : "{% for ifname, v in minigraph_neighbors.iteritems() %}{{"%s" % alias_reverse_map[ifname]}},{% endfor %}"
+            "ports" : "{% for ifname, v in minigraph_neighbors.items() %}{{"%s" % alias_reverse_map[ifname]}},{% endfor %}"
         },
         "OP": "SET"
     }

--- a/ansible/roles/test/templates/bgp_no_export.j2
+++ b/ansible/roles/test/templates/bgp_no_export.j2
@@ -65,7 +65,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endfor %}
 {% endblock vlan_advertisement %}
 {% block bgp_sessions %}
-{% for neighbor_addr, bgp_session in BGP_NEIGHBOR.iteritems() %}
+{% for neighbor_addr, bgp_session in BGP_NEIGHBOR.items() %}
 {% if bgp_session['asn'] | int != 0 %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}

--- a/ansible/roles/test/templates/bgp_plain.j2
+++ b/ansible/roles/test/templates/bgp_plain.j2
@@ -60,7 +60,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endfor %}
 {% endblock vlan_advertisement %}
 {% block bgp_sessions %}
-{% for neighbor_addr, bgp_session in BGP_NEIGHBOR.iteritems() %}
+{% for neighbor_addr, bgp_session in BGP_NEIGHBOR.items() %}
 {% if bgp_session['asn'] | int != 0 %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}

--- a/ansible/roles/test/templates/bgp_speaker_route.j2
+++ b/ansible/roles/test/templates/bgp_speaker_route.j2
@@ -1,8 +1,8 @@
 {% if addr_family == 'ipv6' %}
-{{announce_prefix}} {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+{{announce_prefix}} {% for portchannel, v in minigraph_portchannels.items() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% elif addr_family == 'ipv4' %}
-0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.items() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{{announce_prefix}} {% for vlan, v in minigraph_vlans.iteritems() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}
+{{announce_prefix}} {% for vlan, v in minigraph_vlans.items() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}
 {% endif %}

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -1,16 +1,16 @@
 {# defualt route#}
 {% if testbed_type == 't1' %}
-0.0.0.0/0 {% for ifname, v in minigraph_neighbors.iteritems() %}
+0.0.0.0/0 {% for ifname, v in minigraph_neighbors.items() %}
 {% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
-::/0 {% for ifname, v in minigraph_neighbors.iteritems() %}
+::/0 {% for ifname, v in minigraph_neighbors.items() %}
 {% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
 {% elif testbed_type == 't0' or testbed_type == 't0-52'or testbed_type == 't0-64' or testbed_type == 't1-lag' or testbed_type == 't0-64-32' %}
-0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
+0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.items() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-::/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}
+::/0 {% for portchannel, v in minigraph_portchannels.items() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
@@ -26,17 +26,17 @@
 {% for tor in range(0, [props.tor_number, 10]|min) %}
 {% for subnet in range(0, props.tor_subnet_number) %}
 {% if testbed_type == 't1' %}
-192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {% for ifname, v in minigraph_neighbors.iteritems() %}
+192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {% for ifname, v in minigraph_neighbors.items() %}
 {% if "T2" in v.name %}{{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
-20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for ifname, v in minigraph_neighbors.iteritems() %}
+20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for ifname, v in minigraph_neighbors.items() %}
 {% if "T2" in v.name %}{{ '[%d]' %  minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
 {% elif testbed_type == 't1-lag' %}
-192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {% for portchannel, v in minigraph_portchannels.iteritems() %}
+192.168.{{ podset }}.{{ tor * 16 + subnet }}/32 {% for portchannel, v in minigraph_portchannels.items() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
+20C0:A8{{ '%02X' % podset }}:0:{{ '%02X' % (tor * 16 + subnet)}}::/64 {% for portchannel, v in minigraph_portchannels.items() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% elif (testbed_type == 't1-64-lag') or (testbed_type == 't1-64-lag-clet') %}
@@ -54,10 +54,10 @@
 {% set prefixlen_v4 = (32 - ((props.tor_subnet_size | log(2))) | int) %}
 {# Skip 192.168.0.0 as it is in Vlan1000 subnet  #}
 {% if octet2 != 168 and octet3 != 0 and octet4 != 0 %}
-{{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {% for portchannel, v in minigraph_portchannels.iteritems() %}
+{{ octet1 }}.{{ octet2 }}.{{ octet3 }}.{{ octet4 }}/{{ prefixlen_v4 }} {% for portchannel, v in minigraph_portchannels.items() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {% for portchannel, v in minigraph_portchannels.iteritems() %}
+{{ '20%02x' % octet1 }}:{{ '%02X%02X' % (octet2, octet3) }}:0:{{ '%02X' % octet4 }}::/64 {% for portchannel, v in minigraph_portchannels.items() %}
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% endif %}
@@ -82,7 +82,7 @@
 {% endfor %}
 {# routes to downlink #}
 {% if testbed_type == 't1' or testbed_type == 't1-lag' %}
-{% for ifname, v in minigraph_neighbors.iteritems() %}
+{% for ifname, v in minigraph_neighbors.items() %}
 {% if "T0" in v.name %}
 {% for subnet in range(0, props_tor.tor_subnet_number) %}
 172.16.{{ v.name|replace("ARISTA", "")|replace("T0", "")|int }}.{{ subnet }}/32 {{ '[%d]' % minigraph_port_indices[ifname]}}{% if not loop.last %} {% endif %}

--- a/ansible/roles/test/templates/neighbor_interface_no_shut.j2
+++ b/ansible/roles/test/templates/neighbor_interface_no_shut.j2
@@ -1,6 +1,6 @@
 enable
 configure
-{% for key, value in ansible_interface_up_down_data_struct_facts[item]['nei_interfaces'].iteritems() %}
+{% for key, value in ansible_interface_up_down_data_struct_facts[item]['nei_interfaces'].items() %}
     interface {{ value }}
     no shutdown
     exit

--- a/ansible/roles/test/templates/neighbor_interface_shut.j2
+++ b/ansible/roles/test/templates/neighbor_interface_shut.j2
@@ -1,6 +1,6 @@
 enable
 configure
-{% for key, value in ansible_interface_up_down_data_struct_facts[item]['nei_interfaces'].iteritems() %}
+{% for key, value in ansible_interface_up_down_data_struct_facts[item]['nei_interfaces'].items() %}
     interface {{ value }}
     shutdown
     exit

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -131,20 +131,20 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, ptfadapter):
     acl_table_ports =  defaultdict(list)
 
     if topo == "t0" or tbinfo["topo"]["name"] in ("t1", "t1-lag"):
-        for namespace, port in downstream_ports.iteritems():
+        for namespace, port in downstream_ports.items():
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.
             if namespace:
                 acl_table_ports[''] += port
 
     if topo == "t0" or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet"):
-        for k, v in port_channels.iteritems():
+        for k, v in port_channels.items():
             acl_table_ports[v['namespace']].append(k)
             # In multi-asic we need config both in host and namespace.
             if v['namespace']:
                 acl_table_ports[''].append(k)
     else:
-        for namespace, port in upstream_ports.iteritems():
+        for namespace, port in upstream_ports.items():
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.
             if namespace:

--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -12,7 +12,7 @@ def clear_dut_arp_cache(duthost, ns_option = None):
 
 
 def get_po(mg_facts, intf):
-    for k, v in mg_facts['minigraph_portchannels'].iteritems():
+    for k, v in mg_facts['minigraph_portchannels'].items():
         if intf in v['members']:
             return k
     return None

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -109,7 +109,7 @@ def parse_rib(host, ip_ver):
         cmd = host.get_vtysh_cmd_for_namespace(bgp_cmd, namespace)
 
         route_data = json.loads(host.shell(cmd, verbose=False)['stdout'])
-        for ip, nexthops in route_data['routes'].iteritems():
+        for ip, nexthops in route_data['routes'].items():
             aspath = set()
             for nexthop in nexthops:
                 # if internal route with aspath as '' skip adding

--- a/tests/bgp/templates/bgp_speaker_route.j2
+++ b/tests/bgp/templates/bgp_speaker_route.j2
@@ -1,3 +1,3 @@
-0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.items() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
-{{announce_prefix}} {% for vlan, v in minigraph_vlans.iteritems() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}
+{{announce_prefix}} {% for vlan, v in minigraph_vlans.items() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -68,7 +68,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga
     dut_asn = mg_facts["minigraph_bgp_asn"]
 
     dut_type = ''
-    for k, v in mg_facts['minigraph_devices'].iteritems():
+    for k, v in mg_facts['minigraph_devices'].items():
         if k == duthost.hostname:
             dut_type = v['type']
 

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -104,9 +104,9 @@ def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_v
     logger.info("Verifying all routes(ipv{}) are announced to bgp neighbors".format(ip_ver))
     routes_on_all_eos = parse_routes_on_eos(dut_host, neigh_hosts, ip_ver)
     # Check routes on all neigh
-    for hostname, routes in routes_on_all_eos.iteritems():
+    for hostname, routes in routes_on_all_eos.items():
         logger.info("Verifying all routes(ipv{}) are announced to {}".format(ip_ver, hostname))
-        for route, aspaths in routes_dut.iteritems():
+        for route, aspaths in routes_dut.items():
             # Filter out routes announced by this neigh
             skip = False
             for aspath in aspaths:
@@ -135,9 +135,9 @@ def verify_loopback_route_with_community(dut_host, neigh_hosts, ip_ver, communit
     else:
         lo_addr = lo_addr_v6
     routes_on_all_eos = parse_routes_on_eos(dut_host, neigh_hosts, ip_ver)
-    for hostname, routes in routes_on_all_eos.iteritems():
+    for hostname, routes in routes_on_all_eos.items():
         logger.info("Verifying only loopback routes(ipv{}) are announced to {}".format(ip_ver, hostname))
-        for prefix, received_community in routes.iteritems():
+        for prefix, received_community in routes.items():
             if ipaddress.IPNetwork(prefix) != lo_addr:
                 logger.warn("route for {} is found on {}, which is not in loopback address".format(prefix, hostname))
                 return False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -248,7 +248,7 @@ class SonicHost(AnsibleHostBase):
             try:
                 out = self.command("cat {}".format(platform_file_path))
                 platform_info = json.loads(out["stdout"])
-                for key, value in platform_info.iteritems():
+                for key, value in platform_info.items():
                     result[key] = value
 
             except Exception:

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -514,7 +514,7 @@ class SonicAsic(object):
             pc = mg_facts['minigraph_portchannels'].keys()[0]
             pc_members = mg_facts['minigraph_portchannels'][pc]['members']
         else:
-            for k, v in mg_facts['minigraph_portchannels'].iteritems():
+            for k, v in mg_facts['minigraph_portchannels'].items():
                 if v.has_key('namespace') and self.namespace == v['namespace']:
                     pc = k
                     pc_members = mg_facts['minigraph_portchannels'][pc]['members']

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -259,7 +259,7 @@ class LogAnalyzer:
         expected_lines_total = []
         unused_regex_messages = []
 
-        for key, value in analyzer_parse_result.iteritems():
+        for key, value in analyzer_parse_result.items():
             matching_lines, expecting_lines = value
             analyzer_summary["total"]["match"] += len(matching_lines)
             analyzer_summary["total"]["expected_match"] += len(expecting_lines)

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -8,7 +8,6 @@ import ipaddr as ipaddress
 import json
 import os
 import re
-import string
 import yaml
 import logging
 
@@ -94,7 +93,7 @@ class TestbedInfo(object):
                     line['ptf_ipv6'], line['ptf_netmask_v6'] = \
                         self._cidr_to_ip_mask(line['ptf_ipv6'])
 
-                line['duts'] = line['dut'].translate(string.maketrans("", ""), "[] ").split(';')
+                line['duts'] = line['dut'].translate(str.maketrans("", ""), "[] ").split(';')
                 line['duts_map'] = {dut: line['duts'].index(dut) for dut in line['duts']}
                 del line['dut']
 

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -93,7 +93,7 @@ class TestbedInfo(object):
                     line['ptf_ipv6'], line['ptf_netmask_v6'] = \
                         self._cidr_to_ip_mask(line['ptf_ipv6'])
 
-                line['duts'] = line['dut'].translate(str.maketrans("", ""), "[] ").split(';')
+                line['duts'] = line['dut'].translate(str.maketrans("", "", "[]")).split(';')
                 line['duts_map'] = {dut: line['duts'].index(dut) for dut in line['duts']}
                 del line['dut']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -503,7 +503,7 @@ def creds_on_dut(duthost):
     creds["console_user"] = {}
     creds["console_password"] = {}
 
-    for k, v in console_login_creds.iteritems():
+    for k, v in console_login_creds.items():
         creds["console_user"][k] = v["user"]
         creds["console_password"][k] = v["passwd"]
 

--- a/tests/ixia/ecn/test_red_accuracy.py
+++ b/tests/ixia/ecn/test_red_accuracy.py
@@ -103,6 +103,6 @@ def test_red_accuracy(request,
     """ Dump queue length vs. ECN marking probability into a file """
     queue_mark_cnt = collections.OrderedDict(sorted(queue_mark_cnt.items()))
     f = open(result_file_name, 'w')
-    for queue, mark_cnt in queue_mark_cnt.iteritems():
+    for queue, mark_cnt in queue_mark_cnt.items():
         f.write('{} {}\n'.format(queue, float(mark_cnt)/iters))
     f.close()

--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -99,7 +99,7 @@ def setup_test_env(request, ptfhost, duthost, tbinfo):
     for rif in dut_rifs_in_topo_t0:
         interfaces_nat_zone[rif] = {'interface_name': rif,
                                     "global_interface_name": '{}_INTERFACE'.format(
-                                        (rif.encode()).translate(None, '0123456789').upper())
+                                        (rif.encode()).translate(str.maketrans("", "", "0123456789")).upper())
                                    }
         if rif in inner_zone_interfaces:
             interfaces_nat_zone[rif]['zone_id'] = 0

--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -105,7 +105,7 @@ def setup_test_env(request, ptfhost, duthost, tbinfo):
             interfaces_nat_zone[rif]['zone_id'] = 0
         elif rif in outer_zone_interfaces:
             interfaces_nat_zone[rif]['zone_id'] = 1
-    indices_to_ports_config = dict((v, k) for k, v in config_port_indices.iteritems())
+    indices_to_ports_config = dict((v, k) for k, v in config_port_indices.items())
     if interface_type == "port_in_lag":
         outer_zone_interfaces = [outer_zone_interfaces[-2], outer_zone_interfaces[-3]]
         public_ip = SETUP_CONF["port_in_lag"]["vrf"]["red"]["gw"]

--- a/tests/qos/args/qos_sai_args.py
+++ b/tests/qos/args/qos_sai_args.py
@@ -31,7 +31,7 @@ def add_qos_sai_args(parser):
     qos_group.addoption(
         "--qos_dst_ports",
         action="store",
-        type=lambda opt_value: [int(v) for v in opt_value.translate(None, "[]").split(',')],
+        type=lambda opt_value: [int(v) for v in opt_value.translate(str.maketrans("", "", "[]")).split(',')],
         default=None,
         help="QoS SAI comma separated list of destination ports. Test currently expects exactly 3 destination ports",
     )
@@ -39,7 +39,7 @@ def add_qos_sai_args(parser):
     qos_group.addoption(
         "--qos_src_ports",
         action="store",
-        type=lambda opt_value: [int(v) for v in opt_value.translate(None, "[]").split(',')],
+        type=lambda opt_value: [int(v) for v in opt_value.translate(str.maketrans("", "", "[]")).split(',')],
         default=None,
         help="QoS SAI comma separated list of source ports. Test currently expects exactly 1 source port",
     )

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -136,7 +136,7 @@ class QosSaiBase(QosBase):
                 Updates bufferProfile with computed buffer threshold
         """
         db = "0" if self.isBufferInApplDb(dut_asic) else "4"
-        pool = bufferProfile["pool"].encode("utf-8").translate(None, "[]")
+        pool = bufferProfile["pool"].encode("utf-8").translate(str.maketrans("", "", "[]"))
         bufferSize = int(
             dut_asic.run_redis_cmd(
                 argv = ["redis-cli", "-n", db, "HGET", pool, "size"]
@@ -161,11 +161,11 @@ class QosSaiBase(QosBase):
         """
         if self.isBufferInApplDb(dut_asic):
             bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
-                None, "[]").replace("BUFFER_POOL_TABLE:",''
+                str.maketrans("", "", "[]")).replace("BUFFER_POOL_TABLE:",''
             )
         else:
             bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
-                None, "[]").replace("BUFFER_POOL|",''
+                str.maketrans("", "", "[]")).replace("BUFFER_POOL|",''
             )
 
         bufferPoolVoid = dut_asic.run_redis_cmd(
@@ -204,7 +204,7 @@ class QosSaiBase(QosBase):
             keystr = "{0}|{1}|{2}".format(table, port, priorityGroup)
         bufferProfileName = dut_asic.run_redis_cmd(
             argv = ["redis-cli", "-n", db, "HGET", keystr, "profile"]
-        )[0].encode("utf-8").translate(None, "[]")
+        )[0].encode("utf-8").translate(str.maketrans("", "", "[]"))
 
         result = dut_asic.run_redis_cmd(
             argv = ["redis-cli", "-n", db, "HGETALL", bufferProfileName]
@@ -273,7 +273,7 @@ class QosSaiBase(QosBase):
                 "{0}|{1}|{2}".format(table, port, self.TARGET_QUEUE_WRED),
                 "wred_profile"
             ]
-        )[0].encode("utf-8").translate(None, "[]")
+        )[0].encode("utf-8").translate(str.maketrans("", "", "[]"))
 
         result = dut_asic.run_redis_cmd(
             argv = ["redis-cli", "-n", "4", "HGETALL", wredProfileName]
@@ -319,7 +319,7 @@ class QosSaiBase(QosBase):
                 "redis-cli", "-n", "4", "HGET",
                 "QUEUE|{0}|{1}".format(port, queue), "scheduler"
             ]
-        )[0].encode("utf-8").translate(None, "[]")
+        )[0].encode("utf-8").translate(str.maketrans("", "", "[]"))
 
         schedWeight = dut_asic.run_redis_cmd(
             argv = ["redis-cli", "-n", "4", "HGET", schedProfile, "weight"]

--- a/tests/saitests/copp_tests.py
+++ b/tests/saitests/copp_tests.py
@@ -49,7 +49,7 @@ class ControlPlaneBaseTest(BaseTest):
 
         self.my_mac = {}
         self.peer_mac = {}
-        for port_id, port in self.dataplane.ports.iteritems():
+        for port_id, port in self.dataplane.ports.items():
             if port_id[0] == 0:
                 self.my_mac[port_id[1]] = port.mac()
             elif port_id[0] == 1:

--- a/tests/saitests/switch.py
+++ b/tests/saitests/switch.py
@@ -88,7 +88,7 @@ def switch_init(client):
         for port_id in thrift_attr.value.objlist.object_id_list:
             front_port_list.append(port_id)
 
-    for interface,front in interface_to_front_mapping.iteritems():
+    for interface,front in interface_to_front_mapping.items():
         sai_port_id = client.sai_thrift_get_port_id_by_front_port(front);
         port_list[int(interface)]=sai_port_id
 

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -519,7 +519,7 @@ def get_vm_with_ip(neigh_ip, nbrhosts):
         A dictionary with the vm index for nbrhosts, and port name.
     """
     for a_vm in nbrhosts:
-        for port, a_intf in nbrhosts[a_vm]['conf']['interfaces'].iteritems():
+        for port, a_intf in nbrhosts[a_vm]['conf']['interfaces'].items():
             if 'ipv4' in a_intf and a_intf['ipv4'].split("/")[0] == neigh_ip:
                 return {"vm": a_vm, "port": port}
             if 'ipv6' in a_intf and a_intf['ipv6'].split("/")[0].lower() == neigh_ip.lower():

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -78,7 +78,7 @@ def get_intf_ips(interface_name, cfg_facts):
         'ipv6': []
     }
 
-    for pfx, t_name in prefix_to_intf_table_map.iteritems():
+    for pfx, t_name in prefix_to_intf_table_map.items():
         if pfx in interface_name:
             intf_table_name = t_name
             break
@@ -115,7 +115,7 @@ def get_vrf_intfs(cfg_facts):
     vrf_intfs = {}
 
     for table in intf_tables:
-        for intf, attrs in cfg_facts.get(table, {}).iteritems():
+        for intf, attrs in cfg_facts.get(table, {}).items():
             if '|' not in intf:
                 vrf = attrs['vrf_name']
                 if vrf not in vrf_intfs:
@@ -138,7 +138,7 @@ def get_vrf_ports(cfg_facts):
 
     vrf_intfs = get_vrf_intfs(cfg_facts)
 
-    for vrf, intfs in vrf_intfs.iteritems():
+    for vrf, intfs in vrf_intfs.items():
         vrf_intf_member_port_indices[vrf] = {}
         vrf_member_port_indices[vrf] = []
 
@@ -293,7 +293,7 @@ def setup_vlan_peer(duthost, ptfhost, cfg_facts):
             vlan_peer_ips[(vrf, vlan_peer_port)] = {'ipv4': [], 'ipv6': []}
 
         vlan_ips = get_intf_ips(vlan, cfg_facts)
-        for ver, ips in vlan_ips.iteritems():
+        for ver, ips in vlan_ips.items():
             for ip in ips:
                 neigh_ip = IPNetwork("{}/{}".format(ip.ip+1, ip.prefixlen))
                 ptfhost.shell("ip netns exec {} ip address add {} dev e{}mv1".format(ns, neigh_ip, vlan_peer_port))
@@ -307,7 +307,7 @@ def setup_vlan_peer(duthost, ptfhost, cfg_facts):
     return vlan_peer_ips, vlan_peer_vrf2ns_map
 
 def cleanup_vlan_peer(ptfhost, vlan_peer_vrf2ns_map):
-    for vrf, ns in vlan_peer_vrf2ns_map.iteritems():
+    for vrf, ns in vlan_peer_vrf2ns_map.items():
         ptfhost.shell("ip netns del {}".format(ns))
 
 def gen_vrf_fib_file(vrf, tbinfo, ptfhost, dst_intfs, \
@@ -509,7 +509,7 @@ class TestVrfCreateAndBind():
         for vrf in cfg_facts['VRF'].keys():
             assert vrf in res['stdout'], "%s should be created in kernel!" % vrf
 
-        for vrf, intfs in g_vars['vrf_intfs'].iteritems():
+        for vrf, intfs in g_vars['vrf_intfs'].items():
             for intf in intfs:
                 res = duthost.shell("ip link show %s" % intf)
                 assert vrf in res['stdout'], "The master dev of interface %s should be %s !" % (intf, vrf)
@@ -521,7 +521,7 @@ class TestVrfCreateAndBind():
             res = duthost.shell("redis-cli -n 0 keys VRF_TABLE:%s" % vrf)
             assert vrf in res['stdout'], "%s should be added in APPL_DB!" % vrf
 
-        for vrf, intfs in g_vars['vrf_intfs'].iteritems():
+        for vrf, intfs in g_vars['vrf_intfs'].items():
             for intf in intfs:
                 res = duthost.shell("redis-cli -n 0 hgetall \"INTF_TABLE:%s\"" % intf)
                 assert vrf in res['stdout'], "The vrf of interface %s should be %s !" % (intf, vrf)
@@ -553,8 +553,8 @@ class TestVrfNeigh():
 
     def test_ping_vlan_neigh(self, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
-        for (vrf, _), neigh_ips in g_vars['vlan_peer_ips'].iteritems():
-            for ver, ips in neigh_ips.iteritems():
+        for (vrf, _), neigh_ips in g_vars['vlan_peer_ips'].items():
+            for ver, ips in neigh_ips.items():
                 ping_cmd = 'ping' if ver == 'ipv4' else 'ping6'
                 for ip in ips:
                     duthost.shell("{} {} -c 3 -I {} -f".format(ping_cmd, ip.ip, vrf))
@@ -600,7 +600,7 @@ class TestVrfFib():
             bgp_summary = json.loads(bgp_summary_string)
 
             for info in bgp_summary:
-                for peer, attr in bgp_summary[info]['peers'].iteritems():
+                for peer, attr in bgp_summary[info]['peers'].items():
                     prefix_count = attr['pfxRcd']
                     # skip ipv6 peers under 'ipv4Unicast' and compare only ipv4 peers under 'ipv4Unicast', and ipv6 peers under 'ipv6Unicast'
                     if info == "ipv4Unicast" and attr['idType'] == 'ipv6':
@@ -811,14 +811,14 @@ class TestVrfLoopbackIntf():
         self.c_vars['vlan2000_ip_facts'] = vlan2000_ip_facts
 
         # deploy routes to loopback
-        for ver, ips in lb0_ip_facts.iteritems():
+        for ver, ips in lb0_ip_facts.items():
             for vlan_ip in vlan1000_ip_facts[ver]:
                 nexthop = vlan_ip.ip
                 break
             for ip in ips:
                 ptfhost.shell("ip netns exec {} ip route add {} nexthop via {} ".format(g_vars['vlan_peer_vrf2ns_map']['Vrf1'], ip, nexthop))
 
-        for ver, ips in lb2_ip_facts.iteritems():
+        for ver, ips in lb2_ip_facts.items():
             for vlan_ip in vlan2000_ip_facts[ver]:
                 nexthop = vlan_ip.ip
                 break
@@ -835,7 +835,7 @@ class TestVrfLoopbackIntf():
 
     def test_ping_vrf1_loopback(self, ptfhost, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
-        for ver, ips in self.c_vars['lb0_ip_facts'].iteritems():
+        for ver, ips in self.c_vars['lb0_ip_facts'].items():
             for ip in ips:
                 if ip.version == 4:
                     # FIXME Within a vrf, currently ping(4) does not support using
@@ -849,7 +849,7 @@ class TestVrfLoopbackIntf():
 
     def test_ping_vrf2_loopback(self, ptfhost, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
-        for ver, ips in self.c_vars['lb2_ip_facts'].iteritems():
+        for ver, ips in self.c_vars['lb2_ip_facts'].items():
             for ip in ips:
                 if ip.version == 4:
                     # FIXME Within a vrf, currently ping(4) does not support using
@@ -882,7 +882,7 @@ class TestVrfLoopbackIntf():
         ptf_direct_ip  = g_vars['vlan_peer_ips'][('Vrf1', vlan_peer_port)]['ipv4'][0]
 
         # add route to ptf_speaker_ip
-        for (vrf, vlan_peer_port), ips in g_vars['vlan_peer_ips'].iteritems():
+        for (vrf, vlan_peer_port), ips in g_vars['vlan_peer_ips'].items():
             nh = ips['ipv4'][0].ip
             duthost.shell("vtysh -c 'configure terminal' -c 'ip route {} {} vrf {}'".format(peer_range, nh , vrf))
             duthost.shell("ping {} -I {} -c 3 -f -W2".format(nh, vrf))
@@ -934,7 +934,7 @@ class TestVrfLoopbackIntf():
         # -------- Teardown ---------
 
         # del route to ptf_speaker_ip on dut
-        for (vrf, vlan_peer_port), ips in g_vars['vlan_peer_ips'].iteritems():
+        for (vrf, vlan_peer_port), ips in g_vars['vlan_peer_ips'].items():
             duthost.shell("vtysh -c 'configure terminal' -c 'no ip route {} {} vrf {}'".format(peer_range, ips['ipv4'][0], vrf))
 
         # kill exabgp
@@ -1172,7 +1172,7 @@ class TestVrfCapacity():
         cfg_attrs_map['vrf_intf']       = {'add_sleep_time': 2, 'remove_sleep_time': 5 + 0.04 * 2 * vrf_count}
         cfg_attrs_map['vlan_intf']      = {'add_sleep_time': 2, 'remove_sleep_time': 5}
 
-        for cfg_name, attrs in cfg_attrs_map.iteritems():
+        for cfg_name, attrs in cfg_attrs_map.items():
             src_template = 'vrf/vrf_capacity_{}_cfg.j2'.format(cfg_name)
             render_file = '/tmp/vrf_capacity_{}_cfg.json'.format(cfg_name)
             duthost.template(src=src_template, dest=render_file)
@@ -1309,7 +1309,7 @@ class TestVrfUnbindIntf():
 
     def rebind_intf(self, duthost):
         duthost.shell("config interface vrf bind PortChannel0001 Vrf1")
-        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].iteritems():
+        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].items():
             for ip in ips:
                 duthost.shell("config interface ip add PortChannel0001 {}".format(ip))
 
@@ -1326,7 +1326,7 @@ class TestVrfUnbindIntf():
     def test_pc1_ip_addr_flushed(self, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
         ip_addr_show = duthost.shell("ip addr show PortChannel0001")['stdout']
-        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].iteritems():
+        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].items():
             for ip in ips:
                 assert str(ip) not in ip_addr_show, "The ip addresses on PortChannel0001 should be flushed after unbind from vrf."
 
@@ -1346,7 +1346,7 @@ class TestVrfUnbindIntf():
 
     def test_pc1_neigh_flushed_by_traffic(self, partial_ptf_runner, ptfhost):
         pc1_neigh_ips = []
-        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].iteritems():
+        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0001'].items():
             for ip in ips:
                 pc1_neigh_ips.append(str(ip.ip+1))
 
@@ -1376,7 +1376,7 @@ class TestVrfUnbindIntf():
 
     def test_pc2_neigh(self, partial_ptf_runner, ptfhost):
         pc2_neigh_ips = []
-        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0002'].iteritems():
+        for ver, ips in g_vars['vrf_intfs']['Vrf1']['PortChannel0002'].items():
             for ip in ips:
                 pc2_neigh_ips.append(str(ip.ip+1))
 
@@ -1431,9 +1431,9 @@ class TestVrfDeletion():
 
     def restore_vrf(self, duthost):
         duthost.shell("config vrf add Vrf1")
-        for intf, ip_facts in g_vars['vrf_intfs']['Vrf1'].iteritems():
+        for intf, ip_facts in g_vars['vrf_intfs']['Vrf1'].items():
             duthost.shell("config interface vrf bind %s Vrf1" % intf)
-            for ver, ips in ip_facts.iteritems():
+            for ver, ips in ip_facts.items():
                 for ip in ips:
                     duthost.shell("config interface ip add {} {}".format(intf, ip))
 

--- a/tests/vrf/vrf_neigh.j2
+++ b/tests/vrf/vrf_neigh.j2
@@ -7,9 +7,9 @@
 {% endif -%}
 {%- endmacro %}
 
-{% for intf, ip_facts in intf_ips.iteritems() -%}
+{% for intf, ip_facts in intf_ips.items() -%}
 {% if 'Loopback' not in intf -%}
-{% for ver, ips in ip_facts.iteritems() -%}
+{% for ver, ips in ip_facts.items() -%}
 {% for ip in ips -%}
 {{ ip.ip + 1 }} {{ gen_dst_ports(intf) }}
 {% endfor -%}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use dict.items() instead of dict.iteritems() to support Python 3.x at the same time
Fixes https://github.com/Azure/sonic-mgmt/issues/3730

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Use dict.items() instead of dict.iteritems() to support Python 3.x at the same time

#### How did you do it?

Change the code to a syntax that is both compatible with Python 2.x and 3.x , see: https://stackoverflow.com/questions/30418481/error-dict-object-has-no-attribute-iteritems

#### How did you verify/test it?

Running `./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k vsonic add-topo vms-kvm-t0 password.txt` (https://github.com/Azure/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md#vsonic) now results in no errors.

![image](https://user-images.githubusercontent.com/3787410/124385191-5c6ba480-dd07-11eb-9944-013e0fd20d50.png)


#### Any platform specific information?

vs

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
