### PR TITLE
Support for gen-mg for multi-asic linecards in VoQ chassis

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -457,7 +457,7 @@ def makeLab(data, devices, testbed, outfile):
                             print("\t\t" + host + " num_fabric_asics not found")
 
                         try: #get num_asics
-                            num_asics = dev.get("num_asics")
+                            num_asics = int(dev.get("num_asics"))
                             if num_asics is not None:
                                entry += "\tnum_asics=" + str( num_asics )
                         except AttributeError:
@@ -491,47 +491,59 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " asics_host_ipv6 not found")
 
-                        try: #get voq_inband_ip
-                            voq_inband_ip = dev.get("voq_inband_ip")
-                            if voq_inband_ip is not None:
-                               entry += "\tvoq_inband_ip=" + str( voq_inband_ip )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_ip not found")
-
-                        try: #get voq_inband_ipv6
-                            voq_inband_ipv6 = dev.get("voq_inband_ipv6")
-                            if voq_inband_ipv6 is not None:
-                               entry += "\tvoq_inband_ipv6=" + str( voq_inband_ipv6 )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_ipv6 not found")
-
-                        try: #get voq_inband_intf
-                            voq_inband_intf = dev.get("voq_inband_intf")
-                            if voq_inband_intf is not None:
-                               entry += "\tvoq_inband_intf=" + str( voq_inband_intf )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_intf not found")
-
-                        try: #get voq_inband_type
-                            voq_inband_type = dev.get("voq_inband_type")
-                            if voq_inband_type is not None:
-                               entry += "\tvoq_inband_type=" + str( voq_inband_type )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_type not found")
-
                         try: #get switch_type
                             switch_type = dev.get("switch_type")
                             if switch_type is not None:
