### PR TITLE
[mgmtvrf] curl test: prevent http server timeout

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -91,8 +91,8 @@ def execute_dut_command(duthost, command, mvrf=True, ignore_errors=False):
     result = {}
     prefix = ""
     if mvrf:
-        dut_kernel = duthost.setup()['ansible_facts']['ansible_kernel'].split('-')
-        if parse_version(dut_kernel[0]) > parse_version("4.9.0"):
+        dut_kernel = duthost.shell("cat /proc/version | awk '{ print $3 }' | cut -d '-' -f 1")["stdout"]
+        if parse_version(dut_kernel) > parse_version("4.9.0"):
             prefix = "sudo ip vrf exec mgmt "
         else:
             prefix = "sudo cgexec -g l3mdev:mgmt "


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
The `test_curl` starting `temp_http_server.py` script on ptf with timeout of 60 seconds.
In this time the test creating cli command and sending request to the http server.
But cli creation takes up to 80 seconds.
The change provide another way to get kernel version and reducing the time of cli creation to ~1 second only.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Bug fix

#### How did you do it?
N/A

#### How did you verify/test it?

- Run ` mvrf/test_mgmtvrf.py::TestMvrfOutbound::test_curl`

- Or run full test `mvrf/test_mgmtvrf.py`

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A