### PR TITLE
[test_bgp_update_timer] Enable storage backend topologies

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -24,6 +24,7 @@ from bgp_helpers import BGP_NO_EXPORT_TEMPLATE
 from bgp_helpers import DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST, BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+from tests.common import constants
 
 
 logger = logging.getLogger(__name__)
@@ -274,10 +275,13 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
     def _setup_interfaces_t0(mg_facts, peer_count):
         try:
             connections = []
+            is_backend_topo = "backend" in tbinfo["topo"]["name"]
             vlan_intf = _find_vlan_intferface(mg_facts)
             vlan_intf_name = vlan_intf["attachto"]
             vlan_intf_addr = "%s/%s" % (vlan_intf["addr"], vlan_intf["prefixlen"])
             vlan_members = mg_facts["minigraph_vlans"][vlan_intf_name]["members"]
+            is_vlan_tagged = mg_facts["minigraph_vlans"][vlan_intf_name].get("type", "").lower() == "tagged"
+            vlan_id = mg_facts["minigraph_vlans"][vlan_intf_name]["vlanid"]
             local_interfaces = random.sample(vlan_members, peer_count)
             neighbor_addresses = generate_ips(
                 peer_count,
@@ -299,6 +303,8 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                 conn["local_addr"] = vlan_intf_addr
                 conn["neighbor_addr"] = neighbor_addr
                 conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][local_intf]
+                if is_backend_topo and is_vlan_tagged:
+                    conn["neighbor_intf"] += (constants.VLAN_SUB_INTERFACE_SEPARATOR + vlan_id)
                 conn["loopback_ip"] = loopback_ip
                 connections.append(conn)
 
@@ -318,6 +324,7 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
     def _setup_interfaces_t1(mg_facts, peer_count):
         try:
             connections = []
+            is_backend_topo = "backend" in tbinfo["topo"]["name"]
             ipv4_interfaces = []
             used_subnets = set()
             if mg_facts["minigraph_interfaces"]:
@@ -337,6 +344,13 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                             ipv4_lag_interfaces.append(pt["attachto"])
                         used_subnets.add(ipaddress.ip_network(pt["subnet"]))
 
+            vlan_sub_interfaces = []
+            if is_backend_topo:
+                for intf in mg_facts.get("minigraph_vlan_sub_interfaces"):
+                    if _is_ipv4_address(intf["addr"]):
+                        vlan_sub_interfaces.append(intf["attachto"])
+                        used_subnets.add(ipaddress.ip_network(intf["subnet"]))
+
             subnet_prefixlen = list(used_subnets)[0].prefixlen
             _subnets = ipaddress.ip_network(u"10.0.0.0/24").subnets(new_prefix=subnet_prefixlen)
             subnets = (_ for _ in _subnets if _ not in used_subnets)
@@ -349,7 +363,7 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
             if not loopback_ip:
                 pytest.fail("ipv4 lo interface not found")
 
-            for intf, subnet in zip(random.sample(ipv4_interfaces + ipv4_lag_interfaces, peer_count), subnets):
+            for intf, subnet in zip(random.sample(ipv4_interfaces + ipv4_lag_interfaces + vlan_sub_interfaces, peer_count), subnets):
                 conn = {}
                 local_addr, neighbor_addr = [_ for _ in subnet][:2]
                 conn["local_intf"] = "%s" % intf
@@ -361,6 +375,10 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                     member_intf = mg_facts["minigraph_portchannels"][intf]["members"][0]
                     conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][member_intf]
                     conn["namespace"] = mg_facts["minigraph_portchannels"][intf]["namespace"]
+                elif constants.VLAN_SUB_INTERFACE_SEPARATOR in intf:
+                    orig_intf, vlan_id = intf.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)
+                    ptf_port_index = str(mg_facts["minigraph_port_indices"][orig_intf])
+                    conn["neighbor_intf"] = "eth" + ptf_port_index + constants.VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
                 else:
                     conn["neighbor_intf"] = "eth%s" % mg_facts["minigraph_port_indices"][intf]
                 connections.append(conn)

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -137,7 +137,7 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_d
         """Get bgp update packets from pcap file."""
         packets = sniff(
             offline=pcap_file,
-            lfilter=lambda p: bgp.BGPHeader in p and p[bgp.BGPHeader].type == 2
+            lfilter=lambda p: IP in p and bgp.BGPHeader in p and p[bgp.BGPHeader].type == 2
         )
         return packets
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3840

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enable `test_bgp_update_timer` on storage backend topologies.
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. for `setup_interfaces`, enable it to parse sub interfaces on `t1-backend` or parse tagged vlan ports on `t0-backend`.
2. modify `bgp_update_packets` to filter out only IPv4 packets only.

#### How did you verify/test it?
Run `test_bgp_update_timer` on `t0-backend` and `t1-backend`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
