### PR TITLE
Make some Ansible scripts support both Python 2 and 3

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -179,7 +179,7 @@ class BgpModule(object):
                                 value_dict['rcvd'] = int(rcvd)
                                 message_stats[key] = value_dict
                             except Exception as e:
-                                print"NonFatal: line:'{}' should not have matched for sent/rcvd count".format(line)
+                                print("NonFatal: line:'{}' should not have matched for sent/rcvd count".format(line))
 
                         if capabilities:
                             neighbor['capabilities'] = capabilities
@@ -205,7 +205,7 @@ class BgpModule(object):
         statistics['ipv6_admin_down'] = 0
         statistics['ipv6_idle'] = 0
 
-        for neighbor in self.facts['bgp_neighbors'].itervalues():
+        for neighbor in self.facts['bgp_neighbors'].values():
             if neighbor['ip_version'] == 4:
                 statistics['ipv4'] += 1
                 if neighbor['admin'] == 'down':

--- a/ansible/library/bgp_route.py
+++ b/ansible/library/bgp_route.py
@@ -228,7 +228,7 @@ class BgpRoutes(object):
 
         p = json.loads(cmd_result)
 
-        if not p.has_key('prefix'):
+        if 'prefix' not in p:
             self.facts['bgp_route'][prefix]['found'] = False
             return
 

--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -74,7 +74,7 @@ def create_maps(config):
         #get the port_index from config_db if available
         port_index_map = {
             name: int(v['index']) - 1
-            for name, v in config['PORT'].iteritems()
+            for name, v in config['PORT'].items()
             if 'index' in v
         }
         if not port_index_map:
@@ -82,10 +82,10 @@ def create_maps(config):
             for idx, val in enumerate(port_name_list_sorted):
                 port_index_map[val] = idx
 
-        port_name_to_alias_map = { name : v['alias'] if 'alias' in v else '' for name, v in config["PORT"].iteritems()}
+        port_name_to_alias_map = { name : v['alias'] if 'alias' in v else '' for name, v in config["PORT"].items()}
 
         # Create inverse mapping between port name and alias
