### PR TITLE
[ test_pcied ] Fixed redis status table key value

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -37,7 +37,7 @@ SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
 SIG_KILL = "-9"
 
-pcie_devices_status_tbl_key = "PCIE_DEVICES|status"
+pcie_devices_status_tbl_key = "PCIE_DEVICES"
 status_field = "status"
 expected_pcied_devices_status = "PASSED"
 

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -37,7 +37,6 @@ SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
 SIG_KILL = "-9"
 
-pcie_devices_status_tbl_key = "PCIE_DEVICES"
 status_field = "status"
 expected_pcied_devices_status = "PASSED"
 
@@ -102,7 +101,13 @@ def check_daemon_status(duthosts, rand_one_dut_hostname):
         duthost.start_pmon_daemon(daemon_name)
         time.sleep(10)
 
-def test_pmon_pcied_running_status(duthosts, rand_one_dut_hostname):
+@pytest.fixture(scope="module", autouse=True)
+def get_pcie_devices_tbl_key(duthosts,rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    command_output = duthost.shell("redis-cli -n 6 keys '*' | grep PCIE_DEVICES")
+    return command_output["stdout"]
+
+def test_pmon_pcied_running_status(duthosts, rand_one_dut_hostname, get_pcie_devices_tbl_key):
     """
     @summary: This test case is to check pcied status on dut
     """
@@ -114,9 +119,9 @@ def test_pmon_pcied_running_status(duthosts, rand_one_dut_hostname):
     pytest_assert(daemon_pid != -1,
                           "Pcied expected pid is a positive integer but is {}".format(daemon_pid))
 
-    daemon_db_value = duthost.get_pmon_daemon_db_value(pcie_devices_status_tbl_key, status_field)
+    daemon_db_value = duthost.get_pmon_daemon_db_value(get_pcie_devices_tbl_key, status_field)
     pytest_assert(daemon_db_value == expected_pcied_devices_status,
-                          "Expected {} {} is {} but is {}".format(pcie_devices_status_tbl_key, status_field, expected_pcied_devices_status, daemon_db_value))
+                          "Expected {} {} is {} but is {}".format(get_pcie_devices_tbl_key, status_field, expected_pcied_devices_status, daemon_db_value))
 
 
 


### PR DESCRIPTION
Signed-off-by: Roman Savchuk <romanx.savchuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test test_pmon_pcied_running_status failed as daemon_db_value return empty string
#### How did you do it?
Changed `pcie_devices_status_tbl_key = "PCIE_DEVICES|status"` value  from `"PCIE_DEVICES|status"` to 'PCIE_DEVICES`
#### How did you verify/test it?
Run test, test_pmon_pcied_running_status passed
#### Any platform specific information?
`SONiC Software Version: SONiC.master.15330-dirty-20210516.082409
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: ea803257
Build date: Sun May 16 14:02:33 UTC 2021
Built by: AzDevOps@sonic-build-workers-0009PE

Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
ASIC Count: 1`
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
