### PR TITLE
[portstat] [telemetry ] [snmp] Align tests to delay of flex counters change

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,8 @@ from tests.common.cache import FactsCache
 
 from tests.common.connections.console_host import ConsoleHost
 
+WAIT_FOR_COUNTERS_TIMEOUT = 190
+WAIT_FOR_COUNTERS_INTERVAL = 10
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -1132,3 +1134,25 @@ def duts_minigraph_facts(duthosts, tbinfo):
         }
     """
     return duthosts.get_extended_minigraph_facts(tbinfo)
+
+@pytest.fixture(scope='function')
+def wait_for_counters(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    logger.info('Wait until all counters are enabled on the DUT')
+    counters = ['PORT_STAT', 'PORT_BUFFER_DROP', 'QUEUE_STAT', 'PG_WATERMARK_STAT', 'RIF_STAT']
+    current_attempt = 0
+    while current_attempt < WAIT_FOR_COUNTERS_TIMEOUT / WAIT_FOR_COUNTERS_INTERVAL:
+        output = duthost.shell("counterpoll show | sed '1,2d'", module_ignore_errors=True)
+        assert(output['rc'] == 0, "Failed to get counters status")
+        counters_lines = output['stdout'].splitlines()
+        enabled_counters = 0
+        for line in counters_lines:
+            if any(counter in line for counter in counters) and 'enable' in line:
+                enabled_counters += 1
+                continue
+        if enabled_counters == len(counters):
+            return
+        else:
+            current_attempt += 1
+            time.sleep(WAIT_FOR_COUNTERS_INTERVAL)
+    assert(False, "Not all counters are enabled after {} seconds".format(WAIT_FOR_COUNTERS_TIMEOUT))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1143,7 +1143,7 @@ def wait_for_counters(duthosts, rand_one_dut_hostname):
     current_attempt = 0
     while current_attempt < WAIT_FOR_COUNTERS_TIMEOUT / WAIT_FOR_COUNTERS_INTERVAL:
         output = duthost.shell("counterpoll show | sed '1,2d'", module_ignore_errors=True)
-        assert('rc' in output and output['rc'] == 0, "Failed to get counters status")
+        assert output.has_key('rc') and output['rc'] == 0, "Failed to get counters status"
         counters_lines = output['stdout'].splitlines()
         enabled_counters = 0
         for line in counters_lines:
@@ -1155,4 +1155,4 @@ def wait_for_counters(duthosts, rand_one_dut_hostname):
         else:
             current_attempt += 1
             time.sleep(WAIT_FOR_COUNTERS_INTERVAL)
-    assert(False, "Not all counters are enabled after {} seconds".format(WAIT_FOR_COUNTERS_TIMEOUT))
+    assert False, "Not all counters are enabled after {} seconds".format(WAIT_FOR_COUNTERS_TIMEOUT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1143,7 +1143,7 @@ def wait_for_counters(duthosts, rand_one_dut_hostname):
     current_attempt = 0
     while current_attempt < WAIT_FOR_COUNTERS_TIMEOUT / WAIT_FOR_COUNTERS_INTERVAL:
         output = duthost.shell("counterpoll show | sed '1,2d'", module_ignore_errors=True)
-        assert(output['rc'] == 0, "Failed to get counters status")
+        assert('rc' in output and output['rc'] == 0, "Failed to get counters status")
         counters_lines = output['stdout'].splitlines()
         enabled_counters = 0
         for line in counters_lines:

--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -98,7 +98,7 @@ def reset_portstat(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 
 @pytest.mark.parametrize('command', ['portstat -c', 'portstat --clear'])
-def test_portstat_clear(duthosts, enum_rand_one_per_hwsku_frontend_hostname, command):
+def test_portstat_clear(duthosts, enum_rand_one_per_hwsku_frontend_hostname, command, wait_for_counters):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     wait(30, 'Wait for DUT to receive/send some packets')
     before_portstat = parse_portstat(duthost.command('portstat')['stdout_lines'])

--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -84,15 +84,6 @@ def parse_portstat(content_lines):
 
     return results
 
-@pytest.fixture(scope='module', autouse=True)
-def enable_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    logger.info('Enabling all counters on DUT')
-    counters = ['PORT', 'PORT_BUFFER_DROP', 'QUEUE', 'PG_WATERMARK', 'RIF']
-    for counter in counters:
-        return_value = duthost.shell("sudo redis-cli -n 4 hset 'FLEX_COUNTER_TABLE|{}' 'FLEX_COUNTER_STATUS' 'enable'".format(counter),
-                                module_ignore_errors=True)['rc']
-        pytest_assert(return_value == 0, 'Failed to enable counter: {}'.format(counter))
 
 @pytest.fixture(scope='function', autouse=True)
 def reset_portstat(duthosts, enum_rand_one_per_hwsku_frontend_hostname):

--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -84,6 +84,15 @@ def parse_portstat(content_lines):
 
     return results
 
+@pytest.fixture(scope='module', autouse=True)
+def enable_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    logger.info('Enabling all counters on DUT')
+    counters = ['PORT', 'PORT_BUFFER_DROP', 'QUEUE', 'PG_WATERMARK', 'RIF']
+    for counter in counters:
+        return_value = duthost.shell("sudo redis-cli -n 4 hset 'FLEX_COUNTER_TABLE|{}' 'FLEX_COUNTER_STATUS' 'enable'".format(counter),
+                                module_ignore_errors=True)['rc']
+        pytest_assert(return_value == 0, 'Failed to enable counter: {}'.format(counter))
 
 @pytest.fixture(scope='function', autouse=True)
 def reset_portstat(duthosts, enum_rand_one_per_hwsku_frontend_hostname):

--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -6,6 +6,10 @@ def setup_check_snmp_ready(duthosts):
     for duthost in duthosts:
         assert wait_until(300, 20, duthost.is_service_fully_started, "snmp"), "SNMP service is not running"
 
+@pytest.fixture(scope="function", autouse=True)
+def snmp_wait_for_counters(wait_for_counters):
+    return
+
 def pytest_addoption(parser):
     """
     Adds options to pytest that are used by the snmp tests.

