### PR TITLE
[rsyslog] Fixing pretest and posttest checks for multiasic boards

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -367,7 +367,7 @@ class MultiAsicSonicHost(object):
             # If 'No such command' is found in stderr, the command doesn't exist
             return 'No such command' not in e.results['stderr']
 
-    def disable_syslog_rate_limit(self, feature):
+    def modify_syslog_rate_limit(self, feature, rl_option='disable'):
         """
         Disable Rate limit for a given service
         """
@@ -382,9 +382,18 @@ class MultiAsicSonicHost(object):
                 r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "
                 r"/etc/rsyslog.conf"
             )
+            cmd_enable_rate_limit = (
+                r"docker exec -i {} sed -i "
+                r"'s/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' "
+                r"/etc/rsyslog.conf"
+            )
             cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"
             cmds = []
-            cmds.append(cmd_disable_rate_limit.format(docker))
+
+            if rl_option == 'disable':
+                cmds.append(cmd_disable_rate_limit.format(docker))
+            else:
+                cmds.append(cmd_enable_rate_limit.format(docker))
             cmds.append(cmd_reload.format(docker))
             self.sonichost.shell_cmds(cmds=cmds)
 

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -41,6 +41,7 @@ def test_restore_container_autorestart(duthosts, enum_dut_hostname, enable_conta
     time.sleep(SNMP_RELOADING_TIME)
 
 def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
+
     duthost = duthosts[enum_dut_hostname]
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
@@ -48,13 +49,8 @@ def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
         # We don't want to fail here because it's an util
         logging.warn("Failed to retrieve feature status")
         return
-    cmd_enable_rate_limit = r"docker exec -i {} sed -i 's/^#\$SystemLogRateLimit/\$SystemLogRateLimit/g' /etc/rsyslog.conf"
-    cmd_reload = r"docker exec -i {} supervisorctl restart rsyslogd"
     for feature_name, state in features_dict.items():
         if 'enabled' not in state:
             continue
-        cmds = []
-        cmds.append(cmd_enable_rate_limit.format(feature_name))
-        cmds.append(cmd_reload.format(feature_name))
-        duthost.shell_cmds(cmds=cmds)
+        duthost.modify_syslog_rate_limit(feature_name, rl_option='enable')
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -155,7 +155,8 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     for feature_name, state in features_dict.items():
         if 'enabled' not in state:
             continue
-        duthost.disable_syslog_rate_limit(feature_name)
+        duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
+
 
 def collect_dut_lossless_prio(dut):
     config_facts = dut.config_facts(host=dut.hostname, source="running")['ansible_facts']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixing pretest and posttest check rsyslog_rate_limit for multiasic boards

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

When disabling/enabling rsyslog rate limit, we are using 'show feature status'. The output of this command is being used for 'docker exec -i <dockerName> ....' to disable/enable rsyslog rate limit. For masic, the show feature status doesn't show the namespace features (like bgp0, bgp1, etc.), but only 'bgp'. Thus, when we go and do 'docker exec -i bgp' it fails. 

#### How did you do it?
 Fix is to use output of 'docker ps' instead of 'show feature status'

#### How did you verify/test it?
Verified on VoQ system.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
