### PR TITLE
[NAT]: Fixes for NAT TC

### DIFF
--- a/tests/nat/test_dynamic_nat.py
+++ b/tests/nat/test_dynamic_nat.py
@@ -635,7 +635,7 @@ class TestDynamicNat(object):
         portrange = "{}-{}".format(POOL_RANGE_START_PORT, POOL_RANGE_END_PORT)
         acl_subnet = setup_data[interface_type]["acl_subnet"]
         public_ip = setup_data[interface_type]["public_ip"]
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": [
                               "SNAT tcp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip,
@@ -645,8 +645,8 @@ class TestDynamicNat(object):
                               "SNAT icmp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip,
                                                                                                   portrange)]
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
-                      "Unexpected iptables output for nat table")
+        pytest_assert(iptables_rules == iptables_output,
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
         # Enable outer interface
         dut_interface_control(duthost, "enable", setup_data["config_portchannels"][ifname_to_disable]['members'][0])
         # Send traffic
@@ -801,7 +801,7 @@ class TestDynamicNat(object):
                                                                                                   portrange)]
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Delete NAT bindings
         exec_command(duthost, ["config nat remove bindings"])
         # Confirm that binding has been removed
@@ -822,7 +822,7 @@ class TestDynamicNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
 
     @pytest.mark.nat_dynamic
     def test_nat_dynamic_iptable_snat(self, ptfhost, tbinfo, duthost, ptfadapter, setup_test_env,
@@ -893,7 +893,7 @@ class TestDynamicNat(object):
                 "SNAT icmp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip, portrange)]
             }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Remove outside interface IP
         interface_ip = "{} {}/{}".format(setup_data[interface_type]["vrf_conf"]["red"]["dut_iface"],
                                          setup_data[interface_type]["vrf_conf"]["red"]["gw"],
@@ -906,7 +906,7 @@ class TestDynamicNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Restore previous configuration
         dut_interface_control(duthost, "ip add", setup_data["config_portchannels"][ifname_to_disable]['members'][0], interface_ip)
         # Send TCP/UDP traffic and confirm that restoring previous configuration went well
@@ -936,11 +936,11 @@ class TestDynamicNat(object):
         src_port, dst_port = get_l4_default_ports(protocol_type)
 
         # Check, if iptables is empty
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": []
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
+        pytest_assert(iptables_rules == iptables_output,
                       "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
 
         # Prepare and add configuration json file
@@ -952,7 +952,7 @@ class TestDynamicNat(object):
         }
         write_json(duthost, nat_session, 'dynamic_binding')
         # Check iptables
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": [
                               "SNAT tcp -- {} 0.0.0.0/0 mark match 0x1 to:{}:{} fullcone".format(acl_subnet, public_ip,
@@ -962,7 +962,7 @@ class TestDynamicNat(object):
                               "SNAT icmp -- {} 0.0.0.0/0 mark match 0x1 to:{}:{} fullcone".format(acl_subnet, public_ip,
                                                                                                   port_range)]
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
+        pytest_assert(iptables_rules == iptables_output,
                       "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
         # Check traffic. Zone 1 is not configured, not NAT translations expected
         generate_and_verify_not_translated_traffic(ptfadapter, setup_info, interface_type, direction, protocol_type, nat_type)
@@ -970,7 +970,7 @@ class TestDynamicNat(object):
         # Setup zones
         nat_zones_config(duthost, setup_data, interface_type)
         # Check iptables
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": [
                               "SNAT tcp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip,
@@ -980,7 +980,7 @@ class TestDynamicNat(object):
                               "SNAT icmp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip,
                                                                                                   port_range)]
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
+        pytest_assert(iptables_rules == iptables_output,
                       "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
 
         # Perform TCP handshake (host-tor -> leaf-tor)
@@ -1019,7 +1019,7 @@ class TestDynamicNat(object):
         portrange = "{}-{}".format(POOL_RANGE_START_PORT, POOL_RANGE_END_PORT)
         acl_subnet = setup_data[interface_type]["acl_subnet"]
         public_ip = setup_data[interface_type]["public_ip"]
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": [
                               "SNAT tcp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip,
@@ -1029,7 +1029,7 @@ class TestDynamicNat(object):
                               "SNAT icmp -- {} 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(acl_subnet, public_ip,
                                                                                                   portrange)]
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
+        pytest_assert(iptables_rules == iptables_output,
                       "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
         # Send TCP/UDP traffic and check
         generate_and_verify_traffic(duthost, ptfadapter, setup_data, interface_type, direction, protocol_type, nat_type=nat_type)
@@ -1040,11 +1040,11 @@ class TestDynamicNat(object):
         # Check, if nat bindings is empty
         pytest_assert(len(get_cli_show_nat_config_output(duthost, "bindings")) == 0, "Nat bindings is not empty")
         # Check, if iptables is empty
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": []
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
+        pytest_assert(iptables_rules == iptables_output,
                       "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
         wait_timeout(protocol_type)
         # Send TCP/UDP traffic and check without NAT
@@ -1056,7 +1056,7 @@ class TestDynamicNat(object):
                                                                          nat_binding[0]["pool name"], acl_subnet))
         public_ip = setup_data[interface_type]["public_ip"]
         portrange = "{}-{}".format(POOL_RANGE_START_PORT, POOL_RANGE_END_PORT)
