### PR TITLE
[remove_ip.sh] Support removing addresses on sub-interfaces

### DIFF
--- a/ansible/roles/test/files/helpers/remove_ip.sh
+++ b/ansible/roles/test/files/helpers/remove_ip.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+$")
+INTF_LIST=$(ls /sys/class/net | grep -E "^eth[0-9]+(.[0-9]+)?$")
 
 for INTF in ${INTF_LIST}; do
     echo "Flush ${INTF} IP address"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
`remove_ip.sh` fails to remove IP addresses on sub-interfaces like:
* `eth10.10`
* `eth20.1000`

#### How did you do it?
modify the regex to filter out sub-interfaces.

#### How did you verify/test it?
run `remove_ip.sh`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
