### PR TITLE
Enhancements platform api tests and change in psustatus_json to use enum_supervisor_dut_hostname

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -35,7 +35,7 @@ else:
 
 
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
-REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9]+$'
+REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9\-]+$'
 
 # Valid OCP ONIE TlvInfo EEPROM type codes as defined here:
 # https://opencomputeproject.github.io/onie/design-spec/hw_requirements.html

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -298,10 +298,9 @@ class TestPsuApi(PlatformApiTestBase):
         psus_skipped = 0
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)
-            if duthost.facts.get("chassis").get("psus")[psu_id].get("led"):
-                led_support = duthost.facts.get("chassis").get("psus")[psu_id].get("led")
-                if led_support == "N/A":
-                    logger.info("led not supported for this psu {}".format(name))
+            led_support = duthost.facts.get("chassis").get("psus")[psu_id].get("led")
+            if led_support == "N/A":
+                logger.info("led not supported for this psu {}".format(name))
             elif name in self.psu_skip_list:
                 logger.info("skipping check for {}".format(name))
                 psus_skipped += 1
@@ -395,9 +394,9 @@ class TestPsuApi(PlatformApiTestBase):
         supported_colors = []
         if self.num_psus == 0:
             pytest.skip("No psus found on device skipping for device {}".format(duthost))
-        
-        if duthost.facts.get("chassis").get("master_psu_led_color"):
-            supported_colors = duthost.facts.get("chassis").get("master_psu_led_color")
+
+        supported_colors = duthost.facts.get("chassis").get("master_psu_led_color")
+        if supported_colors:
             for index, colors in enumerate(LED_COLOR_TYPES):
                 for color in colors:
                     if color not in supported_colors:

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -298,7 +298,11 @@ class TestPsuApi(PlatformApiTestBase):
         psus_skipped = 0
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)
-            if name in self.psu_skip_list:
+            if duthost.facts.get("chassis").get("psus")[psu_id].get("led"):
+                led_support = duthost.facts.get("chassis").get("psus")[psu_id].get("led")
+                if led_support == "N/A":
+                    logger.info("led not supported for this psu {}".format(name))
+            elif name in self.psu_skip_list:
                 logger.info("skipping check for {}".format(name))
                 psus_skipped += 1
             else:
@@ -388,9 +392,16 @@ class TestPsuApi(PlatformApiTestBase):
             1: "normal",
             2: "off"
         }
-
+        supported_colors = []
         if self.num_psus == 0:
             pytest.skip("No psus found on device skipping for device {}".format(duthost))
+        
+        if duthost.facts.get("chassis").get("master_psu_led_color"):
+            supported_colors = duthost.facts.get("chassis").get("master_psu_led_color")
+            for index, colors in enumerate(LED_COLOR_TYPES):
+                for color in colors:
+                    if color not in supported_colors:
+                        LED_COLOR_TYPES[index].remove(color)
 
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -197,11 +197,11 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     pytest_assert(num_psu_ok > 0, "No PSUs are displayed with OK status on '{}'".format(duthost.hostname))
 
 
-def test_show_platform_psustatus_json(duthosts, rand_one_dut_hostname):
+def test_show_platform_psustatus_json(duthosts, enum_supervisor_dut_hostname):
     """
     @summary: Verify output of `show platform psustatus --json`
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
 
     if "201811" in duthost.os_version or "201911" in duthost.os_version:
         pytest.skip("JSON output not available in this version")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
change in test_chassis to include '-' in regex for serial number as in case of some Nokia platform.
Include a method to skip led test for psu which do no support and test master led to include only supported colors based on 
platform.json.
In test_show_platform.py fix psu test to use enum_supervisor_dut_hostname to be consistant with other tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enhancement to skip test_led for psu if not supported by platform, change to use consistent dut enumerator in test_platform_psustatus_json test

#### How did you do it?
 tests/platform_tests/api/test_chassis.py : modify regex for serial number to include '-'

 tests/platform_tests/api/test_psu.py :  enhance test_led to skip test if psu does not support led based on information from platform.json
 tests/platform_tests/cli/test_show_platform.py : change show_platform_psu_status to use enum_supervisor_dut_hostname instead of rand_one_dut_hostname

#### How did you verify/test it?
Tested on voq chassis and pizza box 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
