### PR TITLE
[tacacs] Config NOT ignore errors while test read-only allowed commands

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -10,11 +10,11 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-def ssh_remote_run(localhost, remote_ip, username, password, cmd):
+def ssh_remote_run(localhost, remote_ip, username, password, cmd, module_ignore_errors=True):
     res = localhost.shell("sshpass -p {} ssh "\
-                          "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
+                          "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "\
                           "{}@{} {}".format(
-            password, username, remote_ip, cmd), module_ignore_errors=True)
+            password, username, remote_ip, cmd), module_ignore_errors=module_ignore_errors)
     return res
 
 
@@ -34,7 +34,7 @@ def does_command_exist(localhost, remote_ip, username, password, command):
     return len(usr_result["stdout_lines"]) > 0 or len(bin_result["stdout_lines"]) > 0
 
 def ssh_remote_allow_run(localhost, remote_ip, username, password, cmd):
-    res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
+    res = ssh_remote_run(localhost, remote_ip, username, password, cmd, module_ignore_errors=False)
     # Verify that the command is allowed
     logger.info("check command \"{}\" rc={}".format(cmd, res['rc']))
     expected = res['rc'] == 0 or (res['rc'] != 0 and "Make sure your account has RW permission to current device" not in res['stderr'])
@@ -87,8 +87,8 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
             "sudo docker ps -a",
         ],
         "lldpctl": ["sudo lldpctl"],
-        "vtysh": ['sudo vtysh -c "show version"', 'sudo vtysh -c "show bgp ipv4 summary json"', 'sudo vtysh -c "show bgp ipv6 summary json"'],
-        "rvtysh": ['sudo rvtysh -c "show ip bgp su"', 'sudo rvtysh -n 0 -c "show ip bgp su"'],
+        "vtysh": ['sudo vtysh -c "show\ version"', 'sudo vtysh -c "show\ bgp\ ipv4\ summary\ json"', 'sudo vtysh -c "show\ bgp\ ipv6\ summary\ json"'],
+        "rvtysh": ['sudo rvtysh -c "show\ ip\ bgp\ su"', 'sudo rvtysh -n 0 -c "show\ ip\ bgp\ su"'],
         "decode-syseeprom": ["sudo decode-syseeprom"],
         "generate_dump": ['sudo generate_dump -s "5 secs ago"'],
         "lldpshow": ["sudo lldpshow"],


### PR DESCRIPTION
What is the motivation for this PR?
Currently, we ignore most of the errors except permission errors in the read-only command test cases of TACACS.
That may lead to the test case can't detect some basic issues in the code. Especially in the kvm test which is the fundament PR test of sonic_mgmt.

How did you do it?
For the read-only allowed command, don't ignore any errors.

How did you verify/test it?
Run tacacs/test_ro_user.py::test_ro_user_allowed_command, the test case should pass.

Signed-off-by: Kevin Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
