### PR TITLE
[test_pfcwd_function] Enable storage backend topologies

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -2,8 +2,9 @@ import logging
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from .files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 
@@ -162,7 +163,6 @@ def setup_pfc_test(
 
     # set poll interval
     duthost.command("pfcwd interval {}".format(setup_info['pfc_timers']['pfc_wd_poll_time']))
-
     yield setup_info
 
     logger.info("--- Starting Pfcwd ---")

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -192,13 +192,15 @@ class TrafficPorts(object):
         vlan_members = vlan_details['members']
         vlan_type = vlan_details.get('type')
         vlan_id = vlan_details['vlanid']
+        rx_port = self.pfc_wd_rx_port if isinstance(self.pfc_wd_rx_port, list) else [self.pfc_wd_rx_port]
+        rx_port_id = self.pfc_wd_rx_port_id if isinstance(self.pfc_wd_rx_port_id, list) else [self.pfc_wd_rx_port_id]
         for item in vlan_members:
             temp_ports[item] = {'test_neighbor_addr': self.vlan_nw,
-                                'rx_port': self.pfc_wd_rx_port,
+                                'rx_port': rx_port,
                                 'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
                                 'peer_device': self.neighbors[item]['peerdevice'],
                                 'test_port_id': self.port_idx_info[item],
-                                'rx_port_id': self.pfc_wd_rx_port_id,
+                                'rx_port_id': rx_port_id,
                                 'test_port_type': 'vlan'
                                }
             if hasattr(self, 'pfc_wd_rx_port_vlan_id'):

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -1,6 +1,9 @@
 import datetime
 import ipaddress
 
+from tests.common import constants
+
+
 class TrafficPorts(object):
     """ Generate a list of ports needed for the PFC Watchdog test"""
     def __init__(self, mg_facts, neighbors, vlan_nw):
@@ -35,6 +38,8 @@ class TrafficPorts(object):
             self.parse_intf_list()
         elif self.mg_facts['minigraph_portchannels']:
             self.parse_pc_list()
+        elif 'minigraph_vlan_sub_interfaces' in self.mg_facts:
+            self.parse_vlan_sub_interface_list()
         if self.mg_facts['minigraph_vlans']:
             self.test_ports.update(self.parse_vlan_list())
         return self.test_ports
@@ -183,7 +188,10 @@ class TrafficPorts(object):
             temp_ports (dict): port info constructed from the vlan interfaces
         """
         temp_ports = dict()
-        vlan_members = self.vlan_info[self.vlan_info.keys()[0]]['members']
+        vlan_details = self.vlan_info.values()[0]
+        vlan_members = vlan_details['members']
+        vlan_type = vlan_details.get('type')
+        vlan_id = vlan_details['vlanid']
         for item in vlan_members:
             temp_ports[item] = {'test_neighbor_addr': self.vlan_nw,
                                 'rx_port': self.pfc_wd_rx_port,
@@ -193,8 +201,71 @@ class TrafficPorts(object):
                                 'rx_port_id': self.pfc_wd_rx_port_id,
                                 'test_port_type': 'vlan'
                                }
+            if hasattr(self, 'pfc_wd_rx_port_vlan_id'):
+                temp_ports[item]['rx_port_vlan_id'] = self.pfc_wd_rx_port_vlan_id
+            if vlan_type is not None and vlan_type == 'Tagged':
+                temp_ports[item]['test_port_vlan_id'] = vlan_id
 
         return temp_ports
+
+    def parse_vlan_sub_interface_list(self):
+        """Build the port info from the vlan sub-interfaces."""
+        pfc_wd_test_port = None
+        first_pair = False
+        for sub_intf in self.mg_facts['minigraph_vlan_sub_interfaces']:
+            if ipaddress.ip_address(unicode(sub_intf['addr'])).version != 4:
+                continue
+            intf_name, vlan_id = sub_intf['attachto'].split(constants.VLAN_SUB_INTERFACE_SEPARATOR)
+            # first port
+            if not self.pfc_wd_rx_port:
+                self.pfc_wd_rx_port = intf_name
+                self.pfc_wd_rx_port_addr = sub_intf['addr']
+                self.pfc_wd_rx_port_id = self.port_idx_info[self.pfc_wd_rx_port]
+                self.pfc_wd_rx_port_vlan_id = vlan_id
+            elif not pfc_wd_test_port:
+                # second port
+                first_pair = True
+
+            # populate info for all ports except the first one
+            if first_pair or pfc_wd_test_port:
+                pfc_wd_test_port = intf_name
+                pfc_wd_test_port_addr = sub_intf['addr']
+                pfc_wd_test_port_id = self.port_idx_info[pfc_wd_test_port]
+                pfc_wd_test_neighbor_addr = None
+
+                for item in self.bgp_info:
+                    if ipaddress.ip_address(unicode(item['addr'])).version != 4:
+                        continue
+                    if not self.pfc_wd_rx_neighbor_addr and item['peer_addr'] == self.pfc_wd_rx_port_addr:
+                        self.pfc_wd_rx_neighbor_addr = item['addr']
+                    if item['peer_addr'] == pfc_wd_test_port_addr:
+                        pfc_wd_test_neighbor_addr = item['addr']
+
+                self.test_ports[pfc_wd_test_port] = {'test_neighbor_addr': pfc_wd_test_neighbor_addr,
+                                                     'rx_port': [self.pfc_wd_rx_port],
+                                                     'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
+                                                     'peer_device': self.neighbors[pfc_wd_test_port]['peerdevice'],
+                                                     'test_port_id': pfc_wd_test_port_id,
+                                                     'rx_port_id': [self.pfc_wd_rx_port_id],
+                                                     'rx_port_vlan_id': self.pfc_wd_rx_port_vlan_id,
+                                                     'test_port_vlan_id': vlan_id,
+                                                     'test_port_type': 'interface'
+                                                    }
+            # populate info for the first port
+            if first_pair:
+                self.test_ports[self.pfc_wd_rx_port] = {'test_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
+                                                        'rx_port': [pfc_wd_test_port],
+                                                        'rx_neighbor_addr': pfc_wd_test_neighbor_addr,
+                                                        'peer_device': self.neighbors[self.pfc_wd_rx_port]['peerdevice'],
+                                                        'test_port_id': self.pfc_wd_rx_port_id,
+                                                        'rx_port_id': [pfc_wd_test_port_id],
+                                                        'rx_port_vlan_id': vlan_id,
+                                                        'test_port_vlan_id': self.pfc_wd_rx_port_vlan_id,
+                                                        'test_port_type': 'interface'
+                                                       }
+
+            first_pair = False
+
 
 def set_pfc_timers():
     """

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -12,6 +12,9 @@ from .files.pfcwd_helper import start_wd_on_ports
 from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
 
+
+PTF_PORT_MAPPING_MODE = 'use_orig_interface'
+
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
 EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
@@ -293,6 +296,8 @@ class SetupPfcwdFunc(object):
             self.pfc_wd['test_port_ids'] = self.ports[port]['test_portchannel_members']
         elif self.pfc_wd['port_type'] in ["vlan", "interface"]:
             self.pfc_wd['test_port_ids'] = self.pfc_wd['test_port_id']
+        self.pfc_wd['test_port_vlan_id'] = self.ports[port].get('test_port_vlan_id')
+        self.pfc_wd['rx_port_vlan_id'] = self.ports[port].get('rx_port_vlan_id')
         self.queue_oid = self.dut.get_queue_oid(port, self.pfc_wd['queue_index'])
 
     def update_queue(self, port):
@@ -409,6 +414,8 @@ class SendVerifyTraffic():
         self.pfc_wd_test_port_ids = pfc_params['test_port_ids']
         self.pfc_wd_test_neighbor_addr = pfc_params['test_neighbor_addr']
         self.pfc_wd_rx_neighbor_addr = pfc_params['rx_neighbor_addr']
+        self.pfc_wd_test_port_vlan_id = pfc_params['test_port_vlan_id']
+        self.pfc_wd_rx_port_vlan_id = pfc_params['test_port_vlan_id']
         self.port_type = pfc_params['port_type']
 
     def verify_tx_egress(self, action):
@@ -431,6 +438,10 @@ class SendVerifyTraffic():
                       'ip_dst': self.pfc_wd_test_neighbor_addr,
                       'port_type': self.port_type,
                       'wd_action': action}