-                               entry += "\tswitch_type=" + str( switch_type )
+                                entry += "\tswitch_type=" + str( switch_type )
+                                if switch_type == 'voq' and card_type != 'supervisor':
+                                    if num_asics is None:
+                                        num_asics = 1
+
+                                    # All fields are a list. For single asic the list is of size 1.
+                                    switchids = dev.get("switchids")                # switchids
+                                    voq_inband_ip = dev.get("voq_inband_ip")        # voq_inband_ip
+                                    voq_inband_ipv6 = dev.get("voq_inband_ipv6")    # voq_inband_ipv6
+                                    voq_inband_intf = dev.get("voq_inband_intf")    # voq_inband_intf
+                                    voq_inband_type = dev.get("voq_inband_type")    # voq_inband_type
+                                    max_cores = dev.get("max_cores")                # max cores
+                                    if num_asics > 1:
+                                        lo4096_ip = dev.get("loopback4096_ip")      # loopback4096_ip
+                                        lo4096_ipv6 = dev.get("loopback4096_ipv6")  # loopback4096_ipv6
+
+                                    # Set defaults
+                                    if switchids is None:
+                                        switchids = [start_switchid + asic_id for asic_id in range(num_asics)]
+                                    if voq_inband_ip is None:
+                                        voq_inband_ip = ["1.1.1.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    if voq_inband_ipv6 is None:
+                                        voq_inband_ip = ["1111::1:{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    if voq_inband_intf is None:
+                                        voq_inband_intf = ["Ethernet-IB{}".format(asic_id) for asic_id in range(num_asics)]
+                                    if voq_inband_type is None:
+                                        voq_inband_type = "port"
+                                    if max_cores is None:
+                                        max_cores = 48
+                                    if num_asics > 1:
+                                        if lo4096_ip is None:
+                                            lo4096_ip = ["8.0.0.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                        if lo4096_ipv6 is None:
+                                            lo4096_ipv6 = ["2603:10e2:400::{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+
+                                    start_switchid += num_asics
+
+                                    # Add fields
+                                    entry += "\tswitchids=" + str(switchids)
+                                    entry += "\tvoq_inband_ip=" + str(voq_inband_ip)
+                                    entry += "\tvoq_inband_ipv6=" + str(voq_inband_ip)
+                                    entry += "\tvoq_inband_intf=" + str(voq_inband_intf)
+                                    entry += "\tvoq_inband_type=" + voq_inband_type
+                                    entry += "\tmax_cores=" + str(max_cores)
+                                    if num_asics > 1:
+                                        entry += "\tloopback4096_ip=" + lo4096_ip
+                                        entry += "\tloopback4096_ipv6=" + lo4096_ipv6
+
                         except AttributeError:
                             print("\t\t" + host + " switch_type not found")
-
-                        try: #get max_cores
-                            max_cores = dev.get("max_cores")
-                            if max_cores is not None:
-                               entry += "\tmax_cores=" + str( max_cores )
-                        except AttributeError:
-                            print("\t\t" + host + " max_cores not found")
 
                         try: #get os
                             os = dev.get("os")

--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -500,47 +500,50 @@ def makeLab(data, devices, testbed, outfile):
                                         num_asics = 1
 
                                     # All fields are a list. For single asic the list is of size 1.
-                                    switchids = dev.get("switchids")                # switchids
-                                    voq_inband_ip = dev.get("voq_inband_ip")        # voq_inband_ip
-                                    voq_inband_ipv6 = dev.get("voq_inband_ipv6")    # voq_inband_ipv6
-                                    voq_inband_intf = dev.get("voq_inband_intf")    # voq_inband_intf
-                                    voq_inband_type = dev.get("voq_inband_type")    # voq_inband_type
-                                    max_cores = dev.get("max_cores")                # max cores
-                                    if num_asics > 1:
-                                        lo4096_ip = dev.get("loopback4096_ip")      # loopback4096_ip
-                                        lo4096_ipv6 = dev.get("loopback4096_ipv6")  # loopback4096_ipv6
-
-                                    # Set defaults
-                                    if switchids is None:
-                                        switchids = [start_switchid + asic_id for asic_id in range(num_asics)]
-                                    if voq_inband_ip is None:
-                                        voq_inband_ip = ["1.1.1.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
-                                    if voq_inband_ipv6 is None:
-                                        voq_inband_ip = ["1111::1:{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
-                                    if voq_inband_intf is None:
-                                        voq_inband_intf = ["Ethernet-IB{}".format(asic_id) for asic_id in range(num_asics)]
-                                    if voq_inband_type is None:
-                                        voq_inband_type = "port"
-                                    if max_cores is None:
-                                        max_cores = 48
-                                    if num_asics > 1:
-                                        if lo4096_ip is None:
-                                            lo4096_ip = ["8.0.0.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
-                                        if lo4096_ipv6 is None:
-                                            lo4096_ipv6 = ["2603:10e2:400::{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
-
-                                    start_switchid += num_asics
+                                    switchids = dev.get("switchids")                       # switchids, single asic example "[4]", 3 asic example "[4,6,8]"
+                                    voq_inband_ip = dev.get("voq_inband_ip")               # voq_inband_ip
+                                    voq_inband_ipv6 = dev.get("voq_inband_ipv6")           # voq_inband_ipv6
+                                    voq_inband_intf = dev.get("voq_inband_intf")           # voq_inband_intf
+                                    voq_inband_type = dev.get("voq_inband_type")           # voq_inband_type
+                                    max_cores = dev.get("max_cores")                       # max cores
+                                    lo4096_ip = dev.get("loopback4096_ip")                 # loopback4096_ip
+                                    lo4096_ipv6 = dev.get("loopback4096_ipv6")             # loopback4096_ipv6
+                                    num_cores_per_asic = dev.get("num_cores_per_asic", 1)  # number of cores per asic - to be used in calculating the switchids, assuming to be the same for all linecards
 
                                     # Add fields
+                                    if switchids is None:
+                                        switchids = [start_switchid + (asic_id * num_cores_per_asic) for asic_id in range(num_asics)]
                                     entry += "\tswitchids=" + str(switchids)
+
+                                    if voq_inband_ip is None:
+                                        voq_inband_ip = ["1.1.1.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
                                     entry += "\tvoq_inband_ip=" + str(voq_inband_ip)
+
+                                    if voq_inband_ipv6 is None:
+                                        voq_inband_ip = ["1111::1:{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
                                     entry += "\tvoq_inband_ipv6=" + str(voq_inband_ip)
+
+                                    if voq_inband_intf is None:
+                                        voq_inband_intf = ["Ethernet-IB{}".format(asic_id) for asic_id in range(num_asics)]
                                     entry += "\tvoq_inband_intf=" + str(voq_inband_intf)
+
+                                    if voq_inband_type is None:
+                                        voq_inband_type = "port"
                                     entry += "\tvoq_inband_type=" + voq_inband_type
+
+                                    if max_cores is None:
+                                        max_cores = 48
                                     entry += "\tmax_cores=" + str(max_cores)
-                                    if num_asics > 1:
-                                        entry += "\tloopback4096_ip=" + lo4096_ip
-                                        entry += "\tloopback4096_ipv6=" + lo4096_ipv6
+
+                                    if lo4096_ip is None:
+                                        lo4096_ip = ["8.0.0.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tloopback4096_ip=" + lo4096_ip
+
+                                    if lo4096_ipv6 is None:
+                                        lo4096_ipv6 = ["2603:10e2:400::{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tloopback4096_ipv6=" + lo4096_ipv6
+
+                                    start_switchid += (num_asics * num_cores_per_asic)
 
                         except AttributeError:
                             print("\t\t" + host + " switch_type not found")

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -84,7 +84,7 @@
       hwsku: "{{ hwsku }}"
       card_type: "{{ card_type | default('fixed') }}"
       hostname: "{{ inventory_hostname | default('') }}"
-      start_switchid: "{{ start_switchid | default(0) }}"
+      switchids: "{{ switchids | default([0]) }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
@@ -93,7 +93,7 @@
       num_asic: "{{ num_asics }}"
       card_type: "{{ card_type | default('fixed') }}"
       hostname: "{{ inventory_hostname | default('') }}"
-      start_switchid: "{{ start_switchid | default(0) }}"
+      switchids: "{{ switchids | default([0]) }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 
@@ -111,8 +111,7 @@
 
   - name: set all VoQ information for iBGP
     set_fact:
-      all_inbands: "{{ all_inbands | default( [] ) + [ hostvars[item]['voq_inband_ip'] ] }}"
-      all_hostnames: "{{ all_hostnames | default( [] ) + [ item ] }}"
+      all_inbands: "{{ all_inbands | default( {} ) | combine( { item : hostvars[item]['voq_inband_ip']}) }}"
     when: hostvars[item]['voq_inband_ip'] is defined
     loop: "{{ ansible_play_batch }}"
 

--- a/ansible/library/fabric_info.py
+++ b/ansible/library/fabric_info.py
@@ -23,8 +23,8 @@ EXAMPLES = '''
 
 RETURN = '''
       ansible_facts{
-        fabric_info: [{'asicname': 'ASIC0', 'ip_prefix': '10.1.0.1/32', 'ip6_prefix': 'FC00:1::1/128'},
-                      {'asicname': 'ASIC1', 'ip_prefix': '10.1.0.2/32', 'ip6_prefix': 'FC00:1::2/128'}]
+        fabric_info: [{'asicname': 'ASIC0', 'asic_id': 0, 'ip_prefix': '10.1.0.1/32', 'ip6_prefix': 'FC00:1::1/128'},
+                      {'asicname': 'ASIC1', 'asic_id': 1, 'ip_prefix': '10.1.0.2/32', 'ip6_prefix': 'FC00:1::2/128'}]
       }
 '''
 
@@ -55,6 +55,7 @@ def main():
             next_v4addr = str( ipaddress.IPv4Address(v4base + asic_id) )
             next_v6addr = str( ipaddress.IPv6Address(v6base + asic_id) )
             data = { 'asicname': key,
+                     'asic_id' : asic_id,
                      'ip_prefix': next_v4addr + "/" + v4pfx[-1],
                      'ip6_prefix': next_v6addr + "/" + v6pfx[-1] }
             fabric_info.append( data )

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -235,7 +235,7 @@ def main():
                                            'sysports': sysports})
            return
         allmap = SonicPortAliasMap(m_args['hwsku'])
-        switchids = [0]
+        switchids = None
         if 'switchids' in m_args and m_args['switchids'] != None:
            switchids = m_args['switchids']
         # When this script is invoked on sonic-mgmt docker, num_asic 
@@ -258,7 +258,7 @@ def main():
         if 'hostname' in m_args:
             hostname = m_args['hostname']
         for asic_id in range(num_asic):
-            if asic_id is not None:
+            if switchids and asic_id is not None:
                 switchid = switchids[asic_id]
             if num_asic == 1:
                 asic_id = None

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -104,8 +104,8 @@ class SonicPortAliasMap():
         port_coreid_index = -1
         port_core_portid_index = -1
         num_voq_index = -1
-        # default to ASIC0 as minigraph.py parsing code has that assumption.
-        asic_name = "ASIC0" if asic_id is None else "ASIC" + str(asic_id)
+        # default to Asic0 as minigraph.py parsing code has that assumption.
+        asic_name = "Asic0" if asic_id is None else "asic" + str(asic_id)
 
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
@@ -209,7 +209,7 @@ def main():
             include_internal=dict(required=False, type='bool', default=False),
             card_type=dict(type='str', required=False),
             hostname=dict(type='str', required=False),
-            start_switchid=dict(type='int', required=False)
+            switchids=dict(type='list', required=False)
         ),
         supports_check_mode=True
     )
@@ -235,10 +235,10 @@ def main():
                                            'sysports': sysports})
            return
         allmap = SonicPortAliasMap(m_args['hwsku'])
-        start_switchid = 0
-        if  'start_switchid' in m_args and m_args['start_switchid'] != None:
-           start_switchid = int(m_args['start_switchid'])
-        # When this script is invoked on sonic-mgmt docker, num_asic
+        switchids = [0]
+        if 'switchids' in m_args and m_args['switchids'] != None:
+           switchids = m_args['switchids']
+        # When this script is invoked on sonic-mgmt docker, num_asic 
         # parameter is passed.
         if m_args['num_asic'] is not None:
             num_asic = m_args['num_asic']
@@ -259,7 +259,7 @@ def main():
             hostname = m_args['hostname']
         for asic_id in range(num_asic):
             if asic_id is not None:
-                switchid = start_switchid + asic_id
+                switchid = switchids[asic_id]
             if num_asic == 1:
                 asic_id = None
             (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, asicifnames_asic,

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -80,19 +80,39 @@
 {% endfor %}
 {% endif %}
 {% if switch_type is defined and switch_type == 'voq' %}
-{% for all_idx in range(all_inbands|length) %}
-{% if voq_inband_ip != all_inbands[all_idx] %}
+{% set voq_peers = dict() %}
+{% for asic_id in range(num_asics) %}
+{% if num_asics == 1 %}
+{% set start_rtr = inventory_hostname %}
+{% else %}
+{% set start_rtr = "ASIC" + asic_id|string %}
+{% endif %}
+{% for a_linecard in all_inbands %}
+{% for idx in range(all_inbands[a_linecard]|length) %}
+{% if voq_inband_ip[asic_id] != all_inbands[a_linecard][idx] %}
       <BGPSession>
-        <StartRouter>{{ inventory_hostname  }}</StartRouter>
-        <StartPeer>{{ voq_inband_ip.split('/')[0] }}</StartPeer>
-        <EndRouter>{{ all_hostnames[all_idx] }}</EndRouter>
-        <EndPeer>{{ all_inbands[all_idx].split('/')[0] }}</EndPeer>
+        <StartRouter>{{ start_rtr }}</StartRouter>
+        <StartPeer>{{ voq_inband_ip[asic_id].split('/')[0] }}</StartPeer>
+{% if all_inbands[a_linecard]|length == 1 %}
+{% set end_rtr = a_linecard %}
+{% else %}
+{% if a_linecard == inventory_hostname %}
+{% set end_rtr = "ASIC" + idx|string %}
+{% else %}
+{% set end_rtr = a_linecard + "-ASIC" + idx|string %}
+{% endif %}
+{% endif %}
+{% set _dummy = voq_peers.update({ all_inbands[a_linecard][idx].split('/')[0] : end_rtr }) %}
+        <EndRouter>{{ end_rtr }}</EndRouter>
+        <EndPeer>{{ all_inbands[a_linecard][idx].split('/')[0] }}</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>0</HoldTime>
         <KeepAliveTime>0</KeepAliveTime>
         <VoQChassisInternal>true</VoQChassisInternal>
       </BGPSession>
 {% endif %}
+{% endfor %}
+{% endfor %}
 {% endfor %}
 {% endif %}
     </PeeringSessions>
@@ -112,16 +132,14 @@
           </BGPPeer>
 {% endif %}
 {% endfor %}
-{% if switch_type is defined and switch_type == 'voq' %}
-{% for all_idx in range(all_inbands|length) %}
-{% if voq_inband_ip != all_inbands[all_idx] %}
+{% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
+{% for a_voq_peer in voq_peers %}
           <BGPPeer>
-            <Address>{{ all_inbands[all_idx].split('/')[0] }}</Address>
+            <Address>{{ a_voq_peer }}</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
           </BGPPeer>
-{% endif %}
 {% endfor %}
 {% endif %}
 {% if 'tor' in vm_topo_config['dut_type'] | lower %}
@@ -147,17 +165,6 @@
         </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
-{% if switch_type is defined and switch_type == 'voq' %}
-{% for all_idx in range(all_inbands|length) %}
-{% if voq_inband_ip != all_inbands[all_idx] %}
-      <a:BGPRouterDeclaration>
-        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
-        <a:Hostname>{{ all_hostnames[all_idx]  }}</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-{% endif %}
-{% endfor %}
-{% endif %}
 {% for index in range( vms_number) %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length > 0 %}
       <a:BGPRouterDeclaration>
@@ -174,7 +181,7 @@
         <a:Hostname>{{ asic }}</a:Hostname>
         <a:Peers>
 {% for index in range( vms_number) %}
-{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
           <BGPPeer>
             <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
             <RouteMapIn i:nil="true"/>
@@ -197,6 +204,52 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
 {% endfor %}
+{% if switch_type is defined and switch_type == 'voq' %}
+{% for a_linecard in all_inbands %}
+{% if a_linecard != inventory_hostname %}
+{% for idx in range(all_inbands[a_linecard]|length) %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+        <a:Hostname>{{ voq_peers[all_inbands[a_linecard][idx].split('/')[0]] }}</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% if num_asics > 1 %}
+{% for asic_id in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_id|string %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+        <a:Hostname>{{ asic_name }}</a:Hostname>
+        <a:Peers>
+{% for index in range( vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+          <BGPPeer>
+            <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% for a_linecard in all_inbands %}
+{% for idx in range(all_inbands[a_linecard]|length) %}
+{% if voq_inband_ip[asic_id] != all_inbands[a_linecard][idx] %}
+          <BGPPeer>
+            <Address>{{ all_inbands[a_linecard][idx] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% endfor %}
+        </a:Peers>
+      </a:BGPRouterDeclaration>
+{% endfor %}
+{% endif %}
+{% endif %}
     </Routers>
   </CpgDec>
 

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -102,7 +102,7 @@
 {% set end_rtr = a_linecard + "-ASIC" + idx|string %}
 {% endif %}
 {% endif %}
-{% set _dummy = voq_peers.update({ all_inbands[a_linecard][idx].split('/')[0] : end_rtr }) %}
+{% set _ = voq_peers.update({ all_inbands[a_linecard][idx].split('/')[0] : end_rtr }) %}
         <EndRouter>{{ end_rtr }}</EndRouter>
         <EndPeer>{{ all_inbands[a_linecard][idx].split('/')[0] }}</EndPeer>
         <Multihop>1</Multihop>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -19,6 +19,26 @@
           </a:Prefix>
           <a:PrefixStr>{{ lp_ipv6 }}</a:PrefixStr>
         </a:LoopbackIPInterface>
+      {% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
+      {% if loopback4096_ip is defined %}
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback4096_ip[0] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback4096_ip[0] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback4096_ipv6[0] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback4096_ipv6[0] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      {% endif %}
+      {% endif %}
       {%- if 'addl_loopbacks' in dual_tor_facts -%}
       {%- for loopback_num in dual_tor_facts['addl_loopbacks'][inventory_hostname] -%}
         {%- set loopback_facts = dual_tor_facts['addl_loopbacks'][inventory_hostname][loopback_num] -%}

--- a/ansible/templates/minigraph_dpg_voq_asic.j2
+++ b/ansible/templates/minigraph_dpg_voq_asic.j2
@@ -174,6 +174,9 @@
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
+{% endfor %}
+{% endif %}
+{% if switch_type is defined and switch_type == 'fabric' %}
 {% for asic in fabric_info %}
     <DeviceDataPlaneInfo>
       <IPSecTunnels/>
@@ -210,6 +213,6 @@
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
 {% endfor %}
-{% endfor %}
 {% endif %}
+
 

--- a/ansible/templates/minigraph_dpg_voq_asic.j2
+++ b/ansible/templates/minigraph_dpg_voq_asic.j2
@@ -1,8 +1,9 @@
-  <DpgDec>
+{% if num_asics > 1 and switch_type is defined and switch_type == 'voq' %}
+{% for asic_index in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_index|string %}
     <DeviceDataPlaneInfo>
       <IPSecTunnels/>
       <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% if card_type is not defined or card_type != 'supervisor' %}
         <a:LoopbackIPInterface>
           <Name>HostIP</Name>
           <AttachTo>Loopback0</AttachTo>
@@ -19,27 +20,23 @@
           </a:Prefix>
           <a:PrefixStr>{{ lp_ipv6 }}</a:PrefixStr>
         </a:LoopbackIPInterface>
-      {%- if 'addl_loopbacks' in dual_tor_facts -%}
-      {%- for loopback_num in dual_tor_facts['addl_loopbacks'][inventory_hostname] -%}
-        {%- set loopback_facts = dual_tor_facts['addl_loopbacks'][inventory_hostname][loopback_num] -%}
+{% if loopback4096_ip is defined %}
         <a:LoopbackIPInterface>
-          <Name>HostIP{{ loopback_facts['host_ip_base_index'] }}</Name>
-          <AttachTo>Loopback{{ loopback_num }}</AttachTo>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>{{ loopback_facts['ipv4'] }}</b:IPPrefix>
+            <b:IPPrefix>{{ loopback4096_ip[asic_index] }}</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>{{ loopback_facts['ipv4'] }}</a:PrefixStr>
+          <a:PrefixStr>{{ loopback4096_ip[asic_index] }}</a:PrefixStr>
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
-          <Name>HostIP{{ loopback_facts['host_ip_base_index'] + 1 }}</Name>
-          <AttachTo>Loopback{{ loopback_num }}</AttachTo>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>{{ loopback_facts['ipv6'] }}</b:IPPrefix>
+            <b:IPPrefix>{{ loopback4096_ipv6[asic_index] }}</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>{{ loopback_facts['ipv6'] }}</a:PrefixStr>
+          <a:PrefixStr>{{ loopback4096_ipv6[asic_index] }}</a:PrefixStr>
         </a:LoopbackIPInterface>
-      {%- endfor -%}
-      {%- endif -%}
 {% endif %}
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
@@ -61,20 +58,20 @@
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-{% if num_asics == 1 and (voq_inband_ip is defined or voq_inband_ipv6 is defined) %}
+{% if voq_inband_ip is defined or voq_inband_ipv6 is defined %}
       <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% if voq_inband_ip is defined %}
         <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf[0] }}</Name>
+          <Name>{{ voq_inband_intf[asic_index] }}</Name>
           <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ip[0] }}</a:PrefixStr>
+          <a:PrefixStr>{{ voq_inband_ip[asic_index] }}</a:PrefixStr>
         </a:VoqInbandInterface>
 {% endif %}
 {% if voq_inband_ipv6 is defined %}
         <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf[0] }}</Name>
+          <Name>{{ voq_inband_intf[asic_index] }}</Name>
           <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ipv6[0] }}</a:PrefixStr>
+          <a:PrefixStr>{{ voq_inband_ipv6[asic_index] }}</a:PrefixStr>
         </a:VoqInbandInterface>
 {% endif %}
       </VoqInbandInterfaces>
@@ -82,78 +79,33 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>{{ inventory_hostname }}</Hostname>
+      <Hostname>{{ asic_name }}</Hostname>
       <PortChannelInterfaces>
 {% for index in range(vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-{% set port_channel_intf=';'.join(intf_names[vms[index]])  %}
+{% set port_channel_intf=';'.join(vm_asic_ifnames[vms[index]])  %}
         <PortChannel>
           <Name>PortChannel{{ ((index+1)|string).zfill(4) }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
 {% endif %}
-{% endfor %}
-{% if 'tor' in vm_topo_config['dut_type'] | lower %}
-{% for portchannel, params in portchannel_config.items() %}
-{% set port_channel_intf=';'.join(params['intfs'] | map('extract', port_alias)) %}
-        <PortChannel>
-          <Name>{{ portchannel }}</Name>
-          <AttachTo>{{ port_channel_intf }}</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-{% endfor %}
 {% endif %}
+{% endfor %}
       </PortChannelInterfaces>
-{% if tunnel_configs | length > 0 %}
-      <TunnelInterfaces>
-{% for tunnel, tunnel_param in tunnel_configs.items() %}
-        <TunnelInterface Name="{{ tunnel }}" Type="{{ tunnel_param['type'] }}" AttachTo="{{ tunnel_param['attach_to'] }}" DifferentiatedServicesCodePointMode="{{ tunnel_param['dscp'] }}" EcnEncapsulationMode="{{ tunnel_param['ecn_encap'] }}" EcnDecapsulationMode="{{ tunnel_param['ecn_decap'] }}" TtlMode="{{ tunnel_param['ttl_mode'] }}" />
-{% endfor %}
-      </TunnelInterfaces>
-{% endif %}
-      <VlanInterfaces>
-{% if 'tor' in vm_topo_config['dut_type'] | lower %}
-{% for vlan, vlan_param in vlan_configs.items() %}
-        <VlanInterface>
-          <Name>{{ vlan }}</Name>
-{% set vlan_intf_str=';'.join(vlan_param['intfs'] + vlan_param['portchannels']) %}
-          <AttachTo>{{ vlan_intf_str }}</AttachTo>
-          <NoDhcpRelay>False</NoDhcpRelay>
-          <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
-{% if 'type' in vlan_param %}
-{% if vlan_param['type']|lower == 'tagged'%}
-          <Type>Tagged</Type>
-{% else %}
-          <Type i:nil="true"/>
-{% endif %}
-{% endif %}
-{% set dhcp_servers_str=';'.join(dhcp_servers) %}
-          <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
-{% if dhcpv6_servers is defined %}
-{% set dhcpv6_servers_str=';'.join(dhcpv6_servers) %}
-          <Dhcpv6Relays>{{ dhcpv6_servers_str }}</Dhcpv6Relays>
-{% endif %}
-          <VlanID>{{ vlan_param['id'] }}</VlanID>
-          <Tag>{{ vlan_param['tag'] }}</Tag>
-          <Subnets>{{ vlan_param['prefix'] | ipaddr('network') }}/{{ vlan_param['prefix'] | ipaddr('prefix') }}</Subnets>
-{% if 'mac' in vlan_param %}
-          <MacAddress>{{ vlan_param['mac'] }}</MacAddress>
-{% endif %}
-        </VlanInterface>
-{% endfor %}
-{% endif %}
-      </VlanInterfaces>
+      <SubInterfaces/>
+      <VlanInterfaces/>
       <IPInterfaces>
-{% if card_type is not defined or card_type != 'supervisor' %}
 {% for index in range(vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
 {% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv4'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv4mask'][dut_index|int] }}</Prefix>
         </IPInterface>
@@ -162,40 +114,16 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
           <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
-          <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+          <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
           <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv6'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv6mask'][dut_index|int] }}</Prefix>
         </IPInterface>
 {% endif %}
-{% endfor %}
-{% if 'tor' in vm_topo_config['dut_type'] | lower %}
-{% for vlan, vlan_param in vlan_configs.items() %}
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>{{ vlan }}</AttachTo>
-          <Prefix>{{ vlan_param['prefix'] }}</Prefix>
-        </IPInterface>
-{% endfor %}
-{% for vlan, vlan_param in vlan_configs.items() %}
-{%   if 'prefix_v6' in vlan_param %}
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>{{ vlan }}</AttachTo>
-          <Prefix>{{ vlan_param['prefix_v6'] }}</Prefix>
-        </IPInterface>
-{%   endif %}
-{% endfor %}
 {% endif %}
-{% endif %}
+{% endfor %}
       </IPInterfaces>
       <DataAcls/>
       <AclInterfaces>
-{% if card_type is not defined or card_type != 'supervisor' %}
-        <AclInterface>
-          <InAcl>NTP_ACL</InAcl>
-          <AttachTo>NTP</AttachTo>
-          <Type>NTP</Type>
-        </AclInterface>
         <AclInterface>
           <InAcl>SNMP_ACL</InAcl>
           <AttachTo>SNMP</AttachTo>
@@ -216,21 +144,24 @@
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>
         </AclInterface>
-{% if enable_data_plane_acl|default('true')|bool %}
         <AclInterface>
           <AttachTo>
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
-{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% set a_intf = 'PortChannel' + ((index+1) |string).zfill(4) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
+{% endif %}
 {% endfor %}
-{% for index in range(vms_number) %}
-{% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf']|lower %}
+{%- for index in range(vms_number) -%}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
-{% set a_intf = port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
+{% set a_intf = front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
 {{- acl_intfs.append(a_intf) -}}
+{% endif %}
 {% endif %}
 {% endif %}
 {% endfor -%}
@@ -239,13 +170,46 @@
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
-{% endif %}
-{% endif %}
       </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
-{% include 'minigraph_dpg_asic.j2' %}
-{% include 'minigraph_dpg_voq_asic.j2' %}
-  </DpgDec>
+{% for asic in fabric_info %}
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>{{ asic['ip_prefix'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ asic['ip_prefix'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>{{ asic['ip6_prefix'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ asic['ip6_prefix'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      </ManagementIPInterfaces>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>{{ asic['asicname'] }}</Hostname>
+      <PortChannelInterfaces/>
+      <VlanInterfaces/>
+      <IPInterfaces/>
+      <DataAcls/>
+      <AclInterfaces/>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+{% endfor %}
+{% endfor %}
+{% endif %}
 

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -91,7 +91,7 @@
             <a:Value>{{ erspan_dest_str }}</a:Value>
          </a:DeviceProperty>
 {% endif %}
-{% if switch_type is defined and switch_type == 'voq' %}
+{% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
           <a:DeviceProperty>
             <a:Name>SwitchType</a:Name>
             <a:Reference i:nil="true"/>
@@ -100,8 +100,8 @@
           <a:DeviceProperty>
             <a:Name>SwitchId</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>{{ start_switchid }}</a:Value>
-          </a:DeviceProperty>         
+            <a:Value>{{ switchids[0] }}</a:Value>
+          </a:DeviceProperty>
 {% endif %}
 {% if max_cores is defined %}
           <a:DeviceProperty>
@@ -112,7 +112,40 @@
 {% endif %}
         </a:Properties>
       </a:DeviceMetadata>
-{% set idx = 0 %}
+{% if num_asics > 1 and switch_type is defined and switch_type == 'voq' %}
+{% for asic_index in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_index|string %}
+     <a:DeviceMetadata>
+        <a:Name>{{ asic_name }}</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>SubRole</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>FrontEnd</a:Value>
+          </a:DeviceProperty>
+{% if switch_type is defined and switch_type == 'voq' %}
+          <a:DeviceProperty>
+            <a:Name>SwitchType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switch_type }}</a:Value>
+         </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switchids[asic_index] }}</a:Value>
+          </a:DeviceProperty>
+{% endif %}
+{% if max_cores is defined %}
+          <a:DeviceProperty>
+            <a:Name>MaxCores</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ max_cores }}</a:Value>
+         </a:DeviceProperty>
+        </a:Properties>
+{% endif %}
+      </a:DeviceMetadata>
+{% endfor %}
+{% endif %}
 {% for asic in asic_topo_config %}
       <a:DeviceMetadata>
         <a:Name>{{ asic }}</a:Name>

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -176,7 +176,6 @@
 {% endif %}
       </a:DeviceMetadata>
 {% endfor %}
-
 {% for asic in fabric_info %}
       <a:DeviceMetadata>
         <a:Name>{{ asic['asicname'] }}</a:Name>
@@ -191,10 +190,14 @@
             <a:Reference i:nil="true"/>
             <a:Value>Fabric</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switchids[asic['asic_id']] }}</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
 {% endfor %}
-
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -123,7 +123,6 @@
             <a:Reference i:nil="true"/>
             <a:Value>FrontEnd</a:Value>
           </a:DeviceProperty>
-{% if switch_type is defined and switch_type == 'voq' %}
           <a:DeviceProperty>
             <a:Name>SwitchType</a:Name>
             <a:Reference i:nil="true"/>
@@ -134,7 +133,6 @@
             <a:Reference i:nil="true"/>
             <a:Value>{{ switchids[asic_index] }}</a:Value>
           </a:DeviceProperty>
-{% endif %}
 {% if max_cores is defined %}
           <a:DeviceProperty>
             <a:Name>MaxCores</a:Name>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -72,10 +72,11 @@
 {% endfor %}
 {% endfor %}
 {% endfor %}
+{% if switch_type is not defined or switch_type != "voq" %}
 {% for asic_intf in front_panel_asic_ifnames %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
-        <Bandwidth>40000</Bandwidth>
+        <Bandwidth>{{ port_speed[port_alias[loop.index - 1]] }}</Bandwidth>
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>{{ asic_intf.split('-')[1] }}</EndDevice>
         <EndPort>{{ asic_intf }}</EndPort>
@@ -85,6 +86,7 @@
         <Validate>true</Validate>
       </DeviceLinkBase>
 {% endfor %}
+{% endif %}
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>
@@ -217,6 +219,15 @@
         <HwSku>Broadcom-Trident2</HwSku>
       </Device>
 {% endfor %}
+{% if num_asics > 1 and switch_type is defined and switch_type == 'voq' %}
+{% for asic_index in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_index|string %}
+      <Device i:type="Asic">
+        <ElementType>Asic</ElementType>
+        <Hostname>{{ asic_name }}</Hostname>
+      </Device>
+{% endfor %}
+{% endif %}
 {% for asic in fabric_info %}
       <Device i:type="Asic">
         <Hostname>{{ asic['asicname'] }}</Hostname>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -72,8 +72,8 @@
 {% endfor %}
 {% endfor %}
 {% endfor %}
-{% if switch_type is not defined or switch_type != "voq" %}
 {% for asic_intf in front_panel_asic_ifnames %}
+{% if port_alias[loop.index - 1] in device_conn[inventory_hostname] %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <Bandwidth>{{ port_speed[port_alias[loop.index - 1]] }}</Bandwidth>
@@ -85,8 +85,8 @@
         <StartPort>{{ port_alias[loop.index - 1] }}</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
-{% endfor %}
 {% endif %}
+{% endfor %}
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -5,14 +5,11 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
-def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
+
+def test_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
-    duthost = duthosts[enum_dut_hostname]
-
-    # Check if duthost is 'supervisor' card, and skip the test if dealing with supervisor card.
-    if duthost.is_supervisor_node():
-        pytest.skip("bgp_facts not valid on supervisor card '%s'" % enum_dut_hostname)
+    duthost = duthosts[enum_frontend_dut_hostname]
 
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
@@ -32,6 +29,8 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     nbrs_in_cfg_facts = {}
     nbrs_in_cfg_facts.update(config_facts.get('BGP_NEIGHBOR', {}))
     nbrs_in_cfg_facts.update(config_facts.get('BGP_INTERNAL_NEIGHBOR', {}))
+    # In VoQ Chassis, we would have BGP_VOQ_CHASSIS_NEIGHBOR as well.
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_VOQ_CHASSIS_NEIGHBOR', {}))
     for k, v in nbrs_in_cfg_facts.items():
         # Compare the bgp neighbors name with config db bgp neighbors name
         assert v['name'] == bgp_facts['bgp_neighbors'][k]['description']


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Support for gen-mg for multi-asic linecards in VoQ chassis
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Support for generating minigraph for multi-asic linecards in a VoQ chassis is missing. Also, for multi-asic linecards we needed to add support for Loopback4096 interfaces, such that they can be used as the router-id for the iBGP connectivity.

#### How did you do it?

Support for minigraph generation for single asic linecards and supervisor card was done as part of PR https://github.com/Azure/sonic-mgmt/pull/3245. This introduced several fields into the ansible inventory required for VoQ chassis linecard.   However, for multi-asic linecards these fields in the inventory (from TestbedProcessing.py) are converted to lists instead of a single value. The fields changed are:
  - switchids - instead of start_switchid
  - voq_inband_ip
  - voq_inband_ipv6
  - voq_inband_intf

We also added the following fields to support Loopback4096 interfaces on the asics of a multi-asic linecard.

  - loopback4096_ip
  - loopback4096_ipv6

The minigraph templates were modified to use generate asic level metadata for all asics in a linecard.
We added minigraph_dpg_voq_asic.j2 template to generate asic DPG definitions for multi-asic linecards.

Also modified test_bgp_facts to include BGP_VOQ_CHASSIS_NEIGHBOR's in its checking of all bgp neighbors.

#### How did you verify/test it?

Generated minigraphs for single asic and multi-asic linecards and supervisor cards and validated configs generated using 'config load_minigraph' command in SONiC.

Sample gen-mg command

```
./testbed-cli.sh -t testbed.csv -m veos gen-mg chassis8-t2 lab password.txt -e "save=True" -e "deploy=True"
``` 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
