### PR TITLE
[dualtor][orch] Skip orchagent testcases on real dualtor testbed

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -8,8 +8,10 @@ from ipaddress import ip_interface, IPv4Interface, IPv6Interface, \
                       ip_address, IPv4Address
 from tests.common import config_reload
 from tests.common.dualtor.dual_tor_utils import tor_mux_intfs
+from tests.common.helpers.assertions import pytest_require
 
 __all__ = [
+    'require_mocked_dualtor',
     'apply_active_state_to_orchagent',
     'apply_dual_tor_neigh_entries',
     'apply_dual_tor_peer_switch_route',
@@ -133,6 +135,12 @@ def _apply_dual_tor_state_to_orchagent(dut, state, tor_mux_intfs):
 
 def is_mocked_dualtor(tbinfo):
     return 'dualtor' not in tbinfo['topo']['name']
+
+
+@pytest.fixture
+def require_mocked_dualtor(tbinfo):
+    pytest_require(is_t0_mocked_dualtor(tbinfo), "This testcase is designed for "
+        "single tor testbed with mock dualtor config. Skip this testcase on real dualtor testbed")
 
 
 def set_mux_state(dut, tbinfo, state, itfs, toggle_all_simulator_ports):

--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -147,6 +147,7 @@ def config_crm_polling_interval(rand_selected_dut):
 
 
 def test_change_mux_state(
+        require_mocked_dualtor,
         apply_mock_dual_tor_tables,
         apply_mock_dual_tor_kernel_configs,
         rand_selected_dut,
@@ -214,6 +215,7 @@ def add_neighbors(dut, neighbors, interface):
 
 
 def test_flap_neighbor_entry_active(
+        require_mocked_dualtor,
         apply_mock_dual_tor_tables,
         apply_mock_dual_tor_kernel_configs,
         rand_selected_dut,
@@ -247,6 +249,7 @@ def test_flap_neighbor_entry_active(
 
 
 def test_flap_neighbor_entry_standby(
+        require_mocked_dualtor,
         apply_mock_dual_tor_tables,
         apply_mock_dual_tor_kernel_configs,
         rand_selected_dut,

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -33,7 +33,7 @@ pytestmark = [
 def test_active_tor_remove_neighbor_downstream_active(
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, rand_unselected_dut, tbinfo,
-    set_crm_polling_interval,
+    require_mocked_dualtor, set_crm_polling_interval,
     tunnel_traffic_monitor, vmhost
 ):
     """
@@ -84,9 +84,8 @@ def test_active_tor_remove_neighbor_downstream_active(
 
 
 def test_downstream_ecmp_nexthops(
-    ptfadapter,
-    rand_selected_dut, tbinfo,
-    toggle_all_simulator_ports,
+    ptfadapter, rand_selected_dut, tbinfo,
+    require_mocked_dualtor, toggle_all_simulator_ports,
     tor_mux_intfs
     ):
     dst_server_ipv4 = "1.1.1.2"

--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -81,6 +81,7 @@ def enable_garp(duthost):
 
 
 def test_mac_move(
+    require_mocked_dualtor,
     announce_new_neighbor, apply_active_state_to_orchagent,
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, set_crm_polling_interval,

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -99,7 +99,8 @@ def shutdown_one_bgp_session(rand_selected_dut):
     startup_bgp_session(rand_selected_dut, bgp_shutdown)
 
 
-def test_standby_tor_downstream(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo):
+def test_standby_tor_downstream(ptfhost, rand_selected_dut, rand_unselected_dut,
+    tbinfo, require_mocked_dualtor):
     """
     Verify tunnel traffic to active ToR is distributed equally across nexthops, and
     no traffic is forwarded to server from standby ToR
@@ -108,7 +109,8 @@ def test_standby_tor_downstream(ptfhost, rand_selected_dut, rand_unselected_dut,
     check_tunnel_balance(**params)
 
 
-def test_standby_tor_downstream_t1_link_recovered(ptfhost, rand_selected_dut, rand_unselected_dut, verify_crm_nexthop_counter_not_increased, tbinfo):
+def test_standby_tor_downstream_t1_link_recovered(ptfhost, rand_selected_dut, rand_unselected_dut,
+    require_mocked_dualtor, verify_crm_nexthop_counter_not_increased, tbinfo):
     """
     Verify traffic is distributed evenly after t1 link is recovered;
     Verify CRM that no new nexthop created
@@ -134,7 +136,8 @@ def test_standby_tor_downstream_t1_link_recovered(ptfhost, rand_selected_dut, ra
     check_tunnel_balance(**params)
 
 
-def test_standby_tor_downstream_bgp_recovered(ptfhost, rand_selected_dut, rand_unselected_dut, verify_crm_nexthop_counter_not_increased, tbinfo):
+def test_standby_tor_downstream_bgp_recovered(ptfhost, rand_selected_dut, rand_unselected_dut,
+    require_mocked_dualtor, verify_crm_nexthop_counter_not_increased, tbinfo):
     """
     Verify traffic is shifted to the active links and no traffic drop observed;
     Verify traffic is distributed evenly after BGP session is recovered;
@@ -177,7 +180,7 @@ def test_standby_tor_downstream_loopback_route_readded(ptfhost, rand_selected_du
 def test_standby_tor_remove_neighbor_downstream_standby(
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, rand_unselected_dut, tbinfo,
-    set_crm_polling_interval,
+    require_mocked_dualtor, set_crm_polling_interval,
     tunnel_traffic_monitor, vmhost
 ):
     """
@@ -224,8 +227,8 @@ def test_standby_tor_remove_neighbor_downstream_standby(
 def test_downstream_standby_mux_toggle_active(
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, rand_unselected_dut, tbinfo,
-    tunnel_traffic_monitor, vmhost, toggle_all_simulator_ports,
-    tor_mux_intfs
+    require_mocked_dualtor, tunnel_traffic_monitor,
+    vmhost, toggle_all_simulator_ports, tor_mux_intfs
     ):
     # set rand_selected_dut as standby and rand_unselected_dut to active tor
     test_params = dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo)

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -47,7 +47,9 @@ def test_cleanup(rand_selected_dut):
     config_reload(rand_selected_dut)
 
 
-def test_standby_tor_upstream_mux_toggle(rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface, toggle_all_simulator_ports, set_crm_polling_interval):
+def test_standby_tor_upstream_mux_toggle(
+    rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface,
+    require_mocked_dualtor, toggle_all_simulator_ports, set_crm_polling_interval):
     itfs, ip = rand_selected_interface
     PKT_NUM = 100
     # Step 1. Set mux state to standby and verify traffic is dropped by ACL rule and drop counters incremented


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Based on the findings here: https://github.com/Azure/sonic-buildimage/issues/8088#issuecomment-887950628, dualtor testbeds which are part of orchagent test plan are to be skipped.
This PR adds skips below cases real dualtor testbed:

```
test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active
test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops

test_orchagent_mac_move.py::test_mac_move

test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream
test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered
test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered
test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby

test_standby_tor_upstream_mux_toggle.py::test_standby_tor_upstream_mux_toggle

test_orch_stress.py::test_change_mux_state 
test_orch_stress.py::test_flap_neighbor_entry_active 
test_orch_stress.py::test_flap_neighbor_entry_standby 
```

Fixes https://github.com/Azure/sonic-buildimage/issues/8088

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added a new fixture `require_mocked_dualtor` and added it to the testcases which are to be skipped on real dualtor testbed.

#### How did you verify/test it?
With this change, the listed testcases will be skipped on a real dualtor testbed.
```
dualtor/test_standby_tor_upstream_mux_toggle.py::test_standby_tor_upstream_mux_toggle SKIPPED
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered SKIPPED 
dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active SKIPPED                                                                                                  
dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops SKIPPED

dualtor/test_orch_stress.py::test_change_mux_state SKIPPED                                                                                                                                                  
dualtor/test_orch_stress.py::test_flap_neighbor_entry_active SKIPPED                                                                                                                                        
dualtor/test_orch_stress.py::test_flap_neighbor_entry_standby SKIPPED
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
