### PR TITLE
[voq] VoQ multiasic fixes and minigraph support

### DIFF
--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -311,12 +311,9 @@ class AsicDbCli(RedisCli):
             neighbor_key: The full key of the neighbor table.
             field: The field to get in the neighbor hash table.
         """
-        cmd = ["/usr/bin/redis-cli", "-n", "1", "HGET", neighbor_key, field]
-        if self.host.namespace is not None:
-            cmd = ["/usr/bin/redis-cli", "-n", "1", "HGET", neighbor_key, field]
-            cmd = ["sudo", "ip", "netns", "exec"] + [self.host.namespace] + cmd
+        cmd = "%s ASIC_DB HGET '%s' %s" % (self.host.sonic_db_cli, neighbor_key, field)
 
-        result = self.host.sonichost.shell(argv=cmd)
+        result = self.host.sonichost.shell(cmd)
         return result['stdout']
 
     def get_hostif_table(self, refresh=False):

--- a/tests/common/helpers/redis.py
+++ b/tests/common/helpers/redis.py
@@ -313,7 +313,7 @@ class AsicDbCli(RedisCli):
         """
         cmd = ["/usr/bin/redis-cli", "-n", "1", "HGET", neighbor_key, field]
         if self.host.namespace is not None:
-            cmd = ["/usr/bin/redis-cli", "-h", str(self.ip), "-n", "1", "HGET", neighbor_key, field]
+            cmd = ["/usr/bin/redis-cli", "-n", "1", "HGET", neighbor_key, field]
             cmd = ["sudo", "ip", "netns", "exec"] + [self.host.namespace] + cmd
 
         result = self.host.sonichost.shell(argv=cmd)

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -1050,13 +1050,11 @@ class TestFPLinkFlap(LinkFlap):
             # these don't decrement ttl
             check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld=my_src_fld, dst_ip_fld='my_ip', size=size,
                          ttl=ttl, ttl_change=0)
-            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld=my_src_fld, dst_ip_fld='nbr_ip', size=size,
-                         ttl=ttl, ttl_change=0)
-            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld=my_src_fld, dst_ip_fld='nbr_lb', size=size,
+            check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
                          ttl=ttl, ttl_change=0)
 
             vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
-            check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld=my_src_fld, src_ip_fld='nbr_lb',
+            check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
                          dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
 
             # end to end

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -463,6 +463,8 @@ def get_inband_info(cfg_facts):
         intf = cfg_facts['VOQ_INBAND_INTERFACE']
         for a_intf in intf:
             for addrs in intf[a_intf]:
+                if "/" not in addrs:
+                    continue
                 ret['port'] = a_intf
 
                 # Skip fields that are not inband address
@@ -533,6 +535,7 @@ def get_port_by_ip(cfg_facts, ipaddr):
     raise Exception("Dod not find port for IP %s" % ipaddr)
 
 
+<<<<<<< HEAD
 def find_system_port(dev_sysports, slot, asic_index, hostif):
     """
     System key string can be arbitrary text with slot, asic, and port, so try to find the match
@@ -587,7 +590,7 @@ def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all
 
     """
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
-    dev_sysports = get_device_system_ports(cfg_facts)
+
     neighs = cfg_facts['BGP_NEIGHBOR']
     inband_info = get_inband_info(cfg_facts)
     local_ip = neighs[neighbor]['local_addr']
@@ -610,13 +613,8 @@ def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all
     logger.info("Local_dict: %s", local_dict)
 
     # Check the same neighbor entry on the supervisor nodes
