### PR TITLE
Modified VOQ portchannel testcases to get asic with portchannels configured.

### DIFF
--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -352,3 +352,18 @@ def verify_lag_member_in_chassis_db(duthosts, members, deleted=False):
                 if not exist:
                     pytest.fail('lag member {} not found in system lag member table {}'
                                 .format(member, lag_member_list))
+
+def is_lag_in_app_db(asic):
+    """
+    Returnes True if lag in app db else False
+    It runs the command e.g. 'redis-cli -n 0 --raw keys "*LAG_TABLE*"'
+    Args:
+        asic<obj>: asic
+    """
+    appdb = AppDbCli(asic)
+    app_db_lag_list = appdb.get_app_db_lag_list()
+    for lag in app_db_lag_list:
+        if TMP_PC in lag:
+            return True
+
+    return False

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -6,9 +6,29 @@ pytestmark = [
 ]
 
 
+def get_asic_with_pc(duthost):
+    """
+    Returns Asic with portchannel or skip the testcase if portchannel is not present in any of
+    the Asic on dut
+
+    Args:
+        duthost <obj>: The duthost object
+
+    Returns:
+        asic <obj> : Asic object
+
+    """
+    for asic in duthost.asics:
+        config_facts = duthost.config_facts(source='persistent',
+                                            asic_index=asic.asic_index)['ansible_facts']
+        if 'PORTCHANNEL' in config_facts:
+            return asic
+
+    pytest.skip('Skip test since there is no portchannel configured.')
+
+
 @pytest.fixture(scope='module')
-def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                   enum_rand_one_asic_index):
+def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
      Prepares dut for the testcase by deleting the existing port channel members and ip,
      adds a new portchannel and assignes port channel members and ip
@@ -18,7 +38,6 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
          duthosts <list>: The duthosts object
          enum_rand_one_per_hwsku_frontend_hostname <int>:
           random per fromtend per hwsku duthost
-         enum_rand_one_asic_index<int>: random asic index
 
     Returns:
         portchannel_ip <str> : portchannel ip address
@@ -26,17 +45,11 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asics[enum_rand_one_asic_index if enum_rand_one_asic_index else 0]
-
+    asic = get_asic_with_pc(duthost)
     config_facts = duthost.config_facts(source='persistent',
                                         asic_index=asic.asic_index)['ansible_facts']
-    portchannel_members = None
-    if 'PORTCHANNEL' in config_facts:
-        portchannel = config_facts['PORTCHANNEL'].keys()[0]
-        portchannel_members = config_facts['PORTCHANNEL'][portchannel].get('members')
-
-    else:
-        pytest.skip('Skip test since there is no portchannel configured. ')
+    portchannel = config_facts['PORTCHANNEL'].keys()[0]
+    portchannel_members = config_facts['PORTCHANNEL'][portchannel].get('members')
 
     portchannel_ip = None
     if 'PORTCHANNEL_INTERFACE' in config_facts:
@@ -51,7 +64,7 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     voq_lag.delete_lag_members_ip(duthost, asic, portchannel_members, portchannel_ip, portchannel)
     voq_lag.add_lag(duthost, asic, portchannel_members, portchannel_ip)
 
-    yield portchannel_ip, portchannel_members
+    yield asic, portchannel_ip, portchannel_members
 
     voq_lag.delete_lag_members_ip(duthost, asic, portchannel_members, portchannel_ip)
     # remove tmp portchannel
@@ -60,8 +73,7 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     voq_lag.add_lag(duthost, asic, portchannel_members, portchannel_ip, portchannel, add=False)
 
 
-def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                       enum_rand_one_asic_index):
+def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     test to verify when a LAG is added/deleted via CLI on an ASIC,
      It is populated in remote ASIC_DB.
@@ -73,7 +85,7 @@ def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         5. delete the added lag
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asics[enum_rand_one_asic_index if enum_rand_one_asic_index else 0]
+    asic = get_asic_with_pc(duthost)
     voq_lag.verify_lag_id_is_unique_in_chassis_db(duthosts, duthost, asic)
     voq_lag.verify_lag_in_app_db(asic)
     tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
@@ -100,8 +112,7 @@ def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         4. verify lag members exist in local and remote asic db
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = duthost.asics[enum_rand_one_asic_index if enum_rand_one_asic_index else 0]
-    portchannel_ip, portchannel_members = setup_teardown
+    asic, portchannel_ip, portchannel_members = setup_teardown
     tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
     voq_lag.verify_lag_member_in_app_db(asic, portchannel_members)
     voq_lag.verify_lag_member_in_chassis_db(duthosts, portchannel_members)

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -86,22 +86,24 @@ def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = get_asic_with_pc(duthost)
-    voq_lag.verify_lag_id_is_unique_in_chassis_db(duthosts, duthost, asic)
-    voq_lag.verify_lag_in_app_db(asic)
-    tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
-    voq_lag.verify_lag_in_asic_db(duthost.asics, tmp_lag_id)
-    # to verify lag in remote asic db
-    remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
-    voq_lag.verify_lag_in_remote_asic_db(remote_duthosts, tmp_lag_id)
-    voq_lag.verify_lag_id_deleted_in_chassis_db(duthosts, duthost, asic, tmp_lag_id)
-    voq_lag.verify_lag_in_app_db(asic, deleted=True)
-    voq_lag.verify_lag_in_asic_db(duthost.asics, tmp_lag_id, deleted=True)
-    remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
-    voq_lag.verify_lag_in_remote_asic_db(remote_duthosts, tmp_lag_id, deleted=True)
+    try:
+        voq_lag.verify_lag_id_is_unique_in_chassis_db(duthosts, duthost, asic)
+        voq_lag.verify_lag_in_app_db(asic)
+        tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
+        voq_lag.verify_lag_in_asic_db(duthost.asics, tmp_lag_id)
+        # to verify lag in remote asic db
+        remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
+        voq_lag.verify_lag_in_remote_asic_db(remote_duthosts, tmp_lag_id)
+        voq_lag.verify_lag_id_deleted_in_chassis_db(duthosts, duthost, asic, tmp_lag_id)
+        voq_lag.verify_lag_in_app_db(asic, deleted=True)
+        voq_lag.verify_lag_in_asic_db(duthost.asics, tmp_lag_id, deleted=True)
+        remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
+        voq_lag.verify_lag_in_remote_asic_db(remote_duthosts, tmp_lag_id, deleted=True)
+    finally:
+        if voq_lag.is_lag_in_app_db(asic):
+            voq_lag.delete_lag(duthost, asic)
 
-
-def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                              enum_rand_one_asic_index, setup_teardown):
+def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown):
     """
     Test to verify when a LAG members is added/deleted via CLI on an ASIC,
      It is synced to remote ASIC_DB.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Modified existing voq portchannel testcases to get ASIC with portchannel configured in case of multi-asic.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In case of multi-asic testcase was skipping testcase beacuse it was not able to get ASIC with portchannel configured. Modified testcase to ger ASIC with pc configured else skip test testcase if portchannel not configured.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test case was running only on one ASIC and skipping the testcase if portchannel not configured on that ASIC. 

#### How did you do it?
Check on all ASI to get asic with portchannel configured

#### How did you verify/test it?
Tested on multi-asic and single asic testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
