### PR TITLE
Log mux cable status if ```test_fdb``` failed on dualtor testbed

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -183,12 +183,12 @@ def fdb_cleanup(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture
-def record_mux_status(request, rand_selected_dut):
+def record_mux_status(request, rand_selected_dut, tbinfo):
     """
     A function level fixture to record mux cable status if test failed.
     """
     yield
-    if request.node.rep_call.failed:
+    if request.node.rep_call.failed and 'dualtor' in tbinfo['topo']['name']:
         mux_status = rand_selected_dut.shell("show muxcable status", module_ignore_errors=True)['stdout']
         logger.warning("fdb test failed. Mux status are \n {}".format(mux_status))
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -182,9 +182,20 @@ def fdb_cleanup(duthosts, rand_one_dut_hostname):
         pytest_assert(wait_until(20, 2, fdb_table_has_no_dynamic_macs, duthost), "FDB Table Cleanup failed")
 
 
+@pytest.fixture
+def record_mux_status(request, rand_selected_dut):
+    """
+    A function level fixture to record mux cable status if test failed.
+    """
+    yield
+    if request.node.rep_call.failed:
+        mux_status = rand_selected_dut.shell("show muxcable status", module_ignore_errors=True)['stdout']
+        logger.warning("fdb test failed. Mux status are \n {}".format(mux_status))
+
+
 @pytest.mark.bsl
 @pytest.mark.parametrize("pkt_type", PKT_TYPES)
-def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type, toggle_all_simulator_ports_to_rand_selected_tor, record_mux_status):
 
     # Perform FDB clean up before each test and at the end of the final test
     fdb_cleanup(duthosts, rand_one_dut_hostname)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
We noticed that ```test_fdb``` was flaky in nightly regression test. The reason for that was probably unexpected muxcable toggle.
This PR is to add a function level fixture to record mux_cable status if ```test_fdb``` failed. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to add a function level fixture to record mux_cable status if ```test_fdb``` failed. 
#### How did you do it?
Add a function level to do that.
#### How did you verify/test it?
Verified on dualtr testbed, confirmed that mux_cable status was recorded if test failed.
```
tests.fdb.test_fdb:test_fdb.py:193 fdb test failed. Mux status are 
PORT         STATUS    HEALTH
-----------  --------  ---------
Ethernet0    active    unhealthy
Ethernet4    active    unhealthy
Ethernet8    active    unhealthy
Ethernet12   active    unhealthy
Ethernet16   active    unhealthy
Ethernet20   active    unhealthy
Ethernet40   active    unhealthy
Ethernet44   active    unhealthy
Ethernet48   active    unhealthy
Ethernet52   active    unhealthy
Ethernet56   active    unhealthy
Ethernet60   active    unhealthy
Ethernet64   active    unhealthy
Ethernet68   active    unhealthy
Ethernet72   active    unhealthy
Ethernet76   active    unhealthy
Ethernet80   active    unhealthy
Ethernet84   active    unhealthy
Ethernet104  active    unhealthy
Ethernet108  active    unhealthy
Ethernet112  active    unhealthy
Ethernet116  active    unhealthy
Ethernet120  active    unhealthy
Ethernet124  active    unhealthy
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
