### PR TITLE
[Sub-ports] Added test case which validates tunneling over sub-ports

### DIFF
--- a/tests/sub_port_interfaces/Sub-ports-test-plan.md
+++ b/tests/sub_port_interfaces/Sub-ports-test-plan.md
@@ -16,6 +16,7 @@
   - [test_vlan_config_impact](#Test-case-test_vlan_config_impact)
   - [test_routing_between_sub_ports](#Test-case-test_routing_between_sub_ports)
   - [test_routing_between_sub_ports_and_port](#Test-case-test_routing_between_sub_ports_and_port)
+  - [test_tunneling_between_sub_ports](#Test-case-test_tunneling_between_sub_ports)
 
 ## Revision
 
@@ -25,6 +26,7 @@
 | 0.2 |  02/23/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
 | 0.3 |  03/18/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
 | 0.4 |  06/09/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
+| 0.5 |  07/12/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
 
 
 ## Overview
@@ -420,5 +422,81 @@ Example the customized testbed with applied T0 topo for test_routing_between_sub
 
 ### Test teardown
 
+- reload_dut_config function: reload DUT configuration
+- reload_ptf_config function: remove all sub-ports configuration
+
+## Test case test_tunneling_between_sub_ports
+
+### Test objective
+
+Validates that encap-decap tunnel works over sub-port.
+
+### Test set up
+- apply_config_on_the_dut fixture(scope="function"): enable and configures sub-port interfaces on the DUT
+- apply_config_on_the_ptf fixture(scope="function"): enable and configures sub-port interfaces on the PTF
+- apply_route_config fixture(scope="function"): add sub-ports to namespace on the PTF
+- apply_tunnel_table_to_dut fixture(scope="function"): apply tunnel configuration on the DUT and remove after tests
+
+Example the customized testbed with applied T0 topo for test_tunneling_between_sub_ports test case:
+##### Tunneling between sub-ports on the same port
+```
+              VM    VM    VM    VM
+              []    []    []    []
+       _______[]____[]____[]____[]______
+  ╔═══|══════════╗                      |
+  ║   |   _______║    DUT   _________   |
+  ║   |  [Ethernet4]       [Ethernet8]  |
+  ║   |__[_.10_.20_]_______[_.10_.20_]__|
+  ║      [  |    █ ]       [  |   |  ]
+  ║      [  |    █ ]       [  |   |  ]
+  ║ ┌────[──|─┐  █ ]  ┌────[──|─┐ |  ]
+  ║ │  __[__|_│__█_]__│____[__|_│_|__]__
+  ╚═│═|══[>.10│.20 ]  │    [.10 │.20 ]  |
+    │ |  [__eth1___]  │    [__eth2___]  |
+    │ |       │       │         │       |
+    │ |netns4 │       │  netns8 │       |
+    └─|───────┘       └─────────┘       |
+      |                                 |
+      |              PTF                |
+      |_________________________________|
+
+```
+##### Tunneling between sub-ports on different ports
+```
+              VM    VM    VM    VM
+              []    []    []    []
+       _______[]____[]____[]____[]______
+  ╔═══|════════════════════════════╗    |
+  ║   |   _________   DUT   _______║_   |
+  ║   |  [Ethernet4]       [Ethernet8]  |
+  ║   |__[_.10_.20_]_______[_.10_.20_]__|
+  ║      [  |   |  ]       [  |    █ ]
+  ║      [  |   |  ]       [  |    █ ]
+  ║ ┌────[──|─┐ |  ]  ┌────[──|─┐  █ ]
+  ║ │  __[__|_│_| _]__│____[__|_│__█_]__
+  ╚═│═|══[>.10│.20 ]  │    [.10 │.20 ]  |
+    │ |  [__eth1___]  │    [__eth2___]  |
+    │ |       │       │         │       |
+    │ |netns4 │       │  netns8 │       |
+    └─|───────┘       └─────────┘       |
+      |                                 |
+      |              PTF                |
+      |_________________________________|
+
+```
+### Test steps
+- Setup configuration of sub-ports on the DUT.
+- Setup configuration of sub-ports on the PTF.
+- Add one of the sub-ports to namespace on the PTF.
+- Setup tunnel configuration on sub-ports of the DUT.
+- Create encapsulated packet.
+- Send encapsulated packet from sub-port to sub-port in namespace on the PTF.
+- Verify that sub-port in namespace gets decapsulated packet on the PTF.
+- Remove namespaces from PTF.
+- Remove tunnel configuration from PTF.
+- Clear configuration of sub-ports on the DUT.
+- Clear configuration of sub-ports on the PTF.
+
+### Test teardown
 - reload_dut_config function: reload DUT configuration
 - reload_ptf_config function: remove all sub-ports configuration

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -12,6 +12,7 @@ from tests.common.utilities import wait_until
 from sub_ports_helpers import DUT_TMP_DIR
 from sub_ports_helpers import TEMPLATE_DIR
 from sub_ports_helpers import SUB_PORTS_TEMPLATE
+from sub_ports_helpers import TUNNEL_TEMPLATE
 from sub_ports_helpers import check_sub_port
 from sub_ports_helpers import remove_member_from_vlan
 from sub_ports_helpers import get_port
@@ -229,8 +230,9 @@ def apply_route_config(request, ptfhost, define_sub_ports_configuration, apply_c
                                   sub_ports[next_hop_sub_port]['neighbor_port'],
                                   sub_ports[next_hop_sub_port]['neighbor_ip'])
 
-            add_static_route(ptfhost, src_port_network, sub_ports[next_hop_sub_port]['ip'], name_of_namespace)
-            add_static_route(ptfhost, dst_port_network, sub_ports[src_port]['ip'])
+            if 'tunneling' not in request.node.name:
+                add_static_route(ptfhost, src_port_network, sub_ports[next_hop_sub_port]['ip'], name_of_namespace)
+                add_static_route(ptfhost, dst_port_network, sub_ports[src_port]['ip'])
 
             new_sub_ports[src_port].append((next_hop_sub_port, name_of_namespace))
 
@@ -245,8 +247,11 @@ def apply_route_config(request, ptfhost, define_sub_ports_configuration, apply_c
         for next_hop_sub_port in next_hop_sub_ports:
             sub_port, name_of_namespace = next_hop_sub_port
             dst_port_network = ipaddress.ip_network(unicode(sub_ports[sub_port]['ip']), strict=False)
-            remove_static_route(ptfhost, src_port_network, sub_ports[sub_port]['ip'], name_of_namespace)
-            remove_static_route(ptfhost, dst_port_network, sub_ports[src_port]['ip'])
+
+            if 'tunneling' not in request.node.name:
+                remove_static_route(ptfhost, src_port_network, sub_ports[sub_port]['ip'], name_of_namespace)
+                remove_static_route(ptfhost, dst_port_network, sub_ports[src_port]['ip'])
+
             remove_namespace(ptfhost, name_of_namespace)
 
 
@@ -371,6 +376,42 @@ def apply_route_config_for_port(request, duthost, ptfhost, define_sub_ports_conf
 
     if 'svi' in request.param:
         remove_vlan(duthost, vlan_id)
+
+
+@pytest.fixture()
+def apply_tunnel_table_to_dut(duthost, apply_route_config):
+    """
+    Apply tunnel configuration on the DUT and remove after tests
+
+    Args:
+        duthost: DUT host object
+        apply_route_config: Fixture for applying route configuration on the PTF
+    """
+    tunnel_addr_list = []
+
+    new_sub_ports = apply_route_config['new_sub_ports']
+    sub_ports = apply_route_config['sub_ports']
+
+    for src_port in new_sub_ports:
+        tunnel_ip = sub_ports[src_port]['ip'].split('/')[0]
+        tunnel_addr_list.append(tunnel_ip)
+
+    tunnel_config_path = os.path.join(DUT_TMP_DIR, TUNNEL_TEMPLATE)
+    config_template = jinja2.Template(open(os.path.join(TEMPLATE_DIR, TUNNEL_TEMPLATE)).read())
+
+    tunnel_vars = {
+        'tunnel_addr_list': tunnel_addr_list
+    }
+
+    duthost.command("mkdir -p {}".format(DUT_TMP_DIR))
+    duthost.copy(content=config_template.render(tunnel_vars), dest=tunnel_config_path)
+    duthost.command('sonic-cfggen -j {} --write-to-db'.format(tunnel_config_path))
+
+    yield
+
+    # Teardown
+    for index in range(1, len(tunnel_addr_list)+1):
+        duthost.command('docker exec -i database redis-cli -n 4 -c DEL "TUNNEL|MuxTunnel{}"'.format(index))
 
 
 @pytest.fixture

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -396,12 +396,12 @@ def apply_tunnel_table_to_dut(duthost, apply_route_config):
         tunnel_ip = sub_ports[src_port]['ip'].split('/')[0]
         tunnel_addr_list.append(tunnel_ip)
 
-    tunnel_config_path = os.path.join(DUT_TMP_DIR, TUNNEL_TEMPLATE)
-    config_template = jinja2.Template(open(os.path.join(TEMPLATE_DIR, TUNNEL_TEMPLATE)).read())
-
     tunnel_vars = {
         'tunnel_addr_list': tunnel_addr_list
     }
+
+    tunnel_config_path = os.path.join(DUT_TMP_DIR, TUNNEL_TEMPLATE)
+    config_template = jinja2.Template(open(os.path.join(TEMPLATE_DIR, TUNNEL_TEMPLATE)).read())
 
     duthost.command("mkdir -p {}".format(DUT_TMP_DIR))
     duthost.copy(content=config_template.render(tunnel_vars), dest=tunnel_config_path)

--- a/tests/sub_port_interfaces/templates/tunnel_config.j2
+++ b/tests/sub_port_interfaces/templates/tunnel_config.j2
@@ -8,6 +8,7 @@
             "dscp_mode": "pipe",
             "tunnel_type": "IPINIP"
         }{% if not loop.last %},{% endif %}
+
 {% endfor %}
     }
 }

--- a/tests/sub_port_interfaces/templates/tunnel_config.j2
+++ b/tests/sub_port_interfaces/templates/tunnel_config.j2
@@ -1,0 +1,13 @@
+{
+    "TUNNEL": {
+{% for ip in tunnel_addr_list %}
+        "{{ "MuxTunnel" + loop.index|string }}": {
+            "dst_ip" : "{{ ip }}",
+            "ttl_mode": "pipe",
+            "ecn_mode": "copy_from_outer",
+            "dscp_mode": "pipe",
+            "tunnel_type": "IPINIP"
+        }{% if not loop.last %},
+{% endif %}{% endfor %}
+    }
+}

--- a/tests/sub_port_interfaces/templates/tunnel_config.j2
+++ b/tests/sub_port_interfaces/templates/tunnel_config.j2
@@ -7,7 +7,7 @@
             "ecn_mode": "copy_from_outer",
             "dscp_mode": "pipe",
             "tunnel_type": "IPINIP"
-        }{% if not loop.last %},
-{% endif %}{% endfor %}
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 }

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -318,3 +318,39 @@ class TestSubPorts(object):
                                             type_of_traffic=type_of_traffic,
                                             ttl=63,
                                             pktlen=pktlen)
