### PR TITLE
[advance-reboot] Remove extra-verbose logging from ptf test

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -128,7 +128,6 @@ class Arista(object):
             # but wait for v4_routing_ok and v6_routing_ok
             if not quit_enabled:
                 cmd = self.queue.get()
-                self.log('Command received: cmd={}'.format(cmd))
                 if cmd == 'quit':
                     quit_enabled = True
                     continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove verbose logging (from neighbor eos) that was previously added to support debugging efforts.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The ptf log is over-populated now and reading it becomes cumbersome. Remove the extra logging statement from neighbor VMs. This logging isn't necessarily useful.

#### How did you do it?
Remove below repetitive logs from ptf test:

```
2021-07-15 21:15:34 : SSH thread VM=10.64.247.193: Command received: cmd=cpu_up
2021-07-15 21:15:34 : SSH thread VM=10.64.247.192: Command received: cmd=cpu_up
2021-07-15 21:15:34 : SSH thread VM=10.64.247.194: Command received: cmd=cpu_up
2021-07-15 21:15:35 : SSH thread VM=10.64.247.195: Command received: cmd=cpu_up
...
```
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
