### PR TITLE
Changing ipv6 loopback addresses on the linecards to be on different subnets and adding t2 as a supported topology in veos

### DIFF
--- a/ansible/vars/topo_t2-vs.yml
+++ b/ansible/vars/topo_t2-vs.yml
@@ -31,7 +31,7 @@ topology:
         - 10.1.0.2/32
       ipv6:
         - FC00:10::1/128
-        - FC00:10::2/128
+        - FC00:11::1/128
     vs_chassis:
       inband_port:
         - 30

--- a/ansible/vars/topo_t2.yml
+++ b/ansible/vars/topo_t2.yml
@@ -326,8 +326,8 @@ topology:
         - 10.1.0.3/32
       ipv6:
         - FC00:10::1/128
-        - FC00:10::2/128
-        - FC00:10::3/128
+        - FC00:11::1/128
+        - FC00:12::1/128
 
 configuration_properties:
   common:

--- a/ansible/veos
+++ b/ansible/veos
@@ -34,6 +34,7 @@ all:
           - tgen-t0-3
           - tgen-t1-3-lag
           - mgmttor
+          - t2
       children:
         server_1:
         server_2:


### PR DESCRIPTION





<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In t2 topology, we have 2 linecards, and we were assigning two different IPv6 addresses:

- fc00:10::1/128
- fc00:10::2/128

However, in bgpd.main.conf.j2 in sonic-buildimage (http://github.com/Azure/sonic-buildimage/blob/master/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2#L77), ipv6 Loopback0 addresses are using a 64 bit mask. Thus, the route to the Loopback0 address of the remote linecard was being masked by the local Loopback0 address and not pointing to the inband port.

#### How did you do it?

Fix for this is to use different subnets for each linecard. So, changing the Loopback0 addresses to:
- fc00:10::1/128
- fc00:11::1/128

Also, t2 topology was missing from veos as a supported topology

#### How did you verify/test it?

Ran voq suites in tests/voq directory with the changes above.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
