### PR TITLE
[dhcpv6] skip dhcpv6 relay tests for 202012/201911/201811

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -157,6 +157,10 @@ class SonicAsic(object):
     def os_version(self):
         return self.sonichost.os_version
 
+    @property
+    def sonic_release(self):
+        return self.sonichost.sonic_release
+
     def interface_facts(self, *module_args, **complex_args):
         """Wrapper for the interface_facts ansible module.
 
@@ -402,7 +406,7 @@ class SonicAsic(object):
             return port in self.ports
 
         if_db = self.show_interface(
-            command="status", 
+            command="status",
             include_internal_intfs=True
         )["ansible_facts"]["int_status"]
 
@@ -518,7 +522,7 @@ class SonicAsic(object):
                     pc = k
                     pc_members = mg_facts['minigraph_portchannels'][pc]['members']
                     break
-         
+
         return pc, pc_members
 
     def get_bgp_statistic(self, stat):

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -33,6 +33,18 @@ def skip_version(duthost, version_list):
     if any(version in duthost.os_version for version in version_list):
         pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(version_list)))
 
+def skip_release(duthost, release_list):
+    """
+    @summary: Skip current test if any given release keywords are in os_version, match sonic_release.
+              skip_release is more robust than skip_version.
+    @param duthost: The DUT
+    @param release_list: A list of incompatible releases
+    """
+    if any(release in duthost.os_version for release in release_list):
+        pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(release_list)))
+
+    if any(release == duthost.sonic_release for release in release_list):
+        pytest.skip("DUT is release {} and test does not support {}".format(duthost.sonic_release, ", ".join(release_list)))
 
 def wait(seconds, msg=""):
     """

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -6,6 +6,7 @@ import netaddr
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.utilities import skip_release
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
@@ -109,6 +110,7 @@ def test_dhcp_relay_default(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_r
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     duthost = duthosts[rand_one_dut_hostname]
+    skip_release(duthost, ["201811", "201911", "202012"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Run the DHCP relay test on the PTF host
@@ -134,6 +136,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, du
        then test whether the DHCP relay agent relays packets properly.
     """
     duthost = duthosts[rand_one_dut_hostname]
+    skip_release(duthost, ["201811", "201911", "202012"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down
@@ -174,6 +177,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_host
        relays packets properly.
     """
     duthost = duthosts[rand_one_dut_hostname]
+    skip_release(duthost, ["201811", "201911", "202012"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         # Bring all uplink interfaces down


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
202012/201911/201811 does not support dhcpv6 relay tests, skip the tests for those releases

#### How did you do it?
add skip_release function and use it for dhcpv6

#### How did you verify/test it?
run the tests locally.

please do not do squash merge. use rebase merge as the PR contains two separate pr.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
