### PR TITLE
[pmon daemon regression test] Correct the log messages with right daemon name and fix term_and_start_status failure

### DIFF
--- a/tests/platform_tests/daemon/test_fancontrol.py
+++ b/tests/platform_tests/daemon/test_fancontrol.py
@@ -188,13 +188,6 @@ def test_pmon_fancontrol_kill_and_start_status(check_daemon_status, duthosts, ra
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
 
-    if post_daemon_status == expected_exited_status:
-        # in case of autorestart=false, it doesn't restart automatically
-        # we need to start the daemon
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(5)
-        post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-
     pytest_assert(post_daemon_status == expected_running_status,
                           "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,

--- a/tests/platform_tests/daemon/test_fancontrol.py
+++ b/tests/platform_tests/daemon/test_fancontrol.py
@@ -106,9 +106,9 @@ def test_pmon_fancontrol_running_status(duthosts, rand_one_dut_hostname):
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status == expected_running_status,
-                          "Pcied expected running status is {} but is {}".format(expected_running_status, daemon_status))
+                          "Fancontrol expected running status is {} but is {}".format(expected_running_status, daemon_status))
     pytest_assert(daemon_pid != -1,
-                          "Pcied expected pid is a positive integer but is {}".format(daemon_pid))
+                          "Fancontrol expected pid is a positive integer but is {}".format(daemon_pid))
 
 
 def test_pmon_fancontrol_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname):
@@ -124,18 +124,18 @@ def test_pmon_fancontrol_stop_and_start_status(check_daemon_status, duthosts, ra
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_stopped_status,
-                          "Pcied expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
+                          "Fancontrol expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Pcied expected pid is -1 but is {}".format(daemon_pid))
+                          "Fancontrol expected pid is -1 but is {}".format(daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "Fancontrol expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "Fancontrol expected pid is -1 but is {}".format(post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -153,18 +153,18 @@ def test_pmon_fancontrol_term_and_start_status(check_daemon_status, duthosts, ra
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_exited_status,
-                          "Pcied expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
+                          "Fancontrol expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Pcied expected pid is -1 but is {}".format(daemon_pid))
+                          "Fancontrol expected pid is -1 but is {}".format(daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "Fancontrol expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "Fancontrol expected pid is -1 but is {}".format(post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -182,14 +182,14 @@ def test_pmon_fancontrol_kill_and_start_status(check_daemon_status, duthosts, ra
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon got killed unexpectedly and it is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
-                          "Pcied unexpected killed status is not {}".format(daemon_status))
+                          "Fancontrol unexpected killed status is not {}".format(daemon_status))
 
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "Fancontrol expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "Fancontrol expected pid is -1 but is {}".format(post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))

