### PR TITLE
Increased sleep bgp speaker from 30 to 90 seconds

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -16,7 +16,7 @@ from tests.common.dualtor.mux_simulator_control import mux_server_url     # lgtm
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports
 from tests.common.dualtor.dual_tor_utils import map_hostname_to_tor_side
 from tests.common.helpers.assertions import pytest_require
-from tests.common import constants
+from tests.common.utilities import wait_until
 
 
 pytestmark = [
@@ -244,6 +244,14 @@ def get_dut_vlan_ptf_ports(mg_facts):
     return ports
 
 
+def is_all_neighbors_learned(duthost, speaker_ips):
+    bgp_facts = duthost.bgp_facts()['ansible_facts']
+    for ip in speaker_ips:
+        if not str(ip.ip) in bgp_facts['bgp_neighbors']:
+            return False
+    return True
+
+
 def bgp_speaker_announce_routes_common(common_setup_teardown,
                                        tbinfo, duthost, ptfhost, ipv4, ipv6, mtu,
                                        family, prefix, nexthop_ips, vlan_mac):
@@ -263,7 +271,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown,
     announce_route(ptfip, lo_addr, peer_range, vlan_ips[0].ip, port_num[2])
 
     logger.info("Wait some time to make sure routes announced to dynamic bgp neighbors")
-    time.sleep(30)
+    assert wait_until(90, 10, 0, is_all_neighbors_learned, duthost, speaker_ips), "Not all dynamic neighbors were learned"
 
     logger.info("Verify accepted prefixes of the dynamic neighbors are correct")
     bgp_facts = duthost.bgp_facts()['ansible_facts']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increased sleep time from 30 to 90 seconds, because it needs longer time to learn neighbors
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Improve stability of bgp_speaker test

#### How did you do it?

#### How did you verify/test it?
Executed test on Mellanox-SN2700-D48C8, with changed sleep of 60 seconds it did not worked, with sleep of 90 seconds- passed

Tested image:
SONiC Software Version: SONiC.202012.136-a90280faa_Internal
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: a90280faa
Build date: Fri Jul 23 14:12:43 UTC 2021
Built by: sw-r2d2-bot@r-build-sonic-ci03

Platform: x86_64-mlnx_msn2700-r0
HwSKU: Mellanox-SN2700-D48C8
ASIC: mellanox
ASIC Count: 1
Serial Number: MT1822K07815
Uptime: 16:14:59 up  1:52,  1 user,  load average: 1.13, 1.24, 1.10


#### Any platform specific information?

#### Supported testbed topology if it's a new test case? 

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
