### PR TITLE
Changes test_nbr_health test

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -88,10 +88,11 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
         dut_type = dev_meta["localhost"]["type"]
 
     for k, v in nei_meta.items():
-        if v['type'] in ['SmartCable', 'Server'] or dut_type == v['type']:
+        if v['type'] in ['SmartCable', 'Server'] or dut_type == v['type'] or 'ASIC' in k:
             # Smart cable doesn't respond to snmp, it doesn't have BGP session either.
             # DualToR has the peer ToR listed in device as well. If the device type
-            # is the same as testing DUT, then it is the peer.
+            # is the same as testing DUT, then it is the peer. If ASIC in key for multi
+            # asic linecards skip it
             # The server neighbors need to be skipped too.
             continue
 


### PR DESCRIPTION



Summary:
In neighbor health test add ASIC to be ignored for neighbor metadata which is included in multi asic line cards.

### Type of change



- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
With introduced support for generating minigraph for multi asic line cards by PR https://github.com/Azure/sonic-mgmt/pull/3746 which will include asics information in neighbor metadata so changing test to skip check for asic neighbor health as they are part of same DUT.

#### How did you do it?

tests/test_nbr_health.py add ASIC as key to be ignored for neighbor metadata for multi asic line cards
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
