### PR TITLE
[test_crm] Enable storage backend topologies

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -91,7 +91,10 @@ def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, e
     asichost = duthost.asic_instance(enum_frontend_asic_index)
     mg_facts = asichost.get_extended_minigraph_facts(tbinfo)
 
-    if len(mg_facts["minigraph_portchannel_interfaces"]) >= 4:
+    if "backend" in tbinfo["topo"]["name"]:
+        crm_intf1 = mg_facts["minigraph_vlan_sub_interfaces"][0]["attachto"]
+        crm_intf2 = mg_facts["minigraph_vlan_sub_interfaces"][2]["attachto"]
+    elif len(mg_facts["minigraph_portchannel_interfaces"]) >= 4:
         crm_intf1 = mg_facts["minigraph_portchannel_interfaces"][0]["attachto"]
         crm_intf2 = mg_facts["minigraph_portchannel_interfaces"][2]["attachto"]
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3849 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enable `test_crm` to run on storage backend topologies.

#### How did you do it?
Let `crm_interface` select interfaces out of vlan sub interfaces.

#### How did you verify/test it?
* run on `t0-backend`:
```
crm/test_crm.py::test_crm_route[str2-7050qx-32s-acs-02-None-ipv4] PASSED                                                                                                                                                                                                                    [  9%]
crm/test_crm.py::test_crm_nexthop[str2-7050qx-32s-acs-02-None-4-2.2.2.2] PASSED                                                                                                                                                                                                             [ 18%]
crm/test_crm.py::test_crm_neighbor[str2-7050qx-32s-acs-02-None-4-2.2.2.2] PASSED                                                                                                                                                                                                            [ 27%]
crm/test_crm.py::test_crm_nexthop_group[str2-7050qx-32s-acs-02-None-False-2.2.2.0/24] PASSED                                                                                                                                                                                                [ 36%]
crm/test_crm.py::test_acl_entry[str2-7050qx-32s-acs-02-None] PASSED                                                                                                                                                                                                                         [ 45%]
crm/test_crm.py::test_acl_counter[str2-7050qx-32s-acs-02-None] PASSED                                                                                                                                                                                                                       [ 54%]

crm/test_crm.py::test_crm_fdb_entry[str2-7050qx-32s-acs-02-None] PASSED                                                                                                                                                                                                                     [ 63%]
crm/test_crm.py::test_crm_route[str2-7050qx-32s-acs-02-None-ipv6] PASSED                                                                                                                                                                                                                    [ 72%]
crm/test_crm.py::test_crm_nexthop[str2-7050qx-32s-acs-02-None-6-2001::1] PASSED                                                                                                                                                                                                             [ 81%]
crm/test_crm.py::test_crm_neighbor[str2-7050qx-32s-acs-02-None-6-2001::1] PASSED                                                                                                                                                                                                            [ 90%]
crm/test_crm.py::test_crm_nexthop_group[str2-7050qx-32s-acs-02-None-True-2.2.2.0/24] PASSED                                                                                                                                                                                                 [100%]

================================================================================================================================== 11 passed in 2347.24 seconds ===================================================================================================================================
```
* run on `t1-backend`:
```
crm/test_crm.py::test_crm_route[str2-7050qx-32s-acs-03-None-ipv4] PASSED                                                                                                                                                                                                                    [  9%]
crm/test_crm.py::test_crm_nexthop[str2-7050qx-32s-acs-03-None-4-2.2.2.2] PASSED                                                                                                                                                                                                             [ 18%]
crm/test_crm.py::test_crm_neighbor[str2-7050qx-32s-acs-03-None-4-2.2.2.2] PASSED                                                                                                                                                                                                            [ 27%]
crm/test_crm.py::test_crm_nexthop_group[str2-7050qx-32s-acs-03-None-False-2.2.2.0/24] PASSED                                                                                                                                                                                                [ 36%]
crm/test_crm.py::test_acl_entry[str2-7050qx-32s-acs-03-None] PASSED                                                                                                                                                                                                                         [ 45%]
crm/test_crm.py::test_acl_counter[str2-7050qx-32s-acs-03-None] PASSED                                                                                                                                                                                                                       [ 54%]
crm/test_crm.py::test_crm_fdb_entry[str2-7050qx-32s-acs-03-None] SKIPPED                                                                                                                                                                                                                    [ 63%]
crm/test_crm.py::test_crm_route[str2-7050qx-32s-acs-03-None-ipv6] PASSED                                                                                                                                                                                                                    [ 72%]
crm/test_crm.py::test_crm_nexthop[str2-7050qx-32s-acs-03-None-6-2001::1] PASSED                                                                                                                                                                                                             [ 81%]
crm/test_crm.py::test_crm_neighbor[str2-7050qx-32s-acs-03-None-6-2001::1] PASSED                                                                                                                                                                                                            [ 90%]
crm/test_crm.py::test_crm_nexthop_group[str2-7050qx-32s-acs-03-None-True-2.2.2.0/24] PASSED                                                                                                                                                                                                 [100%]

============================================================================================================================= 10 passed, 1 skipped in 2263.21 seconds =============================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