+        if self.pfc_wd_rx_port_vlan_id is not None:
+            ptf_params['port_src_vlan_id'] = self.pfc_wd_rx_port_vlan_id
+        if self.pfc_wd_test_port_vlan_id is not None:
+            ptf_params['port_dst_vlan_id'] = self.pfc_wd_test_port_vlan_id
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
@@ -457,6 +468,10 @@ class SendVerifyTraffic():
                       'ip_dst': self.pfc_wd_rx_neighbor_addr,
                       'port_type': self.port_type,
                       'wd_action': action}
+        if self.pfc_wd_rx_port_vlan_id is not None:
+            ptf_params['port_dst_vlan_id'] = self.pfc_wd_rx_port_vlan_id
+        if self.pfc_wd_test_port_vlan_id is not None:
+            ptf_params['port_src_vlan_id'] = self.pfc_wd_test_port_vlan_id
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
@@ -485,6 +500,10 @@ class SendVerifyTraffic():
                       'ip_dst': self.pfc_wd_test_neighbor_addr,
                       'port_type': self.port_type,
                       'wd_action': 'forward'}
+        if self.pfc_wd_rx_port_vlan_id is not None:
+            ptf_params['port_src_vlan_id'] = self.pfc_wd_rx_port_vlan_id
+        if self.pfc_wd_test_port_vlan_id is not None:
+            ptf_params['port_dst_vlan_id'] = self.pfc_wd_test_port_vlan_id
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
@@ -513,6 +532,10 @@ class SendVerifyTraffic():
                       'ip_dst': self.pfc_wd_rx_neighbor_addr,
                       'port_type': self.port_type,
                       'wd_action': 'forward'}
