### PR TITLE
[dualtor][orchagent] Change the check time of queue counter

### DIFF
--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -113,7 +113,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 check_res.append("outer packet DSCP not same as inner packet DSCP")
             exp_queue = derive_queue_id_from_dscp(outer_dscp)
 
-            time.sleep(10)
+            time.sleep(60)
             queue_counter = self.standby_tor.shell('show queue counters | grep "UC"')['stdout']
             logging.debug('queue_counter:\n{}'.format(queue_counter))
 

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -8,6 +8,8 @@ from ptf import mask, testutils
 from scapy.all import IP, Ether
 from tests.common.dualtor import dual_tor_utils
 from tests.common.utilities import dump_scapy_packet_show_output
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 def derive_queue_id_from_dscp(dscp):
     """ Derive queue id form DSCP using following mapping
@@ -24,6 +26,31 @@ def derive_queue_id_from_dscp(dscp):
     dscp_to_queue = { 8 : 0, 5 : 2, 3 : 3, 4 : 4, 46  : 5,  48 : 6}
 
     return dscp_to_queue.get(dscp, 1)
+
+def queue_stats_check(dut, exp_queue):
+    queue_counter = dut.shell('show queue counters | grep "UC"')['stdout']
+    logging.debug('queue_counter:\n{}'.format(queue_counter))
+
+    """
+    regex search will look for following pattern in queue_counter outpute
+    ----------------------------------------------------------------------------_---
+    Port           TxQ    Counter/pkts     Counter/bytes     Drop/pkts    Drop/bytes
+    -----------  -----  --------------  ---------------  -----------  --------------
+    Ethernet124    UC1              10             1000            0             0
+    """
+    result = re.search(r'\S+\s+UC\d\s+10+\s+\S+\s+\S+\s+\S+', queue_counter)
+
+    if result != None:
+        output = result.group(0)
+        output_list = output.split()
+        rec_queue = int(output_list[1][2])
+        if rec_queue != exp_queue:
+            logging.debug("the expected Queue : {} not matching with received Queue : {}".format(exp_queue, rec_queue))
+        else:
+            logging.info("the expected Queue : {} matching with received Queue : {}".format(exp_queue, rec_queue))
+            return True
+
+    return False
 
 @pytest.fixture(scope="function")
 def tunnel_traffic_monitor(ptfadapter, tbinfo):
@@ -113,29 +140,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 check_res.append("outer packet DSCP not same as inner packet DSCP")
             exp_queue = derive_queue_id_from_dscp(outer_dscp)
 
-            time.sleep(60)
-            queue_counter = self.standby_tor.shell('show queue counters | grep "UC"')['stdout']
-            logging.debug('queue_counter:\n{}'.format(queue_counter))
-
-            """ 
-            regex search will look for following pattern in queue_counter outpute
-            ----------------------------------------------------------------------------_---
-            Port           TxQ    Counter/pkts     Counter/bytes     Drop/pkts    Drop/bytes
-            -----------  -----  --------------  ---------------  -----------  --------------
-            Ethernet124    UC1              10             1000            0             0
-            """
-            result = re.search(r'\S+\s+UC\d\s+10+\s+\S+\s+\S+\s+\S+', queue_counter)
-
-            rec_queue = 0
-            if result != None:
-                output = result.group(0)
-                output_list = output.split()
-                rec_queue = int(output_list[1][2])
-
-            if rec_queue != exp_queue:
-                pytest.fail("the expected Queue : {} not matching with received Queue : {}".format(exp_queue, rec_queue))
-            else:
-                logging.info("the expected Queue : {} matching with received Queue : {}".format(exp_queue, rec_queue))
+            pytest_assert(wait_until(60, 5, queue_stats_check, self.standby_tor, exp_queue))
             return check_res
 
         def __init__(self, standby_tor, active_tor=None, existing=True):


### PR DESCRIPTION
change the check time from 10s to 60s
Signed-off-by: Kevin Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Support to check queue counters up to 60s for the timing issue.

#### How did you do it?
Call the wait_until function to check the queue counters every 5s continuously. The timeout is set to 60s.

#### How did you verify/test it?
Run the queue counters relates test cases that should be passed, such as test_tor_ecn.py.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
