### PR TITLE
[multi-asic] skip the neighbor check if the neighbor is ASIC

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -88,11 +88,12 @@ def test_neighbors_health(duthosts, localhost, nbrhosts, eos, sonic, enum_fronte
         dut_type = dev_meta["localhost"]["type"]
 
     for k, v in nei_meta.items():
-        if v['type'] in ['SmartCable', 'Server'] or dut_type == v['type']:
+        if v['type'] in ['SmartCable', 'Server', 'Asic'] or dut_type == v['type']:
             # Smart cable doesn't respond to snmp, it doesn't have BGP session either.
             # DualToR has the peer ToR listed in device as well. If the device type
             # is the same as testing DUT, then it is the peer.
             # The server neighbors need to be skipped too.
+            # Skip if the neigbhor is asic as well.
             continue
 
         nbrhost = nbrhosts[k]['host']


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
On multi asic platforms skip the neighbor check if the neighbor is ASIC.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x ] 201911

### Approach
#### What is the motivation for this PR?
Currently the test `test_nbr_health` is failing on multi asic platform.
This is because the test tries to incorrectly tries to find internal neighbors in `nbrhost` list for the DUT.

#### How did you do it?
exclude internal neigbors from the check in the test

#### How did you verify/test it?
run the tests in `test_nbr_health.py` on single and multi asic platforms
```
arlakshm@1c0c7668065c:/data/repos/azvm/sonic-mgmt/tests$ ./run_tests.sh -d str-multi-asic-acs-2 -n vms13-t1-multi-asic-2 -c test_nbr_health.py -i ../ansible/str,../ansible/veos -f ../ansible/testbed.csv -l WARNING -k debug -m individual -r  -t t1
,any -e '--skip_sanity --deep_clean  --disable_loganalyzer'
=== Preparing DUT for subsequent tests ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================================== test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 2818 items / 2805 deselected / 13 selected

test_nbr_health.py::test_neighbors_health[str-multi-asic-acs-2] PASSED                                                                                    [  7%]
```

```
arlakshm@1c0c7668065c:/data/repos/azvm/sonic-mgmt/tests$ ./run_tests.sh -d str-single-asic-acs-1 -n vms13-t0-single-asic -c test_nbr_health.py -i ../ansible/str,../ansible/veos -f ../ansible/testbed.csv -l WARNING -k debug -m individual  -r -t t0,a
ny -e '--skip_sanity --allow_recover --showlocals --assert plain -rav --module-path ../ansible/library/ --collect_techsupport False --deep_clean '
=== Preparing DUT for subsequent tests ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================================== test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 2426 items / 2413 deselected / 13 selected

test_nbr_health.py::test_neighbors_health[str-single-asic-acs-1] PASSED                                                                                    [  7%]                                                                                                                                                                                                                     
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
