### PR TITLE
[pytest] Use loganalyzer to check whether a container was stopped

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -11,6 +11,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import check_container_state
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +27,8 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 
 @pytest.fixture(autouse=True, scope="module")
 def modify_monit_config_and_restart(duthost):
-    """Backup Monit configuration file, then customize and restart it before testing. Restore original
-    Monit configuration file and restart it after testing.
+    """Backup Monit configuration files, then customize and restart it before testing.
+    Restore original Monit configuration files and restart Monit service after testing.
 
     Args:
         duthost: Hostname of DuT.
@@ -35,10 +36,14 @@ def modify_monit_config_and_restart(duthost):
     Returns:
         None.
     """
-    logger.info("Back up Monit configuration file ...")
+    logger.info("Back up Monit configuration files on DuT '{}' ...".format(duthost.hostname))
     duthost.shell("sudo cp -f /etc/monit/monitrc /tmp/")
+    duthost.shell("sudo cp -f /etc/monit/conf.d/monit_telemetry /tmp/")
 
+    temp_config_line = '    if status == 3 for 5 times within 10 cycles then exec "/usr/bin/restart_service telemetry"'
     logger.info("Modifying Monit config to eliminate start delay and decrease interval ...")
+    duthost.shell("sudo sed -i '$s/^./#/' /etc/monit/conf.d/monit_telemetry")
+    duthost.shell("echo '{}' | sudo tee -a /etc/monit/conf.d/monit_telemetry".format(temp_config_line))
     duthost.shell("sudo sed -i 's/set daemon 60/set daemon 10/' /etc/monit/monitrc")
     duthost.shell("sudo sed -i '/with start delay 300/s/^./#/' /etc/monit/monitrc")
 
@@ -47,15 +52,16 @@ def modify_monit_config_and_restart(duthost):
 
     yield
 
-    logger.info("Restore original Monit configuration ...")
+    logger.info("Restore original Monit configuration files on DuT '{}' ...".format(duthost.hostname))
     duthost.shell("sudo mv -f /tmp/monitrc /etc/monit/")
+    duthost.shell("sudo mv -f /tmp/monit_telemetry /etc/monit/conf.d/")
 
     logger.info("Restart Monit service ...")
     duthost.shell("sudo systemctl restart monit")
 
 
 def install_stress_utility(duthost, container_name):
-    """Installs the 'stress' utility in container before testing.
+    """Installs the 'stress' utility in container.
 
     Args:
         duthost: The AnsibleHost object of DuT.
@@ -76,7 +82,7 @@ def install_stress_utility(duthost, container_name):
 
 
 def remove_stress_utility(duthost, container_name):
-    """Removes the 'stress' utility from container after testing.
+    """Removes the 'stress' utility from container.
 
     Args:
         duthost: The AnsibleHost object of DuT.
@@ -108,9 +114,10 @@ def consume_memory(duthost, container_name, vm_workers):
     duthost.shell("docker exec {} stress -m {}".format(container_name, vm_workers), module_ignore_errors=True)
 
 
-def consume_memory_and_restart_container(duthost, container_name, vm_workers):
+def consume_memory_and_restart_container(duthost, container_name, vm_workers, loganalyzer, marker):
     """Invokes the 'stress' utility to consume memory more than the threshold asynchronously
-    and checks whether the container can be stopped and restarted.
+    and checks whether the container can be stopped and restarted. Loganalyzer was leveraged
+    to check whether the log messages related to container stopped were generated.
 
     Args:
         duthost: The AnsibleHost object of DuT.