+
+
+    def test_tunneling_between_sub_ports(self, duthost, ptfadapter, apply_tunnel_table_to_dut, apply_route_config):
+        """
+        Validates that packets are routed between sub-ports.
+
+        Test steps:
+            1.) Setup configuration of sub-ports on the DUT.
+            2.) Setup configuration of sub-ports on the PTF.
+            3.) Add one of the sub-ports to namespace on the PTF.
+            4.) Setup tunnel configuration on sub-ports of the DUT.
+            5.) Create encapsulated packet.
+            6.) Send encapsulated packet from sub-port to sub-port in namespace on the PTF.
+            7.) Verify that sub-port in namespace gets decapsulated packet on the PTF.
+            8.) Remove namespaces from PTF.
+            9.) Remove tunnel configuration from PTF.
+            10.) Clear configuration of sub-ports on the DUT.
+            11.) Clear configuration of sub-ports on the PTF.
+
+        Pass Criteria: PTF port gets decapsulated packet from port in namespace on the PTF.
+        """
+        new_sub_ports = apply_route_config['new_sub_ports']
+        sub_ports = apply_route_config['sub_ports']
+
+        for src_port, next_hop_sub_ports in new_sub_ports.items():
+            for sub_port, _ in next_hop_sub_ports:
+                generate_and_verify_traffic(duthost=duthost,
+                                            ptfadapter=ptfadapter,
+                                            src_port=sub_ports[src_port]['neighbor_port'],
+                                            ip_src=sub_ports[src_port]['neighbor_ip'],
+                                            dst_port=sub_ports[sub_port]['neighbor_port'],
+                                            ip_dst=sub_ports[sub_port]['neighbor_ip'],
+                                            ip_tunnel=sub_ports[src_port]['ip'],
+                                            pkt_action='fwd',
+                                            type_of_traffic=['decap',],
+                                            ttl=63)


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Added new sub-ports tests: [test_tunneling_between_sub_ports](https://github.com/Azure/sonic-mgmt/blob/1af07ad0ccb9a9c5be112c1ab2469bef18eb0318/tests/sub_port_interfaces/test_sub_port_interfaces.py#L323-L356)
- Added fixture for setup tunnel configuration on the DUT and remove after tests: [apply_tunnel_table_to_dut](https://github.com/Azure/sonic-mgmt/blob/1af07ad0ccb9a9c5be112c1ab2469bef18eb0318/tests/sub_port_interfaces/conftest.py#L368-L401)
- Added new helpers methods
- Added template for setup tunnel configuration on the DUT: [tunnel_config.j2](https://github.com/Azure/sonic-mgmt/blob/1af07ad0ccb9a9c5be112c1ab2469bef18eb0318/tests/sub_port_interfaces/templates/tunnel_config.j2)
- Updated Test Plan
#### Note:
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Coverage of sub-ports feature by test cases to improve the quality of SONiC.
#### How did you do it?
Added new test cases to PyTest.
Implementation is based on the [Sub-ports design spec](https://github.com/Azure/SONiC/blob/master/doc/subport/sonic-sub-port-intf-hld.md)
#### How did you verify/test it?
`py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library sub_port_interfaces`
#### Any platform specific information?
SONiC Software Version: SONiC.master.162-dirty-20210331.125032
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: ecaf97d8
Build date: Wed Mar 31 13:09:26 UTC 2021
Platform: x86_64-arista_7170_32cd
HwSKU: Arista-7170-32CD-C32
ASIC: barefoot
#### Supported testbed topology if it's a new test case?
T0, T1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
