### PR TITLE
[NAT] Get IP prefix from switch to replace hardcoded.

### DIFF
--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -119,6 +119,7 @@ def setup_test_env(request, ptfhost, duthost, tbinfo):
                          "ptf_ports_available_in_topo": ptf_ports_available_in_topo,
                          "config_portchannels": config_portchannels,
                          "pch_ips": {"PortChannel0001": duthost.setup()['ansible_facts']['ansible_PortChannel0001']['ipv4']['address']},
+                         "pch_masks": {"PortChannel0001": duthost.setup()['ansible_facts']['ansible_PortChannel0001']['ipv4']['netmask']},
                          "outer_vrf": ["red"],
                          "inner_vrf": ["blue", "yellow"],
                          interface_type: {"vrf_conf": SETUP_CONF[interface_type]["vrf"],

--- a/tests/nat/nat_helpers.py
+++ b/tests/nat/nat_helpers.py
@@ -4,6 +4,7 @@ import time
 import logging
 import json
 from collections import namedtuple
+from netaddr import IPAddress
 
 import ptf.mask as mask
 import ptf.packet as packet

--- a/tests/nat/nat_helpers.py
+++ b/tests/nat/nat_helpers.py
@@ -476,7 +476,10 @@ def setup_ptf_interfaces(testbed, ptfhost, duthost, setup_info, interface_type, 
     if "dut_iface" in setup_info[interface_type]["vrf_conf"][key].keys():
         dut_iface = setup_info[interface_type]["vrf_conf"][key]["dut_iface"]
         pch_ip = setup_info["pch_ips"][dut_iface]
-        duthost.shell("sudo config interface ip remove {} {}/31".format(dut_iface, pch_ip))
+        pch_mask = setup_info["pch_masks"][dut_iface]
+        mask_prefix = IPAddress(pch_mask).netmask_bits()
+
+        duthost.shell("sudo config interface ip remove {} {}/{}".format(dut_iface, pch_ip, mask_prefix))
         duthost.shell("sudo config interface ip add {} {}/{}".format(dut_iface, gw_ip, mask))
 
 


### PR DESCRIPTION
# Description of PR
Get IP prefix from switch to replace hardcoded.

## Summary:
Fixes cannot run loopback and port_in_lag in same test case.

## Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
## Back port request
## Approach
## What is the motivation for this PR?
Run NAT test case shows failed on port_in_lag.

## How did you do it?
Get IP prefix from switch to replace hardcoded.

## How did you verify/test it?
Run test cases and results show loopback and port_in_lag passed.

## Any platform specific information?
No

## Supported testbed topology if it's a new test case?
No