### PR TITLE
[pytest] Enable logging exceptions raised by test function

### DIFF
--- a/tests/common/plugins/log_section_start/__init__.py
+++ b/tests/common/plugins/log_section_start/__init__.py
@@ -21,9 +21,22 @@ import logging
 import inspect
 import decorator
 import postimport
+import traceback
+import sys
 
 
 LOGGER_NAME = "SectionStartLogger"
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """Add exception log when test function exits with error."""
+    yield
+    last_type = getattr(sys, "last_type", None)
+    last_value = getattr(sys, "last_value", None)
+    last_traceback = getattr(sys, "last_traceback", None)
+    if last_type is not None and last_value is not None and last_traceback is not None:
+        logging.error("".join(traceback.format_exception(last_type, last_value, last_traceback)))
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enable logging exceptions raised by test function.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Add a hook wrapper of `pytest_runtest_call` to log exception raised.

#### How did you verify/test it?
* demo test
```
def test_demo():
    raise ValueError(100)
```
* log snippet
```
13/07/2021 07:56:07 __init__._log_sep_line                   L0156 INFO   | ==================== test_demo.py::test_demo call ====================
13/07/2021 07:56:07 __init__.pytest_runtest_call             L0036 ERROR  |   File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/data/repo/bugfix/sonic-mgmt/tests/test_demo.py", line 8, in test_demo
    raise ValueError(100)

13/07/2021 07:56:15 __init__._log_sep_line                   L0156 INFO   | ==================== test_demo.py::test_demo teardown ====================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
