### PR TITLE
[bug fix] [test_static_route] missing copy arp_responder and corresponding conf to ptf docker

### DIFF
--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -1,7 +1,3 @@
-import pytest
-from jinja2 import Template
-
-
 # Pytest configuration used by the route tests.
 def pytest_addoption(parser):
     # Add options to pytest that are used by route tests
@@ -10,10 +6,3 @@ def pytest_addoption(parser):
 
     route_group.addoption("--num_routes", action="store", default=10000, type=int,
                      help="Number of routes for add/delete")
-
-
-@pytest.fixture(scope='package', autouse=True)
-def prepare_arp_responder_conf(ptfhost):
-    arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
-    ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="--conf /tmp/from_t1.json"),
-                 dest="/etc/supervisor/conf.d/arp_responder.conf")

--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -1,3 +1,7 @@
+import pytest
+from jinja2 import Template
+
+
 # Pytest configuration used by the route tests.
 def pytest_addoption(parser):
     # Add options to pytest that are used by route tests
@@ -6,3 +10,10 @@ def pytest_addoption(parser):
 
     route_group.addoption("--num_routes", action="store", default=10000, type=int,
                      help="Number of routes for add/delete")
+
+
+@pytest.fixture(scope='package', autouse=True)
+def prepare_arp_responder_conf(ptfhost):
+    arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
+    ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="--conf /tmp/from_t1.json"),
+                 dest="/etc/supervisor/conf.d/arp_responder.conf")

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -7,8 +7,7 @@ import random
 import re
 from collections import defaultdict
 
-from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses, copy_arp_responder_py
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.mux_simulator_control import mux_server_url
@@ -56,6 +55,8 @@ def add_ipaddr(ptfadapter, ptfhost, nexthop_addrs, prefix_len, nexthop_devs, ipv
         with open("/tmp/from_t1.json", "w") as ar_config:
             json.dump(arp_responder_conf, ar_config)
         ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+        ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": "-e"})
+        ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
 
         ptfhost.shell('supervisorctl reread && supervisorctl update')
         ptfhost.shell('supervisorctl restart arp_responder')

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -7,6 +7,7 @@ import random
 import re
 from collections import defaultdict
 
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_static_route  doesn't copy arp_responder  and corresponding conf to ptf docker, so test will raise the following error:
 **"stdout": "arp_responder: ERROR (no such process)\narp_responder: ERROR (no such process)",** 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the issue: miss copying arp_responder and corresponding conf to ptf docker.

#### How did you do it?

1. Import copy_arp_responder_py in test_static_route.py
2. Generate corresponding arp conf and copy to ptf docker

#### How did you verify/test it?
run test like below:
`py.test route/test_static_route.py  --inventory "../ansible/inventory, ../ansible/veos" --host-pattern arc-switch1025 --module-path                ../ansible/library/ --testbed arc-switch1025-t0 --testbed_file ../ansible/testbed.csv                --allow_recover  `         



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
