### PR TITLE
[route] Fix of static route redistribution in test_static_route

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -118,11 +118,23 @@ def check_route_redistribution(duthost, prefix, ipv6, removed=False):
             assert prefix in adv_routes
 
 
+def route_redistribution_static(duthost, ipv6, removed=False):
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+    if ipv6:
+        duthost.shell("vtysh -c 'configure terminal' -c 'router bgp {}' -c 'address-family ipv6' -c '{}redistribute static'".format(mg_facts["minigraph_bgp_asn"],
+                        "no " if removed else ''))
+    else:
+        duthost.shell("vtysh -c 'configure terminal' -c 'router bgp {}' -c '{}redistribute static'".format(mg_facts["minigraph_bgp_asn"],
+                        "no " if removed else ''))
+
+
 def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_addrs, prefix_len, nexthop_devs, ipv6=False, config_reload_test=False):
     # Add ipaddresses in ptf
     add_ipaddr(ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv6=ipv6)
 
     try:
+        # Enable redistribution of static routes
+        route_redistribution_static(duthost, ipv6)
         # Add static route
         duthost.shell("sonic-db-cli CONFIG_DB hmset 'STATIC_ROUTE|{}' nexthop {}".format(prefix, ",".join(nexthop_addrs)))
         time.sleep(5)
@@ -138,6 +150,7 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         if config_reload_test:
             duthost.shell('config save -y')
             config_reload(duthost, wait=350)
+            route_redistribution_static(duthost, ipv6)
             generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
             check_route_redistribution(duthost, prefix, ipv6)
 
@@ -151,7 +164,8 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         # Check the advertised route get removed
         time.sleep(5)
         check_route_redistribution(duthost, prefix, ipv6, removed=True)
-
+        # Disable redistribution of static routes
+        route_redistribution_static(duthost, ipv6, removed=True)
         # Config save if the saved config_db was updated
         if config_reload_test:
             duthost.shell('config save -y')


### PR DESCRIPTION
Signed-off-by: Vladyslav Morokhovych<vladyslavx.morokhovych@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix of static route redistribution in `test_static_route`
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
[PR-3633](https://github.com/Azure/sonic-mgmt/pull/3633) add check if static routes get redistributed in `test_static_route`
But BGP does not redistribute static route by default.
#### How did you do it?
Added function that enable/disable redistribution of static routes.
#### How did you verify/test it?
Run `route/test_static_route.py`
```
route/test_static_route.py::test_static_route PASSED
route/test_static_route.py::test_static_route_ecmp PASSED
route/test_static_route.py::test_static_route_ipv6 PASSED
route/test_static_route.py::test_static_route_ecmp_ipv6 PASSED
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
