### PR TITLE
[install] make swapfile creating more reliable

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -69,7 +69,7 @@ def setup_swap_if_necessary(module):
     if total < 2048 or avail < 1200:
         # Memory size or available amount is low, there is risk of OOM during new
         # image installation. Create a temporary swap file.
-        exec_command(module, cmd="sudo rm -f {0}; sudo fallocate -l 1G {0}; sudo chmod 600 {0}; sudo mkswap {0}; sudo swapon {0}".format('/host/swapfile'),
+        exec_command(module, cmd="if [[ -f {0} ]]; then sudo swapoff {0}; sudo rm -f {0}; fi; sudo fallocate -l 1G {0}; sudo chmod 600 {0}; sudo mkswap {0}; sudo swapon {0}".format('/host/swapfile'),
                      msg="Create a temporary swap file")
 
 


### PR DESCRIPTION
### Description of PR
Summary:

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Device has swapfile enabled already will encounter failure when creating/enabling swapfile again.

#### How did you do it?
Add protection so that the swapfile will be enabled successfully again.

#### How did you verify/test it?
Executed the new command on the DUT with swapfile created and enabled a few times and check final error code to be 0.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

