### PR TITLE
Negative testcases for fastboot and wamrboot

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -70,7 +70,7 @@ class AdvancedReboot:
         self.localhost = localhost
         self.tbinfo = tbinfo
         self.creds = creds
-        self.moduleIgnoreErrors = False
+        self.moduleIgnoreErrors = kwargs["allow_fail"] if "allow_fail" in kwargs else False
         self.__dict__.update(kwargs)
         self.__extractTestParam()
         self.rebootData = {}

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -7,7 +7,6 @@ import logging
 from collections import OrderedDict
 from datetime import datetime
 
-from tests.common.reboot import reboot, REBOOT_TYPE_COLD
 from tests.platform_tests.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, OFFSET_ITEMS, TIME_SPAN_ITEMS
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
@@ -335,29 +334,3 @@ def pytest_generate_tests(metafunc):
                 metafunc.parametrize('power_off_delay', delay_list)
             except ValueError:
                 metafunc.parametrize('power_off_delay', default_delay_list)
-
-@pytest.fixture
-def add_fail_step_to_reboot(request, localhost, duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-
-    test_name = request.node.name
-    if "warm" in test_name:
-        reboot_script = "warm-reboot"
-    elif "fast" in test_name:
-        reboot_script = "fast-reboot"
-
-    cmd_format = "sed -i 's/{}/{}/' {}"
-    reboot_script_path = duthost.shell('which {}'.format(reboot_script))['stdout']
-    original_line = 'set +e'
-    replaced_line = 'exit -1; set +e'
-    replace_cmd = cmd_format.format(original_line, replaced_line, reboot_script_path)
-    logging.info("Modify {} to exit before set +e".format(reboot_script_path))
-    duthost.shell(replace_cmd)
-
-    yield
-
-    replace_cmd = cmd_format.format(replaced_line, original_line, reboot_script_path)
-    logging.info("Revert {} script to original".format(reboot_script_path))
-    duthost.shell(replace_cmd)
-    # cold reboot DUT to restore any bad state caused by negative test
-    reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD)

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -4,6 +4,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
 from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm[py/unused-import]
+from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot # lgtm[py/unused-import]
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -38,7 +39,7 @@ def test_warm_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
 
 
 ### Testcases to verify abruptly failed reboot procedure ###
-def test_cancelled_fast_reboot(request, get_advanced_reboot, add_fail_step_to_reboot):
+def test_cancelled_fast_reboot(request, add_fail_step_to_reboot, verify_dut_health, get_advanced_reboot):
     '''
     Negative fast reboot test case to verify DUT is left in stable state
     when fast reboot procedure abruptly ends.
@@ -51,7 +52,7 @@ def test_cancelled_fast_reboot(request, get_advanced_reboot, add_fail_step_to_re
 
 
 @pytest.mark.device_type('vs')
-def test_cancelled_warm_reboot(request, get_advanced_reboot, add_fail_step_to_reboot):
+def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_health, get_advanced_reboot):
     '''
     Negative warm reboot test case to verify DUT is left in stable state
     when warm reboot procedure abruptly ends.

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -3,12 +3,15 @@ import pytest
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
+from tests.platform_tests.verify_dut_health import verify_dut_health      # lgtm[py/unused-import]
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0')
 ]
 
+
+### Tetcases to verify normal reboot procedure ###
 @pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     '''
@@ -19,6 +22,7 @@ def test_fast_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     '''
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot')
     advancedReboot.runRebootTestcase()
+
 
 @pytest.mark.usefixtures('get_advanced_reboot')
 @pytest.mark.device_type('vs')
@@ -32,6 +36,34 @@ def test_warm_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
     advancedReboot.runRebootTestcase()
 
