### PR TITLE
[ test_autonegotiation ] Added missing topology mark

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -17,6 +17,10 @@ from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.utilities import wait_until
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates
 
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
 logger = logging.getLogger(__name__)
 
 STATE_DB = 'STATE_DB'


### PR DESCRIPTION
Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
TC skipped when run with --topology mark
`is skipped when no topology marker is given`
#### How did you do it?
Run TC with --topology=any, TC was not skipped
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