-    if "portchannel" in local_port.lower() or per_host.is_multi_asic:
-        slotname = cfg_facts['DEVICE_METADATA']['localhost']['hostname']
-        asicname = cfg_facts['DEVICE_METADATA']['localhost']['asic_name']
-    else:
-        sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
-        slotname = sysport_info['slot']
-        asicname = sysport_info['asic']
+    slotname = cfg_facts['DEVICE_METADATA']['localhost']['hostname']
+    asicname = cfg_facts['DEVICE_METADATA']['localhost']['asic_name']
 
     if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
         check_voq_neighbor_on_sup(per_host, slotname, asicname, local_port,
@@ -689,7 +687,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
     """
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
     neighs = cfg_facts['BGP_NEIGHBOR']
-    dev_sysports = get_device_system_ports(cfg_facts)
+
     fail_cnt = 0
 
     # Grab dumps of the asicdb, appdb, voqdb, and arp table
@@ -720,11 +718,9 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
         neigh_mac = nbr_macs[nbr_vm['vm']][nbr_vm['port']]
         local_ip = neighs[neighbor]['local_addr']
         local_port = get_port_by_ip(cfg_facts, local_ip)
-        if 'slot_num' in per_host.facts:
-            sysport_info = find_system_port(dev_sysports, per_host.facts['slot_num'], asic.asic_index, local_port)
-        else:
-            sysport_info = {'slot': cfg_facts['DEVICE_METADATA']['localhost']['hostname'],
-                            'asic': cfg_facts['DEVICE_METADATA']['localhost']['asic_name']}
+
+        sysport_info = {'slot': cfg_facts['DEVICE_METADATA']['localhost']['hostname'],
+                        'asic': cfg_facts['DEVICE_METADATA']['localhost']['asic_name']}
 
         # Validate the asic db entries
         for entry in asic_dump:
@@ -1230,6 +1226,9 @@ def eos_ping(eos, ipaddr, count=2, timeout=3, interface=None, size=None, ttl=Non
         logger.info("Result: %s", output['stdout_lines'][-2:])
 
     output['parsed'] = parse_ping(output['stdout_lines'])
+
+    if "Network is unreachable" in output['stderr']:
+        raise AssertionError('Network is unreachable')
 
     if "error code" in output['stdout_lines'][-1]:
         raise AssertionError(output['parsed'])

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -535,43 +535,6 @@ def get_port_by_ip(cfg_facts, ipaddr):
     raise Exception("Dod not find port for IP %s" % ipaddr)
 
 
-<<<<<<< HEAD
-def find_system_port(dev_sysports, slot, asic_index, hostif):
-    """
-    System key string can be arbitrary text with slot, asic, and port, so try to find the match
-    and return the correct string.  ex.  "Slot1|asic3|Ethernet12" or "Linecard4|Asic1|Portchannel23"
-
-    Args:
-        dev_sysports: dictionary from config_facts with all of the system ports on the system.
-        slot: The slot number of the system port to find.
-        asic_index: The asic number of ths system port to find.
-        hostif: The interface of the system port to find.
-
-    Returns:
-        A dictionary with the system port text strings.
-
-    Raises:
-        KeyError if the system port can't be found in the dictionary.
-
-    """
-
-    if "portchannel" in hostif.lower():
-        sys_re = re.compile(r'^([a-zA-Z0-9\-]+{})\|([a-zA-Z]+{})\|'.format(slot, asic_index))
-    else:
-        sys_re = re.compile(r'^([a-zA-Z0-9\-]+{})\|([a-zA-Z]+{})\|{}$'.format(slot, asic_index, hostif))
-    sys_info = {}
-
-    for sysport in dev_sysports:
-        match = sys_re.match(sysport)
-        if match:
-            sys_info['slot'] = match.group(1)
-            sys_info['asic'] = match.group(2)
-            sys_info['key'] = sysport
-            return sys_info
-
-    raise KeyError("Could not find system port for {}/{}/{}".format(slot, asic_index, hostif))
-
-
 def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts):
     """
     Verifies a single neighbor entry is present in a voq system on local and remote sonic instances.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
updated VoQ test script to support configuration generated from minigraph.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request

### Approach
#### What is the motivation for this PR?
We are updating the VoQ test scripts to be in line with config generated in PR3746.

#### How did you do it?
Changed expected  system port IDs to come from the generated metadata.
Adding support for loopback 4096 in IP forwarding test.
Adding support for the new internal BGP configuration (BGP_VOQ_CHASSIS_NEIGHBOR).
Minor fixes for muliasics tests.
 
#### How did you verify/test it?
Ran against muliascic VoQ chassis.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
T2

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
