### PR TITLE
[static route] Extend config reload wait time for static route tests

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -137,7 +137,7 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         # Config save and reload if specified
         if config_reload_test:
             duthost.shell('config save -y')
-            config_reload(duthost)
+            config_reload(duthost, wait=350)
             generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
             check_route_redistribution(duthost, prefix, ipv6)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Extend config reload wait time for static route tests
Fixes https://github.com/Azure/sonic-buildimage/issues/7968

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The arp_update script updates unresolved neighbors every 300 seconds. As the default config reload wait time is 120 seconds, the arp_update script may not finish the neighbor resolution before the config reload wait time and cause the static route test to fail. This PR aims to fix the timing issue for static route tests.

The test case `test_static_route_ecmp_ipv6` may be affected by https://github.com/Azure/sonic-buildimage/issues/4930, so the test case may still fail in some scenarios

Note: 

#### How did you do it?
Extend config reload wait time for static route tests to 350 seconds.

#### How did you verify/test it?
Confirm that test_static_route_ecmp test case could pass with neighbors not resolved right after config reload.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
