### PR TITLE
[allure] reduce alure configuration missing log

### DIFF
--- a/tests/common/plugins/allure_server/__init__.py
+++ b/tests/common/plugins/allure_server/__init__.py
@@ -61,7 +61,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if report_url:
         logger.info('Allure report URL: {}'.format(report_url))
     else:
-        logger.error('Can not get Allure report URL. Please check logs')
+        logger.info('Can not get Allure report URL. Please check logs')
 
 
 def get_setup_session_info(session):


### PR DESCRIPTION

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The error log comes out after every test call. It is too chatty for testbeds that are not intended to have allure configured.

#### How did you do it?
Lower t he warning to info.

#### How did you verify/test it?
Run any testcase.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
