### PR TITLE
added EOS fanouts support for port autoneg tests

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -1,6 +1,7 @@
 import ipaddress
 import json
 import logging
+import re
 
 from tests.common.devices.base import AnsibleHostBase
 
@@ -183,4 +184,88 @@ class EosHost(AnsibleHostBase):
         return self.eos_command(commands=[{
             'command': '{} {}'.format(cmd, prefix),
             'output': 'json'
-        }])['stdout'][0]
+        }])['stdout'][0]        
+
+    def _raise_err(msg):
+        logger.error(msg)
+        raise Exception(msg)
+
+    def get_auto_negotiation_mode(self, interface_name):
+        output = self.eos_command(commands=[{
+            'command': 'show interfaces %s status' % interface_name,
+            'output': 'json'
+        }])
+        if self._has_cli_cmd_failed(output):
+            _raise_err('Failed to get auto neg state for {}: {}'.format(interface_name, output['msg']))
+        autoneg_enabled = output['stdout'][0]['interfaceStatuses'][interface_name]['autoNegotiateActive']
+        return autoneg_enabled
+
+    def _reset_port_speed(self, interface_name):
+        out = self.eos_config(
+                lines=['default speed'],
+                parents=['interface {}'.format(interface_name)])
+        logger.debug('Reset port speed for %s: %s' % (interface_name, out))
+        return not self._has_cli_cmd_failed(out)
+
+    def set_auto_negotiation_mode(self, interface_name, enabled):
+        if self.get_auto_negotiation_mode(interface_name) == enabled:
+            return True
+        
+        if enabled:
+            speed_to_advertise = self.get_supported_speeds(interface_name)[-1]
+            speed_to_advertise = speed_to_advertise[:-3] + 'gfull'
+            out = self.eos_config(
+                lines=['speed auto %s' % speed_to_advertise],
+                parents=['interface {}'.format(interface_name)])
+            logger.debug('Set auto neg to {} for port {}: {}'.format(enabled, interface_name, out))
+            return not self._has_cli_cmd_failed(out)
+        return self._reset_port_speed(interface_name)
+        
+        
+    def get_speed(self, interface_name):
+        output = self.eos_command(commands=['show interfaces %s transceiver properties' % interface_name])
+        found_txt = re.search(r'Operational Speed: (\S+)', output['stdout'][0])
+        if found_txt == None:
+            _raise_err('Not able to extract interface %s speed from output: %s' % (interface_name, output['stdout']))
+
+        v = found_txt.groups()[0]
+        return v[:-1] + '000'
+
+    def _has_cli_cmd_failed(self, cmd_output_obj):
+        return 'failed' in cmd_output_obj and cmd_output_obj['failed']
+
+    def set_speed(self, interface_name, speed):
+        
+        if not speed:
+            # other set_speed implementations advertise port speeds when speed=None
+            # but in EOS autoneg activation and speeds advertisement is done via a single CLI cmd
+            # so this branch left nop intentionally
+            return True
+            
+        speed = speed[:-3] + 'gfull'
+        out = self.host.eos_config(
+                lines=['speed forced {}'.format(speed)],
+                parents='interface %s' % interface_name)[self.hostname]
+        logger.debug('Set force speed for port {} : {}'.format(interface_name, out))
+        return not self._has_cli_cmd_failed(out)
+
+    def get_supported_speeds(self, interface_name):
+        """Get supported speeds for a given interface
+
+        Args:
+            interface_name (str): Interface name
+
+        Returns:
+            list: A list of supported speed strings or None
+        """
+        output = self.eos_command(commands=['show interfaces %s capabilities' % interface_name])
+        found_txt = re.search("Speed/Duplex: (.+)", output['stdout'][0])
+        if found_txt == None:
+            _raise_err('Failed to find port speeds list in output: %s' % output['stdout'])
+
+        speed_list = found_txt.groups()[0]
+        speed_list = speed_list.split(',')
+        speed_list.remove('auto')
+        def extract_speed_only(v):
+            return re.match('\d+', v).group() + '000'
+        return list(map(extract_speed_only, speed_list))

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -7,7 +7,10 @@ from tests.common.devices.base import AnsibleHostBase
 
 logger = logging.getLogger(__name__)
 
-
+def _raise_err(msg):
+        logger.error(msg)
+        raise Exception(msg)
+        
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch
@@ -186,10 +189,6 @@ class EosHost(AnsibleHostBase):
             'output': 'json'
         }])['stdout'][0]        
 
-    def _raise_err(msg):
-        logger.error(msg)
-        raise Exception(msg)
-
     def get_auto_negotiation_mode(self, interface_name):
         output = self.eos_command(commands=[{
             'command': 'show interfaces %s status' % interface_name,
@@ -225,7 +224,7 @@ class EosHost(AnsibleHostBase):
     def get_speed(self, interface_name):
         output = self.eos_command(commands=['show interfaces %s transceiver properties' % interface_name])
         found_txt = re.search(r'Operational Speed: (\S+)', output['stdout'][0])
-        if found_txt == None:
+        if found_txt is None:
             _raise_err('Not able to extract interface %s speed from output: %s' % (interface_name, output['stdout']))
 
         v = found_txt.groups()[0]
@@ -260,7 +259,7 @@ class EosHost(AnsibleHostBase):
         """
         output = self.eos_command(commands=['show interfaces %s capabilities' % interface_name])
         found_txt = re.search("Speed/Duplex: (.+)", output['stdout'][0])
-        if found_txt == None:
+        if found_txt is None:
             _raise_err('Failed to find port speeds list in output: %s' % output['stdout'])
 
         speed_list = found_txt.groups()[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: added EOS fanouts support for port autoneg tests
Fixes # (issue)
- implemented autoneg related management methods for EOS fanout

Port autoneg setup is required on both sides, per cable connection, so tests use a fanout as neighbor for DUT to establish autoneg with. Interaction with a fanout rely on per OS specific implementation and some methods required by tests were missing for EOS. Implemented those methods
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Adapt port autoneg tests to work with EOS fanouts
#### How did you do it?
Implemented missing methods for autoneg management on EOS fanout switch
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any platform_tests/test_auto_negotiation.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
