### PR TITLE
[Pytest][NHOP max path] Added a new test case to test the max number of ECMP paths

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -132,7 +132,7 @@ class MultiAsicSonicHost(object):
 
         return [asic.namespace for asic in self.backend_asics]
 
-    def asic_instance(self, asic_index):
+    def asic_instance(self, asic_index=None):
         if asic_index is None:
             return self.asics[0]
         return self.asics[asic_index]

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1590,10 +1590,10 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
                (k.startswith("PortChannel") and not
                 self.is_backend_portchannel(k))
             ):
-                # Ping for some time to get ARP Re-learnt.
+                # Ping for some time to get ARP Re-learkeysnt.
                 # We might have to tune it further if needed.
                 if (v["admin"] == "up" and v["oper_state"] == "up" and
-                   self.ping_v4(v["peer_ipv4"], count=10, ns_arg=ns_arg)):
+                   self.ping_v4(v["peer_ipv4"], count=3, ns_arg=ns_arg)):
                     ip_ifaces[k] = {
                         "ipv4": v["ipv4"],
                         "peer_ipv4": v["peer_ipv4"],

--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -1,0 +1,121 @@
+import pytest
+import time
+import logging
+
+from collections import namedtuple
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+
+pytestmark = [
+    pytest.mark.topology('t1', 't2')
+]
+
+
+class NextHopGroup:
+    """
+    Create a list of next hop paths with given IP, MAC parameters
+    """
+    def __init__(self, asic, count, iface, ip="172.16", mac="C0:FF:EE:00"):
+        IP_MAC = namedtuple('IP_MAC', 'ip mac')
+        self.iface = iface
+        self.arp_list = []
+        self.asic = asic
+        self.if_addr = "{}.0.3/16".format(ip)
+        self.ip = None
+
+        for i in range(11, count+11):
+            moff1 = "{0:x}".format(i/255)
+            moff2 = "{0:x}".format(i%255)
+
+            ipoff1 = i / 255
+            ipoff2 = i % 255
+            self.arp_list.append(IP_MAC(
+                "{}.{}.{}".format(ip, ipoff1, ipoff2),
+                "{}:{}:{}".format(mac, moff1, moff2)
+            ))
+
+        ip_iface = "ip address add {} dev {}".format(self.if_addr, self.iface)
+
+        logging.info("IF ADDR ADD {}".format(ip_iface))
+        # add IP address to the eth interface
+        result = asic.command(ip_iface)
+        pytest_assert(result["rc"] == 0, ip_iface)
+
+    def arps_add(self):
+        arp_cmd = "arp -s {} {}"
+        for ip_mac in self.arp_list:
+            cmd = arp_cmd.format(ip_mac.ip, ip_mac.mac)
+            result = self.asic.command(cmd)
+            pytest_assert(result["rc"] == 0, cmd)
+
+    def arps_del(self):
+        arp_cmd = "arp -d {}"
+        for ip_mac in self.arp_list:
+            cmd = arp_cmd.format(ip_mac.ip)
+            try:
+                result = self.asic.command(cmd)
+            except:
+                pass
+
+    def add_ip_route(self, ip="192.168.5.0/24"):
+        self.arps_add()
+        self.ip = ip
+        ip_route = "ip route add {}".format(self.ip)
+        ip_nhop = ""
+        for ip_mac in self.arp_list:
+            ip_nhop += "nexthop via {} ".format(ip_mac.ip)
+
+        ip_cmd = "{} {}".format(ip_route, ip_nhop)
+        logging.info("ROUTE ADD {}".format(ip_cmd))
+        result = self.asic.command(ip_cmd)
+        pytest_assert(result["rc"] == 0, ip_cmd)
+
+    def clean_up(self):
+        # delete ip route
+        if self.ip:
+            ip_route = "ip route del {}".format(self.ip)
+            logging.info("ROUTE DEL {}".format(ip_route))
+            try:
+                self.asic.command(ip_route)
+            except:
+                pass
+
+        # delete static ARPs
+        self.arps_del()
+
+        # del IP address from the eth interface
+        ip_iface = "ip address del {} dev {}".format(self.if_addr, self.iface)
+        logging.info("IF ADDR DEL {}".format(ip_iface))
+        try:
+            self.asic.command(ip_iface)
+        except:
+            pass
+
+
+@pytest.mark.parametrize("nhop_path_count", [32])
+def test_nhop(nhop_path_count, request, duthost):
+
+    asic = duthost.asic_instance()
+    ip_ifaces = asic.get_active_ip_interfaces().keys()
+    pytest_assert(len(ip_ifaces), "No IP interfaces found")
+    eth_if = ip_ifaces[0]
+
+    logging.info("Adding next hops on {}".format(eth_if))
+    marker = "NHOP TEST PATH COUNT {} {}".format(nhop_path_count, eth_if)
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker)
+    marker = loganalyzer.init()
+    loganalyzer.load_common_config()
+    loganalyzer.expect_regex = []
+
+    nhops = NextHopGroup(asic, nhop_path_count, eth_if)
+
+    try:
+        nhops.add_ip_route("192.168.5.0/24")
+        # bake time to program in ASIC
+        time.sleep(3)
+
+    finally:
+        nhops.clean_up()
+
+    loganalyzer.analyze(marker)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Added a new test case to test the max number of ECMP paths

