### PR TITLE
[test_default_route] Fix false pass on backend T1

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -55,7 +55,7 @@ def test_default_ipv6_route_next_hop_global_address(duthosts, enum_rand_one_per_
     asichost = duthost.asic_instance(enum_asic_index)
 
     rtinfo = asichost.get_ip_route_info(ipaddress.ip_network(u"::/0"))
-    pytest_assert(rtinfo['nexthops'] > 0, "cannot find ipv6 nexthop for default route")
+    pytest_assert(len(rtinfo['nexthops']) > 0, "cannot find ipv6 nexthop for default route")
     for nh in rtinfo['nexthops']:
         pytest_assert(not nh[0].is_link_local, \
                 "use link local address {} for nexthop".format(nh[0]))


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This testcase had a false pass on backend T1 topo which does not have a default route. The issue is because 'nexthop' key is always present in the rtinfo dict [in this case, it will have an empty list as its value]. Instead of checking for the key presence, we should check if there are values populated for the 'nexthop'

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran the test with the change on backend T1 and it failed as expected
