### PR TITLE
Added support of AOS fanout

### DIFF
--- a/ansible/plugins/action/apswitch.py
+++ b/ansible/plugins/action/apswitch.py
@@ -26,6 +26,7 @@ class ActionModule(ActionBase):
         _root     = boolean(self._task.args.get('root', 'no'))
         _reboot   = boolean(self._task.args.get('reboot', 'no'))
         _timeout  = self._task.args.get('timeout', None)
+        _os_name  = self._task.args.get('os_name', '')
 
         if (type(_login) == unicode):
             _login = ast.literal_eval(_login)
@@ -58,7 +59,8 @@ class ActionModule(ActionBase):
                                       su=_su,
                                       root=_root,
                                       reboot=_reboot,
-                                      timeout=_timeout)
+                                      timeout=_timeout,
+                                      os_name=_os_name)
 
         return result
 

--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -1,0 +1,92 @@
+import json
+import logging
+
+
+class AosHost():
+    """
+    @summary: Class for Accton switch
+    For running ansible module on the Accton switch
+    """
+
+    def __init__(self, ansible_adhoc, hostname, user, passwd, gather_facts=False):
+        self.hostname = hostname
+        self.user = user
+        self.passwd = passwd
+        self.localhost = ansible_adhoc(inventory='localhost', connection='local', host_pattern="localhost")["localhost"]
+
+    def _exec_jinja_template(self, task_name, jinja_template):
+        inventory = 'lab'
+        ansible_root = '../ansible/'
+        playbook_name = 'accton_os_cmd_exec.yml'
+        jinja_name = 'accton_os_cmd_exec.j2'
+        playbook_text = '- hosts: {}\n'.format(self.hostname) + \
+                        '  gather_facts: no\n\n' + \
+                        '  tasks:\n' + \
+                        '  - conn_graph_facts: host={{ inventory_hostname }}\n' + \
+                        '    delegate_to: localhost\n' + \
+                        '    tags: always\n\n' + \
+                        '  - set_fact:\n' + \
+                        '      peer_host: \"{{device_info[inventory_hostname][\'mgmtip\']}}\"\n' + \
+                        '      peer_hwsku: \"{{device_info[inventory_hostname][\'HwSku\']}}\"\n\n' + \
+                        '  - name: {}\n'.format(task_name) + \
+                        '    action: apswitch template={}\n'.format(jinja_name) + \
+                        '    args:\n' + \
+                        '      host: \"{{peer_host}}\"\n' + \
+                        '      login: \"{{switch_login[hwsku_map[peer_hwsku]]}}\"\n' + \
+                        '      os_name: {}\n'.format('aos') + \
+                        '    connection: switch\n'
+
+        with open(ansible_root + jinja_name, 'w') as f:
+            f.write(jinja_template)
+
+        with open(ansible_root + playbook_name, 'w') as f:
+            f.write(playbook_text)
+
+        res = self.exec_template(ansible_root, playbook_name, inventory)
+
+        os.system("rm {}".format(ansible_root + jinja_name))
+        os.system("rm {}".format(ansible_root + playbook_name))
+
+        return res
+
+    def shutdown(self, interface_name):
+        task_name = 'Shutdown interface {}'.format(interface_name)
+        template = 'configure\n' + \
+                   '    interface {}\n'.format(interface_name) + \
+                   '    shutdown\n' + \
+                   '    exit\n' + \
+                   'exit\n' + \
+                   'exit\n'
+        out = self._exec_jinja_template(task_name, template)
+        logging.info('Shut interface {}'.format(interface_name))
+        return {self.hostname : out }
+
+    def no_shutdown(self, interface_name):
+        task_name = 'No shutdown interface {}'.format(interface_name)
+        template = 'configure\n' + \
+                   '    interface {}\n'.format(interface_name) + \
+                   '    no shutdown\n' + \
+                   '    exit\n' + \
+                   'exit\n' + \
+                   'exit\n'
+        out = self._exec_jinja_template(task_name, template)
+        logging.info('No shut interface {}'.format(interface_name))
+        return {self.hostname : out }
+
+    def command(self, cmd):
+        task_name = 'Execute command \'{}\''.format(cmd)
+        out = self._exec_jinja_template(task_name, cmd)
+        logging.info('Exec command: \'{}\''.format(cmd))
+        return {self.hostname : out }
+
+    def exec_template(self, ansible_root, ansible_playbook, inventory, **kwargs):
+        """
+        Execute ansible playbook with specified parameters
+        """
+        playbook_template = 'cd {ansible_path}; ansible-playbook {playbook} -i {inventory} -l {fanout_host} --extra-vars \'{extra_vars}\' -vvv'
+        cli_cmd = playbook_template.format(ansible_path=ansible_root, playbook=ansible_playbook, inventory=inventory,
+            fanout_host=self.hostname, extra_vars=json.dumps(kwargs))
+        res = self.localhost.shell(cli_cmd)
+
+        if res["localhost"]["rc"] != 0:
+            raise Exception("Unable to execute template\n{}".format(res["localhost"]["stdout"]))

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -1,10 +1,10 @@
-
 import logging
 
 from tests.common.devices.sonic import SonicHost
 from tests.common.devices.onyx import OnyxHost
 from tests.common.devices.ixia import IxiaHost
 from tests.common.devices.eos import EosHost
+from tests.common.devices.aos import AosHost
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,9 @@ class FanoutHost(object):
             # TODO: add ixia chassis abstraction
             self.os = os
             self.host = IxiaHost(ansible_adhoc, os, hostname, device_type)
+        elif os == 'aos':
+            self.os = os
+            self.host = AosHost(ansible_adhoc, hostname, user, passwd)
         else:
             # Use eos host if the os type is unknown
             self.os = 'eos'
@@ -138,7 +141,7 @@ class FanoutHost(object):
             interface_name (str): Interface name
 
         Returns:
-            boolean: True if auto negotiation mode is enabled else False. Return None if 
+            boolean: True if auto negotiation mode is enabled else False. Return None if
             the auto negotiation mode is unknown or unsupported.
         """
         return self.host.get_auto_negotiation_mode(interface_name)


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Added `os_name` parameter for switch connection module.
- Added new module for running ansible module on the AOS switch

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The investigation shows that the framework doesn't support AOS fanout. So was added implementation of the module for running ansible module on the AOS switch.
#### How did you do it?
Added new module and extra parameters for running ansible module on the AOS switch.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
