### PR TITLE
[acl]: Import mock_server_base_ip_addr

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -112,7 +112,7 @@ def setup(duthosts, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
     topo = tbinfo["topo"]["type"]
 
     vlan_ports = []
-    vlan_mac = ""
+    vlan_mac = None
 
     if topo == "t0":
         vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
@@ -121,8 +121,8 @@ def setup(duthosts, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
         config_facts = rand_selected_dut.get_running_config_facts()
         vlan_table = config_facts["VLAN"]
         vlan_name = list(vlan_table.keys())[0]
-        vlan_mac = vlan_table[vlan_name]["mac"]
-
+        if "mac" in vlan_table[vlan_name]:
+            vlan_mac = vlan_table[vlan_name]["mac"]
 
     # Get the list of upstream/downstream ports
     downstream_ports = defaultdict(list)
@@ -134,7 +134,7 @@ def setup(duthosts, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
 
     # For T0/dual ToR testbeds, we need to use the VLAN MAC to interact with downstream ports
     # For T1 testbeds, no VLANs are present so using the router MAC is acceptable
-    downlink_dst_mac = vlan_mac if topo == "t0" else rand_selected_dut.facts["router_mac"]
+    downlink_dst_mac = vlan_mac if vlan_mac is not None else rand_selected_dut.facts["router_mac"]
 
     for interface, neighbor in mg_facts["minigraph_neighbors"].items():
         port_id = mg_facts["minigraph_ptf_indices"][interface]

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -21,6 +21,7 @@ from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_
 from tests.common.utilities import wait_until
 from tests.conftest import duthost
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Non dual-ToR testbeds running the ACL test will all error out due to a missing fixture `mock_server_base_ip_addr`

#### How did you do it?
Import the fixture

#### How did you verify/test it?
Run the tests on T0, T1, and dual ToR testbeds and make sure that tests did not error out due to the missing fixture
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
