### PR TITLE
[bug fix]Add skip_vendor_specific_container argument option for test_monitoring_critical_processes

### DIFF
--- a/tests/process_monitoring/conftest.py
+++ b/tests/process_monitoring/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip_vendor_specific_container",
+        action="store",
+        default="",
+        required=False,
+        help="skip vendor specific container list"
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_vendor_specific_container(request):
+    """ This fixture is to get the skipping vendor container list and return the container information
+
+    For example:
+        pytest --skip_vendor_specific_container "container1,  container2" <other arguments>
+        pytest --skip_vendor_specific_container container1,  container2 <other arguments>
+
+    """
+    skip_vendor_specific_container_opt = request.config.getoption("--skip_vendor_specific_container", default="")
+    vendor_specific_container_list = []
+    if skip_vendor_specific_container_opt:
+        vendor_specific_container_list = [container.strip() for container in skip_vendor_specific_container_opt.split(",")]
+
+    return vendor_specific_container_list

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -518,7 +518,7 @@ def ensure_all_critical_processes_running(duthost, containers_in_namespaces):
                     ensure_process_is_running(duthost, container_name_in_namespace, program_name)
 
 
-def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo):
+def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container):
     """Tests the feature of monitoring critical processes by Monit and Supervisord.
 
     This function will check whether names of critical processes will appear
@@ -551,6 +551,7 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo):
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")
+    skip_containers = skip_containers + skip_vendor_specific_container
 
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When there are some vendor specific container installed in DUT, after run test_monitoring_critical_processes case, it will raise some error logs like " _**Process 'wjhd' is not running in namespace 'host'.***_ ". So we add skip_vendor_specific_container option to skip the specified container check.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
It is to fix the issue: After run test_monitoring_critical_processes, it will raise some error log like " **_Process 'wjhd' is not running in namespace 'host'.*_** ".

#### How did you do it?
Add one argument option of skip_vendor_specific_container, so we can pass the specified vendor container to the test, and then the check for specified container will be skipped.

#### How did you verify/test it?
Run test with follow cmds:

    

- CMD with skip_vendor_specific_container:
py.test process_monitoring/test_critical_process_monitoring.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern r-liger-02 --module-path ../ansible/library/ --testbed r-liger-02-ptf-any --testbed_file ../ansible/testbed.csv --allow_recover **_--skip_vendor_specific_container "vendor_container1, vendor_container2"_**

    

- CMD without skip_vendor_specific_container:
py.test process_monitoring/test_critical_process_monitoring.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern r-liger-02 --module-path ../ansible/library/ --testbed r-liger-02-ptf-any --testbed_file ../ansible/testbed.csv --allow_recover


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
