### PR TITLE
remove the use of config_db to get the port indices in config_facts

### DIFF
--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -2,6 +2,12 @@
 import json
 from collections import defaultdict
 from natsort import natsorted
+from ansible.module_utils.port_utils import get_port_indices_for_asic
+
+try:
+    from sonic_py_common import multi_asic
+except ImportError:
+    print("Failed to import multi_asic")
 
 DOCUMENTATION = '''
 ---
@@ -61,7 +67,7 @@ def format_config(json_data):
     return res
 
 
-def create_maps(config):
+def create_maps(config, namespace):
     """ Create a map of SONiC port name to physical port index """
     port_index_map = {}
     port_name_to_alias_map = {}
@@ -71,13 +77,19 @@ def create_maps(config):
         port_name_list = config["PORT"].keys()
         port_name_list_sorted = natsorted(port_name_list)
 
-        #get the port_index from config_db if available
-        port_index_map = {
-            name: int(v['index']) - 1
-            for name, v in config['PORT'].items()
-            if 'index' in v
-        }
-        if not port_index_map:
+        try:
+            multi_asic_device = multi_asic.is_multi_asic()
+        except Exception:
+            multi_asic_device = False
+
+        
+        if multi_asic_device:
+            asic_id = 0
+            if namespace is not None:
+                asic_id = namespace.split("asic")[1]
+            port_index_map = get_port_indices_for_asic(asic_id,
+                                                       port_name_list_sorted)
+        else:
             #if not available generate an index
             for idx, val in enumerate(port_name_list_sorted):
                 port_index_map[val] = idx
@@ -105,7 +117,7 @@ def get_running_config(module, namespace):
     return json_info
 
 
-def get_facts(config):
+def get_facts(config, namespace):
     """ Create the facts dict """
 
     Tree = lambda: defaultdict(Tree)
@@ -114,7 +126,7 @@ def get_facts(config):
 
     results.update(format_config(config))
 
-    results.update(create_maps(config))
+    results.update(create_maps(config, namespace))
 
     return results
 
@@ -146,7 +158,7 @@ def main():
                 config = json.load(f)
         elif m_args["source"] == "running":
             config = get_running_config(module, namespace)
-        results = get_facts(config)
+        results = get_facts(config, namespace)
         module.exit_json(ansible_facts=results)
     except Exception as e:
         module.fail_json(msg=e.message)


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
remove the use of config_db to get the port indices in config_facts
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ x] 201911

### Approach
#### What is the motivation for this PR?
The PR  #3897  introduced a change to get the port indices from config_db. 
This causes some test regressions for single ASIC testbeds.

The port index was read from config_db or running config after update.
 ```
  #get the port_index from config_db if available 
        port_index_map = {
            name: int(v['index'])
            for name, v in config['PORT'].iteritems()
            if 'index' in v
        }
        if not port_index_map:
            #if not available generate an index
            for idx, val in enumerate(port_name_list_sorted):
                port_index_map[val] = idx
```
The problem is, for some SKUs with port spliting,  the index retrieved from config may be duplicated, which is not expected. 
For example, the port_index for Ethernet0 and Ethernet2 are both 1 in config_db, but Ethernet2 is actually connected to eth1 (not eth0) on ptf. 
This issue may cause some test failure that calls config_facts library to retrieve port mapping, such as `test_fdb`.

#### How did you do it?
The following change are done in this PR:
 - The port_index_map for single asic  and multi asic will not use the index in `config_db`
 -  For multi-asic, the indicies will be generated by adding a asic_offset to make sure the index is different for every asic.
 
#### How did you verify/test it?

**Verify `test_fdb` on single asic devices**
```
+ ./run_tests.sh -d str-a7050-acs-1 -n vms2-5-t0-7050-1 -c fdb/test_fdb.py -i ../ansible/str,../ansible/veos,../ansible/str2 -l WARNING -k debug -m individual -r -u -t '' -e '--skip_sa
nity --deep_clean  --disable_loganalyzer  '
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is
now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
================================================================================= test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 4 items

fdb/test_fdb.py::test_fdb[ethernet] PASSED                                                                                                                                       [ 25%]
fdb/test_fdb.py::test_fdb[arp_request] PASSED                                                                                                                                    [ 50%]
fdb/test_fdb.py::test_fdb[arp_reply] PASSED                                                                                                                                      [ 75%]
fdb/test_fdb.py::test_fdb[cleanup] PASSED                                                                                                                                        [100%]

----------------------------------------------------- generated xml file: /data/repos/azvm/sonic-mgmt/tests/logs/fdb/test_fdb.xml ------------------------------------------------------
============================================================================== 4 passed in 372.24 seconds ==============================================================================
```

```
./run_tests.sh -d str-msn2700-01 -n vms1-t0-2700-1 -c fdb/test_fdb.py -i ../ansible/str,../ansible/veos,../ansible/str2 -l WARNING -k debug -m individual -r -u -t t0 -e '--skip_sanity --deep_clean  --disable_loganalyzer  '
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is
now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
================================================================================= test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 4 items

fdb/test_fdb.py::test_fdb[ethernet] PASSED                                                                                                                                       [ 25%]
fdb/test_fdb.py::test_fdb[arp_request] PASSED                                                                                                                                    [ 50%]
fdb/test_fdb.py::test_fdb[arp_reply] PASSED                                                                                                                                      [ 75%]
fdb/test_fdb.py::test_fdb[cleanup] PASSED                                                                                                                                        [100%]

----------------------------------------------------- generated xml file: /data/repos/azvm/sonic-mgmt/tests/logs/fdb/test_fdb.xml ------------------------------------------------------
============================================================================== 4 passed in 420.97 seconds ==============================================================================
```
**Verify `test_reload_config` on multi asic**
```
+ ./run_tests.sh -d str-multi_asic-acs-2 -n vms13-t1-multi_asic-2 -c platform_tests/test_reload_config.py -i ../ansible/str,../ansible/veos,../ansible/str2 -l WARNING -k debug -m individual -r -u -t t1,any -e '--skip_sanity --deep_clean  --disable_loganalyzer  '
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is
now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
================================================================================= test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/azvm/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 2 items

platform_tests/test_reload_config.py::test_reload_configuration PASSED                                                                                                           [ 50%]
platform_tests/test_reload_config.py::test_reload_configuration_checks PASSED                                                                                                    [100%]

------------------------------------------- generated xml file: /data/repos/azvm/sonic-mgmt/tests/logs/platform_tests/test_reload_config.xml -------------------------------------------
============================================================================== 2 passed in 421.44 seconds ==============================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