+
+### Testcases to verify abruptly failed reboot procedure ###
+def test_cancelled_fast_reboot(request, get_advanced_reboot, add_fail_step_to_reboot):
+    '''
+    Negative fast reboot test case to verify DUT is left in stable state
+    when fast reboot procedure abruptly ends.
+
+    @param request: Pytest request instance
+    @param get_advanced_reboot: advanced reboot test fixture
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='fast-reboot', allow_fail=True)
+    advancedReboot.runRebootTestcase()
+
+
+@pytest.mark.device_type('vs')
+def test_cancelled_warm_reboot(request, get_advanced_reboot, add_fail_step_to_reboot):
+    '''
+    Negative warm reboot test case to verify DUT is left in stable state
+    when warm reboot procedure abruptly ends.
+
+    @param request: Pytest request instance
+    @param get_advanced_reboot: advanced reboot test fixture
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_fail=True)
+    advancedReboot.runRebootTestcase()
+
+
+### Tetcases to verify reboot procedure with SAD cases ###
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad(request, get_advanced_reboot):
     '''
@@ -58,6 +90,7 @@ def test_warm_reboot_sad(request, get_advanced_reboot):
         prebootList=prebootList,
         prebootFiles='peer_dev_info,neigh_port_info'
     )
+
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_multi_sad(request, get_advanced_reboot):
@@ -95,6 +128,7 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
+
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
     '''
@@ -115,6 +149,7 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
         inbootList=inbootList,
         prebootFiles='peer_dev_info,neigh_port_info'
     )
+
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
@@ -137,6 +172,7 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot):
         prebootList=prebootList,
         prebootFiles='peer_dev_info,neigh_port_info'
     )
+
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
@@ -169,6 +205,7 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot):
         prebootFiles='peer_dev_info,neigh_port_info'
     )
 