@@ -123,15 +130,14 @@ def consume_memory_and_restart_container(duthost, container_name, vm_workers):
 
     """
     thread_pool = ThreadPool()
-
     thread_pool.apply_async(consume_memory, (duthost, container_name, vm_workers))
 
-    logger.info("Waiting for '{}' container to be stopped ...".format(container_name))
-    stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
-                         CONTAINER_CHECK_INTERVAL_SECS,
-                         check_container_state, duthost, container_name, False)
-    pytest_assert(stopped, "Failed to stop '{}' container!".format(container_name))
-    logger.info("'{}' container is stopped.".format(container_name))
+    logger.info("Sleep 100 seconds to wait for the alerting messages from syslog...")
+    time.sleep(100)
+
+    logger.info("Checking the alerting messages related to container stopped ...")
+    loganalyzer.analyze(marker)
+    logger.info("Found all the expected alerting messages from syslog!")
 
     logger.info("Waiting for '{}' container to be restarted ...".format(container_name))
     restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
@@ -202,7 +208,17 @@ def test_memory_checker(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                    or parse_version(duthost.kernel_version) > parse_version("4.9.0"),
                    "Test is not supported for 20191130.72 and older image versions!")
 
+    expected_alerting_messages = []
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_restart_due_to_memory")
+    loganalyzer.expect_regex = []
+    expected_alerting_messages.append(".*restart_service.*Restarting service 'telemetry'.*")
+    expected_alerting_messages.append(".*Stopping Telemetry container.*")
+    expected_alerting_messages.append(".*Stopped Telemetry container.*")
+
+    loganalyzer.expect_regex.extend(expected_alerting_messages)
+    marker = loganalyzer.init()
+
     install_stress_utility(duthost, container_name)
-    consume_memory_and_restart_container(duthost, container_name, vm_workers)
+    consume_memory_and_restart_container(duthost, container_name, vm_workers, loganalyzer, marker)
     remove_stress_utility(duthost, container_name)
     postcheck_critical_processes(duthost, container_name)


### PR DESCRIPTION

Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR aims to fix Azure/sonic-buildimage#8104. 

Fixes # (issue)
 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [x ] 201911

### Approach
#### What is the motivation for this PR?
For this pytest script, the basic idea is to let the streaming telemetry container consumes more than 400MB memory and then check
whether it is restarted or not. As such, there are two processes forked in this pytest script. One process is to let streaming telemetry
consume more than 400MB memory to trigger restart operation and another process will continuously check whether it is actually restarted or not.

So the timeline of streaming telemetry controlled by first process is as following:

            ---------------------------------------|--------------------------|----------|-------------------------|------------------------------------>   Timeline
                                                         Stopping                     Stopped   Starting                  Started              

The time interval between `Stopped` and `Starting` is less than 0.05 second.

As I said, the second process will check the state of streaming telemetry every 1 second. If the checking happened between
`Stopped` and `Starting`, then this process will exit since it detects that the container is not running. However, if the checking
happened before `Stopped` or after `Starting`, then it will expire after 200 seconds and then failed this pytest. 

#### How did you do it?
I leveraged the Loganalyzer to check the alerting messages in syslog to know whether the container was stopped.

#### How did you verify/test it?
I tested this change on DuT `str-msn2700-01`.

      21:23:27 test_memory_checker.modify_monit_config_ L0050 INFO | Restart Monit service ...
      21:23:28 __init__.analyzer_logrotate L0016 INFO | logrotate called on str-msn2700-01
      21:23:30 parallel.parallel_run L0088 INFO | Completed running processes for target "analyzer_logrotate" in 0:00:01.824989 seconds
      21:23:30 __init__.analyzer_add_marker L0028 INFO | add marker called on str-msn2700-01
      21:23:30 __init__.analyzer_add_marker L0030 INFO | Add start marker into DUT syslog for host str-msn2700-01
      21:23:32 __init__.analyzer_add_marker L0032 INFO | Load config and analyze log for host str-msn2700-01
      21:23:32 parallel.parallel_run L0088 INFO | Completed running processes for target "analyzer_add_marker" in 0:00:01.827411 seconds
      ------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------
      21:23:33 test_memory_checker.install_stress_utili L0073 INFO | Installing 'stress' utility in 'telemetry' container ...
      21:23:40 test_memory_checker.install_stress_utili L0081 INFO | 'stress' utility was installed.
      21:23:40 test_memory_checker.consume_memory_and_r L0127 INFO | Sleep 100 seconds to wait for the alerting messages from syslog...
      21:23:40 test_memory_checker.consume_memory L0105 INFO | Executing command 'stress -m 4' in 'telemetry' container ...
      21:25:20 test_memory_checker.consume_memory_and_r L0130 INFO | Checking the alerting messages related to container stopped ...
      21:25:24 test_memory_checker.consume_memory_and_r L0132 INFO | Found all the expected alerting messages from syslog!
      21:25:24 test_memory_checker.consume_memory_and_r L0134 INFO | Waiting for 'telemetry' container to be restarted ...
      21:25:25 test_memory_checker.consume_memory_and_r L0139 INFO | 'telemetry' container is restarted.
      21:25:25 test_memory_checker.postcheck_critical_p L0170 INFO | Checking the running status of critical processes in 'telemetry' container ...
      21:25:27 sonic.critical_process_status L0456 INFO | ====== supervisor process status for service telemetry ======
      21:25:27 test_memory_checker.postcheck_critical_p L0176 INFO | All critical processes in 'telemetry' container are running.
      21:25:27 test_memory_checker.remove_stress_utilit L0086 INFO | Removing 'stress' utility from 'telemetry' container ...
      21:25:31 test_memory_checker.remove_stress_utilit L0090 INFO | 'stress' utility was removed.
      PASSED [100%]
      ----------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------
      21:25:31 __init__.loganalyzer L0063 INFO | Starting to analyse on all DUTs
      21:25:35 parallel.parallel_run L0088 INFO | Completed running processes for target "analyze_logs" in 0:00:03.734516 seconds
      21:25:35 test_memory_checker.modify_monit_config_ L0055 INFO | Restore original Monit configuration files on DuT 'str-msn2700-01' ...
      21:25:36 test_memory_checker.modify_monit_config_ L0059 INFO | Restart Monit service ...
      21:25:37 __init__.sanity_check L0249 INFO | No post-test check is required. Done post-test sanity check
      ------------------------------------------------------------------------ generated xml file: /tmp/logs-01/tr.xml -------------------------

      ================================== 1 passed in 193.29 seconds =====================================

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
