### PR TITLE
[memory_checker] Skip testing against DuT of Celestica E1031.

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -213,9 +213,10 @@ def test_memory_checker(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostna
     container_name = "telemetry"
     vm_workers = 4
 
-    pytest_require(("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
-                   or parse_version(duthost.kernel_version) > parse_version("4.9.0"),
-                   "Test is not supported for 20191130.72 and older image versions!")
+    pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
+                   and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
+                   or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
+                   "Test is not supported for platform Celestica E1031, 20191130.72 and older image versions!")
 
 
     expected_alerting_messages = []


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
This PR aims to skip testing the `memory checker` against `streaming telemetry` container on platform `Celestica E1031`. Since the DuT of `Celestica E1031` only has 2GB memory and around 230MB free memory, `streaming telemetry` container will consumes more than 400MB memory in order to test the feature of memory checker and this testing will cause the DuT to be in bad state.

#### How did you do it?
I used the `pytest_require(...)` to skip testing against the `Celestica E1031`.

#### How did you verify/test it?
I tested this change on `str-e1031-acs-3`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
