### PR TITLE
[test_ro_user] Add a delay for 'test_ro_user_banned_command' after recent change

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
@@ -151,6 +152,8 @@ def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hos
             'sudo config'
     ]
 
+    # Wait until hostcfgd started and configured tacas authorization
+    time.sleep(100)
     for command in commands:
         banned = ssh_remote_ban_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
                                     creds_all_duts[duthost]['tacacs_ro_user_passwd'], command)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

After recent change introduced on this PR's:
https://github.com/Azure/sonic-buildimage/pull/7965
https://github.com/Azure/sonic-buildimage/pull/8117

'hostcfgd' will be delayed in 90 seconds.
If the test will run before the daemon has started, it will fail the test.
This is to align with the new change and make sure the test will pass.

#### How did you do it?
Add a delay of 100 seconds before executing authorized commands.

#### How did you verify/test it?
Run the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
