### PR TITLE
[multi asic] get the correct service name for multi asic

### DIFF
--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -53,7 +53,7 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     logging.info("Restart the %s service on asic %s" %(service, enum_frontend_asic_index))
 
     asichost = dut.asic_instance(enum_frontend_asic_index)
-    service_name = asichost.get_docker_name(service)
+    service_name = asichost.get_service_name(service)
     dut.command("sudo systemctl restart {}".format(service_name))
 
     for container in dut.get_default_critical_services_list():


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix for test `test_restart_swss` on multi asic platforms

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ x] 201911

### Approach
#### What is the motivation for this PR?
The test `test_restart_swss` fails on multi asic platform with the below error
```
RunAnsibleModuleFail: run module command failed, Ansible Results => {
    "changed": true,
    "cmd": [
        "sudo",
        "systemctl",
        "restart",
        "swss0"
    ],
    "delta": "0:00:00.011334",
    "end": "2021-08-02 16:48:08.994582",
    "failed": true,
    "invocation": {
        "module_args": {
            "_raw_params": "sudo systemctl restart swss0",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "msg": "non-zero return code",
    "rc": 5,
    "start": "2021-08-02 16:48:08.983248",
    "stderr": "Failed to restart swss0.service: Unit swss0.service not found.",
    "stderr_lines": [
        "Failed to restart swss0.service: Unit swss0.service not found."
    ],
    "stdout": "",
    "stdout_lines": [],
    "warnings": [
        "Consider using 'become', 'become_method', and 'become_user' rather than running sudo"
    ]
}
```
**Reason for the error**
The service name derived in the test is incorrect. The service name should be `swss@0` iso `swss0`

#### How did you do it?
Fix the test to get the correct service name for multi asic platform

#### How did you verify/test it?
Verify running the test on single and multi asic

**Multi asic logs**
```
+ ./run_tests.sh -d str-multi_asic-acs-2 -n vms13-t1-multi_asic-2 -c platform_tests/test_sequential_restart.py -i ../ansible/str,../ansible/veos -l WARNING -k debug -m individual -r -u -t t1,any -e '--skip_sanity --deep_clean  --disable_loganalyzer  '
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is
now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
================================================================================================================================================== test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 8 items


platform_tests/test_sequential_restart.py::test_restart_swss[0] PASSED                                                                                                                                                                                                                                             [ 12%]
platform_tests/test_sequential_restart.py::test_restart_syncd[0] SKIPPED                                                                                                                                                                                                                                           [ 25%]
platform_tests/test_sequential_restart.py::test_restart_swss[1] PASSED                                                                                                                                                                                                                                             [ 37%]
platform_tests/test_sequential_restart.py::test_restart_syncd[1] SKIPPED                                                                                                                                                                                                                                           [ 50%]
platform_tests/test_sequential_restart.py::test_restart_swss[2] PASSED                                                                                                                                                                                                                                             [ 62%]
platform_tests/test_sequential_restart.py::test_restart_syncd[2] SKIPPED                                                                                                                                                                                                                                           [ 75%]
platform_tests/test_sequential_restart.py::test_restart_swss[3] PASSED                                                                                                                                                                                                                                             [ 87%]
platform_tests/test_sequential_restart.py::test_restart_syncd[3] SKIPPED                                                                                                                                                                                                                                           [100%]

--------------------------------------------------------------------------------------------------------- generated xml file: /data/repos/azvm/sonic-mgmt/tests/logs/platform_tests/test_sequential_restart.xml ----------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------------------------------------
00:28:20 __init__.pytest_terminal_summary         L0064 ERROR  | Can not get Allure report URL. Please check logs
================================================================================================================================================ short test summary info =================================================================================================================================================
SKIPPED [4] platform_tests/test_sequential_restart.py:108: Restarting syncd is not supported yet
========================================================================================================================================= 4 passed, 4 skipped in 6678.46 seconds =========================================================================================================================================
```

**Single Asic**
```
================================================================================================================================================= test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 2 items


platform_tests/test_sequential_restart.py::test_restart_swss[None] PASSED                                                                                                                                                                                                                                          [ 50%]
platform_tests/test_sequential_restart.py::test_restart_syncd[None] SKIPPED                                                                                                                                                                                                                                        [100%]

--------------------------------------------------------------------------------------------------------- generated xml file: /data/repos/azvm/sonic-mgmt/tests/logs/platform_tests/test_sequential_restart.xml ----------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------------------------------------
22:44:54 __init__.pytest_terminal_summary         L0064 ERROR  | Can not get Allure report URL. Please check logs
================================================================================================================================================ short test summary info =================================================================================================================================================
SKIPPED [1] platform_tests/test_sequential_restart.py:108: Restarting syncd is not supported yet
========================================================================================================================================= 1 passed, 1 skipped in 492.02 seconds ==========================================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