+        if self.pfc_wd_rx_port_vlan_id is not None:
+            ptf_params['port_dst_vlan_id'] = self.pfc_wd_rx_port_vlan_id
+        if self.pfc_wd_test_port_vlan_id is not None:
+            ptf_params['port_src_vlan_id'] = self.pfc_wd_test_port_vlan_id
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
@@ -531,6 +554,10 @@ class SendVerifyTraffic():
                       'ip_dst': self.pfc_wd_test_neighbor_addr,
                       'port_type': self.port_type,
                       'wd_action': 'dontcare'}
+        if self.pfc_wd_rx_port_vlan_id is not None:
+            ptf_params['port_src_vlan_id'] = self.pfc_wd_rx_port_vlan_id
+        if self.pfc_wd_test_port_vlan_id is not None:
+            ptf_params['port_dst_vlan_id'] = self.pfc_wd_test_port_vlan_id
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -418,7 +418,7 @@ class SendVerifyTraffic():
         self.pfc_wd_test_neighbor_addr = pfc_params['test_neighbor_addr']
         self.pfc_wd_rx_neighbor_addr = pfc_params['rx_neighbor_addr']
         self.pfc_wd_test_port_vlan_id = pfc_params['test_port_vlan_id']
-        self.pfc_wd_rx_port_vlan_id = pfc_params['test_port_vlan_id']
+        self.pfc_wd_rx_port_vlan_id = pfc_params['rx_port_vlan_id']
         self.port_type = pfc_params['port_type']
 
     def verify_tx_egress(self, action):

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -11,6 +11,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from .files.pfcwd_helper import start_wd_on_ports
 from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
+from tests.common import constants
 
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
@@ -354,8 +355,10 @@ class SetupPfcwdFunc(object):
         """
         if self.pfc_wd['port_type'] == "vlan":
             self.ptf.script("./scripts/remove_ip.sh")
-            self.ptf.command("ifconfig eth{} {}".format(self.pfc_wd['test_port_id'],
-                                                        self.pfc_wd['test_neighbor_addr']))
+            ptf_port = 'eth%s' % self.pfc_wd['test_port_id']
+            if self.pfc_wd['test_port_vlan_id'] is not None:
+                ptf_port += (constants.VLAN_SUB_INTERFACE_SEPARATOR + self.pfc_wd['test_port_vlan_id'])
+            self.ptf.command("ifconfig {} {}".format(ptf_port, self.pfc_wd['test_neighbor_addr']))
             self.ptf.command("ping {} -c 10".format(vlan['addr']))
             self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3848

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enable `test_pfcwd_function` over storage backend topologies.

#### How did you do it?
1. Support parsing sub-interfaces to get test IO ports.
2. Enable ptftest `pfc_wd.py` to send VLAN tagged packets with priority.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you verify/test it?
run `test_pfcwd_function` over `t0-backend`, `t1-backend` and other topos.
* `t1-backend`
```
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[None] PASSED                                                                                                                              [ 33%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[None] PASSED                                                                                                                           [ 66%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[None] PASSED                                                                                                                          [100%]

=============================================================================================== warnings summary ================================================================================================
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[None]
  /usr/local/lib/python2.7/dist-packages/pytest_ansible-2.2.2-py2.7.egg/pytest_ansible/module_dispatcher/v28.py:70: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================================================================== 3 passed, 1 warnings in 523.71 seconds =====================================================================================
```
* `t0-backend`
```
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[None] PASSED                                                                                                                              [ 33%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[None] PASSED                                                                                                                           [ 66%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[None] PASSED                                                                                                                          [100%]

=============================================================================================== warnings summary ================================================================================================
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[None]
  /usr/local/lib/python2.7/dist-packages/pytest_ansible-2.2.2-py2.7.egg/pytest_ansible/module_dispatcher/v28.py:70: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================================================================== 3 passed, 1 warnings in 861.31 seconds =====================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
