### PR TITLE
delay after config reload for KVM setup

### DIFF
--- a/ansible/roles/sonic/handlers/main.yml
+++ b/ansible/roles/sonic/handlers/main.yml
@@ -8,7 +8,7 @@
 
 - name: wait for SONiC update config db to finish
   pause:
-    seconds: 60
+    seconds: 180
 
 - name: SONiC restart BGP service
   become: true

--- a/ansible/roles/sonic/handlers/main.yml
+++ b/ansible/roles/sonic/handlers/main.yml
@@ -6,6 +6,10 @@
   become: yes
   listen: "Update config db"
 
+- name: wait for SONiC update config db to finish
+  pause:
+    seconds: 60
+
 - name: SONiC restart BGP service
   become: true
   service: name=bgp

--- a/ansible/roles/sonic/tasks/vsonic.yml
+++ b/ansible/roles/sonic/tasks/vsonic.yml
@@ -48,6 +48,7 @@
   when: hostname in configuration
   notify:
     - Update config db
+    - wait for SONiC update config db to finish
 
 - name: create frr config
   template: src="frr-{{ topo }}-{{ props.swrole }}.j2"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix #3778 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
On our team, we were experiencing issues with the leaf nodes' physical interfaces not being configured correctly after the topology deployment on the KVM testbed. Issue seemed to arise from restarting the bgp service before the updated config had been loaded on some nodes.

This is likely due to CPU time being low on the VMs we are using, may be helpful to others that run into similar issues.

#### How did you do it?
Added one minute delay between the config reload and the restart for the bgp service.

#### How did you verify/test it?
Before change, all four leaf nodes in the t0 topology would only get configured correctly in about 10% of deployments.

After the change, the leaf nodes were consistently configured correctly and passed the sanity-checks that were failed as described in #3778  