### PR TITLE
[dualtor]: Change acceptable traffic disruption time

### DIFF
--- a/tests/dualtor/test_heartbeat_failure.py
+++ b/tests/dualtor/test_heartbeat_failure.py
@@ -8,6 +8,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host  
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
 from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                                                                       # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
+from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
     pytest.mark.topology("dualtor")
@@ -23,7 +24,7 @@ def test_active_tor_heartbeat_failure_upstream(
     Confirm switchover and disruption lasts < 1 second.
     """
     send_server_to_t1_with_action(
-        upper_tor_host, verify=True, delay=1,
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
     verify_tor_states(
@@ -41,7 +42,7 @@ def test_active_tor_heartbeat_failure_downstream_active(
     Confirm switchover and disruption lasts < 1 second.
     """
     send_t1_to_server_with_action(
-        upper_tor_host, verify=True, delay=1,
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
     verify_tor_states(
@@ -59,7 +60,7 @@ def test_active_tor_heartbeat_failure_downstream_standby(
     Confirm switchover and disruption lasts < 1 second.
     """
     send_t1_to_server_with_action(
-        lower_tor_host, verify=True, delay=1,
+        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
     verify_tor_states(

--- a/tests/dualtor/test_link_drop.py
+++ b/tests/dualtor/test_link_drop.py
@@ -16,6 +16,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory
+from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
     pytest.mark.topology("dualtor")
@@ -93,7 +94,7 @@ def test_active_link_drop_upstream(
     send_server_to_t1_with_action(
         upper_tor_host,
         verify=True,
-        delay=1,
+        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=drop_flow_upper_tor
     )
     verify_tor_states(
@@ -118,7 +119,7 @@ def test_active_link_drop_downstream_active(
     send_t1_to_server_with_action(
         upper_tor_host,
         verify=True,
-        delay=1,
+        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=drop_flow_upper_tor
     )
     verify_tor_states(
@@ -143,7 +144,7 @@ def test_active_link_drop_downstream_standby(
     send_t1_to_server_with_action(
         lower_tor_host,
         verify=True,
-        delay=1,
+        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=drop_flow_upper_tor
     )
     verify_tor_states(


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/Azure/sonic-buildimage/issues/8080

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some dual ToR traffic tests have the allowed traffic disruption time set to 1 sec, which is not achievable with simulator cables

#### How did you do it?
Use the existing constant value MUX_SIM_ALLOWED_DISRUPTION_SEC

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
