### PR TITLE
  Changing show chassis-module cli command as per PR  805

### DIFF
--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -9,7 +9,7 @@ pytestmark = [
     pytest.mark.topology('t2')
 ]
 
-CMD_SHOW_CHASSIS_MODULE = "show chassis-module"
+CMD_SHOW_CHASSIS_MODULE = "show chassis modules"
 
 
 def parse_chassis_module(output, expected_headers):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md


Summary:

Fixes # (issue)
show chassis-module command is being changed to show chassis modules so updating test to include that change 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
show chassis-modules command is now being changed to show chassis module please refer to PRs below:

https://github.com/Azure/SONiC/pull/805
https://github.com/Azure/SONiC/pull/801

This PR has dependency on above PRs and can only be merged after they are merged

#### How did you do it?
  tests/platform_tests/cli/test_show_chassis_module.py change cli command from show chassis-modules to show chassis modules

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
