### PR TITLE
Modified iface_namingmode testcases to get spine ports for T2 topology

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -858,7 +858,7 @@ class TestShowIP():
             pytest.skip('No non-portchannel member interface present')
 
     @pytest.fixture(scope='class')
-    def spine_ports(self, setup):
+    def spine_ports(self, setup, tbinfo):
         """
         Returns the alias and names of the spine ports
 
@@ -874,7 +874,7 @@ class TestShowIP():
         spine_ports['alias'] = list()
 
         for key, value in minigraph_neighbors.items():
-            if (key in setup['physical_interfaces']) and ('T2' in value['name']):
+            if key in setup['physical_interfaces'] and ('T2' in value['name'] or (tbinfo['topo']['type'] == 't2' and 'T3' in value['name'])):
                 spine_ports['interface'].append(key)
                 spine_ports['alias'].append(setup['port_name_map'][key])
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -874,7 +874,8 @@ class TestShowIP():
         spine_ports['alias'] = list()
 
         for key, value in minigraph_neighbors.items():
-            if key in setup['physical_interfaces'] and ('T2' in value['name'] or (tbinfo['topo']['type'] == 't2' and 'T3' in value['name'])):
+            if (key in setup['physical_interfaces'] 
+                    and ('T2' in value['name'] or (tbinfo['topo']['type'] == 't2' and 'T3' in value['name']))):
                 spine_ports['interface'].append(key)
                 spine_ports['alias'].append(setup['port_name_map'][key])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Modified iface_namingmode testcases to get spine ports for T2 topology
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Spine ports function was not able to get spine ports for T2 topology, added condition for the same.

#### How did you do it?
Added condition to get spine [ports for T2 topolgy.

#### How did you verify/test it?
Tested on VOQ system.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T2
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
