### PR TITLE
Add wait for critical services in health check for advanced reboot

### DIFF
--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -2,6 +2,7 @@ import copy
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 from tests.common.platform.transceiver_utils import parse_transceiver_info
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD
 
@@ -35,7 +36,8 @@ def check_services(duthost):
     logging.info("Wait until all critical services are fully started")
 
     logging.info("Check critical service status")
-    if not duthost.critical_services_fully_started():
+    # Wait up to 200 seconds for critical services since a part of the services has delayed start (e.g., snmp)
+    if not wait_until(200, 10, duthost.critical_services_fully_started):
         raise RebootHealthError("dut.critical_services_fully_started is False")
 
     for service in duthost.critical_services:

--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -33,8 +33,8 @@ def check_services(duthost):
     Perform a health check of services
     """
     logging.info("Wait until all critical services are fully started")
-    # Wait until 250 seconds after boot up since a part of the services has delayed start (e.g., snmp)
-    wait_until_uptime(duthost, 250)
+    # Wait until 300 seconds after boot up since a part of the services has delayed start (e.g., snmp)
+    wait_until_uptime(duthost, 300)
 
     logging.info("Check critical service status")
     if not duthost.critical_services_fully_started():

--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -2,7 +2,6 @@ import copy
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 from tests.common.platform.transceiver_utils import parse_transceiver_info
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD
 
@@ -34,10 +33,11 @@ def check_services(duthost):
     Perform a health check of services
     """
     logging.info("Wait until all critical services are fully started")
+    # Wait until 250 seconds after boot up since a part of the services has delayed start (e.g., snmp)
+    wait_until_uptime(duthost, 250)
 
     logging.info("Check critical service status")
-    # Wait up to 200 seconds for critical services since a part of the services has delayed start (e.g., snmp)
-    if not wait_until(200, 10, duthost.critical_services_fully_started):
+    if not duthost.critical_services_fully_started():
         raise RebootHealthError("dut.critical_services_fully_started is False")
 
     for service in duthost.critical_services:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add wait for critical services in the health check for advanced reboot
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
There is a health check of the dut recently introduced to advanced reboot tests which checks the status of services including snmp. However, snmp starts three minutes after start-up and the advanced reboot tests do not have a dependency on snmp start. It follows that there is a racing condition between the test cases check the state of snmp and snmp actually starts. If the test case checks snmp state earlier that it starts, the test would fail even though it would come up a few moments later. This PR aims to fix the false alarm.

#### How did you do it?
Add wait for critical services in the health check for advanced reboot tests.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
