### PR TITLE
[rdma] Skip nbrhosts fixture if no VM is present

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,7 +365,8 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
     """
 
     devices = {}
-    if not tbinfo['vm_base']:
+    if not tbinfo['vm_base'] and 'tgen' in tbinfo['topo']['name']:
+        logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['name']))
         return devices
 
     vm_base = int(tbinfo['vm_base'][2:])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,9 +364,12 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
     Shortcut fixture for getting VM host
     """
 
+    devices = {}
+    if not tbinfo['vm_base']:
+        return devices
+
     vm_base = int(tbinfo['vm_base'][2:])
     neighbor_type = request.config.getoption("--neighbor_type")
-    devices = {}
     for k, v in tbinfo['topo']['properties']['topology']['VMs'].items():
         if neighbor_type == "eos":
             devices[k] = {'host': EosHost(ansible_adhoc,


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Tgen topology used for RDMA testcase runs does not have any VMs defined which was causing those testcases to fail after this change #3656

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you do it?
Skip nbrhosts fixture if no VMs are present in the topology

#### How did you verify/test it?
Executed 'tgen' testcases with the fix and they passed