### PR TITLE
Lower level of the "No allure report URL" message from error to info

### DIFF
--- a/tests/common/plugins/allure_server/__init__.py
+++ b/tests/common/plugins/allure_server/__init__.py
@@ -61,7 +61,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if report_url:
         logger.info('Allure report URL: {}'.format(report_url))
     else:
-        logger.error('Can not get Allure report URL. Please check logs')
+        logger.info('Can not get Allure report URL. Please check logs')
 
 
 def get_setup_session_info(session):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When allure server is not configured, there is always an error level message
"Can not get Allure report URL." shown in terminal summary log. It looks
scary and could be confusing. 

#### How did you do it?
This change lower level of this message from error to info.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
