### PR TITLE
[bug fix][test_container_checker] change config of monit to stablize the test #7

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -70,11 +70,12 @@ def update_monit_service(duthost):
     duthost.shell("sudo cp -f /etc/monit/monitrc /tmp/")
     duthost.shell("sudo cp -f /etc/monit/conf.d/sonic-host /tmp/")
 
-    temp_config_line = "    if status != 0 for 2 times within 2 cycles then alert repeat every 1 cycles"
+    temp_config_line = "    if status != 0 for 1 times within 1 cycles then alert repeat every 1 cycles"
     logger.info("Reduce the monitoring interval of container_checker.")
     duthost.shell("sudo sed -i '$s/^./#/' /etc/monit/conf.d/sonic-host")
     duthost.shell("echo '{}' | sudo tee -a /etc/monit/conf.d/sonic-host".format(temp_config_line))
-    duthost.shell("sudo sed -i '/with start delay 300/s/^./#/' /etc/monit/monitrc")
+    duthost.shell("sudo sed -i 's/with start delay 300/with start delay 10/' /etc/monit/monitrc")
+    duthost.shell("sudo sed -i 's/set daemon 60/set daemon 10/' /etc/monit/monitrc")
     logger.info("Restart the Monit service without delaying to monitor.")
     duthost.shell("sudo systemctl restart monit")
     yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide the following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Because the Monit sampling interval is too long (**60s**),  and the syncd container restart time is rather short (**sometimes it just needs about 30s**), and the alert message rule is too strict, so sometimes Monit can not monitoring syncd down for 2 times for 2 mins and there are no syncd alert messages in syslog. By changing the relevant config of Monit, we can stabilize the test.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Stabilize test_container_checker by changing some config of Monit.
#### How did you do it?
Changing the sampling intervals to 10 in /etc/monit/monitrc ensures that the Monit can monitor syncd container down.
Changing the start delay  to 10 in /etc/monit/monitrc ensures that the Monit start quicker than syncd start.


```
## Start Monit in the background (run as a daemon):
#
  set daemon 10             # check services at 1-minute intervals
    with start delay 10    # we delay Monit to start monitoring for 5 minutes
                            # intentionally such that all containers and processes
                            # have ample time to start up.
#
```
Changing the rule of alerting messages in /etc/monit/conf.d/sonic-host makes it is easy to send alert messages.
```
check program container_checker with path "/usr/bin/container_checker"
    if status != 0 for 1 times within 1 cycles then alert repeat every 1 cycles

```
#### How did you verify/test it?
run test:
`py.test container_checker/test_container_checker.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern arc-switch1025 --module-path                ../ansible/library/ --testbed arc-switch1025-t0 --testbed_file ../ansible/testbed.csv                --allow_recover`            

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
