### PR TITLE
RESTAPI - Add delay in `test_data_path`

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -106,6 +106,8 @@ def test_data_path(construct_url, vlan_members):
     pytest_assert(r.status_code == 204)
 
     # Verify routes
+    # Add some delay before query
+    time.sleep(5)
     params = '{}'
     r = restapi.get_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-2', params)
     pytest_assert(r.status_code == 200)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure of ```test_data_path```.
```
        expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036001},
                    {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32", "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036001},
                    {"nexthop": "100.3.152.52", "ip_prefix": "100.0.20.4/32", "vnid": 7036001}]
        for route in expected:
>           pytest_assert(route in r.json())
E           Failed: <Failed instance>

```

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure of ```test_data_path```.

#### How did you do it?
Delay 5 seconds before querying routes.

#### How did you verify/test it?
Verified on SN4600, test case can pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
