### PR TITLE
[test_bgp_allow_list] Enable t1-backend topology

### DIFF
--- a/tests/bgp/test_bgp_allow_list.py
+++ b/tests/bgp/test_bgp_allow_list.py
@@ -88,7 +88,9 @@ def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_hostname):
     tor_neighbors = natsorted([neighbor for neighbor in nbrhosts.keys() if neighbor.endswith('T0')])
     tor1 = tor_neighbors[0]
     spine_neighbors = natsorted([neighbor for neighbor in nbrhosts.keys() if neighbor.endswith('T2')])
-    other_neighbors = tor_neighbors[1:3] + spine_neighbors[0:2]  # Only check a few neighbors to save time
+    other_neighbors = tor_neighbors[1:3]    # Only check a few neighbors to save time
+    if spine_neighbors:
+        other_neighbors += spine_neighbors[0:2]
 
     tor1_offset = tbinfo['topo']['properties']['topology']['VMs'][tor1]['vm_offset']
     tor1_exabgp_port = EXABGP_BASE_PORT + tor1_offset


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
As the subject.

#### How did you do it?
Check `spine_neighbors` before using it because there are no spine
neighbors on t1-backend topo.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you verify/test it?
```
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_default_allow_list_preconfig PASSED                                                                                                                [ 25%]
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_allow_list[permit] PASSED                                                                                                                          [ 50%]
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_allow_list[deny] PASSED                                                                                                                            [ 75%]
bgp/test_bgp_allow_list.py::TestBGPAllowListBase::test_default_allow_list_postconfig PASSED                                                                                                               [100%]

========================================================================================== 4 passed in 397.31 seconds ===========================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
