### PR TITLE
[http copy] skip test until the issue is addressed

### DIFF
--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -16,6 +16,8 @@ HTTP_PORT = "8080"
 def test_http_copy(duthosts, rand_one_dut_hostname, ptfhost):
     """Test that HTTP (copy) can be used to download objects to the DUT"""
 
+    pytest.skip("---- test causes ptf docker to crash after the test is done, skipping until the issue is addressed")
+
     duthost = duthosts[rand_one_dut_hostname]
     ptf_ip = ptfhost.mgmt_ip
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -179,6 +179,7 @@ test_t1_lag() {
     bgp/test_bgp_bounce.py \
     bgp/test_bgp_update_timer.py \
     bgp/test_traffic_shift.py \
+    http/test_http_copy.py \
     lldp/test_lldp.py \
     route/test_default_route.py \
     platform_tests/test_cpu_memory_usage.py \


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
http copy test causes PTF docker to crash after the test, which then will cause all test cases running afterwards to fail if they requires ptf access.

#### How did you do it?
Skip test until the issue is addressed.

Adding this test to the KVM test list so that it will have to pass the test before being enabled again.

#### How did you verify/test it?
Run test to make sure it is skipped.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
