### PR TITLE
ARP: Modified '/arp/test_neighbor_mac_noptf.py' testcase to skip 'bgp shutdown all' for modular chassis

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -69,9 +69,10 @@ class TestNeighborMacNoPtf:
                 None
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        duthost.command("sudo config bgp shutdown all")
-        if not wait_until(120, 2.0, self._check_no_bgp_routes, duthost):
-            pytest.fail('BGP Shutdown Timeout: BGP route removal exceeded 120 seconds.')
+        if not duthost.get_facts().get("modular_chassis"):
+            duthost.command("sudo config bgp shutdown all")
+            if not wait_until(120, 2.0, self._check_no_bgp_routes, duthost):
+                pytest.fail('BGP Shutdown Timeout: BGP route removal exceeded 120 seconds.')
 
         yield
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is to skip 'bgp shutdown all' for modular chassis in arp/test_neighbor_mac_noptf.py 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Teat case 'arp/test_neighbor_mac_noptf.py' brings all bgp down, In case of Modular chassis testcase fails because VOQ chassis has extra routes so when script brings bgp down and verify for the routes and expects routes should be zero never works.

#### How did you do it?
To Take care of this failure, we do not shutdown all BGP neighbors for a modular chassis.

The reasons are:- 
1. When we bring BGP down  using 'sudo config bgp shutdown all' on VOQ chassis linecard, it only brings down the eBGP neighbors, and not the BGP_VOQ_CHASSIS_NEIGHBORs (the iBGP neighbors to other asics in the chassis)
2. The asic has routes that are learnt from other remote asics in the chassis.
3. VoQ architecture adds static routes for inband interfaces and all eBGP peers on the remote asics as well.

To get all the routes to be flushed could be very complex.  Also, the reason that the BGP shutdown was added was because on some DUT's are overwhelmed with the BGP updates and thus causing this test to intermittently fail. However, we don't see such intermittent failure on linecards of a VoQ chassis which has 12K routes in a T2 topology - possibly because CPU is powerful.

#### How did you verify/test it?
Verified on VOQ chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