The number of paths is passed as a parameter.

A static IP route is added in the linux IP stack with ECMP paths, along with static ARPs.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Added a new test case to test max number of ECMp paths.

#### How did you do it?

Steps to create nhop group :
* Add /24 IP address to an active IP interface
* Create static ARP entries 
* Add an IP route with ECMP paths
* Cleanup after the test is done.
* Check logs for any errors.

#### How did you verify/test it?

Failure case
```
self._verify_log(analyzer_summary)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                                                                                                                                                                                                                                                                                                                                                                                    self = <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer instance at 0x7fcc5e0ed820>, result = {'expect_messages': {'/tmp/syslog.str-s6000-acs-8.2021-08-09-23:03:54': []}, 'match_files': {'/tmp/syslog.str-s6000-ac... status: SAI_STATUS_TABLE_FULL\n', ...]}, 'tota
l': {'expected_match': 0, 'expected_missing_match': 0, 'match': 7}, ...}

def _verify_log(self, result):                                                                                                                                                                                                                                                     """
    Verify that total match and expected missing match equals to zero or raise exception otherwise.
    Verify that expected_match is not equal to zero when there is configured expected regexp in self.expect_regex list
    """
    if not result:
        raise LogAnalyzerError("Log analyzer failed - no result.")
    if result["total"]["match"] != 0 or result["total"]["expected_missing_match"] != 0:
>           raise LogAnalyzerError(result)
E           LogAnalyzerError: {'match_messages': {'/tmp/syslog.str-s6000-acs-8.2021-08-09-23:03:54': ['Aug  9 23:03:04.796884 str-s6000-acs-8 ERR syncd#syncd: [none] _brcm_l3_egress_ecmp_add:1409 ecmp nh group add failed with error Table full (0xfffffffa).\n', 'Aug  9 23
:03:04.801262 str-s6000-acs-8 ERR syncd#syncd: [none] brcm_sai_create_next_hop_group_member:404 ecmp nh group add failed with error -13.\n', 'Aug  9 23:03:04.801262 str-s6000-acs-8 ERR syncd#syncd: :- processEvent: attr: SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID:
oid:0x500000000072b\n', 'Aug  9 23:03:04.801567 str-s6000-acs-8 ERR syncd#syncd: :- processEvent: attr: SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID: oid:0x400000000072a\n', 'Aug  9 23:03:04.801877 str-s6000-acs-8 ERR syncd#syncd: :- processEvent: failed to execute api: cr
eate, key: SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:oid:0x2d00000000074c, status: SAI_STATUS_TABLE_FULL\n', 'Aug  9 23:03:04.802795 str-s6000-acs-8 ERR syncd#syncd: :- syncd_main: Runtime error: :- processEvent: failed to execute api: create, key: SAI_OBJECT_TYPE_NEXT_HOP_G
ROUP_MEMBER:oid:0x2d00000000074c, status: SAI_STATUS_TABLE_FULL\n', 'Aug  9 23:03:04.809684 str-s6000-acs-8 ERR swss#orchagent: :- on_switch_shutdown_request: Syncd stopped\n']}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 7}, 'match_files': {'/t
mp/syslog.str-s6000-acs-8.2021-08-09-23:03:54': {'expected_match': 0, 'match': 7}}, 'expect_messages': {'/tmp/syslog.str-s6000-acs-8.2021-08-09-23:03:54': []}, 'unused_expected_regexp': []}                                                                                  
common/plugins/loganalyzer/loganalyzer.py:88: LogAnalyzerError
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------                                                                                                                                                                                    ERROR    root:__init__.py:39 Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
self.ihook.pytest_pyfunc_call(pyfuncitem=self)
File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
return self._hookexec(self, self.get_hookimpls(), kwargs)
File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
return self._inner_hookexec(hook, methods, kwargs)
 
```

Single ASIC

```


samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest --count=3 ipfwd/test_nhop_count.py --testbed vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8  --module-path=../ansible/library --disable_loganalyzer --skip_sanity -k nhop
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 3 items


ipfwd/test_nhop_count.py ...
                                                                                    [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================================================================================= 3 passed, 1 warnings in 549.05 seconds =================================================================================================================================================================

```

MASIC

```

samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest ipfwd/test_nhop_count.py --testbed=vms13-t1-nmasic-2 --inventory=../ansible/veos,../ansible/str,../ansible/str2 --testbed_file=../ansible/testbed.csv --host-pattern=str-nmasic-acs-2 --module-path=../ansible/library --disable_loganalyzer --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 1 item


ipfwd/test_nhop_count.py .
                                                                                    [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=====================================================================================================================================================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T1, T2

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
