### PR TITLE
Set critical service list for a supervisor card based on number of SFMs in a VoQ chassis

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -16,6 +16,7 @@ class SonicAsic(object):
     """
 
     _DEFAULT_ASIC_SERVICES =  ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
+    _DEFAULT_SUPERVISOR_ASIC_SERVICES = ["database", "lldp", "swss", "syncd"]
     _MULTI_ASIC_SERVICE_NAME = "{}@{}"   # service name, asic_id
     _MULTI_ASIC_DOCKER_NAME = "{}{}"     # docker name,  asic_id
 
@@ -53,9 +54,11 @@ class SonicAsic(object):
             [list]: list of the services running the namespace/asic
         """
         a_service = []
-        for service in self._DEFAULT_ASIC_SERVICES:
-           a_service.append("{}{}".format(
-               service, self.asic_index if self.sonichost.is_multi_asic else ""))
+        asic_services = self._DEFAULT_ASIC_SERVICES
+        if self.sonichost.is_supervisor_node() and self.sonichost.get_facts()['asic_type'] != 'vs':
+            asic_services = self._DEFAULT_SUPERVISOR_ASIC_SERVICES
+        for service in asic_services:
+            a_service.append("{}{}".format(service, self.asic_index if self.sonichost.is_multi_asic else ""))
         return a_service
 
     def is_it_frontend(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

On a supervisor card in a VoQ Chassis, we need to 
- dynamically figure out the critical services (dockers) on a supervisor card based on the SFM's present in the chassis
- Not include bgp and teamd dockers for the SFM asic instances in the critical services.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
- On a supervisor card, we have the global dockers pmon, lldp, database, and snmp. For each Switch Fabric (SF) card in a VoQ Chassis, there could be n number of asics per card - where n is vendor specific. However, whether the asic instance is created (syncd/swss etc. dockers are started) for a SF card only if that SF is present/online.

    For example, if a chassis supports max 8 SFM's and 2 asics per SFM, then we would expect 16 asic instances. But if the chassis only 2 out of max 8 SFM's, then we would only have 4 asic instances.

   So, we need to dynamically figure out which asic instances would be present based on the number of SFM's that are present and also in which slot they are present.

- Another difference on asics on supervisor card is that there would be no 'bgp' and 'teamd' dockers created as there are no BGP sessions and ports on a SFM.

#### How did you do it?
The created/active asics on a supervisor card is derived by querying the chassis db using the following command
```
    redis-cli -h 10.0.5.16 -p 6380 -n 13  keys "CHASSIS_ASIC_TABLE|asic*"
```

The output of this gives a line per asic that is created/active.

```  
   1) "CHASSIS_ASIC_TABLE|asic4"
   2) "CHASSIS_ASIC_TABLE|asic5"
   3) "CHASSIS_ASIC_TABLE|asic7"
   4) "CHASSIS_ASIC_TABLE|asic10"
   5) "CHASSIS_ASIC_TABLE|asic15"
   6) "CHASSIS_ASIC_TABLE|asic12"
   7) "CHASSIS_ASIC_TABLE|asic9"
   8) "CHASSIS_ASIC_TABLE|asic13"
   9) "CHASSIS_ASIC_TABLE|asic6"
   10) "CHASSIS_ASIC_TABLE|asic14"
   11) "CHASSIS_ASIC_TABLE|asic8"
   12) "CHASSIS_ASIC_TABLE|asic11"
```

To not include 'bgp' and 'teamd' in the ciritical service list, sonic_asic.get_critical_services uses newly added _DEFAULT_SUPERVISOR_ASIC_SERVICES list instead of _DEFAULT_ASIC_SERVICES if we are a supervisor card.


#### How did you verify/test it?
Ran sanity check on a supervisor card with all SFM's present and also on a supervisor card with only 1 SFM present.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
