### PR TITLE
[test_http_copy] skip the http test

### DIFF
--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -15,7 +15,9 @@ HTTP_PORT = "8080"
 
 def test_http_copy(duthosts, rand_one_dut_hostname, ptfhost):
     """Test that HTTP (copy) can be used to download objects to the DUT"""
-    
+
+    pytest.skip("---- test doesn't clean up the files in /tmp, it will cause the subsequent cases in /tmp fail,"
+                "skipping until the issue is addressed ----")
     duthost = duthosts[rand_one_dut_hostname]
     ptf_ip = ptfhost.mgmt_ip
 


### PR DESCRIPTION
What is the motivation for this PR?
The case doesn't clean up the files in /tmp of ptf, it will casue the subsequent case failed.

How did you do it?
just skip this test before issue is addressed.

Signed-off-by: Kevin Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
