### PR TITLE
[test_hash] Enable backend topologies

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -184,7 +184,7 @@ class HashTest(BaseTest):
         @param src_port: index of port to use for sending packet to switch
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         '''
-        base_mac = self.dataplane.get_mac(0, 0)
+        base_mac = self.dataplane.get_mac(*random.choice(self.dataplane.ports.keys()))
         ip_src = self.src_ip_interval.get_random_ip() if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip() if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
@@ -262,7 +262,7 @@ class HashTest(BaseTest):
         @param dst_port_list: list of ports on which to expect packet to come back from the switch
         @return Boolean
         '''
-        base_mac = self.dataplane.get_mac(0, 0)
+        base_mac = self.dataplane.get_mac(*random.choice(self.dataplane.ports.keys()))
         ip_src = self.src_ip_interval.get_random_ip() if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip() if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -539,6 +539,8 @@ def add_default_route_to_dut(config_facts, duthosts, tbinfo):
                         continue
                     asic.shell("ip route del default", module_ignore_errors=True)
                     asic.shell("ip -6 route del default", module_ignore_errors=True)
+    else:
+        yield
 
 
 def test_hash(add_default_route_to_dut, fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, set_mux_same_side,

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -16,6 +16,8 @@ from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side
 from tests.common.dualtor.mux_simulator_control import mux_server_url
+from tests.common.utilities import is_ipv4_address
+
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +241,7 @@ def fib_info_files(duthosts, ptfhost, config_facts, minigraph_facts, tbinfo):
         files.append(filename)
 
     return files
+
 
 @pytest.fixture(scope='module')
 def disabled_ptf_ports(tbinfo):
@@ -499,7 +502,46 @@ def ipver(request):
     return request.param
 
 
-def test_hash(fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, set_mux_same_side,
+@pytest.fixture
+def add_default_route_to_dut(config_facts, duthosts, tbinfo):
+    """
+    Add a default route to the device for storage backend testbed.
+    This is to ensure the IO packets could be successfully directed.
+    """
+    if "backend" in tbinfo["topo"]["name"]:
+        logging.info("Add default route on the DUT.")
+        try:
+            for duthost in duthosts:
+                cfg_facts = config_facts[duthost.hostname]
+                for asic_index, asic_cfg_facts in enumerate(cfg_facts):
+                    asic = duthost.asic_instance(asic_index)
+                    bgp_neighbors = asic_cfg_facts["BGP_NEIGHBOR"]
+                    ipv4_cmd_parts = ["ip route add default"]
+                    ipv6_cmd_parts = ["ip -6 route add default"]
+                    for neighbor in bgp_neighbors.keys():
+                        if is_ipv4_address(neighbor):
+                            ipv4_cmd_parts.append("nexthop via %s" % neighbor)
+                        else:
+                            ipv6_cmd_parts.append("nexthop via %s" % neighbor)
+                    ipv4_cmd_parts.sort()
+                    ipv6_cmd_parts.sort()
+                    # limit to 4 nexthop entries
+                    ipv4_cmd = " ".join(ipv4_cmd_parts[:5])
+                    ipv6_cmd = " ".join(ipv6_cmd_parts[:5])
+                    asic.shell(ipv4_cmd)
+                    asic.shell(ipv6_cmd)
+            yield
+        finally:
+            logging.info("Remove default route on the DUT.")
+            for duthost in duthosts:
+                for asic in duthost.asics:
+                    if asic.is_it_backend():
+                        continue
+                    asic.shell("ip route del default", module_ignore_errors=True)
+                    asic.shell("ip -6 route del default", module_ignore_errors=True)
+
+
+def test_hash(add_default_route_to_dut, fib_info_files, setup_vlan, hash_keys, ptfhost, ipver, set_mux_same_side,
               tbinfo, mux_server_url, disabled_ptf_ports, vlan_ptf_ports, router_macs, vlan_macs,
               ignore_ttl, single_fib_for_duts):
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Let `test_hash` run on storage backend topo.
The failure reason is that because there is no default route on the DUT in the storage backend testbed, the IO packet that aims to test hashing functionality will not be correctly forwarded.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. add a fixture `add_default_route_to_dut` to add the default route to the DUT.
2. modify ptf test `hash_test.py` to select `base_mac` randomly instead of using the `(0, 0)`(which doesn't exist on the backend topologies)

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
