### PR TITLE
[SNMP] [PSU] Adjust test to wait time from 120s to 180s for system with more ports

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -615,7 +615,7 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_rand_one_per_hwsku_hostn
     pdu_controller.turn_off_outlet(first_outlet)
     assert wait_until(30, 5, check_outlet_status, pdu_controller, first_outlet, False)
     # wait for psud update the database
-    assert wait_until(120, 20, _check_psu_status_after_power_off, duthost, localhost, creds_all_duts)
+    assert wait_until(180, 20, _check_psu_status_after_power_off, duthost, localhost, creds_all_duts)
 
 
 def _check_psu_status_after_power_off(duthost, localhost, creds_all_duts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increase the wait time from 120s to 180s for test_turn_off_psu_and_check_psu_info
Fixes # (issue)  If the  testbed has lots ports, it will take more than 120s to execute the _check_psu_status_after_power_off

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
 If the  testbed has lots ports,  it will take more than 120s to execute the _check_psu_status_after_power_off, if the timeout value for the wait_until is still 120, then the _check_psu_status_after_power_off will be execute only one time, it will casue the testcase failure, Increase the timeout from 120 to 180 to make sure the _check_psu_status_after_power_off can be executed more than one time.

#### How did you do it?
Increase the wait time from 120s to 180s for test_turn_off_psu_and_check_psu_info
#### How did you verify/test it?
Run the the testcase and it can pass:
py.test snmp/test_snmp_phy_entity.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern r-tigris-13 --module-path                ../ansible/library/ --testbed r-tigris-13-t1-lag --testbed_file ../ansible/testbed.csv                --allow_recover                --junit-xml junit_5038854_0.7.1.1.13.1.4.3.7.1.1.xml --assert plain --log-cli-level debug --show-capture=no -ra --showlocals --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --allure_server_project_id r-tigris-13-snmp-test-snmp-phy-entity-py  -k "test_turn_off_psu_and_check_psu_info"

#### Any platform specific information?
admin@r-tigris-13:~$ show platform sum
Platform: x86_64-mlnx_msn3800-r0
HwSKU: Mellanox-SN3800-D112C8
ASIC: mellanox
ASIC Count: 1

admin@r-tigris-13:~$ show interfaces status
                       Interface            Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin             Type    Asym PFC
                      ---------------  ---------------  -------  -----  -----  -------  ---------------  ------  -------  ----- 
  ----------  ----------
      Ethernet0              0,1      50G   9100    N/A    etp1a  PortChannel0002      up       up  QSFP28 or later         off
      Ethernet2              2,3      50G   9100    N/A    etp1b  PortChannel0002      up       up  QSFP28 or later         off
      Ethernet4              4,5      50G   9100    N/A    etp2a  PortChannel0005      up       up  QSFP28 or later         off
      Ethernet6              6,7      50G   9100    N/A    etp2b  PortChannel0005      up       up  QSFP28 or later         off
      Ethernet8              8,9      50G   9100    N/A    etp3a  PortChannel0008      up       up  QSFP28 or later         off
     Ethernet10            10,11      50G   9100    N/A    etp3b  PortChannel0008      up       up  QSFP28 or later         off
     Ethernet12            12,13      50G   9100    N/A    etp4a  PortChannel0011      up       up  QSFP28 or later         off
     Ethernet14            14,15      50G   9100    N/A    etp4b  PortChannel0011      up       up  QSFP28 or later         off
     Ethernet16            16,17      50G   9100    N/A    etp5a  PortChannel0014      up       up  QSFP28 or later         off
     Ethernet18            18,19      50G   9100    N/A    etp5b  PortChannel0014      up       up  QSFP28 or later         off
     Ethernet20            20,21      50G   9100    N/A    etp6a  PortChannel0017      up       up  QSFP28 or later         off
     Ethernet22            22,23      50G   9100    N/A    etp6b  PortChannel0017      up       up  QSFP28 or later         off
     Ethernet24            24,25      50G   9100    N/A    etp7a  PortChannel0020      up       up  QSFP28 or later         off
     Ethernet26            26,27      50G   9100    N/A    etp7b  PortChannel0020      up       up  QSFP28 or later         off
     Ethernet28            28,29      50G   9100    N/A    etp8a  PortChannel0023      up       up  QSFP28 or later         off
     Ethernet30            30,31      50G   9100    N/A    etp8b  PortChannel0023      up       up  QSFP28 or later         off
     Ethernet32            32,33      50G   9100    N/A    etp9a           routed      up       up  QSFP28 or later         off
     Ethernet34            34,35      50G   9100    N/A    etp9b           routed      up       up  QSFP28 or later         off
     Ethernet36            36,37      50G   9100    N/A   etp10a           routed      up       up  QSFP28 or later         off
     Ethernet38            38,39      50G   9100    N/A   etp10b           routed      up       up  QSFP28 or later         off
     Ethernet40            40,41      50G   9100    N/A   etp11a           routed      up       up  QSFP28 or later         off
     Ethernet42            42,43      50G   9100    N/A   etp11b           routed      up       up  QSFP28 or later         off
     Ethernet44            44,45      50G   9100    N/A   etp12a           routed      up       up  QSFP28 or later         off
     Ethernet46            46,47      50G   9100    N/A   etp12b           routed      up       up  QSFP28 or later         off
     Ethernet48            48,49      50G   9100    N/A   etp13a           routed      up       up  QSFP28 or later         off
     Ethernet50            50,51      50G   9100    N/A   etp13b           routed      up       up  QSFP28 or later         off
     Ethernet52            52,53      50G   9100    N/A   etp14a           routed      up       up  QSFP28 or later         off
     Ethernet54            54,55      50G   9100    N/A   etp14b           routed      up       up  QSFP28 or later         off
     Ethernet56            56,57      50G   9100    N/A   etp15a           routed      up       up  QSFP28 or later         off
     Ethernet58            58,59      50G   9100    N/A   etp15b           routed      up       up  QSFP28 or later         off
     Ethernet60            60,61      50G   9100    N/A   etp16a           routed      up       up  QSFP28 or later         off
     Ethernet62            62,63      50G   9100    N/A   etp16b           routed      up       up  QSFP28 or later         off
     Ethernet64            64,65      50G   9100    N/A   etp17a           routed    down     down  QSFP28 or later         off
     Ethernet66            66,67      50G   9100    N/A   etp17b           routed    down     down  QSFP28 or later         off
     Ethernet68            68,69      50G   9100    N/A   etp18a           routed    down     down  QSFP28 or later         off
     Ethernet70            70,71      50G   9100    N/A   etp18b           routed    down     down  QSFP28 or later         off
     Ethernet72            72,73      50G   9100    N/A   etp19a           routed    down     down  QSFP28 or later         off
     Ethernet74            74,75      50G   9100    N/A   etp19b           routed    down     down  QSFP28 or later         off
     Ethernet76            76,77      50G   9100    N/A   etp20a           routed    down     down  QSFP28 or later         off
     Ethernet78            78,79      50G   9100    N/A   etp20b           routed    down     down  QSFP28 or later         off
     Ethernet80            80,81      50G   9100    N/A   etp21a           routed    down     down  QSFP28 or later         off
     Ethernet82            82,83      50G   9100    N/A   etp21b           routed    down     down  QSFP28 or later         off
     Ethernet84            84,85      50G   9100    N/A   etp22a           routed    down     down  QSFP28 or later         off
     Ethernet86            86,87      50G   9100    N/A   etp22b           routed    down     down  QSFP28 or later         off
     Ethernet88            88,89      50G   9100    N/A   etp23a           routed    down     down  QSFP28 or later         off
     Ethernet90            90,91      50G   9100    N/A   etp23b           routed    down     down  QSFP28 or later         off
     Ethernet92            92,93      50G   9100    N/A   etp24a           routed    down     down  QSFP28 or later         off
     Ethernet94            94,95      50G   9100    N/A   etp24b           routed    down     down  QSFP28 or later         off
     Ethernet96      96,97,98,99     100G   9100     rs    etp25           routed    down     down  QSFP28 or later         off
    Ethernet100  100,101,102,103     100G   9100     rs    etp26           routed    down     down  QSFP28 or later         off
    Ethernet104          104,105      50G   9100    N/A   etp27a           routed    down     down  QSFP28 or later         off
    Ethernet106          106,107      50G   9100    N/A   etp27b           routed    down     down  QSFP28 or later         off
    Ethernet108          108,109      50G   9100    N/A   etp28a           routed    down     down  QSFP28 or later         off
    Ethernet110          110,111      50G   9100    N/A   etp28b           routed    down     down  QSFP28 or later         off
    Ethernet112  112,113,114,115     100G   9100     rs    etp29           routed    down     down  QSFP28 or later         off
    Ethernet116  116,117,118,119     100G   9100     rs    etp30           routed    down     down  QSFP28 or later         off
    Ethernet120          120,121      50G   9100    N/A   etp31a           routed    down     down  QSFP28 or later         off
    Ethernet122          122,123      50G   9100    N/A   etp31b           routed    down     down  QSFP28 or later         off
    Ethernet124          124,125      50G   9100    N/A   etp32a           routed    down     down  QSFP28 or later         off
    Ethernet126          126,127      50G   9100    N/A   etp32b           routed    down     down  QSFP28 or later         off
    Ethernet128  128,129,130,131     100G   9100     rs    etp33           routed    down     down  QSFP28 or later         off
    Ethernet132  132,133,134,135     100G   9100     rs    etp34           routed    down     down  QSFP28 or later         off
    Ethernet136          136,137      50G   9100    N/A   etp35a           routed    down     down  QSFP28 or later         off
    Ethernet138          138,139      50G   9100    N/A   etp35b           routed    down     down  QSFP28 or later         off
    Ethernet140          140,141      50G   9100    N/A   etp36a           routed    down     down  QSFP28 or later         off
    Ethernet142          142,143      50G   9100    N/A   etp36b           routed    down     down  QSFP28 or later         off
    Ethernet144  144,145,146,147     100G   9100     rs    etp37           routed    down     down  QSFP28 or later         off
    Ethernet148  148,149,150,151     100G   9100     rs    etp38           routed    down     down  QSFP28 or later         off
    Ethernet152          152,153      50G   9100    N/A   etp39a           routed    down     down  QSFP28 or later         off
    Ethernet154          154,155      50G   9100    N/A   etp39b           routed    down     down  QSFP28 or later         off
    Ethernet156          156,157      50G   9100    N/A   etp40a           routed    down     down  QSFP28 or later         off
    Ethernet158          158,159      50G   9100    N/A   etp40b           routed    down     down  QSFP28 or later         off
    Ethernet160          160,161      50G   9100    N/A   etp41a           routed    down     down  QSFP28 or later         off
    Ethernet162          162,163      50G   9100    N/A   etp41b           routed    down     down  QSFP28 or later         off
    Ethernet164          164,165      50G   9100    N/A   etp42a           routed    down     down  QSFP28 or later         off
    Ethernet166          166,167      50G   9100    N/A   etp42b           routed    down     down  QSFP28 or later         off
    Ethernet168          168,169      50G   9100    N/A   etp43a           routed    down     down  QSFP28 or later         off
    Ethernet170          170,171      50G   9100    N/A   etp43b           routed    down     down  QSFP28 or later         off
    Ethernet172          172,173      50G   9100    N/A   etp44a           routed    down     down  QSFP28 or later         off
    Ethernet174          174,175      50G   9100    N/A   etp44b           routed    down     down  QSFP28 or later         off
    Ethernet176          176,177      50G   9100    N/A   etp45a           routed    down     down  QSFP28 or later         off
    Ethernet178          178,179      50G   9100    N/A   etp45b           routed    down     down  QSFP28 or later         off
    Ethernet180          180,181      50G   9100    N/A   etp46a           routed    down     down  QSFP28 or later         off
    Ethernet182          182,183      50G   9100    N/A   etp46b           routed    down     down  QSFP28 or later         off
    Ethernet184          184,185      50G   9100    N/A   etp47a           routed    down     down  QSFP28 or later         off
    Ethernet186          186,187      50G   9100    N/A   etp47b           routed    down     down  QSFP28 or later         off
    Ethernet188          188,189      50G   9100    N/A   etp48a           routed    down     down  QSFP28 or later         off
    Ethernet190          190,191      50G   9100    N/A   etp48b           routed    down     down  QSFP28 or later         off
    Ethernet192          192,193      50G   9100    N/A   etp49a           routed    down     down  QSFP28 or later         off
    Ethernet194          194,195      50G   9100    N/A   etp49b           routed    down     down  QSFP28 or later         off
    Ethernet196          196,197      50G   9100    N/A   etp50a           routed    down     down  QSFP28 or later         off
    Ethernet198          198,199      50G   9100    N/A   etp50b           routed    down     down  QSFP28 or later         off
    Ethernet200          200,201      50G   9100    N/A   etp51a           routed    down     down  QSFP28 or later         off
    Ethernet202          202,203      50G   9100    N/A   etp51b           routed    down     down  QSFP28 or later         off
    Ethernet204          204,205      50G   9100    N/A   etp52a           routed    down     down  QSFP28 or later         off
    Ethernet206          206,207      50G   9100    N/A   etp52b           routed    down     down  QSFP28 or later         off
    Ethernet208          208,209      50G   9100    N/A   etp53a           routed    down     down  QSFP28 or later         off
    Ethernet210          210,211      50G   9100    N/A   etp53b           routed    down     down  QSFP28 or later         off
    Ethernet212          212,213      50G   9100    N/A   etp54a           routed    down     down  QSFP28 or later         off
    Ethernet214          214,215      50G   9100    N/A   etp54b           routed    down     down  QSFP28 or later         off
    Ethernet216          216,217      50G   9100    N/A   etp55a           routed    down     down  QSFP28 or later         off
    Ethernet218          218,219      50G   9100    N/A   etp55b           routed    down     down  QSFP28 or later         off
    Ethernet220          220,221      50G   9100    N/A   etp56a           routed    down     down  QSFP28 or later         off
    Ethernet222          222,223      50G   9100    N/A   etp56b           routed    down     down  QSFP28 or later         off
    Ethernet224          224,225      50G   9100    N/A   etp57a           routed    down     down  QSFP28 or later         off
    Ethernet226          226,227      50G   9100    N/A   etp57b           routed    down     down  QSFP28 or later         off
    Ethernet228          228,229      50G   9100    N/A   etp58a           routed    down     down  QSFP28 or later         off
    Ethernet230          230,231      50G   9100    N/A   etp58b           routed    down     down  QSFP28 or later         off
    Ethernet232          232,233      50G   9100    N/A   etp59a           routed    down     down  QSFP28 or later         off
    Ethernet234          234,235      50G   9100    N/A   etp59b           routed    down     down  QSFP28 or later         off
    Ethernet236          236,237      50G   9100    N/A   etp60a           routed    down     down  QSFP28 or later         off
    Ethernet238          238,239      50G   9100    N/A   etp60b           routed    down     down  QSFP28 or later         off
    Ethernet240          240,241      50G   9100    N/A   etp61a           routed    down     down  QSFP28 or later         off
    Ethernet242          242,243      50G   9100    N/A   etp61b           routed    down     down  QSFP28 or later         off
    Ethernet244          244,245      50G   9100    N/A   etp62a           routed    down     down  QSFP28 or later         off
    Ethernet246          246,247      50G   9100    N/A   etp62b           routed    down     down  QSFP28 or later         off
    Ethernet248          248,249      50G   9100    N/A   etp63a           routed    down     down  QSFP28 or later         off
    Ethernet250          250,251      50G   9100    N/A   etp63b           routed    down     down  QSFP28 or later         off
    Ethernet252          252,253      50G   9100    N/A   etp64a           routed    down     down  QSFP28 or later         off
    Ethernet254          254,255      50G   9100    N/A   etp64b           routed    down     down  QSFP28 or later         off
    PortChannel0002              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0005              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0008              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0011              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0014              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0017              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0020              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A
    PortChannel0023              N/A     100G   9100    N/A      N/A           routed      up       up              N/A         N/A

