### PR TITLE
Fix case sensitive issue for test_show_platform_syseeprom

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -130,13 +130,14 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
         for line in syseeprom_output_lines[6:]:
             t1 = regex_int.match(line)
             if t1:
-                parsed_syseeprom[t1.group(2).strip()] = t1.group(4).strip()
+                tlv_code_lower_case = t1.group(2).strip().lower()
+                parsed_syseeprom[tlv_code_lower_case] = t1.group(4).strip()
 
         for field in expected_syseeprom_info_dict:
-            pytest_assert(field in parsed_syseeprom, "Expected field '{}' not present in syseeprom on '{}'".format(field, duthost.hostname))
-            pytest_assert(parsed_syseeprom[field] == expected_syseeprom_info_dict[field],
+            pytest_assert(field.lower() in parsed_syseeprom, "Expected field '{}' not present in syseeprom on '{}'".format(field, duthost.hostname))
+            pytest_assert(parsed_syseeprom[field.lower()] == expected_syseeprom_info_dict[field],
                           "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
-                          format(field, parsed_syseeprom[field], expected_syseeprom_info_dict[field], duthost.hostname))
+                          format(field, parsed_syseeprom[field.lower()], expected_syseeprom_info_dict[field], duthost.hostname))
 
     if duthost.facts["asic_type"] in ["mellanox"]:
         expected_fields = [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In test_show_platform_syseeprom, we can get the syseeprom from two ways. One is from  show platform syseeprom like below, and please see the Code column which is upper case:
```
show platform syseeprom 
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 627
TLV Name             Code Len Value
-------------------- ---- --- -----
Product Name         0x21  64 MSN4410
Part Number          0x22  20 MSN4410-WS2FO
Serial Number        0x23  24 MT2039X06760
Base MAC Address     0x24   6 1C:34:DA:23:45:00
Manufacture Date     0x25  19 09/23/2020 19:26:56
Device Version       0x26   1 0
Platform Name        0x28  64 x86_64-mlnx_msn4410-r0
ONIE Version         0x29  21 2020.11-5.3.0005-9600
MAC Addresses        0x2A   2 254
Manufacturer         0x2B   8 Mellanox
Vendor Extension     0xFD  36 
Vendor Extension     0xFD 164 
Vendor Extension     0xFD  36 
Vendor Extension     0xFD  36 
Vendor Extension     0xFD  36 
Vendor Extension     0xFD  52 
CRC-32               0xFE   4 0x108A42F6
```
The other one is from dut_vars like below, and please see the key which is lower case:
`{'0x28': u'x86_64-mlnx_msn4410-r0', '0x29': u'2020.11-5.3.0005-9600', '0x22': u'MSN4410-WS2FO', '0x23': u'MT2039X06760', '0x21': u'MSN4410', '0x26': u'0', '0x24': u'1C:34:DA:23:45:00', '0x25': u'09/23/2020 19:26:56', '0xfe': u'0x108A42F6', '0x2b': u'Mellanox', '0x2a': u'254'}`

So when compare the code key like follow, it will fail.
 ```
  for field in expected_syseeprom_info_dict:
            pytest_assert(field in parsed_syseeprom, "Expected field '{}' not present in syseeprom on '{}'".format(field, duthost.hostname))
```

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix case sensitive issue for test_show_platform_syseeprom

#### How did you do it?
Transfer the all code to lower case.

#### How did you verify/test it?
Run test:  test_show_platform_summary
For example:
`py.test platform_tests/cli/test_show_platform.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern  r-lionfish-13 --module-path                ../ansible/library/ --testbed r-lionfish-13-any --testbed_file ../ansible/testbed.csv                --allow_recover                --junit-xml junit_7_0.10.1.1.1.1.1.3.1.1.1.xml --assert plain --log-cli-level debug --show-capture=no -ra --showlocals `

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