-        port_alias_to_name_map = {v: k for k, v in port_name_to_alias_map.iteritems()}
+        port_alias_to_name_map = {v: k for k, v in port_name_to_alias_map.items()}
 
     return {
     'port_name_to_alias_map' : port_name_to_alias_map,

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -142,7 +142,7 @@ class Parse_Lab_Graph():
                 continue
             elif '-' in vlanid:
                 vlanlist = list(map(str.strip, vlanid.split('-')))
-                vlans.extend(range(int(vlanlist[0]), int(vlanlist[1])+1))
+                vlans.extend(list(range(int(vlanlist[0]), int(vlanlist[1])+1)))
                 continue
             elif vlanid != '':
                 raise ValueError('vlan range error "%s"' % vlanrange)

--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -78,6 +78,7 @@ import gzip
 import re
 import sys
 from datetime import datetime
+from functools import cmp_to_key
 from ansible.module_utils.basic import *
 
 
@@ -176,8 +177,12 @@ def list_files(directory, prefixname):
     of files in @directory starting with @prefixname
     (Comparator used is @filename_comparator)"""
 
-    return sorted([filename for filename in os.listdir(directory)
-        if filename.startswith(prefixname)], cmp=filename_comparator)
+    if sys.version_info < (3, 0):
+        return sorted([filename for filename in os.listdir(directory)
+            if filename.startswith(prefixname)], cmp=filename_comparator)
+    else:
+        return sorted([filename for filename in os.listdir(directory)
+            if filename.startswith(prefixname)], key=cmp_to_key(filename_comparator))
 
 
 def extract_latest_line_with_string(directory, filenames, start_string):

--- a/ansible/library/interface_facts.py
+++ b/ansible/library/interface_facts.py
@@ -14,13 +14,6 @@ import getpass
 import pwd
 import json
 
-if sys.version_info < (3, 0):
-    import ConfigParser
-    import StringIO
-else:
-    import configparser
-    import io
-
 from ansible.module_utils.basic import *
 from collections import defaultdict
 try:

--- a/ansible/library/interface_facts.py
+++ b/ansible/library/interface_facts.py
@@ -12,9 +12,14 @@ import signal
 import datetime
 import getpass
 import pwd
-import ConfigParser
-import StringIO
 import json
+
+if sys.version_info < (3, 0):
+    import ConfigParser
+    import StringIO
+else:
+    import configparser
+    import io
 
 from ansible.module_utils.basic import *
 from collections import defaultdict

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import calendar
 import os
 import sys
@@ -190,14 +191,14 @@ def parse_png(png, hname):
                 startport = link.find(str(QName(ns, "StartPort"))).text
 
                 if enddevice == hname:
-                    if port_alias_to_name_map.has_key(endport):
+                    if endport in port_alias_to_name_map:
                         endport = port_alias_to_name_map[endport]
                     if startdevice.lower() in namespace_list:
                         neighbors_namespace[endport] = startdevice.lower()
                     else:
                         neighbors[endport] = {'name': startdevice, 'port': startport, 'namespace':''}
                 elif startdevice == hname:
-                    if port_alias_to_name_map.has_key(startport):
+                    if startport in port_alias_to_name_map:
                         startport = port_alias_to_name_map[startport]
                     if enddevice.lower() in namespace_list:
                         neighbors_namespace[startport] = enddevice.lower()
@@ -249,7 +250,7 @@ def parse_png(png, hname):
                             elif node.tag == str(QName(ns, "EndDevice")):
                                 mgmt_dev = node.text
 
-    for k, v in neighbors.iteritems():
+    for k, v in neighbors.items():
          v['namespace'] = neighbors_namespace[k]
 
     return (neighbors, devices, console_dev, console_port, mgmt_dev, mgmt_port)
@@ -419,11 +420,11 @@ def parse_dpg(dpg, hname):
             acl_intfs = []
             for member in aclattach:
                 member = member.strip()
-                if pcs.has_key(member):
+                if member in pcs:
                     acl_intfs.extend(pcs[member]['members'])  # For ACL attaching to port channels, we break them into port channel members
-                elif vlans.has_key(member):
-                    print >> sys.stderr, "Warning: ACL " + aclname + " is attached to a Vlan interface, which is currently not supported"
-                elif port_alias_to_name_map.has_key(member):
+                elif member in vlans:
+                    print("Warning: ACL " + aclname + " is attached to a Vlan interface, which is currently not supported", file=sys.stderr)
+                elif member in port_alias_to_name_map:
                     acl_intfs.append(port_alias_to_name_map[member])
             if acl_intfs:
                 acls[aclname] = acl_intfs
@@ -635,7 +636,7 @@ def parse_xml(filename, hostname, asic_name=None):
     port_alias_to_name_map, port_alias_asic_map = get_port_alias_to_name_map(hwsku, asic_id)
 
     # Create inverse mapping between port name and alias
-    port_name_to_alias_map = {v: k for k, v in port_alias_to_name_map.iteritems()}
+    port_name_to_alias_map = {v: k for k, v in port_alias_to_name_map.items()}
 
     for child in root:
         if asic_name is None:
@@ -663,10 +664,10 @@ def parse_xml(filename, hostname, asic_name=None):
 
     # Associate Port Channel to namespace
     try:
-        for pckey, pcval in pcs.iteritems():
+        for pckey, pcval in pcs.items():
             pcval['namespace'] = neighbors[pcval['members'][0]]['namespace']
     except Exception as e:
-        print >> sys.stderr, "Warning: PortChannel " + pckey + " has no member ports."
+        print("Warning: PortChannel " + pckey + " has no member ports.", file=sys.stderr)
 
     # TODO: Move all alias-related code out of minigraph_facts.py and into
     # its own module to be used as another layer after parsing the minigraph.

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -16,6 +16,7 @@ Usage:          Examples of how to use log analyzer
 #---------------------------------------------------------------------
 # Global imports
 #---------------------------------------------------------------------
+from __future__ import print_function
 import sys
 import getopt
 import re
@@ -654,7 +655,7 @@ def main(argv):
 
     analyzer = AnsibleLogAnalyzer(run_id, verbose, start_marker)
 
-    log_file_list = [_f for _f in log_files_in.split(tokenizer) if _f]
+    log_file_list = list(filter(None, log_files_in.split(tokenizer)))
 
     result = {}
     if (action == "init"):

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -24,7 +24,6 @@ import pprint
 import logging
 import logging.handlers
 from datetime import datetime
-from __builtin__ import True
 
 #---------------------------------------------------------------------
 # Global variables
@@ -90,7 +89,7 @@ class AnsibleLogAnalyzer:
         if (not self.verbose):
             return
 
-        print '[LogAnalyzer][diagnostic]:%s' % message
+        print('[LogAnalyzer][diagnostic]:%s' % message)
     #---------------------------------------------------------------------
 
     def create_start_marker(self):
@@ -178,7 +177,7 @@ class AnsibleLogAnalyzer:
         '''
 
         #-- Check if error_string is a string or a list --#
-        if (isinstance(error_string, basestring)):
+        if (isinstance(error_string, str)):
             original_string = error_string
             #-- Escapes out of all the meta characters --#
             error_string = re.escape(error_string)
@@ -248,8 +247,8 @@ class AnsibleLogAnalyzer:
                             messages_regex.append(self.error_to_regx(row[1:]))
 
                     except Exception as e:
-                        print 'ERROR: line %d is formatted incorrectly in file %s. Skipping line' % (index, filename)
-                        print repr(e)
+                        print('ERROR: line %d is formatted incorrectly in file %s. Skipping line' % (index, filename))
+                        print(repr(e))
                         sys.exit(err_invalid_string_format)
 
         if (len(messages_regex)):
@@ -351,7 +350,7 @@ class AnsibleLogAnalyzer:
                 if rev_line.find(end_marker) != -1:
                     self.print_diagnostic_message('found end marker: %s' % end_marker)
                     if (found_end_marker):
-                        print 'ERROR: duplicate end marker found'
+                        print('ERROR: duplicate end marker found')
                         sys.exit(err_duplicate_end_marker)
                     found_end_marker = True
                     in_analysis_range = True
@@ -361,12 +360,12 @@ class AnsibleLogAnalyzer:
                 if rev_line.find(start_marker) != -1 and 'nsible' not in rev_line:
                     self.print_diagnostic_message('found start marker: %s' % start_marker)
                     if (found_start_marker):
-                        print 'ERROR: duplicate start marker found'
+                        print('ERROR: duplicate start marker found')
                         sys.exit(err_duplicate_start_marker)
                     found_start_marker = True
 
                     if(not in_analysis_range):
-                        print 'ERROR: found start marker:%s without corresponding end marker' % rev_line
+                        print('ERROR: found start marker:%s without corresponding end marker' % rev_line)
                         sys.exit(err_no_end_marker)
                     in_analysis_range = False
                     break
@@ -385,11 +384,11 @@ class AnsibleLogAnalyzer:
         # care about the markers only if input is not stdin or no need to check start marker
         if not stdin_as_input and check_marker:
             if (not found_start_marker):
-                print 'ERROR: start marker was not found'
+                print('ERROR: start marker was not found')
                 sys.exit(err_no_start_marker)
 
             if (not found_end_marker):
-                print 'ERROR: end marker was not found'
+                print('ERROR: end marker was not found')
                 sys.exit(err_no_end_marker)
 
         return matching_lines, expected_lines
@@ -428,32 +427,32 @@ class AnsibleLogAnalyzer:
     #---------------------------------------------------------------------
 
 def usage():
-    print 'loganalyzer input parameters:'
-    print '--help                           Print usage'
-    print '--verbose                        Print verbose output during the run'
-    print '--action                         init|analyze - action to perform.'
-    print '                                 init - initialize analysis by placing start-marker'
-    print '                                 to all log files specified in --logs parameter.'
-    print '                                 analyze - perform log analysis of files specified in --logs parameter.'
-    print '                                 add_end_marker - add end marker to all log files specified in --logs parameter.'
-    print '--out_dir path                   Directory path where to place output files, '
-    print '                                 must be present when --action == analyze'
-    print '--logs path{,path}               List of full paths to log files to be analyzed.'
-    print '                                 Implicitly system log file will be also processed'
-    print '--run_id string                  String passed to loganalyzer, uniquely identifying '
-    print '                                 analysis session. Used to construct start/end markers. '
-    print '--match_files_in path{,path}     List of paths to files containing strings. A string from log file'
-    print '                                 By default syslog will be always analyzed and should be passed by match_files_in.'
-    print '                                 matching any string from match_files_in will be collected and '
-    print '                                 reported. Must be present when action == analyze'
-    print '--ignore_files_in path{,path}    List of paths to files containing string. '
-    print '                                 A string from log file matching any string from these'
-    print '                                 files will be ignored during analysis. Must be present'
-    print '                                 when action == analyze.'
-    print '--expect_files_in path{,path}    List of path to files containing string. '
-    print '                                 All the strings from these files will be expected to present'
-    print '                                 in one of specified log files during the analysis. Must be present'
-    print '                                 when action == analyze.'
+    print('loganalyzer input parameters:')
+    print('--help                           Print usage')
+    print('--verbose                        Print verbose output during the run')
+    print('--action                         init|analyze - action to perform.')
+    print('                                 init - initialize analysis by placing start-marker')
+    print('                                 to all log files specified in --logs parameter.')
+    print('                                 analyze - perform log analysis of files specified in --logs parameter.')
+    print('                                 add_end_marker - add end marker to all log files specified in --logs parameter.')
+    print('--out_dir path                   Directory path where to place output files, ')
+    print('                                 must be present when --action == analyze')
+    print('--logs path{,path}               List of full paths to log files to be analyzed.')
+    print('                                 Implicitly system log file will be also processed')
+    print('--run_id string                  String passed to loganalyzer, uniquely identifying ')
+    print('                                 analysis session. Used to construct start/end markers. ')
+    print('--match_files_in path{,path}     List of paths to files containing strings. A string from log file')
+    print('                                 By default syslog will be always analyzed and should be passed by match_files_in.')
+    print('                                 matching any string from match_files_in will be collected and ')
+    print('                                 reported. Must be present when action == analyze')
+    print('--ignore_files_in path{,path}    List of paths to files containing string. ')
+    print('                                 A string from log file matching any string from these')
+    print('                                 files will be ignored during analysis. Must be present')
+    print('                                 when action == analyze.')
+    print('--expect_files_in path{,path}    List of path to files containing string. ')
+    print('                                 All the strings from these files will be expected to present')
+    print('                                 in one of specified log files during the analysis. Must be present')
+    print('                                 when action == analyze.')
 
 #---------------------------------------------------------------------
 
@@ -473,17 +472,17 @@ def check_action(action, log_files_in, out_dir, match_files_in, ignore_files_in,
         ret_code = True
     elif (action == 'analyze'):
         if out_dir is None or len(out_dir) == 0:
-            print 'ERROR: missing required out_dir for analyze action'
+            print('ERROR: missing required out_dir for analyze action')
             ret_code = False
 
         elif match_files_in is None or len(match_files_in) == 0:
-            print 'ERROR: missing required match_files_in for analyze action'
+            print('ERROR: missing required match_files_in for analyze action')
             ret_code = False
 
 
     else:
         ret_code = False
-        print 'ERROR: invalid action:%s specified' % action
+        print('ERROR: invalid action:%s specified' % action)
 
     return ret_code
 #---------------------------------------------------------------------
@@ -500,7 +499,7 @@ def check_run_id(run_id):
     ret_code = True
 
     if ((run_id is None) or (len(run_id) == 0)):
-        print 'ERROR: no run_id specified'
+        print('ERROR: no run_id specified')
         ret_code = False
 
     return ret_code
@@ -524,7 +523,7 @@ def write_result_file(run_id, out_dir, analysis_result_per_file, messages_regex_
     expected_lines_total = []
 
     with open(out_dir + "/result.loganalysis." + run_id + ".log", 'w') as out_file:
-        for key, val in analysis_result_per_file.iteritems():
+        for key, val in analysis_result_per_file.items():
             matching_lines, expected_lines = val
 
             out_file.write("\n-----------Matches found in file:'%s'-----------\n" % key)
@@ -577,7 +576,7 @@ def write_summary_file(run_id, out_dir, analysis_result_per_file, unused_regex_m
     out_file.write("\nLOG ANALYSIS SUMMARY\n")
     total_match_cnt = 0
     total_expect_cnt = 0
-    for key, val in analysis_result_per_file.iteritems():
+    for key, val in analysis_result_per_file.items():
         matching_lines, expecting_lines = val
 
         file_match_cnt = len(matching_lines)
@@ -613,7 +612,7 @@ def main(argv):
         opts, args = getopt.getopt(argv, "a:r:s:l:o:m:i:e:vh", ["action=", "run_id=", "start_marker=", "logs=", "out_dir=", "match_files_in=", "ignore_files_in=", "expect_files_in=", "verbose", "help"])
 
     except getopt.GetoptError:
-        print "Invalid option specified"
+        print("Invalid option specified")
         usage()
         sys.exit(err_invalid_input)
 
@@ -655,7 +654,7 @@ def main(argv):
 
     analyzer = AnsibleLogAnalyzer(run_id, verbose, start_marker)
 
-    log_file_list = filter(None, log_files_in.split(tokenizer))
+    log_file_list = [_f for _f in log_files_in.split(tokenizer) if _f]
 
     result = {}
     if (action == "init"):
@@ -686,7 +685,7 @@ def main(argv):
         return 0
 
     else:
-        print 'Unknown action:%s specified' % action
+        print('Unknown action:%s specified' % action)
     return len(result)
 #---------------------------------------------------------------------
 


### PR DESCRIPTION

### Description of PR

Make some more Ansible scripts and modules compatible with both Python 2 and 3.

This is in preparation for Azure/sonic-buildimage#8191

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

Used 2to3 tool for conversion, followed by manual edits for handling both Python 2 and 3, excluding some changes, and making some additional missed changes.

#### How did you verify/test it?

Tested by running bgp_fact and kvmtest on Bullseye image. bgp_fact appears to fully pass, kvmtest is failing on one test (`platform_tests/test_advanced_reboot.py::test_fast_reboot`)

Need to test on current master image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
