### PR TITLE
[sanity]: Add log for mux sanity failure

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -323,6 +323,7 @@ def _check_intf_names(intf_status, active_intf, mux_intf, expected_side):
     # Verify correct active ToR
     if intf_status['active_side'] != expected_side:
         failed = True
+        import pdb; pdb.set_trace()
         failed_reason = 'Active side mismatch for {}, got {} but expected {}' \
                         .format(bridge, intf_status['active_side'], expected_side)
         return failed, failed_reason
@@ -504,6 +505,7 @@ def check_mux_simulator(toggle_all_simulator_ports, get_mux_status, reset_simula
                 failed, reason = _check_single_intf_status(status, expected_side=side)
 
                 if failed:
+                    logger.warning('Mux sanity check failed for status:\n{}'.format(status))
                     results['failed'] = failed
                     results['failed_reason'] = reason
                     results['action'] = reset_simulator_port

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -323,7 +323,6 @@ def _check_intf_names(intf_status, active_intf, mux_intf, expected_side):
     # Verify correct active ToR
     if intf_status['active_side'] != expected_side:
         failed = True
-        import pdb; pdb.set_trace()
         failed_reason = 'Active side mismatch for {}, got {} but expected {}' \
                         .format(bridge, intf_status['active_side'], expected_side)
         return failed, failed_reason


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The mux simulator sanity check has encountered failures with no obvious cause. More logging will help RCA these failures.

#### How did you do it?
Add a warning log when the check failures which contains the mux status returned by the mux simulator server.

#### How did you verify/test it?
Intentionally place the mux simulator in a bad state so the check fails, ensure the warning log is printed. Restore the mux simulator, ensure the warning log is not printed.

Expected log output: 
```
21:50:11 checks._check                            L0509 WARNING| Mux sanity check failed for status:
{u'bridge': u'mbr-vms17-7-14', u'standby_side': u'lower_tor', u'healthy': True, u'standby_port': u'enp59s0f1.2795', u'vm_set': u'vms17-7', u'flows': {u'enp59s0f1.2763': [{u'action': u'output', u'out_port': u'muxy-vms17-7-14'}], u'muxy-vms17-7-14': [{u'action': u'output', u'out_port': u'enp59s0f1.2763'}, {u'action': u'output', u'out_port': u'enp59s0f1.2795'}]}, u'port_index': 14, u'active_port': u'enp59s0f1.2763', u'flap_counter': 686, u'active_side': u'upper_tor', u'ports': {u'lower_tor': u'enp59s0f1.2795', u'nic': u'muxy-vms17-7-14', u'upper_tor': u'enp59s0f1.2763'}}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
