### PR TITLE
Skip restapi container in test_monitoring_critical_processes

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -241,7 +241,7 @@ def get_expected_alerting_messages_monit(duthost, containers_in_namespaces):
                 # TODO: Should remove `sensord` from the following if statement once it is added
                 # into the 'critical_processes' file.
                 if "pmon" in container_name_in_namespace and ("thermalctld" in critical_process
-                                                              or "syseepromd" in critical_process 
+                                                              or "syseepromd" in critical_process
                                                               or "sensord" in critical_process):
                     continue
 
@@ -543,6 +543,8 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo):
     skip_containers = []
     skip_containers.append("database")
     skip_containers.append("gbsyncd")
+    # Skip 'restapi' container since 'restapi' service will be restarted immediately after exited, which will not trigger alarm message.
+    skip_containers.append("restapi")
     # Skip 'acms' container since 'acms' process is not running on lab devices and
     # another process `cert_converter.py' is set to auto-restart if exited.
     skip_containers.append("acms")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes error of ```test_monitoring_critical_processes``` on ```Mellanox``` platform.

```restapi``` is one feature of ```Mellanox``` platform. And ```restapi``` process in ```restapi``` container will be restarted immediately after exiting, which will not trigger alarm msg in syslog. Hence test will fail on Mellanox platform.

This PR addressed the issue by skipping ```restapi``` container in  ```test_monitoring_critical_processes```.

Signed-off-by: bingwang <bingwang@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fixes error of ```test_monitoring_critical_processes``` on ```Mellanox``` platform.

#### How did you do it?
This PR addressed the issue by skipping ```restapi``` container in  ```test_monitoring_critical_processes```.

#### How did you verify/test it?
Verified by running on SN4600. Test case passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