+
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_lag(request, get_advanced_reboot):
     '''
@@ -190,6 +227,7 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot):
         prebootList=prebootList,
         prebootFiles='peer_dev_info,neigh_port_info'
     )
+
 
 @pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
 def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot):

--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -1,0 +1,150 @@
+import copy
+import pytest
+import logging
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.transceiver_utils import parse_transceiver_info
+
+test_report = dict()
+
+
+def handle_test_error(health_check):
+    def _wrapper(*args, **kwargs):
+        try:
+            health_check(*args, **kwargs)
+        except RebootHealthError as err:
+            # set result to fail
+            logging.error("Health check {} failed with {}".format(health_check.__name__, err.message))
+            test_report[health_check.__name__] = err.message
+            return
+        except Exception as err:
+            traceback.print_exc()
+            logging.error("Health check {} failed with unknown error: {}".format(health_check.__name__, str(err)))
+            test_report[health_check.__name__] = "Unkown error"
+            return
+        # set result to pass
+        test_report[health_check.__name__] = True
+    return _wrapper
+
+
+@handle_test_error
+def check_services(duthost):
+    """
+    Perform a health check of services
+    """
+    logging.info("Wait until all critical services are fully started")
+
+    logging.info("Check critical service status")
+    if not duthost.critical_services_fully_started():
+        raise RebootHealthError("dut.critical_services_fully_started is False")
+
+    for service in duthost.critical_services:
+        status = duthost.get_service_props(service)
+        if status["ActiveState"] != "active":
+            raise RebootHealthError("ActiveState of {} is {}, expected: active".format(service, status["ActiveState"]))
+        if status["SubState"] != "running":
+            raise RebootHealthError("SubState of {} is {}, expected: running".format(service, status["SubState"]))
+
+
+@handle_test_error
+def check_interfaces_and_transceivers(duthost, request):
+    """
+    Perform a check of transceivers, LAGs and interfaces status
+    @param dut: The AnsibleHost object of DUT.
+    @param interfaces: DUT's interfaces defined by minigraph
+    """
+    logging.info("Check if all the interfaces are operational")
+    check_interfaces = request.getfixturevalue("check_interfaces")
+    results = check_interfaces()
+    failed = [result for result in results if "failed" in result and result["failed"]]
+    if failed:
+        raise RebootHealthError("Interface check failed, not all interfaces are up. Failed: {}".format(failed))
+
+    # Skip this step for virtual testbed - KVM testbed has transeivers marked as "Not present"
+    # and the DB returns an "empty array" for "keys TRANSCEIVER_INFO*"
+    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        return
+
+    logging.info("Check whether transceiver information of all ports are in redis")
+    xcvr_info = duthost.command("redis-cli -n 6 keys TRANSCEIVER_INFO*")
+    parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
+    interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    for intf in interfaces:
+        if intf not in parsed_xcvr_info:
+            raise RebootHealthError("TRANSCEIVER INFO of {} is not found in DB".format(intf))
+
+
+@handle_test_error
+def check_neighbors(duthost, tbinfo):
+    """
+    Perform a BGP neighborship check.
+    """
+    logging.info("Check BGP neighbors status. Expected state - established")
+    bgp_facts = duthost.bgp_facts()['ansible_facts']
+    mg_facts  = duthost.get_extended_minigraph_facts(tbinfo)
+
+    for value in bgp_facts['bgp_neighbors'].values():
+        # Verify bgp sessions are established
+        if value['state'] != 'established':
+            raise RebootHealthError("BGP session not established")
+        # Verify locat ASNs in bgp sessions
+        if(value['local AS'] != mg_facts['minigraph_bgp_asn']):
+            raise RebootHealthError("Local ASNs not found in BGP session.\
+                Minigraph: {}. Found {}".format(value['local AS'], mg_facts['minigraph_bgp_asn']))
+    for v in mg_facts['minigraph_bgp']:
+        # Compare the bgp neighbors name with minigraph bgp neigbhors name
+        if(v['name'] != bgp_facts['bgp_neighbors'][v['addr'].lower()]['description']):
+            raise RebootHealthError("BGP neighbor's name does not match minigraph.\
+                Minigraph: {}. Found {}".format(v['name'], bgp_facts['bgp_neighbors'][v['addr'].lower()]['description']))
+        # Compare the bgp neighbors ASN with minigraph
+        if(v['asn'] != bgp_facts['bgp_neighbors'][v['addr'].lower()]['remote AS']):
+            raise RebootHealthError("BGP neighbor's ASN does not match minigraph.\
+                Minigraph: {}. Found {}".format(v['asn'], bgp_facts['bgp_neighbors'][v['addr'].lower()]['remote AS']))
+
+
+@handle_test_error
+def verify_no_coredumps(duthost, pre_existing_cores):
+    coredumps_count = duthost.shell('ls /var/core/ | wc -l')['stdout']
+    if int(coredumps_count) > int(pre_existing_cores):
+        raise RebootHealthError("Core dumps found. Expected: {} Found: {}".format(pre_existing_cores,\
+            coredumps_count))
+
+
+def wait_until_uptime(duthost, post_reboot_delay):
+    logging.info("Wait until DUT uptime reaches {}s".format(post_reboot_delay))
+    while duthost.get_uptime().total_seconds() < post_reboot_delay:
+        time.sleep(1)
+
+
+def get_test_report():
+    global test_report
+    result = copy.deepcopy(test_report)
+    test_report = dict()
+    return result
+
+
+@pytest.fixture(autouse=True)
+def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
+    test_report = {}
+    duthost = duthosts[rand_one_dut_hostname]
+    check_services(duthost)
+    check_interfaces_and_transceivers(duthost, request)
+    check_neighbors(duthost, tbinfo)
+    pre_existing_cores = duthost.shell('ls /var/core/ | wc -l')['stdout']
+    pytest_assert(all(list(test_report.values())), "DUT not ready for test. Health check failed before reboot: {}"
+        .format(test_report))
+
+    yield
+
+    test_report = {}
+    check_services(duthost)
+    check_interfaces_and_transceivers(duthost, request)
+    check_neighbors(duthost, tbinfo)
+    verify_no_coredumps(duthost, pre_existing_cores)
+    pytest_assert(all(list(test_report.values())), "Health check failed after reboot: {}"
+        .format(test_report))
+
+
+class RebootHealthError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super(RebootHealthError, self).__init__(message)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add two new negative testcases: `test_cancelled_fast_reboot` and `test_cancelled_warm_reboot` to verify that DUT remains functional if reboot procedure exits abruptly.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
To test the failure scenario when fast/warm reboot procedure abruptly stops. DUT should be left in stable state.

#### How did you do it?
Add an `exit` call before `set +e` in fast/warm reboot scripts.
This will allow the trap handler logic to be executed.
Verify stability of services, interfaces and neighbors - basically DUT remains in functional state.

#### How did you verify/test it?
Tested two new testcases - `test_cancelled_fast_reboot` and `test_cancelled_warm_reboot`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
