### PR TITLE
[BGP] add `test_bgp_gr_helper_all_routes_preserved`

### DIFF
--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -1,8 +1,13 @@
 import pytest
 import logging
 import ipaddress
+import random
+import json
+
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+from tests.common.utilities import is_ipv4_address
+
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -115,3 +120,112 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
 
     # Verify no route changes in the application db
     # TODO
+
+
+def test_bgp_gr_helper_all_routes_preserved(duthosts, rand_one_dut_hostname, nbrhosts, setup_bgp_graceful_restart, tbinfo):
+    """Verify that routes received from one neighbor are all preserved during peer graceful restart."""
+
+    def _find_test_bgp_neighbors(test_neighbor_name, bgp_neighbors):
+        """Find test BGP neighbor peers."""
+        test_bgp_neighbors = []
+        for bgp_neighbor, neighbor_details in bgp_neighbors.items():
+            if test_neighbor_name == neighbor_details['name']:
+                test_bgp_neighbors.append(bgp_neighbor)
+        return test_bgp_neighbors
+
+    def _get_rib(duthost):
+        """Return DUT rib."""
+        routes = {}
+        for namespace in duthost.get_frontend_asic_namespace_list():
+            bgp_cmd_ipv4 = "vtysh -c \"show bgp ipv4 json\""
+            bgp_cmd_ipv6 = "vtysh -c \"show bgp ipv6 json\""
+            cmd = duthost.get_vtysh_cmd_for_namespace(bgp_cmd_ipv4, namespace)
+            routes.update(json.loads(duthost.shell(cmd, verbose=False)['stdout'])["routes"])
+            cmd = duthost.get_vtysh_cmd_for_namespace(bgp_cmd_ipv6, namespace)
+            routes.update(json.loads(duthost.shell(cmd, verbose=False)['stdout'])["routes"])
+        return routes
+
+    def _get_learned_bgp_routes_from_neighbor(duthost, bgp_neighbor):
+        """Get all learned routes from the BGP neighbor."""
+        if is_ipv4_address(unicode(bgp_neighbor)):
+            cmd = "vtysh -c 'show bgp ipv4 neighbor %s routes json'" % bgp_neighbor
+        else:
+            cmd = "vtysh -c 'show bgp ipv6 neighbor %s routes json'" % bgp_neighbor
+        cmd_result = json.loads(duthost.shell(cmd, verbose=False)["stdout"])
+        return cmd_result["routes"]
+
+    def _verify_prefix_counters_from_neighbor_after_graceful_restart(duthost, bgp_neighbor):
+        """Verify that all routes received from neighbor are stale after graceful restart."""
+        if is_ipv4_address(unicode(bgp_neighbor)):
+            cmd = "vtysh -c 'show bgp ipv4 neighbor %s prefix-counts json'" % bgp_neighbor
+        else:
+            cmd = "vtysh -c 'show bgp ipv6 neighbor %s prefix-counts json'" % bgp_neighbor
+        cmd_result = json.loads(duthost.shell(cmd, verbose=False)["stdout"])
+        logging.debug("Prefix counters for bgp neighbor %s:\n%s\n", bgp_neighbor, cmd_result)
+        assert cmd_result["ribTableWalkCounters"]["Stale"] == cmd_result["ribTableWalkCounters"]["All RIB"]
+
+    def _verify_bgp_neighbor_routes_after_graceful_restart(neighbor_routes, rib):
+        for prefix, nexthops in neighbor_routes.items():
+            if prefix not in rib:
+                pytest.fail("Route to prefix %s doesn't exist after graceful restart." % prefix)
+            nexthop_expected = nexthops[0]
+            bgp_neighbor_expected = nexthop_expected["peerId"]
+            for nexthop in rib[prefix]:
+                if nexthop["peerId"] == bgp_neighbor_expected:
+                    if nexthop.get("stale", False) is False:
+                        pytest.fail(
+                            "Route to prefix %s should be stale after graceful restart, before: %s, after: %s" % (prefix, nexthop_expected, rib[prefix])
+                        )
+                    break
+            else:
+                pytest.fail(
+                    "Route to prefix doesn't originate from BGP neighbor %s, before: %s, after: %s" % (bgp_neighbor_expected, nexthop_expected, rib[prefix])
+                )
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+    dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
+
+    test_interface = random.sample([k for k, v in dev_nbrs.items() if not v['name'].startswith("Server")], 1)[0]
+    test_neighbor_name = dev_nbrs[test_interface]['name']
+    test_neighbor_host = nbrhosts[test_neighbor_name]['host']
+
+    # get neighbor BGP peers
+    test_bgp_neighbors = _find_test_bgp_neighbors(test_neighbor_name, bgp_neighbors)
+
+    logging.info("Select neighbor %s to verify that all bgp routes are preserved during graceful restart", test_neighbor_name)
+
+    # get all routes received from neighbor before GR
+    all_neighbor_routes_before_gr = {}
+    for test_bgp_neighbor in test_bgp_neighbors:
+        all_neighbor_routes_before_gr.update(_get_learned_bgp_routes_from_neighbor(duthost, test_bgp_neighbor))
+    # limit testing routes to 100 entries to save time
+    test_route_count = min(100, len(all_neighbor_routes_before_gr))
+    neighbor_routes_before_gr = dict(random.sample(all_neighbor_routes_before_gr.items(), test_route_count))
+
+    try:
+        # shutdown Rib agent, starting GR process
+        logger.info("shutdown rib process on neighbor {}".format(test_neighbor_name))
+        test_neighbor_host.kill_bgpd()
+
+        # wait till DUT enters NSF state
+        for test_bgp_neighbor in test_bgp_neighbors:
+            pytest_assert(
+                wait_until(60, 5, duthost.check_bgp_session_nsf, test_bgp_neighbor),
+                "neighbor {} does not enter NSF state".format(test_bgp_neighbor)
+            )
+
+        # confirm routes from the neighbor still there
+        rib_after_gr = _get_rib(duthost)
+        for test_bgp_neighbor in test_bgp_neighbors:
+            _verify_prefix_counters_from_neighbor_after_graceful_restart(duthost, test_bgp_neighbor)
+        _verify_bgp_neighbor_routes_after_graceful_restart(neighbor_routes_before_gr, rib_after_gr)
+    finally:
+        # start Rib agent
+        logging.info("start rib process on neighbor %s", test_neighbor_name)
+        test_neighbor_host.start_bgpd()
+
+    if not wait_until(300, 10, duthost.check_bgp_session_state, test_bgp_neighbors):
+        pytest.fail("Not all bgp sessions are up after starting BGP on neighbor %s." % test_neighbor_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3974

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Existing BGP GR testcase `test_bgp_gr_helper_routes_perserved` only checks for default route presence during graceful-restart.
This has two limitations:
1. not support topologies that have no default route(`t0-backend` and `t1-backend`)
2. doesn't check other generic routes received/learned from the neighbor experiencing a BGP restart.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
* Add new test case `bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_all_routes_preserved` to test that those routes received/learned from one neighbor will be kept during the BGP restart, and they should all be in the `STALE` state. 

#### How did you verify/test it?
```
bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved PASSED                                                                                                                                                                                                                       [ 50%]
bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_all_routes_preserved PASSED                                                                                                                                                                                                                   [100%]

=================================================================================================================================== 2 passed in 463.38 seconds ====================================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
