### PR TITLE
made test_decap to check both DSCP/TTL modes for SONiC 202012 and later

### DIFF
--- a/tests/decap/conftest.py
+++ b/tests/decap/conftest.py
@@ -27,3 +27,49 @@ def pytest_addoption(parser):
         default=True,
         help="Specify whether inner layer IPv6 testing will be covered",
     )
+    
+    decap_group.addoption(
+        "--ttl_uniform",
+        action="store_true", 
+        default=False,
+        help="indicates TTL uniform is supported"
+    )
+    decap_group.addoption(
+        "--dscp_uniform",
+        action="store_true",
+        default=True,
+        help="indicates DSCP uniform is supported"
+    )
+    decap_group.addoption(
+        "--no_ttl_uniform",
+        dest='ttl_uniform',
+        action="store_false",
+        help="indicates TTL uniform is not supported"
+    )
+    decap_group.addoption(
+        "--no_dscp_uniform",
+        dest='dscp_uniform',
+        action="store_false",
+        help="indicates DSCP uniform is not supported"
+    )
+
+
+def build_ttl_dscp_params(uniform_support_info):
+    ttl_uni = {'ttl': 'uniform', 'dscp': 'pipe'}
+    dscp_uni = {'ttl': 'pipe', 'dscp': 'uniform'}
+    both_pipe = {'ttl': 'pipe', 'dscp': 'pipe'}
+    params = []
+    if uniform_support_info['ttl']:
+        params.append(ttl_uni)
+    if uniform_support_info['dscp']:
+        params.append(dscp_uni)
+    if len(params) < 2:
+        params.append(both_pipe)
+    return params
+
+def pytest_generate_tests(metafunc):
+  ttl = metafunc.config.getoption("ttl_uniform")
+  dscp = metafunc.config.getoption("dscp_uniform")
+  if "supported_ttl_dscp_params" in metafunc.fixturenames:
+      params = build_ttl_dscp_params({'ttl': ttl, 'dscp': dscp})
+      metafunc.parametrize("supported_ttl_dscp_params", params, ids=lambda p: "ttl=%s, dscp=%s" % (p['ttl'], p['dscp']))

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -27,22 +27,23 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-@pytest.fixture(params=["pipe", "uniform"], scope='module')
-def ttl_dscp_mode(request, duthost):
-    mode = request.param
-    if mode == "uniform" and ("201811" in duthost.os_version or "201911" in duthost.os_version):
+
+@pytest.fixture(scope='module')
+def ttl_dscp_params(duthost, supported_ttl_dscp_params):
+    if "uniform" in supported_ttl_dscp_params.values() and ("201811" in duthost.os_version or "201911" in duthost.os_version):
         pytest.skip('uniform ttl/dscp mode is available from 202012. Current version is %s' % duthost.os_version)
     
-    return mode
+    return supported_ttl_dscp_params
+
 
 @pytest.fixture(scope="module")
-def setup_teardown(request, duthosts, fib_info_files, duts_running_config_facts, ttl_dscp_mode):
+def setup_teardown(request, duthosts, fib_info_files, duts_running_config_facts, ttl_dscp_params):
 
     is_multi_asic = duthosts[0].sonichost.is_multi_asic
 
     ecn_mode = "copy_from_outer"
-    dscp_mode = ttl_dscp_mode
-    ttl_mode = ttl_dscp_mode
+    dscp_mode = ttl_dscp_params['dscp']
+    ttl_mode = ttl_dscp_params['ttl']
 
     # The hostvars dict has definitions defined in ansible/group_vars/sonic/variables
     hostvars = duthosts[0].host.options["variable_manager"]._hostvars[duthosts[0].hostname]
@@ -50,7 +51,6 @@ def setup_teardown(request, duthosts, fib_info_files, duts_running_config_facts,
     mellanox_hwskus = hostvars.get("mellanox_hwskus", [])
 
     if sonic_hwsku in mellanox_hwskus:
-        dscp_mode = "uniform"
         ecn_mode = "standard"
 
     setup_info = {
@@ -135,7 +135,7 @@ def set_mux_random(tbinfo, mux_server_url):
     return set_mux_side(tbinfo, mux_server_url, 'random')
 
 
-def test_decap(tbinfo, duthosts, mux_server_url, setup_teardown, ptfhost, set_mux_random):
+def test_decap(tbinfo, duthosts, mux_server_url, setup_teardown, ptfhost, set_mux_random, ttl_dscp_params):
 
     setup_info = setup_teardown
 

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -27,20 +27,22 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+@pytest.fixture(params=["pipe", "uniform"], scope='module')
+def ttl_dscp_mode(request, duthost):
+    mode = request.param
+    if mode == "uniform" and ("201811" in duthost.os_version or "201911" in duthost.os_version):
+        pytest.skip('uniform ttl/dscp mode is available from 202012. Current version is %s' % duthost.os_version)
+    
+    return mode
 
 @pytest.fixture(scope="module")
-def setup_teardown(request, duthosts, fib_info_files, duts_running_config_facts):
+def setup_teardown(request, duthosts, fib_info_files, duts_running_config_facts, ttl_dscp_mode):
 
     is_multi_asic = duthosts[0].sonichost.is_multi_asic
 
-    # Initialize parameters
-    if "201811" in duthosts[0].os_version or "201911" in duthosts[0].os_version:
-        dscp_mode = "pipe"
-    else:
-        dscp_mode = "uniform"
-
     ecn_mode = "copy_from_outer"
-    ttl_mode = "pipe"
+    dscp_mode = ttl_dscp_mode
+    ttl_mode = ttl_dscp_mode
 
     # The hostvars dict has definitions defined in ansible/group_vars/sonic/variables
     hostvars = duthosts[0].host.options["variable_manager"]._hostvars[duthosts[0].hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: made test_decap to check both DSCP/TTL modes for SONiC 202012 and later
Fix https://github.com/Azure/sonic-mgmt/issues/3355

- uniform mode for ttl and dscp became available for IPinIP tunnel configuration starting from 202012 so made the test to run with ttl/dscp uniform mode for OS ver 202012 and later. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Adapt the test to covered feature improvements
#### How did you do it?
Parametrized the test to run with uniform ttl/dscp mode if supported for a given OS ver
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=any decap/test_decap.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
