### PR TITLE
Fix KeyError in test_qos_sai

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -512,7 +512,7 @@ class QosSaiBase(QosBase):
 
         dutTopo = "topo-"
 
-        if dutTopo + topo in qosConfigs['qos_params'][dutAsic]:
+        if dutTopo + topo in qosConfigs['qos_params'].get(dutAsic, {}):
             dutTopo = dutTopo + topo
         else:
             # Default topo is any
@@ -523,11 +523,14 @@ class QosSaiBase(QosBase):
         # multiple buffer pipes.
         src_port_ids = None
         dst_port_ids = None
-        if "src_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
-            src_port_ids = qosConfigs['qos_params'][dutAsic][dutTopo]["src_port_ids"]
+        try:
+            if "src_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
+                src_port_ids = qosConfigs['qos_params'][dutAsic][dutTopo]["src_port_ids"]
 
-        if "dst_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
-            dst_port_ids = qosConfigs['qos_params'][dutAsic][dutTopo]["dst_port_ids"]
+            if "dst_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
+                dst_port_ids = qosConfigs['qos_params'][dutAsic][dutTopo]["dst_port_ids"]
+        except KeyError:
+            pass
 
         testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids)
         yield {


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes ```KeyError``` in ```test_qos_sai```.
PR #3713 updated the format of ```qos.yml``` and the logic for buiilding test param. Some errors were also introduced on ```Mellanox``` platform

```
        # Support of passing source and dest ptf port id from qos.yml
        # This is needed when on some asic port are distributed across
        # multiple buffer pipes.
        src_port_ids = None
        dst_port_ids = None
>       if "src_port_ids" in  qosConfigs['qos_params'][dutAsic][dutTopo]:
E       KeyError: 'spc3'
```
This PR addressed the issue by catching such error and ignore them.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixes ```KeyError``` in ```test_qos_sai```.

#### How did you do it?
This PR addressed the issue by catching such error and ignore them.

#### How did you verify/test it?
Verified on SN4600, all test cases passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
