### PR TITLE
[crm] Fix test_crm_fdb_entry

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -949,12 +949,10 @@ def test_crm_fdb_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
     if "t0" not in tbinfo["topo"]["name"].lower():
         pytest.skip("Unsupported topology, expected to run only on 'T0*' topology")
     get_fdb_stats = "redis-cli --raw -n 2 HMGET CRM:STATS crm_stats_fdb_entry_used crm_stats_fdb_entry_available"
-    topology = tbinfo["topo"]["properties"]["topology"]
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     port_dict = dict(zip(cfg_facts['port_index_map'].values(), cfg_facts['port_index_map'].keys()))
-    # Use for test 1st in list hosts interface port to add into dummy VLAN
-    host_port_id = [id for id in topology["host_interfaces"]][0]
-    iface = port_dict[host_port_id]
+    # Select the first vlan interface for test
+    iface = duthost.get_vlan_intfs()[0]
     vlan_id = 2
     cmd_add_vlan_member = "config vlan member add {vid} {iface}"
     cmd_add_vlan = "config vlan add {}".format(vlan_id)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
```test_crm_fdb_entry``` failed with follow error message
```
RunAnsibleModuleFail: run module command failed, Ansible Results => {     "changed": true,      "cmd": [         "config",          "vlan",          "member",          "add",          "2",          "Ethernet4"     ],      "delta": "0:00:00.303158",      "end": "2021-07-30 16:22:24.925014",      "failed": true,      "invocation": {         "module_args": {             "_raw_params": "config vlan member add 2 Ethernet4",              "_uses_shell": false,              "argv": null,              "chdir": null,              "creates": null,              "executable": null,              "removes": null,              "stdin": null,              "stdin_add_newline": true,              "strip_empty_ends": true,              "warn": true         }     },      "msg": "non-zero return code",      "rc": 2,      "start": "2021-07-30 16:22:24.621856",      "stderr": "Usage: config vlan member add [OPTIONS] <vid> port\nTry \"config vlan member add -h\" for help.\n\nError: Ethernet4 is part of portchannel!",      "stderr_lines": [         "Usage: config vlan member add [OPTIONS] <vid> port",          "Try \"config vlan member add -h\" for help.",          "",          "Error: Ethernet4 is part of portchannel!"     ],      "stdout": "",      "stdout_lines": [] }
```
The error is cause by recently merged PR #3897, which changed the ```port_index```. As a result, the test case will try to add some interfaces in PortChannel to a dummy vlan, and errors were raised.
This PR addressed the issue by selecting a port from all vlan interfaces.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_crm_fdb_entry```.

#### How did you do it?
This PR addressed the issue by selecting a port from all vlan interfaces.

#### How did you verify/test it?
Verified on SN4600 T0, test passed now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
