### PR TITLE
Increase timeout for sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -584,7 +584,13 @@ def check_monit(duthosts):
 @pytest.fixture(scope="module")
 def check_processes(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=1000)
+        timeout = 600
+        # Increase the timeout for multi-asic virtual switch DUT.
+        for node in duthosts.nodes:
+            if 'kvm' in node.sonichost.facts['platform'] and node.sonichost.is_multi_asic:
+                timeout = 1000
+                break
+        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=timeout)
         return result.values()
 
     @reset_ansible_local_tmp

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -584,7 +584,7 @@ def check_monit(duthosts):
 @pytest.fixture(scope="module")
 def check_processes(duthosts):
     def _check(*args, **kwargs):
-        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=600)
+        result = parallel_run(_check_processes_on_dut, args, kwargs, duthosts, timeout=1000)
         return result.values()
 
     @reset_ansible_local_tmp


### PR DESCRIPTION


Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
On multi-asic VS testbed, due to the increased number of services running, we see sanity check not able to complete critical process check before the timeout. This could be a performance issue, but increasing the timeout should help ensure that sanity check is able to finish execution.
#### How did you do it?
Increase the timeout to wait for completion of check_processes_on_dut parallel runs.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