--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -1,23 +1,10 @@
 import pytest
-import logging
 from tests.common.utilities import wait_until
-
-logger = logging.getLogger('__name__')
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_snmp_ready(duthosts):
     for duthost in duthosts:
         assert wait_until(300, 20, duthost.is_service_fully_started, "snmp"), "SNMP service is not running"
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_enable_counters(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    logger.info('Enabling all counters on DUT')
-    counters = ['PORT', 'PORT_BUFFER_DROP', 'QUEUE', 'PG_WATERMARK', 'RIF']
-    for counter in counters:
-        return_value = duthost.shell("sudo redis-cli -n 4 hset 'FLEX_COUNTER_TABLE|{}' 'FLEX_COUNTER_STATUS' 'enable'".format(counter),
-                                module_ignore_errors=True)['rc']
-        assert return_value == 0, 'Failed to enable counter: {}'.format(counter)
 
 def pytest_addoption(parser):
     """

--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -1,10 +1,23 @@
 import pytest
+import logging
 from tests.common.utilities import wait_until
+
+logger = logging.getLogger('__name__')
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_snmp_ready(duthosts):
     for duthost in duthosts:
         assert wait_until(300, 20, duthost.is_service_fully_started, "snmp"), "SNMP service is not running"
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_enable_counters(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    logger.info('Enabling all counters on DUT')
+    counters = ['PORT', 'PORT_BUFFER_DROP', 'QUEUE', 'PG_WATERMARK', 'RIF']
+    for counter in counters:
+        return_value = duthost.shell("sudo redis-cli -n 4 hset 'FLEX_COUNTER_TABLE|{}' 'FLEX_COUNTER_STATUS' 'enable'".format(counter),
+                                module_ignore_errors=True)['rc']
+        assert return_value == 0, 'Failed to enable counter: {}'.format(counter)
 
 def pytest_addoption(parser):
     """

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -153,7 +153,7 @@ def test_telemetry_enabledbydefault(duthosts, rand_one_dut_hostname):
             status_expected = "enabled";
             pytest_assert(str(v) == status_expected, "Telemetry feature is not enabled")
 
-def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_telemetry, localhost):
+def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_telemetry, localhost, wait_for_counters):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -72,6 +72,16 @@ def assert_equal(actual, expected, message):
     """
     pytest_assert(actual == expected, "{0}. Expected {1} vs actual {2}".format(message, expected, actual))
 
+@pytest.fixture(scope='module', autouse=True)
+def enable_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    logger.info('Enabling all counters on DUT')
+    counters = ['PORT', 'PORT_BUFFER_DROP', 'QUEUE', 'PG_WATERMARK', 'RIF']
+    for counter in counters:
+        return_value = duthost.shell("sudo redis-cli -n 4 hset 'FLEX_COUNTER_TABLE|{}' 'FLEX_COUNTER_STATUS' 'enable'".format(counter),
+                                module_ignore_errors=True)['rc']
+        pytest_assert(return_value == 0, 'Failed to enable counter: {}'.format(counter))
+
 @pytest.fixture(scope="module", autouse=True)
 def verify_telemetry_dockerimage(duthosts, rand_one_dut_hostname):
     """If telemetry docker is available in image then return true

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -72,16 +72,6 @@ def assert_equal(actual, expected, message):
     """
     pytest_assert(actual == expected, "{0}. Expected {1} vs actual {2}".format(message, expected, actual))
 
-@pytest.fixture(scope='module', autouse=True)
-def enable_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    logger.info('Enabling all counters on DUT')
-    counters = ['PORT', 'PORT_BUFFER_DROP', 'QUEUE', 'PG_WATERMARK', 'RIF']
-    for counter in counters:
-        return_value = duthost.shell("sudo redis-cli -n 4 hset 'FLEX_COUNTER_TABLE|{}' 'FLEX_COUNTER_STATUS' 'enable'".format(counter),
-                                module_ignore_errors=True)['rc']
-        pytest_assert(return_value == 0, 'Failed to enable counter: {}'.format(counter))
-
 @pytest.fixture(scope="module", autouse=True)
 def verify_telemetry_dockerimage(duthosts, rand_one_dut_hostname):
     """If telemetry docker is available in image then return true


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Following PR's:
https://github.com/Azure/sonic-swss/pull/1803
https://github.com/Azure/sonic-swss/pull/1804
Flex counters are delayed and these tests are failing as a result of missing information on the DUT.
This PR is to wait until all counters are enabled before running the test.
Timeout value chosen by the delay script which can be found here:
https://github.com/Azure/sonic-buildimage/blob/master/dockers/docker-orchagent/enable_counters.py

#### How did you do it?
Wait until all counters are enabled before running the tests.

#### How did you verify/test it?
Run the tests with this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
