### PR TITLE
tacacs test: fixed skipped assertion issue

### DIFF
--- a/tests/tacacs/test_jit_user.py
+++ b/tests/tacacs/test_jit_user.py
@@ -2,6 +2,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.tacacs import setup_tacacs_server
 from .test_ro_user import ssh_remote_run
+from .utils import check_output
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -18,10 +19,8 @@ def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname
     dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_jit_user'], creds_all_duts[duthost]['tacacs_jit_user_passwd'], 'cat /etc/passwd')
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "test":
-            assert fds[4] == "remote_user"
+    
+    check_output(res, 'test', 'remote_user')
 
     # change jit user to netadmin
     creds_all_duts[duthost]['tacacs_jit_user_membership'] = 'netadmin'
@@ -29,10 +28,8 @@ def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname
 
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_jit_user'],
                          creds_all_duts[duthost]['tacacs_jit_user_passwd'], 'cat /etc/passwd')
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "testadmin":
-            assert fds[4] == "remote_user_su"
+
+    check_output(res, 'testadmin', 'remote_user_su')
 
     # change jit user back to netuser
     creds_all_duts[duthost]['tacacs_jit_user_membership'] = 'netuser'
@@ -40,7 +37,4 @@ def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname
 
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_jit_user'],
                          creds_all_duts[duthost]['tacacs_jit_user_passwd'], 'cat /etc/passwd')
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "test":
-            assert fds[4] == "remote_user"
+    check_output(res, 'test', 'remote_user')

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -1,6 +1,7 @@
 import pytest
 import time
 from tests.common.helpers.assertions import pytest_assert
+from .utils import check_output
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -77,10 +78,7 @@ def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_al
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
                          creds_all_duts[duthost]['tacacs_ro_user_passwd'], 'cat /etc/passwd')
 
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "test":
-            assert fds[4] == "remote_user"
+    check_output(res, 'test', 'remote_user')
 
 def test_ro_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, test_tacacs_v6):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -88,10 +86,7 @@ def test_ro_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, cre
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
                          creds_all_duts[duthost]['tacacs_ro_user_passwd'], 'cat /etc/passwd')
 
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "test":
-            assert fds[4] == "remote_user"
+    check_output(res, 'test', 'remote_user')
 
 def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, test_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -2,6 +2,7 @@ import pytest
 import crypt
 
 from .test_ro_user import ssh_remote_run
+from .utils import check_output
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -18,10 +19,7 @@ def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_al
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_rw_user'],
                          creds_all_duts[duthost]['tacacs_rw_user_passwd'], "cat /etc/passwd")
 
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "testadmin":
-            assert fds[4] == "remote_user_su"
+    check_output(res, 'testadmin', 'remote_user_su')
 
 def test_rw_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, test_tacacs_v6):
     """test tacacs rw user
@@ -31,7 +29,4 @@ def test_rw_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, cre
     res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_rw_user'],
                          creds_all_duts[duthost]['tacacs_rw_user_passwd'], "cat /etc/passwd")
 
-    for l in res['stdout_lines']:
-        fds = l.split(':')
-        if fds[0] == "testadmin":
-            assert fds[4] == "remote_user_su"
+    check_output(res, 'testadmin', 'remote_user_su')

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -1,0 +1,9 @@
+from tests.common.helpers.assertions import pytest_assert
+
+
+def check_output(output, exp_val1, exp_val2):
+    pytest_assert(not output['failed'], output['stderr'])
+    for l in output['stdout_lines']:
+        fds = l.split(':')
+        if fds[0] == exp_val1:
+            pytest_assert(fds[4] == exp_val2)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: tacacs test - fixed skipped assertion issue
Fixes # (issue)
- fixed tests so assertion is not skipped anymore

TACACS tests execute a CLI command on DUT and verify its output is as expected. Command output check is implemented in the way it can be skipped when the command fails and tests pass then. Addressed the issue.
- dedicated a function for repeated test assertion fragment

Problematic code fragment:

```
res = ssh_remote_run(dut, cmd)
for l in res['stdout_lines']: # stdout_lines is empty when cmd fails so assert is never done
  assert ...
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Avoid false positive
#### How did you do it?
Identified skipped assertion and fixed it
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0,any tacacs/test_rw_user.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
