### PR TITLE
[NAT]: Fix the stability for test_nat_interfaces_flap_dynamic

### DIFF
--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -182,8 +182,14 @@ def apply_global_nat_config(duthost, config_nat_feature_enabled):
     if 'nat' not in status or status['nat'] == 'disabled':
         pytest.skip('nat feature is not enabled with image version {}'.format(duthost.os_version))
 
+    # Clear all nat rules in iptables
+    duthost.command("sudo iptables -F -t nat")
+
     nat_global_config(duthost)
     yield
+    duthost.command("sudo config nat feature disable")
+    time.sleep(5)
+
     # reload config on teardown
     config_reload(duthost, config_source='minigraph')
 


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Clear all NAT iptables rules before test.
- Wait more time for the port to be ready to send packets in
  test_nat_interfaces_flap_dynamic

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)
  - TestDynamicNat::test_nat_interfaces_flap_dynamic


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This test sometimes fails with
- Residual iptables rules 
- Port is not ready for sending out packet.

#### How did you do it?
- Clear all nat rules in iptables.
- Wait for more time for port stable after port operStatus from down to up.

#### How did you verify/test it?
Run specific TC to test fixes
nat/test_dynamic_nat.py::TestDynamicNat::test_nat_clear_translations_dynamic[port_in_lag-TCP] PASSED [ 92%]
nat/test_dynamic_nat.py::TestDynamicNat::test_nat_clear_translations_dynamic[port_in_lag-UDP] PASSED [ 93%]
nat/test_dynamic_nat.py::TestDynamicNat::test_nat_interfaces_flap_dynamic[port_in_lag-TCP] PASSED [ 94%]
nat/test_dynamic_nat.py::TestDynamicNat::test_nat_interfaces_flap_dynamic[port_in_lag-UDP] PASSED [ 95%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
