### PR TITLE
[test_bgp_speaker] Skip for dualtor testbeds

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -14,6 +14,8 @@ from tests.common.utilities import wait_tcp_connection
 from tests.common.dualtor.mux_simulator_control import mux_server_url     # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports
 from tests.common.dualtor.dual_tor_utils import map_hostname_to_tor_side
+from tests.common.helpers.assertions import pytest_require
+
 
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -54,6 +56,13 @@ def change_route(operation, ptfip, neighbor, route, nexthop, port):
     data = {"command": "neighbor %s %s route %s next-hop %s" % (neighbor, operation, route, nexthop)}
     r = requests.post(url, data=data)
     assert r.status_code == 200
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_dualtor(tbinfo):
+    """Skip running `test_bgp_speaker` over dualtor."""
+    pytest_require("dualtor" not in tbinfo["topo"]["name"], "Skip 'test_bgp_speaker over dualtor.'")
+
 
 @pytest.fixture(scope="module")
 def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, tbinfo, toggle_all_simulator_ports):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes:
* https://github.com/Azure/sonic-buildimage/issues/8096
* https://github.com/Azure/sonic-buildimage/issues/8097

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip `test_bgp_speaker` for dualtor testbeds.
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Define an autouse fixture `skip_dualtor` to check the testbed name.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
