### PR TITLE
test_tor_ecn: added test skip based on a helper script presence

### DIFF
--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -259,6 +259,18 @@ def test_dscp_to_queue_during_decap_on_active(
     else:
         logging.info("the expected Queue : {} matching with received Queue : {}".format(exp_queue, rec_queue))
 
+@pytest.fixture(scope='module')
+def write_standby(rand_selected_dut):
+    file = "/usr/local/bin/write_standby.py"
+    def runcmd():
+        rand_selected_dut.shell(file)
+
+    try:
+        rand_selected_dut.shell("ls %s" % file)
+        return runcmd
+    except:
+        pytest.skip('file {} not found'.format(file))
+
 def test_dscp_to_queue_during_encap_on_standby(
     build_non_encapsulated_ip_packet,
     rand_selected_interface, ptfadapter,
@@ -266,12 +278,13 @@ def test_dscp_to_queue_during_encap_on_standby(
     rand_selected_dut, 
     tunnel_traffic_monitor, 
     duthosts, 
-    rand_one_dut_hostname
+    rand_one_dut_hostname,
+    write_standby
 ):
     """
     Test if DSCP to Q mapping for outer header is matching with inner header during encap on standby
     """
-    rand_selected_dut.shell("/usr/local/bin/write_standby.py")
+    write_standby()
 
     tor = rand_selected_dut
     non_encapsulated_packet = build_non_encapsulated_ip_packet
@@ -325,12 +338,13 @@ def test_ecn_during_encap_on_standby(
     ptfadapter,
     tbinfo, 
     rand_selected_dut, 
-    tunnel_traffic_monitor
+    tunnel_traffic_monitor,
+    write_standby
 ):
     """
     Test if the ECN stamping on outer header is matching with inner during encap on standby
     """
-    rand_selected_dut.shell("/usr/local/bin/write_standby.py")
+    write_standby()
 
     tor = rand_selected_dut
     non_encapsulated_packet = build_non_encapsulated_ip_packet


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_tor_ecn - added test skip based on a helper script presence
Fixes # (issue)
- some test_tor_ecn tests require a helper script `write_standby.py` which can be missing and no docs provided on it, so added a skip when the script is missing

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Avoid failing tests with not met preconditions
#### How did you do it?
Dedicated a fixture for precondition and skipped tests when the precondition not met
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0,any dualtor/test_tor_ecn.py -k test_dscp_to_queue_during_encap_on_standby
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
