### PR TITLE
[arp] Allow use of discontiguous ports with ARP tests.

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -92,9 +92,28 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             intf1 = ports_for_test[0]
             intf2 = ports_for_test[1]
         else:
-            # Select port index 0 & 1 two interfaces for testing
-            intf1 = ports[0]
-            intf2 = ports[1]
+           # Select first 2 ports that are admin 'up'
+       	   if duthost.is_multi_asic:
+           	intf_status = duthost.show_interface(command='status', namespace=asic.namespace)['ansible_facts'][
+           	     'int_status']
+            else:
+            	intf_status = duthost.show_interface(command='status')['ansible_facts']['int_status']
+
+		intf1 = None
+		intf2 = None
+		for a_port in ports:
+		    if intf_status[a_port]['admin_state'] == 'up':
+		        if intf1 is None:
+		            intf1 = a_port
+		        elif intf2 is None:
+		            intf2 = a_port
+		        else:
+		            break
+
+		if intf1 is None or intf2 is None:
+		    pytest.skip("Not enough interfaces on this host/asic (%s/%s) to support test." % (duthost.hostname,
+		                                                                                      asic.asic_index))
+
 
             po1 = get_po(mg_facts, intf1)
             po2 = get_po(mg_facts, intf2)

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -92,29 +92,23 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             intf1 = ports_for_test[0]
             intf2 = ports_for_test[1]
         else:
-           # Select first 2 ports that are admin 'up'
-       	   if duthost.is_multi_asic:
-           	intf_status = duthost.show_interface(command='status', namespace=asic.namespace)['ansible_facts'][
-           	     'int_status']
-            else:
-            	intf_status = duthost.show_interface(command='status')['ansible_facts']['int_status']
+            # Select first 2 ports that are admin 'up'
+            intf_status = asic.show_interface(command='status')['ansible_facts']['int_status']
 
-		intf1 = None
-		intf2 = None
-		for a_port in ports:
-		    if intf_status[a_port]['admin_state'] == 'up':
-		        if intf1 is None:
-		            intf1 = a_port
-		        elif intf2 is None:
-		            intf2 = a_port
-		        else:
-		            break
+            intf1 = None
+            intf2 = None
+            for a_port in ports:
+                if intf_status[a_port]['admin_state'] == 'up':
+                    if intf1 is None:
+                        intf1 = a_port
+                    elif intf2 is None:
+                        intf2 = a_port
+                    else:
+                        break
 
-		if intf1 is None or intf2 is None:
-		    pytest.skip("Not enough interfaces on this host/asic (%s/%s) to support test." % (duthost.hostname,
-		                                                                                      asic.asic_index))
-
-
+            if intf1 is None or intf2 is None:
+                pytest.skip("Not enough interfaces on this host/asic (%s/%s) to support test." % (duthost.hostname,
+                                                                                              asic.asic_index))
             po1 = get_po(mg_facts, intf1)
             po2 = get_po(mg_facts, intf2)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Allow use of discontiguous ports with ARP tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This change allows the ARP tests to run when not all front panel ports are connected to the fanout.  Support was added for this configuration in PR 2517.

#### How did you do it?
Instead of picking first two ports on the card, do a show interface and find the first two ports that are admin up.  Then proceed with the existing logic to move the port out of port channel if it is present.

#### How did you verify/test it?
Ran test_arpall.py on a card with non-adjacent ports.

15:22:54 conftest.intfs_for_test                  L0093 INFO   | Selected ints are Ethernet1 and Ethernet11


=============================== warnings summary ===============================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 5 passed, 1 warnings in 175.22 seconds ====================


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
