### PR TITLE
REFINE: improve the README documentation for setting up a KVM based t…

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -22,7 +22,7 @@ First, we need to prepare the host where we will be configuring the virtual test
         ```
         sudo apt install python python-pip
         # v0.3.12b Jinja2 is required, lower version may cause uncompatible issue
-        pip install j2cli==0.3.12b0
+        sudo pip install j2cli==0.3.12b0
         ```
 
 3. Run the host setup script to install required packages and initialize the management bridge network

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -4,21 +4,28 @@ This document describes the steps to setup a virtual switch based testbed, deplo
 ## Prepare testbed host
 First, we need to prepare the host where we will be configuring the virtual testbed and running the tests.
 
-1. Install Ubuntu 20.04 AMD64 on your host or VM
+1. Install Ubuntu AMD64 on your host or VM
     - To setup a T0 topology, the server needs to have at least 10GB of memory free
     - If the testbed host is a VM, then it must support nested virtualization
         - [Instructions for Hyper-V based VMs](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/nested-virtualization#configure-nested-virtualization)
-2. Ensure that python and pip are installed
-```
-apt install python3 python3-pip
-```
+2. Prepare your environment based on different Ubuntu version, make sure that python and pip are installed
+   1. Option : If your host is **Ubuntu 20.04**
+        
+        ```
+        sudo apt install python3 python3-pip
+        ```
+        If the server was upgraded from Ubuntu 18.04, check the default python version using command `python --version`. If the default python version is still 2.x, replace it with python3 using symbolic link:
+        ```
+        sudo ln -sf /usr/bin/python3 /usr/bin/python
+        ```
+   2. Option : If your host is **Ubuntu 18.04**
+        ```
+        sudo apt install python python-pip
+        # v0.3.12b Jinja2 is required, lower version may cause uncompatible issue
+        pip install j2cli==0.3.12b0
+        ```
 
-3. If the server was upgraded from Ubuntu 18.04, check the default python version using command `python --version`. If the default python version is still 2.x, replace it with python3 using symbolic link:
-```
-ln -sf /usr/bin/python3 /usr/bin/python
-```
-
-4. Run the host setup script to install required packages and initialize the management bridge network
+3. Run the host setup script to install required packages and initialize the management bridge network
 
 ```
 git clone https://github.com/Azure/sonic-mgmt
@@ -26,7 +33,7 @@ cd sonic-mgmt/ansible
 sudo ./setup-management-network.sh
 ```
 
-5. [Install Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/). Be sure to follow the [post-install instructions](https://docs.docker.com/install/linux/linux-postinstall/) so that you don't need sudo privileges to run docker commands.
+4. [Install Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/). Be sure to follow the [post-install instructions](https://docs.docker.com/install/linux/linux-postinstall/) so that you don't need sudo privileges to run docker commands.
 
 ## Download an VM image
 We currently support EOS-based or SONiC VMs to simulate neighboring devices in the virtual testbed, much like we do for physical testbeds. To do so, we need to download the image to our testbed host.
@@ -43,7 +50,10 @@ We currently support EOS-based or SONiC VMs to simulate neighboring devices in t
 2. Import the cEOS image (it will take several minutes to import, so please be patient!)
 
 ```
-$ docker import cEOS64-lab-4.23.2F.tar.xz ceosimage:4.23.2F
+docker import cEOS64-lab-4.23.2F.tar.xz ceosimage:4.23.2F
+```
+After imported successfully, you can check it by 'docker images'
+```
 $ docker images
 REPOSITORY                                     TAG                 IMAGE ID            CREATED             SIZE
 ceosimage                                      4.23.2F             d53c28e38448        2 hours ago         1.82GB
@@ -65,15 +75,15 @@ To run the tests with a virtual SONiC device, we need a virtual SONiC image. The
 1. Download the sonic-vs image from [here](https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz)
 
 ```
-$ wget https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz -O sonic-vs.img.gz
+wget https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz -O sonic-vs.img.gz
 ```
 
 2. Unzip the image and move it into `~/sonic-vm/images/`
 
 ```
-$ gzip -d sonic-vs.img.gz
-$ mkdir -p ~/sonic-vm/images
-$ mv sonic-vs.img ~/sonic-vm/images
+gzip -d sonic-vs.img.gz
+mkdir -p ~/sonic-vm/images
+mv sonic-vs.img ~/sonic-vm/images
 ```
 
 ## Setup sonic-mgmt docker
@@ -82,8 +92,8 @@ All testbed configuration steps and tests are run from a `sonic-mgmt` docker con
 1. Run the `setup-container.sh` in the root directory of the sonic-mgmt repository:
 
 ```
-$ cd sonic-mgmt
-$ ./setup-container.sh -n <container name> -d /data
+cd sonic-mgmt
+./setup-container.sh -n <container name> -d /data
 ```
 
 2. From now on, **all steps are running inside the sonic-mgmt docker**, unless otherwise specified.
@@ -92,7 +102,7 @@ $ ./setup-container.sh -n <container name> -d /data
 You can enter your sonic-mgmt container with the following command:
 
 ```
-$ docker exec -it <container name> bash
+docker exec -it <container name> bash
 ```
 
 You will find your sonic-mgmt directory mounted at `/data/sonic-mgmt`:
@@ -105,7 +115,7 @@ LICENSE  README.md  __pycache__  ansible  docs	lgtm.yml  setup-container.sh  spy
 ## Setup host public key in sonic-mgmt docker
 In order to configure the testbed on your host automatically, Ansible needs to be able to SSH into it without a password prompt. The `setup-container` script from the previous step will setup all the necessary SSH keys for you, but there are a few more modifications needed to make Ansible work:
 
-1. Modify `veos_vtb` to use the user name (e.g. `foo`) you want to use to login to the host machine (this can be your username on the host)
+1. Modify `/data/sonic-mgmt/ansible/veos_vtb` to use the user name (e.g. `foo`) you want to use to login to the host machine (this can be your username on the host)
 
 ```
 foo@sonic:/data/sonic-mgmt/ansible$ git diff
@@ -129,15 +139,15 @@ index 3e7b3c4e..edabfc40 100644
 
       By default, the testbed scripts require a password file. If you are not using Ansible Vault, you can create a file with a dummy password (e.g. `abc`) and pass the filename to the command line. The file name and location is created and maintained by the user.
 
-3. **On the host,** run `sudo visudo` and add the following line at the end:
+3. On the **host**, run `sudo visudo` and add the following line at the end:
 
 ```
 foo ALL=(ALL) NOPASSWD:ALL
 ```
 
-4. Verify that you can login into the host (e.g. `ssh foo@172.17.0.1`, if the default docker bridge IP is `172.18.0.1/16`, follow https://docs.docker.com/network/bridge/#configure-the-default-bridge-network to change it to `172.17.0.1/16`, delete the current `sonic-mgmt` docker using command `docker rm -f <sonic-mgmt_container_name>`, then start over from step 1 of section **Setup sonic-mgmt docker** ) from the `sonic-mgmt` container without any password prompt.
+4. Verify that you can login into the **host** (e.g. `ssh foo@172.17.0.1`, if the default docker bridge IP is `172.18.0.1/16`, follow https://docs.docker.com/network/bridge/#configure-the-default-bridge-network to change it to `172.17.0.1/16`, delete the current `sonic-mgmt` docker using command `docker rm -f <sonic-mgmt_container_name>`, then start over from step 1 of section **Setup sonic-mgmt docker** ) from the `sonic-mgmt` **container** without any password prompt.
 
-5. Verify that you can use `sudo` without a password prompt inside the host (e.g. `sudo bash`).
+5. Verify that you can use `sudo` without a password prompt inside the **host** (e.g. `sudo bash`).
 
 ## Setup VMs on the server
 **(Skip this step if you are using cEOS - the containers will be automatically setup in a later step.)**
@@ -146,7 +156,7 @@ Now we need to spin up some VMs on the host to act as neighboring devices to our
 
 1. Start the VMs:
 ```
-$ ./testbed-cli.sh -m veos_vtb -n 4 start-vms server_1 password.txt
+./testbed-cli.sh -m veos_vtb -n 4 start-vms server_1 password.txt
 ```
 If you use SONiC image as the VMs, you need to add extra parameters `-k vsonic` so that this command is `./testbed-cli.sh -m veos_vtb -n 4 -k vsonic start-vms server_1 password.txt`. Of course, if you want to stop VMs, you also need to append these parameters after original command.
 
@@ -208,14 +218,14 @@ Now we're finally ready to deploy the topology for our testbed! Run the followin
 
 ### vEOS
 ```
-$ cd /data/sonic-mgmt/ansible
-$ ./testbed-cli.sh -t vtestbed.csv -m veos_vtb add-topo vms-kvm-t0 password.txt
+cd /data/sonic-mgmt/ansible
+./testbed-cli.sh -t vtestbed.csv -m veos_vtb add-topo vms-kvm-t0 password.txt
 ```
 
 ### cEOS
 ```
-$ cd /data/sonic-mgmt/ansible
-$ ./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-t0 password.txt
+cd /data/sonic-mgmt/ansible
+./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-t0 password.txt
 ```
 
 Verify that the cEOS neighbors were created properly:
@@ -236,8 +246,8 @@ c929c622232a        sonicdev-microsoft.azurecr.io:443/docker-ptf:latest   "/usr/
 
 ### vSONiC
 ```
-$ cd /data/sonic-mgmt/ansible
-$ ./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k vsonic add-topo vms-kvm-t0 password.txt
+cd /data/sonic-mgmt/ansible
+./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k vsonic add-topo vms-kvm-t0 password.txt
 ```
 
 ## Deploy minigraph on the DUT
@@ -246,27 +256,39 @@ Once the topology has been created, we need to give the DUT an initial configura
 1. Deploy the `minigraph.xml` to the DUT and save the configuration:
 
 ```
-$ ./testbed-cli.sh -t vtestbed.csv -m veos_vtb deploy-mg vms-kvm-t0 veos_vtb password.txt
+./testbed-cli.sh -t vtestbed.csv -m veos_vtb deploy-mg vms-kvm-t0 veos_vtb password.txt
 ```
 
 2. Verify that you can login to the SONiC KVM using Mgmt IP = 10.250.0.101 and admin:password.
-
-3. You should see BGP sessions up in SONiC:
-
+```
+ssh admin@10.250.0.101
+admin@10.250.0.101's password: <password_in_password.txt>
+```
+3. After logged in to the SONiC KVM, you should be able to see BGP sessions with:
+```
+show ip bgp sum
+```
 If neighbor devices are EOS:
 
 ```
 admin@vlab-01:~$ show ip bgp sum
-BGP router identifier 10.1.0.32, local AS number 65100
-RIB entries 12807, using 1401 KiB of memory
-Peers 8, using 36 KiB of memory
-Peer groups 2, using 112 bytes of memory
 
-Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
-10.0.0.57       4 64600    3208      12        0    0    0 00:00:22     1
-10.0.0.59       4 64600    3208     593        0    0    0 00:00:22     1
-10.0.0.61       4 64600    3205     950        0    0    0 00:00:21     1
-10.0.0.63       4 64600    3204     950        0    0    0 00:00:21     1
+IPv4 Unicast Summary:
+BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
+BGP table version 6405
+RIB entries 12807, using 2458944 bytes of memory
+Peers 4, using 87264 KiB of memory
+Peer groups 4, using 256 bytes of memory
+
+
+Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
+-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
+10.0.0.57      4  64600       3792       3792         0      0       0  00:29:24             6400  ARISTA01T1
+10.0.0.59      4  64600       3792       3795         0      0       0  00:29:24             6400  ARISTA02T1
+10.0.0.61      4  64600       3792       3792         0      0       0  00:29:24             6400  ARISTA03T1
+10.0.0.63      4  64600       3795       3796         0      0       0  00:29:24             6400  ARISTA04T1
+
+Total number of neighbors 4
 ```
 
 If neighbor devices are SONiC


### PR DESCRIPTION
### Description of PR


Summary:
Refine the README documentation for setting up a KVM based testbed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Refine the README documentation for setting up a KVM based testbed.
#### How did you do it?

1.  Split Ubuntu 18.04 and 20.04 into to two individual optional ways in 'Prepare testbed host' step, otherwise if user followed 20.04 actions in 18.04 Ubuntu host, it may cause hard-to-track issues in 'add-topo' step. Current suggestion is: Python2 for Ubuntu 18.04, Python3 for Ubuntu 20.04, and don't let host installs Python2 and Python3 at one time.
2.  Remove the leading '$' for shell commands, reader will be able to copy them more friendly.
3.  Refine some statement and details to help totally new approacher understand easilier.

#### How did you verify/test it?

I just followed the documentation to created a KVM testbed successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
