### PR TITLE
[t0-56] test_sflow adaptation to t0-56 topology

### DIFF
--- a/ansible/roles/test/files/ptftests/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/sflow_test.py
@@ -209,7 +209,7 @@ class SflowTest(BaseTest):
     #---------------------------------------------------------------------------
 
     def sendTraffic(self):
-        self.src_ip_list = ['192.158.8.1','192.168.16.1', '192.168.24.1','192.168.32.1']
+        src_ip_addr_templ = '192.168.{}.1'
         ip_dst_addr = '192.168.0.4'
         src_mac = self.dataplane.get_mac(0, 0)
         pktlen=100
@@ -217,7 +217,7 @@ class SflowTest(BaseTest):
         for j in range(0, 100, 1):
             index = 0
             for intf in self.interfaces:
-                ip_src_addr = str(self.src_ip_list[index])
+                ip_src_addr = src_ip_addr_templ.format(str(8 * index))
                 src_port = self.interfaces[intf]['ptf_indices']
                 dst_port = self.dst_port
                 tcp_pkt = simple_tcp_packet(pktlen=pktlen,

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -356,9 +356,9 @@ class TestSflowInterface():
 
         verify_sflow_interfaces(duthost,sflow_int[0],'down',512)
         verify_sflow_interfaces(duthost,sflow_int[1],'down',512)
-        verify_sflow_interfaces(duthost,sflow_int[2],'up',512)
-        verify_sflow_interfaces(duthost,sflow_int[3],'up',512)
-        enabled_intf = sflow_int[2:4]
+        enabled_intf = sflow_int[2:]
+        for intf in enabled_intf:
+            verify_sflow_interfaces(duthost, intf, 'up', 512)
         partial_ptf_runner(
               enabled_sflow_interfaces=enabled_intf,
               active_collectors="['collector0','collector1']" )


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adaptation of sflow test to other topologies. 
Currently the test using static number of tested PortChannels - 4.
Added option to test dynamic number of LAGs.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Adaptation tests to t0-56

#### How did you do it?
Test changed to use dynamic number of interfaces

#### How did you verify/test it?
Manually run on t0 and t0-56 topologies

