### PR TITLE
Fixed test_bgp_bbr - to prevent overriding errors message at the end

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -247,6 +247,7 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
 
         vm_route = nbrhosts[node]['host'].get_route(route.prefix)
         vm_route['failed'] = False
+        vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
         vm_route['tor_route'] = vm_route
         if accepted:
             if route.prefix not in vm_route['vrfs']['default']['bgpRouteEntries'].keys():
@@ -265,7 +266,6 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
             if route.prefix in vm_route['vrfs']['default']['bgpRouteEntries'].keys():
                 vm_route['failed'] = True
                 vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
-        vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
         results[node] = vm_route
 
     results = parallel_run(check_other_vms, (nbrhosts, setup, route), {'accepted': accepted}, other_vms, timeout=120)


### PR DESCRIPTION
Signe-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed test_bgp_bbr - to prevent overriding errors message at the end

Summary: Fixed test_bgp_bbr - to prevent overriding errors message at the end
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Message in result was incorrect - it was every time overwritten

#### How did you do it?
Move vm_route['message'] setting before the loop so it will not be ovewritten

#### How did you verify/test it?
Executed test test_bgp_bbr.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
