### PR TITLE
[test_warm_reboot_sad_bgp] add "OpenSent" as one of the expected neig…

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -453,7 +453,7 @@ class Arista(object):
                 if 'vrfs' in obj and 'default' in obj['vrfs']:
                     obj = obj['vrfs']['default']
                     if 'peers' in obj:
-                        bgp_state[ver] = (obj['peers'][dut[ver]]['peerState'] == state)
+                        bgp_state[ver] = (obj['peers'][dut[ver]]['peerState'] in state)
                     else:
                         self.fails.add('Verify BGP %S neighbor: Peer attribute missing in output' % ver)
                 else:

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -214,7 +214,7 @@ class SadOper(SadPath):
             self.dut_bgps['changed_state'] = 'Active'
             [self.dut_needed.update({vm:None}) for vm in self.neigh_vms]
         elif self.oper_type == 'dut_bgp_down':
-            self.neigh_bgps['changed_state'] = 'Active'
+            self.neigh_bgps['changed_state'] = 'Active,OpenSent'
             self.dut_bgps['changed_state'] = 'Idle'
         elif 'neigh_lag' in self.oper_type:
             # on the DUT side, bgp states are different pre and post boot. hence passing multiple values


### PR DESCRIPTION
…hbor state

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix the test failure of test_warm_reboot_sad_bgp.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Sometimes test_warm_reboot_sad_bgp is failed because BGP neighbor state is not down in preboot state, it is due to the BGP neighbor state is "OpenSent" not "Active".
VM still sends OPEN message after DUT BGP shutdown, and there is a chance to get the BGP state is "OpenSent".

#### How did you do it?
Add "OpenSent" as one of the expected neighbor state when testing "dut_bgp_down".

#### How did you verify/test it?
Run test_warm_reboot_sad_bgp test case passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
