### PR TITLE
[Platform API] : modified test_sfp for 400G ports

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -165,10 +165,9 @@ class TestSfpApi(PlatformApiTestBase):
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         #For QSFP-DD specification compliance will return type as passive or active
-        if "QSFP-DD" in xcvr_info_dict["type"]:
-            spec_compliance = xcvr_info_dict["specification_compliance"]
-            if spec_compliance == "passive_copper_media_interface":
-              return False
+        if xcvr_info_dict["type_abbrv_name"] == "QSFP-DD":
+            if xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
+               return False
         else:
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
             if xcvr_info_dict["type_abbrv_name"] =="SFP":

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -170,7 +170,7 @@ class TestSfpApi(PlatformApiTestBase):
                return False
         else:
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
-            if xcvr_info_dict["type_abbrv_name"] =="SFP":
+            if xcvr_info_dict["type_abbrv_name"] == "SFP":
                 compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
                 if compliance_code == "Passive Cable":
                    return False


### PR DESCRIPTION

### Description of PR
- For QSFD-DD, transceiver type is  mapped as active or passive under specification compliance. 
Modified script for this change.
- for Tx-bias , included check to verify whether the transceiver is optical .

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
#### How did you verify/test it?
Verified this test with Mix of DAC and AOC cables. 
#### Any platform specific information?
verified in 400G platform Z9332. 
#### Supported testbed topology if it's a new test case?
verified in T0 topology. 
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Logs : 
for Testing purpose,  Testbed is connected with all DAC except 2 AOC cables at 21,22 

[platform_api_logs.txt](https://github.com/Azure/sonic-mgmt/files/6877883/platform_api_logs.txt)

