### PR TITLE
[test_ro_user] improve the delay for 'test_ro_user_banned_command' due to hostcfgd delay on boot

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -10,6 +10,9 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+SLEEP_TIME      = 10
+TIMEOUT_LIMIT   = 120
+
 def ssh_remote_run(localhost, remote_ip, username, password, cmd):
     res = localhost.shell("sshpass -p {} ssh "\
                           "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
@@ -49,6 +52,24 @@ def ssh_remote_ban_run(localhost, remote_ip, username, password, cmd):
     logger.info("check command \"{}\" rc={}".format(cmd, res['rc']))
     return res['rc'] != 0 and "Make sure your account has RW permission to current device" in res['stderr']
 
+def wait_for_tacacs(localhost, remote_ip, username, password):
+    current_attempt = 0
+    cmd = 'systemctl status hostcfgd.service'
+    while (True):
+        # Wait for tacacs to finish configuration from hostcfgd
+        logger.info("Check if hostcfgd started and configured tacac attempt = {}".format(current_attempt))
+        time.sleep(SLEEP_TIME)
+        output = localhost.shell("sshpass -p {} ssh "\
+                        "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
+                        "{}@{} {}".format(
+        password, username, remote_ip, cmd), module_ignore_errors=True)['stdout_lines']
+        if "active (running)" in str(output):
+            return
+        else:
+            if current_attempt == TIMEOUT_LIMIT/SLEEP_TIME:
+                pytest_assert(False, "hostcfgd did not start after {} seconds".format(TIMEOUT_LIMIT))
+            else:
+                current_attempt += 1
 
 def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, test_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -153,7 +174,8 @@ def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hos
     ]
 
     # Wait until hostcfgd started and configured tacas authorization
-    time.sleep(100)
+    wait_for_tacacs(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'], creds_all_duts[duthost]['tacacs_ro_user_passwd'])
+
     for command in commands:
         banned = ssh_remote_ban_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
                                     creds_all_duts[duthost]['tacacs_ro_user_passwd'], command)

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -66,7 +66,7 @@ def wait_for_tacacs(localhost, remote_ip, username, password):
         if "active (running)" in str(output):
             return
         else:
-            if current_attempt == TIMEOUT_LIMIT/SLEEP_TIME:
+            if current_attempt >= TIMEOUT_LIMIT/SLEEP_TIME:
                 pytest_assert(False, "hostcfgd did not start after {} seconds".format(TIMEOUT_LIMIT))
             else:
                 current_attempt += 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

After recent change introduced on this PR's:
https://github.com/Azure/sonic-buildimage/pull/7965
https://github.com/Azure/sonic-buildimage/pull/8117

'hostcfgd' will be delayed in 90 seconds.
If the test will run before the daemon has started, it will fail the test.
This is to align with the new change and make sure the test will pass.

Profiling the time it takes to configure tacacs after the daemon started can take time:
main started -> Mon 12 Jul 2021 02:07:06 PM UTC
'tacacs_server_update' function finished -> Mon 12 Jul 2021 02:08:10 PM UTC

This PR is to improve the previous delay introduced on PR https://github.com/Azure/sonic-mgmt/pull/3741
Since the test is still failing on Azure CI.

#### How did you do it?
Check hostcfgd status and if the daemon started wait until tacacs is well configured.

#### How did you verify/test it?
Run the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
