### PR TITLE
[Vlan] Add barefoot platform to vlan QinQ test case

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -412,7 +412,7 @@ def test_vlan_tc4_tagged_non_broadcast(ptfadapter, vlan_ports_list):
         if "Did not receive expected packet on any of ports" in str(detail):
             logger.error("Expected packet was not received")
         raise
-    
+
     logger.info("One Way Tagged Packet Transmission Works")
     logger.info("Tagged packet successfully sent from port {} to port {}".format(src_port[0], dst_port))
 
@@ -451,7 +451,7 @@ def test_vlan_tc5_untagged_non_broadcast(ptfadapter, vlan_ports_list, duthost):
     src_port = ports_for_test[0]
     dst_port = ports_for_test[-1]
 
-    src_mac = ptfadapter.dataplane.get_mac(0, src_port[0]) 
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
     dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])
 
     transmit_untagged_pkt = build_icmp_packet(vlan_id=0, src_mac=src_mac, dst_mac=dst_mac)
@@ -494,7 +494,7 @@ def test_vlan_tc6_tagged_qinq_switch_on_outer_tag(ptfadapter, vlan_ports_list, d
     """
 
     # Add more supported platforms to the list as they are tested
-    qinq_switching_supported_platforms = ['mellanox']
+    qinq_switching_supported_platforms = ['mellanox', 'barefoot']
     if duthost.facts["asic_type"] not in qinq_switching_supported_platforms:
         pytest.skip("Unsupported platform")
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Added `barefoot` to list of QinQ supported platforms in order to run `test_vlan_tc6_tagged_qinq_switch_on_outer_tag` case, which by default would be skipped.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Run `test_vlan_tc6_tagged_qinq_switch_on_outer_tag`
#### How did you do it?

#### How did you verify/test it?
Run test case on `t0` topo:
`vlan/test_vlan.py::test_vlan_tc6_tagged_qinq_switch_on_outer_tag PASSED`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.15330-dirty-20210516.144534
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: ea803257
Build date: Sun May 16 14:54:14 UTC 2021
Built by: AzDevOps@sonic-build-workers-0009PE
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
