### PR TITLE
added delay before http connection with ptf container

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -5,6 +5,7 @@ import os
 import yaml
 import re
 import requests
+import time
 
 from ansible.module_utils.basic import *
 
@@ -80,6 +81,7 @@ def announce_routes(ptf_ip, port, routes):
 
     url = "http://%s:%d" % (ptf_ip, port)
     data = { "commands": ";".join(messages) }
+    time.sleep(60)
     r = requests.post(url, data=data, timeout=90)
     assert r.status_code == 200
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During the setup of the KVM testbed, I ran into a common problem where I would either get an HTTP 111 error code or a 500 response. Adding a delay before the attempted http connection seems to have addressed this problem and am now able to deploy the topology consistently.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

I had to try to deploy the t0 topology on the KVM several times before it would work.

#### How did you do it?

I added a 1 minute delay for the ptf container to finish network configuration before the `announce_routes` task tries to communicate with it.

#### How did you verify/test it?
I deployed the topology several times without any other change to the setup configuration without any errors. I took away the modification and the HTTP errors returned.
