### PR TITLE
[bug fix] [test_static_route] missing copy arp_responder and corresponding conf to ptf docker

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -6,8 +6,9 @@ import random
 import time
 import traceback
 
+from tests.common.broadcom_data import is_broadcom_device
 from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.reboot import reboot
@@ -36,6 +37,23 @@ pytestmark = [pytest.mark.disable_loganalyzer,
              ]
 
 logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_pfcwd_wb_tests(duthosts, rand_one_dut_hostname):
+    """
+    Skip Pfcwd warm reboot tests on certain asics
+
+    Args:
+        duthosts (pytest fixture): list of Duts
+        rand_one_dut_hostname (str): hostname of DUT
+
+    Returns:
+        None
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    SKIP_LIST = ["td2"]
+    asic_type = duthost.get_asic_name()
+    pytest_require(not (is_broadcom_device(duthost) and asic_type in SKIP_LIST), "Warm reboot is not supported on {}".format(asic_type))
 
 @pytest.fixture(autouse=True)
 def setup_pfcwd(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_static_route doesn't copy arp_responder and corresponding conf to ptf docker, so test will raise the following error:
"stdout": "arp_responder: ERROR (no such process)\narp_responder: ERROR (no such process)",
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the issue: miss copying arp_responder and corresponding conf to ptf docker.

#### How did you do it?
1. Import copy_arp_responder_py in test_static_route.py
2. Generate corresponding arp conf and copy to ptf docker

#### How did you verify/test it?
run test like below:
py.test route/test_static_route.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern arc-switch1025 --module-path ../ansible/library/ --testbed arc-switch1025-t0 --testbed_file ../ansible/testbed.csv --allow_recover

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
