### PR TITLE
[sfp] Skip lpmode test on unsupported platforms

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -445,6 +445,9 @@ class TestSfpApi(PlatformApiTestBase):
             # Enable and disable low-power mode on each transceiver
             for state in [True, False]:
                 ret = sfp.set_lpmode(platform_api_conn, i, state)
+                if ret is None:
+                    logger.warning("test_lpmode: Skipping transceiver {} (not supported on this platform)".format(i))
+                    break
                 self.expect(ret is True, "Failed to {} low-power mode for transceiver {}".format("enable" if state is True else "disable", i))
                 lpmode = sfp.get_lpmode(platform_api_conn, i)
                 if self.expect(lpmode is not None, "Unable to retrieve transceiver {} low-power mode".format(i)):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip test_lpmode in TestSfpApi if platform does not support lpmode accessors
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
https://github.com/Azure/sonic-platform-common/pull/204

With the get/set_lpmode methods now expected to potentially raise NotImplementedError for unsupported platforms, the corresponding test case should be updated to not fail in the event this occurs; it should instead be skipped. 

#### How did you do it?
Add check for return value of sfp.set_lpmode, which will be None if the platform raises NotImplementedError. In this scenario the lpmode-related testing will be skipped.

#### How did you verify/test it?
Tested on an Arista platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
