### PR TITLE
[chassis] Fix in fabric_info to get the asic_host_base prefix

### DIFF
--- a/ansible/library/fabric_info.py
+++ b/ansible/library/fabric_info.py
@@ -48,8 +48,8 @@ def main():
         num_fabric_asic = int( m_args[ 'num_fabric_asic' ] )
         v4pfx = str( m_args[ 'asics_host_basepfx' ] ).split("/")
         v6pfx = str( m_args[ 'asics_host_basepfx6' ] ).split("/")
-        v4base = int( ipaddress.IPv4Address(v4pfx[0]) )
-        v6base = int( ipaddress.IPv6Address(v6pfx[0]) )
+        v4base = int( ipaddress.IPv4Address(unicode(v4pfx[0])) )
+        v6base = int( ipaddress.IPv6Address(unicode(v6pfx[0])) )
         for asic_id in range(num_fabric_asic):
             key = "ASIC%d" % asic_id
             next_v4addr = str( ipaddress.IPv4Address(v4base + asic_id) )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the error seen while generating the minigraph for supervisor card

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For the supervisor card, while generating the minigraph the following error is seen
```
fatal: [str2-sonic-sup-1]: FAILED! => {"changed": false, "msg": "failed to find the correct fabric asic info '20.0.0.1' (len 8 != 4) is not permitted as an IPv4 address. Did you pass in a bytes (str in Python 2) instead of a unicode object?"}
```
#### How did you do it?
pass `unicode` instead of `str` to `ipaddress.IPv4Address`

#### How did you verify/test it?
Generate the minigraph for supervisor card
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