--- a/tests/platform_tests/daemon/test_fancontrol.py
+++ b/tests/platform_tests/daemon/test_fancontrol.py
@@ -58,38 +58,6 @@ def teardown_module(duthosts, rand_one_dut_hostname):
     check_critical_processes(duthost, watch_secs=10)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    """Changes the autorestart of containers from `enabled` to `disabled` before testing.
-       and Rolls them back after testing.
-    Args:
-        duthost: Hostname of DUT.
-    Returns:
-        None.
-    """
-    containers_autorestart_states = duthost.get_container_autorestart_states()
-    disabled_autorestart_containers = []
-
-    for container_name, state in containers_autorestart_states.items():
-        if container_name == "pmon" and state == "enabled":
-            logger.info("Disabling the autorestart of container '{}'.".format(container_name))
-            command_disable_autorestart = "sudo config feature autorestart {} disabled".format(container_name)
-            command_output = duthost.shell(command_disable_autorestart)
-            exit_code = command_output["rc"]
-            pytest_assert(exit_code == 0, "Failed to disable the autorestart of container '{}'".format(container_name))
-            logger.info("The autorestart of container '{}' was disabled.".format(container_name))
-            disabled_autorestart_containers.append(container_name)
-
-    yield
-
-    for container_name in disabled_autorestart_containers:
-        logger.info("Enabling the autorestart of container '{}'...".format(container_name))
-        command_output = duthost.shell("sudo config feature autorestart {} enabled".format(container_name))
-        exit_code = command_output["rc"]
-        pytest_assert(exit_code == 0, "Failed to enable the autorestart of container '{}'".format(container_name))
-        logger.info("The autorestart of container '{}' is enabled.".format(container_name))
-
 @pytest.fixture()
 def check_daemon_status(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/platform_tests/daemon/test_fancontrol.py
+++ b/tests/platform_tests/daemon/test_fancontrol.py
@@ -72,7 +72,7 @@ def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
     disabled_autorestart_containers = []
 
     for container_name, state in containers_autorestart_states.items():
-        if state == "enabled":
+        if container_name == "pmon" and state == "enabled":
             logger.info("Disabling the autorestart of container '{}'.".format(container_name))
             command_disable_autorestart = "sudo config feature autorestart {} disabled".format(container_name)
             command_output = duthost.shell(command_disable_autorestart)

--- a/tests/platform_tests/daemon/test_fancontrol.py
+++ b/tests/platform_tests/daemon/test_fancontrol.py
@@ -106,9 +106,9 @@ def test_pmon_fancontrol_running_status(duthosts, rand_one_dut_hostname):
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status == expected_running_status,
-                          "Fancontrol expected running status is {} but is {}".format(expected_running_status, daemon_status))
+                          "{} expected running status is {} but is {}".format(daemon_name, expected_running_status, daemon_status))
     pytest_assert(daemon_pid != -1,
-                          "Fancontrol expected pid is a positive integer but is {}".format(daemon_pid))
+                          "{} expected pid is a positive integer but is {}".format(daemon_name, daemon_pid))
 
 
 def test_pmon_fancontrol_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname):
