### PR TITLE
[test_read_mac_metadata] Fix check_interface failure and "PORTCHANNEL" keyerror in t1/ptf32 topology

### DIFF
--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -3,7 +3,6 @@ import logging
 
 from tests.common.utilities import wait
 from tests.common.utilities import wait_until
-from tests.common.plugins.sanity_check import checks
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.assertions import pytest_assert
 from datetime import datetime
@@ -111,11 +110,19 @@ class ReadMACMetadata():
             pytest.fail("MAC entry does not exist")
 
         logger.info("Verify interfaces are UP and MTU == 9100")
-        checks.check_interfaces(duthost)
+        check_interfaces = self.request.getfixturevalue("check_interfaces")
+        results = check_interfaces()
+        failed = [result for result in results if "failed" in result and result["failed"]]
+        if failed:
+            pytest.fail("Interface check failed, not all interfaces are up. Failed: {}".format(failed))
 
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
         non_default_ports = [k for k,v in cfg_facts["PORT"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
-        non_default_portchannel = [k for k,v in cfg_facts["PORTCHANNEL"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
+
+        # Not all topology has portchannel in config, therefore, only verify the status if portchannel exists.
+        non_default_portchannel = []
+        if "PORTCHANNEL" in cfg_facts:
+            non_default_portchannel = [k for k,v in cfg_facts["PORTCHANNEL"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
 
         if len(non_default_ports) != 0 or len(non_default_portchannel) != 0:
             pytest.fail("There are ports/portchannel with non default MTU:\nPorts: {}\nPortchannel: {}".format(non_default_ports,non_default_portchannel))

--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -23,17 +23,7 @@ pytestmark = [
 @pytest.fixture(scope='function')
 def cleanup_read_mac(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    initImage = duthost.shell('sonic-installer list | grep Current | cut -f2 -d " "')['stdout']
     yield
-    """
-    Recover the image to image2 which is the image before doing this case.
-    """
-    currentImage = duthost.shell('sonic-installer list | grep Current | cut -f2 -d " "')['stdout']
-    if initImage != currentImage:
-        logger.info("Re-install the image: {} to DUT" .format(initImage))
-        duthost.copy(src=BINARY_FILE_ON_LOCALHOST_2, dest=BINARY_FILE_ON_DUTHOST)
-        duthost.shell("sonic-installer install -y {}".format(BINARY_FILE_ON_DUTHOST))
-        reboot(duthost, localhost, wait=120)
     logger.info('Remove temporary images')
     duthost.shell("rm -rf {}".format(BINARY_FILE_ON_DUTHOST))
     localhost.shell("rm -rf {}".format(BINARY_FILE_ON_LOCALHOST_1))
@@ -110,7 +100,7 @@ class ReadMACMetadata():
             duthost.copy(src=BINARY_FILE_ON_LOCALHOST_2, dest=BINARY_FILE_ON_DUTHOST)
 
         logger.info("Installing new SONiC image")
-        duthost.shell("sonic-installer install -y {}".format(BINARY_FILE_ON_DUTHOST))
+        duthost.shell("sonic_installer install -y {}".format(BINARY_FILE_ON_DUTHOST))
 
     def check_mtu_and_interfaces(self, duthost):
         logger.info("Verify that MAC address fits template XX:XX:XX:XX:XX:XX")


### PR DESCRIPTION
### Description of PR

Summary:
Fixes test_read_mac_metadata while calling check_interfaces to do sanity checking after [PR#2883](https://github.com/Azure/sonic-mgmt/pull/2883/files#).
Fixes not to check portchannel status if the topology does not have portchannel config.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
test_read_mac_metadata will be failing with the following error:
1.

      FAILED                                                                   [100%]
      ------------------------------ live log teardown -------------------------------
      16:49:29 INFO test_read_mac_metadata.py:cleanup_read_mac:27: Remove temporary imagesFixture "check_interfaces" called directly. 
      Fixtures are not meant to be called directly,but are created automatically when test functions request them as parameters.
      See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and
      https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.

2.

    >       non_default_portchannel = [k for k,v in cfg_facts["PORTCHANNEL"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
    E       KeyError: 'PORTCHANNEL'read_mac/test_read_mac_metadata.py:122: KeyError

#### What is the motivation for this PR?

#### How did you do it?
Modify and run test_read_mac_metadata pytest
#### How did you verify/test it?
Run test_read_mac_metadata pytest passed
    
    ============================= test session starts ==============================
    platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python2
    cachedir: .pytest_cache
    metadata: {'Python': '2.7.17', 'Platform': 'Linux-4.15.0-147-generic-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.10.0', 
    'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist': u'1.28.0', u'html': u'1.22.1', u'forked': 
    u'1.3.0', u'metadata': u'1.11.0'}}
    ansible: 2.8.12
    rootdir: /var/ubuntu/sonic-mgmt/tests, inifile: pytest.ini
    plugins: html-1.22.1, metadata-1.11.0, forked-1.3.0, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
    collecting ... collected 1 item

    read_mac/test_read_mac_metadata.py::test_read_mac_metadata[as5835-54x]
    PASSED                                                                   [100%] 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
