### PR TITLE
Add docker login for Ansible task renumber_topo

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -21,6 +21,14 @@
       state: absent
     become: yes
 
+  - name: Try to login into docker registry
+    docker_login:
+      registry_url: "{{ docker_registry_host }}"
+      username: "{{ docker_registry_username }}"
+      password: "{{ docker_registry_password }}"
+    become: yes
+    when: docker_registry_username is defined and docker_registry_password is defined
+
   - name: Create ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add ```docker login``` for Ansible task ```renumber_topo```.

We noticed that docker raised error when doing ```restart-ptf``` because credentials were losing.
```
TASK [vm_set : Create ptf container ptf_vms7-13] *******************************
Monday 26 July 2021  02:58:30 +0000 (0:00:00.852)       0:00:48.967 *********** 
fatal: [SERV-07]: FAILED! => {"changed": false, "msg": "Error pulling image ******/docker-ptf:latest - 500 Server Error: Internal Server Error (\"Head https://******/v2/docker-ptf/manifests/latest: no basic auth credentials\")"}
```
A ```docker login``` job is added in this PR to address such issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to add ```docker login``` for Ansible task ```renumber_topo```.

#### How did you do it?
A ```docker login``` job is added in this PR to address such issue.

#### How did you verify/test it?
Verified on SN4600 by running ```restart-ptf``` task. All passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
