### PR TITLE
[advance-reboot] Add health check before and after fast/warm reboot

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -13,8 +13,8 @@ pytestmark = [
 
 
 ### Tetcases to verify normal reboot procedure ###
-@pytest.mark.usefixtures('get_advanced_reboot')
-def test_fast_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
+def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
+    advanceboot_loganalyzer):
     '''
     Fast reboot test case is run using advacned reboot test fixture
 
@@ -25,9 +25,9 @@ def test_fast_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
     advancedReboot.runRebootTestcase()
 
 
-@pytest.mark.usefixtures('get_advanced_reboot')
 @pytest.mark.device_type('vs')
-def test_warm_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
+def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
+    advanceboot_loganalyzer):
     '''
     Warm reboot test case is run using advacned reboot test fixture
 
@@ -39,7 +39,8 @@ def test_warm_reboot(request, get_advanced_reboot, advanceboot_loganalyzer):
 
 
 ### Testcases to verify abruptly failed reboot procedure ###
-def test_cancelled_fast_reboot(request, add_fail_step_to_reboot, verify_dut_health, get_advanced_reboot):
+def test_cancelled_fast_reboot(request, add_fail_step_to_reboot, verify_dut_health,
+    get_advanced_reboot):
     '''
     Negative fast reboot test case to verify DUT is left in stable state
     when fast reboot procedure abruptly ends.
@@ -52,7 +53,8 @@ def test_cancelled_fast_reboot(request, add_fail_step_to_reboot, verify_dut_heal
 
 
 @pytest.mark.device_type('vs')
-def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_health, get_advanced_reboot):
+def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_health,
+    get_advanced_reboot):
     '''
     Negative warm reboot test case to verify DUT is left in stable state
     when warm reboot procedure abruptly ends.
@@ -65,8 +67,8 @@ def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_heal
 
 
 ### Tetcases to verify reboot procedure with SAD cases ###
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad(request, get_advanced_reboot, advanceboot_neighbor_restore):
+def test_warm_reboot_sad(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path
 
@@ -93,8 +95,8 @@ def test_warm_reboot_sad(request, get_advanced_reboot, advanceboot_neighbor_rest
     )
 
 
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_multi_sad(request, get_advanced_reboot, advanceboot_neighbor_restore):
+def test_warm_reboot_multi_sad(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with multi sad path
 
@@ -130,8 +132,8 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot, advanceboot_neighbo
     )
 
 
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
+def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db):
     '''
     Warm reboot with multi sad path (during boot)
 
@@ -152,8 +154,8 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot):
     )
 
 
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_bgp(request, get_advanced_reboot, advanceboot_neighbor_restore):
+def test_warm_reboot_sad_bgp(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad (bgp)
 
@@ -175,8 +177,8 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot, advanceboot_neighbor_
     )
 
 
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, advanceboot_neighbor_restore):
+def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path (lag member)
 
@@ -207,8 +209,8 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, advanceboot_ne
     )
 
 
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_lag(request, get_advanced_reboot, advanceboot_neighbor_restore):
+def test_warm_reboot_sad_lag(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path (lag)
 
@@ -230,8 +232,8 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot, advanceboot_neighbor_
     )
 
 
-@pytest.mark.usefixtures('get_advanced_reboot', 'backup_and_restore_config_db')
-def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot):
+def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot, verify_dut_health,
+    backup_and_restore_config_db):
     '''
     Warm reboot with sad path (vlan port)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enhance device health check procedure in advance-reboot testcases.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add health checks before and after reboot testcases.
pre test check is needed to verify that the test starts in a healthy state, and to catch any issues that were caused by previous test.

Post test checks are needed as advanced-reboot script takes care of traffic (data/control plane) verification only. This new verification adds:
`check_services`
`check_interfaces_and_transceivers`
`check_neighbors`
`verify_no_coredumps`


#### How did you do it?
- Enabled an existing fixture `verify_dut_health` to test reboot_health for remaining advanced_reboot testcases.
- Removed `pytest.mark.usefixtures` as that usage is redundant if fixtures are specified as an argument.


#### How did you verify/test it?
Tested on KVM and physical device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
