### PR TITLE
[multi-asic][chassis] fix the port index in port_index_map for masic

### DIFF
--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -71,8 +71,16 @@ def create_maps(config):
         port_name_list = config["PORT"].keys()
         port_name_list_sorted = natsorted(port_name_list)
 
-        for idx, val in enumerate(port_name_list_sorted):
-            port_index_map[val] = idx
+        #get the port_index from config_db if available
+        port_index_map = {
+            name: int(v['index'])
+            for name, v in config['PORT'].iteritems()
+            if 'index' in v
+        }
+        if not port_index_map:
+            #if not available generate an index
+            for idx, val in enumerate(port_name_list_sorted):
+                port_index_map[val] = idx
 
         port_name_to_alias_map = { name : v['alias'] if 'alias' in v else '' for name, v in config["PORT"].iteritems()}
 
@@ -136,7 +144,7 @@ def main():
                     cfg_file_path = PERSISTENT_CONFIG_PATH.format("")
             with open(cfg_file_path, "r") as f:
                 config = json.load(f)
-        elif m_args["source"] == "running":    
+        elif m_args["source"] == "running":
             config = get_running_config(module, namespace)
         results = get_facts(config)
         module.exit_json(ansible_facts=results)


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

fix the port index in port_index_map for masic

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ x] 201911

### Approach
#### What is the motivation for this PR?
The change done in PR https://github.com/Azure/sonic-mgmt/pull/3643  to  use the `get_port_map`,  does not work for multi-ASIC platforms. The existing logic in config_facts gives the same index for ports on different ASICs.

The PR is a fix  for this problem. `get_port_map` will use the port index present in the config_db. 
#### How did you do it?
Change in `config_facts` to get the port  index from config_db if its available. If the `index` is not present use the exisiting lofic to  generate the index
#### How did you verify/test it?
run the test `platform_tests/rest_reload_config.py` to verify

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
