### PR TITLE
[pytest] Fix the fast failure when checking the format of Monit alerting message

### DIFF
--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -36,14 +36,14 @@ def stop_and_start_lldpmgrd(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
     stop_command_result = duthost.command("docker exec lldp supervisorctl stop lldpmgrd")
     exit_code = stop_command_result["rc"]
     pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in 'lldp' container!")
-    logger.info("'lldpmgrd' process in 'lldp' container was stopped.")
+    logger.info("'lldpmgrd' process in 'lldp' container is stopped.")
 
     if duthost.is_multi_asic:
         logger.info("Stopping 'lldpmgrd' process in 'lldp0' container ...")
         stop_command_result = duthost.command("docker exec lldp0 supervisorctl stop lldpmgrd")
         exit_code = stop_command_result["rc"]
         pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in 'lldp0' container!")
-        logger.info("'lldpmgrd' process in 'lldp0' container was stopped.")
+        logger.info("'lldpmgrd' process in 'lldp0' container is stopped.")
 
     yield
 
@@ -51,14 +51,14 @@ def stop_and_start_lldpmgrd(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
     start_command_result = duthost.command("docker exec lldp supervisorctl start lldpmgrd")
     exit_code = start_command_result["rc"]
     pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in 'lldp' container!")
-    logger.info("'lldpmgrd' process in 'lldp' container was started.")
+    logger.info("'lldpmgrd' process in 'lldp' container is started.")
 
     if duthost.is_multi_asic:
-        logger.info("Stopping 'lldpmgrd' process in 'lldp0' container ...")
+        logger.info("Starting 'lldpmgrd' process in 'lldp0' container ...")
         start_command_result = duthost.command("docker exec lldp0 supervisorctl start lldpmgrd")
         exit_code = start_command_result["rc"]
         pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in 'lldp0' container!")
-        logger.info("'lldpmgrd' process in 'lldp0' container was started.")
+        logger.info("'lldpmgrd' process in 'lldp0' container is started.")
 
 
 def check_monit_last_output(duthost):

--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -19,7 +19,7 @@ pytestmark = [
 
 
 @pytest.fixture
-def disable_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def stop_and_start_lldpmgrd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Stops `lldpmgrd` process at setup stage and restarts it at teardwon.
 
     Args:
@@ -31,13 +31,34 @@ def disable_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         None.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    duthost.command("docker exec lldp supervisorctl stop lldpmgrd")
+
+    logger.info("Stopping 'lldpmgrd' process in 'lldp' container ...")
+    stop_command_result = duthost.command("docker exec lldp supervisorctl stop lldpmgrd")
+    exit_code = stop_command_result["rc"]
+    pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in 'lldp' container!")
+    logger.info("'lldpmgrd' process in 'lldp' container was stopped.")
+
     if duthost.is_multi_asic:
-        duthost.command("docker exec lldp0 supervisorctl stop lldpmgrd")
+        logger.info("Stopping 'lldpmgrd' process in 'lldp0' container ...")
+        stop_command_result = duthost.command("docker exec lldp0 supervisorctl stop lldpmgrd")
+        exit_code = stop_command_result["rc"]
+        pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in 'lldp0' container!")
+        logger.info("'lldpmgrd' process in 'lldp0' container was stopped.")
+
     yield
-    duthost.command("docker exec lldp supervisorctl start lldpmgrd")
+
+    logger.info("Starting 'lldpmgrd' process in 'lldp' container ...")
+    start_command_result = duthost.command("docker exec lldp supervisorctl start lldpmgrd")
+    exit_code = start_command_result["rc"]
+    pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in 'lldp' container!")
+    logger.info("'lldpmgrd' process in 'lldp' container was started.")
+
     if duthost.is_multi_asic:
-        duthost.command("docker exec lldp0 supervisorctl start lldpmgrd")
+        logger.info("Stopping 'lldpmgrd' process in 'lldp0' container ...")
+        start_command_result = duthost.command("docker exec lldp0 supervisorctl start lldpmgrd")
+        exit_code = start_command_result["rc"]
+        pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in 'lldp0' container!")
+        logger.info("'lldpmgrd' process in 'lldp0' container was started.")
 
 
 def check_monit_last_output(duthost):
@@ -62,7 +83,7 @@ def check_monit_last_output(duthost):
         else:
             return "/usr/bin/lldpmgrd' is not running in host" in monit_last_output
     else:
-        pytest.fail("Failed to get Monit last output of process 'lldpmgrd'!")
+        return False
 
 
 def test_monit_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
@@ -76,16 +97,21 @@ def test_monit_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     Returns:
         None.
     """
+    logger.info("Checking the running status of Monit ...")
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
     def _monit_status():
         monit_status_result = duthost.shell("sudo monit status", module_ignore_errors=True)
         return monit_status_result["rc"] == 0
-    # Monit is configured with start delay = 300s, hence we wait up to 320s here 
-    pytest_assert(wait_until(320, 20, _monit_status), 
-                    "Monit is either not running or not configured correctly")
+    # Monit is configured with start delay = 300s, hence we wait up to 320s here
+    pytest_assert(wait_until(320, 20, _monit_status),
+                  "Monit is either not running or not configured correctly")
+
+    logger.info("Checking the running status of Monit was done!")
 
 
-def test_monit_reporting_message(duthosts, enum_rand_one_per_hwsku_frontend_hostname, disable_lldp):
+def test_monit_reporting_message(duthosts, enum_rand_one_per_hwsku_frontend_hostname, stop_and_start_lldpmgrd):
     """Checks whether the format of alerting message from Monit is correct or not.
        202012 and newer image version will be skipped for testing since Supervisord
        replaced Monit to do the monitoring critical processes.
@@ -105,5 +131,9 @@ def test_monit_reporting_message(duthosts, enum_rand_one_per_hwsku_frontend_host
     pytest_require("201811" in duthost.os_version or "201911" in duthost.os_version,
                    "Test is not supported for 202012 and newer image versions!")
 
-    if not wait_until(180, 60, check_monit_last_output, duthost):
-        pytest.fail("Expected Monit reporting message not found")
+    logger.info("Checking the format of Monit alerting message ...")
+
+    pytest_assert(wait_until(180, 60, check_monit_last_output, duthost),
+                  "Expected Monit reporting message not found")
+
+    logger.info("Checking the format of Monit alerting message was done!")


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ x] 201911

### Approach
#### What is the motivation for this PR?
This PR aims to fix the fast failure issue when checking the format of Monit alerting message. Initially `check_monit_last_output(...)` was called by `wait_until(...)` to continuously check whether the format of Monit alerting message was correct or not. If the Monit alerting message was not found, this script should return false instead of failing this test directly.

#### How did you do it?
I replaced the statement `pytest.fail(...)` in the function `check_monit_last_output(...)` with `return False`. At the same time, some logging statements are added in order to show what action was done during testing.

#### How did you verify/test it?
I test this change on the DuT `str-msn2700-22`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
