### PR TITLE
[sanity]: Recover DUT before VMs

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -242,10 +242,10 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                             and callable(failed_result['action']):
                             infra_recovery_actions.append(failed_result['action'])
                 for dut_name, dut_results in dut_failed_results.items():
-                    # Attempt to restore neighbor VM state
-                    neighbor_vm_restore(duthosts[dut_name], nbrhosts, tbinfo)
                     # Attempt to restore DUT state
                     recover(duthosts[dut_name], localhost, fanouthosts, dut_results, recover_method)
+                    # Attempt to restore neighbor VM state
+                    neighbor_vm_restore(duthosts[dut_name], nbrhosts, tbinfo)
                 for action in infra_recovery_actions:
                     action()
 

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -106,6 +106,7 @@ def recover(dut, localhost, fanouthosts, check_results, recover_method):
 
 
 def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
+    logger.info("Restoring neighbor VMs for {}".format(duthost))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
     lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
If the teamd container on the DUT is stopped, it is possible for the neighbor VM recovery method to fail since it depends on running commands inside the teamd container. This prevents subsequent recovery actions from running, including recovering the DUT itself (via config reload or reboot).

#### How did you do it?
- Recover the DUT before recovering the neighbor methods. This way, when we begin the neighbor VM recovery we ensure that the DUT has been put in a good state.
- Also add a logging statement when recovering neighbor VMs

#### How did you verify/test it?
- Manually stop the teamd container on a DUT. Run the sanity check with these changes, and verify that the sanity check is able to complete and recover the DUT to a healthy state.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
