### PR TITLE
[everflow] Skip everflow tests on backend topology

### DIFF
--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 @pytest.fixture(scope="module", autouse=True)
-def skip_everlow_test(tbinfo):
+def skip_everflow_test(tbinfo):
     """
     Skip everflow tests on certain testbed types
 

--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_everlow_test(tbinfo):
+    """
+    Skip everflow tests on certain testbed types
+
+    Args:
+        tbinfo(fixture): testbed related info fixture
+
+    Yields:
+        None
+    """
+    if 'backend' in tbinfo['topo']['name']:
+        pytest.skip("Skipping everflow tests. Unsupported topology {}".format(tbinfo['topo']['name']))


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Everflow tests should not be run on backend topology

Summary:
Fixes #3976

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
```
=========================================================================== short test summary info ===========================================================================
SKIPPED [60] /var/nejo/Networking-acs-sonic-mgmt/tests/everflow/conftest.py:16: Skipping everflow tests. Unsupported topology t1-backend
========================================================================= 60 skipped in 78.16 seconds =========================================================================
```