### PR TITLE
[bgp] Improve test_bgp_gr_helper_routes_perserved

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -141,9 +141,9 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
         res = False
         err_msg = "not all bgp sessions are up after enable graceful restart"
 
-    if res and not wait_until(100, 5, duthost.check_default_route):
+    if res and not wait_until(100, 5, duthost.check_bgp_default_route):
         res = False
-        err_msg = "ipv4 or ipv6 default route not available"
+        err_msg = "ipv4 or ipv6 bgp default route not available"
 
     if not res:
         # Disable graceful restart in case of failure

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -62,7 +62,7 @@ def check_results(results):
 
 
 @pytest.fixture(scope='module')
-def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
+def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
 
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -141,7 +141,8 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts):
         res = False
         err_msg = "not all bgp sessions are up after enable graceful restart"
 
-    if res and not wait_until(100, 5, duthost.check_bgp_default_route):
+    is_backend_topo = "backend" in tbinfo["topo"]["name"]
+    if not is_backend_topo and res and not wait_until(100, 5, duthost.check_bgp_default_route):
         res = False
         err_msg = "ipv4 or ipv6 bgp default route not available"
 

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -17,18 +17,17 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
     """
     duthost = duthosts[rand_one_dut_hostname]
 
+    if not duthost.check_bgp_default_route():
+        pytest.skip("there is no nexthop for bgp default route")
+
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     po = config_facts.get('PORTCHANNEL', {})
     dev_nbr = config_facts.get('DEVICE_NEIGHBOR', {})
 
     rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_network(u'0.0.0.0/0'))
-    if len(rtinfo_v4['nexthops']) == 0:
-        pytest.skip("there is no next hop for v4 default route")
 
     rtinfo_v6 = duthost.get_ip_route_info(ipaddress.ip_network(u'::/0'))
-    if len(rtinfo_v6['nexthops']) == 0:
-        pytest.skip("there is no next hop for v6 default route")
 
     ifnames_v4 = [nh[1] for nh in rtinfo_v4['nexthops']]
     ifnames_v6 = [nh[1] for nh in rtinfo_v6['nexthops']]

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -427,3 +427,34 @@ class MultiAsicSonicHost(object):
             return True
 
         return False
+
+    def get_bgp_route_info(self, prefix, ns=None):
+        """
+        @summary: return BGP routes information.
+
+        @param prefix: IP prefix
+        @param ns: network namespace
+        """
+        prefix = ipaddress.ip_network(unicode(str(prefix)))
+        if isinstance(prefix, ipaddress.IPv4Network):
+            check_cmd = "vtysh -c 'show bgp ipv4 %s json'"
+        else:
+            check_cmd = "vtysh -c 'show bgp ipv6 %s json'"
+        check_cmd %= prefix
+        if ns is not None:
+            check_cmd = self.get_vtysh_cmd_for_namespace(check_cmd, ns)
+        return json.loads(self.shell(check_cmd, verbose=False)['stdout'])
+
+
+    def check_bgp_default_route(self, ipv4=True,  ipv6=True):
+        """
+        @summary: check if bgp default route is present.
+        
+        @param ipv4: check ipv4 default
+        @param ipv6: check ipv6 default
+        """
+        if ipv4 and len(self.get_bgp_route_info("0.0.0.0/0")) == 0:
+            return False
+        if ipv6 and len(self.get_bgp_route_info("::/0")) == 0:
+            return False
+        return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3838

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. `test_bgp_gr_helper_routes_perserved` needs to verify the default route presence in fixture `setup_bgp_graceful_restart` that would error the testcase for storage backend topologies. So let's skip the check and let the test skip on storage backend topologies.
2. `test_bgp_gr_helper` tries to verify that the default route is present
before the test run and verify that it is preserved during the BGP
restart.
But there is a static default route added by FRR and the
`check_default_route` call still returns True.
So add this PR to improve by adding new method `get_bgp_route_info` and
`check_bgp_route_info` to get and verify only BGP route information.
* the static default route added by FRR on a device with no BGP default route.
```
admin@str2-7050qx-32s-acs-03:~$ ip route list exact 0.0.0.0/0
default via 10.3.146.1 dev eth0 proto 196 metric 20
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
* only check default route for non-storage-backend topology testbeds.
* get BGP only routes and verify BGP default route.

#### How did you verify/test it?
```
bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved SKIPPED                                                                                                                                                                                                                      [ 50%]
bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_all_routes_preserved PASSED                                                                                                                                                                                                                   [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
