### PR TITLE
[test_read_mac_metadata] Check and restore the image before doing thi…

### DIFF
--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -23,7 +23,17 @@ pytestmark = [
 @pytest.fixture(scope='function')
 def cleanup_read_mac(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    initImage = duthost.shell('sonic-installer list | grep Current | cut -f2 -d " "')['stdout']
     yield
+    """
+    Recover the image to image2 which is the image before doing this case.
+    """
+    currentImage = duthost.shell('sonic-installer list | grep Current | cut -f2 -d " "')['stdout']
+    if initImage != currentImage:
+        logger.info("Re-install the image: {} to DUT" .format(initImage))
+        duthost.copy(src=BINARY_FILE_ON_LOCALHOST_2, dest=BINARY_FILE_ON_DUTHOST)
+        duthost.shell("sonic-installer install -y {}".format(BINARY_FILE_ON_DUTHOST))
+        reboot(duthost, localhost, wait=120)
     logger.info('Remove temporary images')
     duthost.shell("rm -rf {}".format(BINARY_FILE_ON_DUTHOST))
     localhost.shell("rm -rf {}".format(BINARY_FILE_ON_LOCALHOST_1))
@@ -100,7 +110,7 @@ class ReadMACMetadata():
             duthost.copy(src=BINARY_FILE_ON_LOCALHOST_2, dest=BINARY_FILE_ON_DUTHOST)
 
         logger.info("Installing new SONiC image")
-        duthost.shell("sonic_installer install -y {}".format(BINARY_FILE_ON_DUTHOST))
+        duthost.shell("sonic-installer install -y {}".format(BINARY_FILE_ON_DUTHOST))
 
     def check_mtu_and_interfaces(self, duthost):
         logger.info("Verify that MAC address fits template XX:XX:XX:XX:XX:XX")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
    In a general test, it is expected to use a image(called tested image) to run all test case in sonic-mgmt.
    However, this test case will change the image on DUT and it caused that
    the rest of test item will use the image not the same as tested image if the iteration/image1/image2 do not set properly.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Let the rest of the test item behind this test case can use the same tested image.
#### How did you do it?
Assume image2 is tested image and reinstall it after the test.
#### How did you verify/test it?
Run test_read_mac_metadata pytest passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
