### PR TITLE
Do neighbor VM restore only if there's VM's in setup

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -109,16 +109,17 @@ def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
     logger.info("Restoring neighbor VMs for {}".format(duthost))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
-    lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    if vm_neighbors:
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
 
-    for lag_name in lag_facts['names']:
-        nbr_intf = lag_facts['lags'][lag_name]['po_config']['ports'].keys()[0]
-        peer_device   = vm_neighbors[nbr_intf]['name']
-        nbr_host = nbrhosts[peer_device]['host']
-        intf_list = nbrhosts[peer_device]['conf']['interfaces'].keys()
-        # restore interfaces and portchannels
-        for intf in intf_list:
-            nbr_host.no_shutdown(intf)
-        asn = nbrhosts[peer_device]['conf']['bgp']['asn']
-        # restore BGP session
-        nbr_host.no_shutdown_bgp(asn)
+        for lag_name in lag_facts['names']:
+            nbr_intf = lag_facts['lags'][lag_name]['po_config']['ports'].keys()[0]
+            peer_device   = vm_neighbors[nbr_intf]['name']
+            nbr_host = nbrhosts[peer_device]['host']
+            intf_list = nbrhosts[peer_device]['conf']['interfaces'].keys()
+            # restore interfaces and portchannels
+            for intf in intf_list:
+                nbr_host.no_shutdown(intf)
+            asn = nbrhosts[peer_device]['conf']['bgp']['asn']
+            # restore BGP session
+            nbr_host.no_shutdown_bgp(asn)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
execute the logic of neighbor_vm_restore only in cases where vm_neighbors is not an empty list.

Summary:
function neighbor_vm_restore is run during sanity in cases of failure in the setup.
However in setups that do not include VM's this function is causing errors in the test.
It is more correct to run the recover logic only if the vm_neighbors list is not empty.
that way we could avoided such errors and the function is more correct.

### Type of change
adding if statement to function 


- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)



### Approach
#### What is the motivation for this PR?
 In setups that do not include VM's this function is causing errors in the test.

#### How did you do it?
add an if statement to function 

#### How did you verify/test it?
I run the tests with sanity afterward and verified they passed

#### Any platform specific information?
 it's relevant to all platforms

