### PR TITLE
Changing the reboot uptime checker to be more robust

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -195,7 +195,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     pool.terminate()
     dut_uptime = duthost.get_up_time()
     logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
-    assert float(dut_uptime.strftime("%s")) - float(dut_datetime.strftime("%s")) > 10, "Device {} did not reboot".format(hostname)
+    assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot".format(hostname)
 
 
 def get_reboot_cause(dut):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The checker is currently using the arbitrary value of 10 seconds gap between the 'now time before rebooting' and the uptime after rebooting.
However,in case of soft boot- it is almost immediate (it executes /sbin/reboot) and with powerful CPUs we see it coming up in about 8-9 seconds which fails the check below. Hence this arbitrary wait was changed and now the test only verifies that the uptime is bigger than 'now time before rebooting'.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Make the reboot downtime checker more robust

#### How did you do it?
Changed the reboot validation that the uptime is bigger than 'now time before rebooting'.

#### How did you verify/test it?
Ran the soft reboot test

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