-        iptables_ouput = dut_nat_iptables_status(duthost)
+        iptables_output = dut_nat_iptables_status(duthost)
         iptables_rules = {"prerouting": ['DNAT all -- 0.0.0.0/0 0.0.0.0/0 to:1.1.1.1 fullcone'],
                           "postrouting": [
                               "SNAT tcp -- 0.0.0.0/0 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(public_ip,
@@ -1066,7 +1066,7 @@ class TestDynamicNat(object):
                               "SNAT icmp -- 0.0.0.0/0 0.0.0.0/0 mark match 0x2 to:{}:{} fullcone".format(public_ip,
                                                                                                          portrange)]
                          }
-        pytest_assert(iptables_rules == iptables_ouput,
+        pytest_assert(iptables_rules == iptables_output,
                       "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
 
         # Perform TCP handshake (host-tor -> leaf-tor)

--- a/tests/nat/test_static_nat.py
+++ b/tests/nat/test_static_nat.py
@@ -630,7 +630,7 @@ class TestStaticNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Set NAT configuration for test
         network_data = get_network_data(ptfadapter, setup_data, direction, interface_type, nat_type=nat_type)
         apply_static_nat_config(duthost, ptfadapter, ptfhost, setup_data, network_data, direction, interface_type, nat_type,
@@ -650,7 +650,7 @@ class TestStaticNat(object):
                 "SNAT all -- {} 0.0.0.0/0 mark match 0x2 to:{}".format(network_data.private_ip, network_data.public_ip)]
             }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Remove with CLI
         crud_remove = {"remove": {"action": "remove", "global_ip": network_data.public_ip, "local_ip": network_data.private_ip}}
         entries_table.update(crud_operations_basic(duthost, crud_remove))
@@ -662,7 +662,7 @@ class TestStaticNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
 
     @pytest.mark.nat_static
     def test_nat_static_global_double_add(self, ptfhost, tbinfo, duthost, ptfadapter, setup_test_env,
@@ -678,7 +678,7 @@ class TestStaticNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table")
+                      "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Set NAT configuration for test
         network_data = get_network_data(ptfadapter, setup_data, direction, interface_type, nat_type=nat_type)
         apply_static_nat_config(duthost, ptfadapter, ptfhost, setup_data, network_data, direction, interface_type, nat_type,
@@ -991,8 +991,6 @@ class TestStaticNat(object):
 
     @pytest.mark.nat_static
     def test_nat_static_redis_asic(self, ptfhost, tbinfo, duthost, ptfadapter, setup_test_env, protocol_type):
-        sai_nat_src_id = {"TCP": 1, "UDP": 2}[protocol_type]
-        sai_nat_dst_id = {"TCP": 2, "UDP": 1}[protocol_type]
         interface_type, setup_info = setup_test_env
         setup_data = copy.deepcopy(setup_info)
         nat_type = 'static_napt'
@@ -1012,8 +1010,11 @@ class TestStaticNat(object):
         db_rules_src = get_db_rules(duthost, ptfadapter, setup_test_env, protocol_type, 'ASIC_DB SRC')
         db_rules_dst = get_db_rules(duthost, ptfadapter, setup_test_env, protocol_type, 'ASIC_DB DST')
         output = get_redis_val(duthost, 1, "NAT_ENTRY")
-        output_src = output[(list(output.keys())[sai_nat_src_id])]['value']
-        output_dst = output[(list(output.keys())[sai_nat_dst_id])]['value']
+        for count, entry in enumerate(output):
+            if 'SAI_NAT_TYPE_SOURCE_NAT' in str(entry):
+                output_src = output[(list(output.keys())[count])]['value']
+            if 'SAI_NAT_TYPE_DESTINATION_NAT"' in str(entry):
+                output_dst = output[(list(output.keys())[count])]['value']
         pytest_assert(db_rules_src["SAI_NAT_ENTRY_ATTR_SRC_IP"] == output_src["SAI_NAT_ENTRY_ATTR_SRC_IP"],
                       "Unexpected output \n Got:\n{}\n Expected:\n{}".format(output_src["SAI_NAT_ENTRY_ATTR_SRC_IP"], db_rules_src["SAI_NAT_ENTRY_ATTR_SRC_IP"]))
         pytest_assert(db_rules_src["SAI_NAT_ENTRY_ATTR_L4_SRC_PORT"] == output_src["SAI_NAT_ENTRY_ATTR_L4_SRC_PORT"],


### PR DESCRIPTION
Signed-off-by: Vladyslav Morokhovych <vladyslavx.morokhovych@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes for NAT static and dynamic TC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
`dut_nat_iptables_status` gives wrong part of the iptables command in output.
In `test_nat_static_redis_asic` source and destination NAT entry are hardcoded and specified in accordance with the protocol, without taking into account the NAT Pool entry.
Also, 'expireat' and 'ttl' fields that are not required, are in the verification.
#### How did you do it?

- Fixed `dut_nat_iptables_status` parser, now use only valid data for postrouting entry.
- Change in `get_redis_val` to remove 'expireat' and 'ttl' fields.
- Fixed `test_nat_static_redis_asic` - now source and destination output will be get dynamically.
- Add minor debug support in asserts for unexpected iptables output in NAT table and fix typo.

#### How did you verify/test it?
Run specific TC to test fixes
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
