### PR TITLE
[test_bgp_update_timer] Set correct neighbor type

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -72,7 +72,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga
         if k == duthost.hostname:
             dut_type = v['type']
 
-    if dut_type == 'ToRRouter':
+    if 'ToRRouter' in dut_type:
         neigh_type = 'LeafRouter'
     else:
         neigh_type = 'ToRRouter'


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3840 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Set correct neighbor type on storage backend topologies since the DUT
type is either `BackEndToRRouter` or `BackEndLeafRouter`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer PASSED                                                                                                                                                                                                             [100%]

========================================================================================================================= 1 passed in 275.19 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
