### PR TITLE
[pfcwd] Skip pfcwd warm reboot tests on Td2

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -6,8 +6,9 @@ import random
 import time
 import traceback
 
+from tests.common.broadcom_data import is_broadcom_device
 from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.reboot import reboot
@@ -36,6 +37,23 @@ pytestmark = [pytest.mark.disable_loganalyzer,
              ]
 
 logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_pfcwd_wb_tests(duthosts, rand_one_dut_hostname):
+    """
+    Skip Pfcwd warm reboot tests on certain asics
+
+    Args:
+        duthosts (pytest fixture): list of Duts
+        rand_one_dut_hostname (str): hostname of DUT
+
+    Returns:
+        None
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    SKIP_LIST = ["td2"]
+    asic_type = duthost.get_asic_name()
+    pytest_require(not (is_broadcom_device(duthost) and asic_type in SKIP_LIST), "Warm reboot is not supported on {}".format(asic_type))
 
 @pytest.fixture(autouse=True)
 def setup_pfcwd(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Warm reboot is not supported on Td2. Hence this test should be skipped

Summary:
Fixes #3984

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
```
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/nejo/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 3 items                                                                                                                                                             

pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[no_storm-None] SKIPPED                                                                                      [ 33%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[storm-None] SKIPPED                                                                                         [ 66%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm-None] SKIPPED                                                                                   [100%]

-------------------------------------------------- generated xml file: /var/nejo/Networking-acs-sonic-mgmt/tests/logs/tr.xml --------------------------------------------------
=========================================================================== short test summary info ===========================================================================
SKIPPED [3] /var/nejo/Networking-acs-sonic-mgmt/tests/common/helpers/assertions.py:13: Warm reboot is not supported on td2
========================================================================= 3 skipped in 51.58 seconds ==========================================================================
```