@@ -124,18 +124,18 @@ def test_pmon_fancontrol_stop_and_start_status(check_daemon_status, duthosts, ra
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_stopped_status,
-                          "Fancontrol expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
+                          "{} expected stopped status is {} but is {}".format(daemon_name, expected_stopped_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Fancontrol expected pid is -1 but is {}".format(daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Fancontrol expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Fancontrol expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is a positive number not {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -153,18 +153,18 @@ def test_pmon_fancontrol_term_and_start_status(check_daemon_status, duthosts, ra
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_exited_status,
-                          "Fancontrol expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
+                          "{} expected terminated status is {} but is {}".format(daemon_name, expected_exited_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Fancontrol expected pid is -1 but is {}".format(daemon_pid))
+                          "{} expected pid is a positive number not {}".format(daemon_name, daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Fancontrol expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Fancontrol expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -182,14 +182,22 @@ def test_pmon_fancontrol_kill_and_start_status(check_daemon_status, duthosts, ra
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon got killed unexpectedly and it is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
-                          "Fancontrol unexpected killed status is not {}".format(daemon_status))
+                          "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
+
+    if post_daemon_status == expected_exited_status:
+        # in case of autorestart=false, it doesn't restart automatically
+        # we need to start the daemon
+        duthost.start_pmon_daemon(daemon_name)
+        time.sleep(5)
+        post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
+
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Fancontrol expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Fancontrol expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is a positive number not {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -188,13 +188,6 @@ def test_pmon_ledd_kill_and_start_status(check_daemon_status, duthosts, rand_one
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
 
-    if post_daemon_status == expected_exited_status:
-        # in case of autorestart=false, it doesn't restart automatically
-        # we need to start the daemon
-        duthost.start_pmon_daemon(daemon_name)
-        time.sleep(5)
-        post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-
     pytest_assert(post_daemon_status == expected_running_status,
                           "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -106,9 +106,9 @@ def test_pmon_ledd_running_status(duthosts, rand_one_dut_hostname):
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status == expected_running_status,
-                          "Ledd expected running status is {} but is {}".format(expected_running_status, daemon_status))
+                          "{} expected running status is {} but is {}".format(daemon_name, expected_running_status, daemon_status))
     pytest_assert(daemon_pid != -1,
-                          "Ledd expected pid is a positive integer but is {}".format(daemon_pid))
+                          "{} expected pid is a positive integer but is {}".format(daemon_name, daemon_pid))
 
 
 def test_pmon_ledd_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname):
@@ -124,18 +124,18 @@ def test_pmon_ledd_stop_and_start_status(check_daemon_status, duthosts, rand_one
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_stopped_status,
-                          "Ledd expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
+                          "{} expected stopped status is {} but is {}".format(daemon_name, expected_stopped_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Ledd expected pid is -1 but is {}".format(daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Ledd expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Ledd expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is a positive integer but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -153,18 +153,18 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_exited_status,
-                          "Ledd expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
+                          "{} expected terminated status is {} but is {}".format(daemon_name, expected_exited_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Ledd expected pid is -1 but is {}".format(daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Ledd expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Ledd expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is a positive integer but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -182,14 +182,22 @@ def test_pmon_ledd_kill_and_start_status(check_daemon_status, duthosts, rand_one
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon got killed unexpectedly and it is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
-                          "Ledd unexpected killed status is not {}".format(daemon_status))
+                          "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
+
+    if post_daemon_status == expected_exited_status:
+        # in case of autorestart=false, it doesn't restart automatically
+        # we need to start the daemon
+        duthost.start_pmon_daemon(daemon_name)
+        time.sleep(5)
+        post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
+
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Ledd expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Ledd expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is a positive integer but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -106,9 +106,9 @@ def test_pmon_ledd_running_status(duthosts, rand_one_dut_hostname):
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status == expected_running_status,
-                          "Pcied expected running status is {} but is {}".format(expected_running_status, daemon_status))
+                          "Ledd expected running status is {} but is {}".format(expected_running_status, daemon_status))
     pytest_assert(daemon_pid != -1,
-                          "Pcied expected pid is a positive integer but is {}".format(daemon_pid))
+                          "Ledd expected pid is a positive integer but is {}".format(daemon_pid))
 
 
 def test_pmon_ledd_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname):
@@ -124,18 +124,18 @@ def test_pmon_ledd_stop_and_start_status(check_daemon_status, duthosts, rand_one
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_stopped_status,
-                          "Pcied expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
+                          "Ledd expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Pcied expected pid is -1 but is {}".format(daemon_pid))
+                          "Ledd expected pid is -1 but is {}".format(daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "Ledd expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "Ledd expected pid is -1 but is {}".format(post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -153,18 +153,18 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_exited_status,
-                          "Pcied expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
+                          "Ledd expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Pcied expected pid is -1 but is {}".format(daemon_pid))
+                          "Ledd expected pid is -1 but is {}".format(daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "Ledd expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "Ledd expected pid is -1 but is {}".format(post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -182,14 +182,14 @@ def test_pmon_ledd_kill_and_start_status(check_daemon_status, duthosts, rand_one
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon got killed unexpectedly and it is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
-                          "Pcied unexpected killed status is not {}".format(daemon_status))
+                          "Ledd unexpected killed status is not {}".format(daemon_status))
 
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "Ledd expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "Ledd expected pid is -1 but is {}".format(post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -58,38 +58,6 @@ def teardown_module(duthosts, rand_one_dut_hostname):
     check_critical_processes(duthost, watch_secs=10)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    """Changes the autorestart of containers from `enabled` to `disabled` before testing.
-       and Rolls them back after testing.
-    Args:
-        duthost: Hostname of DUT.
-    Returns:
-        None.
-    """
-    containers_autorestart_states = duthost.get_container_autorestart_states()
-    disabled_autorestart_containers = []
-
-    for container_name, state in containers_autorestart_states.items():
-        if container_name == "pmon" and state == "enabled":
-            logger.info("Disabling the autorestart of container '{}'.".format(container_name))
-            command_disable_autorestart = "sudo config feature autorestart {} disabled".format(container_name)
-            command_output = duthost.shell(command_disable_autorestart)
-            exit_code = command_output["rc"]
-            pytest_assert(exit_code == 0, "Failed to disable the autorestart of container '{}'".format(container_name))
-            logger.info("The autorestart of container '{}' was disabled.".format(container_name))
-            disabled_autorestart_containers.append(container_name)
-
-    yield
-
-    for container_name in disabled_autorestart_containers:
-        logger.info("Enabling the autorestart of container '{}'...".format(container_name))
-        command_output = duthost.shell("sudo config feature autorestart {} enabled".format(container_name))
-        exit_code = command_output["rc"]
-        pytest_assert(exit_code == 0, "Failed to enable the autorestart of container '{}'".format(container_name))
-        logger.info("The autorestart of container '{}' is enabled.".format(container_name))
-
 @pytest.fixture()
 def check_daemon_status(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -72,7 +72,7 @@ def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
     disabled_autorestart_containers = []
 
     for container_name, state in containers_autorestart_states.items():
-        if state == "enabled":
+        if container_name == "pmon" and state == "enabled":
             logger.info("Disabling the autorestart of container '{}'.".format(container_name))
             command_disable_autorestart = "sudo config feature autorestart {} disabled".format(container_name)
             command_output = duthost.shell(command_disable_autorestart)

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -123,7 +123,6 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    logger.info("{} daemon got killed unexpectedly and it is in {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status and pre_daemon_pid != daemon_pid,
                           "{} status for SIG_TERM should not be {} with pid:{}!".format(daemon_name, daemon_status, daemon_pid))
 
@@ -149,7 +148,6 @@ def test_pmon_ledd_kill_and_start_status(check_daemon_status, duthosts, rand_one
     duthost.stop_pmon_daemon(daemon_name, SIG_KILL, pre_daemon_pid)
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    logger.info("{} daemon got killed unexpectedly and it is in {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
                           "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -37,8 +37,7 @@ SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
 SIG_KILL = "-9"
 
-pcie_devices_status_tbl_key = "PCIE_DEVICES"
-pcie_devices_status_tbl_key_m = "PCIE_DEVICES|status"
+pcie_devices_status_tbl_key = "PCIE_DEVICES|status"
 status_field = "status"
 expected_pcied_devices_status = "PASSED"
 
@@ -116,9 +115,8 @@ def test_pmon_pcied_running_status(duthosts, rand_one_dut_hostname):
                           "{} expected pid is a positive integer but is {}".format(daemon_name, daemon_pid))
 
     daemon_db_value = duthost.get_pmon_daemon_db_value(pcie_devices_status_tbl_key, status_field)
-    daemon_db_value_m = duthost.get_pmon_daemon_db_value(pcie_devices_status_tbl_key_m, status_field)
-    if daemon_db_value != expected_pcied_devices_status and daemon_db_value_m != expected_pcied_devices_status:
-         logger.error("{} expected db value is not set".format(daemon_name))
+    pytest_assert(daemon_db_value == expected_pcied_devices_status,
+                          "Expected {} {} is {} but is {}".format(pcie_devices_status_tbl_key, status_field, expected_pcied_devices_status, daemon_db_value))
 
 
 def test_pmon_pcied_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname):

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -153,19 +153,20 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts, rand_on
     @summary: This test case is to check the pcied terminated and restarted status
     """
     duthost = duthosts[rand_one_dut_hostname]
+
+    if "201811" in duthost.os_version or "201911" in duthost.os_version:
+        pytest.skip("Skip: SIG_TERM behaves differnetly in {} on {}".format(daemon_name, duthost.os_version))
+
     pre_daemon_status, pre_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, pre_daemon_status, pre_daemon_pid))
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
-    time.sleep(2)
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    pytest_assert(daemon_status == expected_exited_status,
-                          "{} expected terminated status is {} but is {}".format(daemon_name, expected_exited_status, daemon_status))
-    pytest_assert(daemon_pid == -1,
-                          "{} expected pid is -1 but is {}".format(daemon_name, daemon_pid))
+    logger.info("{} daemon got killed unexpectedly and it is in {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
+    pytest_assert(daemon_status != expected_running_status and pre_daemon_pid != daemon_pid,
+                         "{} status for SIG_TERM should not be {} with pid:{}!".format(daemon_name, daemon_status, daemon_pid))
 
-    duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
@@ -188,7 +189,7 @@ def test_pmon_pcied_kill_and_start_status(check_daemon_status, duthosts, rand_on
     duthost.stop_pmon_daemon(daemon_name, SIG_KILL, pre_daemon_pid)
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    logger.info("{} daemon got killed unexpectedly and it is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
+    logger.info("{} daemon got killed unexpectedly and it is in {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
                           "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -131,7 +131,6 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts, rand_on
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    logger.info("{} daemon got killed unexpectedly and it is in {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status and pre_daemon_pid != daemon_pid,
                          "{} status for SIG_TERM should not be {} with pid:{}!".format(daemon_name, daemon_status, daemon_pid))
 
@@ -157,7 +156,6 @@ def test_pmon_pcied_kill_and_start_status(check_daemon_status, duthosts, rand_on
     duthost.stop_pmon_daemon(daemon_name, SIG_KILL, pre_daemon_pid)
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    logger.info("{} daemon got killed unexpectedly and it is in {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
                           "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -37,7 +37,8 @@ SIG_STOP_SERVICE = None
 SIG_TERM = "-15"
 SIG_KILL = "-9"
 
-pcie_devices_status_tbl_key = "PCIE_DEVICES|status"
+pcie_devices_status_tbl_key = "PCIE_DEVICES"
+pcie_devices_status_tbl_key_m = "PCIE_DEVICES|status"
 status_field = "status"
 expected_pcied_devices_status = "PASSED"
 
@@ -110,14 +111,14 @@ def test_pmon_pcied_running_status(duthosts, rand_one_dut_hostname):
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status == expected_running_status,
-                          "Pcied expected running status is {} but is {}".format(expected_running_status, daemon_status))
+                          "{} expected running status is {} but is {}".format(daemon_name, expected_running_status, daemon_status))
     pytest_assert(daemon_pid != -1,
-                          "Pcied expected pid is a positive integer but is {}".format(daemon_pid))
+                          "{} expected pid is a positive integer but is {}".format(daemon_name, daemon_pid))
 
     daemon_db_value = duthost.get_pmon_daemon_db_value(pcie_devices_status_tbl_key, status_field)
-    pytest_assert(daemon_db_value == expected_pcied_devices_status,
-                          "Expected {} {} is {} but is {}".format(pcie_devices_status_tbl_key, status_field, expected_pcied_devices_status, daemon_db_value))
-
+    daemon_db_value_m = duthost.get_pmon_daemon_db_value(pcie_devices_status_tbl_key_m, status_field)
+    if daemon_db_value != expected_pcied_devices_status and daemon_db_value_m != expected_pcied_devices_status:
+         logger.error("{} expected db value is not set".format(daemon_name))
 
 
 def test_pmon_pcied_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname):
@@ -133,18 +134,18 @@ def test_pmon_pcied_stop_and_start_status(check_daemon_status, duthosts, rand_on
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_stopped_status,
-                          "Pcied expected stopped status is {} but is {}".format(expected_stopped_status, daemon_status))
+                          "{} expected stopped status is {} but is {}".format(daemon_name, expected_stopped_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Pcied expected pid is -1 but is {}".format(daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -162,18 +163,18 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts, rand_on
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(daemon_status == expected_exited_status,
-                          "Pcied expected terminated status is {} but is {}".format(expected_exited_status, daemon_status))
+                          "{} expected terminated status is {} but is {}".format(daemon_name, expected_exited_status, daemon_status))
     pytest_assert(daemon_pid == -1,
-                          "Pcied expected pid is -1 but is {}".format(daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, daemon_pid))
 
     duthost.start_pmon_daemon(daemon_name)
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
 
@@ -191,14 +192,14 @@ def test_pmon_pcied_kill_and_start_status(check_daemon_status, duthosts, rand_on
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon got killed unexpectedly and it is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status != expected_running_status,
-                          "Pcied unexpected killed status is not {}".format(daemon_status))
+                          "{} unexpected killed status is not {}".format(daemon_name, daemon_status))
 
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,
-                          "Pcied expected restarted status is {} but is {}".format(expected_running_status, post_daemon_status))
+                          "{} expected restarted status is {} but is {}".format(daemon_name, expected_running_status, post_daemon_status))
     pytest_assert(post_daemon_pid != -1,
-                          "Pcied expected pid is -1 but is {}".format(post_daemon_pid))
+                          "{} expected pid is -1 but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -76,7 +76,7 @@ def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
     disabled_autorestart_containers = []
 
     for container_name, state in containers_autorestart_states.items():
-        if state == "enabled":
+        if container_name == "pmon" and state == "enabled":
             logger.info("Disabling the autorestart of container '{}'.".format(container_name))
             command_disable_autorestart = "sudo config feature autorestart {} disabled".format(container_name)
             command_output = duthost.shell(command_disable_autorestart)

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -62,38 +62,6 @@ def teardown_module(duthosts, rand_one_dut_hostname):
     check_critical_processes(duthost, watch_secs=10)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    """Changes the autorestart of containers from `enabled` to `disabled` before testing.
-       and Rolls them back after testing.
-    Args:
-        duthost: Hostname of DUT.
-    Returns:
-        None.
-    """
-    containers_autorestart_states = duthost.get_container_autorestart_states()
-    disabled_autorestart_containers = []
-
-    for container_name, state in containers_autorestart_states.items():
-        if container_name == "pmon" and state == "enabled":
-            logger.info("Disabling the autorestart of container '{}'.".format(container_name))
-            command_disable_autorestart = "sudo config feature autorestart {} disabled".format(container_name)
-            command_output = duthost.shell(command_disable_autorestart)
-            exit_code = command_output["rc"]
-            pytest_assert(exit_code == 0, "Failed to disable the autorestart of container '{}'".format(container_name))
-            logger.info("The autorestart of container '{}' was disabled.".format(container_name))
-            disabled_autorestart_containers.append(container_name)
-
-    yield
-
-    for container_name in disabled_autorestart_containers:
-        logger.info("Enabling the autorestart of container '{}'...".format(container_name))
-        command_output = duthost.shell("sudo config feature autorestart {} enabled".format(container_name))
-        exit_code = command_output["rc"]
-        pytest_assert(exit_code == 0, "Failed to enable the autorestart of container '{}'".format(container_name))
-        logger.info("The autorestart of container '{}' is enabled.".format(container_name))
-
 @pytest.fixture()
 def check_daemon_status(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #(https://github.com/Azure/sonic-buildimage/issues/8239)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
### Approach
#### What is the motivation for this PR?
Needs to fix pmon daemon regression test issues
#### How did you do it?
1. Use `daemon_name` instead of the specific daemon name for log message
2. Support for both old/new db key support for checking the db value.
3. Skip term_and_start_status test cases for 201911 and 201811 since it behaves differently
4. Fix the expected daemon status after sending sig_term based on latest daemon behavior for term_and_start_status 
5. Remove disable_and_enable_autorestart to make sure the daemon regression test doesn't affect any other containers.

#### How did you verify/test it?
Run test_ledd.py on arista 7050 platform which reports issue.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
