### PR TITLE
[psu]To filter and ignore non-ascii charasters in the psu test string

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -186,6 +186,9 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     num_psu_ok = 0
 
     for line in psu_status_output_lines[2:]:
+        if isinstance(line, unicode):
+            line = line.encode('ascii', 'ignore').decode('ascii')
+        logging.info("line is '{}'".format(line))
         psu_match = psu_line_pattern.match(line)
         pytest_assert(psu_match, "Unexpected PSU status output: '{}' on '{}'".format(line, duthost.hostname))
         psu_status = psu_match.group(2)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix the test_show_platform_psustatus fail due to non-ascii character(Ё) in the test string.

Summary:
Fixes # (issue)
Filter and ignore this non-ascii characters in the test string to resolve UnicodeEncodeError.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202106

### Approach
#### What is the motivation for this PR?
The test case test_show_platform_psustatus may fail due to non-ascii
characters in the test string. In my case, the model name contains \xc3\x8b.
The non-ascii characters will result in UnicodeEncodeError.
#### How did you do it?
Filter and ignore this non-ascii characters in the test string.
#### How did you verify/test it?
Run platform_tests/cli/test_show_platform.py::test_show_platform_psustatus, passes with change.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
